### PR TITLE
feat: mintlify title handling via file name inference

### DIFF
--- a/.changeset/open-knives-clean.md
+++ b/.changeset/open-knives-clean.md
@@ -1,0 +1,5 @@
+---
+'gtx-cli': patch
+---
+
+Add flag for Mintlify docs to infer title from source file name when missing title in YAML frontmatter

--- a/packages/cli/src/config/generateSettings.ts
+++ b/packages/cli/src/config/generateSettings.ts
@@ -176,6 +176,12 @@ export async function generateSettings(
 
   mergedOptions.options = {
     ...(mergedOptions.options || {}),
+    mintlify: {
+      ...(mergedOptions.options?.mintlify || {}),
+      inferTitleFromFilename:
+        gtConfig.options?.mintlify?.inferTitleFromFilename ||
+        mergedOptions.options?.mintlify?.inferTitleFromFilename,
+    },
     experimentalLocalizeStaticImports:
       gtConfig.options?.experimentalLocalizeStaticImports ||
       flags.experimentalLocalizeStaticImports,

--- a/packages/cli/src/formats/files/__tests__/translate.test.ts
+++ b/packages/cli/src/formats/files/__tests__/translate.test.ts
@@ -11,6 +11,7 @@ import { isValidMdx } from '../../../utils/validateMdx.js';
 vi.mock('../../../console/logger.js', () => ({
   logger: {
     warn: vi.fn(),
+    error: vi.fn(),
   },
 }));
 vi.mock('../../../fs/findFilepath.js');
@@ -62,6 +63,7 @@ describe('aggregateFiles - Empty File Handling', () => {
     });
 
     mockSanitizeFileContent.mockImplementation((content) => content);
+    mockIsValidMdx.mockReset();
     mockIsValidMdx.mockReturnValue({ isValid: true });
   });
 

--- a/packages/cli/src/formats/files/__tests__/translate.test.ts
+++ b/packages/cli/src/formats/files/__tests__/translate.test.ts
@@ -348,7 +348,9 @@ describe('aggregateFiles - Empty File Handling', () => {
         },
       };
 
-      mockReadFile.mockReturnValueOnce('---\nsummary: "Hello"\n---\n\n# Content');
+      mockReadFile.mockReturnValueOnce(
+        '---\nsummary: "Hello"\n---\n\n# Content'
+      );
 
       const result = await aggregateFiles(settings as any);
 
@@ -372,7 +374,9 @@ describe('aggregateFiles - Empty File Handling', () => {
         },
       };
 
-      mockReadFile.mockReturnValueOnce('---\nsummary: "Hello"\n---\n\n# Content');
+      mockReadFile.mockReturnValueOnce(
+        '---\nsummary: "Hello"\n---\n\n# Content'
+      );
 
       const result = await aggregateFiles(settings as any);
 

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.6.1';
+export const PACKAGE_VERSION = '2.6.2';

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -40,6 +40,7 @@ export type OpenApiConfig = {
 
 export type MintlifyOptions = {
   openapi?: OpenApiConfig;
+  inferTitleFromFilename?: boolean;
 };
 
 export type SharedFlags = {

--- a/packages/cli/src/utils/mintlifyTitleFallback.ts
+++ b/packages/cli/src/utils/mintlifyTitleFallback.ts
@@ -6,7 +6,8 @@ type TitleFallbackResult = {
   addedTitle: boolean;
 };
 
-const FRONTMATTER_REGEX = /^---\s*\r?\n([\s\S]*?)\r?\n(---|\.\.\.)\s*(?:\r?\n|$)/;
+const FRONTMATTER_REGEX =
+  /^---\s*\r?\n([\s\S]*?)\r?\n(---|\.\.\.)\s*(?:\r?\n|$)/;
 
 function toTitleCase(value: string): string {
   return value
@@ -83,8 +84,7 @@ export function applyMintlifyTitleFallback(
     }
 
     const titleLine = YAML.stringify({ title: inferredTitle }).trimEnd();
-    const headerEndIndex =
-      contentBody.indexOf(newline) + newline.length;
+    const headerEndIndex = contentBody.indexOf(newline) + newline.length;
     const updated =
       contentBody.slice(0, headerEndIndex) +
       titleLine +

--- a/packages/cli/src/utils/mintlifyTitleFallback.ts
+++ b/packages/cli/src/utils/mintlifyTitleFallback.ts
@@ -1,0 +1,103 @@
+import path from 'path';
+import YAML from 'yaml';
+
+type TitleFallbackResult = {
+  content: string;
+  addedTitle: boolean;
+};
+
+const FRONTMATTER_REGEX = /^---\s*\r?\n([\s\S]*?)\r?\n(---|\.\.\.)\s*(?:\r?\n|$)/;
+
+function toTitleCase(value: string): string {
+  return value
+    .split(' ')
+    .map((word) => {
+      if (!word) return '';
+      return word[0].toUpperCase() + word.slice(1);
+    })
+    .join(' ');
+}
+
+function deriveTitleFromFilename(
+  fileName: string,
+  defaultLocale?: string
+): string {
+  const base = path.basename(fileName, path.extname(fileName));
+  if (base.toLowerCase() === 'index') {
+    const parentDir = path.dirname(fileName);
+    if (parentDir === '.' || parentDir === path.sep) {
+      return 'Index';
+    }
+    const parent = path.basename(parentDir);
+    if (parent && defaultLocale && parent === defaultLocale) {
+      return 'Index';
+    }
+    if (parent) {
+      return toTitleCase(parent.replace(/[-_]+/g, ' ').trim());
+    }
+    return 'Index';
+  }
+  const normalized = base.replace(/[-_]+/g, ' ').replace(/\s+/g, ' ').trim();
+  if (!normalized) {
+    return base;
+  }
+  return toTitleCase(normalized);
+}
+
+function hasMeaningfulTitle(value: unknown): boolean {
+  if (value === null || value === undefined) {
+    return false;
+  }
+  if (typeof value === 'string') {
+    return value.trim().length > 0;
+  }
+  return true;
+}
+
+export function applyMintlifyTitleFallback(
+  content: string,
+  fileName: string,
+  defaultLocale?: string
+): TitleFallbackResult {
+  const inferredTitle = deriveTitleFromFilename(fileName, defaultLocale);
+  if (!inferredTitle) {
+    return { content, addedTitle: false };
+  }
+
+  const hasBom = content.startsWith('\uFEFF');
+  const contentBody = hasBom ? content.slice(1) : content;
+  const newline = contentBody.includes('\r\n') ? '\r\n' : '\n';
+
+  const frontmatterMatch = contentBody.match(FRONTMATTER_REGEX);
+  if (frontmatterMatch) {
+    const frontmatterContent = frontmatterMatch[1];
+    let parsed: Record<string, unknown> | undefined;
+    try {
+      parsed = YAML.parse(frontmatterContent);
+    } catch {
+      return { content, addedTitle: false };
+    }
+
+    if (parsed && hasMeaningfulTitle(parsed.title)) {
+      return { content, addedTitle: false };
+    }
+
+    const titleLine = YAML.stringify({ title: inferredTitle }).trimEnd();
+    const headerEndIndex =
+      contentBody.indexOf(newline) + newline.length;
+    const updated =
+      contentBody.slice(0, headerEndIndex) +
+      titleLine +
+      newline +
+      contentBody.slice(headerEndIndex);
+
+    return { content: (hasBom ? '\uFEFF' : '') + updated, addedTitle: true };
+  }
+
+  const titleLine = YAML.stringify({ title: inferredTitle }).trimEnd();
+  const frontmatterBlock = `---${newline}${titleLine}${newline}---${newline}${newline}`;
+  return {
+    content: (hasBom ? '\uFEFF' : '') + frontmatterBlock + contentBody,
+    addedTitle: true,
+  };
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds an optional configuration flag `mintlify.inferTitleFromFilename` that automatically infers and adds titles to Mintlify MDX documentation files when the title is missing from the YAML frontmatter. The feature intelligently converts filenames to title-cased strings (e.g., `my-file.mdx` → "My File"), handles special cases for index files by using the parent directory name, and preserves existing titles when present.

**Key Changes:**
- Created `applyMintlifyTitleFallback` utility with proper edge case handling for BOM characters, newline formats, and YAML parsing
- Integrated the title inference into the file processing pipeline before sanitization
- Modified version hash calculation to account for added titles, ensuring proper change detection
- Added comprehensive test coverage for various scenarios including index files, existing titles, and locale-specific cases
- Properly merged the new configuration option in settings generation

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- This PR is safe to merge with minimal risk
- The implementation is well-tested with comprehensive test coverage, follows good TypeScript practices, and handles edge cases properly (BOM, newlines, YAML parsing errors). The feature is opt-in via configuration flag, minimizing risk to existing functionality. Version hash logic correctly accounts for modified content to prevent unintended cache hits.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/cli/src/utils/mintlifyTitleFallback.ts | New utility that infers titles from filenames and adds them to YAML frontmatter, handles edge cases like index files and BOM characters |
| packages/cli/src/formats/files/translate.ts | Integrated title fallback logic into file processing pipeline, applying it before sanitization and adjusting version hash when titles are added |
| packages/cli/src/formats/files/__tests__/translate.test.ts | Comprehensive test coverage for title inference including edge cases for index files, existing titles, and locale handling |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant CLI
    participant generateSettings
    participant aggregateFiles
    participant applyMintlifyTitleFallback
    participant sanitizeFileContent
    
    User->>CLI: Run translate command with config
    CLI->>generateSettings: Generate settings from flags & config
    generateSettings->>generateSettings: Merge mintlify.inferTitleFromFilename option
    generateSettings-->>CLI: Return merged settings
    
    CLI->>aggregateFiles: Process files with settings
    
    loop For each MDX file
        aggregateFiles->>aggregateFiles: Read file content
        
        alt inferTitleFromFilename enabled
            aggregateFiles->>applyMintlifyTitleFallback: Process content
            applyMintlifyTitleFallback->>applyMintlifyTitleFallback: Derive title from filename
            applyMintlifyTitleFallback->>applyMintlifyTitleFallback: Parse YAML frontmatter
            
            alt Title missing in frontmatter
                applyMintlifyTitleFallback->>applyMintlifyTitleFallback: Add inferred title to frontmatter
                applyMintlifyTitleFallback-->>aggregateFiles: Return modified content + addedTitle=true
            else Title exists
                applyMintlifyTitleFallback-->>aggregateFiles: Return original content + addedTitle=false
            end
        end
        
        aggregateFiles->>sanitizeFileContent: Sanitize processed content
        sanitizeFileContent-->>aggregateFiles: Return sanitized content
        
        alt addedMintlifyTitle
            aggregateFiles->>aggregateFiles: Hash processed content for versionId
        else
            aggregateFiles->>aggregateFiles: Hash original content for versionId
        end
        
        aggregateFiles->>aggregateFiles: Create FileToUpload object
    end
    
    aggregateFiles-->>CLI: Return all files to upload
    CLI-->>User: Continue with translation
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->