### PR TITLE
feat(cli): Add installation script for the binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,8 +76,42 @@ jobs:
             echo "should_release_bin=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Release gtx-cli binary
+      - name: Extract gtx-cli version
+        id: gtx-cli-version
         if: steps.check-gtx-cli.outputs.should_release_bin == 'true'
-        run: pnpm run release:gtx-cli-bin
+        run: |
+          published_packages='${{ steps.changesets.outputs.publishedPackages }}'
+          version=$(echo "$published_packages" | grep -A1 '"name": *"gtx-cli"' | grep '"version"' | sed 's/.*"version": *"\([^"]*\)".*/\1/')
+          echo "version=$version" >> $GITHUB_OUTPUT
+
+      - name: Build gtx-cli binaries
+        if: steps.check-gtx-cli.outputs.should_release_bin == 'true'
+        run: pnpm --filter gtx-cli run build:bin:clean
+
+      - name: Upload gtx-cli binaries to R2
+        if: steps.check-gtx-cli.outputs.should_release_bin == 'true'
+        uses: ryand56/r2-upload-action@v1.4
+        with:
+          r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
+          r2-access-key-id: ${{ secrets.R2_ACCESS_KEY_ID }}
+          r2-secret-access-key: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          r2-bucket: ${{ secrets.R2_BUCKET_NAME }}
+          source-dir: packages/cli/binaries
+          destination-dir: cli/v${{ steps.gtx-cli-version.outputs.version }}
+
+      - name: Upload gtx-cli binaries to R2 (latest)
+        if: steps.check-gtx-cli.outputs.should_release_bin == 'true'
+        uses: ryand56/r2-upload-action@v1.4
+        with:
+          r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
+          r2-access-key-id: ${{ secrets.R2_ACCESS_KEY_ID }}
+          r2-secret-access-key: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          r2-bucket: ${{ secrets.R2_BUCKET_NAME }}
+          source-dir: packages/cli/binaries
+          destination-dir: cli/latest
+
+      - name: Release gtx-cli binary to npm
+        if: steps.check-gtx-cli.outputs.should_release_bin == 'true'
+        run: pnpm --filter gtx-cli run bin:prep && pnpm --filter gtx-cli publish --tag bin --no-git-checks && pnpm --filter gtx-cli run bin:restore && pnpm --filter gtx-cli run build:clean
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/assets/install.sh
+++ b/assets/install.sh
@@ -1,0 +1,157 @@
+#!/bin/sh
+# gtx-cli installer
+# Usage: curl -fsSL https://assets.gtx.dev/install.sh | sh
+#
+# This script downloads and installs the gtx-cli binary for your platform.
+
+set -e
+
+# Configuration
+BASE_URL="https://assets.gtx.dev/cli/latest"
+BINARY_NAME="gtx"
+INSTALL_DIR="${GTX_INSTALL_DIR:-/usr/local/bin}"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+info() {
+    printf "${GREEN}info${NC}: %s\n" "$1"
+}
+
+warn() {
+    printf "${YELLOW}warn${NC}: %s\n" "$1"
+}
+
+error() {
+    printf "${RED}error${NC}: %s\n" "$1" >&2
+    exit 1
+}
+
+# Detect OS
+detect_os() {
+    case "$(uname -s)" in
+        Darwin*)
+            echo "darwin"
+            ;;
+        Linux*)
+            echo "linux"
+            ;;
+        MINGW*|MSYS*|CYGWIN*)
+            echo "windows"
+            ;;
+        *)
+            error "Unsupported operating system: $(uname -s)"
+            ;;
+    esac
+}
+
+# Detect architecture
+detect_arch() {
+    case "$(uname -m)" in
+        x86_64|amd64)
+            echo "x64"
+            ;;
+        arm64|aarch64)
+            echo "arm64"
+            ;;
+        *)
+            error "Unsupported architecture: $(uname -m)"
+            ;;
+    esac
+}
+
+# Get the download URL for the binary
+get_download_url() {
+    local os="$1"
+    local arch="$2"
+
+    if [ "$os" = "windows" ]; then
+        echo "${BASE_URL}/gtx-cli-win32-x64.exe"
+    else
+        echo "${BASE_URL}/gtx-cli-${os}-${arch}"
+    fi
+}
+
+# Check if a command exists
+command_exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+# Download the binary
+download_binary() {
+    local url="$1"
+    local output="$2"
+
+    info "Downloading gtx-cli from ${url}..."
+
+    if command_exists curl; then
+        curl -fsSL "$url" -o "$output"
+    elif command_exists wget; then
+        wget -q "$url" -O "$output"
+    else
+        error "Neither curl nor wget found. Please install one of them."
+    fi
+}
+
+# Main installation function
+main() {
+    info "Installing gtx-cli..."
+
+    # Detect platform
+    local os=$(detect_os)
+    local arch=$(detect_arch)
+
+    info "Detected platform: ${os}-${arch}"
+
+    # Windows is not fully supported for this installer
+    if [ "$os" = "windows" ]; then
+        warn "Windows detected. Consider using npm install -g gtx-cli instead."
+        warn "Continuing with installation..."
+        arch="x64"
+    fi
+
+    # Get download URL
+    local url=$(get_download_url "$os" "$arch")
+
+    # Create temp directory
+    local tmp_dir=$(mktemp -d)
+    local tmp_file="${tmp_dir}/gtx-cli"
+
+    # Download binary
+    download_binary "$url" "$tmp_file"
+
+    # Make executable
+    chmod +x "$tmp_file"
+
+    # Determine install location
+    local install_path="${INSTALL_DIR}/${BINARY_NAME}"
+
+    # Check if we need sudo
+    if [ -w "$INSTALL_DIR" ]; then
+        mv "$tmp_file" "$install_path"
+    else
+        info "Elevated permissions required to install to ${INSTALL_DIR}"
+        if command_exists sudo; then
+            sudo mv "$tmp_file" "$install_path"
+        else
+            error "Cannot write to ${INSTALL_DIR} and sudo is not available. Try setting GTX_INSTALL_DIR to a writable directory."
+        fi
+    fi
+
+    # Cleanup
+    rm -rf "$tmp_dir"
+
+    # Verify installation
+    if command_exists "$BINARY_NAME"; then
+        info "gtx-cli installed successfully!"
+        info "Run 'gtx --help' to get started."
+    else
+        warn "gtx-cli was installed to ${install_path}"
+        warn "Make sure ${INSTALL_DIR} is in your PATH."
+    fi
+}
+
+main "$@"

--- a/assets/install.sh
+++ b/assets/install.sh
@@ -147,10 +147,11 @@ main() {
     # Verify installation
     if command_exists "$BINARY_NAME"; then
         info "gtx-cli installed successfully!"
-        info "Run 'gtx --help' to get started."
+        info "Run 'gtx-cli --help' to get started."
     else
         warn "gtx-cli was installed to ${install_path}"
-        warn "Make sure ${INSTALL_DIR} is in your PATH."
+        warn "Add the following to your shell profile (~/.bashrc, ~/.zshrc, etc.):"
+        warn "  export PATH=\"${INSTALL_DIR}:\$PATH\""
     fi
 }
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Added an installation script (`assets/install.sh`) for the gtx-cli binary that users can run via `curl -fsSL https://assets.gtx.dev/install.sh | sh`. The script auto-detects the user's platform (macOS, Linux, Windows) and architecture (x64, arm64), downloads the appropriate binary from Cloudflare R2 storage, and installs it to `/usr/local/bin` (or a custom directory via `GTX_INSTALL_DIR`).

- Modified release workflow to upload binaries to R2 storage at versioned (`cli/v{version}`) and latest (`cli/latest`) paths
- Binary naming in install script matches the build output format (`gtx-cli-{os}-{arch}`)
- Install script handles sudo elevation gracefully and provides helpful messages when PATH isn't configured

<details open><summary><h3>Confidence Score: 4/5</h3></summary>


- This PR is safe to merge with minimal risk - it adds a standard installation script pattern and CI changes that don't affect existing functionality.
- Score reflects well-structured shell script with proper error handling (set -e), platform detection matching existing binary naming conventions, and CI changes that follow established patterns. Minor point deducted for JSON parsing approach in version extraction.
- No files require special attention - both changes are straightforward additions.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Refactored binary release to upload to R2 storage with versioned and latest paths; version extraction uses fragile JSON parsing but follows existing patterns. |
| assets/install.sh | New installation script for gtx-cli binary with platform detection, download from R2, and proper error handling via set -e. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant InstallScript as install.sh
    participant R2 as Cloudflare R2
    participant FileSystem as /usr/local/bin
    
    User->>InstallScript: curl -fsSL ... | sh
    InstallScript->>InstallScript: detect_os() / detect_arch()
    InstallScript->>InstallScript: get_download_url()
    InstallScript->>R2: Download binary (curl/wget)
    R2-->>InstallScript: gtx-cli binary
    InstallScript->>InstallScript: chmod +x
    alt INSTALL_DIR writable
        InstallScript->>FileSystem: mv binary
    else needs sudo
        InstallScript->>FileSystem: sudo mv binary
    end
    InstallScript->>User: Installation complete message
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->