### PR TITLE
fix: npm install versioning bug

### DIFF
--- a/.changeset/clever-jobs-fail.md
+++ b/.changeset/clever-jobs-fail.md
@@ -1,0 +1,6 @@
+---
+'@generaltranslation/compiler': patch
+'gtx-cli': patch
+---
+
+fix: compiler cli deps when installed at the same time caused an bug in npm with the esbuild version

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -110,7 +110,7 @@
     "commander": "^12.1.0",
     "dotenv": "^16.4.5",
     "enhanced-resolve": "^5.18.3",
-    "esbuild": "^0.25.4",
+    "esbuild": "^0.27.2",
     "fast-glob": "^3.3.3",
     "fast-json-stable-stringify": "^2.1.0",
     "generaltranslation": "workspace:*",

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -34,9 +34,6 @@
     "translation",
     "i18n"
   ],
-  "peerDependencies": {
-    "vite": ">=3"
-  },
   "dependencies": {
     "@babel/generator": "^7.23.0",
     "@babel/parser": "^7.23.0",


### PR DESCRIPTION
compiler cli deps when installed at the same time caused an bug in npm with the esbuild version

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR fixes an npm install versioning bug that occurred when the compiler and cli packages were installed simultaneously. The fix involves bumping the cli's esbuild dependency from ^0.25.4 to ^0.27.2 and removing the unnecessary vite peerDependency from the compiler package, which was causing version conflicts when both packages were installed together following the installation script changes in PR #931.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>


- This PR is safe to merge - it addresses a legitimate npm dependency conflict with straightforward, low-risk changes.
- All changes are minimal and targeted: esbuild version bump aligns dependencies across packages, and removing the unnecessary vite peerDependency resolves the conflict. No breaking changes, no new functionality, and the modifications directly address the stated issue. Both affected packages document the change appropriately via the changeset file.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .changeset/clever-jobs-fail.md | Changeset file documenting patch version bumps for compiler and cli packages to fix npm install versioning bug when packages are installed simultaneously. |
| packages/cli/package.json | Updated esbuild dependency from ^0.25.4 to ^0.27.2 to resolve version conflicts when cli and compiler packages are installed together. |
| packages/compiler/package.json | Removed vite peerDependencies declaration as the compiler doesn't directly depend on vite, resolving npm install conflicts when packages are installed simultaneously. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant npm as npm Install
    participant cli as gtx-cli
    participant compiler as @generaltranslation/compiler
    participant esbuild as esbuild v0.27.2
    
    npm->>cli: Install with esbuild ^0.27.2
    npm->>compiler: Install without vite peerDep
    cli->>esbuild: Resolve dependency
    compiler->>esbuild: Compatible with v0.27.2
    esbuild-->>npm: Single version installed
    npm-->>npm: ✓ No conflicts
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->