### PR TITLE
E/ssg rootparam invar

### DIFF
--- a/.changeset/gentle-badgers-march.md
+++ b/.changeset/gentle-badgers-march.md
@@ -1,0 +1,5 @@
+---
+'gt-next': patch
+---
+
+fix: require root param support for SSG

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -15,6 +15,7 @@ import {
   invalidCanonicalLocalesError,
   invalidLocalesError,
   projectIdMissingWarn,
+  ssgInvalidNextVersionError,
   ssgMissingGetStaticLocaleFunctionError,
   standardizedCanonicalLocalesWarning,
   standardizedLocalesWarning,
@@ -509,6 +510,14 @@ export function withGTConfig(
     !requestFunctionPaths.getStaticLocale
   ) {
     throw new Error(ssgMissingGetStaticLocaleFunctionError);
+  }
+
+  // Check: if using SSG, error on invalid Next.js version
+  if (
+    mergedConfig.experimentalEnableSSG &&
+    rootParamStability === 'unsupported'
+  ) {
+    throw new Error(ssgInvalidNextVersionError);
   }
 
   // ---------- STORE CONFIGURATIONS ---------- //

--- a/packages/next/src/errors/ssg.ts
+++ b/packages/next/src/errors/ssg.ts
@@ -1,9 +1,12 @@
+import { ROOT_PARAM_STABILITY } from '../plugin/constants';
 import { RequestFunctions, StaticRequestFunctions } from '../request/types';
 
 // ========== ERRORS ========== //
 
 export const ssgMissingGetStaticLocaleFunctionError =
   'gt-next: You have enabled SSG, but you have not configured a custom getStaticLocale() function. Please visit https://generaltranslation.com/en/docs/next/guides/ssg to configure SSG.';
+
+export const ssgInvalidNextVersionError = `gt-next: SSG support in gt-next is only available for Next.js ${ROOT_PARAM_STABILITY.unstable} and higher. Please visit https://generaltranslation.com/en/docs/next/guides/ssg to configure SSG.`;
 
 // ========== WARNINGS ========== //
 

--- a/packages/next/src/plugin/constants.ts
+++ b/packages/next/src/plugin/constants.ts
@@ -1,3 +1,11 @@
 export const BABEL_PLUGIN_SUPPORT = '17.0.0';
 
 export const SWC_PLUGIN_SUPPORT = '15.2.0';
+
+export const ROOT_PARAM_STABILITY = {
+  unsupported: '0.0.0',
+  unstable: '15.2.0',
+  experimental: '15.5.0',
+};
+
+export const STABLE_TURBO_CONFIG_VERSION = '15.3.0';

--- a/packages/next/src/plugin/getStableNextVersionInfo.ts
+++ b/packages/next/src/plugin/getStableNextVersionInfo.ts
@@ -2,7 +2,12 @@ import {
   createUnresolvedNextVersionError,
   createUnresolvedReactVersionError,
 } from '../errors/createErrors';
-import { BABEL_PLUGIN_SUPPORT, SWC_PLUGIN_SUPPORT } from './constants';
+import {
+  BABEL_PLUGIN_SUPPORT,
+  ROOT_PARAM_STABILITY,
+  STABLE_TURBO_CONFIG_VERSION,
+  SWC_PLUGIN_SUPPORT,
+} from './constants';
 
 /**
  * Get the next version of the package.
@@ -59,18 +64,12 @@ function comparePackageVersion(a: string, b: string): boolean {
  * Starting at version next@15.3.0 experimental field in turbo config was deprecated.
  * Shout out to next-intl: https://github.com/amannn/next-intl/pull/1850
  */
-const STABLE_TURBO_CONFIG_VERSION = '15.3.0';
 export const turboConfigStable = comparePackageVersion(
   getNextVersion(),
   STABLE_TURBO_CONFIG_VERSION
 );
 
 export type RootParam = 'unsupported' | 'unstable' | 'experimental' | 'stable';
-const ROOT_PARAM_STABILITY = {
-  unsupported: '0.0.0',
-  unstable: '15.2.0',
-  experimental: '15.5.0',
-};
 
 export const rootParamStability: RootParam = (() => {
   const nextVersion = getNextVersion();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> SSG now errors on unsupported Next.js versions lacking root param support, with new error messaging and version constants centralized.
> 
> - **SSG validation**:
>   - Enforce version check in `packages/next/src/config.ts`: throw `ssgInvalidNextVersionError` when `experimentalEnableSSG` is enabled and `rootParamStability` is `unsupported`.
>   - Add `ssgInvalidNextVersionError` in `packages/next/src/errors/ssg.ts`.
> - **Version constants**:
>   - Introduce `ROOT_PARAM_STABILITY` and `STABLE_TURBO_CONFIG_VERSION` in `packages/next/src/plugin/constants.ts`.
>   - Update `packages/next/src/plugin/getStableNextVersionInfo.ts` to import these constants and remove in-file duplicates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bcb63368b45a57383ff87a47e3df4258ca423609. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->