### PR TITLE
feat: add staticId to gtjson metadata type

### DIFF
--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.5.49';
+export const PACKAGE_VERSION = '2.6.1';

--- a/packages/core/src/types-dir/api/uploadFiles.ts
+++ b/packages/core/src/types-dir/api/uploadFiles.ts
@@ -17,6 +17,7 @@ export type GTJsonFormatMetadata = Record<
     approved_at?: string | null;
     approved_by?: string | null;
     hash?: string;
+    staticId?: string;
     filePaths?: string[];
   }
 >;


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Added `staticId` as an optional field to the `GTJsonFormatMetadata` type definition, aligning it with the existing usage in `enqueueFiles.ts` and throughout the CLI parsing logic.

- Type addition is consistent with existing codebase patterns where `staticId` is already being used for grouping and tracking static content
- Version bumped from 2.5.49 to 2.6.1 (auto-generated)
- No logic changes, only type definition enhancement

<details open><summary><h3>Confidence Score: 5/5</h3></summary>


- This PR is safe to merge with minimal risk
- The change is a simple type definition addition that formalizes existing usage of `staticId` throughout the codebase, with no logic changes or breaking modifications
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/core/src/types-dir/api/uploadFiles.ts | Added `staticId` optional field to `GTJsonFormatMetadata` type for tracking static content identifiers |
| packages/cli/src/generated/version.ts | Auto-generated version bump from 2.5.49 to 2.6.1 |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant CLI as CLI Parser
    participant Core as Core Types
    participant API as Upload API
    
    CLI->>CLI: Parse JSX/String with staticId
    Note over CLI: parseJsx.ts:730<br/>parseStringFunction.ts:161<br/>Assigns temporaryStaticId
    
    CLI->>CLI: Group by staticId
    Note over CLI: createInlineUpdates.ts:172-176<br/>Groups updates by staticId
    
    CLI->>CLI: Calculate shared staticId
    Note over CLI: createInlineUpdates.ts:189-191<br/>Hash and assign final staticId
    
    CLI->>Core: Format with GTJsonFormatMetadata
    Note over Core: uploadFiles.ts:20<br/>staticId included in metadata
    
    Core->>API: Upload files with metadata
    Note over API: FileUpload.formatMetadata<br/>contains staticId field
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->