### PR TITLE
feat: Add error handling for invalid dates

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gt-next",
-  "version": "5.2.25",
+  "version": "5.2.27",
   "description": "A Next.js library for automatic internationalization.",
   "main": "dist/index.server.js",
   "peerDependencies": {
@@ -11,7 +11,7 @@
   "dependencies": {
     "@generaltranslation/supported-locales": "^2.0.7",
     "generaltranslation": "^6.2.2",
-    "gt-react": "^9.2.16"
+    "gt-react": "^9.2.20"
   },
   "scripts": {
     "patch": "npm version patch",

--- a/packages/next/src/variables/DateTime.tsx
+++ b/packages/next/src/variables/DateTime.tsx
@@ -42,6 +42,13 @@ async function DateTime({
   } else if (defaultValue instanceof Date) {
     dateValue = defaultValue;
   }
+
+  if (typeof dateValue !== 'undefined' && isNaN(dateValue.getTime())) {
+    throw new Error(
+      `DateTime Error -- Invalid date format: "${defaultValue}". Please use a Date object, valid date string, or number.`
+    );
+  }
+
   if (typeof dateValue !== 'undefined') {
     final = formatDateTime(dateValue, { locales, ...options }).replace(
       /[\u200F\u202B\u202E]/g,

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gt-react",
-  "version": "9.2.17",
+  "version": "9.2.20",
   "description": "A React library for automatic internationalization.",
   "main": "./dist/index.cjs.min.cjs",
   "module": "./dist/index.esm.min.mjs",

--- a/packages/react/src/variables/DateTime.tsx
+++ b/packages/react/src/variables/DateTime.tsx
@@ -52,6 +52,13 @@ function DateTime({
   } else if (defaultValue instanceof Date) {
     dateValue = defaultValue;
   }
+
+  if (typeof dateValue !== 'undefined' && isNaN(dateValue.getTime())) {
+    throw new Error(
+      `DateTime Error -- Invalid date format: "${defaultValue}". Please use a Date object, valid date string, or number.`
+    );
+  }
+
   if (typeof dateValue !== 'undefined') {
     final = formatDateTime(dateValue, { locales, ...options }).replace(
       /[\u200F\u202B\u202E]/g,


### PR DESCRIPTION
Some browsers (Safari, Firefox) have stricter requirements for what strings can become Date objects. Therefore, when a uses a string such as "June 2020" within the GT DateTime, it will work on Chrome and not on others. This will throw a meaningful error when this occurs.