### PR TITLE
fix(cli): Fix GTJSON versionId calc

### DIFF
--- a/.changeset/better-loops-sing.md
+++ b/.changeset/better-loops-sing.md
@@ -1,0 +1,5 @@
+---
+'gtx-cli': patch
+---
+
+Fix versionid calculation

--- a/packages/cli/src/formats/files/collectFiles.ts
+++ b/packages/cli/src/formats/files/collectFiles.ts
@@ -54,9 +54,7 @@ export async function collectFiles(
         fileFormat: 'GTJSON',
         formatMetadata: fileMetadata,
         fileId: TEMPLATE_FILE_ID,
-        versionId: hashStringSync(
-          JSON.stringify({ data: fileData, metadata: fileMetadata })
-        ),
+        versionId: hashStringSync(JSON.stringify(Object.keys(fileData).sort())),
         locale: settings.defaultLocale,
       } satisfies FileToUpload);
     }

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.6.6';
+export const PACKAGE_VERSION = '2.6.8';


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Changed GTJSON `versionId` calculation to hash only the sorted keys of `fileData` instead of the full data and metadata object.

**Major changes:**
- Modified `versionId` from `hashStringSync(JSON.stringify({ data: fileData, metadata: fileMetadata }))` to `hashStringSync(JSON.stringify(Object.keys(fileData).sort()))`
- Version bumped from 2.6.6 to 2.6.8

**Critical issue:**
- The new approach only detects structural changes (keys added/removed) but won't detect content or metadata changes - this fundamentally breaks the file move detection logic in `UploadSourcesStep` which relies on matching `versionId` values to identify files with identical content at different paths

<details open><summary><h3>Confidence Score: 1/5</h3></summary>

- Not safe to merge - breaks critical file move detection functionality
- The change fundamentally alters how content changes are detected by only hashing keys instead of actual content, which will cause the system to treat files with different content as identical if they have the same keys
- `packages/cli/src/formats/files/collectFiles.ts` requires immediate attention - the versionId calculation logic is flawed
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/cli/src/formats/files/collectFiles.ts | Changed `versionId` calculation from hashing full data+metadata to only hashing sorted keys - potential logic issue with content change detection |
| packages/cli/src/generated/version.ts | Auto-generated version bump from 2.6.6 to 2.6.8 |
| .changeset/better-loops-sing.md | Changeset documenting patch-level fix for versionId calculation |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant CLI as CLI collectFiles
    participant React as aggregateReactTranslations
    participant Hash as hashStringSync
    participant Upload as UploadSourcesStep
    
    CLI->>React: aggregate React translations
    React-->>CLI: updates array with source+metadata
    
    CLI->>CLI: build fileData from updates
    Note over CLI: fileData[id/hash] = source<br/>fileMetadata[id/hash] = metadata
    
    CLI->>Hash: hash sorted keys only
    Note over Hash: JSON.stringify(Object.keys(fileData).sort())
    Hash-->>CLI: versionId (content hash)
    
    CLI->>CLI: create FileToUpload with versionId
    
    CLI->>Upload: upload files with versionId
    Upload->>Upload: detectMoves() using versionId
    Note over Upload: compares versionId between<br/>local and orphaned files<br/>to detect file moves
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->