### PR TITLE
(fix) make locale properties work for languages with scripts but no region

### DIFF
--- a/.changeset/brave-trees-take.md
+++ b/.changeset/brave-trees-take.md
@@ -1,0 +1,5 @@
+---
+'generaltranslation': patch
+---
+
+corrected nameWithRegionCode and nativeNameWithRegion code

--- a/packages/core/src/locales/getLocaleProperties.ts
+++ b/packages/core/src/locales/getLocaleProperties.ts
@@ -172,9 +172,7 @@ export default function _getLocaleProperties(
         : languageName; // German (AT)
     const nativeNameWithRegionCode =
       customLocaleProperties?.nativeNameWithRegionCode ||
-      (baseRegion
-        ? `${nativeLanguageName} (${baseRegion})`
-        : nativeName) ||
+      (baseRegion ? `${nativeLanguageName} (${baseRegion})` : nativeName) ||
       nameWithRegionCode; // "Deutsch (AT)"
 
     // Region names (default and native)
@@ -291,7 +289,9 @@ export default function _getLocaleProperties(
       (regionName ? `${name} (${regionName})` : name);
     const nativeNameWithRegionCode =
       customLocaleProperties?.nativeNameWithRegionCode ||
-      (nativeRegionName ? `${nativeLanguageName} (${nativeRegionName})` : nativeName);
+      (nativeRegionName
+        ? `${nativeLanguageName} (${nativeRegionName})`
+        : nativeName);
 
     const emoji = customLocaleProperties?.emoji || defaultEmoji;
 

--- a/packages/core/src/locales/getLocaleProperties.ts
+++ b/packages/core/src/locales/getLocaleProperties.ts
@@ -174,7 +174,7 @@ export default function _getLocaleProperties(
       customLocaleProperties?.nativeNameWithRegionCode ||
       (baseRegion
         ? `${nativeLanguageName} (${baseRegion})`
-        : nativeLanguageName) ||
+        : nativeName) ||
       nameWithRegionCode; // "Deutsch (AT)"
 
     // Region names (default and native)
@@ -291,7 +291,7 @@ export default function _getLocaleProperties(
       (regionName ? `${name} (${regionName})` : name);
     const nativeNameWithRegionCode =
       customLocaleProperties?.nativeNameWithRegionCode ||
-      (nativeRegionName ? `${nativeName} (${nativeRegionName})` : nativeName);
+      (nativeRegionName ? `${nativeLanguageName} (${nativeRegionName})` : nativeName);
 
     const emoji = customLocaleProperties?.emoji || defaultEmoji;
 

--- a/packages/core/src/locales/getLocaleProperties.ts
+++ b/packages/core/src/locales/getLocaleProperties.ts
@@ -169,7 +169,7 @@ export default function _getLocaleProperties(
     const nameWithRegionCode =
       customLocaleProperties?.nameWithRegionCode || baseRegion
         ? `${languageName} (${baseRegion})`
-        : languageName; // German (AT)
+        : name; // German (AT)
     const nativeNameWithRegionCode =
       customLocaleProperties?.nativeNameWithRegionCode ||
       (baseRegion ? `${nativeLanguageName} (${baseRegion})` : nativeName) ||

--- a/packages/core/src/locales/getLocaleProperties.ts
+++ b/packages/core/src/locales/getLocaleProperties.ts
@@ -286,7 +286,7 @@ export default function _getLocaleProperties(
 
     const nameWithRegionCode =
       customLocaleProperties?.nameWithRegionCode ||
-      (regionName ? `${name} (${regionName})` : name);
+      (regionName ? `${languageName} (${regionName})` : name);
     const nativeNameWithRegionCode =
       customLocaleProperties?.nativeNameWithRegionCode ||
       (nativeRegionName


### PR DESCRIPTION
### Fix `getLocaleProperties(locale: string)` for languages with scripts but no region

For example, with the following languages:

<img width="232" height="224" alt="Screenshot 2025-08-11 at 11 31 19" src="https://github.com/user-attachments/assets/73cdc908-2610-48d9-be44-916cec93ccdb" />

---

`<LocaleSelector/>`, which relies on `getLocaleProperties`, currently displays the same locale for both `zh-Hant` and `zh-Hans`:

<img width="153" height="128" alt="Screenshot 2025-08-11 at 11 31 04" src="https://github.com/user-attachments/assets/3abba3fb-edf4-4a13-88c0-bad3001bc7c5" />

---

This is not ideal. I've changed `getLocaleProperties` so that it now displays the correct native names of these language codes:

<img width="153" height="128" alt="Screenshot 2025-08-11 at 11 30 28" src="https://github.com/user-attachments/assets/ac497103-c8b5-4e92-8aae-3096a926e7a9" />
