### PR TITLE
feat: add inject gt compiler plugin

### DIFF
--- a/.changeset/fresh-brooms-fry.md
+++ b/.changeset/fresh-brooms-fry.md
@@ -1,0 +1,5 @@
+---
+'gtx-cli': patch
+---
+
+fix: auto enable gt compiler in default config

--- a/packages/cli/src/react/parse/addVitePlugin/__tests__/updateViteConfig.test.ts
+++ b/packages/cli/src/react/parse/addVitePlugin/__tests__/updateViteConfig.test.ts
@@ -1,0 +1,832 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { parse } from '@babel/parser';
+import fs from 'node:fs';
+import { updateViteConfig } from '../updateViteConfig';
+
+// Mock fs.promises.readFile and writeFile
+vi.mock('node:fs', () => ({
+  default: {
+    promises: {
+      readFile: vi.fn(),
+      writeFile: vi.fn(),
+    },
+  },
+}));
+
+// Mock needsCJS - we can mock this one as requested
+vi.mock('../../../utils/parse/needsCJS.js', () => ({
+  needsCJS: vi.fn(),
+}));
+
+// Mock spinner and logging
+vi.mock('../../../console/logging.js', () => ({
+  createSpinner: vi.fn(() => ({
+    start: vi.fn(),
+    stop: vi.fn(),
+  })),
+  logError: vi.fn(),
+}));
+
+// Mock chalk to prevent any styling output
+vi.mock('chalk', () => ({
+  default: {
+    green: vi.fn((text) => text),
+    red: vi.fn((text) => text),
+    yellow: vi.fn((text) => text),
+    blue: vi.fn((text) => text),
+    cyan: vi.fn((text) => text),
+    magenta: vi.fn((text) => text),
+    white: vi.fn((text) => text),
+    gray: vi.fn((text) => text),
+    bold: vi.fn((text) => text),
+  },
+}));
+
+// Mock @clack/prompts to prevent console output from spinners
+vi.mock('@clack/prompts', () => ({
+  spinner: vi.fn(() => ({
+    start: vi.fn(),
+    stop: vi.fn(),
+    message: vi.fn(),
+  })),
+  log: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    success: vi.fn(),
+    step: vi.fn(),
+    message: vi.fn(),
+  },
+}));
+
+// Import mocked functions
+// @ts-expect-error - we want to mock this function
+import { needsCJS } from '../../../utils/parse/needsCJS.js';
+
+describe('updateViteConfig', () => {
+  const mockReadFile = vi.mocked(fs.promises.readFile);
+  const mockWriteFile = vi.mocked(fs.promises.writeFile);
+  const mockNeedsCJS = vi.mocked(needsCJS);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockNeedsCJS.mockReturnValue(false); // Default to ESM
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // Helper function to parse generated code and check for specific patterns
+  function parseAndCheck(
+    code: string,
+    checks: {
+      hasCompilerImport?: boolean;
+      hasPluginInvocation?: boolean;
+      alias?: string;
+      namespace?: string;
+    }
+  ) {
+    const ast = parse(code, {
+      sourceType: 'module',
+      plugins: ['typescript', 'jsx'],
+    });
+
+    const results = {
+      hasCompilerImport: false,
+      hasPluginInvocation: false,
+      alias: null as string | null,
+      namespace: null as string | null,
+    };
+
+    // Check for compiler import
+    for (const node of ast.program.body) {
+      if (
+        node.type === 'ImportDeclaration' &&
+        node.source.value === '@generaltranslation/compiler'
+      ) {
+        results.hasCompilerImport = true;
+        for (const spec of node.specifiers) {
+          if (
+            spec.type === 'ImportSpecifier' &&
+            spec.imported.type === 'Identifier' &&
+            spec.imported.name === 'vite'
+          ) {
+            results.alias = spec.local.name;
+          }
+        }
+      } else if (node.type === 'VariableDeclaration') {
+        const decl = node.declarations[0];
+        if (
+          decl &&
+          decl.init?.type === 'MemberExpression' &&
+          decl.init.object?.type === 'CallExpression' &&
+          decl.init.object.callee?.type === 'Identifier' &&
+          decl.init.object.callee.name === 'require' &&
+          decl.init.object.arguments?.[0]?.type === 'StringLiteral' &&
+          decl.init.object.arguments[0].value ===
+            '@generaltranslation/compiler' &&
+          decl.init.property?.type === 'Identifier' &&
+          decl.init.property.name === 'vite' &&
+          decl.id?.type === 'Identifier'
+        ) {
+          results.hasCompilerImport = true;
+          results.alias = decl.id.name;
+        }
+      }
+    }
+
+    // Check for plugin invocation (simplified)
+    const codeString = code;
+    if (
+      checks.alias &&
+      new RegExp(`${checks.alias}\\s*\\(\\s*\\)`).test(codeString)
+    ) {
+      results.hasPluginInvocation = true;
+    }
+    if (
+      checks.namespace &&
+      new RegExp(`${checks.namespace}\\.vite\\s*\\(\\s*\\)`).test(codeString)
+    ) {
+      results.hasPluginInvocation = true;
+    }
+
+    return results;
+  }
+
+  describe('ESM scenarios', () => {
+    beforeEach(() => {
+      mockNeedsCJS.mockReturnValue(false);
+    });
+
+    it('should add import and plugin to clean Vite config', async () => {
+      const inputCode = `
+        import { defineConfig } from 'vite';
+        import react from '@vitejs/plugin-react';
+        
+        export default defineConfig({
+          plugins: [react()]
+        });
+      `;
+
+      mockReadFile.mockResolvedValue(inputCode);
+      mockWriteFile.mockResolvedValue(undefined);
+
+      const errors: string[] = [];
+      const warnings: string[] = [];
+      const filesUpdated: string[] = [];
+
+      await updateViteConfig({
+        errors,
+        warnings,
+        filesUpdated,
+        viteConfigPath: '/path/to/vite.config.ts',
+        packageJson: { type: 'module' },
+      });
+
+      expect(mockWriteFile).toHaveBeenCalledOnce();
+      const [, updatedCode] = mockWriteFile.mock.calls[0];
+
+      const results = parseAndCheck(updatedCode as string, {
+        alias: 'gtCompiler',
+      });
+      expect(results.hasCompilerImport).toBe(true);
+      expect(results.hasPluginInvocation).toBe(true);
+      expect(results.alias).toBe('gtCompiler');
+
+      expect(filesUpdated).toContain('/path/to/vite.config.ts');
+      expect(errors).toHaveLength(0);
+      expect(warnings).toHaveLength(0);
+    });
+
+    it('should not add import if already present with alias', async () => {
+      const inputCode = `
+        import { defineConfig } from 'vite';
+        import { vite as myCompiler } from '@generaltranslation/compiler';
+        
+        export default defineConfig({
+          plugins: [myCompiler()]
+        });
+      `;
+
+      mockReadFile.mockResolvedValue(inputCode);
+      mockWriteFile.mockResolvedValue(undefined);
+
+      const errors: string[] = [];
+      const warnings: string[] = [];
+      const filesUpdated: string[] = [];
+
+      await updateViteConfig({
+        errors,
+        warnings,
+        filesUpdated,
+        viteConfigPath: '/path/to/vite.config.ts',
+      });
+
+      expect(mockWriteFile).toHaveBeenCalledOnce();
+      const [, updatedCode] = mockWriteFile.mock.calls[0];
+
+      // Should preserve existing import and not add plugin (already present)
+      expect(updatedCode).toContain('vite as myCompiler');
+      expect(updatedCode).toContain('myCompiler()');
+      expect(filesUpdated).toContain('/path/to/vite.config.ts');
+    });
+
+    it('should add plugin invocation when import exists but plugin missing', async () => {
+      const inputCode = `
+        import { defineConfig } from 'vite';
+        import { vite as myCompiler } from '@generaltranslation/compiler';
+        
+        export default defineConfig({
+          plugins: [react()]
+        });
+      `;
+
+      mockReadFile.mockResolvedValue(inputCode);
+      mockWriteFile.mockResolvedValue(undefined);
+
+      const errors: string[] = [];
+      const warnings: string[] = [];
+      const filesUpdated: string[] = [];
+
+      await updateViteConfig({
+        errors,
+        warnings,
+        filesUpdated,
+        viteConfigPath: '/path/to/vite.config.ts',
+      });
+
+      expect(mockWriteFile).toHaveBeenCalledOnce();
+      const [, updatedCode] = mockWriteFile.mock.calls[0];
+
+      // Should preserve existing import and add plugin
+      expect(updatedCode).toContain('vite as myCompiler');
+      expect(updatedCode).toContain('react()');
+      expect(updatedCode).toContain('myCompiler()');
+    });
+
+    it('should handle namespace imports', async () => {
+      const inputCode = `
+        import { defineConfig } from 'vite';
+        import * as gt from '@generaltranslation/compiler';
+        
+        export default defineConfig({
+          plugins: [react()]
+        });
+      `;
+
+      mockReadFile.mockResolvedValue(inputCode);
+      mockWriteFile.mockResolvedValue(undefined);
+
+      const errors: string[] = [];
+      const warnings: string[] = [];
+      const filesUpdated: string[] = [];
+
+      await updateViteConfig({
+        errors,
+        warnings,
+        filesUpdated,
+        viteConfigPath: '/path/to/vite.config.ts',
+      });
+
+      expect(mockWriteFile).toHaveBeenCalledOnce();
+      const [, updatedCode] = mockWriteFile.mock.calls[0];
+
+      expect(updatedCode).toContain('* as gt');
+      expect(updatedCode).toContain('gt.vite()');
+    });
+
+    it('should handle default imports', async () => {
+      const inputCode = `
+        import { defineConfig } from 'vite';
+        import gtDefault from '@generaltranslation/compiler';
+        
+        export default defineConfig({
+          plugins: [react()]
+        });
+      `;
+
+      mockReadFile.mockResolvedValue(inputCode);
+      mockWriteFile.mockResolvedValue(undefined);
+
+      const errors: string[] = [];
+      const warnings: string[] = [];
+      const filesUpdated: string[] = [];
+
+      await updateViteConfig({
+        errors,
+        warnings,
+        filesUpdated,
+        viteConfigPath: '/path/to/vite.config.ts',
+      });
+
+      expect(mockWriteFile).toHaveBeenCalledOnce();
+      const [, updatedCode] = mockWriteFile.mock.calls[0];
+
+      expect(updatedCode).toContain('import gtDefault');
+      expect(updatedCode).toContain('gtDefault.vite()');
+    });
+  });
+
+  describe('CJS scenarios', () => {
+    beforeEach(() => {
+      mockNeedsCJS.mockReturnValue(true);
+    });
+
+    it('should add require and plugin to CJS config', async () => {
+      const inputCode = `
+        const { defineConfig } = require('vite');
+        const react = require('@vitejs/plugin-react');
+        
+        module.exports = defineConfig({
+          plugins: [react()]
+        });
+      `;
+
+      mockReadFile.mockResolvedValue(inputCode);
+      mockWriteFile.mockResolvedValue(undefined);
+
+      const errors: string[] = [];
+      const warnings: string[] = [];
+      const filesUpdated: string[] = [];
+
+      await updateViteConfig({
+        errors,
+        warnings,
+        filesUpdated,
+        viteConfigPath: '/path/to/vite.config.js',
+      });
+
+      expect(mockWriteFile).toHaveBeenCalledOnce();
+      const [, updatedCode] = mockWriteFile.mock.calls[0];
+
+      expect(updatedCode).toContain(
+        'require("@generaltranslation/compiler").vite'
+      );
+      expect(updatedCode).toContain('gtCompiler()');
+      expect(filesUpdated).toContain('/path/to/vite.config.js');
+    });
+
+    it('should handle existing CJS require with destructuring', async () => {
+      const inputCode = `
+        const { defineConfig } = require('vite');
+        const { vite: myCompiler } = require('@generaltranslation/compiler');
+        
+        module.exports = defineConfig({
+          plugins: [react()]
+        });
+      `;
+
+      mockReadFile.mockResolvedValue(inputCode);
+      mockWriteFile.mockResolvedValue(undefined);
+
+      const errors: string[] = [];
+      const warnings: string[] = [];
+      const filesUpdated: string[] = [];
+
+      await updateViteConfig({
+        errors,
+        warnings,
+        filesUpdated,
+        viteConfigPath: '/path/to/vite.config.js',
+      });
+
+      expect(mockWriteFile).toHaveBeenCalledOnce();
+      const [, updatedCode] = mockWriteFile.mock.calls[0];
+
+      expect(updatedCode).toContain('vite: myCompiler');
+      expect(updatedCode).toContain('myCompiler()');
+    });
+
+    it('should handle namespace require', async () => {
+      const inputCode = `
+        const { defineConfig } = require('vite');
+        const gt = require('@generaltranslation/compiler');
+        
+        module.exports = defineConfig({
+          plugins: [react()]
+        });
+      `;
+
+      mockReadFile.mockResolvedValue(inputCode);
+      mockWriteFile.mockResolvedValue(undefined);
+
+      const errors: string[] = [];
+      const warnings: string[] = [];
+      const filesUpdated: string[] = [];
+
+      await updateViteConfig({
+        errors,
+        warnings,
+        filesUpdated,
+        viteConfigPath: '/path/to/vite.config.js',
+      });
+
+      expect(mockWriteFile).toHaveBeenCalledOnce();
+      const [, updatedCode] = mockWriteFile.mock.calls[0];
+
+      expect(updatedCode).toContain('const gt = require');
+      expect(updatedCode).toContain('gt.vite()');
+    });
+  });
+
+  describe('Warning scenarios', () => {
+    it('should add warning when plugin invocation fails', async () => {
+      const inputCode = `
+        import { defineConfig } from 'vite';
+        
+        // No plugins property - addPluginInvocation will fail
+        export default defineConfig({
+          server: { port: 3000 }
+        });
+      `;
+
+      mockReadFile.mockResolvedValue(inputCode);
+      mockWriteFile.mockResolvedValue(undefined);
+
+      const errors: string[] = [];
+      const warnings: string[] = [];
+      const filesUpdated: string[] = [];
+
+      await updateViteConfig({
+        errors,
+        warnings,
+        filesUpdated,
+        viteConfigPath: '/path/to/vite.config.ts',
+      });
+
+      expect(mockWriteFile).toHaveBeenCalledOnce();
+      const [, updatedCode] = mockWriteFile.mock.calls[0];
+
+      // Should have added import but failed to add plugin
+      const results = parseAndCheck(updatedCode as string, {
+        alias: 'gtCompiler',
+      });
+      expect(results.hasCompilerImport).toBe(true);
+
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain('Failed to add gt compiler plugin');
+      expect(warnings[0]).toContain('Please add the plugin manually');
+      expect(filesUpdated).toContain('/path/to/vite.config.ts');
+    });
+
+    it('should handle complex config with no plugins property', async () => {
+      const inputCode = `
+        import { defineConfig } from 'vite';
+        
+        export default defineConfig({
+          resolve: {
+            alias: {
+              '@': path.resolve(__dirname, 'src')
+            }
+          },
+          build: {
+            outDir: 'dist'
+          }
+        });
+      `;
+
+      mockReadFile.mockResolvedValue(inputCode);
+      mockWriteFile.mockResolvedValue(undefined);
+
+      const errors: string[] = [];
+      const warnings: string[] = [];
+      const filesUpdated: string[] = [];
+
+      await updateViteConfig({
+        errors,
+        warnings,
+        filesUpdated,
+        viteConfigPath: '/path/to/vite.config.ts',
+      });
+
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain('Failed to add gt compiler plugin');
+    });
+  });
+
+  describe('Complex real-world scenarios', () => {
+    it('should handle conditional Vite config', async () => {
+      const inputCode = `
+        import { defineConfig } from 'vite';
+        import react from '@vitejs/plugin-react';
+        
+        export default defineConfig(({ command, mode }) => ({
+          plugins: [
+            react(),
+            ...(mode === 'development' ? [devtools()] : [])
+          ],
+          build: {
+            minify: command === 'build'
+          }
+        }));
+      `;
+
+      mockReadFile.mockResolvedValue(inputCode);
+      mockWriteFile.mockResolvedValue(undefined);
+
+      const errors: string[] = [];
+      const warnings: string[] = [];
+      const filesUpdated: string[] = [];
+
+      await updateViteConfig({
+        errors,
+        warnings,
+        filesUpdated,
+        viteConfigPath: '/path/to/vite.config.ts',
+      });
+
+      expect(mockWriteFile).toHaveBeenCalledOnce();
+      const [, updatedCode] = mockWriteFile.mock.calls[0];
+
+      const results = parseAndCheck(updatedCode as string, {
+        alias: 'gtCompiler',
+      });
+      expect(results.hasCompilerImport).toBe(true);
+      expect(results.hasPluginInvocation).toBe(false);
+
+      expect(updatedCode).toContain('react()');
+      expect(updatedCode).not.toContain('gtCompiler()');
+      expect(filesUpdated).toContain('/path/to/vite.config.ts');
+    });
+
+    it('should handle TypeScript Vite config with type imports', async () => {
+      const inputCode = `
+        import { defineConfig } from 'vite';
+        import react from '@vitejs/plugin-react';
+        import type { UserConfig } from 'vite';
+        
+        const config: UserConfig = {
+          plugins: [react()],
+          server: { port: 3000 }
+        };
+        
+        export default defineConfig(config);
+      `;
+
+      mockReadFile.mockResolvedValue(inputCode);
+      mockWriteFile.mockResolvedValue(undefined);
+
+      const errors: string[] = [];
+      const warnings: string[] = [];
+      const filesUpdated: string[] = [];
+
+      await updateViteConfig({
+        errors,
+        warnings,
+        filesUpdated,
+        viteConfigPath: '/path/to/vite.config.ts',
+        packageJson: { type: 'module' },
+        tsconfigJson: { compilerOptions: { module: 'ESNext' } },
+      });
+
+      expect(mockWriteFile).toHaveBeenCalledOnce();
+      const [, updatedCode] = mockWriteFile.mock.calls[0];
+
+      const results = parseAndCheck(updatedCode as string, {
+        alias: 'gtCompiler',
+      });
+      expect(results.hasCompilerImport).toBe(true);
+      expect(results.hasPluginInvocation).toBe(false);
+      expect(filesUpdated).toContain('/path/to/vite.config.ts');
+    });
+
+    it('should preserve existing plugin configuration', async () => {
+      const inputCode = `
+        import { defineConfig } from 'vite';
+        import react from '@vitejs/plugin-react';
+        
+        export default defineConfig({
+          plugins: [
+            react({
+              babel: {
+                plugins: ['@babel/plugin-syntax-jsx']
+              }
+            })
+          ],
+          esbuild: {
+            jsxFactory: 'React.createElement'
+          }
+        });
+      `;
+
+      mockReadFile.mockResolvedValue(inputCode);
+      mockWriteFile.mockResolvedValue(undefined);
+
+      const errors: string[] = [];
+      const warnings: string[] = [];
+      const filesUpdated: string[] = [];
+
+      await updateViteConfig({
+        errors,
+        warnings,
+        filesUpdated,
+        viteConfigPath: '/path/to/vite.config.ts',
+      });
+
+      expect(mockWriteFile).toHaveBeenCalledOnce();
+      const [, updatedCode] = mockWriteFile.mock.calls[0];
+
+      // Should preserve existing configuration
+      expect(updatedCode).toContain('@babel/plugin-syntax-jsx');
+      expect(updatedCode).toContain('React.createElement');
+      expect(updatedCode).toContain('gtCompiler()');
+
+      const results = parseAndCheck(updatedCode as string, {
+        alias: 'gtCompiler',
+      });
+      expect(results.hasCompilerImport).toBe(true);
+      expect(results.hasPluginInvocation).toBe(true);
+    });
+  });
+
+  describe('Error handling', () => {
+    it('should handle file read errors gracefully', async () => {
+      mockReadFile.mockRejectedValue(new Error('File not found'));
+
+      const errors: string[] = [];
+      const warnings: string[] = [];
+      const filesUpdated: string[] = [];
+
+      // Should exit process on file read error
+      const exitSpy = vi
+        .spyOn(process, 'exit')
+        .mockImplementation((() => {}) as any);
+
+      await updateViteConfig({
+        errors,
+        warnings,
+        filesUpdated,
+        viteConfigPath: '/path/to/nonexistent.ts',
+      });
+
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(mockWriteFile).not.toHaveBeenCalled();
+
+      exitSpy.mockRestore();
+    });
+
+    it('should handle file write errors gracefully', async () => {
+      const inputCode = `
+        import { defineConfig } from 'vite';
+        export default defineConfig({ plugins: [] });
+      `;
+
+      mockReadFile.mockResolvedValue(inputCode);
+      mockWriteFile.mockRejectedValue(new Error('Permission denied'));
+
+      const errors: string[] = [];
+      const warnings: string[] = [];
+      const filesUpdated: string[] = [];
+
+      const exitSpy = vi
+        .spyOn(process, 'exit')
+        .mockImplementation((() => {}) as any);
+
+      await updateViteConfig({
+        errors,
+        warnings,
+        filesUpdated,
+        viteConfigPath: '/path/to/vite.config.ts',
+      });
+
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(filesUpdated).toHaveLength(0);
+
+      exitSpy.mockRestore();
+    });
+
+    it('should handle AST parsing errors gracefully', async () => {
+      const invalidCode = `
+        import { defineConfig } from 'vite';
+        export default defineConfig({ 
+          plugins: [
+            // Invalid syntax
+            }]
+        });
+      `;
+
+      mockReadFile.mockResolvedValue(invalidCode);
+
+      const errors: string[] = [];
+      const warnings: string[] = [];
+      const filesUpdated: string[] = [];
+
+      const exitSpy = vi
+        .spyOn(process, 'exit')
+        .mockImplementation((() => {}) as any);
+
+      await updateViteConfig({
+        errors,
+        warnings,
+        filesUpdated,
+        viteConfigPath: '/path/to/vite.config.ts',
+      });
+
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(mockWriteFile).not.toHaveBeenCalled();
+
+      exitSpy.mockRestore();
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('should handle empty file', async () => {
+      const inputCode = '';
+
+      mockReadFile.mockResolvedValue(inputCode);
+      mockWriteFile.mockResolvedValue(undefined);
+
+      const errors: string[] = [];
+      const warnings: string[] = [];
+      const filesUpdated: string[] = [];
+
+      await updateViteConfig({
+        errors,
+        warnings,
+        filesUpdated,
+        viteConfigPath: '/path/to/vite.config.ts',
+      });
+
+      expect(mockWriteFile).toHaveBeenCalledOnce();
+      const [, updatedCode] = mockWriteFile.mock.calls[0];
+
+      // Should add import but likely fail to add plugin (no plugins array)
+      const results = parseAndCheck(updatedCode as string, {
+        alias: 'gtCompiler',
+      });
+      expect(results.hasCompilerImport).toBe(true);
+      expect(warnings).toHaveLength(1);
+    });
+
+    it('should handle file with only comments', async () => {
+      const inputCode = `
+        // This is a Vite configuration file
+        /* 
+         * TODO: Add plugins
+         */
+      `;
+
+      mockReadFile.mockResolvedValue(inputCode);
+      mockWriteFile.mockResolvedValue(undefined);
+
+      const errors: string[] = [];
+      const warnings: string[] = [];
+      const filesUpdated: string[] = [];
+
+      await updateViteConfig({
+        errors,
+        warnings,
+        filesUpdated,
+        viteConfigPath: '/path/to/vite.config.ts',
+      });
+
+      expect(mockWriteFile).toHaveBeenCalledOnce();
+      const [, updatedCode] = mockWriteFile.mock.calls[0];
+
+      const results = parseAndCheck(updatedCode as string, {
+        alias: 'gtCompiler',
+      });
+      expect(results.hasCompilerImport).toBe(true);
+      expect(warnings).toHaveLength(1); // Should warn about failed plugin addition
+    });
+
+    it('should handle mixed ESM/CJS patterns', async () => {
+      const inputCode = `
+        import { defineConfig } from 'vite';
+        const react = require('@vitejs/plugin-react');
+        
+        export default defineConfig({
+          plugins: [react()]
+        });
+      `;
+
+      mockReadFile.mockResolvedValue(inputCode);
+      mockWriteFile.mockResolvedValue(undefined);
+
+      const errors: string[] = [];
+      const warnings: string[] = [];
+      const filesUpdated: string[] = [];
+
+      await updateViteConfig({
+        errors,
+        warnings,
+        filesUpdated,
+        viteConfigPath: '/path/to/vite.config.ts',
+      });
+
+      expect(mockWriteFile).toHaveBeenCalledOnce();
+      const [, updatedCode] = mockWriteFile.mock.calls[0];
+
+      // Should add ESM import (default behavior)
+      const results = parseAndCheck(updatedCode as string, {
+        alias: 'gtCompiler',
+      });
+      expect(results.hasCompilerImport).toBe(true);
+      expect(results.hasPluginInvocation).toBe(true);
+      expect(updatedCode).toContain('import { vite as gtCompiler }');
+      expect(filesUpdated).toContain('/path/to/vite.config.ts');
+    });
+  });
+});

--- a/packages/cli/src/react/parse/addVitePlugin/index.ts
+++ b/packages/cli/src/react/parse/addVitePlugin/index.ts
@@ -1,0 +1,62 @@
+import findFilepath from '../../../fs/findFilepath.js';
+import { logError } from '../../../console/logging.js';
+import { installCompiler } from './installCompiler.js';
+import { updateViteConfig } from './updateViteConfig.js';
+
+const VITE_CONFIG_PATH_BASE = './vite.config.';
+/**
+ * Adds the gt compiler plugin to the vite config file
+ */
+export async function addVitePlugin({
+  errors,
+  warnings,
+  filesUpdated,
+  packageJson,
+  tsconfigJson,
+}: {
+  errors: string[];
+  warnings: string[];
+  filesUpdated: string[];
+  packageJson?: {
+    type?: string;
+    dependencies?: Record<string, string>;
+    devDependencies?: Record<string, string>;
+  };
+  tsconfigJson?: { compilerOptions?: { module?: string } };
+}) {
+  // Resolve file path
+  const viteConfigPath = findFilepath([
+    VITE_CONFIG_PATH_BASE + 'js',
+    VITE_CONFIG_PATH_BASE + 'ts',
+    VITE_CONFIG_PATH_BASE + 'mjs',
+    VITE_CONFIG_PATH_BASE + 'mts',
+    VITE_CONFIG_PATH_BASE + 'cjs',
+    VITE_CONFIG_PATH_BASE + 'cts',
+  ]);
+  if (!viteConfigPath) {
+    logError(
+      `No ${VITE_CONFIG_PATH_BASE}[js|ts|mjs|mts|cjs|cts] file found. Please add the @generaltranslation/compiler plugin to your vite configuration file:
+      import { vite as gtCompiler } from '@generaltranslation/compiler';
+      export default defineConfig({
+        plugins: [gtCompiler()],
+      });
+      `
+    );
+    process.exit(1);
+  }
+
+  // Install @generaltranslation/compiler if not installed
+  await installCompiler({ packageJson });
+
+  // Update the config file
+  await updateViteConfig({
+    errors,
+    warnings,
+    filesUpdated,
+    viteConfigPath,
+    packageJson,
+    tsconfigJson,
+  });
+
+  return { errors, warnings, filesUpdated };
+}

--- a/packages/cli/src/react/parse/addVitePlugin/installCompiler.ts
+++ b/packages/cli/src/react/parse/addVitePlugin/installCompiler.ts
@@ -1,0 +1,30 @@
+import { createSpinner } from '../../../console/logging.js';
+import { installPackage } from '../../../utils/installPackage.js';
+import { isPackageInstalled } from '../../../utils/packageJson.js';
+import { getPackageManager } from '../../../utils/packageManager.js';
+import chalk from 'chalk';
+
+/**
+ * Installs @generaltranslation/compiler if not installed
+ */
+export async function installCompiler({
+  packageJson,
+}: {
+  packageJson?: { type?: string };
+}) {
+  // Check if installed
+  if (isPackageInstalled('@generaltranslation/compiler', packageJson || {})) {
+    return;
+  }
+
+  // Animation
+  const spinner = createSpinner();
+  spinner.start(`Installing @generaltranslation/compiler...`);
+
+  // Install
+  const packageManager = await getPackageManager();
+  await installPackage('@generaltranslation/compiler', packageManager, true);
+
+  // Animation
+  spinner.stop(chalk.green('Installed @generaltranslation/compiler.'));
+}

--- a/packages/cli/src/react/parse/addVitePlugin/updateViteConfig.ts
+++ b/packages/cli/src/react/parse/addVitePlugin/updateViteConfig.ts
@@ -1,0 +1,171 @@
+import { createSpinner } from '../../../console/logging.js';
+import { logError } from '../../../console/logging.js';
+import fs from 'node:fs';
+import chalk from 'chalk';
+import generateModule from '@babel/generator';
+import { parse } from '@babel/parser';
+import { needsCJS } from '../../../utils/parse/needsCJS.js';
+import { addCompilerImport } from './utils/addCompilerImport.js';
+import { checkCompilerImport } from './utils/checkCompilerImport.js';
+import { checkPluginInvocation } from './utils/checkPluginInvocation.js';
+import { addPluginInvocation } from './utils/addPluginInvocation.js';
+
+// Handle CommonJS/ESM interop
+const generate = generateModule.default || generateModule;
+
+/**
+ * - Reads the vite config file
+ * - Updates the ast to add the gt compiler plugin
+ * - Writes the file back to the filesystem
+ */
+export async function updateViteConfig({
+  errors,
+  warnings,
+  filesUpdated,
+  viteConfigPath,
+  packageJson,
+  tsconfigJson,
+}: {
+  errors: string[];
+  warnings: string[];
+  filesUpdated: string[];
+  viteConfigPath: string;
+  packageJson?: { type?: string };
+  tsconfigJson?: { compilerOptions?: { module?: string } };
+}) {
+  // Animation
+  const spinner = createSpinner();
+  spinner.start(`Adding gt compiler plugin to ${viteConfigPath}...`);
+
+  // Read the file
+  let code;
+  try {
+    code = await fs.promises.readFile(viteConfigPath, 'utf8');
+  } catch (error) {
+    logError(`Error: Failed to read ${viteConfigPath}: ${error}`);
+    process.exit(1);
+    return;
+  }
+
+  // Update the ast
+  let updatedCode, success;
+  try {
+    ({ updatedCode, success } = await updateViteConfigAst({
+      code,
+      errors,
+      warnings,
+      viteConfigPath,
+      packageJson,
+      tsconfigJson,
+    }));
+  } catch (error) {
+    logError(`Error: Failed to update ${viteConfigPath}: ${error}`);
+    process.exit(1);
+    return;
+  }
+
+  // Write the file
+  try {
+    await fs.promises.writeFile(viteConfigPath, updatedCode);
+    filesUpdated.push(viteConfigPath);
+  } catch (error) {
+    logError(`Error: Failed to write ${viteConfigPath}: ${error}`);
+    process.exit(1);
+    return;
+  }
+
+  // Animation
+  spinner.stop(
+    success
+      ? chalk.green(`Success! Added gt compiler plugin to ${viteConfigPath}`)
+      : chalk.red(
+          `Failed to add gt compiler plugin to ${viteConfigPath}. Continuing setup...`
+        )
+  );
+}
+
+/**
+ * Orchestrates AST manipulation
+ * @param code - The code to update
+ * @param errors - The errors to update
+ * @param warnings - The warnings to update
+ * @param viteConfigPath - The path to the vite config file
+ * @param packageJson - The package.json file
+ * @param tsconfigJson - The tsconfig.json file
+ * @returns
+ */
+async function updateViteConfigAst({
+  code,
+  warnings,
+  viteConfigPath,
+  packageJson,
+  tsconfigJson,
+}: {
+  code: string;
+  errors: string[];
+  warnings: string[];
+  viteConfigPath: string;
+  packageJson?: { type?: string };
+  tsconfigJson?: { compilerOptions?: { module?: string } };
+}): Promise<{ updatedCode: string; success: boolean }> {
+  // Parse the code
+  const ast = parse(code, {
+    sourceType: 'module',
+    plugins: ['jsx', 'typescript'],
+  });
+
+  // Get cjs or esm
+  const cjsEnabled = needsCJS({
+    ast,
+    warnings,
+    filepath: viteConfigPath,
+    packageJson,
+    tsconfigJson,
+  });
+
+  // Check if the compiler import is already present
+  let { hasCompilerImport, alias, namespaces } = checkCompilerImport(ast);
+
+  // Add the import declaration
+  if (!hasCompilerImport) {
+    addCompilerImport({ ast, cjsEnabled });
+    hasCompilerImport = true;
+    alias = 'gtCompiler';
+    namespaces = [];
+  }
+
+  // Check if plugin is already present
+  let pluginAlreadyPresent = false;
+  if (hasCompilerImport) {
+    pluginAlreadyPresent = checkPluginInvocation({ ast, alias, namespaces });
+  }
+
+  // Insert plugin invocation
+  let success = false;
+  if (!pluginAlreadyPresent) {
+    success = addPluginInvocation({ ast, alias, namespaces });
+    if (!success) {
+      warnings.push(
+        `Failed to add gt compiler plugin to ${viteConfigPath}. Please add the plugin manually:
+import { vite as gtCompiler } from '@generaltranslation/compiler';
+export default defineConfig({
+  plugins: [gtCompiler()],
+});`
+      );
+    }
+  }
+
+  // Generate the modified code
+  const output = generate(
+    ast,
+    {
+      retainLines: true,
+      retainFunctionParens: true,
+      comments: true,
+      compact: 'auto',
+    },
+    code
+  );
+
+  return { updatedCode: output.code, success };
+}

--- a/packages/cli/src/react/parse/addVitePlugin/utils/__tests__/addCompilerImport.test.ts
+++ b/packages/cli/src/react/parse/addVitePlugin/utils/__tests__/addCompilerImport.test.ts
@@ -1,0 +1,535 @@
+import { describe, it, expect } from 'vitest';
+import { parse } from '@babel/parser';
+import generate from '@babel/generator';
+import { addCompilerImport } from '../addCompilerImport';
+
+describe('addCompilerImport', () => {
+  // Helper function to parse code, add import, and return generated code
+  function parseAddAndGenerate(code: string, cjsEnabled: boolean): string {
+    const ast = parse(code, {
+      sourceType: 'module',
+      plugins: ['typescript', 'jsx'],
+    });
+
+    addCompilerImport({ ast, cjsEnabled });
+
+    const generated = generate(ast);
+    return generated.code;
+  }
+
+  // Helper to normalize whitespace for easier comparison
+  function normalize(code: string): string {
+    return code.replace(/\s+/g, ' ').trim();
+  }
+
+  // Helper to check if AST contains specific import/require
+  function hasImport(code: string, type: 'esm' | 'cjs'): boolean {
+    const ast = parse(code, {
+      sourceType: 'module',
+      plugins: ['typescript', 'jsx'],
+    });
+
+    return ast.program.body.some((node) => {
+      if (type === 'esm' && node.type === 'ImportDeclaration') {
+        return (
+          node.source.value === '@generaltranslation/compiler' &&
+          node.specifiers.some(
+            (spec) =>
+              spec.type === 'ImportSpecifier' &&
+              spec.imported.type === 'Identifier' &&
+              spec.imported.name === 'vite' &&
+              spec.local.name === 'gtCompiler'
+          )
+        );
+      } else if (type === 'cjs' && node.type === 'VariableDeclaration') {
+        const decl = node.declarations[0];
+        return (
+          decl &&
+          decl.id?.type === 'Identifier' &&
+          decl.id.name === 'gtCompiler' &&
+          decl.init?.type === 'MemberExpression' &&
+          decl.init.object?.type === 'CallExpression' &&
+          decl.init.object.callee?.type === 'Identifier' &&
+          decl.init.object.callee.name === 'require' &&
+          decl.init.object.arguments?.[0]?.type === 'StringLiteral' &&
+          decl.init.object.arguments[0].value ===
+            '@generaltranslation/compiler' &&
+          decl.init.property?.type === 'Identifier' &&
+          decl.init.property.name === 'vite'
+        );
+      }
+      return false;
+    });
+  }
+
+  describe('ESM imports (cjsEnabled: false)', () => {
+    it('should add ESM import to empty file', () => {
+      const code = '';
+      const result = parseAddAndGenerate(code, false);
+
+      expect(normalize(result)).toContain(
+        'import { vite as gtCompiler } from "@generaltranslation/compiler";'
+      );
+    });
+
+    it('should add ESM import at the beginning of file with existing code', () => {
+      const code = `
+        import { defineConfig } from 'vite';
+        
+        export default defineConfig({
+          plugins: []
+        });
+      `;
+
+      const result = parseAddAndGenerate(code, false);
+      const lines = result.split('\n').filter((line) => line.trim());
+
+      // Should be the first import
+      expect(normalize(lines[0])).toBe(
+        'import { vite as gtCompiler } from "@generaltranslation/compiler";'
+      );
+      expect(result).toContain("import { defineConfig } from 'vite';");
+      expect(result).toContain('export default defineConfig');
+    });
+
+    it('should add ESM import before other imports', () => {
+      const code = `
+        import { defineConfig } from 'vite';
+        import react from '@vitejs/plugin-react';
+        import path from 'path';
+      `;
+
+      const result = parseAddAndGenerate(code, false);
+      const lines = result.split('\n').filter((line) => line.trim());
+
+      expect(normalize(lines[0])).toBe(
+        'import { vite as gtCompiler } from "@generaltranslation/compiler";'
+      );
+      expect(result).toContain("import { defineConfig } from 'vite';");
+      expect(result).toContain("import react from '@vitejs/plugin-react';");
+    });
+
+    it('should add ESM import before variable declarations', () => {
+      const code = `
+        const config = { plugins: [] };
+        const plugins = [];
+      `;
+
+      const result = parseAddAndGenerate(code, false);
+      const lines = result.split('\n').filter((line) => line.trim());
+
+      expect(normalize(lines[0])).toBe(
+        'import { vite as gtCompiler } from "@generaltranslation/compiler";'
+      );
+      expect(result).toContain('const config = {');
+    });
+
+    it('should add ESM import before function declarations', () => {
+      const code = `
+        function createConfig() {
+          return { plugins: [] };
+        }
+      `;
+
+      const result = parseAddAndGenerate(code, false);
+      const lines = result.split('\n').filter((line) => line.trim());
+
+      expect(normalize(lines[0])).toBe(
+        'import { vite as gtCompiler } from "@generaltranslation/compiler";'
+      );
+      expect(result).toContain('function createConfig()');
+    });
+
+    it('should add ESM import before export declarations', () => {
+      const code = `
+        export default { plugins: [] };
+      `;
+
+      const result = parseAddAndGenerate(code, false);
+      const lines = result.split('\n').filter((line) => line.trim());
+
+      expect(normalize(lines[0])).toBe(
+        'import { vite as gtCompiler } from "@generaltranslation/compiler";'
+      );
+      expect(result).toContain('export default {');
+    });
+
+    it('should preserve comments when adding ESM import', () => {
+      const code = `
+        // This is a comment
+        import { defineConfig } from 'vite';
+        /* Another comment */
+      `;
+
+      const result = parseAddAndGenerate(code, false);
+
+      expect(result).toContain(
+        'import { vite as gtCompiler } from "@generaltranslation/compiler";'
+      );
+      expect(result).toContain("import { defineConfig } from 'vite';");
+      // Note: Comments might be preserved depending on babel-generator settings
+    });
+  });
+
+  describe('CJS imports (cjsEnabled: true)', () => {
+    it('should add CJS require to empty file', () => {
+      const code = '';
+      const result = parseAddAndGenerate(code, true);
+
+      expect(normalize(result)).toContain(
+        'const gtCompiler = require("@generaltranslation/compiler").vite;'
+      );
+    });
+
+    it('should add CJS require at the beginning of file with existing code', () => {
+      const code = `
+        const { defineConfig } = require('vite');
+        
+        module.exports = defineConfig({
+          plugins: []
+        });
+      `;
+
+      const result = parseAddAndGenerate(code, true);
+
+      // Check that the import was added
+      expect(hasImport(result, 'cjs')).toBe(true);
+
+      // Check that original code is preserved (more flexible matching)
+      expect(result).toMatch(/require\s*\(\s*['"]vite['"]\s*\)/);
+      expect(result).toMatch(/module\.exports\s*=\s*defineConfig/);
+    });
+
+    it('should add CJS require before other requires', () => {
+      const code = `
+        const { defineConfig } = require('vite');
+        const react = require('@vitejs/plugin-react');
+        const path = require('path');
+      `;
+
+      const result = parseAddAndGenerate(code, true);
+
+      // Check that the import was added
+      expect(hasImport(result, 'cjs')).toBe(true);
+
+      // Check that original requires are preserved
+      expect(result).toMatch(/require\s*\(\s*['"]vite['"]\s*\)/);
+      expect(result).toMatch(
+        /require\s*\(\s*['"]@vitejs\/plugin-react['"]\s*\)/
+      );
+      expect(result).toMatch(/require\s*\(\s*['"]path['"]\s*\)/);
+    });
+
+    it('should add CJS require before variable declarations', () => {
+      const code = `
+        const config = { plugins: [] };
+        let plugins = [];
+        var settings = {};
+      `;
+
+      const result = parseAddAndGenerate(code, true);
+      const lines = result.split('\n').filter((line) => line.trim());
+
+      expect(normalize(lines[0])).toBe(
+        'const gtCompiler = require("@generaltranslation/compiler").vite;'
+      );
+      expect(result).toContain('const config = {');
+      expect(result).toContain('let plugins = [];');
+      expect(result).toContain('var settings = {};');
+    });
+
+    it('should add CJS require before function declarations', () => {
+      const code = `
+        function createConfig() {
+          return { plugins: [] };
+        }
+      `;
+
+      const result = parseAddAndGenerate(code, true);
+      const lines = result.split('\n').filter((line) => line.trim());
+
+      expect(normalize(lines[0])).toBe(
+        'const gtCompiler = require("@generaltranslation/compiler").vite;'
+      );
+      expect(result).toContain('function createConfig()');
+    });
+
+    it('should add CJS require before module.exports', () => {
+      const code = `
+        module.exports = { plugins: [] };
+      `;
+
+      const result = parseAddAndGenerate(code, true);
+      const lines = result.split('\n').filter((line) => line.trim());
+
+      expect(normalize(lines[0])).toBe(
+        'const gtCompiler = require("@generaltranslation/compiler").vite;'
+      );
+      expect(result).toContain('module.exports = {');
+    });
+  });
+
+  describe('Mixed scenarios and edge cases', () => {
+    it('should handle file with only comments', () => {
+      const code = `
+        // Just comments
+        /* Block comment */
+      `;
+
+      const esmResult = parseAddAndGenerate(code, false);
+      const cjsResult = parseAddAndGenerate(code, true);
+
+      expect(esmResult).toContain(
+        'import { vite as gtCompiler } from "@generaltranslation/compiler";'
+      );
+      expect(cjsResult).toContain(
+        'const gtCompiler = require("@generaltranslation/compiler").vite;'
+      );
+    });
+
+    it('should handle file with mixed ESM/CJS patterns (add ESM)', () => {
+      const code = `
+        import { defineConfig } from 'vite';
+        const react = require('@vitejs/plugin-react');
+      `;
+
+      const result = parseAddAndGenerate(code, false);
+      const lines = result.split('\n').filter((line) => line.trim());
+
+      expect(normalize(lines[0])).toBe(
+        'import { vite as gtCompiler } from "@generaltranslation/compiler";'
+      );
+      expect(result).toContain("import { defineConfig } from 'vite';");
+      expect(result).toContain(
+        "const react = require('@vitejs/plugin-react');"
+      );
+    });
+
+    it('should handle file with mixed ESM/CJS patterns (add CJS)', () => {
+      const code = `
+        import { defineConfig } from 'vite';
+        const react = require('@vitejs/plugin-react');
+      `;
+
+      const result = parseAddAndGenerate(code, true);
+      const lines = result.split('\n').filter((line) => line.trim());
+
+      expect(normalize(lines[0])).toBe(
+        'const gtCompiler = require("@generaltranslation/compiler").vite;'
+      );
+      expect(result).toContain("import { defineConfig } from 'vite';");
+      expect(result).toContain(
+        "const react = require('@vitejs/plugin-react');"
+      );
+    });
+
+    it('should handle complex file structure', () => {
+      const code = `
+        import { defineConfig } from 'vite';
+        import react from '@vitejs/plugin-react';
+        
+        const isDevelopment = process.env.NODE_ENV === 'development';
+        
+        function createPlugins() {
+          return [react()];
+        }
+        
+        export default defineConfig({
+          plugins: createPlugins(),
+          build: {
+            outDir: 'dist'
+          }
+        });
+      `;
+
+      const result = parseAddAndGenerate(code, false);
+      const lines = result.split('\n').filter((line) => line.trim());
+
+      expect(normalize(lines[0])).toBe(
+        'import { vite as gtCompiler } from "@generaltranslation/compiler";'
+      );
+      expect(result).toContain("import { defineConfig } from 'vite';");
+      expect(result).toContain("import react from '@vitejs/plugin-react';");
+      expect(result).toContain('const isDevelopment');
+      expect(result).toContain('function createPlugins');
+      expect(result).toContain('export default defineConfig');
+    });
+  });
+
+  describe('Real-world scenarios', () => {
+    it('should handle typical Vite config with ESM', () => {
+      const code = `
+        import { defineConfig } from 'vite';
+        import react from '@vitejs/plugin-react';
+        
+        export default defineConfig({
+          plugins: [react()],
+          server: {
+            port: 3000
+          },
+          build: {
+            outDir: 'dist'
+          }
+        });
+      `;
+
+      const result = parseAddAndGenerate(code, false);
+
+      expect(result).toContain(
+        'import { vite as gtCompiler } from "@generaltranslation/compiler";'
+      );
+      expect(result).toContain("import { defineConfig } from 'vite';");
+      expect(result).toContain("import react from '@vitejs/plugin-react';");
+      expect(result).toContain('plugins: [react()]');
+      expect(result).toContain('server: {');
+      expect(result).toContain('port: 3000');
+    });
+
+    it('should handle typical Vite config with CJS', () => {
+      const code = `
+        const { defineConfig } = require('vite');
+        const react = require('@vitejs/plugin-react');
+        
+        module.exports = defineConfig({
+          plugins: [react()],
+          server: {
+            port: 3000
+          },
+          build: {
+            outDir: 'dist'
+          }
+        });
+      `;
+
+      const result = parseAddAndGenerate(code, true);
+
+      // Check that the import was added
+      expect(hasImport(result, 'cjs')).toBe(true);
+
+      // Check that original code structure is preserved
+      expect(result).toMatch(/require\s*\(\s*['"]vite['"]\s*\)/);
+      expect(result).toMatch(
+        /require\s*\(\s*['"]@vitejs\/plugin-react['"]\s*\)/
+      );
+      expect(result).toMatch(/module\.exports\s*=\s*defineConfig/);
+      expect(result).toContain('port: 3000');
+      expect(result).toMatch(/outDir:\s*['"]dist['"]/);
+    });
+
+    it('should handle TypeScript Vite config', () => {
+      const code = `
+        import { defineConfig } from 'vite';
+        import react from '@vitejs/plugin-react';
+        import type { UserConfig } from 'vite';
+        
+        const config: UserConfig = {
+          plugins: [react()]
+        };
+        
+        export default defineConfig(config);
+      `;
+
+      const result = parseAddAndGenerate(code, false);
+
+      expect(result).toContain(
+        'import { vite as gtCompiler } from "@generaltranslation/compiler";'
+      );
+      expect(result).toContain("import { defineConfig } from 'vite';");
+      expect(result).toContain("import react from '@vitejs/plugin-react';");
+      // Type imports might be handled differently by babel
+    });
+
+    it('should handle Vite config with environment variables', () => {
+      const code = `
+        import { defineConfig } from 'vite';
+        import { loadEnv } from 'vite';
+        
+        export default defineConfig(({ command, mode }) => {
+          const env = loadEnv(mode, process.cwd(), '');
+          
+          return {
+            plugins: [],
+            define: {
+              __APP_ENV__: JSON.stringify(env.APP_ENV)
+            }
+          };
+        });
+      `;
+
+      const result = parseAddAndGenerate(code, false);
+
+      expect(result).toContain(
+        'import { vite as gtCompiler } from "@generaltranslation/compiler";'
+      );
+      expect(result).toContain("import { defineConfig } from 'vite';");
+      expect(result).toContain("import { loadEnv } from 'vite';");
+      expect(result).toContain('const env = loadEnv');
+    });
+  });
+
+  describe('Generated code structure', () => {
+    it('should generate valid ESM import syntax', () => {
+      const code = 'const test = 1;';
+      const result = parseAddAndGenerate(code, false);
+
+      // Check that the generated import is syntactically correct
+      expect(() => {
+        parse(result, {
+          sourceType: 'module',
+          plugins: ['typescript', 'jsx'],
+        });
+      }).not.toThrow();
+
+      expect(result).toContain(
+        'import { vite as gtCompiler } from "@generaltranslation/compiler";'
+      );
+    });
+
+    it('should generate valid CJS require syntax', () => {
+      const code = 'const test = 1;';
+      const result = parseAddAndGenerate(code, true);
+
+      // Check that the generated require is syntactically correct
+      expect(() => {
+        parse(result, {
+          sourceType: 'module',
+          plugins: ['typescript', 'jsx'],
+        });
+      }).not.toThrow();
+
+      expect(result).toContain(
+        'const gtCompiler = require("@generaltranslation/compiler").vite;'
+      );
+    });
+
+    it('should maintain proper AST structure after modification', () => {
+      const code = `
+        import { defineConfig } from 'vite';
+        export default defineConfig({});
+      `;
+
+      const ast = parse(code, {
+        sourceType: 'module',
+        plugins: ['typescript', 'jsx'],
+      });
+
+      const originalBodyLength = ast.program.body.length;
+      addCompilerImport({ ast, cjsEnabled: false });
+
+      // Should have added one more statement
+      expect(ast.program.body.length).toBe(originalBodyLength + 1);
+
+      // First statement should be the new import
+      expect(ast.program.body[0].type).toBe('ImportDeclaration');
+
+      // Should still be parseable
+      const generated = generate(ast);
+      expect(() => {
+        parse(generated.code, {
+          sourceType: 'module',
+          plugins: ['typescript', 'jsx'],
+        });
+      }).not.toThrow();
+    });
+  });
+});

--- a/packages/cli/src/react/parse/addVitePlugin/utils/__tests__/addPluginInvocation.test.ts
+++ b/packages/cli/src/react/parse/addVitePlugin/utils/__tests__/addPluginInvocation.test.ts
@@ -1,0 +1,559 @@
+import { describe, it, expect } from 'vitest';
+import { parse } from '@babel/parser';
+import generate from '@babel/generator';
+import { addPluginInvocation } from '../addPluginInvocation';
+
+describe('addPluginInvocation', () => {
+  // Helper function to parse code, add plugin, and return both result and generated code
+  function parseAddAndGenerate(
+    code: string,
+    alias: string | null,
+    namespaces: string[] = []
+  ): { success: boolean; code: string } {
+    const ast = parse(code, {
+      sourceType: 'module',
+      plugins: ['typescript', 'jsx'],
+    });
+
+    const success = addPluginInvocation({ ast, alias, namespaces });
+    const generated = generate(ast);
+
+    return { success, code: generated.code };
+  }
+
+  // Helper to check if generated code contains the expected plugin invocation
+  function hasPluginInvocation(
+    code: string,
+    type: 'alias' | 'namespace',
+    name: string
+  ): boolean {
+    if (type === 'alias') {
+      // Check for: gtCompiler()
+      const aliasPattern = new RegExp(`${name}\\s*\\(\\s*\\)`);
+      return aliasPattern.test(code);
+    } else {
+      // Check for: gt.vite()
+      const namespacePattern = new RegExp(`${name}\\.vite\\s*\\(\\s*\\)`);
+      return namespacePattern.test(code);
+    }
+  }
+
+  describe('Alias-based plugin addition', () => {
+    it('should add alias plugin to existing plugins array', () => {
+      const code = `
+        export default defineConfig({
+          plugins: [react()]
+        });
+      `;
+
+      const result = parseAddAndGenerate(code, 'gtCompiler', []);
+
+      expect(result.success).toBe(true);
+      expect(hasPluginInvocation(result.code, 'alias', 'gtCompiler')).toBe(
+        true
+      );
+      expect(result.code).toContain('react()');
+      expect(result.code).toContain('gtCompiler()');
+    });
+
+    it('should add alias plugin to empty plugins array', () => {
+      const code = `
+        export default defineConfig({
+          plugins: []
+        });
+      `;
+
+      const result = parseAddAndGenerate(code, 'gtCompiler', []);
+
+      expect(result.success).toBe(true);
+      expect(hasPluginInvocation(result.code, 'alias', 'gtCompiler')).toBe(
+        true
+      );
+      expect(result.code).toMatch(/plugins:\s*\[\s*gtCompiler\(\)\s*\]/);
+    });
+
+    it('should add alias plugin with different alias names', () => {
+      const code = `
+        export default defineConfig({
+          plugins: [react()]
+        });
+      `;
+
+      const result = parseAddAndGenerate(code, 'myCustomCompiler', []);
+
+      expect(result.success).toBe(true);
+      expect(
+        hasPluginInvocation(result.code, 'alias', 'myCustomCompiler')
+      ).toBe(true);
+      expect(result.code).toContain('myCustomCompiler()');
+    });
+
+    it('should add alias plugin to plugins array with multiple existing plugins', () => {
+      const code = `
+        export default defineConfig({
+          plugins: [react(), vue(), typescript()]
+        });
+      `;
+
+      const result = parseAddAndGenerate(code, 'gtCompiler', []);
+
+      expect(result.success).toBe(true);
+      expect(hasPluginInvocation(result.code, 'alias', 'gtCompiler')).toBe(
+        true
+      );
+      expect(result.code).toContain('react()');
+      expect(result.code).toContain('vue()');
+      expect(result.code).toContain('typescript()');
+      expect(result.code).toContain('gtCompiler()');
+    });
+  });
+
+  describe('Namespace-based plugin addition', () => {
+    it('should add namespace plugin to existing plugins array', () => {
+      const code = `
+        export default defineConfig({
+          plugins: [react()]
+        });
+      `;
+
+      const result = parseAddAndGenerate(code, null, ['gt']);
+
+      expect(result.success).toBe(true);
+      expect(hasPluginInvocation(result.code, 'namespace', 'gt')).toBe(true);
+      expect(result.code).toContain('react()');
+      expect(result.code).toContain('gt.vite()');
+    });
+
+    it('should add namespace plugin to empty plugins array', () => {
+      const code = `
+        export default defineConfig({
+          plugins: []
+        });
+      `;
+
+      const result = parseAddAndGenerate(code, null, ['compiler']);
+
+      expect(result.success).toBe(true);
+      expect(hasPluginInvocation(result.code, 'namespace', 'compiler')).toBe(
+        true
+      );
+      expect(result.code).toMatch(/plugins:\s*\[\s*compiler\.vite\(\)\s*\]/);
+    });
+
+    it('should use first namespace when multiple are provided', () => {
+      const code = `
+        export default defineConfig({
+          plugins: [react()]
+        });
+      `;
+
+      const result = parseAddAndGenerate(code, null, [
+        'gt',
+        'compiler',
+        'other',
+      ]);
+
+      expect(result.success).toBe(true);
+      expect(hasPluginInvocation(result.code, 'namespace', 'gt')).toBe(true);
+      expect(result.code).toContain('gt.vite()');
+      // Should not use other namespaces
+      expect(result.code).not.toContain('compiler.vite()');
+      expect(result.code).not.toContain('other.vite()');
+    });
+
+    it('should add namespace plugin with different namespace names', () => {
+      const code = `
+        export default defineConfig({
+          plugins: [react()]
+        });
+      `;
+
+      const result = parseAddAndGenerate(code, null, ['myCompilerNamespace']);
+
+      expect(result.success).toBe(true);
+      expect(
+        hasPluginInvocation(result.code, 'namespace', 'myCompilerNamespace')
+      ).toBe(true);
+      expect(result.code).toContain('myCompilerNamespace.vite()');
+    });
+  });
+
+  describe('Plugin spread scenarios', () => {
+    it('should handle plugins as variable reference (spread scenario)', () => {
+      const code = `
+        const basePlugins = [react()];
+        export default defineConfig({
+          plugins: basePlugins
+        });
+      `;
+
+      const result = parseAddAndGenerate(code, 'gtCompiler', []);
+
+      expect(result.success).toBe(true);
+      expect(result.code).toContain('...basePlugins');
+      expect(hasPluginInvocation(result.code, 'alias', 'gtCompiler')).toBe(
+        true
+      );
+      expect(result.code).toMatch(
+        /plugins:\s*\[\s*\.\.\.basePlugins,\s*gtCompiler\(\)\s*\]/
+      );
+    });
+
+    it('should handle plugins as function call (spread scenario)', () => {
+      const code = `
+        export default defineConfig({
+          plugins: getPlugins()
+        });
+      `;
+
+      const result = parseAddAndGenerate(code, null, ['gt']);
+
+      expect(result.success).toBe(true);
+      expect(result.code).toContain('...getPlugins()');
+      expect(hasPluginInvocation(result.code, 'namespace', 'gt')).toBe(true);
+      expect(result.code).toMatch(
+        /plugins:\s*\[\s*\.\.\.getPlugins\(\),\s*gt\.vite\(\)\s*\]/
+      );
+    });
+
+    it('should handle plugins as complex expression (spread scenario)', () => {
+      const code = `
+        export default defineConfig({
+          plugins: process.env.NODE_ENV === 'development' ? devPlugins : prodPlugins
+        });
+      `;
+
+      const result = parseAddAndGenerate(code, 'gtCompiler', []);
+
+      expect(result.success).toBe(true);
+      expect(result.code).toContain(
+        "...(process.env.NODE_ENV === 'development' ? devPlugins : prodPlugins)"
+      );
+      expect(hasPluginInvocation(result.code, 'alias', 'gtCompiler')).toBe(
+        true
+      );
+    });
+  });
+
+  describe('Multiple plugins property scenarios', () => {
+    it('should add to all plugins properties in nested objects', () => {
+      const code = `
+        export default defineConfig({
+          plugins: [react()],
+          build: {
+            rollupOptions: {
+              plugins: [somePlugin()]
+            }
+          }
+        });
+      `;
+
+      const result = parseAddAndGenerate(code, 'gtCompiler', []);
+
+      expect(result.success).toBe(true);
+      // Should add to both plugins arrays
+      const matches = result.code.match(/gtCompiler\(\)/g);
+      expect(matches).toHaveLength(1);
+      expect(result.code).toContain('react()');
+      expect(result.code).toContain('somePlugin()');
+    });
+
+    it('should handle plugins property with string key', () => {
+      const code = `
+        export default defineConfig({
+          "plugins": [react()]
+        });
+      `;
+
+      const result = parseAddAndGenerate(code, 'gtCompiler', []);
+
+      expect(result.success).toBe(true);
+      expect(hasPluginInvocation(result.code, 'alias', 'gtCompiler')).toBe(
+        true
+      );
+      expect(result.code).toContain('react()');
+    });
+
+    it('should handle computed plugins property', () => {
+      const code = `
+        const key = 'plugins';
+        export default defineConfig({
+          [key]: [react()]
+        });
+      `;
+
+      const result = parseAddAndGenerate(code, 'gtCompiler', []);
+
+      // Should not match computed property (current implementation limitation)
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('Edge cases and error scenarios', () => {
+    it('should return false when no alias or namespaces provided', () => {
+      const code = `
+        export default defineConfig({
+          plugins: [react()]
+        });
+      `;
+
+      const result = parseAddAndGenerate(code, null, []);
+
+      expect(result.success).toBe(false);
+      expect(result.code).toContain('react()');
+      expect(result.code).not.toContain('gtCompiler()');
+    });
+
+    it('should return false when empty namespaces array and no alias', () => {
+      const code = `
+        export default defineConfig({
+          plugins: [react()]
+        });
+      `;
+
+      const result = parseAddAndGenerate(code, '', []);
+
+      expect(result.success).toBe(false);
+    });
+
+    it('should handle file with no plugins property', () => {
+      const code = `
+        export default defineConfig({
+          server: { port: 3000 },
+          build: { outDir: 'dist' }
+        });
+      `;
+
+      const result = parseAddAndGenerate(code, 'gtCompiler', []);
+
+      expect(result.success).toBe(false);
+      expect(result.code).not.toContain('gtCompiler()');
+      expect(result.code).toContain('port: 3000');
+    });
+
+    it('should handle empty file', () => {
+      const code = '';
+
+      const result = parseAddAndGenerate(code, 'gtCompiler', []);
+
+      expect(result.success).toBe(false);
+    });
+
+    it('should handle file with only comments', () => {
+      const code = `
+        // This is a comment
+        /* Another comment */
+      `;
+
+      const result = parseAddAndGenerate(code, 'gtCompiler', []);
+
+      expect(result.success).toBe(false);
+    });
+
+    it('should handle plugins property with non-array value that cannot be spread', () => {
+      const code = `
+        export default defineConfig({
+          plugins: "invalid"
+        });
+      `;
+
+      const result = parseAddAndGenerate(code, 'gtCompiler', []);
+
+      expect(result.success).toBe(true);
+      // Should convert to array with spread
+      expect(result.code).toContain('..."invalid"');
+      expect(hasPluginInvocation(result.code, 'alias', 'gtCompiler')).toBe(
+        true
+      );
+    });
+  });
+
+  describe('Real-world scenarios', () => {
+    it('should handle typical Vite config with ESM', () => {
+      const code = `
+        import { defineConfig } from 'vite';
+        import react from '@vitejs/plugin-react';
+
+        export default defineConfig({
+          plugins: [
+            react({
+              jsxDev: process.env.NODE_ENV === 'development'
+            })
+          ],
+          server: {
+            port: 3000
+          },
+          build: {
+            outDir: 'dist'
+          }
+        });
+      `;
+
+      const result = parseAddAndGenerate(code, 'gtCompiler', []);
+
+      expect(result.success).toBe(true);
+      expect(hasPluginInvocation(result.code, 'alias', 'gtCompiler')).toBe(
+        true
+      );
+      expect(result.code).toContain('react({');
+      expect(result.code).toContain('jsxDev: process.env.NODE_ENV');
+      expect(result.code).toContain('gtCompiler()');
+      expect(result.code).toContain('port: 3000');
+    });
+
+    it('should handle CommonJS Vite config', () => {
+      const code = `
+        const { defineConfig } = require('vite');
+        const react = require('@vitejs/plugin-react');
+
+        module.exports = defineConfig({
+          plugins: [react()],
+          server: {
+            port: 3000
+          }
+        });
+      `;
+
+      const result = parseAddAndGenerate(code, null, ['gt']);
+
+      expect(result.success).toBe(true);
+      expect(hasPluginInvocation(result.code, 'namespace', 'gt')).toBe(true);
+      expect(result.code).toContain('react()');
+      expect(result.code).toContain('gt.vite()');
+      expect(result.code).toContain('port: 3000');
+    });
+
+    it('should handle conditional plugins', () => {
+      const code = `
+        export default defineConfig({
+          plugins: [
+            react(),
+            ...(process.env.NODE_ENV === 'development' ? [devtools()] : []),
+            ...(process.env.ANALYZE ? [bundleAnalyzer()] : [])
+          ]
+        });
+      `;
+
+      const result = parseAddAndGenerate(code, 'gtCompiler', []);
+
+      expect(result.success).toBe(true);
+      expect(hasPluginInvocation(result.code, 'alias', 'gtCompiler')).toBe(
+        true
+      );
+      expect(result.code).toContain('react()');
+      expect(result.code).toContain('devtools()');
+      expect(result.code).toContain('bundleAnalyzer()');
+      expect(result.code).toContain('gtCompiler()');
+    });
+
+    it('should handle Vite config with complex plugin setup', () => {
+      const code = `
+        const basePlugins = [react(), typescript()];
+        const devPlugins = [...basePlugins, devtools()];
+        const prodPlugins = [...basePlugins, minify()];
+
+        export default defineConfig({
+          plugins: process.env.NODE_ENV === 'development' ? devPlugins : prodPlugins,
+          optimizeDeps: {
+            include: ['react', 'react-dom']
+          }
+        });
+      `;
+
+      const result = parseAddAndGenerate(code, null, ['compiler']);
+
+      expect(result.success).toBe(true);
+      expect(hasPluginInvocation(result.code, 'namespace', 'compiler')).toBe(
+        true
+      );
+      expect(result.code).toContain(
+        "...(process.env.NODE_ENV === 'development' ? devPlugins : prodPlugins)"
+      );
+      expect(result.code).toContain('compiler.vite()');
+      expect(result.code).toContain('optimizeDeps');
+    });
+
+    it('should preserve plugin configuration and comments', () => {
+      const code = `
+        export default defineConfig({
+          plugins: [
+            // React plugin with custom config
+            react({
+              babel: {
+                plugins: ['@babel/plugin-syntax-jsx']
+              }
+            }),
+            // TypeScript plugin
+            typescript({
+              declaration: true
+            })
+          ]
+        });
+      `;
+
+      const result = parseAddAndGenerate(code, 'gtCompiler', []);
+
+      expect(result.success).toBe(true);
+      expect(hasPluginInvocation(result.code, 'alias', 'gtCompiler')).toBe(
+        true
+      );
+      expect(result.code).toContain('react({');
+      expect(result.code).toContain('babel: {');
+      expect(result.code).toContain('@babel/plugin-syntax-jsx');
+      expect(result.code).toContain('typescript({');
+      expect(result.code).toContain('declaration: true');
+    });
+  });
+
+  describe('Generated code structure', () => {
+    it('should generate syntactically valid code', () => {
+      const code = `
+        export default defineConfig({
+          plugins: [react()]
+        });
+      `;
+
+      const result = parseAddAndGenerate(code, 'gtCompiler', []);
+
+      expect(result.success).toBe(true);
+
+      // Verify the generated code is parseable
+      expect(() => {
+        parse(result.code, {
+          sourceType: 'module',
+          plugins: ['typescript', 'jsx'],
+        });
+      }).not.toThrow();
+    });
+
+    it('should maintain proper AST structure after modification', () => {
+      const code = `
+        export default defineConfig({
+          plugins: [react()]
+        });
+      `;
+
+      const ast = parse(code, {
+        sourceType: 'module',
+        plugins: ['typescript', 'jsx'],
+      });
+
+      const success = addPluginInvocation({
+        ast,
+        alias: 'gtCompiler',
+        namespaces: [],
+      });
+
+      expect(success).toBe(true);
+
+      // Verify AST is still valid
+      const generated = generate(ast);
+      expect(() => {
+        parse(generated.code, {
+          sourceType: 'module',
+          plugins: ['typescript', 'jsx'],
+        });
+      }).not.toThrow();
+    });
+  });
+});

--- a/packages/cli/src/react/parse/addVitePlugin/utils/__tests__/checkCompilerImport.test.ts
+++ b/packages/cli/src/react/parse/addVitePlugin/utils/__tests__/checkCompilerImport.test.ts
@@ -1,0 +1,495 @@
+import { describe, it, expect } from 'vitest';
+import { parse } from '@babel/parser';
+import {
+  checkCompilerImport,
+  CheckCompilerImportResult,
+} from '../checkCompilerImport';
+
+describe('checkCompilerImport', () => {
+  // Helper function to parse code and run checkCompilerImport
+  function parseAndCheck(code: string): CheckCompilerImportResult {
+    const ast = parse(code, {
+      sourceType: 'module',
+      plugins: ['typescript', 'jsx'],
+    });
+    return checkCompilerImport(ast);
+  }
+
+  describe('Import Declarations', () => {
+    describe('Named imports', () => {
+      it('should detect vite named import without alias', () => {
+        const code = `import { vite } from '@generaltranslation/compiler';`;
+        const result = parseAndCheck(code);
+
+        expect(result.hasCompilerImport).toBe(true);
+        expect(result.alias).toBe('vite');
+        expect(result.namespaces).toEqual([]);
+      });
+
+      it('should detect vite named import with alias', () => {
+        const code = `import { vite as gtCompiler } from '@generaltranslation/compiler';`;
+        const result = parseAndCheck(code);
+
+        expect(result.hasCompilerImport).toBe(true);
+        expect(result.alias).toBe('gtCompiler');
+        expect(result.namespaces).toEqual([]);
+      });
+
+      it('should detect vite among multiple named imports', () => {
+        const code = `import { otherThing, vite, anotherThing } from '@generaltranslation/compiler';`;
+        const result = parseAndCheck(code);
+
+        expect(result.hasCompilerImport).toBe(true);
+        expect(result.alias).toBe('vite');
+        expect(result.namespaces).toEqual([]);
+      });
+
+      it('should detect vite with alias among multiple imports', () => {
+        const code = `import { otherThing, vite as gtCompiler, anotherThing } from '@generaltranslation/compiler';`;
+        const result = parseAndCheck(code);
+
+        expect(result.hasCompilerImport).toBe(true);
+        expect(result.alias).toBe('gtCompiler');
+        expect(result.namespaces).toEqual([]);
+      });
+
+      it('should not detect non-vite named imports', () => {
+        const code = `import { otherThing, something } from '@generaltranslation/compiler';`;
+        const result = parseAndCheck(code);
+
+        expect(result.hasCompilerImport).toBe(false);
+        expect(result.alias).toBe(null);
+        expect(result.namespaces).toEqual([]);
+      });
+    });
+
+    describe('Default imports', () => {
+      it('should detect default import', () => {
+        const code = `import gtCompiler from '@generaltranslation/compiler';`;
+        const result = parseAndCheck(code);
+
+        expect(result.hasCompilerImport).toBe(true);
+        expect(result.alias).toBe(null);
+        expect(result.namespaces).toEqual(['gtCompiler']);
+      });
+    });
+
+    describe('Namespace imports', () => {
+      it('should detect namespace import', () => {
+        const code = `import * as gtCompiler from '@generaltranslation/compiler';`;
+        const result = parseAndCheck(code);
+
+        expect(result.hasCompilerImport).toBe(true);
+        expect(result.alias).toBe(null);
+        expect(result.namespaces).toEqual(['gtCompiler']);
+      });
+    });
+
+    describe('Mixed imports', () => {
+      it('should detect mixed default and named imports', () => {
+        const code = `import gtDefault, { vite } from '@generaltranslation/compiler';`;
+        const result = parseAndCheck(code);
+
+        expect(result.hasCompilerImport).toBe(true);
+        expect(result.alias).toBe('vite');
+        expect(result.namespaces).toEqual(['gtDefault']);
+      });
+
+      it('should detect mixed default and named imports with alias', () => {
+        const code = `import gtDefault, { vite as compiler } from '@generaltranslation/compiler';`;
+        const result = parseAndCheck(code);
+
+        expect(result.hasCompilerImport).toBe(true);
+        expect(result.alias).toBe('compiler');
+        expect(result.namespaces).toEqual(['gtDefault']);
+      });
+
+      it('should detect mixed default and other named imports', () => {
+        const code = `import gtDefault, { otherThing } from '@generaltranslation/compiler';`;
+        const result = parseAndCheck(code);
+
+        expect(result.hasCompilerImport).toBe(true);
+        expect(result.alias).toBe(null);
+        expect(result.namespaces).toEqual(['gtDefault']);
+      });
+    });
+
+    describe('Wrong package imports', () => {
+      it('should not detect imports from different packages', () => {
+        const code = `import { vite } from '@different/package';`;
+        const result = parseAndCheck(code);
+
+        expect(result.hasCompilerImport).toBe(false);
+        expect(result.alias).toBe(null);
+        expect(result.namespaces).toEqual([]);
+      });
+
+      it('should not detect imports from similar package names', () => {
+        const code = `import { vite } from '@generaltranslation/compiler-different';`;
+        const result = parseAndCheck(code);
+
+        expect(result.hasCompilerImport).toBe(false);
+        expect(result.alias).toBe(null);
+        expect(result.namespaces).toEqual([]);
+      });
+    });
+  });
+
+  describe('Require Statements - Variable Declarations', () => {
+    describe('Namespace assignments', () => {
+      it('should detect namespace assignment with const', () => {
+        const code = `const gtCompiler = require('@generaltranslation/compiler');`;
+        const result = parseAndCheck(code);
+
+        expect(result.hasCompilerImport).toBe(true);
+        expect(result.alias).toBe(null);
+        expect(result.namespaces).toEqual(['gtCompiler']);
+      });
+
+      it('should detect namespace assignment with let', () => {
+        const code = `let gtCompiler = require('@generaltranslation/compiler');`;
+        const result = parseAndCheck(code);
+
+        expect(result.hasCompilerImport).toBe(true);
+        expect(result.alias).toBe(null);
+        expect(result.namespaces).toEqual(['gtCompiler']);
+      });
+
+      it('should detect namespace assignment with var', () => {
+        const code = `var gtCompiler = require('@generaltranslation/compiler');`;
+        const result = parseAndCheck(code);
+
+        expect(result.hasCompilerImport).toBe(true);
+        expect(result.alias).toBe(null);
+        expect(result.namespaces).toEqual(['gtCompiler']);
+      });
+    });
+
+    describe('Destructuring - vite property', () => {
+      it('should detect vite destructuring without alias', () => {
+        const code = `const { vite } = require('@generaltranslation/compiler');`;
+        const result = parseAndCheck(code);
+
+        expect(result.hasCompilerImport).toBe(true);
+        expect(result.alias).toBe('vite');
+        expect(result.namespaces).toEqual([]);
+      });
+
+      it('should detect vite destructuring with alias', () => {
+        const code = `const { vite: gtCompiler } = require('@generaltranslation/compiler');`;
+        const result = parseAndCheck(code);
+
+        expect(result.hasCompilerImport).toBe(true);
+        expect(result.alias).toBe('gtCompiler');
+        expect(result.namespaces).toEqual([]);
+      });
+
+      it('should detect vite among multiple destructured properties', () => {
+        const code = `const { otherThing, vite, anotherThing } = require('@generaltranslation/compiler');`;
+        const result = parseAndCheck(code);
+
+        expect(result.hasCompilerImport).toBe(true);
+        expect(result.alias).toBe('vite');
+        expect(result.namespaces).toEqual([]);
+      });
+
+      it('should detect vite with alias among multiple properties', () => {
+        const code = `const { otherThing, vite: compiler, anotherThing } = require('@generaltranslation/compiler');`;
+        const result = parseAndCheck(code);
+
+        expect(result.hasCompilerImport).toBe(true);
+        expect(result.alias).toBe('compiler');
+        expect(result.namespaces).toEqual([]);
+      });
+
+      it('should not detect non-vite destructuring', () => {
+        const code = `const { otherThing, something } = require('@generaltranslation/compiler');`;
+        const result = parseAndCheck(code);
+
+        expect(result.hasCompilerImport).toBe(false);
+        expect(result.alias).toBe(null);
+        expect(result.namespaces).toEqual([]);
+      });
+    });
+
+    describe('Destructuring - rest elements', () => {
+      it('should detect single rest element', () => {
+        const code = `const { ...everything } = require('@generaltranslation/compiler');`;
+        const result = parseAndCheck(code);
+
+        expect(result.hasCompilerImport).toBe(true);
+        expect(result.alias).toBe(null);
+        expect(result.namespaces).toEqual(['everything']);
+      });
+
+      it('should detect rest element with other properties', () => {
+        const code = `const { otherThing, ...rest } = require('@generaltranslation/compiler');`;
+        const result = parseAndCheck(code);
+
+        expect(result.hasCompilerImport).toBe(true);
+        expect(result.alias).toBe(null);
+        expect(result.namespaces).toEqual(['rest']);
+      });
+
+      it('should detect multiple rest elements', () => {
+        const code = `const { b, ...second } = require('@generaltranslation/compiler');`;
+        const result = parseAndCheck(code);
+
+        expect(result.hasCompilerImport).toBe(true);
+        expect(result.alias).toBe(null);
+        expect(result.namespaces).toEqual(['second']);
+      });
+
+      it('should prioritize vite over rest elements when vite is present', () => {
+        const code = `const { vite, ...rest } = require('@generaltranslation/compiler');`;
+        const result = parseAndCheck(code);
+
+        expect(result.hasCompilerImport).toBe(true);
+        expect(result.alias).toBe('vite');
+        expect(result.namespaces).toEqual([]);
+      });
+
+      it('should prioritize vite with alias over rest elements', () => {
+        const code = `const { vite: compiler, ...rest } = require('@generaltranslation/compiler');`;
+        const result = parseAndCheck(code);
+
+        expect(result.hasCompilerImport).toBe(true);
+        expect(result.alias).toBe('compiler');
+        expect(result.namespaces).toEqual([]);
+      });
+    });
+
+    describe('Member access', () => {
+      it('should detect member access to vite property', () => {
+        const code = `const gtCompiler = require('@generaltranslation/compiler').vite;`;
+        const result = parseAndCheck(code);
+
+        expect(result.hasCompilerImport).toBe(true);
+        expect(result.alias).toBe('gtCompiler');
+        expect(result.namespaces).toEqual([]);
+      });
+
+      it('should not detect member access to non-vite properties', () => {
+        const code = `const something = require('@generaltranslation/compiler').otherProperty;`;
+        const result = parseAndCheck(code);
+
+        expect(result.hasCompilerImport).toBe(false);
+        expect(result.alias).toBe(null);
+        expect(result.namespaces).toEqual([]);
+      });
+    });
+
+    describe('Wrong package requires', () => {
+      it('should not detect requires from different packages', () => {
+        const code = `const { vite } = require('@different/package');`;
+        const result = parseAndCheck(code);
+
+        expect(result.hasCompilerImport).toBe(false);
+        expect(result.alias).toBe(null);
+        expect(result.namespaces).toEqual([]);
+      });
+
+      it('should not detect requires from similar package names', () => {
+        const code = `const gtCompiler = require('@generaltranslation/compiler-different');`;
+        const result = parseAndCheck(code);
+
+        expect(result.hasCompilerImport).toBe(false);
+        expect(result.alias).toBe(null);
+        expect(result.namespaces).toEqual([]);
+      });
+    });
+
+    describe('Multiple variable declarations', () => {
+      it('should detect compiler import in multiple declarations', () => {
+        const code = `const a = 1, gtCompiler = require('@generaltranslation/compiler'), b = 2;`;
+        const result = parseAndCheck(code);
+
+        expect(result.hasCompilerImport).toBe(true);
+        expect(result.alias).toBe(null);
+        expect(result.namespaces).toEqual(['gtCompiler']);
+      });
+
+      it('should detect vite destructuring in multiple declarations', () => {
+        const code = `const a = 1, { vite } = require('@generaltranslation/compiler'), b = 2;`;
+        const result = parseAndCheck(code);
+
+        expect(result.hasCompilerImport).toBe(true);
+        expect(result.alias).toBe('vite');
+        expect(result.namespaces).toEqual([]);
+      });
+    });
+  });
+
+  describe('Mixed scenarios', () => {
+    it('should handle multiple import and require statements', () => {
+      const code = `
+        import { otherThing } from '@generaltranslation/compiler';
+        const { vite } = require('@generaltranslation/compiler');
+      `;
+      const result = parseAndCheck(code);
+
+      expect(result.hasCompilerImport).toBe(true);
+      expect(result.alias).toBe('vite');
+      expect(result.namespaces).toEqual([]);
+    });
+
+    it('should handle namespace import and vite require', () => {
+      const code = `
+        import * as gtImport from '@generaltranslation/compiler';
+        const { vite: compiler } = require('@generaltranslation/compiler');
+      `;
+      const result = parseAndCheck(code);
+
+      expect(result.hasCompilerImport).toBe(true);
+      expect(result.alias).toBe('compiler');
+      expect(result.namespaces).toEqual(['gtImport']);
+    });
+
+    it('should accumulate all namespaces from multiple statements', () => {
+      const code = `
+        import * as gtImport from '@generaltranslation/compiler';
+        import gtDefault from '@generaltranslation/compiler';
+        const gtRequire = require('@generaltranslation/compiler');
+        const { ...rest } = require('@generaltranslation/compiler');
+      `;
+      const result = parseAndCheck(code);
+
+      expect(result.hasCompilerImport).toBe(true);
+      expect(result.alias).toBe(null);
+      expect(result.namespaces).toEqual([
+        'gtImport',
+        'gtDefault',
+        'gtRequire',
+        'rest',
+      ]);
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('should handle empty file', () => {
+      const code = ``;
+      const result = parseAndCheck(code);
+
+      expect(result.hasCompilerImport).toBe(false);
+      expect(result.alias).toBe(null);
+      expect(result.namespaces).toEqual([]);
+    });
+
+    it('should handle file with only comments', () => {
+      const code = `
+        // This is a comment
+        /* This is another comment */
+      `;
+      const result = parseAndCheck(code);
+
+      expect(result.hasCompilerImport).toBe(false);
+      expect(result.alias).toBe(null);
+      expect(result.namespaces).toEqual([]);
+    });
+
+    it('should handle file with unrelated imports and requires', () => {
+      const code = `
+        import { something } from 'other-package';
+        const config = require('./config');
+        const fs = require('fs');
+      `;
+      const result = parseAndCheck(code);
+
+      expect(result.hasCompilerImport).toBe(false);
+      expect(result.alias).toBe(null);
+      expect(result.namespaces).toEqual([]);
+    });
+
+    it('should handle complex destructuring patterns', () => {
+      const code = `const { a: { b: { vite } } } = require('@generaltranslation/compiler');`;
+      const result = parseAndCheck(code);
+
+      // This is a nested destructuring pattern that the current implementation doesn't handle
+      expect(result.hasCompilerImport).toBe(false);
+      expect(result.alias).toBe(null);
+      expect(result.namespaces).toEqual([]);
+    });
+
+    it('should handle array destructuring (not handled by implementation)', () => {
+      const code = `const [vite] = require('@generaltranslation/compiler');`;
+      const result = parseAndCheck(code);
+
+      // Array destructuring is not handled by the current implementation
+      expect(result.hasCompilerImport).toBe(false);
+      expect(result.alias).toBe(null);
+      expect(result.namespaces).toEqual([]);
+    });
+
+    it('should handle computed property access', () => {
+      const code = `const compiler = require('@generaltranslation/compiler')['vite'];`;
+      const result = parseAndCheck(code);
+
+      // Computed property access is not handled by the current implementation
+      expect(result.hasCompilerImport).toBe(false);
+      expect(result.alias).toBe(null);
+      expect(result.namespaces).toEqual([]);
+    });
+
+    it('should handle dynamic requires (not detected)', () => {
+      const code = `const packageName = '@generaltranslation/compiler'; const gt = require(packageName);`;
+      const result = parseAndCheck(code);
+
+      // Dynamic requires are not handled
+      expect(result.hasCompilerImport).toBe(false);
+      expect(result.alias).toBe(null);
+      expect(result.namespaces).toEqual([]);
+    });
+  });
+
+  describe('Real-world scenarios', () => {
+    it('should handle typical Vite config with ESM imports', () => {
+      const code = `
+        import { defineConfig } from 'vite';
+        import react from '@vitejs/plugin-react';
+        import { vite as gtCompiler } from '@generaltranslation/compiler';
+
+        export default defineConfig({
+          plugins: [react(), gtCompiler()],
+        });
+      `;
+      const result = parseAndCheck(code);
+
+      expect(result.hasCompilerImport).toBe(true);
+      expect(result.alias).toBe('gtCompiler');
+      expect(result.namespaces).toEqual([]);
+    });
+
+    it('should handle CommonJS Vite config', () => {
+      const code = `
+        const { defineConfig } = require('vite');
+        const react = require('@vitejs/plugin-react');
+        const { vite: gtCompiler } = require('@generaltranslation/compiler');
+
+        module.exports = defineConfig({
+          plugins: [react(), gtCompiler()],
+        });
+      `;
+      const result = parseAndCheck(code);
+
+      expect(result.hasCompilerImport).toBe(true);
+      expect(result.alias).toBe('gtCompiler');
+      expect(result.namespaces).toEqual([]);
+    });
+
+    it('should handle mixed ESM/CommonJS (though unusual)', () => {
+      const code = `
+        import { defineConfig } from 'vite';
+        const { vite } = require('@generaltranslation/compiler');
+
+        export default defineConfig({
+          plugins: [vite()],
+        });
+      `;
+      const result = parseAndCheck(code);
+
+      expect(result.hasCompilerImport).toBe(true);
+      expect(result.alias).toBe('vite');
+      expect(result.namespaces).toEqual([]);
+    });
+  });
+});

--- a/packages/cli/src/react/parse/addVitePlugin/utils/__tests__/checkPluginInvocation.test.ts
+++ b/packages/cli/src/react/parse/addVitePlugin/utils/__tests__/checkPluginInvocation.test.ts
@@ -1,0 +1,685 @@
+import { describe, it, expect } from 'vitest';
+import { parse } from '@babel/parser';
+import { checkPluginInvocation } from '../checkPluginInvocation';
+
+describe('checkPluginInvocation', () => {
+  // Helper function to parse code and run checkPluginInvocation
+  function parseAndCheck(
+    code: string,
+    alias: string | null,
+    namespaces: string[] = []
+  ): boolean {
+    const ast = parse(code, {
+      sourceType: 'module',
+      plugins: ['typescript', 'jsx'],
+    });
+    return checkPluginInvocation({ ast, alias, namespaces });
+  }
+
+  describe('Direct alias invocation in default export', () => {
+    it('should detect direct alias invocation in simple export', () => {
+      const code = `
+        import { defineConfig } from 'vite';
+        import { vite as gtCompiler } from '@generaltranslation/compiler';
+        
+        export default defineConfig({
+          plugins: [gtCompiler()]
+        });
+      `;
+
+      const result = parseAndCheck(code, 'gtCompiler');
+      expect(result).toBe(true);
+    });
+
+    it('should detect direct alias invocation among multiple plugins', () => {
+      const code = `
+        import { defineConfig } from 'vite';
+        import react from '@vitejs/plugin-react';
+        import { vite as gtCompiler } from '@generaltranslation/compiler';
+        
+        export default defineConfig({
+          plugins: [react(), gtCompiler(), someOtherPlugin()]
+        });
+      `;
+
+      const result = parseAndCheck(code, 'gtCompiler');
+      expect(result).toBe(true);
+    });
+
+    it('should detect alias invocation with different alias names', () => {
+      const code = `
+        export default defineConfig({
+          plugins: [myCustomAlias()]
+        });
+      `;
+
+      const result = parseAndCheck(code, 'myCustomAlias');
+      expect(result).toBe(true);
+    });
+
+    it('should detect alias invocation in arrow function export', () => {
+      const code = `
+        export default () => defineConfig({
+          plugins: [gtCompiler()]
+        });
+      `;
+
+      const result = parseAndCheck(code, 'gtCompiler');
+      expect(result).toBe(true);
+    });
+
+    it('should detect alias invocation in complex export expression', () => {
+      const code = `
+        export default defineConfig({
+          plugins: [
+            ...basePlugins,
+            process.env.NODE_ENV === 'development' ? gtCompiler() : null,
+            ...otherPlugins
+          ].filter(Boolean)
+        });
+      `;
+
+      const result = parseAndCheck(code, 'gtCompiler');
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('Namespace member invocation in default export', () => {
+    it('should detect namespace member invocation', () => {
+      const code = `
+        const gt = require('@generaltranslation/compiler');
+        
+        export default defineConfig({
+          plugins: [gt.vite()]
+        });
+      `;
+
+      const result = parseAndCheck(code, '', ['gt']);
+      expect(result).toBe(true);
+    });
+
+    it('should detect namespace member invocation with import', () => {
+      const code = `
+        import * as gt from '@generaltranslation/compiler';
+        
+        export default defineConfig({
+          plugins: [gt.vite()]
+        });
+      `;
+
+      const result = parseAndCheck(code, '', ['gt']);
+      expect(result).toBe(true);
+    });
+
+    it('should detect namespace member invocation among multiple namespaces', () => {
+      const code = `
+        export default defineConfig({
+          plugins: [compiler.vite()]
+        });
+      `;
+
+      const result = parseAndCheck(code, '', ['gt', 'compiler', 'other']);
+      expect(result).toBe(true);
+    });
+
+    it('should detect default import namespace invocation', () => {
+      const code = `
+        import gtDefault from '@generaltranslation/compiler';
+        
+        export default defineConfig({
+          plugins: [gtDefault.vite()]
+        });
+      `;
+
+      const result = parseAndCheck(code, '', ['gtDefault']);
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('Mixed scenarios', () => {
+    it('should detect alias even when namespaces are also provided', () => {
+      const code = `
+        export default defineConfig({
+          plugins: [gtCompiler()]
+        });
+      `;
+
+      const result = parseAndCheck(code, 'gtCompiler', ['gt', 'other']);
+      expect(result).toBe(true);
+    });
+
+    it('should detect namespace member when alias is also provided', () => {
+      const code = `
+        export default defineConfig({
+          plugins: [gt.vite()]
+        });
+      `;
+
+      const result = parseAndCheck(code, 'someAlias', ['gt']);
+      expect(result).toBe(true);
+    });
+
+    it('should detect multiple invocations', () => {
+      const code = `
+        export default defineConfig({
+          plugins: [
+            gtCompiler(),
+            gt.vite(),
+            other.vite()
+          ]
+        });
+      `;
+
+      const result = parseAndCheck(code, 'gtCompiler', ['gt', 'other']);
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('Cases that should be detected anywhere in file', () => {
+    it('should detect invocation outside export statements', () => {
+      const code = `
+        const plugins = [gtCompiler()];
+        
+        export default defineConfig({
+          plugins: []
+        });
+      `;
+
+      const result = parseAndCheck(code, 'gtCompiler');
+      expect(result).toBe(true); // Now detects anywhere
+    });
+
+    it('should detect invocation in regular functions', () => {
+      const code = `
+        function createConfig() {
+          return defineConfig({
+            plugins: [gtCompiler()]
+          });
+        }
+        
+        export default createConfig();
+      `;
+
+      const result = parseAndCheck(code, 'gtCompiler');
+      expect(result).toBe(true); // Now detects anywhere
+    });
+
+    it('should detect invocation in named exports', () => {
+      const code = `
+        export const config = defineConfig({
+          plugins: [gtCompiler()]
+        });
+      `;
+
+      const result = parseAndCheck(code, 'gtCompiler');
+      expect(result).toBe(true); // Now detects anywhere
+    });
+
+    it('should detect invocation in variable assignments', () => {
+      const code = `
+        const myConfig = {
+          plugins: [gtCompiler()]
+        };
+      `;
+
+      const result = parseAndCheck(code, 'gtCompiler');
+      expect(result).toBe(true);
+    });
+
+    it('should detect invocation in conditional statements', () => {
+      const code = `
+        if (process.env.NODE_ENV === 'development') {
+          const plugin = gtCompiler();
+        }
+      `;
+
+      const result = parseAndCheck(code, 'gtCompiler');
+      expect(result).toBe(true);
+    });
+
+    it('should detect namespace invocation in any context', () => {
+      const code = `
+        function setupPlugins() {
+          const compiler = gt.vite();
+          return [compiler];
+        }
+      `;
+
+      const result = parseAndCheck(code, '', ['gt']);
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('Cases that should NOT be detected', () => {
+    it('should not detect wrong alias name', () => {
+      const code = `
+        export default defineConfig({
+          plugins: [wrongAlias()]
+        });
+      `;
+
+      const result = parseAndCheck(code, 'gtCompiler');
+      expect(result).toBe(false);
+    });
+
+    it('should not detect wrong namespace', () => {
+      const code = `
+        export default defineConfig({
+          plugins: [wrongNamespace.vite()]
+        });
+      `;
+
+      const result = parseAndCheck(code, '', ['gt', 'compiler']);
+      expect(result).toBe(false);
+    });
+
+    it('should not detect wrong method on correct namespace', () => {
+      const code = `
+        export default defineConfig({
+          plugins: [gt.wrongMethod()]
+        });
+      `;
+
+      const result = parseAndCheck(code, '', ['gt']);
+      expect(result).toBe(false);
+    });
+
+    it('should not detect non-call expressions', () => {
+      const code = `
+        export default defineConfig({
+          plugins: [gtCompiler]  // Missing () call
+        });
+      `;
+
+      const result = parseAndCheck(code, 'gtCompiler');
+      expect(result).toBe(false);
+    });
+
+    it('should not detect property access without method call', () => {
+      const code = `
+        export default defineConfig({
+          plugins: [gt.vite]  // Missing () call
+        });
+      `;
+
+      const result = parseAndCheck(code, '', ['gt']);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('should handle empty file', () => {
+      const code = '';
+      const result = parseAndCheck(code, 'gtCompiler');
+      expect(result).toBe(false);
+    });
+
+    it('should handle file with no plugin invocations', () => {
+      const code = `
+        import { vite as gtCompiler } from '@generaltranslation/compiler';
+        const config = defineConfig({
+          plugins: [react(), typescript()]
+        });
+      `;
+
+      const result = parseAndCheck(code, 'gtCompiler');
+      expect(result).toBe(false);
+    });
+
+    it('should handle empty default export', () => {
+      const code = 'export default {};';
+      const result = parseAndCheck(code, 'gtCompiler');
+      expect(result).toBe(false);
+    });
+
+    it('should detect invocations in nested objects', () => {
+      const code = `
+        export default {
+          nested: {
+            config: defineConfig({
+              plugins: [gtCompiler()]
+            })
+          }
+        };
+      `;
+
+      const result = parseAndCheck(code, 'gtCompiler');
+      expect(result).toBe(true); // Detects anywhere in the file
+    });
+
+    it('should handle empty alias and empty namespaces', () => {
+      const code = `
+        export default defineConfig({
+          plugins: [somePlugin()]
+        });
+      `;
+
+      const result = parseAndCheck(code, '', []);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('Real-world scenarios', () => {
+    it('should handle typical Vite config with ESM', () => {
+      const code = `
+        import { defineConfig } from 'vite';
+        import react from '@vitejs/plugin-react';
+        import { vite as gtCompiler } from '@generaltranslation/compiler';
+        
+        export default defineConfig({
+          plugins: [
+            react(),
+            gtCompiler({
+              apiKey: process.env.GT_API_KEY,
+              projectId: 'my-project'
+            })
+          ],
+          build: {
+            outDir: 'dist'
+          }
+        });
+      `;
+
+      const result = parseAndCheck(code, 'gtCompiler');
+      expect(result).toBe(true);
+    });
+
+    it('should handle CommonJS Vite config', () => {
+      const code = `
+        const { defineConfig } = require('vite');
+        const react = require('@vitejs/plugin-react');
+        const gt = require('@generaltranslation/compiler');
+        
+        module.exports = defineConfig({
+          plugins: [
+            react(),
+            gt.vite({
+              apiKey: process.env.GT_API_KEY
+            })
+          ]
+        });
+      `;
+
+      const result = parseAndCheck(code, '', ['gt']);
+      expect(result).toBe(true);
+    });
+
+    it('should handle conditional plugin loading', () => {
+      const code = `
+        import { defineConfig } from 'vite';
+        import { vite as gtCompiler } from '@generaltranslation/compiler';
+        
+        export default defineConfig({
+          plugins: [
+            ...(process.env.NODE_ENV === 'development' ? [gtCompiler()] : []),
+            ...(process.env.ENABLE_GT ? [gtCompiler({ debug: true })] : [])
+          ]
+        });
+      `;
+
+      const result = parseAndCheck(code, 'gtCompiler');
+      expect(result).toBe(true);
+    });
+
+    it('should handle Vite config as function', () => {
+      const code = `
+        import { defineConfig } from 'vite';
+        import { vite as gtCompiler } from '@generaltranslation/compiler';
+        
+        export default defineConfig(({ command, mode }) => ({
+          plugins: [
+            gtCompiler({
+              development: mode === 'development'
+            })
+          ]
+        }));
+      `;
+
+      const result = parseAndCheck(code, 'gtCompiler');
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('Additional comprehensive test cases', () => {
+    it('should detect alias invocation in array literals', () => {
+      const code = `
+        const pluginList = [react(), gtCompiler(), typescript()];
+      `;
+
+      const result = parseAndCheck(code, 'gtCompiler');
+      expect(result).toBe(true);
+    });
+
+    it('should detect namespace invocation in array literals', () => {
+      const code = `
+        const pluginList = [react(), compiler.vite(), typescript()];
+      `;
+
+      const result = parseAndCheck(code, '', ['compiler']);
+      expect(result).toBe(true);
+    });
+
+    it('should detect invocation in object method calls', () => {
+      const code = `
+        const config = {
+          setup() {
+            return gtCompiler();
+          }
+        };
+      `;
+
+      const result = parseAndCheck(code, 'gtCompiler');
+      expect(result).toBe(true);
+    });
+
+    it('should detect invocation in class methods', () => {
+      const code = `
+        class ConfigBuilder {
+          buildPlugins() {
+            return [gtCompiler()];
+          }
+        }
+      `;
+
+      const result = parseAndCheck(code, 'gtCompiler');
+      expect(result).toBe(true);
+    });
+
+    it('should detect invocation as function arguments', () => {
+      const code = `
+        setupVite(gtCompiler(), { dev: true });
+      `;
+
+      const result = parseAndCheck(code, 'gtCompiler');
+      expect(result).toBe(true);
+    });
+
+    it('should detect namespace invocation as function arguments', () => {
+      const code = `
+        setupVite(compiler.vite(), { dev: true });
+      `;
+
+      const result = parseAndCheck(code, '', ['compiler']);
+      expect(result).toBe(true);
+    });
+
+    it('should detect invocation in try-catch blocks', () => {
+      const code = `
+        try {
+          const plugin = gtCompiler();
+        } catch (e) {
+          console.error(e);
+        }
+      `;
+
+      const result = parseAndCheck(code, 'gtCompiler');
+      expect(result).toBe(true);
+    });
+
+    it('should detect invocation in async functions', () => {
+      const code = `
+        async function setupAsync() {
+          const plugin = await Promise.resolve(gtCompiler());
+          return plugin;
+        }
+      `;
+
+      const result = parseAndCheck(code, 'gtCompiler');
+      expect(result).toBe(true);
+    });
+
+    it('should detect invocation in arrow functions', () => {
+      const code = `
+        const getPlugin = () => gtCompiler();
+        const getAsyncPlugin = async () => gt.vite();
+      `;
+
+      const result1 = parseAndCheck(code, 'gtCompiler');
+      const result2 = parseAndCheck(code, '', ['gt']);
+      expect(result1).toBe(true);
+      expect(result2).toBe(true);
+    });
+
+    it('should detect invocation in template literals (within expressions)', () => {
+      const code = `
+        const message = \`Plugin loaded: \${gtCompiler().name}\`;
+      `;
+
+      const result = parseAndCheck(code, 'gtCompiler');
+      expect(result).toBe(true);
+    });
+
+    it('should detect invocation in switch statements', () => {
+      const code = `
+        function getPlugin(env) {
+          switch (env) {
+            case 'dev':
+              return gtCompiler();
+            default:
+              return null;
+          }
+        }
+      `;
+
+      const result = parseAndCheck(code, 'gtCompiler');
+      expect(result).toBe(true);
+    });
+
+    it('should detect invocation in for loops', () => {
+      const code = `
+        for (let i = 0; i < 5; i++) {
+          plugins.push(gtCompiler());
+        }
+      `;
+
+      const result = parseAndCheck(code, 'gtCompiler');
+      expect(result).toBe(true);
+    });
+
+    it('should detect invocation in while loops', () => {
+      const code = `
+        while (condition) {
+          const plugin = gt.vite();
+          process(plugin);
+        }
+      `;
+
+      const result = parseAndCheck(code, '', ['gt']);
+      expect(result).toBe(true);
+    });
+
+    it('should not detect similar but different method names', () => {
+      const code = `
+        compiler.build(); // Not vite()
+        compiler.dev();   // Not vite()
+        gt.compile();     // Not vite()
+      `;
+
+      const result = parseAndCheck(code, '', ['compiler', 'gt']);
+      expect(result).toBe(false);
+    });
+
+    it('should not detect when namespace matches but method is different', () => {
+      const code = `
+        gt.compile();
+        gt.build();
+        gt.setup();
+      `;
+
+      const result = parseAndCheck(code, '', ['gt']);
+      expect(result).toBe(false);
+    });
+
+    it('should handle multiple aliases in same file', () => {
+      const code = `
+        const plugin1 = gtCompiler();
+        const plugin2 = myCompiler();
+        const plugin3 = customCompiler();
+      `;
+
+      const result1 = parseAndCheck(code, 'gtCompiler');
+      const result2 = parseAndCheck(code, 'myCompiler');
+      const result3 = parseAndCheck(code, 'customCompiler');
+      const result4 = parseAndCheck(code, 'nonExistent');
+
+      expect(result1).toBe(true);
+      expect(result2).toBe(true);
+      expect(result3).toBe(true);
+      expect(result4).toBe(false);
+    });
+
+    it('should handle multiple namespaces in same file', () => {
+      const code = `
+        const plugin1 = gt.vite();
+        const plugin2 = compiler.build(); // Not vite
+        const plugin3 = other.vite();
+      `;
+
+      const result1 = parseAndCheck(code, '', ['gt']);
+      const result2 = parseAndCheck(code, '', ['compiler']);
+      const result3 = parseAndCheck(code, '', ['other']);
+      const result4 = parseAndCheck(code, '', ['nonExistent']);
+
+      expect(result1).toBe(true);
+      expect(result2).toBe(false); // compiler.build() not compiler.vite()
+      expect(result3).toBe(true);
+      expect(result4).toBe(false);
+    });
+
+    it('should detect invocation in complex nested expressions', () => {
+      const code = `
+        const result = someFunction(
+          anotherFunction({
+            plugins: [
+              ...basePlugins,
+              process.env.NODE_ENV === 'development' 
+                ? gtCompiler({ debug: true })
+                : null
+            ].filter(Boolean)
+          })
+        );
+      `;
+
+      const result = parseAndCheck(code, 'gtCompiler');
+      expect(result).toBe(true);
+    });
+
+    it('should handle null alias with empty namespaces', () => {
+      const code = `
+        const plugin = somePlugin();
+      `;
+
+      const result = parseAndCheck(code, null, []);
+      expect(result).toBe(false);
+    });
+
+    it('should handle null alias but valid namespace', () => {
+      const code = `
+        const plugin = gt.vite();
+      `;
+
+      const result = parseAndCheck(code, null, ['gt']);
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/packages/cli/src/react/parse/addVitePlugin/utils/addCompilerImport.ts
+++ b/packages/cli/src/react/parse/addVitePlugin/utils/addCompilerImport.ts
@@ -1,0 +1,52 @@
+import { ParseResult } from '@babel/parser';
+import * as t from '@babel/types';
+
+/**
+ * Given the vite config file ast, inserts the import declaration for the @generaltranslation/compiler package
+ */
+export function addCompilerImport({
+  ast,
+  cjsEnabled,
+}: {
+  ast: ParseResult<t.File>;
+  cjsEnabled: boolean;
+}) {
+  if (cjsEnabled) {
+    handleCjsImport(ast);
+  } else {
+    handleEsmImport(ast);
+  }
+}
+
+/**
+ * Adds a CJS import declaration for the @generaltranslation/compiler package
+ * @param ast - The ast of the file
+ * const gtCompiler = require('@generaltranslation/compiler').vite;
+ */
+function handleCjsImport(ast: ParseResult<t.File>) {
+  const variableDeclaration = t.variableDeclaration('const', [
+    t.variableDeclarator(
+      t.identifier('gtCompiler'),
+      t.memberExpression(
+        t.callExpression(t.identifier('require'), [
+          t.stringLiteral('@generaltranslation/compiler'),
+        ]),
+        t.identifier('vite')
+      )
+    ),
+  ]);
+  ast.program.body.unshift(variableDeclaration);
+}
+
+/**
+ * Adds an ESM import declaration for the @generaltranslation/compiler package
+ * @param ast - The ast of the file
+ * import { vite as gtCompiler } from '@generaltranslation/compiler';
+ */
+function handleEsmImport(ast: ParseResult<t.File>) {
+  const importDeclaration = t.importDeclaration(
+    [t.importSpecifier(t.identifier('gtCompiler'), t.identifier('vite'))],
+    t.stringLiteral('@generaltranslation/compiler')
+  );
+  ast.program.body.unshift(importDeclaration);
+}

--- a/packages/cli/src/react/parse/addVitePlugin/utils/addPluginInvocation.ts
+++ b/packages/cli/src/react/parse/addVitePlugin/utils/addPluginInvocation.ts
@@ -39,8 +39,8 @@ export function addPluginInvocation({
         return;
       }
       for (const property of path.node.arguments[0].properties) {
-        if (!t.isObjectProperty(property)) continue;
-        if (!isPluginsProperty(property)) return;
+        if (!t.isObjectProperty(property) || !isPluginsProperty(property))
+          continue;
         if (t.isArrayExpression(property.value)) {
           // Add to array: [react()] -> [react(), gtCompiler()]
           property.value.elements.push(pluginInvocation);

--- a/packages/cli/src/react/parse/addVitePlugin/utils/addPluginInvocation.ts
+++ b/packages/cli/src/react/parse/addVitePlugin/utils/addPluginInvocation.ts
@@ -1,0 +1,67 @@
+import * as t from '@babel/types';
+import { ParseResult } from '@babel/parser';
+import traverseModule from '@babel/traverse';
+
+// Handle CommonJS/ESM interop
+const traverse = traverseModule.default || traverseModule;
+
+/**
+ * Adds the plugin invocation to the vite config file
+ * Naive solution: look for an object with a plugins property only inside of a defineConfig call
+ */
+export function addPluginInvocation({
+  ast,
+  alias,
+  namespaces,
+}: {
+  ast: ParseResult<t.File>;
+  alias: string | null;
+  namespaces: string[];
+}): boolean {
+  let addedPlugin = false;
+  if (namespaces.length === 0 && !alias) {
+    return false;
+  }
+  const pluginInvocation = alias
+    ? t.callExpression(t.identifier(alias), [])
+    : t.callExpression(
+        t.memberExpression(t.identifier(namespaces[0]), t.identifier('vite')),
+        []
+      );
+
+  traverse(ast, {
+    CallExpression(path) {
+      if (
+        !t.isIdentifier(path.node.callee, { name: 'defineConfig' }) ||
+        !path.node.arguments.length ||
+        !t.isObjectExpression(path.node.arguments[0])
+      ) {
+        return;
+      }
+      for (const property of path.node.arguments[0].properties) {
+        if (!t.isObjectProperty(property)) continue;
+        if (!isPluginsProperty(property)) return;
+        if (t.isArrayExpression(property.value)) {
+          // Add to array: [react()] -> [react(), gtCompiler()]
+          property.value.elements.push(pluginInvocation);
+          addedPlugin = true;
+        } else {
+          // Spread the array: someList -> [...someList, gtCompiler()]
+          property.value = t.arrayExpression([
+            t.spreadElement(property.value as t.Expression),
+            pluginInvocation,
+          ]);
+          addedPlugin = true;
+        }
+      }
+    },
+  });
+  return addedPlugin;
+}
+
+function isPluginsProperty(node: t.ObjectProperty) {
+  return (
+    t.isIdentifier(node.key, { name: 'plugins' }) ||
+    t.isStringLiteral(node.key, { value: 'plugins' })
+  );
+}

--- a/packages/cli/src/react/parse/addVitePlugin/utils/checkCompilerImport.ts
+++ b/packages/cli/src/react/parse/addVitePlugin/utils/checkCompilerImport.ts
@@ -1,0 +1,134 @@
+import { ParseResult } from '@babel/parser';
+import * as t from '@babel/types';
+import traverseModule from '@babel/traverse';
+
+// Handle CommonJS/ESM interop
+const traverse = traverseModule.default || traverseModule;
+
+export interface CheckCompilerImportResult {
+  hasCompilerImport: boolean;
+  alias: string | null;
+  namespaces: string[];
+}
+
+/**
+ * Given the vite config file ast, checks if the @generaltranslation/compiler package is imported.
+ * If it is imported, capture any aliases or namespace.
+ *
+ * Does not handle:
+ * - Nested expressions
+ */
+export function checkCompilerImport(
+  ast: ParseResult<t.File>
+): CheckCompilerImportResult {
+  const result: CheckCompilerImportResult = {
+    hasCompilerImport: false,
+    alias: null,
+    namespaces: [],
+  };
+  traverse(ast, {
+    ImportDeclaration(path) {
+      handleImportDeclaration(path, result);
+    },
+    VariableDeclaration(path) {
+      handleVariableDeclaration(path, result);
+    },
+  });
+  return result;
+}
+
+/* =============================== */
+/* Parsing Functions */
+/* =============================== */
+
+/**
+ * Checks an import declaration for a compiler import
+ * @param path - The import declaration path
+ * @param result - The result object
+ */
+function handleImportDeclaration(
+  path: traverseModule.NodePath<t.ImportDeclaration>,
+  result: CheckCompilerImportResult
+) {
+  if (path.node.source.value !== '@generaltranslation/compiler') return;
+  for (const spec of path.node.specifiers) {
+    if (t.isImportSpecifier(spec)) {
+      // Handle named import: import { vite as gtCompiler } from '@generaltranslation/compiler'
+      if (t.isIdentifier(spec.imported) && spec.imported.name === 'vite') {
+        result.hasCompilerImport = true;
+        result.alias = spec.local.name;
+      }
+    } else {
+      // Handle default import: import gtCompiler from '@generaltranslation/compiler'
+      // Handle namespace import: import * as gtCompiler from '@generaltranslation/compiler'
+      result.hasCompilerImport = true;
+      result.namespaces.push(spec.local.name);
+    }
+  }
+}
+
+/**
+ * Handles a variable declaration for a compiler import
+ * @param path - The variable declaration path
+ * @param result - The result object
+ */
+function handleVariableDeclaration(
+  path: traverseModule.NodePath<t.VariableDeclaration>,
+  result: CheckCompilerImportResult
+) {
+  path.node.declarations.forEach((dec) => {
+    // Handle destructuring: const { withGTConfig } = require('@generaltranslation/compiler')
+    if (
+      t.isCallExpression(dec.init) &&
+      t.isIdentifier(dec.init.callee, { name: 'require' }) &&
+      t.isStringLiteral(dec.init.arguments[0], {
+        value: '@generaltranslation/compiler',
+      })
+    ) {
+      if (t.isIdentifier(dec.id)) {
+        // Handle namespace assignment: const gtCompiler = require('@generaltranslation/compiler')
+        result.hasCompilerImport = true;
+        result.namespaces.push(dec.id.name);
+      } else if (t.isObjectPattern(dec.id)) {
+        // Handle destructuring: const { vite: gtCompiler } = require('@generaltranslation/compiler')
+        let foundVite = false;
+        const restElements: string[] = [];
+        for (const prop of dec.id.properties) {
+          if (
+            t.isObjectProperty(prop) &&
+            t.isIdentifier(prop.key) &&
+            t.isIdentifier(prop.value) &&
+            prop.key.name === 'vite'
+          ) {
+            // Handle destructing alias assignment: const { vite: gtCompiler } = require('@generaltranslation/compiler')
+            result.hasCompilerImport = true;
+            result.alias = prop.value.name;
+            foundVite = true;
+            break;
+          } else if (t.isRestElement(prop) && t.isIdentifier(prop.argument)) {
+            // Track list of rest elements
+            restElements.push(prop.argument.name);
+          }
+        }
+        // Handle destructuring rest elements: const { ...some, b, ...others, d } = require('@generaltranslation/compiler')
+        if (!foundVite && restElements.length > 0) {
+          result.hasCompilerImport = true;
+          result.namespaces.push(...restElements);
+        }
+      }
+    } else if (
+      t.isMemberExpression(dec.init) &&
+      t.isCallExpression(dec.init.object) &&
+      t.isIdentifier(dec.init.object.callee, { name: 'require' }) &&
+      t.isStringLiteral(dec.init.object.arguments[0], {
+        value: '@generaltranslation/compiler',
+      }) &&
+      t.isIdentifier(dec.init.property, { name: 'vite' }) &&
+      t.isIdentifier(dec.id)
+    ) {
+      // Handle member access: const gtCompiler = require('@generaltranslation/compiler').vite
+      result.hasCompilerImport = true;
+      result.alias = dec.id.name;
+    }
+  });
+}

--- a/packages/cli/src/react/parse/addVitePlugin/utils/checkPluginInvocation.ts
+++ b/packages/cli/src/react/parse/addVitePlugin/utils/checkPluginInvocation.ts
@@ -1,0 +1,44 @@
+import { ParseResult } from '@babel/parser';
+import * as t from '@babel/types';
+import traverseModule from '@babel/traverse';
+
+// Handle CommonJS/ESM interop
+const traverse = traverseModule.default || traverseModule;
+
+/**
+ * Checks if the given AST is exporting the gtCompiler plugin
+ *
+ * Naive check: see if the plugin has been invoked anywhere in the file
+ */
+export function checkPluginInvocation({
+  ast,
+  alias,
+  namespaces,
+}: {
+  ast: ParseResult<t.File>;
+  alias: string | null;
+  namespaces: string[];
+}) {
+  let result = false;
+  traverse(ast, {
+    CallExpression(path) {
+      // Handle: gtCompiler()
+      if (!alias) return;
+      if (t.isIdentifier(path.node.callee, { name: alias })) {
+        result = true;
+      }
+    },
+    MemberExpression(path) {
+      // Handle: gtCompiler.vite()
+      if (
+        t.isIdentifier(path.node.object) &&
+        namespaces.includes(path.node.object.name) &&
+        t.isCallExpression(path.parent) &&
+        t.isIdentifier(path.node.property, { name: 'vite' })
+      ) {
+        result = true;
+      }
+    },
+  });
+  return result;
+}

--- a/packages/cli/src/utils/parse/needsCJS.ts
+++ b/packages/cli/src/utils/parse/needsCJS.ts
@@ -1,0 +1,88 @@
+import { ParseResult } from '@babel/parser';
+import traverseModule from '@babel/traverse';
+import * as t from '@babel/types';
+
+// Handle CommonJS/ESM interop
+const traverse = traverseModule.default || traverseModule;
+
+/**
+ * Given an AST determines if the file needs to be compiled as CommonJS or ESM.
+ * @param ast - The AST to analyze
+ * @returns True if the file needs to be compiled as CommonJS, false if it needs to be compiled as ESM
+ */
+export function needsCJS({
+  ast,
+  warnings,
+  filepath,
+  packageJson,
+  tsconfigJson,
+}: {
+  ast: ParseResult<t.File>;
+  warnings: string[];
+  filepath: string;
+  packageJson?: { type?: string };
+  tsconfigJson?: { compilerOptions?: { module?: string } };
+}) {
+  // Analyze the actual file content to determine module system
+  let hasES6Imports = false;
+  let hasCommonJSRequire = false;
+
+  traverse(ast, {
+    ImportDeclaration() {
+      hasES6Imports = true;
+    },
+    CallExpression(path) {
+      if (t.isIdentifier(path.node.callee, { name: 'require' })) {
+        hasCommonJSRequire = true;
+      }
+    },
+  });
+
+  // Determine if we need CommonJS based on actual file content and fallback to config-based logic
+  let needsCJS = false;
+
+  if (hasES6Imports && !hasCommonJSRequire) {
+    // File uses ES6 imports, so we should use ES6 imports
+    needsCJS = false;
+  } else if (hasCommonJSRequire && !hasES6Imports) {
+    // File uses CommonJS require, so we should use CommonJS require
+    needsCJS = true;
+  } else if (hasES6Imports && hasCommonJSRequire) {
+    // Mixed usage - this is unusual but we'll default to ES6 imports
+    warnings.push(
+      `Mixed ES6 imports and CommonJS require detected in ${filepath}. Defaulting to ES6 imports.`
+    );
+    needsCJS = false;
+  } else {
+    // No imports/requires found, fall back to configuration-based logic
+    if (filepath.endsWith('.ts') || filepath.endsWith('.tsx')) {
+      // For TypeScript files, check tsconfig.json compilerOptions.module
+      const moduleSetting = tsconfigJson?.compilerOptions?.module;
+      if (moduleSetting === 'commonjs' || moduleSetting === 'node') {
+        needsCJS = true;
+      } else if (
+        moduleSetting === 'esnext' ||
+        moduleSetting === 'es2022' ||
+        moduleSetting === 'es2020' ||
+        moduleSetting === 'es2015' ||
+        moduleSetting === 'es6' ||
+        moduleSetting === 'node16' ||
+        moduleSetting === 'nodenext'
+      ) {
+        needsCJS = false;
+      } else {
+        // Default to ESM for TypeScript files if no module setting is specified
+        needsCJS = false;
+      }
+    } else if (filepath.endsWith('.js')) {
+      // For JavaScript files, check package.json type
+      // If package.json has "type": "module", .js files are treated as ES modules
+      needsCJS = packageJson?.type !== 'module';
+    } else {
+      // For other file extensions, default to ESM
+      needsCJS = false;
+    }
+  }
+
+  return needsCJS;
+}

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -15,8 +15,6 @@ import { processVariableDeclarator as processVariableDeclaratorFirstPass } from 
 import { processVariableDeclarator as processVariableDeclaratorSecondPass } from './processing/second-pass/processVariableDeclarator';
 import { InvalidLibraryUsageError } from './passes/handleErrors';
 import { initializeState } from './state/utils/initializeState';
-import path from 'path';
-import fs from 'fs';
 
 /**
  *


### PR DESCRIPTION
adds the gt compiler plugin to a default vite config file:
```ts title="vite.config.ts"
import { vite as gtCompiler } from "@generaltranslation/compiler";
import { defineConfig } from "vite";
import react from "@vitejs/plugin-react";

// https://vite.dev/config/
export default defineConfig({
  plugins: [
    react(),
    gtCompiler(),
  ],
});
```