### PR TITLE
fix: static resolution

### DIFF
--- a/.changeset/gentle-badgers-march.md
+++ b/.changeset/gentle-badgers-march.md
@@ -1,5 +1,5 @@
 ---
-'gt-next': patch
+'gtx-cli': patch
 ---
 
-fix: require root param support for SSG
+fix: jsx parse with Static component

--- a/.changeset/gentle-badgers-march.md
+++ b/.changeset/gentle-badgers-march.md
@@ -1,5 +1,0 @@
----
-'gtx-cli': patch
----
-
-fix: jsx parse with Static component

--- a/.changeset/quick-badgers-grin.md
+++ b/.changeset/quick-badgers-grin.md
@@ -1,0 +1,5 @@
+---
+'gtx-cli': patch
+---
+
+fix: Static component resolution edge cases

--- a/packages/cli/src/console/index.ts
+++ b/packages/cli/src/console/index.ts
@@ -229,7 +229,7 @@ export const warnRecursiveFunctionCallSync = (
   withLocation(
     file,
     withStaticError(
-      `Recursive function call detected: ${colorizeFunctionName(functionName)}. A static function use recursive calls to construct its result.`
+      `Recursive function call detected: ${colorizeFunctionName(functionName)}. A static function cannot use recursive calls to construct its result.`
     ),
     location
   );

--- a/packages/cli/src/react/jsx/utils/getPathsAndAliases.ts
+++ b/packages/cli/src/react/jsx/utils/getPathsAndAliases.ts
@@ -15,7 +15,10 @@ import { extractImportName } from './parseAst.js';
 const traverse = traverseModule.default || traverseModule;
 
 /**
- *
+ * Constructs tracking for gt related variables of interest
+ * inlineTranslationPaths: these are string-related translation functions
+ * translationComponentPaths: these are just <T> components
+ * importAliases: any other GT related imports
  */
 export function getPathsAndAliases(
   ast: any,

--- a/packages/cli/src/react/jsx/utils/jsxParsing/__tests__/parseJsx.test.ts
+++ b/packages/cli/src/react/jsx/utils/jsxParsing/__tests__/parseJsx.test.ts
@@ -1295,7 +1295,9 @@ describe('parseTranslationComponent with cross-file resolution', () => {
     );
 
     // Verify specific content variations exist
-    const staticContents = hashedUpdates.map((u) => (u.source[1] as { c: string }).c);
+    const staticContents = hashedUpdates.map(
+      (u) => (u.source[1] as { c: string }).c
+    );
     expect(staticContents).toContain('utils1-a');
     expect(staticContents).toContain('utils1-b');
   });

--- a/packages/cli/src/react/jsx/utils/jsxParsing/__tests__/parseJsx.test.ts
+++ b/packages/cli/src/react/jsx/utils/jsxParsing/__tests__/parseJsx.test.ts
@@ -799,4 +799,163 @@ describe('parseTranslationComponent with cross-file resolution', () => {
     expect(staticContents).toContain('utils1-a');
     expect(staticContents).toContain('utils1-b');
   });
+
+  it('should handle function resolution failure when import chain is broken', () => {
+    // Mock the file contents with broken import chain
+    const pageFile = `
+      import { T, Static } from "gt-next";
+      import { utils1 } from "./libs/utils1";
+
+      export default function Page() {
+        return (
+          <>
+            <T>test <Static>{utils1()}</Static></T>
+          </>
+        );
+      }
+    `;
+
+    const utils1File = `
+      import { utils3 } from "./utils2";
+
+      export function utils1() {
+        if (Math.random() > 0.5) {
+          return utils3();
+        }
+        return 1 ? "utils1-a" : "utils1-b";
+      }
+    `;
+
+    const utils2File = `
+      export * from "./utils1";
+      // export * from "./utils3";
+    `;
+
+    const utils3File = `
+      export function utils3() {
+        return 1 ? "utils3-a" : "utils3-b";
+      }
+    `;
+
+    // Set up file system mocks (using unique paths for cache isolation)
+    mockFs.readFileSync.mockImplementation((path: fs.PathOrFileDescriptor) => {
+      switch (path) {
+        case '/test/broken/libs/utils1.ts':
+          return utils1File;
+        case '/test/broken/libs/utils2.ts':
+          return utils2File;
+        case '/test/broken/libs/utils3.ts':
+          return utils3File;
+        default:
+          throw new Error(`File not found: ${path}`);
+      }
+    });
+
+    // Set up import path resolution mocks
+    mockResolveImportPath.mockImplementation(
+      (_currentFile: string, importPath: string) => {
+        if (importPath === './libs/utils1') {
+          return '/test/broken/libs/utils1.ts';
+        }
+        if (importPath === './utils2') {
+          return '/test/broken/libs/utils2.ts';
+        }
+        if (importPath === './utils3') {
+          return '/test/broken/libs/utils3.ts';
+        }
+        if (importPath === './utils1') {
+          return '/test/broken/libs/utils1.ts';
+        }
+        return null;
+      }
+    );
+
+    // Parse the page file
+    const ast = parse(pageFile, {
+      sourceType: 'module',
+      plugins: ['jsx', 'typescript'],
+    });
+
+    // Find the T component import and local name
+    let tLocalName = '';
+    const importAliases: Record<string, string> = {};
+
+    traverse(ast, {
+      ImportDeclaration(path) {
+        if (path.node.source.value === 'gt-next') {
+          path.node.specifiers.forEach((spec) => {
+            if (
+              t.isImportSpecifier(spec) &&
+              t.isIdentifier(spec.imported) &&
+              spec.imported.name === 'T'
+            ) {
+              tLocalName = spec.local.name;
+              importAliases[tLocalName] = 'T';
+            }
+            if (
+              t.isImportSpecifier(spec) &&
+              t.isIdentifier(spec.imported) &&
+              spec.imported.name === 'Static'
+            ) {
+              importAliases[spec.local.name] = 'Static';
+            }
+          });
+        }
+      },
+    });
+
+    // Find the T component usage and test parsing
+    traverse(ast, {
+      Program(programPath) {
+        const tBinding = programPath.scope.getBinding(tLocalName);
+
+        if (tBinding) {
+          parseTranslationComponent({
+            ast,
+            pkg: 'gt-next',
+            originalName: 'T',
+            importAliases,
+            localName: tLocalName,
+            path: tBinding.path,
+            updates,
+            errors,
+            warnings,
+            file: '/test/broken/page.tsx',
+            parsingOptions,
+          });
+        }
+      },
+    });
+
+    // Should have warnings about function not found
+    expect(warnings.size).toBeGreaterThan(0);
+    expect(
+      Array.from(warnings).some((warning) =>
+        warning.includes('Function utils3 definition could not be resolved')
+      )
+    ).toBe(true);
+    expect(
+      Array.from(warnings).some((warning) =>
+        warning.includes('This might affect translation resolution')
+      )
+    ).toBe(true);
+
+    // Should still process the parts that can be resolved (utils1-a, utils1-b)
+    expect(updates.length).toBeGreaterThan(0);
+
+    // Verify that utils1 was still processed despite utils3 resolution failure
+    const staticContents = updates.map((u) => (u.source[1] as { c: string }).c);
+    expect(staticContents).toContain('utils1-a');
+    expect(staticContents).toContain('utils1-b');
+
+    // Verify that files were attempted to be read
+    expect(mockFs.readFileSync).toHaveBeenCalledWith(
+      '/test/broken/libs/utils1.ts',
+      'utf8'
+    );
+    expect(mockFs.readFileSync).toHaveBeenCalledWith(
+      '/test/broken/libs/utils2.ts',
+      'utf8'
+    );
+  });
 });

--- a/packages/cli/src/react/jsx/utils/jsxParsing/__tests__/parseJsx.test.ts
+++ b/packages/cli/src/react/jsx/utils/jsxParsing/__tests__/parseJsx.test.ts
@@ -1,0 +1,351 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as t from '@babel/types';
+import { parse } from '@babel/parser';
+import traverse from '@babel/traverse';
+import fs from 'node:fs';
+import { parseTranslationComponent } from '../parseJsx.js';
+import { resolveImportPath } from '../../resolveImportPath.js';
+import { ParsingConfigOptions } from '../../../../../types/parsing.js';
+import { Updates } from '../../../../../types/index.js';
+import { hashSource } from 'generaltranslation/id';
+
+// Mock fs and resolveImportPath
+vi.mock('node:fs');
+vi.mock('../../resolveImportPath.js');
+
+const mockFs = vi.mocked(fs);
+const mockResolveImportPath = vi.mocked(resolveImportPath);
+
+describe('parseTranslationComponent with cross-file resolution', () => {
+  let updates: Updates;
+  let errors: string[];
+  let warnings: Set<string>;
+  let parsingOptions: ParsingConfigOptions;
+
+  beforeEach(() => {
+    updates = [];
+    errors = [];
+    warnings = new Set();
+    parsingOptions = {
+      conditionNames: ['import', 'require'],
+    };
+
+    // Reset all mocks
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should resolve functions across multiple files with re-exports', () => {
+    // Mock the file contents based on the playground scenario
+    const pageFile = `
+      import { T, Static } from "gt-next";
+      import { utils1 } from "./libs/utils1";
+
+      function getStatic() {
+        return 1 ? "static" : "dynamic";
+      }
+
+      export default function Page() {
+        return (
+          <>
+            <T>test <Static>{utils1()}</Static></T>
+          </>
+        );
+      }
+    `;
+
+    const utils1File = `
+      import { utils3 } from "./utils2";
+
+      export function utils1() {
+        if (Math.random() > 0.5) {
+          return utils3();
+        }
+        return 1 ? "utils1-a" : "utils1-b";
+      }
+    `;
+
+    const utils2File = `
+      export * from "./utils3";
+
+      // export function utils2() {
+      //   return 1 ? "utils2-a" : "utils2-b";
+      // }
+    `;
+
+    const utils3File = `
+      import { utils1 } from "./utils1";
+      export function utils3() {
+        if (Math.random() > 0.5) {
+          // return utils1();
+          // return utils3();
+        }
+        return 1 ? "utils3-a" : "utils3-b";
+      }
+    `;
+
+    // Set up file system mocks
+    mockFs.readFileSync.mockImplementation((path: fs.PathOrFileDescriptor) => {
+      switch (path) {
+        case '/test/project/libs/utils1.ts':
+          return utils1File;
+        case '/test/project/libs/utils2.ts':
+          return utils2File;
+        case '/test/project/libs/utils3.ts':
+          return utils3File;
+        default:
+          throw new Error(`File not found: ${path}`);
+      }
+    });
+
+    // Set up import path resolution mocks
+    mockResolveImportPath.mockImplementation(
+      (_currentFile: string, importPath: string) => {
+        if (importPath === './libs/utils1') {
+          return '/test/project/libs/utils1.ts';
+        }
+        if (importPath === './utils2') {
+          return '/test/project/libs/utils2.ts';
+        }
+        if (importPath === './utils3') {
+          return '/test/project/libs/utils3.ts';
+        }
+        if (importPath === './utils1') {
+          return '/test/project/libs/utils1.ts';
+        }
+        return null;
+      }
+    );
+
+    // Parse the page file
+    const ast = parse(pageFile, {
+      sourceType: 'module',
+      plugins: ['jsx', 'typescript'],
+    });
+
+    // Find the T component import and local name
+    let tLocalName = '';
+    const importAliases: Record<string, string> = {};
+
+    traverse(ast, {
+      ImportDeclaration(path) {
+        if (path.node.source.value === 'gt-next') {
+          path.node.specifiers.forEach((spec) => {
+            if (
+              t.isImportSpecifier(spec) &&
+              t.isIdentifier(spec.imported) &&
+              spec.imported.name === 'T'
+            ) {
+              tLocalName = spec.local.name;
+              importAliases[tLocalName] = 'T';
+            }
+            if (
+              t.isImportSpecifier(spec) &&
+              t.isIdentifier(spec.imported) &&
+              spec.imported.name === 'Static'
+            ) {
+              importAliases[spec.local.name] = 'Static';
+            }
+          });
+        }
+      },
+    });
+
+    // Find the T component usage and test parsing
+    traverse(ast, {
+      Program(programPath) {
+        // Find variable declarator for the T import
+        const tBinding = programPath.scope.getBinding(tLocalName);
+
+        if (tBinding) {
+          parseTranslationComponent({
+            ast,
+            pkg: 'gt-next',
+            originalName: 'T',
+            importAliases,
+            localName: tLocalName,
+            path: tBinding.path,
+            updates,
+            errors,
+            warnings,
+            file: '/test/project/page.tsx',
+            parsingOptions,
+          });
+        }
+      },
+    });
+
+    // Verify the parsing results - should have 4 updates based on conditional returns
+    expect(errors).toHaveLength(0);
+    expect(updates).toHaveLength(4); // Should have 4 branches: utils3-a, utils3-b, utils1-a, utils1-b
+
+    // Calculate hashes for each update
+    const hashedUpdates = updates.map((update) => {
+      const context = update.metadata.context;
+      const hash = hashSource({
+        source: update.source,
+        ...(context && { context }),
+        ...(update.metadata.id && { id: update.metadata.id }),
+        dataFormat: update.dataFormat,
+      });
+      return { hash, source: update.source };
+    });
+
+    // Expected hash-to-source mappings from your playground scenario
+    const expectedData = {
+      '837be41703617441': [
+        'test ',
+        {
+          t: 'Static',
+          i: 1,
+          c: 'utils3-a',
+        },
+      ],
+      '6c4330bad929001a': [
+        'test ',
+        {
+          t: 'Static',
+          i: 1,
+          c: 'utils3-b',
+        },
+      ],
+      '40d52de32ba666ce': [
+        'test ',
+        {
+          t: 'Static',
+          i: 1,
+          c: 'utils1-a',
+        },
+      ],
+      '081fa70a614caa27': [
+        'test ',
+        {
+          t: 'Static',
+          i: 1,
+          c: 'utils1-b',
+        },
+      ],
+    };
+
+    // Hard check: Verify we have exactly the expected hashes
+    const actualHashes = hashedUpdates.map((u) => u.hash).sort();
+    const expectedHashes = Object.keys(expectedData).sort();
+    expect(actualHashes).toEqual(expectedHashes);
+
+    // Hard check: Verify each specific hash and data structure exists
+    expect(hashedUpdates.some((u) => u.hash === '837be41703617441')).toBe(true);
+    expect(hashedUpdates.some((u) => u.hash === '6c4330bad929001a')).toBe(true);
+    expect(hashedUpdates.some((u) => u.hash === '40d52de32ba666ce')).toBe(true);
+    expect(hashedUpdates.some((u) => u.hash === '081fa70a614caa27')).toBe(true);
+
+    // Hard check: Verify each hash maps to the exact expected content
+    const update837 = hashedUpdates.find((u) => u.hash === '837be41703617441')!;
+    expect(update837.source).toEqual([
+      'test ',
+      {
+        t: 'Static',
+        i: 1,
+        c: 'utils3-a',
+      },
+    ]);
+
+    const update6c4 = hashedUpdates.find((u) => u.hash === '6c4330bad929001a')!;
+    expect(update6c4.source).toEqual([
+      'test ',
+      {
+        t: 'Static',
+        i: 1,
+        c: 'utils3-b',
+      },
+    ]);
+
+    const update40d = hashedUpdates.find((u) => u.hash === '40d52de32ba666ce')!;
+    expect(update40d.source).toEqual([
+      'test ',
+      {
+        t: 'Static',
+        i: 1,
+        c: 'utils1-a',
+      },
+    ]);
+
+    const update081 = hashedUpdates.find((u) => u.hash === '081fa70a614caa27')!;
+    expect(update081.source).toEqual([
+      'test ',
+      {
+        t: 'Static',
+        i: 1,
+        c: 'utils1-b',
+      },
+    ]);
+
+    // Hard check: Verify hash calculation is correct for each
+    expect(
+      hashSource({
+        source: expectedData['837be41703617441'],
+        dataFormat: 'JSX',
+      })
+    ).toBe('837be41703617441');
+
+    expect(
+      hashSource({
+        source: expectedData['6c4330bad929001a'],
+        dataFormat: 'JSX',
+      })
+    ).toBe('6c4330bad929001a');
+
+    expect(
+      hashSource({
+        source: expectedData['40d52de32ba666ce'],
+        dataFormat: 'JSX',
+      })
+    ).toBe('40d52de32ba666ce');
+
+    expect(
+      hashSource({
+        source: expectedData['081fa70a614caa27'],
+        dataFormat: 'JSX',
+      })
+    ).toBe('081fa70a614caa27');
+
+    // Verify that utils1 and utils3 functions were resolved
+    expect(mockFs.readFileSync).toHaveBeenCalledWith(
+      '/test/project/libs/utils1.ts',
+      'utf8'
+    );
+    expect(mockFs.readFileSync).toHaveBeenCalledWith(
+      '/test/project/libs/utils2.ts',
+      'utf8'
+    );
+    expect(mockFs.readFileSync).toHaveBeenCalledWith(
+      '/test/project/libs/utils3.ts',
+      'utf8'
+    );
+
+    // Check that import paths were resolved correctly
+    expect(mockResolveImportPath).toHaveBeenCalledWith(
+      '/test/project/page.tsx',
+      './libs/utils1',
+      parsingOptions,
+      expect.any(Map)
+    );
+    expect(mockResolveImportPath).toHaveBeenCalledWith(
+      '/test/project/libs/utils1.ts',
+      './utils2',
+      parsingOptions,
+      expect.any(Map)
+    );
+
+    // Verify all expected content variations are present
+    const staticContents = hashedUpdates.map(
+      (u) => (u.source[1] as { c: string }).c
+    );
+    expect(staticContents).toContain('utils3-a');
+    expect(staticContents).toContain('utils3-b');
+    expect(staticContents).toContain('utils1-a');
+    expect(staticContents).toContain('utils1-b');
+  });
+});

--- a/packages/cli/src/react/jsx/utils/jsxParsing/parseJsx.ts
+++ b/packages/cli/src/react/jsx/utils/jsxParsing/parseJsx.ts
@@ -865,7 +865,7 @@ function resolveStaticFunctionInvocationFromBinding({
     if (filePath) {
       const functionName = callee.name;
       return withRecusionGuard({
-        filename: file,
+        filename: filePath,
         functionName,
         cb: () =>
           processFunctionInFile({
@@ -989,7 +989,7 @@ function processFunctionInFile({
             updates,
             errors,
             warnings,
-            file,
+            file: filePath,
             parsingOptions,
             importedFunctionsMap,
           });
@@ -1016,7 +1016,7 @@ function processFunctionInFile({
             warnings,
             visited,
             unwrappedExpressions,
-            file,
+            file: filePath,
             parsingOptions,
             importedFunctionsMap,
           });
@@ -1068,7 +1068,7 @@ function processFunctionInFile({
             updates,
             errors,
             warnings,
-            file,
+            file: filePath,
             pkg,
           });
           if (foundResult != null) {

--- a/packages/cli/src/react/jsx/utils/jsxParsing/parseJsx.ts
+++ b/packages/cli/src/react/jsx/utils/jsxParsing/parseJsx.ts
@@ -974,7 +974,7 @@ function processFunctionInFile({
     const warnDuplicateFuncDef = (path: NodePath) => {
       warnings.add(
         warnDuplicateFunctionDefinitionSync(
-          file,
+          filePath,
           functionName,
           `${path.node.loc?.start?.line}:${path.node.loc?.start?.column}`
         )

--- a/packages/cli/src/react/jsx/utils/jsxParsing/parseJsx.ts
+++ b/packages/cli/src/react/jsx/utils/jsxParsing/parseJsx.ts
@@ -779,9 +779,6 @@ function resolveStaticFunctionInvocationFromBinding({
   importedFunctionsMap: Map<string, string>;
   pkg: 'gt-react' | 'gt-next';
 }): MultiplicationNode | null {
-  console.log('===== resolveStaticFunctionInvocationFromBinding =====');
-  console.log('callee', callee.name + '()');
-  console.log('file', file.split('/').pop());
   // Stop recursive calls
   type RecursiveGuardCallback = () =>
     | ReturnType<typeof processFunctionDeclarationNodePath>
@@ -941,20 +938,15 @@ function processFunctionInFile({
   unwrappedExpressions: string[];
   pkg: 'gt-react' | 'gt-next';
 }): MultiplicationNode | null {
-  console.log('===== processFunctionInFile =====');
-  console.log('filePath    ', filePath.split('/').pop());
-  console.log('functionName', functionName + '()');
   // Create a custom key for the function call
   const cacheKey = `${filePath}::${functionName}`;
   // Check cache first to avoid redundant parsing
   if (processFunctionCache.has(cacheKey)) {
-    console.log('cache hit', cacheKey);
     return processFunctionCache.get(cacheKey) ?? null;
   }
 
   // Prevent infinite loops from circular re-exports
   if (visited.has(filePath)) {
-    console.log('visited', filePath);
     return null;
   }
   visited.add(filePath);
@@ -1100,12 +1092,6 @@ function processFunctionInFile({
   } catch {
     // Silently skip files that can't be parsed or accessed
     // Still mark as processed to avoid retrying failed parses
-    console.log(
-      'failed to parse file',
-      filePath.split('/').pop(),
-      'for function',
-      functionName + '()'
-    );
     processFunctionCache.set(cacheKey, null);
   }
   return result !== undefined ? result : null;

--- a/packages/cli/src/react/jsx/utils/jsxParsing/parseJsx.ts
+++ b/packages/cli/src/react/jsx/utils/jsxParsing/parseJsx.ts
@@ -867,7 +867,7 @@ function resolveStaticFunctionInvocationFromBinding({
     );
     if (filePath) {
       const functionName = callee.name;
-      return withRecusionGuard({
+      const result = withRecusionGuard({
         filename: filePath,
         functionName,
         cb: () =>
@@ -885,6 +885,9 @@ function resolveStaticFunctionInvocationFromBinding({
             pkg,
           }),
       });
+      if (result !== null) {
+        return result;
+      }
     }
   }
   warnings.add(
@@ -1092,6 +1095,12 @@ function processFunctionInFile({
   } catch {
     // Silently skip files that can't be parsed or accessed
     // Still mark as processed to avoid retrying failed parses
+    console.log(
+      'failed to parse file',
+      filePath.split('/').pop(),
+      'for function',
+      functionName + '()'
+    );
     processFunctionCache.set(cacheKey, null);
   }
   return result !== undefined ? result : null;

--- a/packages/cli/src/react/jsx/utils/jsxParsing/parseJsx.ts
+++ b/packages/cli/src/react/jsx/utils/jsxParsing/parseJsx.ts
@@ -155,7 +155,7 @@ export function buildJSXTree({
   node: any;
   callStack: string[];
   unwrappedExpressions: string[];
-  visited: Set<string>;
+  visited: Set<string> | null;
   updates: Updates;
   errors: string[];
   warnings: Set<string>;
@@ -314,6 +314,9 @@ export function buildJSXTree({
 
     if (elementIsVariable) {
       if (componentType === STATIC_COMPONENT) {
+        if (visited === null) {
+          visited = new Set();
+        }
         return resolveStaticComponentChildren({
           importAliases,
           scopeNode,
@@ -529,7 +532,7 @@ export function parseJSXElement({
     importAliases,
     node,
     scopeNode,
-    visited: new Set(),
+    visited: null,
     callStack: [],
     pkg,
     unwrappedExpressions,
@@ -930,15 +933,20 @@ function processFunctionInFile({
   unwrappedExpressions: string[];
   pkg: 'gt-react' | 'gt-next';
 }): MultiplicationNode | null {
+  console.log('===== processFunctionInFile =====');
+  console.log('filePath    ', filePath.split('/').pop());
+  console.log('functionName', functionName + '()');
   // Create a custom key for the function call
   const cacheKey = `${filePath}::${functionName}`;
   // Check cache first to avoid redundant parsing
   if (processFunctionCache.has(cacheKey)) {
+    console.log('cache hit', cacheKey);
     return processFunctionCache.get(cacheKey) ?? null;
   }
 
   // Prevent infinite loops from circular re-exports
   if (visited.has(filePath)) {
+    console.log('visited', filePath);
     return null;
   }
   visited.add(filePath);

--- a/packages/cli/src/react/jsx/utils/jsxParsing/parseJsx.ts
+++ b/packages/cli/src/react/jsx/utils/jsxParsing/parseJsx.ts
@@ -713,10 +713,12 @@ function resolveStaticComponentChildren({
     const calleeBinding = scopeNode.scope.getBinding(callee.name);
 
     if (!calleeBinding) {
-      warnFunctionNotFoundSync(
-        file,
-        callee.name,
-        `${callee.loc?.start?.line}:${callee.loc?.start?.column}`
+      warnings.add(
+        warnFunctionNotFoundSync(
+          file,
+          callee.name,
+          `${callee.loc?.start?.line}:${callee.loc?.start?.column}`
+        )
       );
       continue;
     }
@@ -777,6 +779,9 @@ function resolveStaticFunctionInvocationFromBinding({
   importedFunctionsMap: Map<string, string>;
   pkg: 'gt-react' | 'gt-next';
 }): MultiplicationNode | null {
+  console.log('===== resolveStaticFunctionInvocationFromBinding =====');
+  console.log('callee', callee.name + '()');
+  console.log('file', file.split('/').pop());
   // Stop recursive calls
   type RecursiveGuardCallback = () =>
     | ReturnType<typeof processFunctionDeclarationNodePath>

--- a/packages/cli/src/react/parse/createInlineUpdates.ts
+++ b/packages/cli/src/react/parse/createInlineUpdates.ts
@@ -64,7 +64,7 @@ export async function createInlineUpdates(
     // Parse <T> components
     for (const { localName, path } of translationComponentPaths) {
       parseTranslationComponent({
-        importAliases: importAliases,
+        importAliases,
         originalName: localName,
         localName,
         ast,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enhances <Static> resolution with cross-file import/re-export support, recursion detection, better warnings, and adds comprehensive tests.
> 
> - **Parsing/Resolution**:
>   - Improve `<Static>` function resolution across files, using original imported names and resolved file paths; follow `export *` and named re-exports; initialize `visited` lazily; prevent infinite loops and detect self/cross-function recursion.
>   - Refine warnings: add "function not found" to warnings set; correct file paths in duplicate-definition warnings; tweak recursive-call message.
> - **Tests**:
>   - Add extensive tests for cross-file resolution, re-exports, recursion (self and cyclic), circular imports handling, broken import chains, undefined bindings, and import aliases.
> - **Misc**:
>   - Minor cleanup (import alias pass-through, comments/docs).
>   - Changeset: patch release for `gtx-cli`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d869bf2d8630bde80c479bc3c959e1015f4e3147. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->