### PR TITLE
feat(cli): Update flags

### DIFF
--- a/.changeset/fair-women-design.md
+++ b/.changeset/fair-women-design.md
@@ -1,0 +1,5 @@
+---
+'gtx-cli': patch
+---
+
+Add branch config options

--- a/packages/cli/src/cli/flags.ts
+++ b/packages/cli/src/cli/flags.ts
@@ -101,7 +101,12 @@ export function attachTranslateFlags(command: Command) {
       'Disable additional branch detection and optimizations and use the manually specified branch',
       false
     )
-    .option('--enable-branching', 'Enable branching for the project', false); // disabled by default for now
+    .option('--enable-branching', 'Enable branching for the project', false) // disabled by default for now
+    .option(
+      '--remote-name <name>',
+      'Specify a custom remote name to use for branch detection',
+      'origin'
+    );
   return command;
 }
 

--- a/packages/cli/src/cli/flags.ts
+++ b/packages/cli/src/cli/flags.ts
@@ -1,5 +1,6 @@
 import { Command } from 'commander';
 import findFilepath from '../fs/findFilepath.js';
+import { DEFAULT_GIT_REMOTE_NAME } from '../utils/constants.js';
 
 const DEFAULT_TIMEOUT = 600;
 
@@ -105,7 +106,7 @@ export function attachTranslateFlags(command: Command) {
     .option(
       '--remote-name <name>',
       'Specify a custom remote name to use for branch detection',
-      'origin'
+      DEFAULT_GIT_REMOTE_NAME
     );
   return command;
 }

--- a/packages/cli/src/config/generateSettings.ts
+++ b/packages/cli/src/config/generateSettings.ts
@@ -14,7 +14,10 @@ import fs from 'node:fs';
 import { createOrUpdateConfig } from '../fs/config/setupConfig.js';
 import { resolveFiles } from '../fs/config/parseFilesConfig.js';
 import { validateSettings } from './validateSettings.js';
-import { GT_DASHBOARD_URL } from '../utils/constants.js';
+import {
+  DEFAULT_GIT_REMOTE_NAME,
+  GT_DASHBOARD_URL,
+} from '../utils/constants.js';
 import { resolveProjectId } from '../fs/utils.js';
 import path from 'node:path';
 import chalk from 'chalk';
@@ -252,7 +255,9 @@ export async function generateSettings(
     ? false
     : (gtConfig.branchOptions?.autoDetectBranches ?? true);
   branchOptions.remoteName =
-    flags.remoteName ?? gtConfig.branchOptions?.remoteName ?? 'origin';
+    flags.remoteName ??
+    gtConfig.branchOptions?.remoteName ??
+    DEFAULT_GIT_REMOTE_NAME;
   mergedOptions.branchOptions = branchOptions;
 
   // if there's no existing config file, creates one

--- a/packages/cli/src/config/generateSettings.ts
+++ b/packages/cli/src/config/generateSettings.ts
@@ -244,13 +244,15 @@ export async function generateSettings(
 
   // Add branch options if not provided
   const branchOptions = mergedOptions.branchOptions || {};
-  branchOptions.enabled = flags.enableBranching ?? false;
+  branchOptions.enabled =
+    flags.enableBranching ?? gtConfig.branchOptions?.enabled ?? false;
   branchOptions.currentBranch =
     flags.branch ?? gtConfig.branchOptions?.currentBranch ?? undefined;
   branchOptions.autoDetectBranches = flags.disableBranchDetection
     ? false
-    : true;
-  branchOptions.remoteName = gtConfig.branchOptions?.remoteName ?? 'origin';
+    : (gtConfig.branchOptions?.autoDetectBranches ?? true);
+  branchOptions.remoteName =
+    flags.remoteName ?? gtConfig.branchOptions?.remoteName ?? 'origin';
   mergedOptions.branchOptions = branchOptions;
 
   // if there's no existing config file, creates one

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.6.4';
+export const PACKAGE_VERSION = '2.6.5';

--- a/packages/cli/src/utils/constants.ts
+++ b/packages/cli/src/utils/constants.ts
@@ -6,3 +6,5 @@ export const GT_CONFIG_SCHEMA_URL = 'https://assets.gtx.dev/config-schema.json';
 
 export const TEMPLATE_FILE_NAME = '__INTERNAL_GT_TEMPLATE_NAME__';
 export const TEMPLATE_FILE_ID = hashStringSync(TEMPLATE_FILE_NAME);
+
+export const DEFAULT_GIT_REMOTE_NAME = 'origin';


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds support for configuring a custom git remote name for branch detection in the CLI. The `--remote-name` flag allows users to specify an alternative remote (instead of the default `origin`) when the CLI detects branch information for translation branching features.

**Changes:**
- Added `--remote-name <name>` flag with default value of `'origin'`
- Updated `generateSettings.ts` to respect the precedence: CLI flag > config file > default value
- Improved config merging logic for `branchOptions.enabled` and `branchOptions.autoDetectBranches` to properly fallback to config file values
- Version bumped to 2.6.5

The implementation correctly maintains the priority chain where CLI flags override config file settings, which override defaults. This allows users working with non-standard git remote names (e.g., `upstream`, `fork`) to use branch detection features properly.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge with no identified issues
- The changes are straightforward and well-implemented. The new flag follows existing patterns, the config merging logic correctly implements precedence rules, and no breaking changes are introduced. The code is clean with no console.log statements or security concerns.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/cli/src/cli/flags.ts | Added `--remote-name` flag for custom git remote configuration |
| packages/cli/src/config/generateSettings.ts | Updated branch options to respect config file settings and new `remoteName` flag |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant CLI
    participant Flags as flags.ts
    participant GenSettings as generateSettings.ts
    participant BranchStep as BranchStep.ts
    participant Git as git/branches.ts

    User->>CLI: Run CLI command with --remote-name flag
    CLI->>Flags: Parse CLI flags
    Flags-->>CLI: Flags object with remoteName
    CLI->>GenSettings: generateSettings(flags)
    GenSettings->>GenSettings: Load gt.config.json
    GenSettings->>GenSettings: Merge flags.remoteName with config branchOptions
    Note over GenSettings: Priority: flags.remoteName > config.remoteName > 'origin'
    GenSettings->>GenSettings: Merge flags.enableBranching with config
    GenSettings->>GenSettings: Merge flags.disableBranchDetection with config
    GenSettings-->>CLI: Settings with branchOptions
    CLI->>BranchStep: run() with settings
    BranchStep->>Git: getCurrentBranch(remoteName)
    BranchStep->>Git: getIncomingBranches(remoteName)
    BranchStep->>Git: getCheckedOutBranches(remoteName)
    Git-->>BranchStep: Branch data using custom remote
    BranchStep-->>CLI: Branch information resolved
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->