### PR TITLE
chore: upload shared id for static content

### DIFF
--- a/.changeset/smart-ties-talk.md
+++ b/.changeset/smart-ties-talk.md
@@ -1,0 +1,6 @@
+---
+'generaltranslation': patch
+'gtx-cli': patch
+---
+
+chore: upload shared id for static content

--- a/packages/cli/src/react/jsx/utils/jsxParsing/parseJsx.ts
+++ b/packages/cli/src/react/jsx/utils/jsxParsing/parseJsx.ts
@@ -694,7 +694,7 @@ function parseJSXElement({
 
   // We know its static if there are multiple entries
   const isStatic = minifiedTress.length > 1;
-  // Create a temporary unique flag for
+  // Create a temporary unique flag for static content
   const temporaryStaticId = `static-temp-id-${randomUUID()}`;
 
   // <T> is valid here

--- a/packages/cli/src/react/jsx/utils/jsxParsing/parseJsx.ts
+++ b/packages/cli/src/react/jsx/utils/jsxParsing/parseJsx.ts
@@ -1,5 +1,6 @@
 import { Updates } from '../../../../types/index.js';
 
+import { randomUUID } from 'node:crypto';
 import generateModule from '@babel/generator';
 // Handle CommonJS/ESM interop
 const generate = generateModule.default || generateModule;
@@ -138,7 +139,6 @@ export function buildJSXTree({
   inStatic,
   visited,
   callStack,
-  updates,
   errors,
   warnings,
   file,
@@ -153,7 +153,6 @@ export function buildJSXTree({
   node: any;
   callStack: string[];
   unwrappedExpressions: string[];
-  updates: Updates;
   errors: string[];
   warnings: Set<string>;
   file: string;
@@ -182,7 +181,6 @@ export function buildJSXTree({
         importAliases,
         visited: visited!,
         callStack,
-        updates,
         errors,
         warnings,
         file,
@@ -200,7 +198,6 @@ export function buildJSXTree({
         unwrappedExpressions,
         visited,
         callStack,
-        updates,
         errors,
         warnings,
         file,
@@ -307,7 +304,6 @@ export function buildJSXTree({
                 unwrappedExpressions,
                 visited,
                 callStack,
-                updates,
                 errors: errors,
                 warnings: warnings,
                 file: file,
@@ -363,7 +359,6 @@ export function buildJSXTree({
             unwrappedExpressions,
             visited,
             callStack,
-            updates,
             errors,
             warnings,
             file,
@@ -397,7 +392,6 @@ export function buildJSXTree({
           unwrappedExpressions,
           visited,
           callStack,
-          updates,
           errors,
           warnings,
           file,
@@ -436,7 +430,6 @@ export function buildJSXTree({
           unwrappedExpressions,
           visited,
           callStack,
-          updates,
           errors,
           warnings,
           file,
@@ -526,7 +519,6 @@ export function buildJSXTree({
         visited: visited!, // we know this is true bc of inStatic
         callStack,
         file,
-        updates,
         errors,
         warnings,
         unwrappedExpressions,
@@ -545,7 +537,6 @@ export function buildJSXTree({
       unwrappedExpressions,
       visited,
       callStack,
-      updates,
       errors,
       warnings,
       file,
@@ -580,7 +571,7 @@ export function buildJSXTree({
 // end buildJSXTree
 
 // Parses a JSX element and adds it to the updates array
-export function parseJSXElement({
+function parseJSXElement({
   importAliases,
   node,
   originalName,
@@ -642,7 +633,6 @@ export function parseJSXElement({
     callStack: [],
     pkgs,
     unwrappedExpressions,
-    updates,
     errors: componentErrors,
     warnings: componentWarnings,
     file,
@@ -702,6 +692,11 @@ export function parseJSXElement({
     return;
   }
 
+  // We know its static if there are multiple entries
+  const isStatic = minifiedTress.length > 1;
+  // Create a temporary unique flag for
+  const temporaryStaticId = `static-temp-id-${randomUUID()}`;
+
   // <T> is valid here
   for (const minifiedTree of minifiedTress) {
     // Clean the tree by removing null 'c' fields from JsxElements
@@ -710,8 +705,11 @@ export function parseJSXElement({
     updates.push({
       dataFormat: 'JSX',
       source: cleanedTree,
-      // eslint-disable-next-line no-undef
-      metadata: { ...structuredClone(metadata) },
+      metadata: {
+        // eslint-disable-next-line no-undef
+        ...structuredClone(metadata),
+        ...(isStatic && { staticId: temporaryStaticId }),
+      },
     });
   }
 }
@@ -724,7 +722,6 @@ function resolveStaticFunctionInvocationFromBinding({
   visited,
   callStack,
   file,
-  updates,
   errors,
   warnings,
   parsingOptions,
@@ -738,7 +735,6 @@ function resolveStaticFunctionInvocationFromBinding({
   visited: Set<string>;
   callStack: string[];
   file: string;
-  updates: Updates;
   errors: string[];
   warnings: Set<string>;
   parsingOptions: ParsingConfigOptions;
@@ -785,7 +781,6 @@ function resolveStaticFunctionInvocationFromBinding({
           path,
           unwrappedExpressions,
           callStack,
-          updates,
           errors,
           warnings,
           visited,
@@ -813,7 +808,6 @@ function resolveStaticFunctionInvocationFromBinding({
           functionName,
           path,
           unwrappedExpressions,
-          updates,
           callStack,
           pkgs,
           errors,
@@ -856,7 +850,6 @@ function resolveStaticFunctionInvocationFromBinding({
             visited,
             callStack,
             unwrappedExpressions,
-            updates,
             errors,
             warnings,
             file,
@@ -896,7 +889,6 @@ function processFunctionInFile({
   visited,
   callStack,
   parsingOptions,
-  updates,
   errors,
   warnings,
   file,
@@ -908,7 +900,6 @@ function processFunctionInFile({
   visited: Set<string>;
   callStack: string[];
   parsingOptions: ParsingConfigOptions;
-  updates: Updates;
   errors: string[];
   warnings: Set<string>;
   file: string;
@@ -971,7 +962,6 @@ function processFunctionInFile({
             callStack,
             visited,
             pkgs,
-            updates,
             errors,
             warnings,
             file: filePath,
@@ -996,7 +986,6 @@ function processFunctionInFile({
             path,
             callStack,
             pkgs,
-            updates,
             errors,
             warnings,
             visited,
@@ -1050,7 +1039,6 @@ function processFunctionInFile({
             visited,
             callStack,
             parsingOptions,
-            updates,
             errors,
             warnings,
             file: filePath,
@@ -1085,7 +1073,6 @@ function processFunctionDeclarationNodePath({
   unwrappedExpressions,
   visited,
   callStack,
-  updates,
   errors,
   warnings,
   file,
@@ -1099,7 +1086,6 @@ function processFunctionDeclarationNodePath({
   unwrappedExpressions: string[];
   visited: Set<string>;
   callStack: string[];
-  updates: Updates;
   errors: string[];
   warnings: Set<string>;
   file: string;
@@ -1129,7 +1115,6 @@ function processFunctionDeclarationNodePath({
           expressionNodePath: returnNodePath,
           importAliases,
           visited,
-          updates,
           errors,
           warnings,
           file,
@@ -1158,7 +1143,6 @@ function processVariableDeclarationNodePath({
   unwrappedExpressions,
   visited,
   callStack,
-  updates,
   errors,
   warnings,
   file,
@@ -1172,7 +1156,6 @@ function processVariableDeclarationNodePath({
   unwrappedExpressions: string[];
   visited: Set<string>;
   callStack: string[];
-  updates: Updates;
   errors: string[];
   warnings: Set<string>;
   file: string;
@@ -1210,7 +1193,6 @@ function processVariableDeclarationNodePath({
         importAliases,
         visited,
         callStack,
-        updates,
         errors,
         warnings,
         file,
@@ -1238,7 +1220,6 @@ function processVariableDeclarationNodePath({
             importAliases,
             visited,
             callStack,
-            updates,
             errors,
             warnings,
             file,
@@ -1273,7 +1254,6 @@ function processStaticExpression({
   importAliases,
   visited,
   callStack,
-  updates,
   errors,
   warnings,
   file,
@@ -1288,7 +1268,6 @@ function processStaticExpression({
   importAliases: Record<string, string>;
   visited: Set<string>;
   callStack: string[];
-  updates: Updates;
   errors: string[];
   warnings: Set<string>;
   file: string;
@@ -1309,7 +1288,6 @@ function processStaticExpression({
       expressionNodePath: expressionNodePath.get('expression'),
       visited,
       callStack,
-      updates,
       errors,
       warnings,
       file,
@@ -1343,7 +1321,6 @@ function processStaticExpression({
       callStack,
       visited,
       file,
-      updates,
       errors,
       warnings,
       pkgs,
@@ -1377,7 +1354,6 @@ function processStaticExpression({
       visited,
       callStack,
       file,
-      updates,
       errors,
       warnings,
       pkgs,
@@ -1395,7 +1371,6 @@ function processStaticExpression({
       unwrappedExpressions,
       visited,
       callStack,
-      updates,
       errors,
       warnings,
       file,
@@ -1423,7 +1398,6 @@ function processStaticExpression({
             expressionNodePath,
             visited,
             callStack,
-            updates,
             errors,
             warnings,
             file,
@@ -1441,7 +1415,6 @@ function processStaticExpression({
       unwrappedExpressions,
       visited,
       callStack,
-      updates,
       errors,
       warnings,
       file,

--- a/packages/cli/src/react/jsx/utils/parseStringFunction.ts
+++ b/packages/cli/src/react/jsx/utils/parseStringFunction.ts
@@ -36,6 +36,7 @@ import { handleStaticExpression } from './parseDeclareStatic.js';
 import { nodeToStrings } from './parseString.js';
 import { isNumberLiteral } from './isNumberLiteral.js';
 import { indexVars } from 'generaltranslation/internal';
+import { randomUUID } from 'node:crypto';
 
 /**
  * Cache for resolved import paths to avoid redundant I/O operations.
@@ -152,11 +153,12 @@ function processTranslationCall(
             }
           });
         }
+        const temporaryStaticId = `static-temp-id-${randomUUID()}`;
         for (const string of strings) {
           updates.push({
             dataFormat: 'ICU',
             source: string,
-            metadata: { ...metadata },
+            metadata: { ...metadata, staticId: temporaryStaticId },
           });
         }
         return;

--- a/packages/cli/src/react/parse/__tests__/dedupeUpdates.test.ts
+++ b/packages/cli/src/react/parse/__tests__/dedupeUpdates.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { mergeUpdatesByHash } from '../createInlineUpdates.js';
+import { _test_dedupeUpdates as dedupeUpdates } from '../createInlineUpdates.js';
 import type { Updates } from '../../../types/index.js';
 
-describe('mergeUpdatesByHash', () => {
+describe('dedupeUpdates', () => {
   it('coalesces filePaths for identical hashes', () => {
     const updates: Updates = [
       {
@@ -22,7 +22,7 @@ describe('mergeUpdatesByHash', () => {
       },
     ];
 
-    mergeUpdatesByHash(updates);
+    dedupeUpdates(updates);
 
     expect(updates).toHaveLength(2);
     const merged = updates.find((u) => u.metadata.hash === 'h1');
@@ -43,7 +43,7 @@ describe('mergeUpdatesByHash', () => {
       },
     ];
 
-    mergeUpdatesByHash(updates);
+    dedupeUpdates(updates);
 
     const merged = updates.find((u) => u.metadata.hash === 'h1');
     expect(merged?.metadata.filePaths).toEqual(['pathA', 'pathB']);

--- a/packages/cli/src/react/parse/createInlineUpdates.ts
+++ b/packages/cli/src/react/parse/createInlineUpdates.ts
@@ -192,3 +192,5 @@ function linkStaticUpdates(updates: Updates): void {
     });
   });
 }
+
+export { dedupeUpdates as _test_dedupeUpdates };

--- a/packages/core/src/types-dir/api/enqueueFiles.ts
+++ b/packages/core/src/types-dir/api/enqueueFiles.ts
@@ -2,7 +2,7 @@ import { JsxChildren } from '../jsx/content';
 
 // Types for the enqueueTranslationEntries function
 export type Updates = ({
-  metadata: Record<string, any>;
+  metadata: Record<string, any> & { staticId?: string };
 } & (
   | {
       dataFormat: 'JSX';

--- a/packages/core/src/types-dir/api/file.ts
+++ b/packages/core/src/types-dir/api/file.ts
@@ -1,4 +1,5 @@
 import { DataFormat } from '../jsx/content';
+import { Updates } from './enqueueFiles';
 import { Entry } from './entry';
 
 export type FileFormat =
@@ -36,7 +37,7 @@ export type File = {
  */
 export type FileToUpload = {
   content: string;
-  formatMetadata?: Record<string, any>;
+  formatMetadata?: Record<string, any> | Updates[number]['metadata'];
   incomingBranchId?: string;
   checkedOutBranchId?: string;
   locale: string;


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR implements shared ID tracking for static translation content. The changes introduce a two-phase approach: during parsing, temporary UUIDs mark content originating from the same static source; during post-processing, these temporary IDs are replaced with deterministic hashes computed from the combined content hashes.

Key changes:
- Added `StaticTracker` mechanism threaded through JSX parsing to detect static content
- Generated temporary static IDs using `randomUUID()` during parsing phase
- Implemented `linkStaticUpdates()` function to replace temporary IDs with deterministic shared IDs based on content hashes
- Refactored internal functions (`buildJSXTree`, `parseJSXElement`) to be private
- Extended type definitions to include optional `staticId` in metadata

The implementation enables the system to identify and group related static translation content for optimized handling.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>


- This PR is safe to merge with one minor issue to address
- The implementation is well-structured with clear separation of concerns. The static tracking mechanism is sound, and the refactoring improves code encapsulation by making internal functions private. However, there's one logical issue in `linkStaticUpdates` where undefined hash values aren't filtered before joining, which could produce incorrect shared static IDs if any hash calculation fails or returns undefined.
- Pay close attention to `packages/cli/src/react/parse/createInlineUpdates.ts` for the undefined hash handling issue
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/cli/src/react/jsx/utils/jsxParsing/parseJsx.ts | Added static content tracking mechanism by threading `StaticTracker` through function calls, removed `updates` parameter from internal functions |
| packages/cli/src/react/parse/createInlineUpdates.ts | Refactored post-processing into separate functions, added `linkStaticUpdates` to replace temporary IDs with deterministic hashes |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Parser as parseJsx/parseStrings
    participant Tracker as StaticTracker
    participant Updates as Updates Array
    participant Post as Post-Processing
    
    Parser->>Tracker: Create StaticTracker {isStatic: false}
    Parser->>Parser: Build JSX tree recursively
    
    alt Static content detected
        Parser->>Tracker: Set isStatic = true
    end
    
    Parser->>Parser: Generate temporary UUID
    Parser->>Updates: Push update with temporary staticId
    
    Note over Parser,Updates: Multiple static content items<br/>may share same temporary staticId
    
    Parser->>Post: All files parsed
    Post->>Post: calculateHashes(updates)
    Note over Post: Calculate hash for each update
    
    Post->>Post: dedupeUpdates(updates)
    Note over Post: Merge updates with same hash
    
    Post->>Post: linkStaticUpdates(updates)
    Note over Post: Group by temporary staticId<br/>Hash combined hashes<br/>Replace with shared staticId
    
    Post-->>Updates: Updates with final staticId values
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->