### PR TITLE
feat: feature flag support for gt-react

### DIFF
--- a/.changeset/yummy-cloths-win.md
+++ b/.changeset/yummy-cloths-win.md
@@ -1,0 +1,6 @@
+---
+'@generaltranslation/react-core': minor
+'gt-react': minor
+---
+
+feat: enable i18n feature flag for gt-react

--- a/packages/react-core/src/internal.ts
+++ b/packages/react-core/src/internal.ts
@@ -19,6 +19,7 @@ import renderSkeleton from './rendering/renderSkeleton';
 import {
   defaultLocaleCookieName,
   defaultRegionCookieName,
+  defaultEnableI18nCookieName,
 } from './utils/cookies';
 import mergeDictionaries from './dictionaries/mergeDictionaries';
 import { reactHasUse } from './promises/reactHasUse';
@@ -50,6 +51,7 @@ export {
   getDefaultRenderSettings,
   defaultLocaleCookieName,
   defaultRegionCookieName,
+  defaultEnableI18nCookieName,
   mergeDictionaries,
   reactHasUse,
   getSubtree,

--- a/packages/react-core/src/provider/GTProvider.tsx
+++ b/packages/react-core/src/provider/GTProvider.tsx
@@ -12,6 +12,7 @@ import useCreateInternalUseTranslationsFunction from './hooks/translation/useCre
 import {
   defaultLocaleCookieName,
   defaultRegionCookieName,
+  defaultEnableI18nCookieName,
 } from '../utils/cookies';
 import { InternalGTProviderProps } from '../types-dir/config';
 import { useLocaleState } from './hooks/locales/useLocaleState';
@@ -20,34 +21,14 @@ import { GT, resolveAliasLocale } from 'generaltranslation';
 import { useLoadDictionary } from './hooks/useLoadDictionary';
 import { useLoadTranslations } from './hooks/useLoadTranslations';
 import { useCreateInternalUseTranslationsObjFunction } from './hooks/translation/useCreateInternalUseTranslationsObjFunction';
+import { useEnableI18n as _useEnableI18n } from './hooks/useEnableI18n';
 
 // Deprecated functions, will be removed in a future version
 import { readAuthFromEnv as _readAuthFromEnv } from '../utils/utils';
 import { isSSREnabled } from './helpers/isSSREnabled';
 import { useDetermineLocale as _useDetermineLocale } from './hooks/locales/useDetermineLocale';
 import { useRegionState as _useRegionState } from './hooks/useRegionState';
-/**
- * Provides General Translation context to its children, which can then access `useGT`, `useLocale`, and `useDefaultLocale`.
- *
- * @param {React.ReactNode} children - The children components that will use the translation context.
- * @param {string} [projectId] - The project ID required for General Translation cloud services.
- * @param {Dictionary} [dictionary=defaultDictionary] - The translation dictionary for the project.
- * @param {string[]} [locales] - The list of approved locales for the project.
- * @param {string} [defaultLocale=libraryDefaultLocale] - The default locale to use if no other locale is found.
- * @param {string} [locale] - The current locale, if already set.
- * @param {string} [cacheUrl='https://cdn.gtx.dev'] - The URL of the cache service for fetching translations.
- * @param {string} [runtimeUrl='https://runtime.gtx.dev'] - The URL of the runtime service for fetching translations.
- * @param {RenderSettings} [renderSettings=defaultRenderSettings] - The settings for rendering translations.
- * @param {string} [_versionId] - The version ID for fetching translations.
- * @param {string} [devApiKey] - The API key for development environments.
- * @param {object} [metadata] - Additional metadata to pass to the context.
- * @param {boolean} [ssr=isSSREnabled()] - Whether to enable server-side rendering.
- * @param {string} [localeCookieName=defaultLocaleCookieName] - The name of the cookie to store the locale.
- * @param {Translations | null} [translations=null] - The translations to use for the context.
- * @param {React.ReactNode} [fallback = undefined] - Custom fallback to display while loading
- *
- * @returns {JSX.Element} The provider component for General Translation context.
- */
+
 export default function GTProvider({
   children,
   config,
@@ -71,6 +52,11 @@ export default function GTProvider({
   fallback = undefined,
   translations: _translations = null,
   customMapping = config?.customMapping,
+  enableI18n: _enableI18n = config?.enableI18n !== undefined
+    ? config.enableI18n
+    : true,
+  enableI18nLoaded,
+  useEnableI18n = _useEnableI18n,
   readAuthFromEnv = _readAuthFromEnv,
   useDetermineLocale = _useDetermineLocale,
   useRegionState = _useRegionState,
@@ -85,6 +71,14 @@ export default function GTProvider({
   const { projectId, devApiKey } = readAuthFromEnv({
     projectId: _projectId,
     devApiKey: _devApiKey,
+  });
+
+  // Enable I18n feature flags
+  const { enableI18n } = useEnableI18n({
+    enableI18n: _enableI18n,
+    enableI18nLoaded,
+    enableI18nCookieName: defaultEnableI18nCookieName,
+    ssr,
   });
 
   // Get locale data including
@@ -107,6 +101,7 @@ export default function GTProvider({
     localeCookieName,
     customMapping,
     useDetermineLocale,
+    enableI18n,
   });
 
   // Define the region instance

--- a/packages/react-core/src/provider/hooks/locales/types.ts
+++ b/packages/react-core/src/provider/hooks/locales/types.ts
@@ -3,6 +3,7 @@ import { CustomMapping } from 'generaltranslation/types';
 export type UseDetermineLocaleParams = {
   defaultLocale: string;
   locales: string[];
+  enableI18n: boolean;
   locale?: string;
   localeCookieName?: string;
   ssr?: boolean;

--- a/packages/react-core/src/provider/hooks/locales/useLocaleState.ts
+++ b/packages/react-core/src/provider/hooks/locales/useLocaleState.ts
@@ -19,6 +19,7 @@ export function useLocaleState({
   localeCookieName,
   customMapping,
   useDetermineLocale,
+  enableI18n,
 }: {
   _locale: string;
   defaultLocale: string;
@@ -26,14 +27,17 @@ export function useLocaleState({
   ssr: boolean;
   localeCookieName: string;
   customMapping?: CustomMapping;
+  enableI18n: boolean;
   useDetermineLocale: (
     params: UseDetermineLocaleParams
   ) => UseDetermineLocaleReturn;
 }) {
   // Locale standardization
   const locales = useMemo(() => {
-    return Array.from(new Set([defaultLocale, ..._locales]));
-  }, [defaultLocale, _locales]);
+    return Array.from(
+      new Set([defaultLocale, ...(enableI18n ? _locales : [])])
+    );
+  }, [defaultLocale, _locales, enableI18n]);
 
   const [locale, setLocale] = useDetermineLocale({
     locale: _locale,
@@ -42,6 +46,7 @@ export function useLocaleState({
     ssr,
     localeCookieName,
     customMapping,
+    enableI18n,
   });
 
   const [translationRequired, dialectTranslationRequired] = useMemo(() => {

--- a/packages/react-core/src/provider/hooks/types.ts
+++ b/packages/react-core/src/provider/hooks/types.ts
@@ -1,3 +1,4 @@
+// Region
 export type UseRegionStateParams = {
   _region: string | undefined;
   ssr: boolean;
@@ -7,4 +8,16 @@ export type UseRegionStateParams = {
 export type UseRegionStateReturn = {
   region: string | undefined;
   setRegion: (region: string | undefined) => void;
+};
+
+// Enable I18n
+export type UseEnableI18nParams = {
+  enableI18n: boolean;
+  enableI18nCookieName: string;
+  enableI18nLoaded?: boolean;
+  ssr: boolean;
+};
+
+export type UseEnableI18nReturn = {
+  enableI18n: boolean;
 };

--- a/packages/react-core/src/provider/hooks/useEnableI18n.ts
+++ b/packages/react-core/src/provider/hooks/useEnableI18n.ts
@@ -1,0 +1,10 @@
+import { useState } from 'react';
+import { UseEnableI18nParams, UseEnableI18nReturn } from './types';
+
+// Fallback behavior for useEnableI18n
+export function useEnableI18n({
+  enableI18n: _enableI18n,
+}: UseEnableI18nParams): UseEnableI18nReturn {
+  const [enableI18n] = useState(_enableI18n);
+  return { enableI18n };
+}

--- a/packages/react-core/src/types-dir/config.ts
+++ b/packages/react-core/src/types-dir/config.ts
@@ -82,6 +82,6 @@ export type InternalGTProviderProps = {
     params: UseDetermineLocaleParams
   ) => UseDetermineLocaleReturn;
   useRegionState: (params: UseRegionStateParams) => UseRegionStateReturn;
-  useEnableI18n: (params: UseEnableI18nParams) => UseEnableI18nReturn;
+  useEnableI18n?: (params: UseEnableI18nParams) => UseEnableI18nReturn;
   [key: string]: any;
 };

--- a/packages/react-core/src/types-dir/config.ts
+++ b/packages/react-core/src/types-dir/config.ts
@@ -43,8 +43,6 @@ export type GTConfig = {
   customMapping?: CustomMapping;
   modelProvider?: string;
   enableI18n?: boolean;
-  defaultEnableI18nValue?: boolean | undefined; // default val while enableI18n flag is loaded asynchronously
-  enableI18nCookieMaxAge?: number;
 };
 
 export type InternalGTProviderProps = {

--- a/packages/react-core/src/types-dir/config.ts
+++ b/packages/react-core/src/types-dir/config.ts
@@ -12,7 +12,17 @@ import {
 import {
   UseRegionStateParams,
   UseRegionStateReturn,
+  UseEnableI18nParams,
+  UseEnableI18nReturn,
 } from '../provider/hooks/types';
+
+// Configuration for the enableI18n feature flag
+export type EnableI18nConfig = {
+  /** Persist the feature flag as a cookie @default false (use when loading flag asynchronously) */
+  persist?: boolean;
+  /** Name of cookie @default defaultEnableI18nCookieName */
+  cookieName?: string;
+};
 
 // Type definition for the config object passed to the GTProvider
 export type GTConfig = {
@@ -32,6 +42,9 @@ export type GTConfig = {
   localeCookieName?: string;
   customMapping?: CustomMapping;
   modelProvider?: string;
+  enableI18n?: boolean;
+  defaultEnableI18nValue?: boolean | undefined; // default val while enableI18n flag is loaded asynchronously
+  enableI18nCookieMaxAge?: number;
 };
 
 export type InternalGTProviderProps = {
@@ -60,10 +73,15 @@ export type InternalGTProviderProps = {
   customMapping?: CustomMapping;
   modelProvider?: string;
   environment: 'development' | 'production' | 'test';
+  /* flag to enable i18n, true by default */
+  enableI18n?: boolean;
+  /** Flag to indicate if the enableI18n flag is finished loading asynchronously */
+  enableI18nLoaded?: boolean;
   readAuthFromEnv: (params: AuthFromEnvParams) => AuthFromEnvReturn;
   useDetermineLocale: (
     params: UseDetermineLocaleParams
   ) => UseDetermineLocaleReturn;
   useRegionState: (params: UseRegionStateParams) => UseRegionStateReturn;
+  useEnableI18n: (params: UseEnableI18nParams) => UseEnableI18nReturn;
   [key: string]: any;
 };

--- a/packages/react-core/src/types.ts
+++ b/packages/react-core/src/types.ts
@@ -30,6 +30,8 @@ import {
 import {
   UseRegionStateParams,
   UseRegionStateReturn,
+  UseEnableI18nParams,
+  UseEnableI18nReturn,
 } from './provider/hooks/types';
 import { LocaleSelectorProps, RegionSelectorProps } from './ui/types';
 
@@ -70,5 +72,7 @@ export {
   UseDetermineLocaleReturn,
   UseRegionStateParams,
   UseRegionStateReturn,
+  UseEnableI18nParams,
+  UseEnableI18nReturn,
   GTConfig,
 };

--- a/packages/react-core/src/utils/cookies.ts
+++ b/packages/react-core/src/utils/cookies.ts
@@ -10,4 +10,4 @@ export const defaultRegionCookieName = 'generaltranslation.region';
  * Cookie name for persisting the enableI18n feature flag
  * "true" or "false"
  */
-export const defaultEnableI18nCookieName = 'generaltranslation.enableI18n';
+export const defaultEnableI18nCookieName = 'generaltranslation.enable-i18n';

--- a/packages/react-core/src/utils/cookies.ts
+++ b/packages/react-core/src/utils/cookies.ts
@@ -6,3 +6,8 @@ export const defaultLocaleCookieName = 'generaltranslation.locale';
  * Cookie name for tracking the user's selected region
  */
 export const defaultRegionCookieName = 'generaltranslation.region';
+/**
+ * Cookie name for persisting the enableI18n feature flag
+ * "true" or "false"
+ */
+export const defaultEnableI18nCookieName = 'generaltranslation.enableI18n';

--- a/packages/react/src/provider/GTProvider.tsx
+++ b/packages/react/src/provider/GTProvider.tsx
@@ -1,11 +1,36 @@
 import { GTProvider as _GTProvider } from '@generaltranslation/react-core';
 import { readAuthFromEnv } from '../utils/utils';
 import { useRegionState } from './hooks/useRegionState';
+import { useEnableI18n } from './hooks/useEnableI18n';
 import { useDetermineLocale } from './hooks/locales/useDetermineLocale';
 import { isSSREnabled } from './helpers/isSSREnabled';
 import { GTProviderProps } from '../types/config';
 import React from 'react';
 
+/**
+ * Provides General Translation context to its children, which can then access `useGT`, `useLocale`, and `useDefaultLocale`.
+ *
+ * @param {React.ReactNode} children - The children components that will use the translation context.
+ * @param {string} [projectId] - The project ID required for General Translation cloud services.
+ * @param {Dictionary} [dictionary=defaultDictionary] - The translation dictionary for the project.
+ * @param {string[]} [locales] - The list of approved locales for the project.
+ * @param {string} [defaultLocale=libraryDefaultLocale] - The default locale to use if no other locale is found.
+ * @param {string} [locale] - The current locale, if already set.
+ * @param {string} [cacheUrl='https://cdn.gtx.dev'] - The URL of the cache service for fetching translations.
+ * @param {string} [runtimeUrl='https://runtime.gtx.dev'] - The URL of the runtime service for fetching translations.
+ * @param {RenderSettings} [renderSettings=defaultRenderSettings] - The settings for rendering translations.
+ * @param {string} [_versionId] - The version ID for fetching translations.
+ * @param {string} [devApiKey] - The API key for development environments.
+ * @param {object} [metadata] - Additional metadata to pass to the context.
+ * @param {boolean} [ssr=isSSREnabled()] - Whether to enable server-side rendering.
+ * @param {string} [localeCookieName=defaultLocaleCookieName] - The name of the cookie to store the locale.
+ * @param {boolean} [enableI18n=true] - Whether to enable i18n.
+ * @param {boolean|undefined} [enableI18nLoaded=undefined] - Flag to indicate if the enableI18n flag is finished loading asynchronously. Undefined means flag is loaded synchronously.
+ * @param {Translations | null} [translations=null] - The translations to use for the context.
+ * @param {React.ReactNode} [fallback = undefined] - Custom fallback to display while loading
+ *
+ * @returns {JSX.Element} The provider component for General Translation context.
+ */
 export function GTProvider(props: GTProviderProps): React.JSX.Element {
   return (
     <_GTProvider
@@ -17,6 +42,7 @@ export function GTProvider(props: GTProviderProps): React.JSX.Element {
       readAuthFromEnv={readAuthFromEnv}
       useDetermineLocale={useDetermineLocale}
       useRegionState={useRegionState}
+      useEnableI18n={useEnableI18n}
     />
   );
 }

--- a/packages/react/src/provider/hooks/useEnableI18n.ts
+++ b/packages/react/src/provider/hooks/useEnableI18n.ts
@@ -1,0 +1,143 @@
+import { useEffect, useState, useRef } from 'react';
+import {
+  UseEnableI18nParams,
+  UseEnableI18nReturn,
+} from '@generaltranslation/react-core/types';
+
+/**
+ * Sync: no cookie
+ * Async: listen to cookie, until promise resolves
+ *
+ * Unfortunately, when dealing with SSR and an async enableI18n flag, there is no way to avoid a flicker of the default locale
+ * @returns enableI18n flag
+ */
+export function useEnableI18n({
+  enableI18n: _enableI18n,
+  enableI18nCookieName,
+  enableI18nLoaded,
+  ssr,
+}: UseEnableI18nParams): UseEnableI18nReturn {
+  // undefined means loading synchronously, otherwise loading asynchronously
+  const asyncEnabled = enableI18nLoaded !== undefined;
+
+  // Track if this is the first render for SSR hydration recovery
+  const isFirstRender = useRef(true);
+
+  // Extract state from cookie or default _enableI18n flag
+  const [enableI18n, setEnableI18n] = useState(
+    getInitialEnableI18n({
+      _enableI18n,
+      asyncEnabled,
+      enableI18nCookieName,
+      ssr,
+    })
+  );
+
+  // SSR hydration recovery: check cookie after first render
+  useEffect(() => {
+    if (ssr && asyncEnabled && isFirstRender.current) {
+      isFirstRender.current = false;
+      const cookieValue = getCookieEnableI18nValue(enableI18nCookieName);
+      if (cookieValue !== null && cookieValue !== enableI18n) {
+        setEnableI18n(cookieValue);
+      }
+      return;
+    }
+    isFirstRender.current = false;
+  }, [ssr, asyncEnabled, enableI18nCookieName, enableI18n]);
+
+  // Update state on param changes
+  useEffect(() => {
+    // no change, return
+    if (enableI18n === _enableI18n) {
+      return;
+    }
+
+    // if no async loaded, use _enableI18n flag
+    if (!asyncEnabled) {
+      setEnableI18n(_enableI18n);
+      return;
+    }
+
+    // if still waiting on async, don't respond to changes
+    if (!enableI18nLoaded) {
+      return;
+    }
+
+    // sync loaded, so listen to the _enableI18n flag
+    persistEnableI18nFlagToCookie({
+      enableI18n: _enableI18n,
+      enableI18nCookieName,
+    });
+    // update state
+    setEnableI18n(_enableI18n);
+  }, [
+    _enableI18n,
+    enableI18n,
+    asyncEnabled,
+    enableI18nLoaded,
+    enableI18nCookieName,
+  ]);
+
+  // return established flag
+  return { enableI18n };
+}
+
+/**
+ * Get initial enableI18n flag
+ */
+function getInitialEnableI18n({
+  _enableI18n,
+  asyncEnabled,
+  enableI18nCookieName,
+  ssr,
+}: {
+  _enableI18n: boolean;
+  asyncEnabled: boolean;
+  enableI18nCookieName: string;
+  ssr: boolean;
+}): boolean {
+  // Sync behavior: return _enableI18n flag
+  if (!asyncEnabled) {
+    return _enableI18n;
+  }
+  // Unfortunately, for SSR, we have to sacrifice the first render cycle to avoid hydration errors
+  if (ssr) {
+    return _enableI18n;
+  }
+  // Async behavior: listen to cookie
+  const cookieValue = getCookieEnableI18nValue(enableI18nCookieName);
+  if (cookieValue !== null) {
+    return cookieValue;
+  }
+  // Fallback to default value
+  return _enableI18n;
+}
+
+function getCookieEnableI18nValue(
+  enableI18nCookieName: string
+): boolean | null {
+  if (typeof document === 'undefined') return null;
+  // eslint-disable-next-line no-undef -- document is defined in browser
+  const rawCookieValue = document.cookie
+    .split('; ')
+    .find((row) => row.startsWith(`${enableI18nCookieName}=`))
+    ?.split('=')[1];
+  return rawCookieValue === 'true'
+    ? true
+    : rawCookieValue === 'false'
+      ? false
+      : null;
+}
+
+function persistEnableI18nFlagToCookie({
+  enableI18n,
+  enableI18nCookieName,
+}: {
+  enableI18n: boolean;
+  enableI18nCookieName: string;
+}): void {
+  if (typeof document === 'undefined') return;
+  // eslint-disable-next-line no-undef -- document is defined in browser
+  document.cookie = `${enableI18nCookieName}=${enableI18n ? 'true' : 'false'};path=/;`;
+}

--- a/packages/react/src/types/config.ts
+++ b/packages/react/src/types/config.ts
@@ -63,5 +63,7 @@ export type GTProviderProps = {
   fallback?: React.ReactNode;
   customMapping?: CustomMapping;
   modelProvider?: string;
+  enableI18n?: boolean;
+  enableI18nLoaded?: boolean;
   [key: string]: any;
 };


### PR DESCRIPTION
Support for sync + async feature flags
- for sync feature flags, just pass `enableI18n` (`true` by default)
- for async feature flags, pass `enableI18n` and `enableI18nLoaded=false` while loading and `enableI18nLoaded=true` when done loading
- note: for SSG first render cycle must be sacrificed because server would not know if i18n is enabled