### PR TITLE
fix: anchor ID escape regex fix to avoid double escaping

### DIFF
--- a/.changeset/easy-beans-cover.md
+++ b/.changeset/easy-beans-cover.md
@@ -1,0 +1,5 @@
+---
+'gtx-cli': patch
+---
+
+Fix to avoid anchor ID double escaping during parse fallback on MDX

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.5.45';
+export const PACKAGE_VERSION = '2.5.46';

--- a/packages/cli/src/utils/__tests__/addExplicitAnchorIds.test.ts
+++ b/packages/cli/src/utils/__tests__/addExplicitAnchorIds.test.ts
@@ -109,9 +109,7 @@ Another section here.
     const result = addExplicitAnchorIds(translated, sourceHeadingMap);
 
     expect(result.hasChanges).toBe(true);
-    expect(result.content).toContain(
-      '## Traducción \\{#custom-source-id\\}'
-    );
+    expect(result.content).toContain('## Traducción \\{#custom-source-id\\}');
     // Normalization counts as a recorded ID in MDX mode
     expect(result.addedIds).toHaveLength(1);
   });

--- a/packages/cli/src/utils/__tests__/addExplicitAnchorIds.test.ts
+++ b/packages/cli/src/utils/__tests__/addExplicitAnchorIds.test.ts
@@ -597,6 +597,19 @@ This is just an example
       );
       expect(result.content).not.toContain('\\{#fake-heading-in-code-block\\}');
     });
+
+    it('normalizes unescaped anchors to a single-escaped form in fallback mode', () => {
+      const input = `## Titulo {#titulo}
+
+{ this will break mdx parsing
+`;
+      const sourceHeadingMap = extractHeadingInfo(input);
+      const result = addExplicitAnchorIds(input, sourceHeadingMap);
+
+      expect(result.hasChanges).toBe(true);
+      expect(result.content).toContain('## Titulo \\{#titulo\\}');
+      expect(result.content).not.toContain('## Titulo \\\\{#titulo\\\\}');
+    });
   });
 
   describe('Special Characters - Both Modes', () => {

--- a/packages/cli/src/utils/__tests__/addExplicitAnchorIds.test.ts
+++ b/packages/cli/src/utils/__tests__/addExplicitAnchorIds.test.ts
@@ -70,7 +70,7 @@ Another section here.
     expect(result.hasChanges).toBe(true);
     // We track the normalized anchor as an addition in MDX mode
     expect(result.addedIds).toHaveLength(1);
-    expect(result.content).toContain('## Already has ID \\\\{#custom-id\\\\}');
+    expect(result.content).toContain('## Already has ID \\{#custom-id\\}');
   });
 
   it('reuses explicit IDs from source when translation lacks them', () => {
@@ -110,7 +110,7 @@ Another section here.
 
     expect(result.hasChanges).toBe(true);
     expect(result.content).toContain(
-      '## Traducción \\\\{#custom-source-id\\\\}'
+      '## Traducción \\{#custom-source-id\\}'
     );
     // Normalization counts as a recorded ID in MDX mode
     expect(result.addedIds).toHaveLength(1);

--- a/packages/cli/src/utils/addExplicitAnchorIds.ts
+++ b/packages/cli/src/utils/addExplicitAnchorIds.ts
@@ -452,7 +452,7 @@ function applyInlineIdsStringFallback(
       if (!escapeAnchors) {
         return line;
       }
-      return `${prefix}${text.replace(/\{#([^}]+)\}\s*$/, '\\\\{#$1\\\\}')}`;
+      return `${prefix}${text.replace(/\{#([^}]+)\}\s*$/, '\\{#$1\\}')}`;
     }
 
     const suffix = escapeAnchors ? ` \\{#${id}\\}` : ` {#${id}}`;


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Fixed a double-escaping bug in the anchor ID normalization logic within the fallback string-based processing mode. When MDX parsing fails and the system falls back to line-by-line processing, unescaped anchor IDs like `{#titulo}` need to be normalized to the escaped form `\{#titulo\}` for MDX compatibility. The previous regex replacement on line 455 used `\\\\{#$1\\\\}` which produced double-escaped output `\\{#titulo\\}` instead of the correct single-escaped form `\{#titulo\}`.

The fix changes the regex replacement from `\\\\` to `\\` in the template string, which correctly produces a single backslash in the output. This ensures consistency with the rest of the codebase where escaped anchors use the `\{#id\}` format.

- Changed regex replacement pattern on `addExplicitAnchorIds.ts:455` from double-escaped to single-escaped form
- Added test case to verify single-escaped normalization in fallback mode
- Version bumped to 2.5.46

<details open><summary><h3>Confidence Score: 5/5</h3></summary>


- This PR is safe to merge with minimal risk
- The fix is a targeted one-character change that corrects a clear bug in the regex replacement pattern. The change is well-tested with a new test case that explicitly validates the expected behavior. The bug fix ensures that anchor IDs are properly single-escaped rather than double-escaped in the fallback string processing mode, which aligns with the rest of the codebase's escaping conventions.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/cli/src/generated/version.ts | Auto-generated version bump from 2.5.45 to 2.5.46 |
| packages/cli/src/utils/addExplicitAnchorIds.ts | Fixed double-escaping bug in anchor ID normalization regex (line 455) |
| packages/cli/src/utils/__tests__/addExplicitAnchorIds.test.ts | Added test coverage for single-escaped anchor normalization in fallback mode |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant addExplicitAnchorIds
    participant extractHeadingInfo
    participant applyInlineIds
    participant applyInlineIdsStringFallback
    
    User->>addExplicitAnchorIds: translatedContent + sourceHeadingMap
    addExplicitAnchorIds->>extractHeadingInfo: extract translated headings
    extractHeadingInfo-->>addExplicitAnchorIds: translatedHeadings
    
    alt MDX parsing succeeds
        addExplicitAnchorIds->>applyInlineIds: apply IDs via AST
        applyInlineIds-->>addExplicitAnchorIds: modified content
    else MDX parsing fails
        addExplicitAnchorIds->>applyInlineIdsStringFallback: fallback string processing
        Note over applyInlineIdsStringFallback: Line 455: Normalize unescaped {#id}<br/>to escaped \{#id\} (fixed from \\{#id\\})
        applyInlineIdsStringFallback-->>addExplicitAnchorIds: modified content
    end
    
    addExplicitAnchorIds-->>User: result with hasChanges flag
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->