### PR TITLE
fix(cli): Fix locale superset & file finding

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gtx-cli",
-  "version": "1.2.9",
+  "version": "1.2.10-alpha.1",
   "main": "dist/index.js",
   "bin": "dist/main.js",
   "scripts": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gtx-cli",
-  "version": "1.2.10-alpha.1",
+  "version": "1.2.10",
   "main": "dist/index.js",
   "bin": "dist/main.js",
   "scripts": {

--- a/packages/cli/src/config/validateSettings.ts
+++ b/packages/cli/src/config/validateSettings.ts
@@ -20,8 +20,10 @@ export function validateSettings(settings: Settings) {
   // defaultLocale cannot be a superset of any other locale
   if (
     settings.defaultLocale &&
-    settings.locales.some((locale) =>
-      isSupersetLocale(settings.defaultLocale, locale)
+    settings.locales.some(
+      (locale) =>
+        isSupersetLocale(settings.defaultLocale, locale) &&
+        !isSupersetLocale(locale, settings.defaultLocale)
     )
   ) {
     const locale = settings.locales.find((locale) =>


### PR DESCRIPTION
This PR fixes the error that occurs when defaultLocale is "en", and "en" is also included as a supported locale in the config.

Additionally, it makes file pattern matching more robust.