### PR TITLE
fix: cli warning for composite jsons

### DIFF
--- a/.changeset/itchy-lines-open.md
+++ b/.changeset/itchy-lines-open.md
@@ -1,0 +1,5 @@
+---
+'gtx-cli': patch
+---
+
+fix: showing superfluous warning for composite json paths

--- a/packages/cli/src/config/__tests__/generateSettings.test.ts
+++ b/packages/cli/src/config/__tests__/generateSettings.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { generateSettings } from '../generateSettings';
+import { resolveFiles } from '../../fs/config/parseFilesConfig';
+
+// Mock resolveFiles
+vi.mock('../../fs/config/parseFilesConfig', () => ({
+  resolveFiles: vi.fn(),
+}));
+
+// Mock other dependencies
+vi.mock('../../console/logging.js', () => ({
+  logWarning: vi.fn(),
+  logInfo: vi.fn(),
+  logError: vi.fn(),
+  logErrorAndExit: vi.fn(),
+  displayProjectId: vi.fn(),
+  displayCreatedConfigFile: vi.fn(),
+  warnApiKeyInConfig: vi.fn(),
+}));
+
+vi.mock('../../fs/config/findGTConfig.js', () => ({
+  findGTConfig: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock('../../fs/config/parseGTConfig.js', () => ({
+  parseGTConfig: vi.fn().mockResolvedValue({
+    defaultLocale: 'en',
+    locales: ['fr', 'es'],
+  }),
+}));
+
+vi.mock('../../fs/config/setupConfig.js', () => ({
+  createOrUpdateConfig: vi.fn(),
+}));
+
+vi.mock('../validateSettings.js', () => ({
+  validateSettings: vi.fn(),
+}));
+
+vi.mock('../resolveConfig.js', () => ({
+  resolveConfig: vi.fn().mockReturnValue({
+    config: {
+      defaultLocale: 'en',
+      locales: ['fr', 'es'],
+    },
+    path: '/test/gt.config.json',
+  }),
+}));
+
+vi.mock('../../fs/utils.js', () => ({
+  resolveProjectId: vi.fn().mockReturnValue('test-project-id'),
+}));
+
+vi.mock('../../utils/gt.js', () => ({
+  gt: {
+    setConfig: vi.fn(),
+  },
+}));
+
+vi.mock('../optionPresets.js', () => ({
+  generatePreset: vi.fn(),
+}));
+
+vi.mock('node:fs', () => ({
+  default: {
+    existsSync: vi.fn().mockReturnValue(false),
+  },
+}));
+
+describe('generateSettings - composite patterns', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(resolveFiles).mockReturnValue({
+      resolvedPaths: {},
+      placeholderPaths: {},
+      transformPaths: {},
+    });
+  });
+
+  it('should extract composite patterns from jsonSchema options and pass to resolveFiles', async () => {
+    const options = {
+      files: {
+        json: { include: ['src/*.json'] },
+      },
+      options: {
+        jsonSchema: {
+          'composite-pattern-1': { composite: true },
+          'composite-pattern-2': { composite: true },
+          'regular-pattern': { composite: false },
+          'another-pattern': {},
+        },
+      },
+    };
+
+    await generateSettings(options, '/test/cwd');
+
+    expect(resolveFiles).toHaveBeenCalledWith(
+      { json: { include: ['src/*.json'] } },
+      'en',
+      ['fr', 'es'],
+      '/test/cwd',
+      ['composite-pattern-1', 'composite-pattern-2']
+    );
+  });
+
+  it('should pass empty array when no composite patterns exist', async () => {
+    const options = {
+      files: {
+        json: { include: ['src/*.json'] },
+      },
+      options: {
+        jsonSchema: {
+          'regular-pattern-1': { composite: false },
+          'regular-pattern-2': {},
+        },
+      },
+    };
+
+    await generateSettings(options, '/test/cwd');
+
+    expect(resolveFiles).toHaveBeenCalledWith(
+      { json: { include: ['src/*.json'] } },
+      'en',
+      ['fr', 'es'],
+      '/test/cwd',
+      []
+    );
+  });
+
+  it('should pass empty array when jsonSchema options are not provided', async () => {
+    const options = {
+      files: {
+        json: { include: ['src/*.json'] },
+      },
+    };
+
+    await generateSettings(options, '/test/cwd');
+
+    expect(resolveFiles).toHaveBeenCalledWith(
+      { json: { include: ['src/*.json'] } },
+      'en',
+      ['fr', 'es'],
+      '/test/cwd',
+      []
+    );
+  });
+
+  it('should pass empty array when options are not provided', async () => {
+    const options = {
+      files: {
+        json: { include: ['src/*.json'] },
+      },
+      options: undefined,
+    };
+
+    await generateSettings(options, '/test/cwd');
+
+    expect(resolveFiles).toHaveBeenCalledWith(
+      { json: { include: ['src/*.json'] } },
+      'en',
+      ['fr', 'es'],
+      '/test/cwd',
+      []
+    );
+  });
+
+  it('should handle mixed composite and non-composite patterns', async () => {
+    const options = {
+      files: {
+        yaml: { include: ['data/*.yaml'] },
+      },
+      options: {
+        jsonSchema: {
+          'pattern-1': { composite: true },
+          'pattern-2': { composite: false },
+          'pattern-3': { composite: true },
+          'pattern-4': { someOtherProperty: true },
+        },
+      },
+    };
+
+    await generateSettings(options, '/project/root');
+
+    expect(resolveFiles).toHaveBeenCalledWith(
+      { yaml: { include: ['data/*.yaml'] } },
+      'en',
+      ['fr', 'es'],
+      '/project/root',
+      ['pattern-1', 'pattern-3']
+    );
+  });
+
+  it('should extract composite patterns only from jsonSchema', async () => {
+    const options = {
+      files: {
+        json: { include: ['src/*.json'] },
+        yaml: { include: ['data/*.yaml'] },
+      },
+      options: {
+        jsonSchema: {
+          'json-composite-1': { composite: true },
+          'json-regular': { composite: false },
+        },
+        yamlSchema: {
+          'yaml-composite-1': { composite: true },
+          'yaml-composite-2': { composite: true },
+          'yaml-regular': {},
+        },
+      },
+    };
+
+    await generateSettings(options, '/test/cwd');
+
+    expect(resolveFiles).toHaveBeenCalledWith(
+      {
+        json: { include: ['src/*.json'] },
+        yaml: { include: ['data/*.yaml'] },
+      },
+      'en',
+      ['fr', 'es'],
+      '/test/cwd',
+      ['json-composite-1']
+    );
+  });
+
+  it('should not call resolveFiles when files are not provided', async () => {
+    const options = {
+      options: {
+        jsonSchema: {
+          'composite-pattern': { composite: true },
+        },
+      },
+    };
+
+    await generateSettings(options, '/test/cwd');
+
+    expect(resolveFiles).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/config/generateSettings.ts
+++ b/packages/cli/src/config/generateSettings.ts
@@ -158,12 +158,18 @@ export async function generateSettings(
   mergedOptions.src = mergedOptions.src || DEFAULT_SRC_PATTERNS;
 
   // Resolve all glob patterns in the files object
+  const compositePatterns = [
+    ...Object.entries(mergedOptions.options?.jsonSchema || {}),
+  ]
+    .filter(([, schema]) => schema.composite)
+    .map(([key]) => key);
   mergedOptions.files = mergedOptions.files
     ? resolveFiles(
         mergedOptions.files as FilesOptions,
         mergedOptions.defaultLocale,
         mergedOptions.locales,
-        cwd
+        cwd,
+        compositePatterns
       )
     : undefined;
 

--- a/packages/cli/src/fs/config/parseFilesConfig.ts
+++ b/packages/cli/src/fs/config/parseFilesConfig.ts
@@ -47,7 +47,8 @@ export function resolveFiles(
   files: FilesOptions,
   locale: string,
   locales: string[],
-  cwd: string
+  cwd: string,
+  compositePatterns?: string[]
 ): {
   resolvedPaths: ResolvedFiles;
   placeholderPaths: ResolvedFiles;
@@ -81,7 +82,8 @@ export function resolveFiles(
         files[fileType]?.exclude || [],
         locale,
         locales,
-        transformPaths[fileType] || undefined
+        transformPaths[fileType] || undefined,
+        compositePatterns
       );
       result[fileType] = filePaths.resolvedPaths;
       placeholderResult[fileType] = filePaths.placeholderPaths;
@@ -102,7 +104,8 @@ export function expandGlobPatterns(
   excludePatterns: string[],
   locale: string,
   locales: string[],
-  transformPatterns?: TransformOption | string
+  transformPatterns?: TransformOption | string,
+  compositePatterns?: string[]
 ): {
   resolvedPaths: string[];
   placeholderPaths: string[];
@@ -116,7 +119,12 @@ export function expandGlobPatterns(
     // Track positions where [locale] appears in the original pattern
     // It must be included in the pattern, otherwise the CLI tool will not be able to find the correct output path
     // Warn if it's not included
-    if (!pattern.includes('[locale]') && !transformPatterns) {
+    // Ignore if is composite pattern
+    if (
+      !pattern.includes('[locale]') &&
+      !transformPatterns &&
+      !compositePatterns?.includes(pattern)
+    ) {
       logWarning(
         chalk.yellow(
           `Pattern "${pattern}" does not include [locale], so the CLI tool may incorrectly save translated files.`


### PR DESCRIPTION
fix: cli warning for json paths without "[locale]" but are actually composit