### PR TITLE
fix: improve path localization customization

### DIFF
--- a/.changeset/dry-spoons-tease.md
+++ b/.changeset/dry-spoons-tease.md
@@ -1,0 +1,5 @@
+---
+'gtx-cli': patch
+---
+
+feat: add customizability for localize static url

--- a/packages/cli/src/config/generateSettings.ts
+++ b/packages/cli/src/config/generateSettings.ts
@@ -81,6 +81,15 @@ export async function generateSettings(
     );
   }
 
+  if (
+    options.options?.docsUrlPattern &&
+    !options.options?.docsUrlPattern.includes('[locale]')
+  ) {
+    logErrorAndExit(
+      'Failed to localize static urls: URL pattern must include "[locale]" to denote the location of the locale'
+    );
+  }
+
   // merge options
   const mergedOptions = { ...gtConfig, ...options };
 

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -138,7 +138,7 @@ export type AdditionalOptions = {
   jsonSchema?: {
     [fileGlob: string]: JsonSchema;
   };
-  urlPattern?: string; // eg /docs/[locale] or /[locale]
+  docsUrlPattern?: string; // eg /docs/[locale] or /[locale] for localizing static urls in markdown files
 };
 
 export type JsonSchema = {

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -138,6 +138,7 @@ export type AdditionalOptions = {
   jsonSchema?: {
     [fileGlob: string]: JsonSchema;
   };
+  urlPattern?: string; // eg /docs/[locale] or /[locale]
 };
 
 export type JsonSchema = {

--- a/packages/cli/src/utils/localizeStaticUrls.ts
+++ b/packages/cli/src/utils/localizeStaticUrls.ts
@@ -38,16 +38,6 @@ export default async function localizeStaticUrls(
     settings.locales
   );
 
-  if (
-    settings.options?.urlPattern &&
-    !settings.options?.urlPattern.includes('[locale]')
-  ) {
-    logError(
-      'Failed to localize static urls: URL pattern must include "[locale]" to denote the location of the locale'
-    );
-    return;
-  }
-
   // Process all file types at once with a single call
   await Promise.all(
     Object.entries(fileMapping).map(async ([locale, filesMap]) => {
@@ -67,7 +57,7 @@ export default async function localizeStaticUrls(
             settings.defaultLocale,
             locale,
             settings.experimentalHideDefaultLocale || false,
-            settings.options?.urlPattern
+            settings.options?.docsUrlPattern
           );
           // Write the localized file to the target path
           await fs.promises.writeFile(filePath, localizedFile);

--- a/packages/cli/src/utils/localizeStaticUrls.ts
+++ b/packages/cli/src/utils/localizeStaticUrls.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import { Options, Settings } from '../types/index.js';
 import { createFileMapping } from '../formats/files/translate.js';
+import { logError } from '../console/logging.js';
 
 /**
  * Localizes static urls in content files.
@@ -37,6 +38,16 @@ export default async function localizeStaticUrls(
     settings.locales
   );
 
+  if (
+    settings.options?.urlPattern &&
+    !settings.options?.urlPattern.includes('[locale]')
+  ) {
+    logError(
+      'Failed to localize static urls: URL pattern must include "[locale]" to denote the location of the locale'
+    );
+    return;
+  }
+
   // Process all file types at once with a single call
   await Promise.all(
     Object.entries(fileMapping).map(async ([locale, filesMap]) => {
@@ -66,13 +77,13 @@ export default async function localizeStaticUrls(
   );
 }
 
-// Assumption: we will be seeing localized paths in the source files: (docs/en/ -> docs/ja/)
+// Naive find and replace, in the future, construct an AST
 function localizeStaticUrlsForFile(
   file: string,
   defaultLocale: string,
   targetLocale: string,
   hideDefaultLocale: boolean,
-  pattern: string = '/docs/[locale]' // eg /docs/[locale] or /[locale]
+  pattern: string = '/[locale]' // eg /docs/[locale] or /[locale]
 ): string {
   if (!pattern.startsWith('/')) {
     pattern = '/' + pattern;


### PR DESCRIPTION
Allow user to specify a path for locale customization. This still only works for md and mdx files. In the future, would like to construct an AST instead of pattern matching to find the location of all of the urls.