### PR TITLE
Fixed example-next-create-app deployment

### DIFF
--- a/examples/next-create-app/next.config.ts
+++ b/examples/next-create-app/next.config.ts
@@ -6,7 +6,4 @@ const nextConfig: NextConfig = {
   /* config options here */
 };
 
-export default withGTConfig(nextConfig, {
-  defaultLocale: 'en-US',
-  locales: ['en-US', 'fr', 'es', 'zh'],
-});
+export default withGTConfig(nextConfig, {});


### PR DESCRIPTION
removed the locales from the next config to fix conflicts with GT config