### PR TITLE
chore: add uzbek locale support

### DIFF
--- a/.changeset/seven-masks-drum.md
+++ b/.changeset/seven-masks-drum.md
@@ -1,0 +1,5 @@
+---
+'@generaltranslation/supported-locales': patch
+---
+
+chore: add uzbek

--- a/packages/supported-locales/src/supportedLocales.ts
+++ b/packages/supported-locales/src/supportedLocales.ts
@@ -130,6 +130,7 @@ const supportedLocales = {
   tr: ['tr'], // Turkish
   uk: ['uk'], // Ukrainian
   ur: ['ur'], // Urdu
+  uz: ['uz'], // Uzbek
   vi: ['vi'], // Vietnamese
   zh: [
     // Chinese


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR adds support for the Uzbek locale (`uz`) to the supported locales list. The change follows the existing pattern and maintains alphabetical ordering.

- Added `uz: ['uz']` entry between Urdu and Vietnamese in `supportedLocales.ts`
- Created appropriate changeset file for version tracking
- No issues found

<details open><summary><h3>Confidence Score: 5/5</h3></summary>


- This PR is safe to merge with no risk
- The change is minimal, adds a single locale entry in the correct format and position, includes proper changeset documentation, and follows all existing patterns in the codebase
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .changeset/seven-masks-drum.md | Added changeset documenting Uzbek locale addition as a patch change |
| packages/supported-locales/src/supportedLocales.ts | Added Uzbek (`uz`) locale in correct alphabetical position |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant CS as Changeset File
    participant SL as supportedLocales.ts
    participant Pkg as @generaltranslation/supported-locales
    
    Dev->>CS: Create seven-masks-drum.md
    Note over CS: Document patch change<br/>for Uzbek locale
    
    Dev->>SL: Add uz locale entry
    Note over SL: Insert 'uz': ['uz']<br/>between 'ur' and 'vi'
    
    SL->>Pkg: Export updated locale list
    Note over Pkg: Uzbek now available<br/>for translation
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->