### PR TITLE
feat(cli): Add ability to generate dev vs prod API keys

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gtx-cli",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "main": "dist/index.js",
   "bin": "dist/main.js",
   "scripts": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -69,7 +69,7 @@
     "chalk": "^4.1.2",
     "commander": "^12.1.0",
     "dotenv": "^16.4.5",
-    "esbuild": "^0.23.1",
+    "esbuild": "^0.25.4",
     "fast-glob": "^3.3.3",
     "form-data": "^4.0.2",
     "generaltranslation": "^6.2.4",

--- a/packages/cli/src/cli/base.ts
+++ b/packages/cli/src/cli/base.ts
@@ -27,7 +27,6 @@ import {
   SupportedLibraries,
   SetupOptions,
 } from '../types';
-import { resolveProjectId } from '../fs/utils';
 import { DataFormat } from '../types/data';
 import { generateSettings } from '../config/generateSettings';
 import chalk from 'chalk';
@@ -91,11 +90,7 @@ export class BaseCLI {
         '--api-key <key>',
         'API key for General Translation cloud service'
       )
-      .option(
-        '--project-id <id>',
-        'Project ID for the translation service',
-        resolveProjectId()
-      )
+      .option('--project-id <id>', 'Project ID for the translation service')
       .option(
         '--default-language, --default-locale <locale>',
         'Default locale (e.g., en)'

--- a/packages/cli/src/cli/react.ts
+++ b/packages/cli/src/cli/react.ts
@@ -70,7 +70,7 @@ export class ReactCLI extends BaseCLI {
         'Submits the project to the General Translation API for translation. Translations created using this command will require human approval.'
       )
       .option(
-        '--config <path>',
+        '-c, --config <path>',
         'Filepath to config file, by default gt.config.json',
         findFilepath(['gt.config.json'])
       )
@@ -136,7 +136,7 @@ export class ReactCLI extends BaseCLI {
         'Scans the project for a dictionary and/or <T> tags, and sends the updates to the General Translation API for translation.'
       )
       .option(
-        '--config <path>',
+        '-c, --config <path>',
         'Filepath to config file, by default gt.config.json',
         findFilepath(['gt.config.json'])
       )
@@ -248,7 +248,7 @@ export class ReactCLI extends BaseCLI {
         findFilepaths(['./src', './app', './pages', './components'])
       )
       .option(
-        '--config <path>',
+        '-c, --config <path>',
         'Filepath to config file, by default gt.config.json',
         findFilepath(['gt.config.json'])
       )

--- a/packages/cli/src/cli/react.ts
+++ b/packages/cli/src/cli/react.ts
@@ -3,7 +3,6 @@ import { program } from 'commander';
 import {
   Options,
   SupportedFrameworks,
-  Updates,
   WrapOptions,
   GenerateSourceOptions,
   SupportedLibraries,
@@ -24,7 +23,6 @@ import chalk from 'chalk';
 import { formatFiles } from '../hooks/postProcess';
 import { BaseCLI } from './base';
 import wrapContentReact from '../react/parse/wrapContent';
-import { resolveProjectId } from '../fs/utils';
 import { generateSettings } from '../config/generateSettings';
 import { saveJSON } from '../fs/saveJSON';
 import { resolveLocaleFiles } from '../fs/config/parseFilesConfig';
@@ -78,11 +76,7 @@ export class ReactCLI extends BaseCLI {
         '--api-key <key>',
         'API key for General Translation cloud service'
       )
-      .option(
-        '--project-id <id>',
-        'Project ID for the translation service',
-        resolveProjectId()
-      )
+      .option('--project-id <id>', 'Project ID for the translation service')
       .option('--version-id <id>', 'Version ID for the translation service')
       .option(
         '--tsconfig, --jsconfig <path>',
@@ -144,11 +138,7 @@ export class ReactCLI extends BaseCLI {
         '--api-key <key>',
         'API key for General Translation cloud service'
       )
-      .option(
-        '--project-id <id>',
-        'Project ID for the translation service',
-        resolveProjectId()
-      )
+      .option('--project-id <id>', 'Project ID for the translation service')
       .option('--version-id <id>', 'Version ID for the translation service')
       .option(
         '--tsconfig, --jsconfig <path>',

--- a/packages/cli/src/cli/react.ts
+++ b/packages/cli/src/cli/react.ts
@@ -294,22 +294,22 @@ export class ReactCLI extends BaseCLI {
     if (errors.length > 0) {
       if (options.ignoreErrors) {
         logWarning(
-          chalk.red(
-            `CLI tool encountered errors while scanning for ${chalk.green(
-              '<T>'
-            )} tags. These components will not be translated.\n` +
+          chalk.yellow(
+            `CLI tool encountered errors while scanning for translatable content. These components will not be translated.\n` +
               errors
-                .map((error) => chalk.yellow('• Warning: ') + error)
+                .map(
+                  (error) => chalk.yellow('• Warning: ') + chalk.white(error)
+                )
                 .join('\n')
           )
         );
       } else {
         logErrorAndExit(
           chalk.red(
-            `CLI tool encountered errors while scanning for ${chalk.green(
-              '<T>'
-            )} tags. ${chalk.gray('To ignore these errors, re-run with --ignore-errors')}\n` +
-              errors.map((error) => chalk.red('• Error: ') + error).join('\n')
+            `CLI tool encountered errors while scanning for translatable content. ${chalk.gray('To ignore these errors, re-run with --ignore-errors')}\n` +
+              errors
+                .map((error) => chalk.red('• Error: ') + chalk.white(error))
+                .join('\n')
           )
         );
       }

--- a/packages/cli/src/config/generateSettings.ts
+++ b/packages/cli/src/config/generateSettings.ts
@@ -13,6 +13,7 @@ import { resolveFiles } from '../fs/config/parseFilesConfig';
 import { findFilepaths } from '../fs/findFilepath';
 import { validateSettings } from './validateSettings';
 import { GT_DASHBOARD_URL } from '../utils/constants';
+import { resolveProjectId } from '../fs/utils';
 /**
  * Generates settings from any
  * @param options - The options to generate settings from
@@ -56,8 +57,7 @@ export async function generateSettings(options: any): Promise<Settings> {
   mergedOptions.apiKey = mergedOptions.apiKey || process.env.GT_API_KEY;
 
   // Add projectId if not provided
-  mergedOptions.projectId =
-    mergedOptions.projectId || process.env.GT_PROJECT_ID;
+  mergedOptions.projectId = mergedOptions.projectId || resolveProjectId();
 
   // Add baseUrl if not provided
   mergedOptions.baseUrl = mergedOptions.baseUrl || defaultBaseUrl;

--- a/packages/cli/src/config/generateSettings.ts
+++ b/packages/cli/src/config/generateSettings.ts
@@ -2,7 +2,7 @@ import { isValidLocale } from 'generaltranslation';
 import { displayProjectId } from '../console/console';
 import { warnApiKeyInConfig } from '../console/warnings';
 import loadConfig from '../fs/config/loadConfig';
-import { Settings } from '../types';
+import { Settings, SupportedFrameworks } from '../types';
 import {
   defaultBaseUrl,
   libraryDefaultLocale,
@@ -100,6 +100,7 @@ export async function generateSettings(options: any): Promise<Settings> {
       defaultLocale: mergedOptions.defaultLocale as string,
       locales:
         mergedOptions.locales?.length > 0 ? mergedOptions.locales : undefined,
+      framework: mergedOptions.framework as SupportedFrameworks,
     });
   }
   validateSettings(mergedOptions);

--- a/packages/cli/src/console/colors.ts
+++ b/packages/cli/src/console/colors.ts
@@ -1,0 +1,20 @@
+import chalk from 'chalk';
+
+export function colorizeFilepath(filepath: string) {
+  return chalk.cyan(filepath);
+}
+
+export function colorizeComponent(component: string) {
+  return chalk.yellow(component);
+}
+
+export function colorizeIdString(id: string) {
+  return chalk.yellow(id);
+}
+export function colorizeContent(content: string) {
+  return chalk.yellow(content);
+}
+
+export function colorizeLine(line: string) {
+  return chalk.gray(line);
+}

--- a/packages/cli/src/console/index.ts
+++ b/packages/cli/src/console/index.ts
@@ -1,39 +1,100 @@
 // Export all logging functions
 export * from './logging';
+import {
+  colorizeFilepath,
+  colorizeComponent,
+  colorizeIdString,
+  colorizeContent,
+  colorizeLine,
+} from './colors';
 
 // Synchronous wrappers for backward compatibility
 export const warnApiKeyInConfigSync = (optionsFilepath: string): string =>
-  `Found apiKey in "${optionsFilepath}". Your API key is exposed! Please remove it from the file and include it as an environment variable.`;
+  `${colorizeFilepath(
+    optionsFilepath
+  )}: Your API key is exposed! Please remove it from the file and include it as an environment variable.`;
 
 export const warnVariablePropSync = (
   file: string,
   attrName: string,
-  value: string
+  value: string,
+  location?: string
 ): string =>
-  `Found <T> component in ${file} with variable ${attrName}: "${value}". Change "${attrName}" to ensure this content is translated.`;
-
-export const warnNoIdSync = (file: string): string =>
-  `Found <T> component in ${file} with no id. Add an id to ensure the content is translated.`;
+  withLocation(
+    file,
+    `${colorizeComponent('<T>')} component has dynamic attribute ${colorizeIdString(attrName)} with value: ${colorizeContent(
+      value
+    )}. Change ${colorizeIdString(attrName)} to ensure this content is translated.`,
+    location
+  );
 
 export const warnHasUnwrappedExpressionSync = (
   file: string,
-  id: string,
-  unwrappedExpressions: string[]
+  unwrappedExpressions: string[],
+  id?: string,
+  location?: string
 ): string =>
-  `<T> with id "${id}" in ${file} has children: ${unwrappedExpressions.join(', ')} that could change at runtime. Use a variable component like <Var> to translate this properly.`;
+  withLocation(
+    file,
+    `${colorizeComponent('<T>')} component${
+      id ? ` with id ${colorizeIdString(id)}` : ''
+    } has children that could change at runtime. Use a variable component like ${colorizeComponent(
+      '<Var>'
+    )} to ensure this content is translated.\n${colorizeContent(
+      unwrappedExpressions.join('\n')
+    )}`,
+    location
+  );
 
 export const warnNonStaticExpressionSync = (
   file: string,
   attrName: string,
-  value: string
+  value: string,
+  location?: string
 ): string =>
-  `Found non-static expression in ${file} for attribute ${attrName}: "${value}". Change "${attrName}" to ensure this content is translated.`;
+  withLocation(
+    file,
+    `Found non-static expression for attribute ${colorizeIdString(
+      attrName
+    )}: ${colorizeContent(value)}. Change "${colorizeIdString(attrName)}" to ensure this content is translated.`,
+    location
+  );
 
-export const warnTemplateLiteralSync = (file: string, value: string): string =>
-  `Found template literal with quasis (${value}) in ${file}. Change the template literal to a string to ensure this content is translated.`;
+export const warnTemplateLiteralSync = (
+  file: string,
+  value: string,
+  location?: string
+): string =>
+  withLocation(
+    file,
+    `Found template literal with quasis (${colorizeContent(value)}). Change the template literal to a string to ensure this content is translated.`,
+    location
+  );
 
-export const warnTernarySync = (file: string): string =>
-  `Found ternary expression in ${file}. A Branch component may be more appropriate here.`;
+export const warnNonStringSync = (
+  file: string,
+  value: string,
+  location?: string
+): string =>
+  withLocation(
+    file,
+    `Found non-string literal (${colorizeContent(value)}). Change the value to a string literal to ensure this content is translated.`,
+    location
+  );
+
+export const warnTernarySync = (file: string, location?: string): string =>
+  withLocation(
+    file,
+    'Found ternary expression. A Branch component may be more appropriate here.',
+    location
+  );
+
+export const withLocation = (
+  file: string,
+  message: string,
+  location?: string
+): string =>
+  `${colorizeFilepath(file)}${location ? ` (${colorizeLine(location)})` : ''}: ${message}`;
 
 // Re-export error messages
 export const noLocalesError = `No locales found! Please provide a list of locales to translate to, or specify them in your gt.config.json file.`;

--- a/packages/cli/src/console/index.ts
+++ b/packages/cli/src/console/index.ts
@@ -104,5 +104,6 @@ export const noSourceFileError = `No source file found! Please double check your
 export const noDataFormatError = `No data format found! Please make sure your translationsDir parameter ends with a supported file extension.`;
 export const noSupportedDataFormatError = `Unsupported data format! Please make sure your translationsDir parameter ends with a supported file extension.`;
 export const noApiKeyError = `No API key found! Please provide an API key using the --api-key flag or set the GT_API_KEY environment variable.`;
+export const devApiKeyError = `You are using a development API key. Please use a production API key to send files to General Translation.\nYou can generate a production API key with the command: npx gtx-cli auth -t production`;
 export const noProjectIdError = `No project ID found! Please provide a project ID using the --project-id flag, specify it in your gt.config.json file, or set the GT_PROJECT_ID environment variable.`;
 export const noVersionIdError = `No version ID found! Please provide a version ID using the --version-id flag or specify it in your gt.config.json file as the _versionId property.`;

--- a/packages/cli/src/console/index.ts
+++ b/packages/cli/src/console/index.ts
@@ -104,6 +104,6 @@ export const noSourceFileError = `No source file found! Please double check your
 export const noDataFormatError = `No data format found! Please make sure your translationsDir parameter ends with a supported file extension.`;
 export const noSupportedDataFormatError = `Unsupported data format! Please make sure your translationsDir parameter ends with a supported file extension.`;
 export const noApiKeyError = `No API key found! Please provide an API key using the --api-key flag or set the GT_API_KEY environment variable.`;
-export const devApiKeyError = `You are using a development API key. Please use a production API key to send files to General Translation.\nYou can generate a production API key with the command: npx gtx-cli auth -t production`;
+export const devApiKeyError = `You are using a development API key. Please use a production API key to use the General Translation API.\nYou can generate a production API key with the command: npx gtx-cli auth -t production`;
 export const noProjectIdError = `No project ID found! Please provide a project ID using the --project-id flag, specify it in your gt.config.json file, or set the GT_PROJECT_ID environment variable.`;
 export const noVersionIdError = `No version ID found! Please provide a version ID using the --version-id flag or specify it in your gt.config.json file as the _versionId property.`;

--- a/packages/cli/src/formats/files/translate.ts
+++ b/packages/cli/src/formats/files/translate.ts
@@ -10,6 +10,7 @@ import {
   noDefaultLocaleError,
   noApiKeyError,
   noProjectIdError,
+  devApiKeyError,
 } from '../../console';
 import { resolveLocaleFiles } from '../../fs/config/parseFilesConfig';
 import { getRelative, readFile } from '../../fs/findFilepath';
@@ -105,6 +106,9 @@ export async function translateFiles(
   }
   if (!options.apiKey) {
     logErrorAndExit(noApiKeyError);
+  }
+  if (options.apiKey.startsWith('gtx-dev-')) {
+    logErrorAndExit(devApiKeyError);
   }
   if (!options.projectId) {
     logErrorAndExit(noProjectIdError);

--- a/packages/cli/src/fs/config/setupConfig.ts
+++ b/packages/cli/src/fs/config/setupConfig.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import { displayCreatedConfigFile, logError } from '../../console';
-import { FilesOptions } from '../../types';
+import { FilesOptions, SupportedFrameworks } from '../../types';
 
 /**
  * Checks if the config file exists.
@@ -16,6 +16,7 @@ export default async function createOrUpdateConfig(
     defaultLocale?: string;
     locales?: string[];
     files?: FilesOptions;
+    framework?: SupportedFrameworks;
   }
 ): Promise<string> {
   // Filter out empty string values from the config object
@@ -23,6 +24,7 @@ export default async function createOrUpdateConfig(
     ...(options.projectId && { projectId: options.projectId }),
     ...(options.defaultLocale && { defaultLocale: options.defaultLocale }),
     ...(options.files && { files: options.files }),
+    ...(options.framework && { framework: options.framework }),
   };
   try {
     // if file exists

--- a/packages/cli/src/react/jsx/parse/parseStringFunction.ts
+++ b/packages/cli/src/react/jsx/parse/parseStringFunction.ts
@@ -83,7 +83,8 @@ export function parseStrings(
                           warnNonStaticExpressionSync(
                             file,
                             attribute,
-                            generate(prop.value).code
+                            generate(prop.value).code,
+                            `${prop.loc?.start?.line}:${prop.loc?.start?.column}`
                           )
                         );
                       }
@@ -102,7 +103,13 @@ export function parseStrings(
               });
             } else if (t.isTemplateLiteral(arg)) {
               // warn if template literal
-              errors.push(warnTemplateLiteralSync(file, generate(arg).code));
+              errors.push(
+                warnTemplateLiteralSync(
+                  file,
+                  generate(arg).code,
+                  `${arg.loc?.start?.line}:${arg.loc?.start?.column}`
+                )
+              );
             }
           }
         });

--- a/packages/cli/src/react/jsx/utils/parseJsx.ts
+++ b/packages/cli/src/react/jsx/utils/parseJsx.ts
@@ -5,7 +5,6 @@ import * as t from '@babel/types';
 import addGTIdentifierToSyntaxTree from '../../data-_gt/addGTIdentifierToSyntaxTree';
 import {
   warnHasUnwrappedExpressionSync,
-  warnNoIdSync,
   warnVariablePropSync,
 } from '../../../console';
 import { isAcceptedPluralForm } from 'generaltranslation/internal';
@@ -224,7 +223,14 @@ export function parseJSXElement(
           if (attrName === 'id' || attrName === 'context') {
             const staticAnalysis = isStaticExpression(expr);
             if (!staticAnalysis.isStatic) {
-              errors.push(warnVariablePropSync(file, attrName, code));
+              errors.push(
+                warnVariablePropSync(
+                  file,
+                  attrName,
+                  code,
+                  `${expr.loc?.start?.line}:${expr.loc?.start?.column}`
+                )
+              );
             }
             // Use the static value if available
             if (staticAnalysis.isStatic && staticAnalysis.value !== undefined) {
@@ -262,7 +268,12 @@ export function parseJSXElement(
     // If we found an unwrapped expression, skip
     if (unwrappedExpressions.length > 0) {
       errors.push(
-        warnHasUnwrappedExpressionSync(file, id, unwrappedExpressions)
+        warnHasUnwrappedExpressionSync(
+          file,
+          unwrappedExpressions,
+          id,
+          `${node.loc?.start?.line}:${node.loc?.start?.column}`
+        )
       );
     }
 

--- a/packages/cli/src/react/jsx/wrapJsx.ts
+++ b/packages/cli/src/react/jsx/wrapJsx.ts
@@ -89,7 +89,12 @@ function wrapJsxExpression(
 
       // Warn about ternary (should use branch instead)
       if (result.wrappedInT && !mark) {
-        options.warnings.push(warnTernarySync(options.file));
+        options.warnings.push(
+          warnTernarySync(
+            options.file,
+            `${consequent.loc?.start?.line}:${consequent.loc?.start?.column}`
+          )
+        );
       }
     } else if (
       t.isConditionalExpression(consequent) ||

--- a/packages/cli/src/setup/wizard.ts
+++ b/packages/cli/src/setup/wizard.ts
@@ -13,6 +13,7 @@ import wrapContentReact from '../react/parse/wrapContent';
 import wrapContentNext from '../next/parse/wrapContent';
 import { getPackageManager } from '../utils/packageManager';
 import { installPackage } from '../utils/installPackage';
+import createOrUpdateConfig from '../fs/config/setupConfig';
 
 export async function handleSetupReactCommand(
   options: SetupOptions
@@ -57,6 +58,11 @@ Please let us know what you would like to see supported at https://github.com/ge
     process.exit(0);
   }
 
+  // ----- Create a starter gt.config.json file -----
+  await createOrUpdateConfig(options.config || 'gt.config.json', {
+    framework: frameworkType as SupportedFrameworks,
+  });
+
   const packageJson = await getPackageJson();
   // Check if gt-next or gt-react is installed
   if (
@@ -80,9 +86,6 @@ Please let us know what you would like to see supported at https://github.com/ge
     await installPackage('gt-react', packageManager);
     spinner.stop(chalk.green('Automatically installed gt-react.'));
   }
-
-  // ----- Create a starter gt.config.json file -----
-  await generateSettings(options);
 
   let errors: string[] = [];
   let warnings: string[] = [];

--- a/packages/cli/src/translation/stage.ts
+++ b/packages/cli/src/translation/stage.ts
@@ -1,4 +1,4 @@
-import { logErrorAndExit } from '../console/errors';
+import { devApiKeyError, logErrorAndExit } from '../console/errors';
 import chalk from 'chalk';
 
 import findFilepath from '../fs/findFilepath';
@@ -97,6 +97,9 @@ export async function stageProject(
   }
   if (!settings.apiKey) {
     logErrorAndExit(noApiKeyError);
+  }
+  if (settings.apiKey.startsWith('gtx-dev-')) {
+    logErrorAndExit(devApiKeyError);
   }
   if (!settings.projectId) {
     logErrorAndExit(noProjectIdError);

--- a/packages/cli/src/translation/stage.ts
+++ b/packages/cli/src/translation/stage.ts
@@ -53,23 +53,19 @@ export async function stageProject(
   if (errors.length > 0) {
     if (settings.ignoreErrors) {
       logWarning(
-        chalk.red(
-          `CLI tool encountered errors while scanning for ${chalk.green(
-            '<T>'
-          )} tags. These components will not be translated.\n` +
+        chalk.yellow(
+          `Warning: CLI tool encountered syntax errors while scanning for translatable content. These components will not be translated.\n` +
             errors
-              .map((error) => chalk.yellow('• Warning: ') + error + '\n')
+              .map((error) => chalk.yellow('• ') + chalk.white(error) + '\n')
               .join('')
         )
       );
     } else {
       logErrorAndExit(
         chalk.red(
-          `CLI tool encountered errors while scanning for ${chalk.green(
-            '<T>'
-          )} tags. ${chalk.gray('To ignore these errors, re-run with --ignore-errors')}\n` +
+          `Error: CLI tool encountered syntax errors while scanning for translatable content. ${chalk.gray('To ignore these errors, re-run with --ignore-errors')}\n` +
             errors
-              .map((error) => chalk.red('• Error: ') + error + '\n')
+              .map((error) => chalk.red('• ') + chalk.white(error) + '\n')
               .join('')
         )
       );

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -137,4 +137,5 @@ export type Settings = {
   version?: string; // for specifying a custom version id to use. Should be unique
   description?: string;
   src?: string[]; // src directory for gt-next and gt-react
+  framework?: SupportedFrameworks;
 };


### PR DESCRIPTION
This PR modifies the CLI & allows npx gtx-cli auth to specify either a dev or prod api key.

Automatic detection: 
- If the project has gt-next or gt-react installed, defaults to dev api key
- Else, defaults to prod api key
- Also prefixes dev api keys with NEXT_PUBLIC_, VITE_, etc. 