### PR TITLE
New CLI Flags: no logo and json errors

### DIFF
--- a/.changeset/yellow-bananas-repair.md
+++ b/.changeset/yellow-bananas-repair.md
@@ -2,4 +2,4 @@
 'gtx-cli': patch
 ---
 
-Added ---no-logo and --json-errors flags to CLI
+Added --no-logo and --json-errors flags to CLI

--- a/.changeset/yellow-bananas-repair.md
+++ b/.changeset/yellow-bananas-repair.md
@@ -1,0 +1,5 @@
+---
+'gtx-cli': patch
+---
+
+Added ---no-logo and --json-errors flags to CLI

--- a/packages/cli/gt.config.json
+++ b/packages/cli/gt.config.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://assets.gtx.dev/config-schema.json",
+  "defaultLocale": "en"
+}

--- a/packages/cli/src/cli/base.ts
+++ b/packages/cli/src/cli/base.ts
@@ -88,11 +88,13 @@ export class BaseCLI {
   }
 
   /**
-   * Enable JSON error collection if the flag is set
+   * Enable or disable JSON error collection based on the flag
    */
   protected enableJsonErrors(options: SharedFlags): void {
     if (options.jsonErrors) {
       errorCollector.enable();
+    } else {
+      errorCollector.disable();
     }
   }
 

--- a/packages/cli/src/cli/flags.ts
+++ b/packages/cli/src/cli/flags.ts
@@ -12,7 +12,13 @@ export function attachSharedFlags(command: Command) {
       findFilepath(['gt.config.json'])
     )
     .option('--api-key <key>', 'API key for General Translation cloud service')
-    .option('--project-id <id>', 'General Translation project ID');
+    .option('--project-id <id>', 'General Translation project ID')
+    .option('--no-logo', 'Disable the ASCII logo display')
+    .option(
+      '--json-errors',
+      'Output errors as JSON array at end of execution',
+      false
+    );
   return command;
 }
 

--- a/packages/cli/src/cli/react.ts
+++ b/packages/cli/src/cli/react.ts
@@ -6,6 +6,7 @@ import {
   GenerateSourceOptions,
   SupportedLibraries,
   TranslateFlags,
+  SharedFlags,
 } from '../types/index.js';
 import { displayHeader, exitSync, promptConfirm } from '../console/logging.js';
 import { logger } from '../console/logger.js';
@@ -27,6 +28,7 @@ import {
   attachAdditionalReactTranslateFlags,
   attachTranslateFlags,
 } from './flags.js';
+import { errorCollector } from '../console/errorCollector.js';
 
 const pkg = 'gt-react';
 
@@ -68,9 +70,14 @@ export class ReactCLI extends BaseCLI {
           )
       )
     ).action(async (options: TranslateFlags) => {
-      displayHeader('Uploading source files and setting up project...');
+      this.enableJsonErrors(options);
+      displayHeader(
+        'Uploading source files and setting up project...',
+        options.logo !== false
+      );
       await this.handleSetupProject(options);
       logger.endCommand('Done!');
+      this.outputJsonErrors();
     });
   }
 
@@ -84,11 +91,14 @@ export class ReactCLI extends BaseCLI {
           )
       )
     ).action(async (options: TranslateFlags) => {
+      this.enableJsonErrors(options);
       displayHeader(
-        'Staging project for translation with approval required...'
+        'Staging project for translation with approval required...',
+        options.logo !== false
       );
       await this.handleStage(options);
       logger.endCommand('Done!');
+      this.outputJsonErrors();
     });
   }
 
@@ -102,9 +112,11 @@ export class ReactCLI extends BaseCLI {
           )
       )
     ).action(async (options: TranslateFlags) => {
-      displayHeader('Translating project...');
+      this.enableJsonErrors(options);
+      displayHeader('Translating project...', options.logo !== false);
       await this.handleTranslate(options);
       logger.endCommand('Done!');
+      this.outputJsonErrors();
     });
   }
 
@@ -134,11 +146,18 @@ export class ReactCLI extends BaseCLI {
         'Include inline <T> tags in addition to dictionary file',
         true
       )
-      .action(async (files: string[], options: Options) => {
+      .option(
+        '--json-errors',
+        'Output errors as JSON array at end of execution',
+        false
+      )
+      .action(async (files: string[], options: Options & SharedFlags) => {
+        this.enableJsonErrors(options);
         // intro here since we don't want to show the ascii title
         intro(chalk.cyan('Validating project...'));
         await this.handleValidate(options, files);
         logger.endCommand('Done!');
+        this.outputJsonErrors();
       });
   }
 
@@ -152,9 +171,14 @@ export class ReactCLI extends BaseCLI {
           )
       )
     ).action(async (initOptions: TranslateFlags) => {
-      displayHeader('Generating source templates...');
+      this.enableJsonErrors(initOptions);
+      displayHeader(
+        'Generating source templates...',
+        initOptions.logo !== false
+      );
       await this.handleGenerateSourceCommand(initOptions);
       logger.endCommand('Done!');
+      this.outputJsonErrors();
     });
   }
 

--- a/packages/cli/src/console/errorCollector.ts
+++ b/packages/cli/src/console/errorCollector.ts
@@ -1,0 +1,46 @@
+/**
+ * Central error collector singleton for collecting errors during command execution.
+ * When enabled via --json-errors flag, errors are collected and output as JSON at the end.
+ */
+class ErrorCollector {
+  private static instance: ErrorCollector;
+  private errors: string[] = [];
+  private enabled: boolean = false;
+
+  private constructor() {}
+
+  static getInstance(): ErrorCollector {
+    if (!ErrorCollector.instance) {
+      ErrorCollector.instance = new ErrorCollector();
+    }
+    return ErrorCollector.instance;
+  }
+
+  enable(): void {
+    this.enabled = true;
+  }
+
+  isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  addError(message: string): void {
+    if (this.enabled) {
+      this.errors.push(message);
+    }
+  }
+
+  getErrors(): string[] {
+    return [...this.errors];
+  }
+
+  clear(): void {
+    this.errors = [];
+  }
+
+  toJSON(): string {
+    return JSON.stringify({ errors: this.errors });
+  }
+}
+
+export const errorCollector = ErrorCollector.getInstance();

--- a/packages/cli/src/console/errorCollector.ts
+++ b/packages/cli/src/console/errorCollector.ts
@@ -2,9 +2,15 @@
  * Central error collector singleton for collecting errors during command execution.
  * When enabled via --json-errors flag, errors are collected and output as JSON at the end.
  */
+
+type ErrorEntry = {
+  file?: string;
+  message: string;
+};
+
 class ErrorCollector {
   private static instance: ErrorCollector;
-  private errors: string[] = [];
+  private errors: ErrorEntry[] = [];
   private enabled: boolean = false;
 
   private constructor() {}
@@ -18,19 +24,28 @@ class ErrorCollector {
 
   enable(): void {
     this.enabled = true;
+    this.errors = []; // Clear any stale errors from previous runs
   }
 
   isEnabled(): boolean {
     return this.enabled;
   }
 
+  // For general errors without file context
   addError(message: string): void {
     if (this.enabled) {
-      this.errors.push(message);
+      this.errors.push({ message });
     }
   }
 
-  getErrors(): string[] {
+  // For errors with file context
+  addFileError(file: string, message: string): void {
+    if (this.enabled) {
+      this.errors.push({ file, message });
+    }
+  }
+
+  getErrors(): ErrorEntry[] {
     return [...this.errors];
   }
 

--- a/packages/cli/src/console/errorCollector.ts
+++ b/packages/cli/src/console/errorCollector.ts
@@ -27,6 +27,11 @@ class ErrorCollector {
     this.errors = []; // Clear any stale errors from previous runs
   }
 
+  disable(): void {
+    this.enabled = false;
+    this.errors = [];
+  }
+
   isEnabled(): boolean {
     return this.enabled;
   }

--- a/packages/cli/src/console/logging.ts
+++ b/packages/cli/src/console/logging.ts
@@ -16,7 +16,7 @@ import { errorCollector } from './errorCollector.js';
 /**
  * Strip ANSI escape codes from a string for clean JSON output
  */
-function stripAnsi(str: string): string {
+export function stripAnsi(str: string): string {
   return str.replace(/\x1B\[[0-9;]*m/g, '');
 }
 
@@ -27,8 +27,8 @@ export function logErrorAndExit(message: string): never {
 }
 
 export function exitSync(code: number): never {
-  // Output JSON errors if enabled
-  if (errorCollector.isEnabled()) {
+  // Output JSON errors if enabled and exiting due to an error
+  if (errorCollector.isEnabled() && code !== 0) {
     console.log(errorCollector.toJSON());
   }
   // Flush logs before exit

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.6.6';
+export const PACKAGE_VERSION = '2.6.7';

--- a/packages/cli/src/react/parse/createInlineUpdates.ts
+++ b/packages/cli/src/react/parse/createInlineUpdates.ts
@@ -1,11 +1,10 @@
 import fs from 'node:fs';
-import { Options, Updates } from '../../types/index.js';
+import { Updates } from '../../types/index.js';
 
 import { parse } from '@babel/parser';
 import { hashSource, hashString } from 'generaltranslation/id';
 import { parseTranslationComponent } from '../jsx/utils/jsxParsing/parseJsx.js';
 import { parseStrings } from '../jsx/utils/parseStringFunction.js';
-import { extractImportName } from '../jsx/utils/parseAst.js';
 import { logger } from '../../console/logger.js';
 import { matchFiles } from '../../fs/matchFiles.js';
 import { DEFAULT_SRC_PATTERNS } from '../../config/generateSettings.js';

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -48,6 +48,8 @@ export type SharedFlags = {
   config?: string;
   apiKey?: string;
   projectId?: string;
+  logo?: boolean;
+  jsonErrors?: boolean;
 };
 
 export type TranslateFlags = SharedFlags & {


### PR DESCRIPTION
# What
Added new Flags to remove the GT logo in CLI and to push descriptive error Jsons at the end of the CLI for improved error collection

Usage: 
`npx gtx-cli translate --no-logo`
`npx gtx-cli translate --json-errors`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds two new CLI flags: `--no-logo` (to suppress the ASCII banner) and `--json-errors` (to collect errors and emit them as a JSON blob). It implements a new `ErrorCollector` singleton, threads the flags through several BaseCLI/ReactCLI command actions, updates logging to optionally skip the header, and changes validation to parse errors into `{file,message}` entries.

Main issues to address before merge are around **consistency and correctness** of the JSON error feature: some commands don’t actually accept `--json-errors` because they bypass `attachSharedFlags`, the collector is a process-wide singleton that is enabled but never disabled, and the new error parsing regex will mis-handle Windows drive-letter paths (breaking the `file` field).

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

- Reasonably safe to merge after addressing a few correctness/consistency gaps in the new JSON error flag behavior.
- Core flag wiring and new collector are straightforward, but there are some behavior mismatches: `--json-errors` isn’t consistently available across commands, the collector singleton isn’t disabled after use (can leak in-process), and validation’s file parsing breaks on Windows paths. These are likely to surprise users and break downstream tooling that relies on JSON output.
- packages/cli/src/cli/base.ts, packages/cli/src/translation/validate.ts, packages/cli/src/console/errorCollector.ts, packages/cli/src/console/logging.ts
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .changeset/yellow-bananas-repair.md | Adds changeset entry for new --no-logo and --json-errors CLI flags (previous thread noted a typo; current diff shows corrected). |
| packages/cli/gt.config.json | Adds default gt.config.json with schema URL and defaultLocale; file lacks trailing newline. |
| packages/cli/src/cli/base.ts | Wires --no-logo and --json-errors into several commands via enableJsonErrors/outputJsonErrors; some commands still omit shared flags and may not support --json-errors consistently. |
| packages/cli/src/cli/flags.ts | Adds shared flags --no-logo and --json-errors; uses commander boolean option with explicit default false (may be unnecessary) and increases inconsistency where some commands bypass shared flags. |
| packages/cli/src/cli/react.ts | Adds enable/output JSON errors and logo suppression to React CLI commands; validate command defines --json-errors separately rather than via shared flags. |
| packages/cli/src/console/errorCollector.ts | Introduces process-wide ErrorCollector singleton for JSON error output; enabled state is never reset/disabled, which can leak between runs in the same process. |
| packages/cli/src/console/logging.ts | Adds ANSI stripping + JSON error emission on exit; exitSync prints JSON via console.log when enabled and code!=0 (previous thread said this was fixed), and introduces potential stdout/stderr behavior concerns. |
| packages/cli/src/generated/version.ts | Bumps generated CLI package version from 2.6.6 to 2.6.7. |
| packages/cli/src/react/parse/createInlineUpdates.ts | Removes unused imports in createInlineUpdates.ts. |
| packages/cli/src/translation/validate.ts | Switches to collecting errors into ErrorCollector and exiting via exitSync; parseFileFromError regex can misparse Windows drive-letter paths (colon in path). |
| packages/cli/src/types/index.ts | Extends SharedFlags type with logo and jsonErrors booleans. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant U as User
  participant CLI as gtx-cli (Commander)
  participant Base as BaseCLI/ReactCLI
  participant Log as logging.ts/logger
  participant EC as ErrorCollector

  U->>CLI: "run command with flags"
  CLI->>Base: "action(options)"

  alt "--no-logo"
    Base->>Log: "displayHeader(msg, showLogo=false)"
  else "default"
    Base->>Log: "displayHeader(msg, showLogo=true)"
  end

  opt "--json-errors"
    Base->>EC: "enable() (clears previous errors)"
  end

  Base->>Base: "run handler (setup/stage/translate/validate...)"

  opt "errors occur"
    Base->>EC: "addError/addFileError(...)"
    Base->>Log: "logger.error(...)"
  end

  alt "normal completion"
    Base->>Log: "logger.endCommand(...)"
    opt "--json-errors"
      Base->>EC: "toJSON()"
      Base->>Log: "emit JSON block"
    end
  else "fatal error"
    Base->>Log: "exitSync(nonzero)"
    opt "--json-errors"
      Log->>EC: "toJSON()"
      Log->>Log: "emit JSON block"
    end
    Log->>Log: "logger.flush()"
    Log->>Log: "process.exit(code)"
  end
```
</details>


<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - Remove console.log statements and debug logging from production code before merging. ([source](https://app.greptile.com/review/custom-context?memory=ea076fa4-7856-4d31-9266-35f86e49f4b6))

<!-- /greptile_comment -->