### PR TITLE
F/auto update openapi paths

### DIFF
--- a/.changeset/cool-kids-lay.md
+++ b/.changeset/cool-kids-lay.md
@@ -1,0 +1,5 @@
+---
+'gtx-cli': patch
+---
+
+Auto-update OpenAPI spec paths when specs are modified

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.5.39';
+export const PACKAGE_VERSION = '2.5.40';

--- a/packages/cli/src/utils/processOpenApi.ts
+++ b/packages/cli/src/utils/processOpenApi.ts
@@ -470,9 +470,7 @@ function resolveSpec(
         warnings.add(
           `OpenAPI reference ${refDescription} in ${filePath} points to ${foundSpec.configPath}, but the entry was not found there and matches multiple specs (${alternatives
             .map((spec) => spec.configPath)
-            .join(
-              ', '
-            )}). Skipping localization for this reference.`
+            .join(', ')}). Skipping localization for this reference.`
         );
         return null;
       }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR enhances the OpenAPI path auto-update feature to intelligently repoint references when entries move between spec files. The implementation adds a new `specHasMatch()` helper function and extends the `resolveSpec()` function to detect when an explicitly referenced spec no longer contains a required operation/webhook/schema, then searches for alternatives. When exactly one alternative is found, it automatically repoints the reference with a warning; when multiple alternatives or none exist, it gracefully skips localization. The feature is well-tested with a new comprehensive test case covering the spec-switching scenario. This improves developer experience by automatically correcting stale OpenAPI references in frontmatter when documentation schemas evolve.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>


- This PR is safe to merge with no critical issues identified. Changes are well-tested, logically sound, and maintain backward compatibility.
- Score reflects: (1) Feature is well-designed with clear separation of concerns through the new `specHasMatch()` helper; (2) Comprehensive test coverage with a new test case validating the spec-repointing behavior; (3) Robust error handling with appropriate warnings for edge cases (missing entries, multiple matches, no matches); (4) No breaking changes to existing logic - new behavior only triggers when explicit specs don't contain referenced entries; (5) Code quality is high with proper type safety and documentation.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/cli/src/utils/processOpenApi.ts | Added logic to auto-update OpenAPI spec paths in frontmatter when referenced entries move between specs. New helper function `specHasMatch` checks if a spec contains operations, webhooks, or schemas. Enhanced `resolveSpec` function now handles spec changes: single alternative repoints, multiple alternatives skip with warning, no alternatives skip with warning. Code quality is high with proper error handling and warnings. |
| packages/cli/src/utils/__tests__/processOpenApi.test.ts | Added comprehensive test case for spec path repointing behavior. Test 'repoints explicit spec paths when entry moves to another spec' validates that when an entry is found in a different spec than explicitly referenced, the path is correctly updated to the new spec location in both source and localized files. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant MD as Markdown File
    participant PR as processOpenApi()
    participant RS as resolveSpec()
    participant SM as specHasMatch()
    participant FM as fileMapping

    MD->>PR: Start processing file
    PR->>RS: Resolve explicit spec path
    RS->>SM: Check if spec contains entry
    SM-->>RS: Entry not in spec
    RS->>RS: Find alternatives in other specs
    RS->>SM: Check each alternative
    SM-->>RS: Found in spec-b only
    RS->>FM: Resolve localized path for spec-b
    FM-->>RS: Return locale-specific path
    RS->>PR: Return alternative spec
    PR->>MD: Update frontmatter with new spec path
    Note over PR: Warnings logged for reference changes
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->