### PR TITLE
F/mdx anchor escaping

### DIFF
--- a/.changeset/fancy-singers-wink.md
+++ b/.changeset/fancy-singers-wink.md
@@ -1,0 +1,5 @@
+---
+'gtx-cli': patch
+---
+
+Add escpaing of anchor ID syntax to all files passed in as MDX via gt.config.json

--- a/.changeset/fancy-singers-wink.md
+++ b/.changeset/fancy-singers-wink.md
@@ -2,4 +2,4 @@
 'gtx-cli': patch
 ---
 
-Add escpaing of anchor ID syntax to all files passed in as MDX via gt.config.json
+Add escaping of anchor ID syntax to all files passed in as MDX via gt.config.json

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.5.44';
+export const PACKAGE_VERSION = '2.5.45';

--- a/packages/cli/src/utils/__tests__/addExplicitAnchorIds.test.ts
+++ b/packages/cli/src/utils/__tests__/addExplicitAnchorIds.test.ts
@@ -175,6 +175,46 @@ No links here either.
     );
   });
 
+  it('escapes inline anchors when fileTypeHint is mdx even if target path is .md', () => {
+    const source = `## Source heading {#custom-source-id}`;
+    const translated = `## Encabezado traducido`;
+    const sourceHeadingMap = extractHeadingInfo(source);
+
+    const result = addExplicitAnchorIds(
+      translated,
+      sourceHeadingMap,
+      undefined,
+      source,
+      '/tmp/file.md',
+      'mdx'
+    );
+
+    expect(result.hasChanges).toBe(true);
+    expect(result.content).toContain(
+      '## Encabezado traducido \\{#custom-source-id\\}'
+    );
+  });
+
+  it('keeps inline anchors unescaped when fileTypeHint is md even if target path is .mdx', () => {
+    const source = `## Source heading {#custom-source-id}`;
+    const translated = `## Encabezado traducido`;
+    const sourceHeadingMap = extractHeadingInfo(source);
+
+    const result = addExplicitAnchorIds(
+      translated,
+      sourceHeadingMap,
+      undefined,
+      source,
+      '/tmp/file.mdx',
+      'md'
+    );
+
+    expect(result.hasChanges).toBe(true);
+    expect(result.content).toContain(
+      '## Encabezado traducido {#custom-source-id}'
+    );
+  });
+
   it('should handle JSX href attributes in raw JSX', () => {
     const input = `## Implementation Details
 

--- a/packages/cli/src/utils/addExplicitAnchorIds.ts
+++ b/packages/cli/src/utils/addExplicitAnchorIds.ts
@@ -181,7 +181,8 @@ export function addExplicitAnchorIds(
   sourceHeadingMap: HeadingInfo[],
   settings?: any,
   sourcePath?: string,
-  translatedPath?: string
+  translatedPath?: string,
+  fileTypeHint?: 'md' | 'mdx'
 ): {
   content: string;
   hasChanges: boolean;
@@ -235,6 +236,8 @@ export function addExplicitAnchorIds(
   const translatedIsMdx = translatedPath
     ? translatedPath.toLowerCase().endsWith('.mdx')
     : true; // default to mdx-style escaping when unknown
+  const shouldEscapeAnchors =
+    fileTypeHint === 'mdx' ? true : fileTypeHint === 'md' ? false : translatedIsMdx;
 
   // Apply IDs to translated content
   let content: string;
@@ -245,7 +248,7 @@ export function addExplicitAnchorIds(
       idMappings
     );
   } else {
-    content = applyInlineIds(translatedContent, idMappings, translatedIsMdx);
+    content = applyInlineIds(translatedContent, idMappings, shouldEscapeAnchors);
   }
 
   return {

--- a/packages/cli/src/utils/addExplicitAnchorIds.ts
+++ b/packages/cli/src/utils/addExplicitAnchorIds.ts
@@ -237,7 +237,11 @@ export function addExplicitAnchorIds(
     ? translatedPath.toLowerCase().endsWith('.mdx')
     : true; // default to mdx-style escaping when unknown
   const shouldEscapeAnchors =
-    fileTypeHint === 'mdx' ? true : fileTypeHint === 'md' ? false : translatedIsMdx;
+    fileTypeHint === 'mdx'
+      ? true
+      : fileTypeHint === 'md'
+        ? false
+        : translatedIsMdx;
 
   // Apply IDs to translated content
   let content: string;
@@ -248,7 +252,11 @@ export function addExplicitAnchorIds(
       idMappings
     );
   } else {
-    content = applyInlineIds(translatedContent, idMappings, shouldEscapeAnchors);
+    content = applyInlineIds(
+      translatedContent,
+      idMappings,
+      shouldEscapeAnchors
+    );
   }
 
   return {


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR fixes anchor ID escaping to respect file type configuration from `gt.config.json` rather than relying solely on file extensions. Previously, a `.md` file configured as MDX would not have its anchor IDs properly escaped, causing rendering issues.

**Key Changes:**
- Added `fileTypeHint` parameter to `addExplicitAnchorIds()` to explicitly control anchor escaping behavior
- Built `sourceTypeByPath` map in `processAnchorIds()` from `resolvedPaths.md` and `resolvedPaths.mdx` configuration
- Anchor IDs now escape as `\{#id\}` for MDX files and remain unescaped as `{#id}` for MD files, based on configuration
- Added comprehensive test coverage for both scenarios (`.md` file as MDX and `.mdx` file as MD)

**Issues Found:**
- Typo in changeset: "escpaing" should be "escaping"

<details open><summary><h3>Confidence Score: 5/5</h3></summary>


- This PR is safe to merge with one minor typo fix needed
- The implementation is well-tested, follows existing patterns, and correctly solves the stated problem. The logic is clean with proper fallback behavior when fileTypeHint is undefined. Only a cosmetic typo in the changeset description needs correction.
- No files require special attention beyond fixing the typo in .changeset/fancy-singers-wink.md
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .changeset/fancy-singers-wink.md | Changeset file documenting the patch release with a typo in "escpaing" |
| packages/cli/src/utils/addExplicitAnchorIds.ts | Introduced fileTypeHint parameter to control anchor escaping based on file type configuration rather than file extension |
| packages/cli/src/utils/processAnchorIds.ts | Built sourceTypeByPath map from config and passes fileTypeHint to ensure correct anchor escaping for all configured files |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Config as gt.config.json
    participant Process as processAnchorIds
    participant Map as sourceTypeByPath Map
    participant Extract as extractHeadingInfo
    participant Apply as addExplicitAnchorIds
    participant Output as Translated Files
    
    Config->>Process: resolvedPaths.md & resolvedPaths.mdx
    Process->>Map: Build map of source paths to file types
    Map-->>Process: sourceTypeByPath Map
    
    loop For each locale
        loop For each translated file
            Process->>Extract: Extract headings from source file
            Extract-->>Process: sourceHeadingMap
            Process->>Map: Get fileTypeHint for source path
            Map-->>Process: 'md' or 'mdx'
            Process->>Apply: Pass translated content, sourceHeadingMap, fileTypeHint
            
            alt fileTypeHint is 'mdx'
                Apply->>Apply: Escape anchors as \\{#id\\}
            else fileTypeHint is 'md'
                Apply->>Apply: Keep anchors unescaped as {#id}
            else fileTypeHint is undefined
                Apply->>Apply: Use translatedPath extension as fallback
            end
            
            Apply-->>Process: Modified content with anchor IDs
            Process->>Output: Write updated translated file
        end
    end
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->