### PR TITLE
CLI New Default Workflow

### DIFF
--- a/.changeset/cold-spoons-switch.md
+++ b/.changeset/cold-spoons-switch.md
@@ -1,0 +1,5 @@
+---
+'gtx-cli': minor
+---
+
+CLI New Default Workflow

--- a/packages/cli/src/cli/base.ts
+++ b/packages/cli/src/cli/base.ts
@@ -352,7 +352,7 @@ export class BaseCLI {
             const wrap = useDefaults
               ? true
               : await promptConfirm({
-                  message: `${frameworkDisplayName} detected. Would you like to install ${library} and add the GTProvider? See the docs for more information: https://generaltranslation.com/docs/react/tutorials/quickstart`,
+                  message: `Would you like to install ${library} and add the GTProvider? See the docs for more information: https://generaltranslation.com/docs/react/tutorials/quickstart`,
                   defaultValue: true,
                 });
 

--- a/packages/cli/src/setup/userInput.ts
+++ b/packages/cli/src/setup/userInput.ts
@@ -3,35 +3,40 @@ import { promptText } from '../console/logging.js';
 import chalk from 'chalk';
 import { gt } from '../utils/gt.js';
 
-export async function getDesiredLocales(): Promise<{
+export async function getDesiredLocales(useDefaults: boolean = false): Promise<{
   defaultLocale: string;
   locales: string[];
 }> {
   // Ask for the default locale
-  const defaultLocale = await promptText({
-    message: 'What is the default locale for your project?',
-    defaultValue: libraryDefaultLocale,
-  });
+  const defaultLocale = useDefaults
+    ? libraryDefaultLocale
+    : await promptText({
+        message:
+          'What is the default language for your project? Enter a BCP-47 locale tag.',
+        defaultValue: libraryDefaultLocale,
+      });
 
   // Ask for the locales
-  const locales = await promptText({
-    message: `Which languages would you like to translate your project into? Enter your response as a list of BCP-47 locale tags. ${chalk.dim('(space-separated list)')}`,
-    defaultValue: 'es fr de ja zh',
-    validate: (input) => {
-      const localeList = input.split(' ');
-      if (localeList.length === 0) {
-        return 'Please enter at least one locale';
-      }
-      if (localeList.some((locale) => !locale.trim())) {
-        return 'Please enter a valid locale (e.g., es fr de)';
-      }
-      for (const locale of localeList) {
-        if (!gt.isValidLocale(locale)) {
-          return 'Please enter a valid locale (e.g., es fr de)';
-        }
-      }
-      return true;
-    },
-  });
+  const locales = useDefaults
+    ? 'es fr de ja zh'
+    : await promptText({
+        message: `Which languages would you like to translate your project into? Enter your response as a list of BCP-47 locale tags. ${chalk.dim('(space-separated list)')}`,
+        defaultValue: 'es fr de ja zh',
+        validate: (input) => {
+          const localeList = input.split(' ');
+          if (localeList.length === 0) {
+            return 'Please enter at least one locale';
+          }
+          if (localeList.some((locale) => !locale.trim())) {
+            return 'Please enter a valid locale (e.g., es fr de)';
+          }
+          for (const locale of localeList) {
+            if (!gt.isValidLocale(locale)) {
+              return 'Please enter a valid locale (e.g., es fr de)';
+            }
+          }
+          return true;
+        },
+      });
   return { defaultLocale, locales: locales.split(' ') };
 }

--- a/packages/cli/src/setup/userInput.ts
+++ b/packages/cli/src/setup/userInput.ts
@@ -3,40 +3,35 @@ import { promptText } from '../console/logging.js';
 import chalk from 'chalk';
 import { gt } from '../utils/gt.js';
 
-export async function getDesiredLocales(useDefaults: boolean = false): Promise<{
+export async function getDesiredLocales(): Promise<{
   defaultLocale: string;
   locales: string[];
 }> {
   // Ask for the default locale
-  const defaultLocale = useDefaults
-    ? libraryDefaultLocale
-    : await promptText({
-        message:
-          'What is the default language for your project? Enter a BCP-47 locale tag.',
-        defaultValue: libraryDefaultLocale,
-      });
+  const defaultLocale = await promptText({
+    message: 'What is the default locale for your project?',
+    defaultValue: libraryDefaultLocale,
+  });
 
   // Ask for the locales
-  const locales = useDefaults
-    ? 'es fr de ja zh'
-    : await promptText({
-        message: `Which languages would you like to translate your project into? Enter your response as a list of BCP-47 locale tags. ${chalk.dim('(space-separated list)')}`,
-        defaultValue: 'es fr de ja zh',
-        validate: (input) => {
-          const localeList = input.split(' ');
-          if (localeList.length === 0) {
-            return 'Please enter at least one locale';
-          }
-          if (localeList.some((locale) => !locale.trim())) {
-            return 'Please enter a valid locale (e.g., es fr de)';
-          }
-          for (const locale of localeList) {
-            if (!gt.isValidLocale(locale)) {
-              return 'Please enter a valid locale (e.g., es fr de)';
-            }
-          }
-          return true;
-        },
-      });
+  const locales = await promptText({
+    message: `Which languages would you like to translate your project into? Enter your response as a list of BCP-47 locale tags. ${chalk.dim('(space-separated list)')}`,
+    defaultValue: 'es fr de ja zh',
+    validate: (input) => {
+      const localeList = input.split(' ');
+      if (localeList.length === 0) {
+        return 'Please enter at least one locale';
+      }
+      if (localeList.some((locale) => !locale.trim())) {
+        return 'Please enter a valid locale (e.g., es fr de)';
+      }
+      for (const locale of localeList) {
+        if (!gt.isValidLocale(locale)) {
+          return 'Please enter a valid locale (e.g., es fr de)';
+        }
+      }
+      return true;
+    },
+  });
   return { defaultLocale, locales: locales.split(' ') };
 }


### PR DESCRIPTION
# What
Created a "use default" question for the cli that uses the defaults for all questions (except for the locales selector question, that remains up for the user to decide)

# Why
Easier and less confusing for users to navigate using default values

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Added a "use defaults" prompt to the CLI init workflow that allows users to skip configuration questions and use recommended defaults (local file storage in `./public/_gt`, detected framework settings, auto-formatting enabled), while still prompting for locale selection as intended.

- Modified `handleInitCommand()` and `handleSetupReactCommand()` to accept a `useDefaults` parameter
- When `useDefaults` is true, skips prompts for CDN/local storage, translations directory, file extensions, API key generation, confirmation dialogs, and formatting preferences
- Locale selection intentionally remains interactive even with defaults enabled
- Cleaned up unused import (`ReactFrameworkObject`) in `base.ts`

<details open><summary><h3>Confidence Score: 4/5</h3></summary>


- This PR is safe to merge with minor review recommended
- The implementation is well-structured and achieves the stated goal of simplifying the CLI workflow. Code changes are focused and logical. One unused import was removed. The feature correctly preserves locale prompts as intended. Confidence reduced by 1 point due to previous thread noting locale prompts appearing even with defaults (though this appears to be intentional based on the comment in the code).
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .changeset/cold-spoons-switch.md | Added changeset file for CLI new default workflow feature |
| packages/cli/src/cli/base.ts | Added `useDefaults` parameter to skip prompts and use recommended defaults, but locale selection still prompts user as intended |
| packages/cli/src/setup/wizard.ts | Propagated `useDefaults` parameter to skip confirmation and framework selection prompts when using defaults |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant CLI as CLI (init command)
    participant Framework as detectFramework()
    participant Wizard as handleSetupReactCommand()
    participant Config as handleInitCommand()
    participant Locales as getDesiredLocales()

    User->>CLI: Run init command
    CLI->>Framework: Detect framework
    Framework-->>CLI: Return framework info
    
    alt Locadex flow
        CLI->>User: Ask about Locadex agent
        User-->>CLI: No
    end
    
    CLI->>User: Use defaults? (library, framework, local storage)
    User-->>CLI: useDefaults = true/false
    
    alt React framework detected
        alt useDefaults = true
            CLI->>Wizard: handleSetupReactCommand(useDefaults=true)
            Note over Wizard: Skip confirmation prompt
            Note over Wizard: Use detected framework
            Note over Wizard: Skip formatting prompt (default: true)
        else useDefaults = false
            CLI->>User: Install library & add GTProvider?
            User-->>CLI: Yes
            CLI->>Wizard: handleSetupReactCommand(useDefaults=false)
            Wizard->>User: Ask for confirmation
            Wizard->>User: Select framework
            Wizard->>User: Ask about formatting
        end
        Wizard-->>CLI: React setup complete
    end
    
    CLI->>Config: handleInitCommand(useDefaults)
    Config->>Locales: getDesiredLocales()
    Note over Locales: Always prompts user for locales
    Locales-->>Config: Return default locale & locales
    
    alt useDefaults = true
        Note over Config: Use CDN = false (local)
        Note over Config: translationsDir = './public/_gt'
        Note over Config: fileExtensions = [] (none)
        Note over Config: loginQuestion = true
    else useDefaults = false
        Config->>User: Ask about CDN vs local
        Config->>User: Ask for translations directory
        Config->>User: Ask for additional file extensions
        Config->>User: Ask about auto-generating API key
    end
    
    Config-->>CLI: Configuration complete
    CLI->>User: Setup complete
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->