### PR TITLE
F/composite save-local fix

### DIFF
--- a/.changeset/puny-worlds-serve.md
+++ b/.changeset/puny-worlds-serve.md
@@ -1,0 +1,5 @@
+---
+'gtx-cli': patch
+---
+
+Fixing `save-local` behavior for composite JSONs

--- a/packages/cli/src/formats/json/__tests__/extractJson.test.ts
+++ b/packages/cli/src/formats/json/__tests__/extractJson.test.ts
@@ -1,0 +1,915 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { extractJson } from '../extractJson';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { logger } from '../../../console/logger.js';
+import { exitSync } from '../../../console/logging.js';
+import { gt } from '../../../utils/gt.js';
+
+vi.mock('../../../console/logger.js');
+vi.mock('../../../console/logging.js');
+
+const mockLogError = vi.spyOn(logger, 'error');
+const mockLogWarning = vi.spyOn(logger, 'warn');
+const mockExit = vi.mocked(exitSync).mockImplementation(() => {
+  throw new Error('Process exit called');
+});
+
+describe('extractJson', () => {
+  beforeEach(() => {
+    mockLogError.mockClear();
+    mockLogWarning.mockClear();
+    mockExit.mockClear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('No Schema Tests', () => {
+    it('should return null when no schema matches', () => {
+      const localContent = JSON.stringify({ title: 'Hello', desc: 'World' });
+
+      const result = extractJson(
+        localContent,
+        'file.txt', // doesn't match any schema
+        {
+          jsonSchema: {
+            '**/*.json': {
+              include: ['$.title'],
+            },
+          },
+        },
+        'es',
+        'en'
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null when no jsonSchema option provided', () => {
+      const localContent = JSON.stringify({ title: 'Hello' });
+
+      const result = extractJson(localContent, 'test.json', {}, 'es', 'en');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('Include Schema Tests', () => {
+    it('should extract values using include schema', () => {
+      const localContent = JSON.stringify({
+        title: 'Título Español',
+        description: 'Descripción Española',
+        metadata: {
+          author: 'John Doe',
+          version: '1.0.0',
+        },
+      });
+
+      const result = extractJson(
+        localContent,
+        'test.json',
+        {
+          jsonSchema: {
+            '**/*.json': {
+              include: ['$.title', '$.description'],
+            },
+          },
+        },
+        'es',
+        'en'
+      );
+
+      expect(result).not.toBeNull();
+      const parsed = JSON.parse(result!);
+      expect(parsed['/title']).toBe('Título Español');
+      expect(parsed['/description']).toBe('Descripción Española');
+      expect(parsed['/metadata']).toBeUndefined();
+    });
+
+    it('should extract nested values using include schema', () => {
+      const localContent = JSON.stringify({
+        app: {
+          ui: {
+            buttons: {
+              save: 'Guardar',
+              cancel: 'Cancelar',
+            },
+          },
+        },
+      });
+
+      const result = extractJson(
+        localContent,
+        'test.json',
+        {
+          jsonSchema: {
+            '**/*.json': {
+              include: ['$.app.ui.buttons.*'],
+            },
+          },
+        },
+        'es',
+        'en'
+      );
+
+      expect(result).not.toBeNull();
+      const parsed = JSON.parse(result!);
+      expect(parsed['/app/ui/buttons/save']).toBe('Guardar');
+      expect(parsed['/app/ui/buttons/cancel']).toBe('Cancelar');
+    });
+  });
+
+  describe('Composite Schema Array Type Tests', () => {
+    it('should extract array composite values for target locale', () => {
+      const localContent = JSON.stringify({
+        items: [
+          { locale: 'en', title: 'English Title', desc: 'English Description' },
+          {
+            locale: 'es',
+            title: 'Título Español',
+            desc: 'Descripción Española',
+          },
+        ],
+      });
+
+      const result = extractJson(
+        localContent,
+        'test.json',
+        {
+          jsonSchema: {
+            '**/*.json': {
+              composite: {
+                '$.items': {
+                  type: 'array',
+                  include: ['$.title', '$.desc'],
+                  key: '$.locale',
+                },
+              },
+            },
+          },
+        },
+        'es',
+        'en'
+      );
+
+      expect(result).not.toBeNull();
+      const parsed = JSON.parse(result!);
+      // Should extract Spanish values at index 1
+      expect(parsed['/items']).toBeDefined();
+      expect(parsed['/items']['/1']).toBeDefined();
+      expect(parsed['/items']['/1']['/title']).toBe('Título Español');
+      expect(parsed['/items']['/1']['/desc']).toBe('Descripción Española');
+    });
+
+    it('should extract array composite values when target locale is at index 0', () => {
+      const localContent = JSON.stringify({
+        items: [
+          {
+            locale: 'es',
+            title: 'Título Español',
+            desc: 'Descripción Española',
+          },
+          { locale: 'en', title: 'English Title', desc: 'English Description' },
+        ],
+      });
+
+      const result = extractJson(
+        localContent,
+        'test.json',
+        {
+          jsonSchema: {
+            '**/*.json': {
+              composite: {
+                '$.items': {
+                  type: 'array',
+                  include: ['$.title', '$.desc'],
+                  key: '$.locale',
+                },
+              },
+            },
+          },
+        },
+        'es',
+        'en'
+      );
+
+      expect(result).not.toBeNull();
+      const parsed = JSON.parse(result!);
+      // Should extract Spanish values at index 0
+      expect(parsed['/items']).toBeDefined();
+      expect(parsed['/items']['/0']).toBeDefined();
+      expect(parsed['/items']['/0']['/title']).toBe('Título Español');
+      expect(parsed['/items']['/0']['/desc']).toBe('Descripción Española');
+    });
+
+    it('should extract multiple matching items for same locale', () => {
+      const localContent = JSON.stringify({
+        items: [
+          { locale: 'en', title: 'English Title 1' },
+          { locale: 'es', title: 'Título Español 1' },
+          { locale: 'en', title: 'English Title 2' },
+          { locale: 'es', title: 'Título Español 2' },
+        ],
+      });
+
+      const result = extractJson(
+        localContent,
+        'test.json',
+        {
+          jsonSchema: {
+            '**/*.json': {
+              composite: {
+                '$.items': {
+                  type: 'array',
+                  include: ['$.title'],
+                  key: '$.locale',
+                },
+              },
+            },
+          },
+        },
+        'es',
+        'en'
+      );
+
+      expect(result).not.toBeNull();
+      const parsed = JSON.parse(result!);
+      expect(parsed['/items']['/1']['/title']).toBe('Título Español 1');
+      expect(parsed['/items']['/3']['/title']).toBe('Título Español 2');
+    });
+
+    it('should handle nested key paths in array type', () => {
+      const localContent = JSON.stringify({
+        items: [
+          { meta: { locale: 'en' }, title: 'English Title' },
+          { meta: { locale: 'es' }, title: 'Título Español' },
+        ],
+      });
+
+      const result = extractJson(
+        localContent,
+        'test.json',
+        {
+          jsonSchema: {
+            '**/*.json': {
+              composite: {
+                '$.items': {
+                  type: 'array',
+                  include: ['$.title'],
+                  key: '$.meta.locale',
+                },
+              },
+            },
+          },
+        },
+        'es',
+        'en'
+      );
+
+      expect(result).not.toBeNull();
+      const parsed = JSON.parse(result!);
+      expect(parsed['/items']['/1']['/title']).toBe('Título Español');
+    });
+
+    it('should warn when no matching items found for locale', () => {
+      const localContent = JSON.stringify({
+        items: [{ locale: 'en', title: 'English Title' }],
+      });
+
+      const result = extractJson(
+        localContent,
+        'test.json',
+        {
+          jsonSchema: {
+            '**/*.json': {
+              composite: {
+                '$.items': {
+                  type: 'array',
+                  include: ['$.title'],
+                  key: '$.locale',
+                },
+              },
+            },
+          },
+        },
+        'fr', // French not present
+        'en'
+      );
+
+      expect(mockLogWarning).toHaveBeenCalledWith(
+        'No matching items found for locale fr at path: /items'
+      );
+    });
+
+    it('should warn when source object value is not an array', () => {
+      const localContent = JSON.stringify({
+        items: 'not-an-array',
+      });
+
+      extractJson(
+        localContent,
+        'test.json',
+        {
+          jsonSchema: {
+            '**/*.json': {
+              composite: {
+                '$.items': {
+                  type: 'array',
+                  include: ['$.title'],
+                  key: '$.locale',
+                },
+              },
+            },
+          },
+        },
+        'es',
+        'en'
+      );
+
+      expect(mockLogWarning).toHaveBeenCalledWith(
+        'Source object value is not an array at path: /items'
+      );
+    });
+  });
+
+  describe('Composite Schema Object Type Tests', () => {
+    it('should extract object composite values for target locale', () => {
+      const localContent = JSON.stringify({
+        translations: {
+          en: { title: 'English Title', desc: 'English Description' },
+          es: { title: 'Título Español', desc: 'Descripción Española' },
+        },
+      });
+
+      const result = extractJson(
+        localContent,
+        'test.json',
+        {
+          jsonSchema: {
+            '**/*.json': {
+              composite: {
+                '$.translations': {
+                  type: 'object',
+                  include: ['$.title', '$.desc'],
+                },
+              },
+            },
+          },
+        },
+        'es',
+        'en'
+      );
+
+      expect(result).not.toBeNull();
+      const parsed = JSON.parse(result!);
+      expect(parsed['/translations']['/title']).toBe('Título Español');
+      expect(parsed['/translations']['/desc']).toBe('Descripción Española');
+    });
+
+    it('should handle multiple composite objects', () => {
+      const localContent = JSON.stringify({
+        nav: {
+          en: { home: 'Home', about: 'About' },
+          es: { home: 'Inicio', about: 'Acerca de' },
+        },
+        content: {
+          en: { title: 'Title', body: 'Body' },
+          es: { title: 'Título', body: 'Cuerpo' },
+        },
+      });
+
+      const result = extractJson(
+        localContent,
+        'test.json',
+        {
+          jsonSchema: {
+            '**/*.json': {
+              composite: {
+                '$.nav': {
+                  type: 'object',
+                  include: ['$.*'],
+                },
+                '$.content': {
+                  type: 'object',
+                  include: ['$.*'],
+                },
+              },
+            },
+          },
+        },
+        'es',
+        'en'
+      );
+
+      expect(result).not.toBeNull();
+      const parsed = JSON.parse(result!);
+      expect(parsed['/nav']['/home']).toBe('Inicio');
+      expect(parsed['/nav']['/about']).toBe('Acerca de');
+      expect(parsed['/content']['/title']).toBe('Título');
+      expect(parsed['/content']['/body']).toBe('Cuerpo');
+    });
+
+    it('should warn when no matching item found for locale in object', () => {
+      const localContent = JSON.stringify({
+        translations: {
+          en: { title: 'English Title' },
+        },
+      });
+
+      extractJson(
+        localContent,
+        'test.json',
+        {
+          jsonSchema: {
+            '**/*.json': {
+              composite: {
+                '$.translations': {
+                  type: 'object',
+                  include: ['$.title'],
+                },
+              },
+            },
+          },
+        },
+        'fr', // French not present
+        'en'
+      );
+
+      expect(mockLogWarning).toHaveBeenCalledWith(
+        'No matching item found for locale fr at path: /translations'
+      );
+    });
+
+    it('should warn when source object value is not an object', () => {
+      const localContent = JSON.stringify({
+        translations: 'not-an-object',
+      });
+
+      extractJson(
+        localContent,
+        'test.json',
+        {
+          jsonSchema: {
+            '**/*.json': {
+              composite: {
+                '$.translations': {
+                  type: 'object',
+                  include: ['$.title'],
+                },
+              },
+            },
+          },
+        },
+        'es',
+        'en'
+      );
+
+      expect(mockLogWarning).toHaveBeenCalledWith(
+        'Source object value is not an object at path: /translations'
+      );
+    });
+
+    it('should warn when source object value is null', () => {
+      const localContent = JSON.stringify({
+        translations: null,
+      });
+
+      extractJson(
+        localContent,
+        'test.json',
+        {
+          jsonSchema: {
+            '**/*.json': {
+              composite: {
+                '$.translations': {
+                  type: 'object',
+                  include: ['$.title'],
+                },
+              },
+            },
+          },
+        },
+        'es',
+        'en'
+      );
+
+      expect(mockLogWarning).toHaveBeenCalledWith(
+        'Source object value is not an object at path: /translations'
+      );
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should return null and log error for invalid JSON', () => {
+      const result = extractJson(
+        '{ invalid json }',
+        'test.json',
+        {
+          jsonSchema: {
+            '**/*.json': {
+              include: ['$.title'],
+            },
+          },
+        },
+        'es',
+        'en'
+      );
+
+      expect(result).toBeNull();
+      expect(mockLogError).toHaveBeenCalledWith('Invalid JSON file: test.json');
+    });
+
+    it('should exit when schema has no include or composite', () => {
+      const localContent = JSON.stringify({ title: 'Test' });
+
+      expect(() => {
+        extractJson(
+          localContent,
+          'test.json',
+          {
+            jsonSchema: {
+              '**/*.json': {
+                // Missing both include and composite
+              },
+            },
+          },
+          'es',
+          'en'
+        );
+      }).toThrow('Process exit called');
+
+      expect(mockLogError).toHaveBeenCalledWith(
+        'No include or composite property found in JSON schema'
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('Real-world Scenarios', () => {
+    it('should extract navigation structure from merged file', () => {
+      const localContent = readFileSync(
+        path.join(__dirname, '../__mocks__', 'test_file1.json'),
+        'utf8'
+      );
+
+      const result = extractJson(
+        localContent,
+        'test_file1.json',
+        {
+          jsonSchema: {
+            '**/*.json': {
+              composite: {
+                '$.navigation.languages': {
+                  type: 'array',
+                  include: ['$.global.anchors[*].anchor', '$.tabs[*].tab'],
+                  key: '$.language',
+                },
+              },
+            },
+          },
+        },
+        'pt-BR',
+        'en'
+      );
+
+      expect(result).not.toBeNull();
+      const parsed = JSON.parse(result!);
+
+      // pt-BR is at index 1 in the test file
+      expect(parsed['/navigation/languages']).toBeDefined();
+      expect(parsed['/navigation/languages']['/1']).toBeDefined();
+      expect(
+        parsed['/navigation/languages']['/1']['/global/anchors/0/anchor']
+      ).toBe('Anúncios');
+      expect(
+        parsed['/navigation/languages']['/1']['/global/anchors/1/anchor']
+      ).toBe('Status');
+      expect(parsed['/navigation/languages']['/1']['/tabs/0/tab']).toBe(
+        'Introdução'
+      );
+      expect(parsed['/navigation/languages']['/1']['/tabs/1/tab']).toBe(
+        'Funcionalidades'
+      );
+    });
+
+    it('should extract English content from merged file', () => {
+      const localContent = readFileSync(
+        path.join(__dirname, '../__mocks__', 'test_file1.json'),
+        'utf8'
+      );
+
+      const result = extractJson(
+        localContent,
+        'test_file1.json',
+        {
+          jsonSchema: {
+            '**/*.json': {
+              composite: {
+                '$.navigation.languages': {
+                  type: 'array',
+                  include: ['$.global.anchors[*].anchor', '$.tabs[*].tab'],
+                  key: '$.language',
+                },
+              },
+            },
+          },
+        },
+        'en',
+        'en'
+      );
+
+      expect(result).not.toBeNull();
+      const parsed = JSON.parse(result!);
+
+      // en is at index 0 in the test file
+      expect(parsed['/navigation/languages']['/0']).toBeDefined();
+      expect(
+        parsed['/navigation/languages']['/0']['/global/anchors/0/anchor']
+      ).toBe('Announcements');
+      expect(
+        parsed['/navigation/languages']['/0']['/global/anchors/1/anchor']
+      ).toBe('Status');
+      expect(parsed['/navigation/languages']['/0']['/tabs/0/tab']).toBe(
+        'Introduction'
+      );
+      expect(parsed['/navigation/languages']['/0']['/tabs/1/tab']).toBe(
+        'Features'
+      );
+    });
+
+    it('should handle special characters in extracted values', () => {
+      const localContent = JSON.stringify({
+        items: [
+          { locale: 'en', message: 'Simple message' },
+          {
+            locale: 'es',
+            message:
+              'Mensaje con "comillas", \'apostrofes\', y\nnuevas líneas\tcon tabs',
+          },
+        ],
+      });
+
+      const result = extractJson(
+        localContent,
+        'test.json',
+        {
+          jsonSchema: {
+            '**/*.json': {
+              composite: {
+                '$.items': {
+                  type: 'array',
+                  include: ['$.message'],
+                  key: '$.locale',
+                },
+              },
+            },
+          },
+        },
+        'es',
+        'en'
+      );
+
+      expect(result).not.toBeNull();
+      const parsed = JSON.parse(result!);
+      expect(parsed['/items']['/1']['/message']).toBe(
+        'Mensaje con "comillas", \'apostrofes\', y\nnuevas líneas\tcon tabs'
+      );
+    });
+
+    it('should handle deeply nested structures', () => {
+      const localContent = JSON.stringify({
+        data: {
+          pages: [
+            {
+              language: 'en',
+              sections: {
+                header: {
+                  nav: {
+                    links: [{ text: 'Home' }, { text: 'About' }],
+                  },
+                },
+              },
+            },
+            {
+              language: 'es',
+              sections: {
+                header: {
+                  nav: {
+                    links: [{ text: 'Inicio' }, { text: 'Acerca de' }],
+                  },
+                },
+              },
+            },
+          ],
+        },
+      });
+
+      const result = extractJson(
+        localContent,
+        'test.json',
+        {
+          jsonSchema: {
+            '**/*.json': {
+              composite: {
+                '$.data.pages': {
+                  type: 'array',
+                  include: ['$.sections.header.nav.links[*].text'],
+                  key: '$.language',
+                },
+              },
+            },
+          },
+        },
+        'es',
+        'en'
+      );
+
+      expect(result).not.toBeNull();
+      const parsed = JSON.parse(result!);
+      expect(
+        parsed['/data/pages']['/1']['/sections/header/nav/links/0/text']
+      ).toBe('Inicio');
+      expect(
+        parsed['/data/pages']['/1']['/sections/header/nav/links/1/text']
+      ).toBe('Acerca de');
+    });
+  });
+
+  describe('Canonical Locale Keys', () => {
+    it('should use canonical locale when experimentalCanonicalLocaleKeys is enabled', () => {
+      const localContent = JSON.stringify({
+        items: [
+          { locale: 'en', title: 'English Title' },
+          { locale: 'fr-CA', title: 'Titre Français Canadien' },
+        ],
+      });
+
+      const customMapping = {
+        'fr-ca': { code: 'fr-CA' },
+      };
+      gt.setConfig({ sourceLocale: 'en', customMapping });
+
+      const result = extractJson(
+        localContent,
+        'test.json',
+        {
+          jsonSchema: {
+            '**/*.json': {
+              composite: {
+                '$.items': {
+                  type: 'array',
+                  include: ['$.title'],
+                  key: '$.locale',
+                },
+              },
+            },
+          },
+          experimentalCanonicalLocaleKeys: true,
+        },
+        'fr-ca',
+        'en'
+      );
+
+      gt.setConfig({ sourceLocale: 'en', customMapping: undefined as any });
+
+      expect(result).not.toBeNull();
+      const parsed = JSON.parse(result!);
+      // Should match fr-CA in the data using canonical locale lookup
+      expect(parsed['/items']['/1']['/title']).toBe('Titre Français Canadien');
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('should handle empty items array', () => {
+      const localContent = JSON.stringify({
+        items: [],
+      });
+
+      const result = extractJson(
+        localContent,
+        'test.json',
+        {
+          jsonSchema: {
+            '**/*.json': {
+              composite: {
+                '$.items': {
+                  type: 'array',
+                  include: ['$.title'],
+                  key: '$.locale',
+                },
+              },
+            },
+          },
+        },
+        'es',
+        'en'
+      );
+
+      expect(result).not.toBeNull();
+      // Should return empty composite result
+      expect(mockLogWarning).toHaveBeenCalledWith(
+        'No matching items found for locale es at path: /items'
+      );
+    });
+
+    it('should handle empty translations object', () => {
+      const localContent = JSON.stringify({
+        translations: {},
+      });
+
+      const result = extractJson(
+        localContent,
+        'test.json',
+        {
+          jsonSchema: {
+            '**/*.json': {
+              composite: {
+                '$.translations': {
+                  type: 'object',
+                  include: ['$.title'],
+                },
+              },
+            },
+          },
+        },
+        'es',
+        'en'
+      );
+
+      expect(result).not.toBeNull();
+      expect(mockLogWarning).toHaveBeenCalledWith(
+        'No matching item found for locale es at path: /translations'
+      );
+    });
+
+    it('should handle items without the key field', () => {
+      const localContent = JSON.stringify({
+        items: [
+          { title: 'No locale field' },
+          { locale: 'es', title: 'Spanish' },
+        ],
+      });
+
+      const result = extractJson(
+        localContent,
+        'test.json',
+        {
+          jsonSchema: {
+            '**/*.json': {
+              composite: {
+                '$.items': {
+                  type: 'array',
+                  include: ['$.title'],
+                  key: '$.locale',
+                },
+              },
+            },
+          },
+        },
+        'es',
+        'en'
+      );
+
+      expect(result).not.toBeNull();
+      const parsed = JSON.parse(result!);
+      // Should only extract the item that has the locale field
+      expect(parsed['/items']['/1']['/title']).toBe('Spanish');
+      expect(parsed['/items']['/0']).toBeUndefined();
+    });
+
+    it('should return empty result for composite with no matching locales', () => {
+      const localContent = JSON.stringify({
+        items: [
+          { locale: 'de', title: 'German' },
+          { locale: 'ja', title: 'Japanese' },
+        ],
+      });
+
+      extractJson(
+        localContent,
+        'test.json',
+        {
+          jsonSchema: {
+            '**/*.json': {
+              composite: {
+                '$.items': {
+                  type: 'array',
+                  include: ['$.title'],
+                  key: '$.locale',
+                },
+              },
+            },
+          },
+        },
+        'es', // Spanish not present
+        'en'
+      );
+
+      expect(mockLogWarning).toHaveBeenCalledWith(
+        'No matching items found for locale es at path: /items'
+      );
+    });
+  });
+});

--- a/packages/cli/src/formats/json/extractJson.ts
+++ b/packages/cli/src/formats/json/extractJson.ts
@@ -51,7 +51,10 @@ export function extractJson(
 
   // Handle include-style schemas (simple path-based extraction)
   if (jsonSchema.include) {
-    const extracted = flattenJsonWithStringFilter(localJson, jsonSchema.include);
+    const extracted = flattenJsonWithStringFilter(
+      localJson,
+      jsonSchema.include
+    );
     return JSON.stringify(extracted, null, 2);
   }
 

--- a/packages/cli/src/formats/json/extractJson.ts
+++ b/packages/cli/src/formats/json/extractJson.ts
@@ -1,0 +1,153 @@
+import { AdditionalOptions, SourceObjectOptions } from '../../types/index.js';
+import { logger } from '../../console/logger.js';
+import {
+  findMatchingItemArray,
+  findMatchingItemObject,
+  generateSourceObjectPointers,
+  validateJsonSchema,
+} from './utils.js';
+import { flattenJsonWithStringFilter } from './flattenJson.js';
+import { gt } from '../../utils/gt.js';
+
+/**
+ * Extracts translated values from a full JSON file back into composite JSON format.
+ * This is the inverse of mergeJson - it takes a merged/reconstructed JSON file
+ * and extracts the values for a specific locale into the composite structure
+ * that the server expects.
+ *
+ * @param localContent - The full JSON content from the user's local file
+ * @param inputPath - The path to the file (used for matching jsonSchema)
+ * @param options - Additional options containing jsonSchema config
+ * @param targetLocale - The locale to extract values for
+ * @param defaultLocale - The default/source locale
+ * @returns The composite JSON string, or null if no extraction needed
+ */
+export function extractJson(
+  localContent: string,
+  inputPath: string,
+  options: AdditionalOptions,
+  targetLocale: string,
+  defaultLocale: string
+): string | null {
+  const jsonSchema = validateJsonSchema(options, inputPath);
+  if (!jsonSchema) {
+    // No schema - return content as-is
+    return null;
+  }
+
+  let localJson: any;
+  try {
+    localJson = JSON.parse(localContent);
+  } catch {
+    logger.error(`Invalid JSON file: ${inputPath}`);
+    return null;
+  }
+
+  const useCanonicalLocaleKeys =
+    options?.experimentalCanonicalLocaleKeys ?? false;
+  const canonicalTargetLocale = useCanonicalLocaleKeys
+    ? gt.resolveCanonicalLocale(targetLocale)
+    : targetLocale;
+
+  // Handle include-style schemas (simple path-based extraction)
+  if (jsonSchema.include) {
+    const extracted = flattenJsonWithStringFilter(localJson, jsonSchema.include);
+    return JSON.stringify(extracted, null, 2);
+  }
+
+  if (!jsonSchema.composite) {
+    logger.error('No include or composite property found in JSON schema');
+    return null;
+  }
+
+  // Handle composite schemas
+  const compositeResult: Record<string, any> = {};
+
+  // Generate source object pointers from the local JSON
+  const sourceObjectPointers = generateSourceObjectPointers(
+    jsonSchema.composite,
+    localJson
+  );
+
+  for (const [
+    sourceObjectPointer,
+    { sourceObjectValue, sourceObjectOptions },
+  ] of Object.entries(sourceObjectPointers)) {
+    if (sourceObjectOptions.type === 'array') {
+      if (!Array.isArray(sourceObjectValue)) {
+        logger.warn(
+          `Source object value is not an array at path: ${sourceObjectPointer}`
+        );
+        continue;
+      }
+
+      // Find the matching items for the target locale
+      const matchingTargetLocaleItems = findMatchingItemArray(
+        canonicalTargetLocale,
+        sourceObjectOptions,
+        sourceObjectPointer,
+        sourceObjectValue
+      );
+
+      if (!Object.keys(matchingTargetLocaleItems).length) {
+        logger.warn(
+          `No matching items found for locale ${targetLocale} at path: ${sourceObjectPointer}`
+        );
+        continue;
+      }
+
+      // Initialize the nested structure for this source object pointer
+      if (!compositeResult[sourceObjectPointer]) {
+        compositeResult[sourceObjectPointer] = {};
+      }
+
+      // For each matching item, extract the included values
+      for (const [itemPointer, { sourceItem }] of Object.entries(
+        matchingTargetLocaleItems
+      )) {
+        // Extract values at the include paths
+        const extractedValues = flattenJsonWithStringFilter(
+          sourceItem,
+          sourceObjectOptions.include
+        );
+
+        // Store under the item pointer (e.g., "/0")
+        compositeResult[sourceObjectPointer][itemPointer] = extractedValues;
+      }
+    } else {
+      // Object type
+      if (typeof sourceObjectValue !== 'object' || sourceObjectValue === null) {
+        logger.warn(
+          `Source object value is not an object at path: ${sourceObjectPointer}`
+        );
+        continue;
+      }
+
+      // Find the matching item for the target locale
+      const matchingTargetItem = findMatchingItemObject(
+        canonicalTargetLocale,
+        sourceObjectPointer,
+        sourceObjectOptions,
+        sourceObjectValue
+      );
+
+      if (!matchingTargetItem.sourceItem) {
+        logger.warn(
+          `No matching item found for locale ${targetLocale} at path: ${sourceObjectPointer}`
+        );
+        continue;
+      }
+
+      // Extract values at the include paths
+      const extractedValues = flattenJsonWithStringFilter(
+        matchingTargetItem.sourceItem,
+        sourceObjectOptions.include
+      );
+
+      // Store the extracted values
+      compositeResult[sourceObjectPointer] = extractedValues;
+    }
+  }
+
+  return JSON.stringify(compositeResult, null, 2);
+}

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.6.4';
+export const PACKAGE_VERSION = '2.6.5';


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes the `save-local` behavior for composite JSON files by introducing a new `extractJson` function that converts full JSON files back into the composite format expected by the server.

**Key Changes:**
- Added `extractJson.ts` to handle the inverse operation of `mergeJson` - extracting locale-specific values from full JSON files back into composite format
- Integrated extraction logic into `collectUserEditDiffs.ts` to transform local JSON content before sending diffs to the server when `jsonSchema` config is present
- Added comprehensive test coverage with 915 lines of tests covering include schemas, composite schemas (array/object types), error handling, and edge cases
- Supports both include-style schemas (simple path-based extraction) and composite schemas (array and object types with locale keys)
- Handles canonical locale keys when `experimentalCanonicalLocaleKeys` is enabled

**How it works:**
When collecting user edits for files with `jsonSchema` configuration, the system now:
1. Reads the local file content
2. For JSON files with `jsonSchema` and non-default locales, calls `extractJson` to transform from full format to composite format
3. Sends the properly formatted composite content to the server for diff comparison

This ensures that when users edit merged/full JSON files locally, the system correctly extracts and sends only the relevant locale-specific content in the composite format that the server expects.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge with high confidence
- The implementation is well-structured with comprehensive test coverage (915 lines of tests), proper error handling, and clear separation of concerns. The logic correctly handles both include and composite schema types, validates inputs properly, and gracefully handles edge cases. The integration point in collectUserEditDiffs is minimal and non-invasive.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/cli/src/formats/json/extractJson.ts | Added new extractJson function to convert full JSON files back into composite format for server submission, with comprehensive support for array and object type composite schemas |
| packages/cli/src/formats/json/__tests__/extractJson.test.ts | Added comprehensive test suite covering include schemas, composite schemas (array and object types), error handling, edge cases, and real-world scenarios |
| packages/cli/src/api/collectUserEditDiffs.ts | Integrated extractJson to transform local JSON files with jsonSchema config back to composite format before sending diffs to server, ensuring proper format consistency |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant collectUserEditDiffs
    participant extractJson
    participant validateJsonSchema
    participant flattenJsonWithStringFilter
    participant findMatchingItem
    participant Server

    User->>collectUserEditDiffs: trigger save-local
    collectUserEditDiffs->>collectUserEditDiffs: read local file content
    
    alt JSON file with jsonSchema config
        collectUserEditDiffs->>extractJson: extract composite format
        extractJson->>validateJsonSchema: validate schema for file
        
        alt No matching schema
            validateJsonSchema-->>extractJson: return null
            extractJson-->>collectUserEditDiffs: return null (use raw content)
        else Has matching schema
            validateJsonSchema-->>extractJson: return jsonSchema
            extractJson->>extractJson: parse JSON content
            
            alt Include-style schema
                extractJson->>flattenJsonWithStringFilter: extract values by paths
                flattenJsonWithStringFilter-->>extractJson: flattened result
            else Composite schema
                extractJson->>extractJson: generate source object pointers
                loop For each source object
                    alt Array type
                        extractJson->>findMatchingItem: find items for target locale
                        findMatchingItem-->>extractJson: matching items with indices
                        extractJson->>flattenJsonWithStringFilter: extract included values
                    else Object type
                        extractJson->>findMatchingItem: find item for target locale
                        findMatchingItem-->>extractJson: matching item
                        extractJson->>flattenJsonWithStringFilter: extract included values
                    end
                end
            end
            extractJson-->>collectUserEditDiffs: composite JSON string
        end
    end
    
    collectUserEditDiffs->>Server: submit diffs with localContent
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->