### PR TITLE
fix(cli): Remove early return

### DIFF
--- a/.changeset/wet-lights-carry.md
+++ b/.changeset/wet-lights-carry.md
@@ -1,0 +1,5 @@
+---
+'gtx-cli': patch
+---
+
+Fix CLI failure handling

--- a/packages/cli/src/workflow/download.ts
+++ b/packages/cli/src/workflow/download.ts
@@ -115,7 +115,6 @@ export async function downloadTranslations(
           .map(([key, value]) => `- ${value.fileName}`)
           .join('\n')}`
       );
-      return false;
     }
 
     if (!pollResult.success) {


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Removed an early return statement that incorrectly aborted the entire download process when some translation jobs failed, allowing successfully translated files to be downloaded.

- Fixed bug where presence of any failed translation jobs would prevent all successful translations from being downloaded
- The early return at line 117 was redundant since line 120-122 already handles the `pollResult.success === false` case (timeout scenario)
- Now correctly distinguishes between jobs that finished processing (some may have failed) vs jobs that timed out

<details open><summary><h3>Confidence Score: 5/5</h3></summary>


- This PR is safe to merge with minimal risk
- The change fixes a clear logic bug by removing a premature early return. The existing check at line 120-122 already handles failure cases (timeout), and the DownloadStep only processes files in `fileTracker.completed`, so partial failures won't affect the download logic. The fix is minimal, focused, and well-tested through the existing workflow structure.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| .changeset/wet-lights-carry.md | 5/5 | Added changeset documenting patch fix for CLI failure handling |
| packages/cli/src/workflow/download.ts | 5/5 | Removed premature early return that prevented downloading successful translations when some files failed |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant CLI as downloadTranslations
    participant Poll as PollTranslationJobsStep
    participant Download as DownloadTranslationsStep
    participant GT as GT API
    
    CLI->>Poll: Poll translation jobs
    Poll->>GT: Check job status
    GT-->>Poll: Job statuses (some completed, some failed)
    Poll->>Poll: Update fileTracker<br/>(move jobs to completed/failed)
    Poll-->>CLI: success=true, fileTracker
    
    alt Has failed files
        CLI->>CLI: Log failed files (no early return)
    end
    
    alt pollResult.success is false
        CLI-->>CLI: Return false (timeout case)
    else pollResult.success is true
        CLI->>Download: Download completed translations
        Download->>GT: Query & download files from fileTracker.completed
        GT-->>Download: Translation files
        Download-->>CLI: Download result
        CLI-->>CLI: Return download result
    end
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->