### PR TITLE
F/gt remark heading update

### DIFF
--- a/.changeset/light-mails-teach.md
+++ b/.changeset/light-mails-teach.md
@@ -1,0 +1,5 @@
+---
+'gt-remark': patch
+---
+
+Remove underscore escaping from headers

--- a/packages/remark/src/index.ts
+++ b/packages/remark/src/index.ts
@@ -31,8 +31,8 @@ const IGNORE_ALWAYS = [
   'inlineMath',
 ];
 
-// Want to ignore braces in headings to avoid escaping fragment ids ( {#my-id} )
-const IGNORE_FOR_BRACES = [...IGNORE_ALWAYS, 'heading'];
+// Want to ignore headings to avoid escaping fragment ids ( {#my-id} )
+const IGNORE_HEADINGS = [...IGNORE_ALWAYS, 'heading'];
 
 // & that is NOT already an entity: &word;  &#123;  &#x1A2B;
 const AMP_NOT_ENTITY = /&(?![a-zA-Z][a-zA-Z0-9]*;|#\d+;|#x[0-9A-Fa-f]+;)/g;
@@ -53,7 +53,6 @@ const escapeHtmlInTextNodes: Plugin<[], Root> = function () {
         [/>/g, '&gt;'],
         [/"/g, '&quot;'],
         [/'/g, '&#39;'],
-        [/_/g, '&#95;'],
       ],
       { ignore: IGNORE_ALWAYS }
     );
@@ -64,8 +63,9 @@ const escapeHtmlInTextNodes: Plugin<[], Root> = function () {
       [
         [/\{/g, '&#123;'],
         [/\}/g, '&#125;'],
+        [/_/g, '&#95;'],
       ],
-      { ignore: IGNORE_FOR_BRACES }
+      { ignore: IGNORE_HEADINGS }
     );
   };
 };


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

### Greptile Summary

This PR fixes underscore escaping behavior in markdown headings by moving underscore escaping from the first pass to the second pass, alongside curly brace escaping.

**What Changed:**
- Moved underscore (`_`) escaping from the first escaping pass to the second pass (line 66)
- Renamed constant from `IGNORE_FOR_BRACES` to `IGNORE_HEADINGS` for better clarity
- Updated comment to reflect that headings are ignored for escaping (not just braces)

**Why This Matters:**
The change prevents underscores from being escaped in headings, which is necessary for:
1. Preserving fragment IDs that may contain underscores (e.g., `{#my_custom_id}`)
2. Displaying heading text correctly (e.g., `# My_Variable_Name` should not become `# My&#95;Variable&#95;Name`)

**How It Works:**
- **First pass** (ignores: code, math, MDX): Escapes `&`, `<`, `>`, `"`, `'`
- **Second pass** (ignores: code, math, MDX, **and headings**): Escapes `{`, `}`, `_`

This ensures underscores are still escaped in regular text (paragraphs, lists) but NOT in headings, matching the behavior for curly braces.

**Documentation Issue:**
The JSDoc comment on line 40-44 doesn't mention that underscores are escaped, and doesn't explain that curly braces and underscores are not escaped in headings. This should be updated for clarity.

### Confidence Score: 4/5

- This PR is safe to merge with minor documentation improvements recommended
- The logic change is correct and solves the underscore escaping issue in headings. The code properly moves underscore escaping to the second pass alongside curly braces, which prevents them from being escaped in headings while still escaping them in regular text. Variable renaming improves code clarity. However, the JSDoc comment is outdated and doesn't document that underscores are escaped or explain the heading exception, which could confuse future maintainers. No functional bugs or security issues detected.
- packages/remark/src/index.ts needs JSDoc comment update to document underscore escaping and heading exceptions

<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| .changeset/light-mails-teach.md | 5/5 | Changeset file documenting the patch that removes underscore escaping from headings - accurately describes the change |
| packages/remark/src/index.ts | 4/5 | Moves underscore escaping to second pass with curly braces, preventing escape in headings; JSDoc comment needs update to reflect underscore escaping |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant Plugin as escapeHtmlInTextNodes
    participant Tree as Markdown AST
    participant Pass1 as First Pass
    participant Pass2 as Second Pass
    
    User->>Plugin: Process markdown with plugin
    Plugin->>Tree: Receive AST tree
    
    Note over Pass1: Escape ampersand, angle brackets, quotes
    Plugin->>Pass1: findAndReplace with IGNORE_ALWAYS
    Pass1->>Tree: Scan all text nodes
    
    alt Node is code, math, or MDX
        Pass1->>Tree: Skip escaping
    else Regular text or heading
        Pass1->>Tree: Escape ampersand, angle brackets, quotes
    end
    
    Note over Pass2: Escape curly braces and underscores
    Plugin->>Pass2: findAndReplace with IGNORE_HEADINGS
    Pass2->>Tree: Scan all text nodes
    
    alt Node is code, math, MDX, or heading
        Pass2->>Tree: Skip escaping (preserve in headings)
    else Regular text node
        Pass2->>Tree: Escape curly braces and underscores
    end
    
    Plugin->>User: Return transformed tree
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->