### PR TITLE
chore: set up gt-node

### DIFF
--- a/.changeset/small-ends-learn.md
+++ b/.changeset/small-ends-learn.md
@@ -1,0 +1,5 @@
+---
+'gt-node': patch
+---
+
+chore: setup package boilerplate

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,5 +22,6 @@
   },
   "[markdown]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
-  }
+  },
+  "vitest.disableWorkspaceWarning": true
 }

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -2,6 +2,8 @@
 
 Node.js utilities for General Translation.
 
+This is currently a placeholder package.
+
 ## Installation
 
 ```bash

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -1,0 +1,44 @@
+# gt-node
+
+Node.js utilities for General Translation.
+
+## Installation
+
+```bash
+npm install gt-node
+# or
+yarn add gt-node
+# or
+pnpm add gt-node
+```
+
+## Usage
+
+```typescript
+import { /* utilities */ } from 'gt-node';
+```
+
+This package provides Node.js-specific utilities built on top of the General Translation toolkit. It includes all functionality from:
+
+- `gt-i18n` - Pure JS i18n library for General Translation
+- `generaltranslation` - Core General Translation functionality
+
+## Development
+
+```bash
+# Install dependencies
+pnpm install
+
+# Build the package
+pnpm build
+
+# Run tests
+pnpm test
+
+# Lint code
+pnpm lint
+```
+
+## License
+
+FSL-1.1-ALv2

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,0 +1,80 @@
+{
+  "name": "gt-node",
+  "version": "0.1.0",
+  "description": "Node.js utilities for General Translation",
+  "main": "dist/index.cjs.min.cjs",
+  "module": "dist/index.esm.min.mjs",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "CHANGELOG.md"
+  ],
+  "scripts": {
+    "build:release": "pnpm run build:clean",
+    "build:clean": "sh ../../scripts/clean.sh && pnpm run build",
+    "build": "rollup -c",
+    "lint": "eslint \"src/**/*.{js,ts}\" \"./**/__tests__/**/*.{js,ts}\"",
+    "lint:fix": "eslint \"src/**/*.{js,ts}\" \"./**/__tests__/**/*.{js,ts}\" --fix",
+    "test": "vitest run --config=./vitest.config.ts",
+    "test:watch": "vitest --config=./vitest.config.ts",
+    "release": "pnpm run build:clean && pnpm publish",
+    "release:alpha": "pnpm run build:clean && pnpm publish --tag alpha",
+    "release:beta": "pnpm run build:clean && pnpm publish --tag beta",
+    "release:latest": "pnpm run build:clean && pnpm publish --tag latest"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/generaltranslation/gt.git"
+  },
+  "keywords": [
+    "node",
+    "nodejs",
+    "language",
+    "translation",
+    "internationalization",
+    "localization",
+    "translate",
+    "locale",
+    "i18n",
+    "toolkit"
+  ],
+  "author": "General Translation, Inc.",
+  "license": "FSL-1.1-ALv2",
+  "bugs": {
+    "url": "https://github.com/generaltranslation/gt/issues"
+  },
+  "homepage": "https://generaltranslation.com/",
+  "devDependencies": {
+    "@rollup/plugin-commonjs": "^28.0.1",
+    "@rollup/plugin-node-resolve": "^16.0.1",
+    "@rollup/plugin-terser": "^0.4.4",
+    "@rollup/plugin-typescript": "^12.1.1",
+    "@types/node": "^20.14.9",
+    "rollup": "^4.24.0",
+    "rollup-plugin-dts": "^6.1.1",
+    "tslib": "^2.8.0",
+    "typescript": "^5.6.2"
+  },
+  "typescript": {
+    "definition": "dist/index.d.ts"
+  },
+  "dependencies": {
+    "gt-i18n": "workspace:*",
+    "generaltranslation": "workspace:*"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index.cjs.min.cjs",
+      "import": "./dist/index.esm.min.mjs"
+    }
+  },
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "gt-node": [
+        "/dist/index"
+      ]
+    }
+  }
+}

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gt-node",
-  "version": "0.0.0-alpha.0",
+  "version": "0.0.0",
   "description": "Node.js utilities for General Translation",
   "main": "dist/index.cjs.min.cjs",
   "module": "dist/index.esm.min.mjs",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gt-node",
-  "version": "0.1.0",
+  "version": "0.0.0-alpha.0",
   "description": "Node.js utilities for General Translation",
   "main": "dist/index.cjs.min.cjs",
   "module": "dist/index.esm.min.mjs",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -69,12 +69,14 @@
       "import": "./dist/index.esm.min.mjs"
     }
   },
-  "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "gt-node": [
-        "/dist/index"
+  "typesVersions": {
+    "*": {
+      "types": [
+        "./dist/index.d.ts"
       ]
     }
+  },
+  "compilerOptions": {
+    "baseUrl": "."
   }
 }

--- a/packages/node/rollup.config.mjs
+++ b/packages/node/rollup.config.mjs
@@ -1,0 +1,44 @@
+import typescript from '@rollup/plugin-typescript';
+import commonjs from '@rollup/plugin-commonjs';
+import terser from '@rollup/plugin-terser';
+import resolve from '@rollup/plugin-node-resolve';
+import { dts } from 'rollup-plugin-dts';
+
+export default [
+  // Bundling for the main library (index.ts)
+  {
+    input: 'src/index.ts',
+    output: [
+      {
+        file: 'dist/index.cjs.min.cjs',
+        format: 'cjs',
+        exports: 'auto',
+        sourcemap: true,
+      },
+      {
+        file: 'dist/index.esm.min.mjs',
+        format: 'es',
+        exports: 'named',
+        sourcemap: true,
+      },
+    ],
+    plugins: [
+      resolve({ extensions: ['.js', '.mjs', '.ts'] }),
+      typescript({ tsconfig: './tsconfig.json' }),
+      commonjs(),
+      terser(),
+    ],
+    external: ['gt-i18n', 'generaltranslation'],
+  },
+
+  // TypeScript declarations for the main library
+  {
+    input: 'src/index.ts',
+    output: {
+      file: 'dist/index.d.ts',
+      format: 'es',
+    },
+    plugins: [dts()],
+    external: ['gt-i18n', 'generaltranslation'],
+  },
+];

--- a/packages/node/src/__tests__/index.test.ts
+++ b/packages/node/src/__tests__/index.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import gtNode from './index';
+import { helloWorld } from '../index';
 
 describe('gt-node', () => {
   it('should return hello world', () => {
-    expect(gtNode()).toBe('Hello World');
+    expect(helloWorld()).toBe('Hello World');
   });
 });

--- a/packages/node/src/index.test.ts
+++ b/packages/node/src/index.test.ts
@@ -1,0 +1,8 @@
+import { describe, it, expect } from 'vitest';
+import gtNode from './index';
+
+describe('gt-node', () => {
+  it('should return hello world', () => {
+    expect(gtNode()).toBe('Hello World');
+  });
+});

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -1,0 +1,3 @@
+export default function () {
+  return 'Hello World';
+}

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -1,3 +1,3 @@
-export default function () {
+export function helloWorld(): string {
   return 'Hello World';
 }

--- a/packages/node/tsconfig.json
+++ b/packages/node/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "strict": true,
+    "composite": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationDir": "./dist",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "removeComments": false,
+    "stripInternal": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "baseUrl": "./",
+    "paths": {
+      "gt-node": ["dist/index.d.ts"]
+    },
+    "lib": ["ES2023"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/packages/node/tsconfig.json
+++ b/packages/node/tsconfig.json
@@ -21,5 +21,16 @@
     "lib": ["ES2023"]
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts"],
+  "references": [
+    {
+      "path": "../core"
+    },
+    {
+      "path": "../supported-locales"
+    },
+    {
+      "path": "../i18n"
+    }
+  ]
 }

--- a/packages/node/vitest.config.ts
+++ b/packages/node/vitest.config.ts
@@ -1,0 +1,58 @@
+import { defineConfig } from 'vitest/config';
+import { loadEnv } from 'vite';
+
+export default defineConfig(({ mode }) => {
+  // Load environment variables
+  const env = loadEnv(mode || 'test', process.cwd(), '');
+
+  // Get environment variables from either source
+  const projectId =
+    process.env.VITE_CI_TEST_GT_PROJECT_ID || env.VITE_CI_TEST_GT_PROJECT_ID;
+  const apiKey =
+    process.env.VITE_CI_TEST_GT_API_KEY || env.VITE_CI_TEST_GT_API_KEY;
+
+  return {
+    test: {
+      // Enable parallel execution
+      pool: 'threads',
+      poolOptions: {
+        threads: {
+          // Use more workers for better parallelization
+          minThreads: 2,
+          maxThreads: 4,
+        },
+      },
+      // Run tests in parallel (default is true, but being explicit)
+      fileParallelism: true,
+      // Enable concurrent test execution within files
+      sequence: {
+        concurrent: true,
+      },
+      // Set reasonable timeout for all tests
+      testTimeout: 15000,
+      // Proper test isolation to prevent mock interference
+      isolate: true,
+      // Environment setup
+      environment: 'node',
+      // Globals for easier test writing
+      globals: true,
+      // Load environment variables from .env files
+      env: {
+        ...env,
+        // Suppress GT logger output during tests for cleaner output
+        _GT_LOG_LEVEL: 'off',
+        // Pass environment variables directly to test environment
+        ...(projectId && { VITE_CI_TEST_GT_PROJECT_ID: projectId }),
+        ...(apiKey && { VITE_CI_TEST_GT_API_KEY: apiKey }),
+      },
+      reporters: [
+        [
+          'default',
+          {
+            summary: true,
+          },
+        ],
+      ],
+    },
+  };
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -596,6 +596,43 @@ importers:
         specifier: ^2.0.0
         version: 2.1.9(@types/node@20.19.17)(jsdom@27.0.0(bufferutil@4.0.9)(postcss@8.5.6))(lightningcss@1.30.1)(terser@5.44.0)
 
+  packages/node:
+    dependencies:
+      generaltranslation:
+        specifier: workspace:*
+        version: link:../core
+      gt-i18n:
+        specifier: workspace:*
+        version: link:../i18n
+    devDependencies:
+      '@rollup/plugin-commonjs':
+        specifier: ^28.0.1
+        version: 28.0.6(rollup@4.52.3)
+      '@rollup/plugin-node-resolve':
+        specifier: ^16.0.1
+        version: 16.0.1(rollup@4.52.3)
+      '@rollup/plugin-terser':
+        specifier: ^0.4.4
+        version: 0.4.4(rollup@4.52.3)
+      '@rollup/plugin-typescript':
+        specifier: ^12.1.1
+        version: 12.1.4(rollup@4.52.3)(tslib@2.8.1)(typescript@5.9.2)
+      '@types/node':
+        specifier: ^20.14.9
+        version: 20.19.17
+      rollup:
+        specifier: ^4.24.0
+        version: 4.52.3
+      rollup-plugin-dts:
+        specifier: ^6.1.1
+        version: 6.2.3(rollup@4.52.3)(typescript@5.9.2)
+      tslib:
+        specifier: ^2.8.0
+        version: 2.8.1
+      typescript:
+        specifier: ^5.6.2
+        version: 5.9.2
+
   packages/react:
     dependencies:
       '@generaltranslation/react-core':


### PR DESCRIPTION
add the gt-node package

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new `gt-node` package under `packages/node` with a Rollup build (CJS/ESM + `.d.ts` bundling), Vitest configuration, and initial placeholder entrypoint/README. It also updates the workspace VSCode settings to disable Vitest workspace warnings and updates `pnpm-lock.yaml` to include the new package.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- Mostly safe to merge; one manifest issue should be fixed before publishing.
- The PR is a straightforward package scaffold (Rollup + TS + Vitest) with minimal functional code. The main merge-blocker is the invalid `compilerOptions` block in `packages/node/package.json`, which can break schema validation/publishing workflows and contains an incorrect absolute path mapping.
- packages/node/package.json
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .vscode/settings.json | Adds `vitest.disableWorkspaceWarning: true` to reduce VSCode Vitest workspace warnings. |
| packages/node/README.md | Adds initial README describing `gt-node` as a placeholder package with install/usage/dev commands. |
| packages/node/package.json | Introduces new package manifest for `gt-node`; includes an invalid top-level `compilerOptions` block and an absolute `/dist/index` path mapping that should be removed. |
| packages/node/rollup.config.mjs | Adds Rollup config to build minified CJS/ESM bundles and generate bundled type declarations. |
| packages/node/src/index.ts | Adds placeholder default export function returning 'Hello World'. |
| packages/node/tsconfig.json | Adds TypeScript config for the new package; `paths` mapping points at built `dist/index.d.ts`, which may confuse dev resolution. |
| packages/node/vitest.config.ts | Adds Vitest config that loads env vars via Vite; pins thread pool sizing and injects `_GT_LOG_LEVEL: off` into test env. |
| pnpm-lock.yaml | Updates lockfile to register `packages/node` importer and its Rollup/TS dev dependencies. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Dev as Developer
  participant Pnpm as pnpm workspace
  participant Rollup as rollup
  participant TS as TypeScript
  participant DTS as rollup-plugin-dts
  participant Vitest as vitest

  Dev->>Pnpm: pnpm -C packages/node build
  Pnpm->>Rollup: rollup -c (packages/node/rollup.config.mjs)
  Rollup->>TS: @rollup/plugin-typescript compiles src/index.ts
  TS-->>Rollup: JS output
  Rollup-->>Pnpm: dist/index.cjs.min.cjs + dist/index.esm.min.mjs
  Rollup->>DTS: dts() bundles declarations
  DTS-->>Pnpm: dist/index.d.ts

  Dev->>Pnpm: pnpm -C packages/node test
  Pnpm->>Vitest: vitest run --config vitest.config.ts
  Vitest->>Vitest: loadEnv(mode, cwd, '') + merge process.env overrides
  Vitest-->>Dev: test results
```
</details>


<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - Remove console.log statements and debug logging from production code before merging. ([source](https://app.greptile.com/review/custom-context?memory=ea076fa4-7856-4d31-9266-35f86e49f4b6))
- Rule from `dashboard` - Move server actions and database-related functions to the 'node' package instead of keeping them in ... ([source](https://app.greptile.com/review/custom-context?memory=c8d8f4ee-3b53-426d-8c49-e9799df196c8))

<!-- /greptile_comment -->