### PR TITLE
E/add cli options

### DIFF
--- a/.changeset/empty-oranges-boil.md
+++ b/.changeset/empty-oranges-boil.md
@@ -1,0 +1,5 @@
+---
+'gtx-cli': patch
+---
+
+feat: add experimental options to translate

--- a/packages/cli/.gitignore
+++ b/packages/cli/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 package-lock.json
+**.tgz

--- a/packages/cli/src/cli/react.ts
+++ b/packages/cli/src/cli/react.ts
@@ -33,7 +33,8 @@ import updateConfig from '../fs/config/updateConfig.js';
 import { validateConfigExists } from '../config/validateSettings.js';
 import { validateProject } from '../translation/validate.js';
 import { intro } from '@clack/prompts';
-import localizeStaticUrls from '../translation/localizeStaticUrls.js';
+import localizeStaticUrls from '../utils/localizeStaticUrls.js';
+import flattenJsonFiles from '../utils/flattenJsonFiles.js';
 
 const DEFAULT_TIMEOUT = 600;
 const pkg = 'gt-react';
@@ -190,6 +191,11 @@ export class ReactCLI extends BaseCLI {
       .option(
         '--experimental-hide-default-locale',
         'When localizing static locales, hide the default locale from the path',
+        false
+      )
+      .option(
+        '--experimental-flatten-json-files',
+        'Triggering this will flatten the json files into a single file. This is useful for projects that have a lot of json files.',
         false
       )
       .action(async (options: Options) => {
@@ -511,7 +517,12 @@ export class ReactCLI extends BaseCLI {
 
     // Localize static urls (/docs -> /[locale]/docs)
     if (options.experimentalLocalizeStaticUrls) {
-      localizeStaticUrls(options);
+      await localizeStaticUrls(options);
+    }
+
+    // Flatten json files into a single file
+    if (options.experimentalFlattenJsonFiles) {
+      await flattenJsonFiles(options);
     }
   }
 

--- a/packages/cli/src/cli/react.ts
+++ b/packages/cli/src/cli/react.ts
@@ -33,6 +33,7 @@ import updateConfig from '../fs/config/updateConfig.js';
 import { validateConfigExists } from '../config/validateSettings.js';
 import { validateProject } from '../translation/validate.js';
 import { intro } from '@clack/prompts';
+import localizeStaticUrls from '../translation/localizeStaticUrls.js';
 
 const DEFAULT_TIMEOUT = 600;
 const pkg = 'gt-react';
@@ -181,6 +182,15 @@ export class ReactCLI extends BaseCLI {
         '--timeout <seconds>',
         'Timeout in seconds for waiting for updates to be deployed to the CDN',
         DEFAULT_TIMEOUT.toString()
+      )
+      .option(
+        '--experimental-localize-static-urls',
+        'Triggering this will run a script after the cli tool that localizes all urls in content files. Currently only supported for md and mdx files.'
+      )
+      .option(
+        '--experimental-hide-default-locale',
+        'When localizing static locales, hide the default locale from the path',
+        false
       )
       .action(async (options: Options) => {
         displayHeader('Translating project...');
@@ -480,7 +490,7 @@ export class ReactCLI extends BaseCLI {
     try {
       await super.handleGenericTranslate(options);
       // If the base class's handleTranslate completes successfully, continue with ReactCLI-specific code
-    } catch (error) {
+    } catch {
       // Continue with ReactCLI-specific code even if base handleTranslate failed
     }
 
@@ -497,6 +507,11 @@ export class ReactCLI extends BaseCLI {
         process.exit(1);
       }
       await translate(options, settings._versionId);
+    }
+
+    // Localize static urls (/docs -> /[locale]/docs)
+    if (options.experimentalLocalizeStaticUrls) {
+      localizeStaticUrls(options);
     }
   }
 

--- a/packages/cli/src/cli/react.ts
+++ b/packages/cli/src/cli/react.ts
@@ -186,7 +186,8 @@ export class ReactCLI extends BaseCLI {
       )
       .option(
         '--experimental-localize-static-urls',
-        'Triggering this will run a script after the cli tool that localizes all urls in content files. Currently only supported for md and mdx files.'
+        'Triggering this will run a script after the cli tool that localizes all urls in content files. Currently only supported for md and mdx files.',
+        false
       )
       .option(
         '--experimental-hide-default-locale',

--- a/packages/cli/src/formats/files/translate.ts
+++ b/packages/cli/src/formats/files/translate.ts
@@ -25,6 +25,7 @@ import { downloadFile } from '../../api/downloadFile.js';
 import { downloadFileBatch } from '../../api/downloadFileBatch.js';
 import { SUPPORTED_FILE_EXTENSIONS } from './supportedFiles.js';
 import { TranslateOptions } from '../../cli/base.js';
+import sanitizeFileContent from '../../utils/sanitizeFileContent.js';
 const SUPPORTED_DATA_FORMATS = ['JSX', 'ICU', 'I18NEXT'];
 
 /**
@@ -76,9 +77,10 @@ export async function translateFiles(
     if (filePaths[fileType]) {
       const files = filePaths[fileType].map((filePath) => {
         const content = readFile(filePath);
+        const sanitizedContent = sanitizeFileContent(content);
         const relativePath = getRelative(filePath);
         return {
-          content,
+          content: sanitizedContent,
           fileName: relativePath,
           fileFormat: fileType.toUpperCase() as FileFormats,
           dataFormat,

--- a/packages/cli/src/formats/files/translate.ts
+++ b/packages/cli/src/formats/files/translate.ts
@@ -163,7 +163,7 @@ export async function translateFiles(
 /**
  * Creates a mapping between source files and their translated counterparts for each locale
  */
-function createFileMapping(
+export function createFileMapping(
   filePaths: ResolvedFiles,
   placeholderPaths: ResolvedFiles,
   transformPaths: TransformFiles,

--- a/packages/cli/src/translation/localizeStaticUrls.ts
+++ b/packages/cli/src/translation/localizeStaticUrls.ts
@@ -1,0 +1,102 @@
+import * as fs from 'fs';
+import { Options, Settings } from '../types/index.js';
+import { createFileMapping } from '../formats/files/translate.js';
+
+/**
+ * Localizes static urls in content files.
+ * Currently only supported for md and mdx files. (/docs/ -> /[locale]/docs/)
+ * @param settings - The settings object containing the project configuration.
+ * @returns void
+ *
+ * @TODO This is an experimental feature, and only works in very specific cases. This needs to be improved before
+ * it can be enabled by default.
+ *
+ * Before this becomes a non-experimental feature, we need to:
+ * - Support more file types
+ * - Support more complex paths
+ */
+export default function localizeStaticUrls(settings: Settings & Options) {
+  if (
+    !settings.files ||
+    (Object.keys(settings.files.placeholderPaths).length === 1 &&
+      settings.files.placeholderPaths.gt)
+  ) {
+    return;
+  }
+  const { resolvedPaths: sourceFiles } = settings.files;
+
+  const fileMapping = createFileMapping(
+    sourceFiles,
+    settings.files.placeholderPaths,
+    settings.files.transformPaths,
+    settings.locales
+  );
+
+  // Process all file types at once with a single call
+  for (const [locale, filesMap] of Object.entries(fileMapping)) {
+    // Get all files that are md or mdx
+    const targetFiles = Object.values(filesMap);
+
+    // Replace the placeholder path with the target path
+    targetFiles.forEach((filePath) => {
+      // Get file content
+      const fileContent = fs.readFileSync(filePath, 'utf8');
+      // Localize the file
+      const localizedFile = localizeStaticUrlsForFile(
+        fileContent,
+        settings.defaultLocale,
+        locale,
+        true // Force to true for testing hideDefaultLocale - change back to settings.experimentalHideDefaultLocale || false when done
+      );
+      // Write the localized file to the target path
+      fs.writeFileSync(filePath, localizedFile);
+    });
+  }
+}
+
+// Assumption: we will be seeing localized paths in the source files: (docs/en/ -> docs/ja/)
+function localizeStaticUrlsForFile(
+  file: string,
+  defaultLocale: string,
+  targetLocale: string,
+  hideDefaultLocale: boolean
+): string {
+  // 1. Search for all instances of:
+  let regex;
+  if (hideDefaultLocale) {
+    // Match complete markdown links: `](/docs/...)` or `](/docs)`
+    regex = new RegExp(`\\]\\(/docs(?:/([^)]*))?\\)`, 'g');
+  } else {
+    // Match complete markdown links with default locale: `](/docs/${defaultLocale}/...)` or `](/docs/${defaultLocale})`
+    regex = new RegExp(`\\]\\(/docs/${defaultLocale}(?:/([^)]*))?\\)`, 'g');
+  }
+  const matches = file.match(regex);
+
+  if (!matches) {
+    return file;
+  }
+  // 2. Replace the default locale with the target locale in all matched instances
+  const localizedFile = file.replace(regex, (match, pathContent) => {
+    if (hideDefaultLocale) {
+      // For hideDefaultLocale, check if path already has target locale
+      if (pathContent) {
+        if (
+          pathContent.startsWith(`${targetLocale}/`) ||
+          pathContent === targetLocale
+        ) {
+          return match; // Already localized
+        }
+      }
+      // Add target locale to the path
+      if (!pathContent || pathContent === '') {
+        return `](/docs/${targetLocale})`;
+      }
+      return `](/docs/${targetLocale}/${pathContent})`;
+    } else {
+      // For non-hideDefaultLocale, replace defaultLocale with targetLocale
+      // pathContent contains everything after the default locale (no leading slash if present)
+      return `](/docs/${targetLocale}${pathContent ? '/' + pathContent : ''})`;
+    }
+  });
+  return localizedFile;
+}

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -32,6 +32,8 @@ export type Options = {
   dryRun: boolean;
   timeout: string;
   stageTranslations?: boolean;
+  experimentalLocalizeStaticUrls?: boolean;
+  experimentalHideDefaultLocale?: boolean;
 };
 
 export type WrapOptions = {

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -34,6 +34,7 @@ export type Options = {
   stageTranslations?: boolean;
   experimentalLocalizeStaticUrls?: boolean;
   experimentalHideDefaultLocale?: boolean;
+  experimentalFlattenJsonFiles?: boolean;
 };
 
 export type WrapOptions = {

--- a/packages/cli/src/utils/flattenJsonFiles.ts
+++ b/packages/cli/src/utils/flattenJsonFiles.ts
@@ -1,0 +1,61 @@
+import { createFileMapping } from '../formats/files/translate.js';
+import fs from 'node:fs';
+import { Settings, Options } from '../types/index.js';
+
+export default async function flattenJsonFiles(settings: Settings & Options) {
+  if (
+    !settings.files ||
+    (Object.keys(settings.files.placeholderPaths).length === 1 &&
+      settings.files.placeholderPaths.gt)
+  ) {
+    return;
+  }
+  const { resolvedPaths: sourceFiles } = settings.files;
+
+  const fileMapping = createFileMapping(
+    sourceFiles,
+    settings.files.placeholderPaths,
+    settings.files.transformPaths,
+    settings.locales
+  );
+
+  await Promise.all(
+    Object.values(fileMapping).map(async (filesMap) => {
+      const targetFiles = Object.values(filesMap).filter((path) =>
+        path.endsWith('.json')
+      );
+
+      await Promise.all(
+        targetFiles.map(async (file) => {
+          // Read each json file
+          const json = JSON.parse(fs.readFileSync(file, 'utf8'));
+          // Flatten the json
+          const flattenedJson = flattenJson(json);
+
+          // Write the flattened json to the target file
+          await fs.promises.writeFile(
+            file,
+            JSON.stringify(flattenedJson, null, 2)
+          );
+          return flattenedJson;
+        })
+      );
+    })
+  );
+}
+
+function flattenJson(json: unknown, prefix = ''): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(json as Record<string, unknown>)) {
+    const newKey = prefix ? `${prefix}.${key}` : key;
+
+    if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+      Object.assign(result, flattenJson(value, newKey));
+    } else {
+      result[newKey] = value;
+    }
+  }
+
+  return result;
+}

--- a/packages/cli/src/utils/localizeStaticUrls.ts
+++ b/packages/cli/src/utils/localizeStaticUrls.ts
@@ -50,7 +50,7 @@ export default async function localizeStaticUrls(settings: Settings & Options) {
             fileContent,
             settings.defaultLocale,
             locale,
-            true // Force to true for testing hideDefaultLocale - change back to settings.experimentalHideDefaultLocale || false when done
+            settings.experimentalHideDefaultLocale || false
           );
           // Write the localized file to the target path
           await fs.promises.writeFile(filePath, localizedFile);

--- a/packages/cli/src/utils/sanitizeFileContent.ts
+++ b/packages/cli/src/utils/sanitizeFileContent.ts
@@ -1,0 +1,42 @@
+/**
+ * Processes content to escape curl commands within tick marks and existing escape strings
+ * @param content - The content to process
+ * @returns the processed content with escaped curl commands
+ */
+export default function sanitizeFileContent(content: string): string {
+  const ESCAPE_STRING = '_GT_INTERNAL_ESCAPE';
+  const allTickMarkRegex = /`([^`]*)`/g;
+
+  let processedContent = content;
+
+  // First, escape any existing tick marks followed by _GT_INTERNAL_ESCAPE
+  // This protects pre-existing escapes
+  processedContent = processedContent.replace(
+    new RegExp('`' + ESCAPE_STRING, 'g'),
+    '`' + ESCAPE_STRING + ESCAPE_STRING
+  );
+
+  // Then find ALL tick mark pairs and process them individually
+  // This approach is more reliable than negative lookahead with modified content
+
+  processedContent = processedContent.replace(
+    allTickMarkRegex,
+    (match, innerContent) => {
+      // Skip if this already starts with our escape string (protected or already processed)
+      if (innerContent.startsWith(ESCAPE_STRING)) {
+        return match;
+      }
+
+      // Check if the content contains a curl command
+      if (/\bcurl\b/i.test(innerContent)) {
+        // Insert escape string after opening tick
+        return '`' + ESCAPE_STRING + innerContent + '`';
+      }
+
+      // Return original match if no curl command found
+      return match;
+    }
+  );
+
+  return processedContent;
+}

--- a/packages/core/.gitignore
+++ b/packages/core/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 package-lock.json
+**.tgz


### PR DESCRIPTION
add the following experimental options:

--experimental-localize-static-urls: Triggering this will run a script after the cli tool that localizes all urls in content files. Currently only supported for md and mdx files

--experimental-hide-default-locale: When localizing static locales, hide the default locale from the path
 
--experimental-flatten-json-files: Triggering this will flatten the json files into a single file. This is useful for projects that have a lot of json files