### PR TITLE
fix: disable swc plugin (temporary)

### DIFF
--- a/.changeset/real-spoons-glow.md
+++ b/.changeset/real-spoons-glow.md
@@ -1,0 +1,5 @@
+---
+'gt-next': patch
+---
+
+fix: disable swc plugin (temporary)

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.5.36';
+export const PACKAGE_VERSION = '2.5.37';

--- a/packages/next/src/config-dir/props/defaultWithGTConfigProps.ts
+++ b/packages/next/src/config-dir/props/defaultWithGTConfigProps.ts
@@ -68,7 +68,7 @@ const defaultWithGTConfigProps: DefaultGTConfigProps = {
     resetLocaleCookieName: defaultResetLocaleCookieName,
   },
   experimentalCompilerOptions: {
-    type: 'swc',
+    type: 'none',
     logLevel: 'warn',
     compileTimeHash: true,
     disableBuildChecks: false,


### PR DESCRIPTION
# Why
Current version of SWC plugin is compiled against wrong next@16.1.0 swc

# What
Disable swc plugin (temporary)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR temporarily disables the SWC compiler plugin by changing the default `experimentalCompilerOptions.type` from `'swc'` to `'none'` in the Next.js package configuration.

**Key Changes:**
- Default compiler type changed from SWC to none in `defaultWithGTConfigProps.ts`
- This affects build-time translation compilation behavior for new users or projects without explicit compiler configuration
- Existing validation logic in `validateCompiler.ts` will still override to `'none'` if SWC is incompatible with the Next.js version
- Users can still explicitly configure `experimentalCompilerOptions.type` to `'swc'` or `'babel'` in their config if desired

**Impact:**
- Translation processing will fall back to runtime handling instead of compile-time optimization
- This is marked as temporary, suggesting a known issue with the SWC plugin that needs to be resolved
- No breaking changes for users who have explicitly configured their compiler type

<details open><summary><h3>Confidence Score: 4/5</h3></summary>


- This PR is safe to merge with low risk as it's a conservative temporary workaround
- The change is a simple, reversible configuration default update that disables a potentially problematic feature. The fallback behavior (runtime translation) is well-tested and stable. Minor concern is the lack of context about what specific issue prompted this temporary fix.
- No files require special attention - the change is straightforward and well-contained
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .changeset/real-spoons-glow.md | Adds changeset for patch release documenting the SWC plugin being disabled temporarily |
| packages/cli/src/generated/version.ts | Auto-generated version bump from 2.5.36 to 2.5.37 |
| packages/next/src/config-dir/props/defaultWithGTConfigProps.ts | Changes default compiler type from 'swc' to 'none', disabling SWC plugin compilation temporarily |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User as User Application
    participant Config as withGTConfig
    participant Default as defaultWithGTConfigProps
    participant Validate as validateCompiler
    participant Compiler as Compiler Plugin

    User->>Config: Initialize GT config
    Config->>Default: Load default config
    Note over Default: type: 'none' (changed from 'swc')
    Default-->>Config: Return defaults
    Config->>Config: Merge user config with defaults
    Config->>Validate: Validate compiler compatibility
    alt SWC Plugin Incompatible
        Validate->>Validate: Set type to 'none'
        Validate->>Validate: Log warning
    else Babel Plugin Incompatible
        Validate->>Validate: Set type to 'none'
        Validate->>Validate: Log warning
    end
    Validate-->>Config: Return validated config
    Config->>Compiler: Initialize with type='none'
    Note over Compiler: No compilation plugin active
    Compiler-->>User: Runtime translation handling
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->