### PR TITLE
feat: adding config flag for mintlify docs.json file path filtering

### DIFF
--- a/.changeset/silver-turkeys-bow.md
+++ b/.changeset/silver-turkeys-bow.md
@@ -1,0 +1,5 @@
+---
+'gtx-cli': patch
+---
+
+Add config flag to filter Mintlify files based on `docs.json` pages

--- a/packages/cli/src/config/generateSettings.ts
+++ b/packages/cli/src/config/generateSettings.ts
@@ -21,6 +21,7 @@ import chalk from 'chalk';
 import { resolveConfig } from './resolveConfig.js';
 import { gt } from '../utils/gt.js';
 import { generatePreset } from './optionPresets.js';
+import { applyMintlifyDocsJsonFilter } from '../utils/mintlifyDocsJson.js';
 
 export const DEFAULT_SRC_PATTERNS = [
   'src/**/*.{js,jsx,ts,tsx}',
@@ -176,6 +177,12 @@ export async function generateSettings(
 
   mergedOptions.options = {
     ...(mergedOptions.options || {}),
+    mintlify: {
+      ...(mergedOptions.options?.mintlify || {}),
+      useDocsJsonNavigation:
+        gtConfig.options?.mintlify?.useDocsJsonNavigation ||
+        mergedOptions.options?.mintlify?.useDocsJsonNavigation,
+    },
     experimentalLocalizeStaticImports:
       gtConfig.options?.experimentalLocalizeStaticImports ||
       flags.experimentalLocalizeStaticImports,
@@ -194,6 +201,8 @@ export async function generateSettings(
     clearLocaleDirsExclude:
       gtConfig.options?.clearLocaleDirsExclude || flags.clearLocaleDirsExclude,
   };
+
+  applyMintlifyDocsJsonFilter(mergedOptions, cwd);
 
   // Add additional options if provided
   if (mergedOptions.options) {

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -40,6 +40,7 @@ export type OpenApiConfig = {
 
 export type MintlifyOptions = {
   openapi?: OpenApiConfig;
+  useDocsJsonNavigation?: boolean;
 };
 
 export type SharedFlags = {

--- a/packages/cli/src/utils/__tests__/mintlifyDocsJson.test.ts
+++ b/packages/cli/src/utils/__tests__/mintlifyDocsJson.test.ts
@@ -1,0 +1,155 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { applyMintlifyDocsJsonFilter } from '../mintlifyDocsJson.js';
+import { Settings } from '../../types/index.js';
+
+const ORIGINAL_CWD = process.cwd();
+
+function writeFile(filePath: string, content: string) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+}
+
+function createSettings(
+  tmpDir: string,
+  useDocsJsonNavigation: boolean
+): Settings {
+  return {
+    config: path.join(tmpDir, 'gt.config.json'),
+    configDirectory: path.join(tmpDir, '.gt'),
+    baseUrl: '',
+    dashboardUrl: '',
+    defaultLocale: 'en',
+    locales: ['es'],
+    src: [],
+    stageTranslations: false,
+    publish: false,
+    files: {
+      resolvedPaths: { mdx: [], md: [] },
+      placeholderPaths: { mdx: [], md: [] },
+      transformPaths: {},
+    },
+    parsingOptions: { conditionNames: [] },
+    branchOptions: { enabled: false, remoteName: 'origin' },
+    options: {
+      mintlify: {
+        useDocsJsonNavigation,
+      },
+    },
+  } as Settings;
+}
+
+describe('applyMintlifyDocsJsonFilter', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gt-mintlify-docs-'));
+    process.chdir(tmpDir);
+  });
+
+  afterEach(() => {
+    process.chdir(ORIGINAL_CWD);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('filters mdx files to exact docs.json pages for the default locale', () => {
+    const docsJsonPath = path.join(tmpDir, 'docs.json');
+    writeFile(
+      docsJsonPath,
+      JSON.stringify({
+        $schema: 'https://mintlify.com/docs.json',
+        navigation: {
+          languages: [
+            {
+              language: 'en',
+              tabs: [
+                {
+                  groups: [
+                    {
+                      pages: [
+                        'index',
+                        'guide/intro',
+                        {
+                          group: 'Nested',
+                          pages: ['docs/index'],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              language: 'es',
+              tabs: [
+                {
+                  groups: [
+                    {
+                      pages: ['es/index'],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      })
+    );
+
+    const files = [
+      path.join(tmpDir, 'index.mdx'),
+      path.join(tmpDir, 'guide', 'intro.mdx'),
+      path.join(tmpDir, 'guide', 'index.mdx'),
+      path.join(tmpDir, 'docs', 'index.mdx'),
+      path.join(tmpDir, 'other.mdx'),
+    ];
+    files.forEach((file) => writeFile(file, '# test'));
+
+    const settings = createSettings(tmpDir, true);
+    settings.files.resolvedPaths.mdx = [...files];
+    settings.files.placeholderPaths.mdx = [...files];
+
+    applyMintlifyDocsJsonFilter(settings, tmpDir);
+
+    const filtered = settings.files.resolvedPaths.mdx.map((filePath) =>
+      path.relative(tmpDir, filePath).replace(/\\/g, '/')
+    );
+
+    expect(filtered).toEqual([
+      'index.mdx',
+      'guide/intro.mdx',
+      'docs/index.mdx',
+    ]);
+  });
+
+  it('keeps files untouched when disabled', () => {
+    const docsJsonPath = path.join(tmpDir, 'docs.json');
+    writeFile(
+      docsJsonPath,
+      JSON.stringify({
+        $schema: 'https://mintlify.com/docs.json',
+        navigation: {
+          groups: [
+            {
+              pages: ['index'],
+            },
+          ],
+        },
+      })
+    );
+
+    const files = [path.join(tmpDir, 'index.mdx')];
+    files.forEach((file) => writeFile(file, '# test'));
+
+    const settings = createSettings(tmpDir, false);
+    settings.files.resolvedPaths.mdx = [...files];
+    settings.files.placeholderPaths.mdx = [...files];
+
+    applyMintlifyDocsJsonFilter(settings, tmpDir);
+
+    expect(settings.files.resolvedPaths.mdx).toEqual(files);
+    expect(settings.files.placeholderPaths.mdx).toEqual(files);
+  });
+});

--- a/packages/cli/src/utils/mintlifyDocsJson.ts
+++ b/packages/cli/src/utils/mintlifyDocsJson.ts
@@ -1,0 +1,186 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { logger } from '../console/logger.js';
+import { Settings } from '../types/index.js';
+
+type JsonRecord = Record<string, unknown>;
+
+export function applyMintlifyDocsJsonFilter(
+  settings: Settings,
+  cwd: string
+): void {
+  if (!settings.options?.mintlify?.useDocsJsonNavigation) return;
+  if (!settings.files) return;
+
+  const docsJsonPath = resolveDocsJsonPath(cwd);
+  if (!docsJsonPath) {
+    logger.warn(
+      'Mintlify docs.json not found. Skipping docs.json navigation filtering.'
+    );
+    return;
+  }
+
+  const pages = readDocsJsonPages(docsJsonPath, settings.defaultLocale);
+  if (pages.size === 0) {
+    logger.warn(
+      'No pages found in docs.json navigation. Skipping docs.json navigation filtering.'
+    );
+    return;
+  }
+
+  const normalizedPages = normalizePages(pages);
+  const pageList = Array.from(normalizedPages);
+  const matchedPages = new Set<string>();
+
+  const filterByPages = (filePaths?: string[], placeholderPaths?: string[]) => {
+    if (!filePaths || !placeholderPaths) {
+      return { filePaths, placeholderPaths };
+    }
+    const nextFiles: string[] = [];
+    const nextPlaceholders: string[] = [];
+    for (let i = 0; i < filePaths.length; i++) {
+      const filePath = filePaths[i];
+      const relativeNoExt = stripExtension(
+        toPosix(path.relative(cwd, filePath))
+      );
+      const matches = pageList.some((page) => {
+        const match = relativeNoExt === page;
+        if (match) {
+          matchedPages.add(page);
+        }
+        return match;
+      });
+      if (matches) {
+        nextFiles.push(filePath);
+        nextPlaceholders.push(placeholderPaths[i]);
+      }
+    }
+    return { filePaths: nextFiles, placeholderPaths: nextPlaceholders };
+  };
+
+  const filteredMdx = filterByPages(
+    settings.files.resolvedPaths.mdx,
+    settings.files.placeholderPaths.mdx
+  );
+  const filteredMd = filterByPages(
+    settings.files.resolvedPaths.md,
+    settings.files.placeholderPaths.md
+  );
+
+  settings.files.resolvedPaths.mdx = filteredMdx.filePaths;
+  settings.files.placeholderPaths.mdx = filteredMdx.placeholderPaths;
+  settings.files.resolvedPaths.md = filteredMd.filePaths;
+  settings.files.placeholderPaths.md = filteredMd.placeholderPaths;
+
+  const missingPages = pageList.filter((page) => !matchedPages.has(page));
+  if (missingPages.length > 0) {
+    logger.warn(
+      `Some docs.json pages were not found in your files config: ${missingPages
+        .slice(0, 5)
+        .join(', ')}${missingPages.length > 5 ? '...' : ''}`
+    );
+  }
+}
+
+function resolveDocsJsonPath(cwd: string): string | null {
+  const docsJsonPath = path.join(cwd, 'docs.json');
+  if (fs.existsSync(docsJsonPath)) return docsJsonPath;
+  const mintJsonPath = path.join(cwd, 'mint.json');
+  if (fs.existsSync(mintJsonPath)) return mintJsonPath;
+  return null;
+}
+
+function readDocsJsonPages(
+  filePath: string,
+  defaultLocale: string
+): Set<string> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch {
+    return new Set();
+  }
+
+  if (!isRecord(parsed)) return new Set();
+  const navigation = parsed.navigation;
+  if (!isRecord(navigation)) return new Set();
+
+  const navigationRoot = selectNavigationRoot(navigation, defaultLocale);
+  if (!navigationRoot) return new Set();
+
+  const pages = new Set<string>();
+  collectPages(navigationRoot, pages);
+  return pages;
+}
+
+function selectNavigationRoot(
+  navigation: JsonRecord,
+  defaultLocale: string
+): unknown | null {
+  const languages = navigation.languages;
+  if (Array.isArray(languages)) {
+    const byLocale = languages.find(
+      (entry) =>
+        isRecord(entry) &&
+        typeof entry.language === 'string' &&
+        entry.language === defaultLocale
+    );
+    return byLocale ?? languages[0] ?? null;
+  }
+
+  return navigation;
+}
+
+function collectPages(node: unknown, pages: Set<string>): void {
+  if (typeof node === 'string') {
+    const normalized = normalizePage(node);
+    if (normalized) pages.add(normalized);
+    return;
+  }
+
+  if (Array.isArray(node)) {
+    node.forEach((item) => collectPages(item, pages));
+    return;
+  }
+
+  if (!isRecord(node)) return;
+
+  for (const [key, value] of Object.entries(node)) {
+    if (key === 'pages' && Array.isArray(value)) {
+      value.forEach((item) => collectPages(item, pages));
+      continue;
+    }
+    collectPages(value, pages);
+  }
+}
+
+function normalizePage(page: string): string | null {
+  let normalized = page.trim();
+  if (!normalized) return null;
+  normalized = normalized.split('#')[0]?.split('?')[0] ?? normalized;
+  normalized = normalized.replace(/^\.\//, '').replace(/^\/+/, '');
+  normalized = normalized.replace(/\.(mdx|md)$/i, '');
+  return normalized || null;
+}
+
+function normalizePages(pages: Set<string>): Set<string> {
+  const normalized = new Set<string>();
+  for (const page of pages) {
+    const cleaned = normalizePage(page);
+    if (!cleaned) continue;
+    normalized.add(cleaned);
+  }
+  return normalized;
+}
+
+function stripExtension(filePath: string): string {
+  return filePath.replace(/\.[^/.]+$/, '');
+}
+
+function toPosix(filePath: string): string {
+  return filePath.split(path.sep).join(path.posix.sep);
+}
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === 'object' && value !== null;
+}

--- a/packages/cli/src/utils/mintlifyDocsJson.ts
+++ b/packages/cli/src/utils/mintlifyDocsJson.ts
@@ -28,8 +28,7 @@ export function applyMintlifyDocsJsonFilter(
     return;
   }
 
-  const normalizedPages = normalizePages(pages);
-  const pageList = Array.from(normalizedPages);
+  const pageList = Array.from(pages);
   const matchedPages = new Set<string>();
 
   const filterByPages = (filePaths?: string[], placeholderPaths?: string[]) => {
@@ -161,16 +160,6 @@ function normalizePage(page: string): string | null {
   normalized = normalized.replace(/^\.\//, '').replace(/^\/+/, '');
   normalized = normalized.replace(/\.(mdx|md)$/i, '');
   return normalized || null;
-}
-
-function normalizePages(pages: Set<string>): Set<string> {
-  const normalized = new Set<string>();
-  for (const page of pages) {
-    const cleaned = normalizePage(page);
-    if (!cleaned) continue;
-    normalized.add(cleaned);
-  }
-  return normalized;
 }
 
 function stripExtension(filePath: string): string {


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Added a new configuration flag `useDocsJsonNavigation` to the Mintlify options that filters markdown files based on pages defined in `docs.json` or `mint.json` navigation structures.

**Key Changes:**
- Added `useDocsJsonNavigation` boolean to `MintlifyOptions` type
- Implemented `applyMintlifyDocsJsonFilter` function that parses Mintlify docs.json files, extracts page paths from navigation structures, and filters resolved MDX/MD files to only include pages referenced in the navigation
- Integrated the filter into `generateSettings` to automatically apply when the flag is enabled
- Added comprehensive tests covering multi-language navigation support and disabled state
- Handles both `docs.json` and `mint.json` file names
- Supports nested navigation structures with tabs, groups, and language-specific navigation
- Provides helpful warnings when docs.json is missing or pages aren't found

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- This PR is safe to merge with minimal risk
- The implementation is well-tested, handles edge cases gracefully with appropriate warnings, and includes proper null/undefined checks. The code follows existing patterns in the codebase. Minor performance improvement opportunity exists with redundant normalization, but this doesn't affect correctness.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/cli/src/config/generateSettings.ts | Integrated Mintlify docs.json filtering by merging config option and calling filter function |
| packages/cli/src/utils/__tests__/mintlifyDocsJson.test.ts | Added comprehensive tests for docs.json filtering functionality with multi-language support |
| packages/cli/src/utils/mintlifyDocsJson.ts | Implements docs.json parsing and file filtering with navigation extraction and path normalization |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant CLI as CLI Command
    participant GS as generateSettings
    participant Filter as applyMintlifyDocsJsonFilter
    participant FS as File System
    participant Logger as Logger

    CLI->>GS: generateSettings(flags, cwd)
    GS->>GS: Load and merge config
    GS->>GS: Resolve file patterns
    GS->>GS: Merge mintlify.useDocsJsonNavigation option
    GS->>Filter: applyMintlifyDocsJsonFilter(settings, cwd)
    
    alt useDocsJsonNavigation enabled
        Filter->>Filter: resolveDocsJsonPath(cwd)
        Filter->>FS: Check docs.json exists
        FS-->>Filter: Return path or null
        
        alt docs.json found
            Filter->>FS: Read docs.json
            FS-->>Filter: Return JSON content
            Filter->>Filter: readDocsJsonPages(path, defaultLocale)
            Filter->>Filter: selectNavigationRoot(navigation, defaultLocale)
            Filter->>Filter: collectPages(navigationRoot, pages)
            Filter->>Filter: normalizePages(pages)
            
            alt pages found
                Filter->>Filter: filterByPages(mdx files)
                Filter->>Filter: filterByPages(md files)
                Filter->>Filter: Update settings.files paths
                
                alt some pages not matched
                    Filter->>Logger: Warn about missing pages
                end
            else no pages found
                Filter->>Logger: Warn no pages in navigation
            end
        else docs.json not found
            Filter->>Logger: Warn docs.json not found
        end
    else useDocsJsonNavigation disabled
        Filter->>Filter: Return without filtering
    end
    
    Filter-->>GS: Modified settings
    GS-->>CLI: Return settings
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->