### PR TITLE
E/deprecate old ssg

### DIFF
--- a/packages/next/src/config-dir/props/withGTConfigProps.ts
+++ b/packages/next/src/config-dir/props/withGTConfigProps.ts
@@ -89,6 +89,7 @@ type withGTConfigProps = {
   _usingPlugin?: boolean;
   // SSG
   experimentalEnableSSG?: boolean;
+  /** @deprecated */
   disableSSGWarnings?: boolean;
   // Request function paths
   getLocalePath?: string;

--- a/packages/next/src/config-dir/props/withGTConfigProps.ts
+++ b/packages/next/src/config-dir/props/withGTConfigProps.ts
@@ -32,21 +32,19 @@ export type CompilerOptions = {
   disableBuildChecks?: boolean;
 };
 
-export const REQUEST_FUNCTION_TO_CONFIG_KEY = {
-  getLocale: 'getLocalePath',
-  getRegion: 'getRegionPath',
-  getDomain: 'getDomainPath',
+export const DEPRECATED_REQUEST_FUNCTION_TO_CONFIG_KEY = {
   getStaticLocale: 'getStaticLocalePath',
   getStaticRegion: 'getStaticRegionPath',
   getStaticDomain: 'getStaticDomainPath',
 } as const;
 
-type RequestFunctionPaths = Partial<
-  Record<
-    (typeof REQUEST_FUNCTION_TO_CONFIG_KEY)[keyof typeof REQUEST_FUNCTION_TO_CONFIG_KEY],
-    string
-  >
->;
+export const REQUEST_FUNCTION_TO_CONFIG_KEY = {
+  getLocale: 'getLocalePath',
+  getRegion: 'getRegionPath',
+  getDomain: 'getDomainPath',
+  ...DEPRECATED_REQUEST_FUNCTION_TO_CONFIG_KEY,
+} as const;
+
 type withGTConfigProps = {
   // Request scoped filepath
   dictionary?: string;
@@ -92,7 +90,17 @@ type withGTConfigProps = {
   // SSG
   experimentalEnableSSG?: boolean;
   disableSSGWarnings?: boolean;
+  // Request function paths
+  getLocalePath?: string;
+  getRegionPath?: string;
+  getDomainPath?: string;
+  /** @deprecated use getLocalePath instead */
+  getStaticLocalePath?: string;
+  /** @deprecated use getRegionPath instead */
+  getStaticRegionPath?: string;
+  /** @deprecated use getDomainPath instead */
+  getStaticDomainPath?: string;
   [key: string]: any;
-} & RequestFunctionPaths;
+};
 
 export default withGTConfigProps;

--- a/packages/next/src/config-dir/utils/resolveRequestFunctionPaths.ts
+++ b/packages/next/src/config-dir/utils/resolveRequestFunctionPaths.ts
@@ -18,7 +18,7 @@ export const REQUEST_FUNCTION_ALIASES = {
   getStaticDomain: 'gt-next/internal/static/_getDomain',
 } as const;
 
-type RequestFunctionPaths = Partial<
+export type RequestFunctionPaths = Partial<
   Record<RequestFunctions | StaticRequestFunctions, string>
 >;
 
@@ -36,9 +36,7 @@ export function resolveRequestFunctionPaths(
     ...REQUEST_FUNCTIONS,
     ...STATIC_REQUEST_FUNCTIONS,
   ]) {
-    const configKey = REQUEST_FUNCTION_TO_CONFIG_KEY[
-      functionName
-    ] as keyof withGTConfigProps;
+    const configKey = REQUEST_FUNCTION_TO_CONFIG_KEY[functionName];
     const path =
       typeof mergedConfig[configKey] === 'string'
         ? mergedConfig[configKey]

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -73,7 +73,7 @@ import ssgChecks from './plugin/checks/ssgChecks';
  * @param {boolean} [ignoreBrowserLocales=defaultWithGTConfigProps.ignoreBrowserLocales] - Whether to ignore browser's preferred locales.
  * @param {object} headersAndCookies - Additional headers and cookies that can be passed for extended configuration.
  * @param {boolean} [experimentalEnableSSG=false] - Whether to enable SSG.
- * @param {boolean} [disableSSGWarnings=defaultWithGTConfigProps.disableSSGWarnings] - Whether to disable SSG warnings.
+ * @param {boolean} [disableSSGWarnings=defaultWithGTConfigProps.disableSSGWarnings] - Whether to disable SSG warnings. (deprecated)
  * @param {string|undefined} [getStaticLocalePath="getStaticLocale"] - The path to the static getLocale function. (deprecated)
  * @param {string|undefined} [getStaticRegionPath="getStaticRegion"] - The path to the static getRegion function. (deprecated)
  * @param {string|undefined} [getStaticDomainPath="getStaticDomain"] - The path to the static getDomain function. (deprecated)

--- a/packages/next/src/errors/ssg.ts
+++ b/packages/next/src/errors/ssg.ts
@@ -1,12 +1,10 @@
-import { ROOT_PARAM_STABILITY } from '../plugin/constants';
+import { DEPRECATED_REQUEST_FUNCTION_TO_CONFIG_KEY } from '../config-dir/props/withGTConfigProps';
 import { RequestFunctions, StaticRequestFunctions } from '../request/types';
 
 // ========== ERRORS ========== //
 
 export const ssgMissingGetStaticLocaleFunctionError =
   'gt-next: You have enabled SSG, but you have not configured a custom getStaticLocale() function. Please visit https://generaltranslation.com/en/docs/next/guides/ssg to configure SSG.';
-
-export const ssgInvalidNextVersionError = `gt-next: SSG support in gt-next is only available for Next.js ${ROOT_PARAM_STABILITY.unstable} and higher. Please visit https://generaltranslation.com/en/docs/next/guides/ssg to configure SSG.`;
 
 // ========== WARNINGS ========== //
 
@@ -44,3 +42,11 @@ export const createSsrFunctionDuringSsgWarning = (
 
 export const ssrDetectionFailedWarning =
   'gt-next: Unable to determine if runtime is SSR or SSG. Falling back to SSR behavior.';
+
+export const deprecatedExperimentalEnableSSGWarning =
+  'gt-next: You are using the deprecated experimentalEnableSSG configuration. Please use experimental.enableSSG instead.';
+
+export const createDeprecatedGetStaticLocaleFunctionWarning = (
+  functionName: keyof typeof DEPRECATED_REQUEST_FUNCTION_TO_CONFIG_KEY
+) =>
+  `gt-next: You are using the deprecated ${functionName} function. Please use ${functionName.replace('Static', '')} instead.`;

--- a/packages/next/src/errors/ssg.ts
+++ b/packages/next/src/errors/ssg.ts
@@ -44,7 +44,7 @@ export const ssrDetectionFailedWarning =
   'gt-next: Unable to determine if runtime is SSR or SSG. Falling back to SSR behavior.';
 
 export const deprecatedExperimentalEnableSSGWarning =
-  'gt-next: You are using the deprecated experimentalEnableSSG configuration. Please use experimental.enableSSG instead.';
+  'gt-next: You are using the deprecated experimentalEnableSSG configuration. This will be removed in a future version.';
 
 export const createDeprecatedGetStaticLocaleFunctionWarning = (
   functionName: keyof typeof DEPRECATED_REQUEST_FUNCTION_TO_CONFIG_KEY

--- a/packages/next/src/internal/static/_getDomain.ts
+++ b/packages/next/src/internal/static/_getDomain.ts
@@ -1,5 +1,8 @@
 import { RequestFunctionReturnType } from '../../request/types';
 
+/**
+ * @deprecated
+ */
 export default async function getDomain(): Promise<RequestFunctionReturnType> {
   return undefined;
 }

--- a/packages/next/src/internal/static/_getLocale.ts
+++ b/packages/next/src/internal/static/_getLocale.ts
@@ -1,6 +1,9 @@
 // Fallback when SSG enabled to skip next/headers import
 import { RequestFunctionReturnType } from '../../request/types';
 
+/**
+ * @deprecated
+ */
 export default async function getLocale(): Promise<RequestFunctionReturnType> {
   return undefined;
 }

--- a/packages/next/src/internal/static/_getRegion.ts
+++ b/packages/next/src/internal/static/_getRegion.ts
@@ -1,6 +1,9 @@
 // Fallback when SSG enabled to skip next/headers import
 import { RequestFunctionReturnType } from '../../request/types';
 
+/**
+ * @deprecated
+ */
 export default async function getRegion(): Promise<RequestFunctionReturnType> {
   return undefined;
 }

--- a/packages/next/src/plugin/checks/ssgChecks.ts
+++ b/packages/next/src/plugin/checks/ssgChecks.ts
@@ -1,0 +1,41 @@
+import {
+  createDeprecatedGetStaticLocaleFunctionWarning,
+  deprecatedExperimentalEnableSSGWarning,
+  ssgMissingGetStaticLocaleFunctionError,
+} from '../../errors/ssg';
+import withGTConfigProps, {
+  DEPRECATED_REQUEST_FUNCTION_TO_CONFIG_KEY,
+} from '../../config-dir/props/withGTConfigProps';
+import { RequestFunctionPaths } from '../../config-dir/utils/resolveRequestFunctionPaths';
+import { StaticRequestFunctions } from '../../request/types';
+
+export default function ssgChecks(
+  mergedConfig: withGTConfigProps,
+  requestFunctionPaths: RequestFunctionPaths
+) {
+  // Check (warn): if using deprecated experimentalEnableSSG configuration
+  if (mergedConfig.experimentalEnableSSG) {
+    console.warn(deprecatedExperimentalEnableSSGWarning);
+  }
+
+  // Check: if using SSG, error on missing getStaticLocale function
+  if (
+    mergedConfig.experimentalEnableSSG &&
+    !requestFunctionPaths.getStaticLocale
+  ) {
+    throw new Error(ssgMissingGetStaticLocaleFunctionError);
+  }
+
+  // Check (warn): if using deprecated getStaticLocale function
+  for (const functionName of Object.keys(
+    DEPRECATED_REQUEST_FUNCTION_TO_CONFIG_KEY
+  )) {
+    if (requestFunctionPaths[functionName as StaticRequestFunctions]) {
+      console.warn(
+        createDeprecatedGetStaticLocaleFunctionWarning(
+          functionName as keyof typeof DEPRECATED_REQUEST_FUNCTION_TO_CONFIG_KEY
+        )
+      );
+    }
+  }
+}

--- a/packages/next/src/request/getLocale.ts
+++ b/packages/next/src/request/getLocale.ts
@@ -1,8 +1,5 @@
 import getI18NConfig from '../config-dir/getI18NConfig';
 import use from '../utils/use';
-import { RequestFunctionReturnType } from './types';
-import { legacyGetRequestFunction } from './utils/legacyGetRequestFunction';
-import isSSR from './utils/isSSR';
 import { legacyGetLocaleFunction } from './utils/legacyGetLocaleFunction';
 import { getRequestFunction } from './utils/getRequestFunction';
 

--- a/packages/next/src/request/getLocale.ts
+++ b/packages/next/src/request/getLocale.ts
@@ -23,9 +23,9 @@ export async function getLocale(): Promise<string> {
   const gt = I18NConfig.getGTClass();
 
   if (process.env._GENERALTRANSLATION_ENABLE_SSG === 'false') {
+    const requestFunction = getRequestFunction('getLocale');
     // Support new behavior
     getLocaleFunction = async () => {
-      const requestFunction = getRequestFunction('getLocale');
       const requestLocale = await requestFunction();
       return gt.resolveAliasLocale(
         requestLocale || I18NConfig.getDefaultLocale()

--- a/packages/next/src/request/getRegion.ts
+++ b/packages/next/src/request/getRegion.ts
@@ -1,4 +1,4 @@
-import { getRequestFunction } from './utils/getRequestFunction';
+import { legacyGetRequestFunction } from './utils/legacyGetRequestFunction';
 import isSSR from './utils/isSSR';
 
 let getRegionFunction: () => Promise<string | undefined>;
@@ -18,8 +18,8 @@ let getRegionFunctionWrapper: () => Promise<string | undefined>;
 export async function getRegion(): Promise<string | undefined> {
   if (getRegionFunctionWrapper) return await getRegionFunctionWrapper();
 
-  getRegionFunction = getRequestFunction('getRegion', true);
-  getStaticRegionFunction = getRequestFunction('getRegion', false);
+  getRegionFunction = legacyGetRequestFunction('getRegion', true);
+  getStaticRegionFunction = legacyGetRequestFunction('getRegion', false);
 
   getRegionFunctionWrapper = async () => {
     const region = isSSR()

--- a/packages/next/src/request/getRegion.ts
+++ b/packages/next/src/request/getRegion.ts
@@ -1,9 +1,9 @@
 import { legacyGetRequestFunction } from './utils/legacyGetRequestFunction';
 import isSSR from './utils/isSSR';
+import { getRequestFunction } from './utils/getRequestFunction';
+import { legacyGetRegionFunction } from './utils/legacyGetRegionFunction';
 
 let getRegionFunction: () => Promise<string | undefined>;
-let getStaticRegionFunction: () => Promise<string | undefined>;
-let getRegionFunctionWrapper: () => Promise<string | undefined>;
 /**
  * @internal
  *
@@ -16,17 +16,15 @@ let getRegionFunctionWrapper: () => Promise<string | undefined>;
  * console.log(region); // "US" or undefined
  */
 export async function getRegion(): Promise<string | undefined> {
-  if (getRegionFunctionWrapper) return await getRegionFunctionWrapper();
+  if (getRegionFunction) return await getRegionFunction();
 
-  getRegionFunction = legacyGetRequestFunction('getRegion', true);
-  getStaticRegionFunction = legacyGetRequestFunction('getRegion', false);
+  if (process.env._GENERALTRANSLATION_ENABLE_SSG === 'false') {
+    // Support new behavior
+    getRegionFunction = getRequestFunction('getRegion');
+  } else {
+    // Support legacy behavior
+    getRegionFunction = legacyGetRegionFunction();
+  }
 
-  getRegionFunctionWrapper = async () => {
-    const region = isSSR()
-      ? await getRegionFunction()
-      : await getStaticRegionFunction();
-    return region;
-  };
-
-  return await getRegionFunctionWrapper();
+  return await getRegionFunction();
 }

--- a/packages/next/src/request/getRegion.ts
+++ b/packages/next/src/request/getRegion.ts
@@ -1,5 +1,3 @@
-import { legacyGetRequestFunction } from './utils/legacyGetRequestFunction';
-import isSSR from './utils/isSSR';
 import { getRequestFunction } from './utils/getRequestFunction';
 import { legacyGetRegionFunction } from './utils/legacyGetRegionFunction';
 

--- a/packages/next/src/request/types.ts
+++ b/packages/next/src/request/types.ts
@@ -3,6 +3,9 @@
  */
 export type RequestFunctionReturnType = string | undefined;
 
+/**
+ * @deprecated
+ */
 export const STATIC_REQUEST_FUNCTIONS = [
   'getStaticLocale',
   'getStaticRegion',
@@ -16,4 +19,8 @@ export const REQUEST_FUNCTIONS = [
 ] as const;
 
 export type RequestFunctions = (typeof REQUEST_FUNCTIONS)[number];
+
+/**
+ * @deprecated
+ */
 export type StaticRequestFunctions = (typeof STATIC_REQUEST_FUNCTIONS)[number];

--- a/packages/next/src/request/utils/__tests__/legacyGetRequestFunction.test.ts
+++ b/packages/next/src/request/utils/__tests__/legacyGetRequestFunction.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { setupGetRequestFunctionMocks } from '../__mocks__/mockGetRequestFunction';
 
-// Set up comprehensive mocking for getRequestFunction and all its dependencies
+// Set up comprehensive mocking for legacyGetRequestFunction and all its dependencies
 setupGetRequestFunctionMocks();
 
-describe('getRequestFunction', () => {
+describe('legacyGetRequestFunction', () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
@@ -20,25 +20,31 @@ describe('getRequestFunction', () => {
   });
 
   describe('basic functionality', () => {
-    it('should export getRequestFunction as a function', async () => {
-      const { getRequestFunction } = await import('../getRequestFunction');
-      expect(typeof getRequestFunction).toBe('function');
+    it('should export legacyGetRequestFunction as a function', async () => {
+      const { legacyGetRequestFunction } = await import(
+        '../legacyGetRequestFunction'
+      );
+      expect(typeof legacyGetRequestFunction).toBe('function');
     });
 
     it('should accept valid function names', async () => {
-      const { getRequestFunction } = await import('../getRequestFunction');
+      const { legacyGetRequestFunction } = await import(
+        '../legacyGetRequestFunction'
+      );
 
-      expect(() => getRequestFunction('getLocale', true)).not.toThrow();
-      expect(() => getRequestFunction('getRegion', true)).not.toThrow();
-      expect(() => getRequestFunction('getDomain', true)).not.toThrow();
+      expect(() => legacyGetRequestFunction('getLocale', true)).not.toThrow();
+      expect(() => legacyGetRequestFunction('getRegion', true)).not.toThrow();
+      expect(() => legacyGetRequestFunction('getDomain', true)).not.toThrow();
     });
 
     it('should return functions for each valid input', async () => {
-      const { getRequestFunction } = await import('../getRequestFunction');
+      const { legacyGetRequestFunction } = await import(
+        '../legacyGetRequestFunction'
+      );
 
-      const localeFunction = getRequestFunction('getLocale', true);
-      const regionFunction = getRequestFunction('getRegion', true);
-      const domainFunction = getRequestFunction('getDomain', true);
+      const localeFunction = legacyGetRequestFunction('getLocale', true);
+      const regionFunction = legacyGetRequestFunction('getRegion', true);
+      const domainFunction = legacyGetRequestFunction('getDomain', true);
 
       expect(typeof localeFunction).toBe('function');
       expect(typeof regionFunction).toBe('function');
@@ -48,11 +54,13 @@ describe('getRequestFunction', () => {
 
   describe('SSR mode', () => {
     it('should use default functions when no custom functions are enabled', async () => {
-      const { getRequestFunction } = await import('../getRequestFunction');
+      const { legacyGetRequestFunction } = await import(
+        '../legacyGetRequestFunction'
+      );
 
-      const localeFunction = getRequestFunction('getLocale', true);
-      const regionFunction = getRequestFunction('getRegion', true);
-      const domainFunction = getRequestFunction('getDomain', true);
+      const localeFunction = legacyGetRequestFunction('getLocale', true);
+      const regionFunction = legacyGetRequestFunction('getRegion', true);
+      const domainFunction = legacyGetRequestFunction('getDomain', true);
 
       expect(typeof localeFunction).toBe('function');
       expect(typeof regionFunction).toBe('function');
@@ -76,11 +84,13 @@ describe('getRequestFunction', () => {
       process.env._GENERALTRANSLATION_STATIC_GET_REGION_ENABLED = 'true';
       process.env._GENERALTRANSLATION_STATIC_GET_DOMAIN_ENABLED = 'true';
 
-      const { getRequestFunction } = await import('../getRequestFunction');
+      const { legacyGetRequestFunction } = await import(
+        '../legacyGetRequestFunction'
+      );
 
-      const localeFunction = getRequestFunction('getLocale', false);
-      const regionFunction = getRequestFunction('getRegion', false);
-      const domainFunction = getRequestFunction('getDomain', false);
+      const localeFunction = legacyGetRequestFunction('getLocale', false);
+      const regionFunction = legacyGetRequestFunction('getRegion', false);
+      const domainFunction = legacyGetRequestFunction('getDomain', false);
 
       expect(typeof localeFunction).toBe('function');
       expect(typeof regionFunction).toBe('function');
@@ -90,11 +100,13 @@ describe('getRequestFunction', () => {
     it('should force SSR when _GENERALTRANSLATION_ENABLE_SSG is false', async () => {
       process.env._GENERALTRANSLATION_ENABLE_SSG = 'false';
 
-      const { getRequestFunction } = await import('../getRequestFunction');
+      const { legacyGetRequestFunction } = await import(
+        '../legacyGetRequestFunction'
+      );
 
       // Even when requesting SSG (false), should use SSR due to env var
-      const regionFunction = getRequestFunction('getRegion', false);
-      const domainFunction = getRequestFunction('getDomain', false);
+      const regionFunction = legacyGetRequestFunction('getRegion', false);
+      const domainFunction = legacyGetRequestFunction('getDomain', false);
 
       expect(typeof regionFunction).toBe('function');
       expect(typeof domainFunction).toBe('function');
@@ -108,11 +120,13 @@ describe('getRequestFunction', () => {
     });
 
     it('should use static function names in SSG mode', async () => {
-      const { getRequestFunction } = await import('../getRequestFunction');
+      const { legacyGetRequestFunction } = await import(
+        '../legacyGetRequestFunction'
+      );
 
-      const localeFunction = getRequestFunction('getLocale', false);
-      const regionFunction = getRequestFunction('getRegion', false);
-      const domainFunction = getRequestFunction('getDomain', false);
+      const localeFunction = legacyGetRequestFunction('getLocale', false);
+      const regionFunction = legacyGetRequestFunction('getRegion', false);
+      const domainFunction = legacyGetRequestFunction('getDomain', false);
 
       expect(typeof localeFunction).toBe('function');
       expect(typeof regionFunction).toBe('function');
@@ -122,10 +136,12 @@ describe('getRequestFunction', () => {
 
   describe('error handling', () => {
     it('should handle module loading errors gracefully', async () => {
-      const { getRequestFunction } = await import('../getRequestFunction');
+      const { legacyGetRequestFunction } = await import(
+        '../legacyGetRequestFunction'
+      );
 
       // Even with potential module loading issues, should return a function
-      const localeFunction = getRequestFunction('getLocale', true);
+      const localeFunction = legacyGetRequestFunction('getLocale', true);
       expect(typeof localeFunction).toBe('function');
 
       // The function should return mocked values
@@ -134,12 +150,14 @@ describe('getRequestFunction', () => {
     });
 
     it('should return mocked values when modules are mocked', async () => {
-      const { getRequestFunction } = await import('../getRequestFunction');
+      const { legacyGetRequestFunction } = await import(
+        '../legacyGetRequestFunction'
+      );
 
       // All functions should return functions that resolve to mocked values
-      const localeFunction = getRequestFunction('getLocale', true);
-      const regionFunction = getRequestFunction('getRegion', true);
-      const domainFunction = getRequestFunction('getDomain', true);
+      const localeFunction = legacyGetRequestFunction('getLocale', true);
+      const regionFunction = legacyGetRequestFunction('getRegion', true);
+      const domainFunction = legacyGetRequestFunction('getDomain', true);
 
       const localeResult = await localeFunction();
       const regionResult = await regionFunction();

--- a/packages/next/src/request/utils/isSSR.ts
+++ b/packages/next/src/request/utils/isSSR.ts
@@ -1,6 +1,9 @@
 import { PHASE_PRODUCTION_BUILD } from 'next/constants';
 import { ssrDetectionFailedWarning } from '../../errors';
 
+/**
+ * @deprecated
+ */
 export default function isSSR() {
   const isSSR = true;
   if (process.env._GENERALTRANSLATION_ENABLE_SSG === 'false') {

--- a/packages/next/src/request/utils/legacyGetLocaleFunction.ts
+++ b/packages/next/src/request/utils/legacyGetLocaleFunction.ts
@@ -1,0 +1,29 @@
+import { GT } from 'generaltranslation';
+import { RequestFunctionReturnType } from '../types';
+import { legacyGetRequestFunction } from './legacyGetRequestFunction';
+import isSSR from './isSSR';
+import I18NConfiguration from '../../config-dir/I18NConfiguration';
+
+let getLocaleFunction: () => Promise<RequestFunctionReturnType>;
+let getStaticLocaleFunction: () => Promise<RequestFunctionReturnType>;
+
+/**
+ * @deprecated
+ */
+export function legacyGetLocaleFunction(
+  I18NConfig: I18NConfiguration,
+  gt: GT
+): () => Promise<string> {
+  // Construct getLocale function
+  getLocaleFunction = legacyGetRequestFunction('getLocale', true);
+  getStaticLocaleFunction = legacyGetRequestFunction('getLocale', false);
+
+  // Construct locale function
+  return async () => {
+    // Always fallback to default locale
+    const locale = isSSR()
+      ? await getLocaleFunction()
+      : await getStaticLocaleFunction();
+    return gt.resolveAliasLocale(locale || I18NConfig.getDefaultLocale());
+  };
+}

--- a/packages/next/src/request/utils/legacyGetRegionFunction.ts
+++ b/packages/next/src/request/utils/legacyGetRegionFunction.ts
@@ -1,0 +1,19 @@
+import { RequestFunctionReturnType } from '../types';
+import { legacyGetRequestFunction } from './legacyGetRequestFunction';
+import isSSR from './isSSR';
+
+let getRegionFunction: () => Promise<RequestFunctionReturnType>;
+let getStaticRegionFunction: () => Promise<RequestFunctionReturnType>;
+
+/**
+ * @deprecated
+ */
+export function legacyGetRegionFunction(): () => Promise<string | undefined> {
+  // Construct getLocale function
+  getRegionFunction = legacyGetRequestFunction('getRegion', true);
+  getStaticRegionFunction = legacyGetRequestFunction('getRegion', false);
+
+  // Construct locale function
+  return async (): Promise<string | undefined> =>
+    isSSR() ? await getRegionFunction() : await getStaticRegionFunction();
+}


### PR DESCRIPTION
Deprecate old SSG behavior:
- consolidate into 1 getLocale()/getRegion() function
- must maintain back compat
- fixes dev infinite loop issue
- warnings for old behavior