### PR TITLE
chore(mcp): Fix base docs URL

### DIFF
--- a/.changeset/tired-squids-call.md
+++ b/.changeset/tired-squids-call.md
@@ -1,0 +1,5 @@
+---
+'@generaltranslation/mcp': patch
+---
+
+Fix base URL for fetching docs

--- a/packages/mcp/src/resources/docs.ts
+++ b/packages/mcp/src/resources/docs.ts
@@ -35,7 +35,7 @@ export async function addDocsResource(server: McpServer) {
   // Resource for llms-full.txt
   server.resource('llms-full.txt', 'llms://llms-full.txt', async (uri) => {
     try {
-      const content = await fetchDocContent('llms-full.txt');
+      const content = await fetchDocContent('llms-full.txt', false);
 
       return {
         contents: [
@@ -61,7 +61,7 @@ export async function addDocsResource(server: McpServer) {
   // Resource for llms.txt
   server.resource('llms.txt', 'llms://llms.txt', async (uri) => {
     try {
-      const content = await fetchDocContent('llms.txt');
+      const content = await fetchDocContent('llms.txt', false);
 
       return {
         contents: [
@@ -90,8 +90,8 @@ export function startCacheRefreshJob() {
   const refreshCache = async () => {
     try {
       console.error('Refreshing MCP resources cache...');
-      await fetchDocContent('llms.txt');
-      await fetchDocContent('llms-full.txt');
+      await fetchDocContent('llms.txt', false);
+      await fetchDocContent('llms-full.txt', false);
       console.error('Cache refresh complete');
     } catch (error) {
       console.error('Error refreshing cache:', error);

--- a/packages/mcp/src/tools/docs.ts
+++ b/packages/mcp/src/tools/docs.ts
@@ -65,7 +65,7 @@ export function addDocsTools(server: McpServer) {
     async ({ type }) => {
       try {
         const filename = type === 'full' ? 'llms-full.txt' : 'llms.txt';
-        const content = await fetchDocContent(filename);
+        const content = await fetchDocContent(filename, false);
 
         if (!content) {
           return {

--- a/packages/mcp/src/utils/getDocs.ts
+++ b/packages/mcp/src/utils/getDocs.ts
@@ -1,10 +1,9 @@
-export const GITHUB_URL =
-  'https://raw.githubusercontent.com/generaltranslation/gt/refs/heads/main/apps/docs/content/docs/en';
+const BASE_URL = 'https://generaltranslation.com';
 
-export const DOCS_URL = 'https://docs.generaltranslation.app';
+export const DOCS_URL = `${BASE_URL}/docs`;
 
 export const getDocs = async (path: string) => {
-  const url = `${GITHUB_URL}/${path}`;
+  const url = `${DOCS_URL}/${path}`;
   console.error(`Fetching document from: ${url}`);
 
   try {
@@ -30,7 +29,10 @@ export const CACHE_TTL = 5 * 60 * 1000; // 5 minutes in milliseconds
  * Fetches content from the docs URL with caching
  * Refreshes cache every 5 minutes
  */
-export async function fetchDocContent(path: string): Promise<string> {
+export async function fetchDocContent(
+  path: string,
+  includeDocsPath: boolean = true
+): Promise<string> {
   const now = Date.now();
 
   // Check if we have a valid cached entry
@@ -38,7 +40,8 @@ export async function fetchDocContent(path: string): Promise<string> {
     return cache[path].content;
   }
 
-  const url = `${DOCS_URL}/${path}`;
+  // Fetch fresh content
+  const url = includeDocsPath ? `${DOCS_URL}/${path}` : `${BASE_URL}/${path}`;
   console.error(`Fetching document from: ${url}`);
 
   try {


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR updates the base URL for fetching documentation files in the MCP package, changing from GitHub raw content URLs to the production domain at `generaltranslation.com`.

**Key Changes:**
- Changed base URL from `https://raw.githubusercontent.com/generaltranslation/gt/refs/heads/main/apps/docs/content/docs/en` to `https://generaltranslation.com`
- Updated `DOCS_URL` to derive from the new `BASE_URL` (`https://generaltranslation.com/docs`)
- Added `includeDocsPath` parameter to `fetchDocContent()` function for flexible URL construction
- Updated all calls fetching `llms.txt` and `llms-full.txt` to bypass the `/docs` path segment by passing `includeDocsPath=false`

**Impact:**
The change ensures that LLM specification files (`llms.txt`, `llms-full.txt`) are fetched from the root domain (`https://generaltranslation.com/llms.txt`) while documentation paths continue using the `/docs` subdirectory. The caching mechanism and background refresh job remain unchanged.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>


- This PR is safe to merge with minimal risk
- The changes are straightforward URL configuration updates with clear intent. The refactoring adds a boolean parameter for URL path flexibility, all call sites are properly updated, and the logic is well-structured. No breaking changes to the API surface, no security concerns, and the caching behavior remains intact.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/mcp/src/utils/getDocs.ts | Refactored URL handling to fetch from `generaltranslation.com` instead of GitHub raw content, added `includeDocsPath` parameter for flexibility |
| packages/mcp/src/resources/docs.ts | Updated `fetchDocContent` calls to use `includeDocsPath=false` for `llms.txt` and `llms-full.txt` resources |
| packages/mcp/src/tools/docs.ts | Updated `list-docs` tool to use `includeDocsPath=false` when fetching llms specification files |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant McpServer
    participant Resources/Tools
    participant fetchDocContent
    participant Cache
    participant Network
    
    Client->>McpServer: Request llms.txt resource
    McpServer->>Resources/Tools: Handle resource request
    Resources/Tools->>fetchDocContent: fetchDocContent('llms.txt', false)
    fetchDocContent->>Cache: Check cache[path]
    
    alt Cache valid (< 5 min old)
        Cache-->>fetchDocContent: Return cached content
        fetchDocContent-->>Resources/Tools: Return content
    else Cache expired/missing
        fetchDocContent->>Network: fetch(BASE_URL/llms.txt)
        Note over Network: https://generaltranslation.com/llms.txt
        Network-->>fetchDocContent: Response
        fetchDocContent->>Cache: Update cache[path]
        fetchDocContent-->>Resources/Tools: Return content
    end
    
    Resources/Tools-->>McpServer: Return resource
    McpServer-->>Client: Resource content
    
    Note over McpServer,Cache: Background refresh job runs every 5 minutes
    McpServer->>Resources/Tools: refreshCache()
    Resources/Tools->>fetchDocContent: fetchDocContent('llms.txt', false)
    Resources/Tools->>fetchDocContent: fetchDocContent('llms-full.txt', false)
    fetchDocContent->>Network: Fetch and update cache
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->