### PR TITLE
chore: add branch id field to gt.config.json

### DIFF
--- a/.changeset/seven-places-shake.md
+++ b/.changeset/seven-places-shake.md
@@ -1,0 +1,5 @@
+---
+'gtx-cli': patch
+---
+
+chore: include branchid in gt config

--- a/packages/cli/src/cli/base.ts
+++ b/packages/cli/src/cli/base.ts
@@ -175,8 +175,7 @@ export class BaseCLI {
     if (!settings.stageTranslations) {
       // Update settings.stageTranslations to true
       settings.stageTranslations = true;
-      await updateConfig({
-        configFilepath: settings.config,
+      await updateConfig(settings.config, {
         stageTranslations: true,
       });
     }

--- a/packages/cli/src/cli/commands/stage.ts
+++ b/packages/cli/src/cli/commands/stage.ts
@@ -99,12 +99,18 @@ export async function handleStage(
     if (templateData?.versionId) {
       await updateConfig(settings.config, {
         _versionId: templateData.versionId,
-        _branchId: settings.branchOptions.enabled
-          ? branchData.currentBranch.id
-          : null,
+        _branchId: branchData.currentBranch.id,
       });
     }
   }
+
+  // Always delete branch id from config if branching is disabled
+  if (!settings.branchOptions.enabled) {
+    await updateConfig(settings.config, {
+      _branchId: null,
+    });
+  }
+
   return {
     fileVersionData,
     jobData,

--- a/packages/cli/src/cli/commands/stage.ts
+++ b/packages/cli/src/cli/commands/stage.ts
@@ -105,6 +105,7 @@ export async function handleStage(
   }
 
   // Always delete branch id from config if branching is disabled
+  // Avoids incorrect CDN queries at runtime
   if (!settings.branchOptions.enabled) {
     await updateConfig(settings.config, {
       _branchId: null,

--- a/packages/cli/src/cli/commands/stage.ts
+++ b/packages/cli/src/cli/commands/stage.ts
@@ -100,6 +100,9 @@ export async function handleStage(
       await updateConfig({
         configFilepath: settings.config,
         _versionId: templateData.versionId,
+        ...(settings.branchOptions.enabled && {
+          _branchId: branchData.currentBranch.id,
+        }),
       });
     }
   }

--- a/packages/cli/src/cli/commands/stage.ts
+++ b/packages/cli/src/cli/commands/stage.ts
@@ -97,12 +97,11 @@ export async function handleStage(
       (file) => file.fileId === TEMPLATE_FILE_ID
     );
     if (templateData?.versionId) {
-      await updateConfig({
-        configFilepath: settings.config,
+      await updateConfig(settings.config, {
         _versionId: templateData.versionId,
-        ...(settings.branchOptions.enabled && {
-          _branchId: branchData.currentBranch.id,
-        }),
+        _branchId: settings.branchOptions.enabled
+          ? branchData.currentBranch.id
+          : null,
       });
     }
   }

--- a/packages/cli/src/fs/config/updateConfig.ts
+++ b/packages/cli/src/fs/config/updateConfig.ts
@@ -10,17 +10,20 @@ export default async function updateConfig({
   configFilepath,
   projectId,
   _versionId,
+  _branchId,
   stageTranslations,
 }: {
   configFilepath: string;
   projectId?: string;
   _versionId?: string;
+  _branchId?: string;
   stageTranslations?: boolean;
 }): Promise<void> {
   // Filter out empty string values from the config object
   const newContent = {
     ...(projectId && { projectId }),
     ...(_versionId && { _versionId }),
+    ...(_branchId && { _branchId }),
     ...(stageTranslations && { stageTranslations }),
     // ...(locales && { locales }), // Don't override locales
   };

--- a/packages/cli/src/fs/config/updateConfig.ts
+++ b/packages/cli/src/fs/config/updateConfig.ts
@@ -74,7 +74,7 @@ export default async function updateConfig(
  */
 function applyNullFilter<T extends Record<string, unknown>>(
   obj: T,
-  filter: Partial<Record<keyof T, unknown>>
+  filter: Partial<Record<keyof T, null | unknown>>
 ): T {
   const result = { ...obj };
   for (const key of Object.keys(filter)) {

--- a/packages/cli/src/fs/config/updateConfig.ts
+++ b/packages/cli/src/fs/config/updateConfig.ts
@@ -32,7 +32,7 @@ export default async function updateConfig(
     ...(projectId && { projectId }),
     ...(_versionId && { _versionId }),
     ...(_branchId && { _branchId }),
-    // By default its false
+    // Omit when false
     ...(stageTranslations && { stageTranslations }),
   };
 

--- a/packages/cli/src/fs/config/updateConfig.ts
+++ b/packages/cli/src/fs/config/updateConfig.ts
@@ -52,7 +52,7 @@ export default async function updateConfig(
     };
 
     // Apply null filter to remove values that were marked for removal
-    const filteredContent = applyNullFilter(mergedContent, newContent);
+    const filteredContent = applyNullFilter(mergedContent, options);
 
     // write to file
     const jsonContent = JSON.stringify(filteredContent, null, 2);

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.6.6';
+export const PACKAGE_VERSION = '2.6.8';


### PR DESCRIPTION
if branching enabled, record field in gt.config.json file

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds support for storing `_branchId` in the `gt.config.json` file when branching is enabled, and removes it when branching is disabled.

**Key Changes:**
- Refactored `updateConfig()` function signature to accept filepath as first parameter and options object as second parameter
- Added `_branchId` field support to `UpdateConfigOptions` type
- Implemented null-based field removal mechanism via `applyNullFilter()` helper
- Updated `stage.ts` to write `_branchId` to config when template data exists
- Added cleanup logic to remove `_branchId` from config when branching is disabled

**Critical Issue:**
- Line 102 in `stage.ts` accesses `branchData.currentBranch.id` without checking if `branchData` is defined, which will cause a runtime error if `branchData` is undefined

<details open><summary><h3>Confidence Score: 1/5</h3></summary>

- This PR contains a critical null pointer bug that will cause runtime errors in production
- The code on line 102 of stage.ts will throw a runtime error when branchData is undefined, which can occur if stageFiles returns undefined branchData. This is a blocking issue that must be resolved before merging.
- packages/cli/src/cli/commands/stage.ts requires immediate attention to fix the null pointer access on line 102
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/cli/src/fs/config/updateConfig.ts | Refactored to support _branchId field and null-based field removal, changed function signature |
| packages/cli/src/cli/commands/stage.ts | Added _branchId to config when staging; contains critical null pointer bug on line 102 |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant CLI as BaseCLI
    participant Stage as handleStage()
    participant API as stageFiles()
    participant Update as updateConfig()
    participant FS as gt.config.json

    CLI->>Stage: Call handleStage()
    Stage->>Stage: collectFiles()
    
    alt allFiles.length > 0
        Stage->>API: stageFiles(allFiles, options, settings)
        API-->>Stage: {branchData, enqueueResult}
        Stage->>Stage: Extract templateData from allFiles
        
        alt templateData.versionId exists
            Stage->>Update: updateConfig(config, {_versionId, _branchId})
            Update->>FS: Write _versionId and _branchId
        end
    end
    
    alt branchOptions.enabled is false
        Stage->>Update: updateConfig(config, {_branchId: null})
        Update->>FS: Remove _branchId from config
    end
    
    Stage-->>CLI: Return {fileVersionData, jobData, branchData}
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->