### PR TITLE
feat(cli): Log file paths in Dry Run

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gtx-cli",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "main": "dist/index.js",
   "bin": "dist/main.js",
   "scripts": {

--- a/packages/cli/src/formats/files/translate.ts
+++ b/packages/cli/src/formats/files/translate.ts
@@ -93,7 +93,10 @@ export async function translateFiles(
     return;
   }
   if (options.dryRun) {
-    logSuccess('Dry run: No files were sent to General Translation.');
+    const fileNames = allFiles.map((file) => `- ${file.fileName}`).join('\n');
+    logSuccess(
+      `Dry run: No files were sent to General Translation. Found files:\n${fileNames}`
+    );
     return;
   }
 


### PR DESCRIPTION
This PR adds logging for gtx-cli translate --dry-run, where all filepaths that are discovered are logged.

Without the --dry-run flag, the logged filespaths would be uploaded for translation.