### PR TITLE
chore: changeset

### DIFF
--- a/.changeset/light-hairs-tap.md
+++ b/.changeset/light-hairs-tap.md
@@ -1,0 +1,5 @@
+---
+'gtx-cli': patch
+---
+
+Fixing `save-local` behavior for composite JSONs

--- a/packages/cli/src/formats/json/extractJson.ts
+++ b/packages/cli/src/formats/json/extractJson.ts
@@ -31,7 +31,7 @@ export function extractJson(
 ): string | null {
   const jsonSchema = validateJsonSchema(options, inputPath);
   if (!jsonSchema) {
-    // No schema - return content as-is
+    // No schema
     return null;
   }
 

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.6.5';
+export const PACKAGE_VERSION = '2.6.6';


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a changeset to document the composite JSON `save-local` fix that was implemented in PR #974, preparing for a patch release.

- Adds changeset file documenting the fix for `save-local` behavior with composite JSONs
- Cleans up a comment in `extractJson.ts` (removes redundant "return content as-is" text)
- Bumps auto-generated version from 2.6.5 to 2.6.6

This is a standard changeset PR with minimal code changes - just documentation and version management.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge with zero risk
- The changes are minimal and administrative: adding a changeset file for release documentation, an auto-generated version bump, and a minor comment cleanup with no functional impact
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .changeset/light-hairs-tap.md | Adds changeset for patch release documenting the composite JSON save-local fix |
| packages/cli/src/formats/json/extractJson.ts | Minor comment modification removing redundant text, no functional changes |
| packages/cli/src/generated/version.ts | Auto-generated version bump from 2.6.5 to 2.6.6 |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant PR974 as PR #974 Merge
    participant CI as CI System
    participant CS as Changeset File
    participant Ver as Version File
    participant Code as extractJson.ts

    Dev->>PR974: Merge composite save-local fix
    PR974->>Code: Add extractJson function (line 34 comment)
    PR974->>CI: Trigger release workflow
    CI->>Ver: Auto-generate version bump (2.6.5 → 2.6.6)
    Dev->>CS: Create changeset for patch release
    CS-->>CS: Document: "Fixing save-local behavior for composite JSONs"
    Dev->>Code: Clean up comment (line 34)
    Note over Code: Remove "return content as-is" <br/>Keep "No schema"
    Dev->>PR978: Submit changeset PR
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->