### PR TITLE
feat: add skipping file validations to config

### DIFF
--- a/.changeset/fresh-comics-fold.md
+++ b/.changeset/fresh-comics-fold.md
@@ -1,0 +1,5 @@
+---
+'gtx-cli': patch
+---
+
+Add option to skip file validation when passing for translation

--- a/assets/config-schema.json
+++ b/assets/config-schema.json
@@ -484,6 +484,25 @@
           },
           "additionalProperties": false
         },
+        "skipFileValidation": {
+          "type": "object",
+          "description": "Skip pre-parse validation for specific file types before sending content to the translation pipeline.",
+          "properties": {
+            "json": {
+              "type": "boolean",
+              "description": "Skip JSON parseability checks."
+            },
+            "yaml": {
+              "type": "boolean",
+              "description": "Skip YAML parseability checks."
+            },
+            "mdx": {
+              "type": "boolean",
+              "description": "Skip MDX AST parseability checks."
+            }
+          },
+          "additionalProperties": false
+        },
         "mintlify": {
           "type": "object",
           "description": "Mintlify-specific options.",

--- a/packages/cli/src/formats/files/__tests__/translate.test.ts
+++ b/packages/cli/src/formats/files/__tests__/translate.test.ts
@@ -120,6 +120,31 @@ describe('aggregateFiles - Empty File Handling', () => {
       expect(result[0].fileName).toBe('valid.json');
     });
 
+    it('should allow invalid JSON when validation is skipped', async () => {
+      const settings = {
+        files: {
+          resolvedPaths: {
+            json: ['/full/path/invalid.json'],
+          },
+          placeholderPaths: {},
+        },
+        options: {
+          skipFileValidation: {
+            json: true,
+          },
+        },
+        defaultLocale: 'en',
+      };
+
+      mockReadFile.mockReturnValueOnce('{ invalid json');
+
+      const result = await aggregateFiles(settings as any);
+
+      expect(mockLogWarning).not.toHaveBeenCalled();
+      expect(result).toHaveLength(1);
+      expect(result[0].fileName).toBe('invalid.json');
+    });
+
     it('should skip JSON files that return null content and log warning', async () => {
       const settings = {
         files: {
@@ -219,6 +244,35 @@ describe('aggregateFiles - Empty File Handling', () => {
       );
       expect(result).toHaveLength(1);
       expect(result[0].fileName).toBe('valid.mdx');
+    });
+
+    it('should skip MDX validation when configured', async () => {
+      const settings = {
+        files: {
+          resolvedPaths: {
+            mdx: ['/full/path/invalid.mdx'],
+          },
+          placeholderPaths: {},
+        },
+        options: {
+          skipFileValidation: {
+            mdx: true,
+          },
+        },
+      };
+
+      mockReadFile.mockReturnValueOnce('<>Invalid mdx');
+      mockIsValidMdx.mockReturnValueOnce({
+        isValid: false,
+        error: 'bad',
+      });
+
+      const result = await aggregateFiles(settings as any);
+
+      expect(mockIsValidMdx).not.toHaveBeenCalled();
+      expect(mockLogWarning).not.toHaveBeenCalled();
+      expect(result).toHaveLength(1);
+      expect(result[0].fileName).toBe('invalid.mdx');
     });
 
     it('should skip files that are empty after sanitization and log warning', async () => {

--- a/packages/cli/src/formats/files/translate.ts
+++ b/packages/cli/src/formats/files/translate.ts
@@ -26,11 +26,11 @@ export async function aggregateFiles(
   }
 
   const { resolvedPaths: filePaths } = settings.files;
+  const skipValidation = settings.options?.skipFileValidation;
 
   // Process JSON files
   if (filePaths.json) {
     const { library, additionalModules } = determineLibrary();
-    const skipValidation = settings.options?.skipFileValidation;
 
     // Determine dataFormat for JSONs
     let dataFormat: DataFormat;
@@ -91,7 +91,6 @@ export async function aggregateFiles(
 
   // Process YAML files
   if (filePaths.yaml) {
-    const skipValidation = settings.options?.skipFileValidation;
     const yamlFiles = filePaths.yaml
       .map((filePath) => {
         const content = readFile(filePath);
@@ -143,7 +142,6 @@ export async function aggregateFiles(
           const relativePath = getRelative(filePath);
 
           if (fileType === 'mdx') {
-            const skipValidation = settings.options?.skipFileValidation;
             if (!skipValidation?.mdx) {
               const validation = isValidMdx(content, filePath);
               if (!validation.isValid) {

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -228,6 +228,12 @@ export type AdditionalOptions = {
   yamlSchema?: {
     [fileGlob: string]: YamlSchema;
   };
+  // Skip pre-parse validation checks for specific file types
+  skipFileValidation?: {
+    json?: boolean;
+    yaml?: boolean;
+    mdx?: boolean;
+  };
   // Optional Mintlify-specific options container
   mintlify?: MintlifyOptions;
   docsUrlPattern?: string; // eg /docs/[locale] or /[locale] for localizing static urls in markdown files


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR adds a `skipFileValidation` configuration option to allow users to bypass pre-parse validation checks for JSON, YAML, and MDX files before sending them to the translation pipeline.

**Key changes:**
- Added `skipFileValidation` type definition with boolean flags for `json`, `yaml`, and `mdx`
- Updated JSON schema configuration to include the new option
- Modified `aggregateFiles()` to conditionally skip validation based on config
- Added test coverage for the validation skip functionality

**Issues found:**
- The validation skip only prevents the pre-check in `translate.ts`, but `parseJson()` and `parseYaml()` will still attempt to parse invalid files when schemas are configured, causing process exits. The feature only works correctly when no `jsonSchema` or `yamlSchema` is defined for the file.

<details open><summary><h3>Confidence Score: 3/5</h3></summary>


- This PR has a critical logic flaw that breaks the feature when schemas are configured
- The validation skip feature is incomplete - it only prevents pre-validation in translate.ts but parseJson/parseYaml still attempt to parse when schemas exist, causing exits. This makes the feature unreliable for users with schema configurations.
- packages/cli/src/formats/files/translate.ts requires fixes to handle schema-configured files when validation is skipped
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/cli/src/formats/files/__tests__/translate.test.ts | Added tests for skipping validation, but tests use mocks and don't catch the schema parsing issue |
| packages/cli/src/formats/files/translate.ts | Added validation skip logic, but parseJson/parseYaml still attempt to parse when schemas are configured |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant aggregateFiles
    participant Settings
    participant parseJson
    participant parseYaml
    participant isValidMdx
    
    User->>aggregateFiles: Call with settings
    aggregateFiles->>Settings: Check skipFileValidation options
    
    alt Processing JSON files
        aggregateFiles->>aggregateFiles: Read file content
        alt skipFileValidation.json = false
            aggregateFiles->>aggregateFiles: JSON.parse(content) pre-validation
            alt Parse fails
                aggregateFiles->>User: Log warning & skip file
            end
        end
        aggregateFiles->>parseJson: parseJson(content, filePath, options)
        parseJson->>parseJson: Validate schema & parse
        parseJson-->>aggregateFiles: Return parsed content
    end
    
    alt Processing YAML files
        aggregateFiles->>aggregateFiles: Read file content
        alt skipFileValidation.yaml = false
            aggregateFiles->>aggregateFiles: YAML.parse(content) pre-validation
            alt Parse fails
                aggregateFiles->>User: Log warning & skip file
            end
        end
        aggregateFiles->>parseYaml: parseYaml(content, filePath, options)
        parseYaml->>parseYaml: Validate schema & parse
        parseYaml-->>aggregateFiles: Return parsed content
    end
    
    alt Processing MDX files
        aggregateFiles->>aggregateFiles: Read file content
        alt skipFileValidation.mdx = false
            aggregateFiles->>isValidMdx: isValidMdx(content, filePath)
            isValidMdx-->>aggregateFiles: Validation result
            alt Validation fails
                aggregateFiles->>User: Log warning & skip file
            end
        end
        aggregateFiles->>aggregateFiles: Sanitize content
    end
    
    aggregateFiles-->>User: Return FileToUpload[]
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->