### PR TITLE
fix(cli): Fix errors not causing cmd to fail

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gtx-cli",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "main": "dist/index.js",
   "bin": "dist/main.js",
   "scripts": {

--- a/packages/cli/src/cli/react.ts
+++ b/packages/cli/src/cli/react.ts
@@ -304,7 +304,7 @@ export class ReactCLI extends BaseCLI {
           )
         );
       } else {
-        logError(
+        logErrorAndExit(
           chalk.red(
             `CLI tool encountered errors while scanning for ${chalk.green(
               '<T>'

--- a/packages/cli/src/translation/stage.ts
+++ b/packages/cli/src/translation/stage.ts
@@ -63,7 +63,7 @@ export async function stageProject(
         )
       );
     } else {
-      logError(
+      logErrorAndExit(
         chalk.red(
           `CLI tool encountered errors while scanning for ${chalk.green(
             '<T>'


### PR DESCRIPTION
This PR makes the CLI translate cmd fail if there are any parsing errors, and --ignore-errors is not present