### PR TITLE
Add newline in Locadex CLI tool

### DIFF
--- a/packages/locadex/src/logging/console.ts
+++ b/packages/locadex/src/logging/console.ts
@@ -77,6 +77,7 @@ function displayInitializingText() {
   console.log(
     `\n${chalk.bold.blue('General Translation, Inc.')}
 ${chalk.dim('https://generaltranslation.com/docs')}
+
 Locadex is in research preview and may make mistakes. Please report any bugs or issues to https://github.com/generaltranslation/gt/issues.
 `
   );


### PR DESCRIPTION
Add a newline in the Locadex CLI display text to visually separate the docs URL from the research preview disclaimer.