### PR TITLE
feat: adding relative asset flag

### DIFF
--- a/.changeset/major-otters-wish.md
+++ b/.changeset/major-otters-wish.md
@@ -1,0 +1,5 @@
+---
+'gtx-cli': patch
+---
+
+Adding `experimentalLocalizeRelativeAssets` config option to handle asset paths

--- a/assets/config-schema.json
+++ b/assets/config-schema.json
@@ -577,6 +577,11 @@
           "description": "Inserts locale in static url paths in md/mdx files",
           "default": false
         },
+        "experimentalLocalizeRelativeAssets": {
+          "type": "boolean",
+          "description": "Rewrites relative image asset URLs in translated md/mdx files to valid paths",
+          "default": false
+        },
         "experimentalHideDefaultLocale": {
           "type": "boolean",
           "description": "Hides the default locale in the import path",

--- a/packages/cli/src/cli/commands/translate.ts
+++ b/packages/cli/src/cli/commands/translate.ts
@@ -10,6 +10,7 @@ import { getStagedVersions } from '../../fs/config/updateVersions.js';
 import copyFile from '../../fs/copyFile.js';
 import flattenJsonFiles from '../../utils/flattenJsonFiles.js';
 import localizeStaticUrls from '../../utils/localizeStaticUrls.js';
+import localizeRelativeAssets from '../../utils/localizeRelativeAssets.js';
 import processAnchorIds from '../../utils/processAnchorIds.js';
 import processOpenApi from '../../utils/processOpenApi.js';
 import { noFilesError, noVersionIdError } from '../../console/index.js';
@@ -102,6 +103,16 @@ export async function postProcessTranslations(
     );
     if (nonDefaultLocales.length > 0) {
       await localizeStaticUrls(settings, nonDefaultLocales, includeFiles);
+    }
+  }
+
+  // Rewrite relative asset URLs in translated md/mdx files
+  if (settings.options?.experimentalLocalizeRelativeAssets) {
+    const nonDefaultLocales = settings.locales.filter(
+      (locale) => locale !== settings.defaultLocale
+    );
+    if (nonDefaultLocales.length > 0) {
+      await localizeRelativeAssets(settings, nonDefaultLocales, includeFiles);
     }
   }
 

--- a/packages/cli/src/cli/flags.ts
+++ b/packages/cli/src/cli/flags.ts
@@ -73,6 +73,11 @@ export function attachTranslateFlags(command: Command) {
       false
     )
     .option(
+      '--experimental-localize-relative-assets',
+      'Triggering this will rewrite relative image asset URLs in translated md/mdx files to valid paths.',
+      false
+    )
+    .option(
       '--force',
       'Force a retranslation, invalidating all existing cached translations if they exist.',
       false

--- a/packages/cli/src/config/generateSettings.ts
+++ b/packages/cli/src/config/generateSettings.ts
@@ -188,6 +188,9 @@ export async function generateSettings(
     experimentalLocalizeStaticUrls:
       gtConfig.options?.experimentalLocalizeStaticUrls ||
       flags.experimentalLocalizeStaticUrls,
+    experimentalLocalizeRelativeAssets:
+      gtConfig.options?.experimentalLocalizeRelativeAssets ||
+      flags.experimentalLocalizeRelativeAssets,
     experimentalHideDefaultLocale:
       gtConfig.options?.experimentalHideDefaultLocale ||
       flags.experimentalHideDefaultLocale,

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.6.2';
+export const PACKAGE_VERSION = '2.6.4';

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -26,6 +26,7 @@ export type Options = {
   experimentalHideDefaultLocale?: boolean;
   experimentalFlattenJsonFiles?: boolean;
   experimentalLocalizeStaticImports?: boolean;
+  experimentalLocalizeRelativeAssets?: boolean;
   experimentalAddHeaderAnchorIds?: 'mintlify' | 'default';
   docsImportRewrites?: Array<{
     match: string;
@@ -69,6 +70,7 @@ export type TranslateFlags = SharedFlags & {
   experimentalHideDefaultLocale?: boolean;
   experimentalFlattenJsonFiles?: boolean;
   experimentalLocalizeStaticImports?: boolean;
+  experimentalLocalizeRelativeAssets?: boolean;
   experimentalAddHeaderAnchorIds?: 'mintlify' | 'default';
   excludeStaticUrls?: string[];
   excludeStaticImports?: string[];
@@ -247,6 +249,7 @@ export type AdditionalOptions = {
   clearLocaleDirsExclude?: string[]; // array of glob patterns with [locale] or [locales] placeholder to exclude from clearing (e.g., "./snippets/[locale]/preserved/**" or "./[locales]/static/**")
   experimentalLocalizeStaticImports?: boolean; // Inserts locale in static import paths in md/mdx files
   experimentalLocalizeStaticUrls?: boolean; // Inserts locale in static url paths in md/mdx files and adds anchor IDs to preserve navigation
+  experimentalLocalizeRelativeAssets?: boolean; // Rewrites relative asset URLs in translated md/mdx files to valid paths
   experimentalAddHeaderAnchorIds?: 'mintlify' | 'default'; // Format for anchor IDs: 'mintlify' for div wrapping, 'default' or undefined for inline {#id}. Can run independently of static url localization
   experimentalHideDefaultLocale?: boolean; // Hides the default locale in the import path
   experimentalFlattenJsonFiles?: boolean; // Flattens JSON files into a single file

--- a/packages/cli/src/utils/__tests__/localizeRelativeAssets.test.ts
+++ b/packages/cli/src/utils/__tests__/localizeRelativeAssets.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import localizeRelativeAssets, {
+  localizeRelativeAssetsForContent,
+} from '../localizeRelativeAssets';
+
+vi.mock('fs', () => ({
+  promises: {
+    readFile: vi.fn(),
+    writeFile: vi.fn(),
+  },
+  existsSync: vi.fn(),
+}));
+
+vi.mock('../../formats/files/fileMapping.js', () => ({
+  createFileMapping: vi.fn(),
+}));
+
+import { createFileMapping } from '../../formats/files/fileMapping.js';
+
+describe('localizeRelativeAssets', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('rewrites relative image urls to absolute paths when source asset exists', async () => {
+    const mockFileMapping = {
+      es: {
+        '/proj/demoIndex.mdx': '/proj/es/demoIndex.mdx',
+      },
+    };
+
+    vi.mocked(createFileMapping).mockReturnValue(mockFileMapping);
+    vi.mocked(fs.promises.readFile).mockResolvedValue(
+      "<img src='whatsapp-clawd.jpg' />"
+    );
+    vi.mocked(fs.promises.writeFile).mockResolvedValue(undefined);
+    vi.mocked(fs.existsSync).mockImplementation((p: any) => {
+      if (p === '/proj/es/demoIndex.mdx') return true;
+      if (p === '/proj/demoIndex.mdx') return true;
+      if (p === '/proj/es/whatsapp-clawd.jpg') return false;
+      if (p === '/proj/whatsapp-clawd.jpg') return true;
+      return false;
+    });
+
+    const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue('/proj');
+
+    const settings = {
+      files: {
+        placeholderPaths: { docs: '/docs' },
+        resolvedPaths: {},
+        transformPaths: {},
+      },
+      locales: ['en', 'es'],
+      defaultLocale: 'en',
+    };
+
+    await localizeRelativeAssets(settings as any, ['es']);
+
+    expect(fs.promises.writeFile).toHaveBeenCalledTimes(1);
+    const written = vi.mocked(fs.promises.writeFile).mock.calls[0][1] as string;
+    expect(written).toContain("src='/whatsapp-clawd.jpg'");
+
+    cwdSpy.mockRestore();
+  });
+
+  it('does not rewrite if target-relative asset exists', () => {
+    vi.mocked(fs.existsSync).mockImplementation((p: any) => {
+      if (p === '/proj/es/whatsapp-clawd.jpg') return true;
+      return false;
+    });
+
+    const result = localizeRelativeAssetsForContent(
+      "<img src='whatsapp-clawd.jpg' />",
+      '/proj/demoIndex.mdx',
+      '/proj/es/demoIndex.mdx',
+      '/proj'
+    );
+
+    expect(result.hasChanges).toBe(false);
+  });
+
+  it('ignores absolute and remote urls', () => {
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+
+    const result = localizeRelativeAssetsForContent(
+      "<img src='https://example.com/a.jpg' />\\n<img src='/a.jpg' />",
+      '/proj/demoIndex.mdx',
+      '/proj/es/demoIndex.mdx',
+      '/proj'
+    );
+
+    expect(result.hasChanges).toBe(false);
+    expect(result.content).toContain("src='https://example.com/a.jpg'");
+    expect(result.content).toContain("src='/a.jpg'");
+  });
+
+  it('does not rewrite markdown links', () => {
+    vi.mocked(fs.existsSync).mockImplementation((p: any) => {
+      if (p === '/proj/whatsapp-clawd.jpg') return true;
+      return false;
+    });
+
+    const result = localizeRelativeAssetsForContent(
+      '![img](whatsapp-clawd.jpg) and [doc](whatsapp-clawd.jpg)',
+      '/proj/demoIndex.mdx',
+      '/proj/es/demoIndex.mdx',
+      '/proj'
+    );
+
+    expect(result.hasChanges).toBe(true);
+    expect(result.content).toContain('/whatsapp-clawd.jpg');
+    expect(result.content).toContain('[doc](whatsapp-clawd.jpg)');
+  });
+});

--- a/packages/cli/src/utils/__tests__/localizeRelativeAssets.test.ts
+++ b/packages/cli/src/utils/__tests__/localizeRelativeAssets.test.ts
@@ -63,7 +63,7 @@ describe('localizeRelativeAssets', () => {
 
     expect(fs.promises.writeFile).toHaveBeenCalledTimes(1);
     const written = vi.mocked(fs.promises.writeFile).mock.calls[0][1] as string;
-    expect(written).toContain("src='/whatsapp-clawd.jpg'");
+    expect(written).toContain('src="/whatsapp-clawd.jpg"');
 
     cwdSpy.mockRestore();
   });
@@ -95,8 +95,8 @@ describe('localizeRelativeAssets', () => {
     );
 
     expect(result.hasChanges).toBe(false);
-    expect(result.content).toContain("src='https://example.com/a.jpg'");
-    expect(result.content).toContain("src='/a.jpg'");
+    expect(result.content).toContain('src="https://example.com/a.jpg"');
+    expect(result.content).toContain('src="/a.jpg"');
   });
 
   it('does not rewrite markdown links', () => {

--- a/packages/cli/src/utils/localizeRelativeAssets.ts
+++ b/packages/cli/src/utils/localizeRelativeAssets.ts
@@ -1,0 +1,201 @@
+import * as fs from 'fs';
+import path from 'node:path';
+import { unified } from 'unified';
+import remarkParse from 'remark-parse';
+import remarkMdx from 'remark-mdx';
+import remarkFrontmatter from 'remark-frontmatter';
+import remarkStringify from 'remark-stringify';
+import { visit } from 'unist-util-visit';
+import type { Root } from 'mdast';
+import escapeHtmlInTextNodes from 'gt-remark';
+import { Settings } from '../types/index.js';
+import { createFileMapping } from '../formats/files/fileMapping.js';
+
+type RewriteResult = { content: string; hasChanges: boolean };
+
+function stripQueryAndHash(url: string): { base: string; suffix: string } {
+  const match = url.match(/^[^?#]+/);
+  const base = match ? match[0] : url;
+  const suffix = url.slice(base.length);
+  return { base, suffix };
+}
+
+function isSkippableUrl(url: string): boolean {
+  if (!url) return true;
+  if (url.startsWith('/')) return true;
+  if (/^(https?:)?\/\//i.test(url)) return true;
+  if (url.startsWith('data:')) return true;
+  if (url.startsWith('#')) return true;
+  if (url.startsWith('mailto:')) return true;
+  if (url.startsWith('tel:')) return true;
+  return false;
+}
+
+function toPosix(p: string): string {
+  return p.replace(/\\/g, '/');
+}
+
+function isSubPath(child: string, parent: string): boolean {
+  const rel = path.relative(parent, child);
+  return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
+}
+
+export function localizeRelativeAssetsForContent(
+  content: string,
+  sourcePath: string,
+  targetPath: string,
+  cwd: string
+): RewriteResult {
+  let changed = false;
+
+  let ast: Root;
+  try {
+    const processor = unified()
+      .use(remarkParse)
+      .use(remarkFrontmatter, ['yaml', 'toml'])
+      .use(remarkMdx);
+    ast = processor.runSync(processor.parse(content)) as Root;
+  } catch {
+    return { content, hasChanges: false };
+  }
+
+  const sourceDir = path.dirname(sourcePath);
+  const targetDir = path.dirname(targetPath);
+
+  const maybeRewrite = (url: string): string | null => {
+    if (isSkippableUrl(url)) return null;
+    const { base, suffix } = stripQueryAndHash(url);
+    if (isSkippableUrl(base)) return null;
+
+    const targetResolved = path.resolve(targetDir, base);
+    if (fs.existsSync(targetResolved)) {
+      return null;
+    }
+
+    const sourceResolved = path.resolve(sourceDir, base);
+    if (!fs.existsSync(sourceResolved)) {
+      return null;
+    }
+
+    let newPath: string;
+    if (isSubPath(sourceResolved, cwd)) {
+      newPath = '/' + toPosix(path.relative(cwd, sourceResolved));
+    } else {
+      const rel = toPosix(path.relative(targetDir, sourceResolved));
+      newPath = rel || toPosix(path.basename(sourceResolved));
+    }
+
+    if (newPath === base) return null;
+    changed = true;
+    return newPath + suffix;
+  };
+
+  visit(ast, (node: any) => {
+    if (node.type === 'image' && typeof node.url === 'string') {
+      const newUrl = maybeRewrite(node.url);
+      if (newUrl) node.url = newUrl;
+      return;
+    }
+    if (
+      (node.type === 'mdxJsxFlowElement' ||
+        node.type === 'mdxJsxTextElement') &&
+      node.name === 'img' &&
+      Array.isArray(node.attributes)
+    ) {
+      for (const attr of node.attributes) {
+        if (
+          attr &&
+          attr.type === 'mdxJsxAttribute' &&
+          attr.name === 'src' &&
+          typeof attr.value === 'string'
+        ) {
+          const newUrl = maybeRewrite(attr.value);
+          if (newUrl) attr.value = newUrl;
+        }
+      }
+    }
+  });
+
+  try {
+    const s = unified()
+      .use(remarkFrontmatter, ['yaml', 'toml'])
+      .use(remarkMdx)
+      .use(escapeHtmlInTextNodes)
+      .use(remarkStringify, {
+        handlers: {
+          text(node: any) {
+            return node.value;
+          },
+        },
+      });
+    const outTree = s.runSync(ast);
+    let out = s.stringify(outTree as any);
+    if (out.endsWith('\n') && !content.endsWith('\n')) out = out.slice(0, -1);
+    if (content.startsWith('\n') && !out.startsWith('\n')) out = '\n' + out;
+    return { content: out, hasChanges: changed };
+  } catch {
+    return { content, hasChanges: false };
+  }
+}
+
+export default async function localizeRelativeAssets(
+  settings: Settings,
+  targetLocales?: string[],
+  includeFiles?: Set<string>
+) {
+  if (
+    !settings.files ||
+    (Object.keys(settings.files.placeholderPaths).length === 1 &&
+      settings.files.placeholderPaths.gt)
+  ) {
+    return;
+  }
+
+  const { resolvedPaths: sourceFiles } = settings.files;
+  const locales = targetLocales || settings.locales;
+
+  const fileMapping = createFileMapping(
+    sourceFiles,
+    settings.files.placeholderPaths,
+    settings.files.transformPaths,
+    settings.locales,
+    settings.defaultLocale
+  );
+
+  const cwd = process.cwd();
+  const processPromises = Object.entries(fileMapping)
+    .filter(([locale]) => locales.includes(locale))
+    .map(async ([locale, filesMap]) => {
+      const reverseMap = new Map<string, string>();
+      for (const [sourcePath, targetPath] of Object.entries(filesMap)) {
+        reverseMap.set(targetPath, sourcePath);
+      }
+      const targetFiles = Object.values(filesMap).filter(
+        (p) =>
+          (p.endsWith('.md') || p.endsWith('.mdx')) &&
+          (!includeFiles || includeFiles.has(p))
+      );
+
+      await Promise.all(
+        targetFiles.map(async (targetPath) => {
+          if (!fs.existsSync(targetPath)) return;
+          const sourcePath = reverseMap.get(targetPath);
+          if (!sourcePath) return;
+          if (!fs.existsSync(sourcePath)) return;
+
+          const content = await fs.promises.readFile(targetPath, 'utf8');
+          const result = localizeRelativeAssetsForContent(
+            content,
+            sourcePath,
+            targetPath,
+            cwd
+          );
+          if (result.hasChanges) {
+            await fs.promises.writeFile(targetPath, result.content);
+          }
+        })
+      );
+    });
+
+  await Promise.all(processPromises);
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new experimental feature `experimentalLocalizeRelativeAssets` that fixes broken relative image paths in translated markdown/MDX files. When translations are placed in locale-specific subdirectories, relative image references like `./image.jpg` break because the image assets remain in the source directory. This feature intelligently rewrites these paths to absolute paths when the source asset exists but the target-relative asset doesn't.

**Key changes:**
- New utility function `localizeRelativeAssets()` that processes translated md/mdx files
- Uses AST parsing (remark/unified) to identify and rewrite relative image URLs in both markdown syntax `![](url)` and JSX `<img src="url" />`
- Only rewrites paths when: (1) target-relative asset doesn't exist, (2) source-relative asset exists
- Preserves absolute URLs, remote URLs, and markdown document links unchanged
- Integrated into post-processing pipeline after static URL localization
- Full test coverage for main scenarios
- Configuration available via CLI flag or config file option

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge with minimal risk - well-tested experimental feature with proper integration
- The implementation follows existing patterns in the codebase (similar to localizeStaticUrls), has comprehensive test coverage, proper error handling with try-catch blocks, and is opt-in via experimental flag. No console.log statements or security issues found.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/cli/src/cli/commands/translate.ts | Integrated `localizeRelativeAssets` into post-processing pipeline for non-default locales |
| packages/cli/src/utils/__tests__/localizeRelativeAssets.test.ts | Comprehensive test suite covering main scenarios: relative path rewrites, target-relative assets, absolute/remote URLs, and markdown links |
| packages/cli/src/utils/localizeRelativeAssets.ts | New utility that rewrites relative image paths in translated md/mdx files to point to source assets when target-relative assets don't exist |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant CLI as translate command
    participant PP as postProcessTranslations
    participant LRA as localizeRelativeAssets
    participant FM as createFileMapping
    participant LC as localizeRelativeAssetsForContent
    participant FS as File System

    User->>CLI: Run translate with --experimental-localize-relative-assets
    CLI->>PP: Call postProcessTranslations(settings, includeFiles)
    
    alt experimentalLocalizeRelativeAssets enabled
        PP->>PP: Filter non-default locales
        PP->>LRA: Call localizeRelativeAssets(settings, nonDefaultLocales, includeFiles)
        
        LRA->>FM: createFileMapping(sourceFiles, placeholderPaths, ...)
        FM-->>LRA: Return fileMapping {locale: {source: target}}
        
        loop For each target locale
            LRA->>LRA: Build reverseMap (target->source)
            LRA->>LRA: Filter .md/.mdx files
            
            loop For each target file
                LRA->>FS: Check if target file exists
                FS-->>LRA: File exists
                LRA->>FS: readFile(targetPath)
                FS-->>LRA: Return content
                
                LRA->>LC: localizeRelativeAssetsForContent(content, sourcePath, targetPath, cwd)
                LC->>LC: Parse MDX into AST
                LC->>LC: Visit nodes (image, mdxJsxFlowElement, mdxJsxTextElement)
                
                loop For each relative image URL
                    LC->>FS: Check if target-relative asset exists
                    alt Target-relative asset exists
                        LC->>LC: Skip (no rewrite needed)
                    else Target-relative doesn't exist
                        LC->>FS: Check if source-relative asset exists
                        alt Source-relative exists
                            LC->>LC: Rewrite to absolute path from cwd
                        else Source-relative doesn't exist
                            LC->>LC: Skip (no valid asset)
                        end
                    end
                end
                
                LC->>LC: Stringify modified AST back to content
                LC-->>LRA: Return {content, hasChanges}
                
                alt hasChanges is true
                    LRA->>FS: writeFile(targetPath, newContent)
                end
            end
        end
        
        LRA-->>PP: Complete
    end
    
    PP-->>CLI: Post-processing complete
    CLI-->>User: Translation complete
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->