### PR TITLE
feat: custom gfm plugin for gt-remark

### DIFF
--- a/.changeset/sixty-poems-smash.md
+++ b/.changeset/sixty-poems-smash.md
@@ -1,0 +1,5 @@
+---
+'gt-remark': patch
+---
+
+Adding custom GFM plugin

--- a/packages/remark/package.json
+++ b/packages/remark/package.json
@@ -45,7 +45,15 @@
   },
   "homepage": "https://generaltranslation.com/",
   "dependencies": {
-    "mdast-util-find-and-replace": "^3.0.1"
+    "mdast-util-find-and-replace": "^3.0.1",
+    "mdast-util-gfm-footnote": "^2.1.0",
+    "mdast-util-gfm-strikethrough": "^2.0.0",
+    "mdast-util-gfm-table": "^2.0.0",
+    "mdast-util-gfm-task-list-item": "^2.0.0",
+    "micromark-extension-gfm-footnote": "^2.1.0",
+    "micromark-extension-gfm-strikethrough": "^2.1.0",
+    "micromark-extension-gfm-table": "^2.1.1",
+    "micromark-extension-gfm-task-list-item": "^2.1.0"
   },
   "devDependencies": {
     "@types/mdast": "^4.0.4",

--- a/packages/remark/package.json
+++ b/packages/remark/package.json
@@ -57,6 +57,7 @@
   },
   "devDependencies": {
     "@types/mdast": "^4.0.4",
+    "remark-parse": "^11.0.0",
     "remark-stringify": "^11.0.0",
     "typescript": "^5.7.3",
     "unified": "^11.0.5",

--- a/packages/remark/src/__tests__/index.test.ts
+++ b/packages/remark/src/__tests__/index.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import { unified } from 'unified';
+import remarkParse from 'remark-parse';
 import remarkStringify from 'remark-stringify';
-import escapeHtmlInTextNodes from '../index';
+import escapeHtmlInTextNodes, { remarkGfmCustom } from '../index';
 import type { Root, Text, Paragraph, Code, InlineCode } from 'mdast';
 
 describe('escapeHtmlInTextNodes', () => {
@@ -418,5 +419,50 @@ describe('escapeHtmlInTextNodes', () => {
       const result = processAst(tree);
       expect(result).toContain('&lt;placeholder&gt; &amp; &quot;special&quot;');
     });
+  });
+});
+
+describe('remarkGfmCustom', () => {
+  const processMarkdown = (markdown: string) => {
+    const processor = unified()
+      .use(remarkParse)
+      .use(remarkGfmCustom)
+      .use(remarkStringify, {
+        bullet: '-',
+        emphasis: '_',
+        strong: '*',
+        rule: '-',
+        ruleRepetition: 3,
+        ruleSpaces: false,
+        handlers: {
+          text(node: any) {
+            return node.value;
+          },
+        },
+      });
+
+    return String(processor.processSync(markdown));
+  };
+
+  it('should keep bare URLs as plain text', () => {
+    const input =
+      'See https://github.com/ClickHouse/ClickHouse/issues/92752 for details.';
+    const result = processMarkdown(input);
+    expect(result).toContain(
+      'See https://github.com/ClickHouse/ClickHouse/issues/92752 for details.'
+    );
+    expect(result).not.toContain('<https://github.com/ClickHouse/ClickHouse/issues/92752>');
+    expect(result).not.toContain('[https://github.com/ClickHouse/ClickHouse/issues/92752]');
+  });
+
+  it('should keep GFM tables working', () => {
+    const input = [
+      '| Format | Support | Notes |',
+      '|---|---|---|',
+      '| JSON | OK | Supports `JSON` |',
+    ].join('\n');
+    const result = processMarkdown(input);
+    expect(result).toContain('| Format | Support | Notes |');
+    expect(result).toContain('| JSON | OK | Supports `JSON` |');
   });
 });

--- a/packages/remark/src/__tests__/index.test.ts
+++ b/packages/remark/src/__tests__/index.test.ts
@@ -451,8 +451,12 @@ describe('remarkGfmCustom', () => {
     expect(result).toContain(
       'See https://github.com/ClickHouse/ClickHouse/issues/92752 for details.'
     );
-    expect(result).not.toContain('<https://github.com/ClickHouse/ClickHouse/issues/92752>');
-    expect(result).not.toContain('[https://github.com/ClickHouse/ClickHouse/issues/92752]');
+    expect(result).not.toContain(
+      '<https://github.com/ClickHouse/ClickHouse/issues/92752>'
+    );
+    expect(result).not.toContain(
+      '[https://github.com/ClickHouse/ClickHouse/issues/92752]'
+    );
   });
 
   it('should keep GFM tables working', () => {

--- a/packages/remark/src/__tests__/index.test.ts
+++ b/packages/remark/src/__tests__/index.test.ts
@@ -466,7 +466,7 @@ describe('remarkGfmCustom', () => {
       '| JSON | OK | Supports `JSON` |',
     ].join('\n');
     const result = processMarkdown(input);
-    expect(result).toContain('| Format | Support | Notes |');
-    expect(result).toContain('| JSON | OK | Supports `JSON` |');
+    expect(result).toMatch(/\| Format \| Support \| Notes\s*\|/);
+    expect(result).toMatch(/\| JSON\s+\| OK\s+\| Supports `JSON` \|/);
   });
 });

--- a/packages/remark/src/index.ts
+++ b/packages/remark/src/index.ts
@@ -1,6 +1,23 @@
 import type { Plugin } from 'unified';
 import type { Root } from 'mdast';
 import { findAndReplace } from 'mdast-util-find-and-replace';
+import { gfmFootnote } from 'micromark-extension-gfm-footnote';
+import { gfmStrikethrough } from 'micromark-extension-gfm-strikethrough';
+import { gfmTable } from 'micromark-extension-gfm-table';
+import { gfmTaskListItem } from 'micromark-extension-gfm-task-list-item';
+import {
+  gfmFootnoteFromMarkdown,
+  gfmFootnoteToMarkdown,
+} from 'mdast-util-gfm-footnote';
+import {
+  gfmStrikethroughFromMarkdown,
+  gfmStrikethroughToMarkdown,
+} from 'mdast-util-gfm-strikethrough';
+import { gfmTableFromMarkdown, gfmTableToMarkdown } from 'mdast-util-gfm-table';
+import {
+  gfmTaskListItemFromMarkdown,
+  gfmTaskListItemToMarkdown,
+} from 'mdast-util-gfm-task-list-item';
 
 const IGNORE_ALWAYS = [
   'code',
@@ -53,5 +70,39 @@ const escapeHtmlInTextNodes: Plugin<[], Root> = function () {
   };
 };
 
+const remarkGfmCustom: Plugin = function () {
+  const data = this.data() as {
+    micromarkExtensions?: unknown[];
+    fromMarkdownExtensions?: unknown[];
+    toMarkdownExtensions?: unknown[];
+  };
+
+  const micromarkExtensions =
+    data.micromarkExtensions || (data.micromarkExtensions = []);
+  const fromMarkdownExtensions =
+    data.fromMarkdownExtensions || (data.fromMarkdownExtensions = []);
+  const toMarkdownExtensions =
+    data.toMarkdownExtensions || (data.toMarkdownExtensions = []);
+
+  micromarkExtensions.push(
+    gfmStrikethrough(),
+    gfmTable(),
+    gfmTaskListItem(),
+    gfmFootnote()
+  );
+  fromMarkdownExtensions.push(
+    gfmStrikethroughFromMarkdown(),
+    gfmTableFromMarkdown(),
+    gfmTaskListItemFromMarkdown(),
+    gfmFootnoteFromMarkdown()
+  );
+  toMarkdownExtensions.push(
+    gfmStrikethroughToMarkdown(),
+    gfmTableToMarkdown(),
+    gfmTaskListItemToMarkdown(),
+    gfmFootnoteToMarkdown()
+  );
+};
+
 export default escapeHtmlInTextNodes;
-export { escapeHtmlInTextNodes };
+export { escapeHtmlInTextNodes, remarkGfmCustom };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -689,6 +689,30 @@ importers:
       mdast-util-find-and-replace:
         specifier: ^3.0.1
         version: 3.0.2
+      mdast-util-gfm-footnote:
+        specifier: ^2.1.0
+        version: 2.1.0
+      mdast-util-gfm-strikethrough:
+        specifier: ^2.0.0
+        version: 2.0.0
+      mdast-util-gfm-table:
+        specifier: ^2.0.0
+        version: 2.0.0
+      mdast-util-gfm-task-list-item:
+        specifier: ^2.0.0
+        version: 2.0.0
+      micromark-extension-gfm-footnote:
+        specifier: ^2.1.0
+        version: 2.1.0
+      micromark-extension-gfm-strikethrough:
+        specifier: ^2.1.0
+        version: 2.1.0
+      micromark-extension-gfm-table:
+        specifier: ^2.1.1
+        version: 2.1.1
+      micromark-extension-gfm-task-list-item:
+        specifier: ^2.1.0
+        version: 2.1.0
     devDependencies:
       '@types/mdast':
         specifier: ^4.0.4
@@ -7835,6 +7859,9 @@ packages:
     resolution: {integrity: sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==}
     engines: {node: '>=8'}
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -7850,6 +7877,18 @@ packages:
 
   mdast-util-frontmatter@2.0.1:
     resolution: {integrity: sha512-LRqI9+wdgC25P0URIJY9vwocIzCcksduHQ9OF2joxQoyTNVduwLAFUzjoopuRJbJAReaKrNQKAZKL3uCMugWJA==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
 
   mdast-util-mdx-expression@2.0.1:
     resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
@@ -7921,6 +7960,18 @@ packages:
 
   micromark-extension-frontmatter@2.0.0:
     resolution: {integrity: sha512-C4AkuM3dA58cgZha7zVnuVxBhDsbttIMiytjgsM2XbHAB2faRVaHRle40558FBN+DJcrLNCoqG5mlrpdU4cRtg==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
 
   micromark-extension-mdx-expression@3.0.1:
     resolution: {integrity: sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==}
@@ -18694,6 +18745,8 @@ snapshots:
 
   map-obj@4.3.0: {}
 
+  markdown-table@3.0.4: {}
+
   math-intrinsics@1.1.0: {}
 
   md5-o-matic@0.1.1: {}
@@ -18730,6 +18783,43 @@ snapshots:
       mdast-util-from-markdown: 2.0.2
       mdast-util-to-markdown: 2.1.2
       micromark-extension-frontmatter: 2.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
@@ -18875,6 +18965,42 @@ snapshots:
   micromark-extension-frontmatter@2.0.0:
     dependencies:
       fault: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
       micromark-util-character: 2.1.1
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -717,6 +717,9 @@ importers:
       '@types/mdast':
         specifier: ^4.0.4
         version: 4.0.4
+      remark-parse:
+        specifier: ^11.0.0
+        version: 11.0.0
       remark-stringify:
         specifier: ^11.0.0
         version: 11.0.0


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h2>Greptile Overview</h2>

### Greptile Summary

This PR adds a custom GitHub Flavored Markdown (GFM) plugin to the `gt-remark` package by implementing `remarkGfmCustom`. The plugin registers GFM extensions for strikethrough, tables, task lists, and footnotes.

**Key Changes:**
- Added `remarkGfmCustom` plugin that configures micromark and mdast extensions for GFM features
- Added 8 new dependencies: 4 micromark extensions and 4 mdast utilities
- Exported `remarkGfmCustom` alongside existing `escapeHtmlInTextNodes` plugin

**Issues Found:**
- Missing tests for the new `remarkGfmCustom` plugin - no verification it works correctly
- Plugin implementation uses data-only pattern (doesn't return transformer), which is valid but should be tested to ensure GFM features work as expected

### Confidence Score: 3/5

- This PR is functionally safe but lacks test coverage for new functionality
- The implementation follows unified plugin patterns correctly and adds standard GFM dependencies. However, the new `remarkGfmCustom` plugin has zero test coverage, making it impossible to verify it works correctly with strikethrough, tables, task lists, and footnotes. The existing `escapeHtmlInTextNodes` has comprehensive tests, but the new plugin needs similar coverage.
- Pay attention to `packages/remark/src/index.ts` - the new plugin needs testing before production use

<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| packages/remark/src/index.ts | 3/5 | Added custom GFM plugin implementation with all GFM extensions, but missing tests and no return statement clarification |
| packages/remark/package.json | 5/5 | Added 8 new GFM-related dependencies for micromark extensions and mdast utilities |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant Unified as Unified Processor
    participant Plugin as remarkGfmCustom
    participant Data as Processor Data
    participant Extensions as GFM Extensions
    
    User->>Unified: .use(remarkGfmCustom)
    Unified->>Plugin: Call plugin function
    Plugin->>Data: Access this.data()
    Plugin->>Data: Initialize extension arrays
    Plugin->>Extensions: Load micromark extensions
    Extensions-->>Plugin: gfmStrikethrough, gfmTable, etc.
    Plugin->>Data: Push to micromarkExtensions
    Plugin->>Extensions: Load from/to markdown utils
    Extensions-->>Plugin: gfmStrikethroughFromMarkdown, etc.
    Plugin->>Data: Push to fromMarkdownExtensions
    Plugin->>Data: Push to toMarkdownExtensions
    Plugin-->>Unified: Extensions registered
    Unified->>User: Processor ready with GFM support
```
</details>


<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| packages/remark/src/index.ts | 3/5 | Added custom GFM plugin implementation with all GFM extensions, but missing tests and no return statement clarification |
| packages/remark/package.json | 5/5 | Added 8 new GFM-related dependencies for micromark extensions and mdast utilities |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant Unified as Unified Processor
    participant Plugin as remarkGfmCustom
    participant Data as Processor Data
    participant Extensions as GFM Extensions
    
    User->>Unified: .use(remarkGfmCustom)
    Unified->>Plugin: Call plugin function
    Plugin->>Data: Access this.data()
    Plugin->>Data: Initialize extension arrays
    Plugin->>Extensions: Load micromark extensions
    Extensions-->>Plugin: gfmStrikethrough, gfmTable, etc.
    Plugin->>Data: Push to micromarkExtensions
    Plugin->>Extensions: Load from/to markdown utils
    Extensions-->>Plugin: gfmStrikethroughFromMarkdown, etc.
    Plugin->>Data: Push to fromMarkdownExtensions
    Plugin->>Data: Push to toMarkdownExtensions
    Plugin-->>Unified: Extensions registered
    Unified->>User: Processor ready with GFM support
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->