### PR TITLE
F/openapi handling docs json

### DIFF
--- a/.changeset/wide-kings-like.md
+++ b/.changeset/wide-kings-like.md
@@ -1,0 +1,5 @@
+---
+'gtx-cli': patch
+---
+
+Add handling for OpenAPI configurations via Mintlify's `docs.json`

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.5.46';
+export const PACKAGE_VERSION = '2.5.48';

--- a/packages/cli/src/utils/__tests__/processOpenApi.test.ts
+++ b/packages/cli/src/utils/__tests__/processOpenApi.test.ts
@@ -203,10 +203,8 @@ describe('processOpenApi', () => {
     await processOpenApi(settings);
 
     const updatedDocs = JSON.parse(fs.readFileSync(docsJsonPath, 'utf8'));
-    const enGroup =
-      updatedDocs.navigation.languages[0].tabs[0].groups[0];
-    const esGroup =
-      updatedDocs.navigation.languages[1].tabs[0].groups[0];
+    const enGroup = updatedDocs.navigation.languages[0].tabs[0].groups[0];
+    const esGroup = updatedDocs.navigation.languages[1].tabs[0].groups[0];
     expect(enGroup.openapi.source).toBe('openapi.json');
     expect(enGroup.pages[0]).toBe('GET /foo');
     expect(esGroup.openapi.source).toBe('es/openapi.json');

--- a/packages/cli/src/utils/__tests__/processOpenApi.test.ts
+++ b/packages/cli/src/utils/__tests__/processOpenApi.test.ts
@@ -130,6 +130,364 @@ describe('processOpenApi', () => {
     expect(updatedTranslated).toContain('/es/openapi.demo.yaml POST /foo');
   });
 
+  it('rewrites Mintlify docs.json openapi source and strips locale prefixes from openapi pages', async () => {
+    const spec = { openapi: '3.0.0', paths: { '/foo': { get: {} } } };
+    const specPath = path.join(tmpDir, 'openapi.json');
+    fs.writeFileSync(specPath, JSON.stringify(spec));
+    const translatedSpecPath = path.join(tmpDir, 'es', 'openapi.json');
+    fs.mkdirSync(path.dirname(translatedSpecPath), { recursive: true });
+    fs.writeFileSync(translatedSpecPath, JSON.stringify(spec));
+
+    const docsJsonPath = path.join(tmpDir, 'docs.json');
+    fs.writeFileSync(
+      docsJsonPath,
+      JSON.stringify(
+        {
+          $schema: 'https://mintlify.com/docs.json',
+          navigation: {
+            languages: [
+              {
+                language: 'en',
+                tabs: [
+                  {
+                    tab: 'API',
+                    groups: [
+                      {
+                        group: 'Endpoints',
+                        openapi: { source: 'openapi.json', directory: 'api' },
+                        pages: ['GET /foo'],
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                language: 'es',
+                tabs: [
+                  {
+                    tab: 'API',
+                    groups: [
+                      {
+                        group: 'Endpoints',
+                        openapi: { source: 'openapi.json', directory: 'api' },
+                        pages: ['es/GET /foo'],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        null,
+        2
+      )
+    );
+
+    const settings = createSettings(tmpDir, ['./openapi.json']);
+    settings.files = {
+      resolvedPaths: {
+        json: [specPath, docsJsonPath],
+      },
+      placeholderPaths: {
+        json: [specPath, docsJsonPath],
+      },
+      transformPaths: {
+        json: {
+          match: 'openapi.json$',
+          replace: '{locale}/openapi.json',
+        },
+      },
+    };
+
+    await processOpenApi(settings);
+
+    const updatedDocs = JSON.parse(fs.readFileSync(docsJsonPath, 'utf8'));
+    const enGroup =
+      updatedDocs.navigation.languages[0].tabs[0].groups[0];
+    const esGroup =
+      updatedDocs.navigation.languages[1].tabs[0].groups[0];
+    expect(enGroup.openapi.source).toBe('openapi.json');
+    expect(enGroup.pages[0]).toBe('GET /foo');
+    expect(esGroup.openapi.source).toBe('es/openapi.json');
+    expect(esGroup.pages[0]).toBe('GET /foo');
+  });
+
+  it('rewrites docs.json openapi source with nested locale paths and respects absolute style', async () => {
+    const spec = { openapi: '3.0.0', paths: { '/foo': { get: {} } } };
+    const specPath = path.join(tmpDir, 'api', 'specs', 'openapi.json');
+    fs.mkdirSync(path.dirname(specPath), { recursive: true });
+    fs.writeFileSync(specPath, JSON.stringify(spec));
+
+    const localizedSpecPath = path.join(
+      tmpDir,
+      'api',
+      'es',
+      'specs',
+      'openapi.json'
+    );
+    fs.mkdirSync(path.dirname(localizedSpecPath), { recursive: true });
+    fs.writeFileSync(localizedSpecPath, JSON.stringify(spec));
+
+    const docsJsonPath = path.join(tmpDir, 'docs.json');
+    fs.writeFileSync(
+      docsJsonPath,
+      JSON.stringify(
+        {
+          $schema: 'https://mintlify.com/docs.json',
+          navigation: {
+            languages: [
+              {
+                language: 'es',
+                tabs: [
+                  {
+                    tab: 'API',
+                    groups: [
+                      {
+                        group: 'Endpoints',
+                        openapi: {
+                          source: '/api/specs/openapi.json',
+                          directory: 'api',
+                        },
+                        pages: ['es/GET /foo'],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        null,
+        2
+      )
+    );
+
+    const settings = createSettings(tmpDir, ['./api/specs/openapi.json']);
+    settings.files = {
+      resolvedPaths: { json: [specPath, docsJsonPath] },
+      placeholderPaths: { json: [specPath, docsJsonPath] },
+      transformPaths: {
+        json: {
+          match: 'api/specs/openapi\\.json$',
+          replace: 'api/{locale}/specs/openapi.json',
+        },
+      },
+    };
+
+    await processOpenApi(settings);
+
+    const updatedDocs = JSON.parse(fs.readFileSync(docsJsonPath, 'utf8'));
+    const esGroup = updatedDocs.navigation.languages[0].tabs[0].groups[0];
+    expect(esGroup.openapi.source).toBe('/api/es/specs/openapi.json');
+    expect(esGroup.pages[0]).toBe('GET /foo');
+  });
+
+  it('leaves docs.json openapi source unchanged when localized file is missing', async () => {
+    const spec = { openapi: '3.0.0', paths: { '/foo': { get: {} } } };
+    const specPath = path.join(tmpDir, 'openapi.json');
+    fs.writeFileSync(specPath, JSON.stringify(spec));
+
+    const docsJsonPath = path.join(tmpDir, 'docs.json');
+    fs.writeFileSync(
+      docsJsonPath,
+      JSON.stringify(
+        {
+          $schema: 'https://mintlify.com/docs.json',
+          navigation: {
+            languages: [
+              {
+                language: 'es',
+                tabs: [
+                  {
+                    tab: 'API',
+                    groups: [
+                      {
+                        group: 'Endpoints',
+                        openapi: { source: 'openapi.json', directory: 'api' },
+                        pages: ['es/GET /foo'],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        null,
+        2
+      )
+    );
+
+    const settings = createSettings(tmpDir, ['./openapi.json']);
+    settings.files = {
+      resolvedPaths: { json: [specPath, docsJsonPath] },
+      placeholderPaths: { json: [specPath, docsJsonPath] },
+      transformPaths: {
+        json: {
+          match: 'openapi.json$',
+          replace: '{locale}/openapi.json',
+        },
+      },
+    };
+
+    await processOpenApi(settings);
+
+    const updatedDocs = JSON.parse(fs.readFileSync(docsJsonPath, 'utf8'));
+    const esGroup = updatedDocs.navigation.languages[0].tabs[0].groups[0];
+    expect(esGroup.openapi.source).toBe('openapi.json');
+    expect(esGroup.pages[0]).toBe('GET /foo');
+  });
+
+  it('preserves ./relative openapi source style while localizing', async () => {
+    const spec = { openapi: '3.0.0', paths: { '/foo': { get: {} } } };
+    const specPath = path.join(tmpDir, 'api', 'openapi.json');
+    fs.mkdirSync(path.dirname(specPath), { recursive: true });
+    fs.writeFileSync(specPath, JSON.stringify(spec));
+
+    const localizedSpecPath = path.join(tmpDir, 'api', 'es', 'openapi.json');
+    fs.mkdirSync(path.dirname(localizedSpecPath), { recursive: true });
+    fs.writeFileSync(localizedSpecPath, JSON.stringify(spec));
+
+    const docsJsonPath = path.join(tmpDir, 'docs.json');
+    fs.writeFileSync(
+      docsJsonPath,
+      JSON.stringify(
+        {
+          $schema: 'https://mintlify.com/docs.json',
+          navigation: {
+            languages: [
+              {
+                language: 'es',
+                tabs: [
+                  {
+                    tab: 'API',
+                    groups: [
+                      {
+                        group: 'Endpoints',
+                        openapi: { source: './api/openapi.json' },
+                        pages: ['es/GET /foo'],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        null,
+        2
+      )
+    );
+
+    const settings = createSettings(tmpDir, ['./api/openapi.json']);
+    settings.files = {
+      resolvedPaths: { json: [specPath, docsJsonPath] },
+      placeholderPaths: { json: [specPath, docsJsonPath] },
+      transformPaths: {
+        json: {
+          match: 'api/openapi\\.json$',
+          replace: 'api/{locale}/openapi.json',
+        },
+      },
+    };
+
+    await processOpenApi(settings);
+
+    const updatedDocs = JSON.parse(fs.readFileSync(docsJsonPath, 'utf8'));
+    const esGroup = updatedDocs.navigation.languages[0].tabs[0].groups[0];
+    expect(esGroup.openapi.source).toBe('./api/es/openapi.json');
+    expect(esGroup.pages[0]).toBe('GET /foo');
+  });
+
+  it('localizes docs.json openapi source when multiple specs share a basename', async () => {
+    const spec = { openapi: '3.0.0', paths: { '/foo': { get: {} } } };
+    const specAPath = path.join(tmpDir, 'api', 'a', 'openapi.json');
+    const specBPath = path.join(tmpDir, 'api', 'b', 'openapi.json');
+    fs.mkdirSync(path.dirname(specAPath), { recursive: true });
+    fs.mkdirSync(path.dirname(specBPath), { recursive: true });
+    fs.writeFileSync(specAPath, JSON.stringify(spec));
+    fs.writeFileSync(specBPath, JSON.stringify(spec));
+
+    const localizedSpecAPath = path.join(
+      tmpDir,
+      'api',
+      'es',
+      'a',
+      'openapi.json'
+    );
+    const localizedSpecBPath = path.join(
+      tmpDir,
+      'api',
+      'es',
+      'b',
+      'openapi.json'
+    );
+    fs.mkdirSync(path.dirname(localizedSpecAPath), { recursive: true });
+    fs.mkdirSync(path.dirname(localizedSpecBPath), { recursive: true });
+    fs.writeFileSync(localizedSpecAPath, JSON.stringify(spec));
+    fs.writeFileSync(localizedSpecBPath, JSON.stringify(spec));
+
+    const docsJsonPath = path.join(tmpDir, 'docs.json');
+    fs.writeFileSync(
+      docsJsonPath,
+      JSON.stringify(
+        {
+          $schema: 'https://mintlify.com/docs.json',
+          navigation: {
+            languages: [
+              {
+                language: 'es',
+                tabs: [
+                  {
+                    tab: 'API',
+                    groups: [
+                      {
+                        group: 'Endpoints',
+                        openapi: { source: 'openapi.json' },
+                        pages: ['es/GET /foo'],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        null,
+        2
+      )
+    );
+
+    const settings = createSettings(tmpDir, [
+      './api/a/openapi.json',
+      './api/b/openapi.json',
+    ]);
+    settings.files = {
+      resolvedPaths: { json: [specAPath, specBPath, docsJsonPath] },
+      placeholderPaths: { json: [specAPath, specBPath, docsJsonPath] },
+      transformPaths: {
+        json: [
+          {
+            match: 'api/a/openapi\\.json$',
+            replace: 'api/{locale}/a/openapi.json',
+          },
+          {
+            match: 'api/b/openapi\\.json$',
+            replace: 'api/{locale}/b/openapi.json',
+          },
+        ],
+      },
+    };
+
+    await processOpenApi(settings);
+
+    const updatedDocs = JSON.parse(fs.readFileSync(docsJsonPath, 'utf8'));
+    const esGroup = updatedDocs.navigation.languages[0].tabs[0].groups[0];
+    expect(esGroup.openapi.source).toBe('api/es/a/openapi.json');
+    expect(esGroup.pages[0]).toBe('GET /foo');
+  });
+
   it('skips ambiguous operations when multiple specs match and leaves frontmatter unchanged', async () => {
     const specA = { openapi: '3.0.0', paths: { '/dup': { get: {} } } };
     const specB = { openapi: '3.0.0', paths: { '/dup': { get: {} } } };

--- a/packages/cli/src/utils/processOpenApi.ts
+++ b/packages/cli/src/utils/processOpenApi.ts
@@ -197,8 +197,7 @@ function collectDocsJsonTargets(
   }
 
   for (const [filePath, locales] of seen.entries()) {
-    const localeHint =
-      locales.size === 1 ? Array.from(locales)[0] : undefined;
+    const localeHint = locales.size === 1 ? Array.from(locales)[0] : undefined;
     targets.push({ path: filePath, localeHint });
   }
 
@@ -371,10 +370,7 @@ function matchSpecBySource(
   const explicitBase = path.basename(normalizedExplicit);
   const explicitBaseWithoutExt = stripExtension(explicitBase);
   const matches = specs.filter((spec) => {
-    const configPath = normalizeSlashes(spec.configPath).replace(
-      /^\.?\/+/,
-      ''
-    );
+    const configPath = normalizeSlashes(spec.configPath).replace(/^\.?\/+/, '');
     const configBase = path.basename(configPath);
     const configPathNoExt = stripExtension(configPath);
     const configBaseNoExt = stripExtension(configBase);
@@ -391,7 +387,9 @@ function matchSpecBySource(
     warnings.add(
       `OpenAPI source "${source}" matches multiple specs (${matches
         .map((m) => m.configPath)
-        .join(', ')}). Using the first configured match (${matches[0].configPath}).`
+        .join(
+          ', '
+        )}). Using the first configured match (${matches[0].configPath}).`
     );
     return matches[0];
   }

--- a/packages/cli/src/utils/processOpenApi.ts
+++ b/packages/cli/src/utils/processOpenApi.ts
@@ -132,9 +132,290 @@ export default async function processOpenApi(
     }
   }
 
+  const docsJsonTargets = collectDocsJsonTargets(
+    settings,
+    fileMapping,
+    includeFiles
+  );
+  for (const target of docsJsonTargets) {
+    if (!fs.existsSync(target.path)) continue;
+    const content = fs.readFileSync(target.path, 'utf8');
+    const updated = rewriteDocsJsonOpenApi(
+      content,
+      target.path,
+      target.localeHint,
+      specAnalyses,
+      fileMappingAbs,
+      fileMapping,
+      warnings,
+      configDir,
+      settings.defaultLocale
+    );
+    if (updated?.changed) {
+      await fs.promises.writeFile(target.path, updated.content, 'utf8');
+    }
+  }
+
   for (const message of warnings) {
     logger.warn(message);
   }
+}
+
+function collectDocsJsonTargets(
+  settings: Settings,
+  fileMapping: Record<string, Record<string, string>>,
+  includeFiles?: Set<string>
+): Array<{ path: string; localeHint?: string }> {
+  const targets: Array<{ path: string; localeHint?: string }> = [];
+  const seen = new Map<string, Set<string>>();
+
+  const addTarget = (filePath: string, locale?: string) => {
+    const canonicalPath = path.resolve(filePath);
+    if (
+      includeFiles &&
+      !includeFiles.has(filePath) &&
+      !includeFiles.has(canonicalPath)
+    ) {
+      return;
+    }
+    const locales = seen.get(canonicalPath) ?? new Set<string>();
+    if (locale) locales.add(locale);
+    seen.set(canonicalPath, locales);
+  };
+
+  if (!includeFiles && settings.files?.resolvedPaths.json) {
+    for (const filePath of settings.files.resolvedPaths.json) {
+      addTarget(filePath, settings.defaultLocale);
+    }
+  }
+
+  for (const [locale, filesMap] of Object.entries(fileMapping)) {
+    for (const filePath of Object.values(filesMap)) {
+      if (!filePath.endsWith('.json')) continue;
+      addTarget(filePath, locale);
+    }
+  }
+
+  for (const [filePath, locales] of seen.entries()) {
+    const localeHint =
+      locales.size === 1 ? Array.from(locales)[0] : undefined;
+    targets.push({ path: filePath, localeHint });
+  }
+
+  return targets;
+}
+
+function isMintlifyDocsJson(filePath: string, json: unknown): boolean {
+  if (!isRecord(json)) return false;
+  const schema = json.$schema;
+  if (typeof schema === 'string') {
+    return (
+      schema.includes('mintlify.com/docs.json') ||
+      schema.includes('mintlify.com/mint.json')
+    );
+  }
+  const base = path.basename(filePath);
+  return base === 'docs.json' || base === 'mint.json';
+}
+
+function rewriteDocsJsonOpenApi(
+  content: string,
+  filePath: string,
+  localeHint: string | undefined,
+  specs: SpecAnalysis[],
+  fileMappingAbs: Record<string, Record<string, string>>,
+  fileMappingRel: Record<string, Record<string, string>>,
+  warnings: Set<string>,
+  configDir: string,
+  defaultLocale: string
+): { changed: boolean; content: string } | null {
+  let json: unknown;
+  try {
+    json = JSON.parse(content);
+  } catch {
+    return null;
+  }
+
+  if (!isMintlifyDocsJson(filePath, json)) return null;
+
+  let changed = false;
+
+  const visitNode = (node: unknown, activeLocale?: string) => {
+    if (Array.isArray(node)) {
+      node.forEach((item) => visitNode(item, activeLocale));
+      return;
+    }
+    if (!isRecord(node)) return;
+
+    let nextLocale = activeLocale;
+    if (typeof node.language === 'string') {
+      nextLocale = node.language;
+    }
+
+    if (isRecord(node.openapi) && Array.isArray(node.pages)) {
+      const locale = nextLocale || localeHint || defaultLocale;
+      const openapiConfig = node.openapi as Record<string, unknown>;
+      const sourceValue = openapiConfig.source;
+      if (typeof sourceValue === 'string') {
+        const localizedSource = localizeDocsJsonSpecPath(
+          sourceValue,
+          locale,
+          filePath,
+          specs,
+          fileMappingAbs,
+          fileMappingRel,
+          warnings,
+          configDir
+        );
+        if (localizedSource && localizedSource !== sourceValue) {
+          openapiConfig.source = localizedSource;
+          changed = true;
+        }
+      }
+
+      const pages = node.pages;
+      for (let i = 0; i < pages.length; i += 1) {
+        const page = pages[i];
+        if (typeof page !== 'string') continue;
+        const updated = stripLocaleFromOpenApiPage(page, locale);
+        if (updated !== page) {
+          pages[i] = updated;
+          changed = true;
+        }
+      }
+    }
+
+    for (const value of Object.values(node)) {
+      visitNode(value, nextLocale);
+    }
+  };
+
+  visitNode(json, undefined);
+
+  if (!changed) return null;
+  return { changed, content: JSON.stringify(json, null, 2) };
+}
+
+function stripLocaleFromOpenApiPage(value: string, locale: string): string {
+  const trimmed = value.trim();
+  const prefix = `${locale}/`;
+  if (!trimmed.startsWith(prefix)) return value;
+  const candidate = trimmed.slice(prefix.length);
+  const parsed = parseOpenApiValue(candidate);
+  if (!parsed) return value;
+  return candidate;
+}
+
+function localizeDocsJsonSpecPath(
+  source: string,
+  locale: string,
+  filePath: string,
+  specs: SpecAnalysis[],
+  fileMappingAbs: Record<string, Record<string, string>>,
+  _fileMappingRel: Record<string, Record<string, string>>,
+  warnings: Set<string>,
+  configDir: string
+): string | null {
+  const resolvedAbs = resolveDocsJsonSpecPath(source, filePath, configDir);
+  const matched = matchSpecBySource(source, resolvedAbs, specs, warnings);
+  if (!matched) return source;
+
+  const localizedSpecPath = resolveLocalizedSpecPath(
+    matched,
+    locale,
+    fileMappingAbs,
+    configDir,
+    source
+  );
+  const localizedAbs = resolveDocsJsonSpecPath(
+    localizedSpecPath,
+    filePath,
+    configDir
+  );
+  if (!fs.existsSync(localizedAbs)) {
+    warnings.add(
+      `OpenAPI source "${source}" localized for locale "${locale}" points to a missing file (${localizedAbs}). Keeping original source.`
+    );
+    return source;
+  }
+
+  const rel = normalizeSlashes(path.relative(configDir, localizedAbs));
+  return formatSpecPathForDocsJson(rel, source);
+}
+
+function resolveDocsJsonSpecPath(
+  source: string,
+  filePath: string,
+  configDir: string
+): string {
+  if (source.startsWith('/')) {
+    return path.resolve(configDir, source.replace(/^\/+/, ''));
+  }
+  if (source.startsWith('./') || source.startsWith('../')) {
+    return path.resolve(path.dirname(filePath), source);
+  }
+  return path.resolve(configDir, source);
+}
+
+function matchSpecBySource(
+  source: string,
+  resolvedAbs: string,
+  specs: SpecAnalysis[],
+  warnings: Set<string>
+): SpecAnalysis | null {
+  const exact = specs.find((spec) => samePath(resolvedAbs, spec.absPath));
+  if (exact) return exact;
+
+  const normalizedExplicit = normalizeSlashes(source).replace(/^\.?\/+/, '');
+  const explicitWithoutExt = stripExtension(normalizedExplicit);
+  const explicitBase = path.basename(normalizedExplicit);
+  const explicitBaseWithoutExt = stripExtension(explicitBase);
+  const matches = specs.filter((spec) => {
+    const configPath = normalizeSlashes(spec.configPath).replace(
+      /^\.?\/+/,
+      ''
+    );
+    const configBase = path.basename(configPath);
+    const configPathNoExt = stripExtension(configPath);
+    const configBaseNoExt = stripExtension(configBase);
+    return (
+      configPath === normalizedExplicit ||
+      configPathNoExt === explicitWithoutExt ||
+      configBase === explicitBase ||
+      configBaseNoExt === explicitBaseWithoutExt
+    );
+  });
+
+  if (matches.length === 1) return matches[0];
+  if (matches.length > 1) {
+    warnings.add(
+      `OpenAPI source "${source}" matches multiple specs (${matches
+        .map((m) => m.configPath)
+        .join(', ')}). Using the first configured match (${matches[0].configPath}).`
+    );
+    return matches[0];
+  }
+
+  return null;
+}
+
+function formatSpecPathForDocsJson(
+  relativePath: string,
+  originalPathText: string
+): string {
+  const normalized = normalizeSlashes(relativePath);
+  const base = normalized.replace(/^\.\//, '').replace(/\/+/g, '/');
+
+  if (originalPathText.startsWith('/')) {
+    return `/${base.replace(/^\/+/, '')}`;
+  }
+  if (originalPathText.startsWith('../')) {
+    return normalized;
+  }
+  if (originalPathText.startsWith('./')) {
+    return `./${base.replace(/^\/+/, '')}`;
+  }
+  return base.replace(/^\/+/, '');
 }
 
 /**


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR extends OpenAPI localization support to handle `docs.json` configuration files when they clash with YAML frontmatter. The implementation adds functionality to:
- Detect and process Mintlify `docs.json` files (identified by `$schema` or filename)
- Localize OpenAPI spec source paths within `docs.json` based on the navigation language settings
- Strip locale prefixes from OpenAPI page paths (e.g., `es/GET /foo` becomes `GET /foo`)
- Preserve various path styles (absolute `/`, relative `./`, nested paths)
- Handle missing localized files gracefully by keeping original source paths

The code is well-tested with 5 new comprehensive test cases covering edge cases including nested paths, missing files, multiple specs with same basename, and various path style preservation scenarios. No console.log statements or debugging code were found in production code.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>


- This PR is safe to merge with minimal risk
- The changes are well-structured, thoroughly tested, and follow existing patterns in the codebase. The new functionality is additive and includes comprehensive test coverage with 5 new test cases. No breaking changes, security issues, or code quality concerns were identified.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/cli/src/generated/version.ts | Auto-generated version bump from 2.5.46 to 2.5.48 |
| packages/cli/src/utils/__tests__/processOpenApi.test.ts | Added comprehensive test coverage for docs.json OpenAPI source localization with 5 new test cases covering various path styles and edge cases |
| packages/cli/src/utils/processOpenApi.ts | Added new functionality to process and localize OpenAPI references in docs.json files, including locale stripping from page paths and spec source rewriting |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant processOpenApi
    participant collectDocsJsonTargets
    participant rewriteDocsJsonOpenApi
    participant localizeDocsJsonSpecPath
    participant matchSpecBySource
    participant stripLocaleFromOpenApiPage
    participant fs

    Caller->>processOpenApi: settings, includeFiles?
    processOpenApi->>processOpenApi: buildSpecAnalyses(openapiConfig.files)
    processOpenApi->>processOpenApi: createFileMapping()
    
    Note over processOpenApi: Process frontmatter (existing logic)
    processOpenApi->>fs: Read & update MDX files
    
    Note over processOpenApi: NEW: Process docs.json files
    processOpenApi->>collectDocsJsonTargets: settings, fileMapping, includeFiles
    collectDocsJsonTargets-->>processOpenApi: Array of {path, localeHint}
    
    loop For each docs.json target
        processOpenApi->>fs: readFileSync(target.path)
        processOpenApi->>rewriteDocsJsonOpenApi: content, specs, mappings
        
        rewriteDocsJsonOpenApi->>rewriteDocsJsonOpenApi: Parse JSON
        rewriteDocsJsonOpenApi->>rewriteDocsJsonOpenApi: Check isMintlifyDocsJson()
        
        rewriteDocsJsonOpenApi->>rewriteDocsJsonOpenApi: visitNode(json) - recursive traversal
        
        alt Found openapi config
            rewriteDocsJsonOpenApi->>localizeDocsJsonSpecPath: source, locale, specs
            localizeDocsJsonSpecPath->>matchSpecBySource: source, resolvedAbs, specs
            matchSpecBySource-->>localizeDocsJsonSpecPath: matched spec
            localizeDocsJsonSpecPath->>fs: existsSync(localizedAbs)
            localizeDocsJsonSpecPath-->>rewriteDocsJsonOpenApi: localizedSource
            rewriteDocsJsonOpenApi->>rewriteDocsJsonOpenApi: Update openapi.source
        end
        
        alt Found pages array
            loop For each page
                rewriteDocsJsonOpenApi->>stripLocaleFromOpenApiPage: page, locale
                stripLocaleFromOpenApiPage-->>rewriteDocsJsonOpenApi: stripped page
                rewriteDocsJsonOpenApi->>rewriteDocsJsonOpenApi: Update pages[i]
            end
        end
        
        rewriteDocsJsonOpenApi-->>processOpenApi: {changed, content}
        
        alt If changed
            processOpenApi->>fs: writeFile(target.path, content)
        end
    end
    
    processOpenApi->>Caller: Complete
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->