### PR TITLE
F/save local persistence fix

### DIFF
--- a/.changeset/fast-ideas-turn.md
+++ b/.changeset/fast-ideas-turn.md
@@ -1,0 +1,5 @@
+---
+'gtx-cli': patch
+---
+
+Assign `save-local` changes to most recent download

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,5 +3,5 @@ pre-commit:
   jobs:
     - run: npx eslint --fix {staged_files}
       glob: '**/*.{js,ts,jsx,tsx,json,sh,mjs,yaml,yml}'
-    - run: cd packages/cli && node scripts/generate-version.js && git add src/generated/version.ts
+    - run: node scripts/generate-version.js && git add src/generated/version.ts
       root: packages/cli

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.5.29';
+export const PACKAGE_VERSION = '2.5.33';


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Fixed persistence issue where local user edits were lost when file versions changed. The fix ensures the CLI tracks user edits against the latest downloaded version from the lock file rather than the newly uploaded version.

Key changes:
- Added `findLatestDownloadedVersion()` function to locate the most recent downloaded version by `updatedAt` timestamp
- Modified diff collection logic to compare against latest downloaded version instead of uploaded version
- Added test coverage verifying behavior when uploaded version differs from downloaded version
- Simplified lefthook pre-commit hook configuration by removing redundant `cd` command

<details open><summary><h3>Confidence Score: 5/5</h3></summary>


- This PR is safe to merge with minimal risk
- Well-tested bug fix with clear logic, comprehensive test coverage, and no breaking changes or security concerns
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| lefthook.yml | 5/5 | simplified git pre-commit hook by removing redundant `cd` command since `root` already sets working directory |
| packages/cli/src/api/collectUserEditDiffs.ts | 5/5 | added logic to find and use latest downloaded version from lock file when uploaded version differs, preventing loss of local edits |
| packages/cli/src/api/__tests__/collectUserEditDiffs.test.ts | 5/5 | added test verifying that latest downloaded version is used when uploaded version has changed |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant CLI
    participant LockFile as gt-lock.json
    participant Server
    
    User->>CLI: Upload new file version (v2)
    CLI->>LockFile: Check downloaded versions
    Note over LockFile: Has v1 downloaded<br/>with postProcessHash
    CLI->>CLI: findLatestDownloadedVersion()<br/>Returns v1 (latest by updatedAt)
    CLI->>CLI: Compare local file hash<br/>vs postProcessHash
    alt Hashes differ (user made edits)
        CLI->>Server: queryFileData(v1)
        Server-->>CLI: Translation metadata
        CLI->>Server: downloadFileBatch(v1)
        Server-->>CLI: Original v1 content
        CLI->>CLI: getGitUnifiedDiff()<br/>(v1 server vs local)
        CLI->>Server: submitUserEditDiffs()<br/>with diff
    else Hashes match
        Note over CLI: Skip - no user edits
    end
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->