### PR TITLE
feat: adding support for yaml in mintlify openapi config

### DIFF
--- a/.changeset/happy-buses-raise.md
+++ b/.changeset/happy-buses-raise.md
@@ -1,0 +1,5 @@
+---
+'gtx-cli': patch
+---
+
+Adding YAML support for Mintlify OpenAPI configurations

--- a/packages/cli/src/config/optionPresets.ts
+++ b/packages/cli/src/config/optionPresets.ts
@@ -66,6 +66,10 @@ export function generatePreset(
         return {
           include: ['$..summary', '$..description'],
         };
+      case 'openapi':
+        return {
+          include: ['$..summary', '$..description'],
+        };
       default:
         return {};
     }

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.5.37';
+export const PACKAGE_VERSION = '2.5.39';

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -267,7 +267,7 @@ export type JsonSchema = {
 };
 
 export type YamlSchema = {
-  preset?: 'mintlify';
+  preset?: 'mintlify' | 'openapi';
   include?: string[];
   transform?: TransformOptions;
 };


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR extends OpenAPI spec support from JSON-only to also include YAML (`.yaml` and `.yml`) formats, enabling Mintlify OpenAPI configuration to work with YAML spec files.

**Key changes:**
- Added `OPENAPI_SPEC_EXTENSIONS` constant containing `.json`, `.yaml`, and `.yml` extensions
- Updated `buildSpecAnalyses()` to parse YAML files using `YAML.parse()` alongside JSON parsing
- Refactored spec path detection logic to use `hasOpenApiSpecExtension()` helper function
- Added `openapi` preset to `YamlSchema` type definition and preset generation
- Included comprehensive test coverage for YAML OpenAPI spec frontmatter rewrites

The implementation correctly handles YAML parsing, maintains backward compatibility with existing JSON specs, and includes proper error handling with updated warning messages.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>


- This PR is safe to merge with minimal risk
- The implementation is clean, well-tested, and maintains backward compatibility. All changes are additive (extending JSON support to include YAML), with comprehensive test coverage including the new YAML path. The refactoring uses a helper function to centralize extension checking logic, error handling is appropriate, and the YAML parsing library is already imported and used elsewhere in the file.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/cli/src/utils/processOpenApi.ts | Added YAML support for OpenAPI specs - robust implementation with proper parsing and extension checking |
| packages/cli/src/types/index.ts | Extended YamlSchema type to support 'openapi' preset alongside existing 'mintlify' preset |
| packages/cli/src/config/optionPresets.ts | Added 'openapi' case to YAML preset generation with appropriate JSONPath includes |
| packages/cli/src/utils/__tests__/processOpenApi.test.ts | Added comprehensive test coverage for YAML OpenAPI spec support |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant processOpenApi
    participant buildSpecAnalyses
    participant fs
    participant YAML
    participant rewriteFrontmatter
    
    User->>processOpenApi: Process OpenAPI files
    processOpenApi->>buildSpecAnalyses: Build spec analyses from config files
    
    loop For each OpenAPI file
        buildSpecAnalyses->>fs: Check if file exists
        fs-->>buildSpecAnalyses: File exists
        buildSpecAnalyses->>buildSpecAnalyses: Extract extension (.json/.yaml/.yml)
        
        alt Extension not in OPENAPI_SPEC_EXTENSIONS
            buildSpecAnalyses->>buildSpecAnalyses: Warn and skip file
        else Valid extension
            buildSpecAnalyses->>fs: Read file content
            fs-->>buildSpecAnalyses: Raw file content
            
            alt Extension is .json
                buildSpecAnalyses->>buildSpecAnalyses: JSON.parse(raw)
            else Extension is .yaml or .yml
                buildSpecAnalyses->>YAML: YAML.parse(raw)
                YAML-->>buildSpecAnalyses: Parsed spec object
            end
            
            buildSpecAnalyses->>buildSpecAnalyses: Extract operations/schemas/webhooks
        end
    end
    
    buildSpecAnalyses-->>processOpenApi: Array of SpecAnalysis
    
    loop For each MDX/MD file
        processOpenApi->>rewriteFrontmatter: Rewrite frontmatter with localized spec paths
        rewriteFrontmatter->>rewriteFrontmatter: Parse openapi/openapi-schema values
        rewriteFrontmatter->>rewriteFrontmatter: hasOpenApiSpecExtension() checks for .json/.yaml/.yml
        rewriteFrontmatter->>rewriteFrontmatter: Resolve spec and generate localized path
        rewriteFrontmatter-->>processOpenApi: Updated content
        processOpenApi->>fs: Write updated file
    end
    
    processOpenApi-->>User: Processing complete
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->