### PR TITLE
E/middleware hotfix

### DIFF
--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -1,7 +1,6 @@
 import { createMDX } from 'fumadocs-mdx/next';
 import { withGTConfig } from 'gt-next/config';
 
-
 const withMDX = createMDX();
 
 /** @type {import('next').NextConfig} */
@@ -13,5 +12,5 @@ const config = {
 
 export default withGTConfig(withMDX(config), {
   defaultLocale: 'en',
-  dictionary: "content/ui.en.json"
+  dictionary: 'content/ui.en.json',
 });

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -16,7 +16,7 @@
         "fumadocs-core": "^15.1.2",
         "fumadocs-mdx": "^11.5.7",
         "fumadocs-ui": "^15.1.2",
-        "gt-next": "^5.2.24-alpha.3",
+        "gt-next": "^5.2.23",
         "gtx-cli": "^1.1.13",
         "next": "^15.2.3",
         "next-sitemap": "^4.2.3",
@@ -5625,9 +5625,9 @@
       }
     },
     "node_modules/gt-next": {
-      "version": "5.2.24-alpha.3",
-      "resolved": "https://registry.npmjs.org/gt-next/-/gt-next-5.2.24-alpha.3.tgz",
-      "integrity": "sha512-bx4LetpukPQIF5q27HCqNnYGOCwGGtwptdZu/cpvPaYsGYbPhZ/U44+GKGLHb0IpXC9L87JLbQACAM1CZ2PqUQ==",
+      "version": "5.2.23",
+      "resolved": "https://registry.npmjs.org/gt-next/-/gt-next-5.2.23.tgz",
+      "integrity": "sha512-6/bV8xq1IzluMYk99gD27uEoX1U//vgMktOoO3kmCcWCQPAWMpkwnq21U4K4eVKSRjy4pckSB0Gz+2qLCcTsjg==",
       "license": "FSL-1.1-ALv2",
       "dependencies": {
         "@generaltranslation/supported-locales": "^2.0.7",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -16,7 +16,7 @@
         "fumadocs-core": "^15.1.2",
         "fumadocs-mdx": "^11.5.7",
         "fumadocs-ui": "^15.1.2",
-        "gt-next": "^5.2.24-alpha.1",
+        "gt-next": "^5.2.24-alpha.3",
         "gtx-cli": "^1.1.13",
         "next": "^15.2.3",
         "next-sitemap": "^4.2.3",
@@ -5625,9 +5625,9 @@
       }
     },
     "node_modules/gt-next": {
-      "version": "5.2.24-alpha.1",
-      "resolved": "https://registry.npmjs.org/gt-next/-/gt-next-5.2.24-alpha.1.tgz",
-      "integrity": "sha512-7DBLf7AMAS9tEPXIMym9snWb8fP/PCloftKliRr9zeHAUDXGEzv9MHvFv/KwB1NLFSV8C1UiuVoMwV0eGi6b7A==",
+      "version": "5.2.24-alpha.3",
+      "resolved": "https://registry.npmjs.org/gt-next/-/gt-next-5.2.24-alpha.3.tgz",
+      "integrity": "sha512-bx4LetpukPQIF5q27HCqNnYGOCwGGtwptdZu/cpvPaYsGYbPhZ/U44+GKGLHb0IpXC9L87JLbQACAM1CZ2PqUQ==",
       "license": "FSL-1.1-ALv2",
       "dependencies": {
         "@generaltranslation/supported-locales": "^2.0.7",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -16,7 +16,7 @@
         "fumadocs-core": "^15.1.2",
         "fumadocs-mdx": "^11.5.7",
         "fumadocs-ui": "^15.1.2",
-        "gt-next": "^5.2.22",
+        "gt-next": "^5.2.24-alpha.1",
         "gtx-cli": "^1.1.13",
         "next": "^15.2.3",
         "next-sitemap": "^4.2.3",
@@ -5625,9 +5625,10 @@
       }
     },
     "node_modules/gt-next": {
-      "version": "5.2.22",
-      "resolved": "https://registry.npmjs.org/gt-next/-/gt-next-5.2.22.tgz",
-      "integrity": "sha512-nNeBHsYjZJcfF4C1ZkSUWZY1Nvy+U4zkj8k0DIYFs8A3hcvFSOXWfycUsYK/VMRNljzkDpLCwUmm+aWqjFpMTA==",
+      "version": "5.2.24-alpha.1",
+      "resolved": "https://registry.npmjs.org/gt-next/-/gt-next-5.2.24-alpha.1.tgz",
+      "integrity": "sha512-7DBLf7AMAS9tEPXIMym9snWb8fP/PCloftKliRr9zeHAUDXGEzv9MHvFv/KwB1NLFSV8C1UiuVoMwV0eGi6b7A==",
+      "license": "FSL-1.1-ALv2",
       "dependencies": {
         "@generaltranslation/supported-locales": "^2.0.7",
         "generaltranslation": "^6.2.2",

--- a/docs/package.json
+++ b/docs/package.json
@@ -23,7 +23,7 @@
     "fumadocs-core": "^15.1.2",
     "fumadocs-mdx": "^11.5.7",
     "fumadocs-ui": "^15.1.2",
-    "gt-next": "^5.2.24-alpha.1",
+    "gt-next": "^5.2.24-alpha.3",
     "gtx-cli": "^1.1.13",
     "next": "^15.2.3",
     "next-sitemap": "^4.2.3",

--- a/docs/package.json
+++ b/docs/package.json
@@ -23,7 +23,7 @@
     "fumadocs-core": "^15.1.2",
     "fumadocs-mdx": "^11.5.7",
     "fumadocs-ui": "^15.1.2",
-    "gt-next": "^5.2.24-alpha.3",
+    "gt-next": "^5.2.23",
     "gtx-cli": "^1.1.13",
     "next": "^15.2.3",
     "next-sitemap": "^4.2.3",

--- a/docs/package.json
+++ b/docs/package.json
@@ -23,7 +23,7 @@
     "fumadocs-core": "^15.1.2",
     "fumadocs-mdx": "^11.5.7",
     "fumadocs-ui": "^15.1.2",
-    "gt-next": "^5.2.23",
+    "gt-next": "^5.2.24-alpha.1",
     "gtx-cli": "^1.1.13",
     "next": "^15.2.3",
     "next-sitemap": "^4.2.3",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gt-next",
-  "version": "5.2.24-alpha.2",
+  "version": "5.2.24-alpha.3",
   "description": "A Next.js library for automatic internationalization.",
   "main": "dist/index.server.js",
   "peerDependencies": {

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gt-next",
-  "version": "5.2.24-alpha.1",
+  "version": "5.2.24-alpha.2",
   "description": "A Next.js library for automatic internationalization.",
   "main": "dist/index.server.js",
   "peerDependencies": {

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gt-next",
-  "version": "5.2.23",
+  "version": "5.2.24-alpha.1",
   "description": "A Next.js library for automatic internationalization.",
   "main": "dist/index.server.js",
   "peerDependencies": {

--- a/packages/next/src/errors/createErrors.ts
+++ b/packages/next/src/errors/createErrors.ts
@@ -43,6 +43,13 @@ export const unresolvedLoadDictionaryBuildError = (path: string) =>
 export const unresolvedLoadTranslationsBuildError = (path: string) =>
   `gt-next Error: File defining loadTranslations() function could not be resolved at ${path}`;
 
+export const conflictingConfigurationBuildError = (conflicts: string[]) =>
+  `gt-next Error: Conflicting configuration${
+    conflicts.length > 1 ? 's' : ''
+  } detected. Please resolve the following conflicts before building your app:\n${conflicts.join(
+    '\n'
+  )}`;
+
 // ---- WARNINGS ---- //
 
 export const usingDefaultsWarning =

--- a/packages/next/src/middleware-dir/createNextMiddleware.ts
+++ b/packages/next/src/middleware-dir/createNextMiddleware.ts
@@ -132,7 +132,7 @@ export default function createNextMiddleware({
    * @param {NextRequest} req - The incoming request object, containing URL and headers.
    * @returns {NextResponse} - The Next.js response, either continuing the request or redirecting to the localized URL.
    */
-  function nextMiddleware(req: NextRequest) {
+  async function middleware(req: NextRequest) {
     // ---------- LOCALE DETECTION ---------- //
 
     const {
@@ -325,5 +325,5 @@ export default function createNextMiddleware({
     return getNextResponse();
   }
 
-  return nextMiddleware;
+  return middleware;
 }

--- a/packages/next/src/middleware-dir/utils.ts
+++ b/packages/next/src/middleware-dir/utils.ts
@@ -296,7 +296,6 @@ export function getLocaleFromRequest(
       isValidLocale(extractedLocale) &&
       determineLocale([extractedLocale], approvedLocales)
     ) {
-      // NOTICE HERE: we are checking extractedLocale agains the list of approved locales
       const determinedLocale = determineLocale(
         [extractedLocale],
         approvedLocales
@@ -338,7 +337,6 @@ export function getLocaleFromRequest(
     !clearResetCookie
   ) {
     const referrerLocale = referrerLocaleCookie.value;
-    // NOTICE HERE: we are checking referrerLocale agains the list of approved locales
     if (determineLocale([referrerLocale], approvedLocales)) {
       candidates.push(referrerLocale);
     }

--- a/packages/next/src/middleware-dir/utils.ts
+++ b/packages/next/src/middleware-dir/utils.ts
@@ -296,8 +296,15 @@ export function getLocaleFromRequest(
       isValidLocale(extractedLocale) &&
       determineLocale([extractedLocale], approvedLocales)
     ) {
-      pathnameLocale = extractedLocale;
-      candidates.push(pathnameLocale);
+      // NOTICE HERE: we are checking extractedLocale agains the list of approved locales
+      const determinedLocale = determineLocale(
+        [extractedLocale],
+        approvedLocales
+      );
+      if (determinedLocale) {
+        pathnameLocale = determinedLocale;
+        candidates.push(pathnameLocale);
+      }
     }
   }
 
@@ -324,13 +331,17 @@ export function getLocaleFromRequest(
   }
 
   // Check referrer locale
-  const referrerLocale = req.cookies.get(referrerLocaleCookieName);
+  const referrerLocaleCookie = req.cookies.get(referrerLocaleCookieName);
   if (
-    referrerLocale?.value &&
-    isValidLocale(referrerLocale?.value) &&
+    referrerLocaleCookie?.value &&
+    isValidLocale(referrerLocaleCookie.value) &&
     !clearResetCookie
   ) {
-    candidates.push(referrerLocale.value);
+    const referrerLocale = referrerLocaleCookie.value;
+    // NOTICE HERE: we are checking referrerLocale agains the list of approved locales
+    if (determineLocale([referrerLocale], approvedLocales)) {
+      candidates.push(referrerLocale);
+    }
   }
 
   // Get locales from accept-language header


### PR DESCRIPTION
Two changes:
(1) Bug fix in middleware, now checks that a supplied locale is in the list of approved locales using `determineLocale()` rather than just using `.includes()`. This allows us to check for variants of supported locales (e.g. if you support `en` then you should be able to handle a user requesting `en-US`. (Additionally, we now forward source maps if detected, but this is pretty minor)
(2) Throw a build error if your `gt.config.json` does not match the parameters you have supplied to `withGTConfig()` which we noticed was a common point of confusion for new users.