### PR TITLE
F/use canonical local keys

### DIFF
--- a/.changeset/happy-suits-fail.md
+++ b/.changeset/happy-suits-fail.md
@@ -2,4 +2,4 @@
 'gtx-cli': patch
 ---
 
-Adding `experimentalUseCanonicalLocaleKeys` option to `gt.config.json`. It overrides alias configurations when setting keys in a JSON schema
+Adding `experimentalCanonicalLocaleKeys` option to `gt.config.json`. It overrides alias configurations when setting keys in a JSON schema

--- a/.changeset/happy-suits-fail.md
+++ b/.changeset/happy-suits-fail.md
@@ -1,0 +1,5 @@
+---
+'gtx-cli': patch
+---
+
+Adding `experimentalUseCanonicalLocaleKeys` option to `gt.config.json`. It overrides alias configurations when setting keys in a JSON schema

--- a/packages/cli/src/formats/json/__tests__/mergeJson.test.ts
+++ b/packages/cli/src/formats/json/__tests__/mergeJson.test.ts
@@ -1472,7 +1472,9 @@ describe('mergeJson', () => {
 
       expect(frenchNav).toBeDefined();
       expect(
-        parsed.navigation.languages.find((lang: any) => lang.language === 'fr-ca')
+        parsed.navigation.languages.find(
+          (lang: any) => lang.language === 'fr-ca'
+        )
       ).toBeUndefined();
       expect(frenchNav.tabs[0].tab).toBe('Accueil');
       expect(frenchNav.tabs[0].pages[0]).toBe('docs/fr-ca/index');

--- a/packages/cli/src/formats/json/__tests__/mergeJson.test.ts
+++ b/packages/cli/src/formats/json/__tests__/mergeJson.test.ts
@@ -4,6 +4,7 @@ import { readFileSync } from 'fs';
 import path from 'path';
 import { logger } from '../../../console/logger.js';
 import { exitSync } from '../../../console/logging.js';
+import { gt } from '../../../utils/gt.js';
 
 vi.mock('../../../console/logger.js');
 vi.mock('../../../console/logging.js');
@@ -1406,6 +1407,75 @@ describe('mergeJson', () => {
       expect(englishItem.desc).toBe('English Description');
       expect(germanItem.title).toBe('Deutscher Titel');
       expect(germanItem.desc).toBe('Deutsche Beschreibung');
+    });
+
+    it('should force canonical locale for locale keys when canonical locale flag enabled', () => {
+      const originalContent = JSON.stringify({
+        navigation: {
+          languages: [
+            {
+              language: 'en',
+              tabs: [{ tab: 'Home', pages: ['docs/index'] }],
+            },
+          ],
+        },
+      });
+
+      const targets = [
+        {
+          translatedContent: JSON.stringify({
+            '/navigation/languages': {
+              '/0': {
+                '/language': 'fr-ca',
+                '/tabs/0/tab': 'Accueil',
+                '/tabs/0/pages/0': 'docs/fr-ca/index',
+              },
+            },
+          }),
+          targetLocale: 'fr-ca',
+        },
+      ];
+
+      const customMapping = {
+        'fr-ca': { code: 'fr-CA' },
+      };
+      gt.setConfig({ sourceLocale: 'en', customMapping });
+
+      const result = mergeJson(
+        originalContent,
+        'docs.json',
+        {
+          jsonSchema: {
+            '**/*.json': {
+              composite: {
+                '$.navigation.languages': {
+                  type: 'array',
+                  include: ['$.tabs[*].tab', '$.tabs[*].pages[*]'],
+                  key: '$.language',
+                },
+              },
+            },
+          },
+          experimentalCanonicalLocaleKeys: true,
+        },
+        targets,
+        'en',
+        ['fr-ca']
+      );
+
+      gt.setConfig({ sourceLocale: 'en', customMapping: undefined as any });
+
+      const parsed = JSON.parse(result[0]);
+      const frenchNav = parsed.navigation.languages.find(
+        (lang: any) => lang.language === 'fr-CA'
+      );
+
+      expect(frenchNav).toBeDefined();
+      expect(
+        parsed.navigation.languages.find((lang: any) => lang.language === 'fr-ca')
+      ).toBeUndefined();
+      expect(frenchNav.tabs[0].tab).toBe('Accueil');
+      expect(frenchNav.tabs[0].pages[0]).toBe('docs/fr-ca/index');
     });
 
     it('should order array items to match locales when sort is set to locale', () => {

--- a/packages/cli/src/formats/json/mergeJson.ts
+++ b/packages/cli/src/formats/json/mergeJson.ts
@@ -13,6 +13,7 @@ import {
 import { JSONPath } from 'jsonpath-plus';
 import { getLocaleProperties } from 'generaltranslation';
 import { replaceLocalePlaceholders } from '../utils.js';
+import { gt } from '../../utils/gt.js';
 
 export function mergeJson(
   originalContent: string,
@@ -37,6 +38,15 @@ export function mergeJson(
     logger.error(`Invalid JSON file: ${inputPath}`);
     return exitSync(1);
   }
+
+  const useCanonicalLocaleKeys =
+    options?.experimentalCanonicalLocaleKeys ?? false;
+  const canonicalDefaultLocale = useCanonicalLocaleKeys
+    ? gt.resolveCanonicalLocale(defaultLocale)
+    : defaultLocale;
+  const canonicalLocaleOrder = useCanonicalLocaleKeys
+    ? localeOrder.map((locale) => gt.resolveCanonicalLocale(locale))
+    : localeOrder;
 
   // Handle include
   if (jsonSchema.include) {
@@ -93,7 +103,7 @@ export function mergeJson(
 
       // Get source item for default locale
       const matchingDefaultLocaleItems = findMatchingItemArray(
-        defaultLocale,
+        canonicalDefaultLocale,
         sourceObjectOptions,
         sourceObjectPointer,
         sourceObjectValue
@@ -134,7 +144,9 @@ export function mergeJson(
 
         // 2. Track all array indecies to remove (will be overwritten)
         const targetItemsToRemove = findMatchingItemArray(
-          target.targetLocale,
+          useCanonicalLocaleKeys
+            ? gt.resolveCanonicalLocale(target.targetLocale)
+            : target.targetLocale,
           sourceObjectOptions,
           sourceObjectPointer,
           sourceObjectValue
@@ -175,7 +187,9 @@ export function mergeJson(
           const mutatedSourceItem = structuredClone(defaultLocaleSourceItem);
           const { identifyingLocaleProperty: targetLocaleKeyProperty } =
             getSourceObjectOptionsArray(
-              target.targetLocale,
+              useCanonicalLocaleKeys
+                ? gt.resolveCanonicalLocale(target.targetLocale)
+                : target.targetLocale,
               sourceObjectPointer,
               sourceObjectOptions
             );
@@ -212,6 +226,14 @@ export function mergeJson(
             defaultLocale
           );
 
+          if (useCanonicalLocaleKeys && defaultLocaleKeyPointer) {
+            JSONPointer.set(
+              mutatedSourceItem,
+              defaultLocaleKeyPointer,
+              targetLocaleKeyProperty
+            );
+          }
+
           itemsToAdd.push(mutatedSourceItem);
         }
       }
@@ -238,9 +260,9 @@ export function mergeJson(
         sortByLocaleOrder(
           filteredSourceObjectValue,
           sourceObjectOptions,
-          localeOrder,
+          canonicalLocaleOrder,
           sourceObjectPointer,
-          defaultLocale
+          canonicalDefaultLocale
         )
       );
     } else {
@@ -253,7 +275,7 @@ export function mergeJson(
       }
       // Validate localeProperty
       const matchingDefaultLocaleItem = findMatchingItemObject(
-        defaultLocale,
+        canonicalDefaultLocale,
         sourceObjectPointer,
         sourceObjectOptions,
         sourceObjectValue
@@ -285,7 +307,9 @@ export function mergeJson(
 
         // 2. Find the source item for the target locale
         const matchingTargetItem = findMatchingItemObject(
-          target.targetLocale,
+          useCanonicalLocaleKeys
+            ? gt.resolveCanonicalLocale(target.targetLocale)
+            : target.targetLocale,
           sourceObjectPointer,
           sourceObjectOptions,
           sourceObjectValue

--- a/packages/cli/src/formats/json/mergeJson.ts
+++ b/packages/cli/src/formats/json/mergeJson.ts
@@ -202,6 +202,12 @@ export function mergeJson(
             translatedKeyJsonPointer,
             translatedValue,
           ] of Object.entries(targetItem || {})) {
+            const valueToSet =
+              useCanonicalLocaleKeys &&
+              defaultLocaleKeyPointer &&
+              translatedKeyJsonPointer === defaultLocaleKeyPointer
+                ? targetLocaleKeyProperty
+                : translatedValue;
             try {
               const value = JSONPointer.get(
                 mutatedSourceItem,
@@ -211,7 +217,7 @@ export function mergeJson(
               JSONPointer.set(
                 mutatedSourceItem,
                 translatedKeyJsonPointer,
-                translatedValue
+                valueToSet
               );
             } catch {
               /* empty */
@@ -225,14 +231,6 @@ export function mergeJson(
             target.targetLocale,
             defaultLocale
           );
-
-          if (useCanonicalLocaleKeys && defaultLocaleKeyPointer) {
-            JSONPointer.set(
-              mutatedSourceItem,
-              defaultLocaleKeyPointer,
-              targetLocaleKeyProperty
-            );
-          }
 
           itemsToAdd.push(mutatedSourceItem);
         }

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.5.35';
+export const PACKAGE_VERSION = '2.5.36';

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -237,6 +237,7 @@ export type AdditionalOptions = {
     match: string; // prefix to match, e.g. '@site/docs'
     replace: string; // replacement prefix, can include [locale] or [defaultLocale]
   }>;
+  experimentalCanonicalLocaleKeys?: boolean; // For composite JSON schemas with locale keys, force canonical locale even when alias provided
 };
 
 export type SharedStaticAssetsConfig = {


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR adds a new experimental option `experimentalCanonicalLocaleKeys` to the CLI's JSON merging functionality. When enabled, locale keys in composite JSON schemas will use canonical locale codes (e.g., `fr-CA`) instead of aliases (e.g., `fr-ca`) when custom mappings are configured.

- Added `experimentalCanonicalLocaleKeys` boolean option to `AdditionalOptions` type
- Modified `mergeJson` to resolve canonical locales for default locale, locale order, and target locales when the flag is enabled
- Uses existing `gt.resolveCanonicalLocale()` method from the `generaltranslation` core package
- Added comprehensive test case demonstrating the feature with `fr-ca` → `fr-CA` mapping
- Version bump to 2.5.36
- **Issue**: Changeset documentation uses incorrect option name `experimentalUseCanonicalLocaleKeys` instead of `experimentalCanonicalLocaleKeys`

<details open><summary><h3>Confidence Score: 4/5</h3></summary>


- This PR is safe to merge with a minor documentation fix needed in the changeset
- The implementation is well-structured and follows existing patterns in the codebase. The feature is behind an experimental flag, limiting blast radius. Comprehensive test coverage validates the new functionality. Only issue is a naming mismatch in the changeset documentation.
- The changeset file `.changeset/happy-suits-fail.md` has an incorrect option name that should be fixed before merging to avoid user confusion
</details>


<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| .changeset/happy-suits-fail.md | 3/5 | Changeset describing new option but uses incorrect name `experimentalUseCanonicalLocaleKeys` instead of actual implementation name `experimentalCanonicalLocaleKeys` |
| packages/cli/src/formats/json/__tests__/mergeJson.test.ts | 5/5 | Added comprehensive test for canonical locale key resolution feature with proper setup/teardown using `gt.setConfig` |
| packages/cli/src/formats/json/mergeJson.ts | 5/5 | Added experimental canonical locale key resolution for JSON schema merging, properly uses `gt.resolveCanonicalLocale` throughout array and object handling paths |
| packages/cli/src/generated/version.ts | 5/5 | Auto-generated version bump from 2.5.35 to 2.5.36 |
| packages/cli/src/types/index.ts | 5/5 | Added `experimentalCanonicalLocaleKeys` boolean option to `AdditionalOptions` type with clear documentation comment |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant CLI as CLI Command
    participant MJ as mergeJson()
    participant GT as gt.resolveCanonicalLocale()
    participant CM as customMapping

    CLI->>MJ: mergeJson(content, options, targets)
    
    alt experimentalCanonicalLocaleKeys enabled
        MJ->>GT: resolveCanonicalLocale(defaultLocale)
        GT->>CM: check customMapping
        CM-->>GT: return canonical code (e.g., fr-CA)
        GT-->>MJ: canonicalDefaultLocale
        
        loop for each locale in localeOrder
            MJ->>GT: resolveCanonicalLocale(locale)
            GT-->>MJ: canonical locale
        end
        
        loop for each target
            MJ->>GT: resolveCanonicalLocale(targetLocale)
            GT-->>MJ: canonical locale for key matching
        end
    else flag disabled
        MJ->>MJ: use original locale values
    end
    
    MJ-->>CLI: merged JSON with canonical locale keys
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->