### PR TITLE
F/cli warnings

### DIFF
--- a/.changeset/short-buttons-allow.md
+++ b/.changeset/short-buttons-allow.md
@@ -1,0 +1,5 @@
+---
+'gtx-cli': patch
+---
+
+Improve warning display for CLI

--- a/packages/cli/src/api/downloadFileBatch.ts
+++ b/packages/cli/src/api/downloadFileBatch.ts
@@ -13,6 +13,7 @@ import {
   ensureNestedObject,
 } from '../fs/config/downloadedVersions.js';
 import { recordDownloaded } from '../state/recentDownloads.js';
+import { recordWarning } from '../state/translateWarnings.js';
 import stringify from 'fast-json-stable-stringify';
 import type { FileStatusTracker } from '../workflow/PollJobsStep.js';
 
@@ -93,6 +94,7 @@ export async function downloadFileBatch(
 
         if (!outputPath || !fileProperties) {
           logger.warn(`No input/output path found for file: ${fileKey}`);
+          recordWarning('failed_download', fileKey, 'No input/output path found');
           result.failed.push(requestedFile);
           continue;
         }
@@ -200,6 +202,7 @@ export async function downloadFileBatch(
         }
       } catch (error) {
         logger.error(`Error saving file ${fileKey}: ` + error);
+        recordWarning('failed_download', fileKey, `Error saving file: ${error}`);
         result.failed.push(requestedFile);
       }
     }

--- a/packages/cli/src/api/downloadFileBatch.ts
+++ b/packages/cli/src/api/downloadFileBatch.ts
@@ -94,7 +94,11 @@ export async function downloadFileBatch(
 
         if (!outputPath || !fileProperties) {
           logger.warn(`No input/output path found for file: ${fileKey}`);
-          recordWarning('failed_download', fileKey, 'No input/output path found');
+          recordWarning(
+            'failed_download',
+            fileKey,
+            'No input/output path found'
+          );
           result.failed.push(requestedFile);
           continue;
         }
@@ -202,7 +206,11 @@ export async function downloadFileBatch(
         }
       } catch (error) {
         logger.error(`Error saving file ${fileKey}: ` + error);
-        recordWarning('failed_download', fileKey, `Error saving file: ${error}`);
+        recordWarning(
+          'failed_download',
+          fileKey,
+          `Error saving file: ${error}`
+        );
         result.failed.push(requestedFile);
       }
     }

--- a/packages/cli/src/cli/base.ts
+++ b/packages/cli/src/cli/base.ts
@@ -44,6 +44,8 @@ import {
   postProcessTranslations,
 } from './commands/translate.js';
 import { getDownloaded, clearDownloaded } from '../state/recentDownloads.js';
+import { clearWarnings } from '../state/translateWarnings.js';
+import { displayTranslateSummary } from '../console/displayTranslateSummary.js';
 import updateConfig from '../fs/config/updateConfig.js';
 import { createLoadTranslationsFile } from '../fs/createLoadTranslationsFile.js';
 import { saveLocalEdits } from '../api/saveLocalEdits.js';
@@ -213,6 +215,8 @@ export class BaseCLI {
       await postProcessTranslations(settings, include);
     }
     clearDownloaded();
+    displayTranslateSummary();
+    clearWarnings();
   }
 
   protected setupUploadCommand(): void {

--- a/packages/cli/src/console/displayTranslateSummary.ts
+++ b/packages/cli/src/console/displayTranslateSummary.ts
@@ -26,7 +26,10 @@ export function displayTranslateSummary() {
   const warnings = getWarnings();
 
   // Group by category
-  const grouped = new Map<WarningCategory, { fileName: string; reason: string }[]>();
+  const grouped = new Map<
+    WarningCategory,
+    { fileName: string; reason: string }[]
+  >();
   for (const w of warnings) {
     let list = grouped.get(w.category);
     if (!list) {

--- a/packages/cli/src/console/displayTranslateSummary.ts
+++ b/packages/cli/src/console/displayTranslateSummary.ts
@@ -1,0 +1,52 @@
+import chalk from 'chalk';
+import { logger } from './logger.js';
+import {
+  getWarnings,
+  hasWarnings,
+  type WarningCategory,
+} from '../state/translateWarnings.js';
+
+const CATEGORY_LABELS: Record<WarningCategory, string> = {
+  skipped_file: 'Files skipped',
+  failed_move: 'File moves failed',
+  failed_translation: 'Translations failed',
+  failed_download: 'Downloads failed',
+};
+
+const CATEGORY_ORDER: WarningCategory[] = [
+  'skipped_file',
+  'failed_move',
+  'failed_translation',
+  'failed_download',
+];
+
+export function displayTranslateSummary() {
+  if (!hasWarnings()) return;
+
+  const warnings = getWarnings();
+
+  // Group by category
+  const grouped = new Map<WarningCategory, { fileName: string; reason: string }[]>();
+  for (const w of warnings) {
+    let list = grouped.get(w.category);
+    if (!list) {
+      list = [];
+      grouped.set(w.category, list);
+    }
+    list.push({ fileName: w.fileName, reason: w.reason });
+  }
+
+  const lines: string[] = [chalk.yellow('⚠  Warnings:'), ''];
+
+  for (const category of CATEGORY_ORDER) {
+    const items = grouped.get(category);
+    if (!items) continue;
+    lines.push(`    ${CATEGORY_LABELS[category]} (${items.length}):`);
+    for (const item of items) {
+      lines.push(`      - ${item.fileName}: ${item.reason}`);
+    }
+    lines.push('');
+  }
+
+  logger.warn(lines.join('\n'));
+}

--- a/packages/cli/src/formats/files/translate.ts
+++ b/packages/cli/src/formats/files/translate.ts
@@ -1,4 +1,5 @@
 import { logger } from '../../console/logger.js';
+import { recordWarning } from '../../state/translateWarnings.js';
 import { getRelative, readFile } from '../../fs/findFilepath.js';
 import { Settings } from '../../types/index.js';
 import type { FileFormat, DataFormat, FileToUpload } from '../../types/data.js';
@@ -58,6 +59,7 @@ export async function aggregateFiles(
             JSON.parse(content);
           } catch (e: any) {
             logger.warn(`Skipping ${relativePath}: JSON file is not parsable`);
+            recordWarning('skipped_file', relativePath, 'JSON file is not parsable');
             return null;
           }
         }
@@ -83,6 +85,7 @@ export async function aggregateFiles(
         if (!file) return false;
         if (typeof file.content !== 'string' || !file.content.trim()) {
           logger.warn(`Skipping ${file.fileName}: JSON file is empty`);
+          recordWarning('skipped_file', file.fileName, 'JSON file is empty');
           return false;
         }
         return true;
@@ -103,6 +106,7 @@ export async function aggregateFiles(
             YAML.parse(content);
           } catch (e: any) {
             logger.warn(`Skipping ${relativePath}: YAML file is not parsable`);
+            recordWarning('skipped_file', relativePath, 'YAML file is not parsable');
             return null;
           }
         }
@@ -127,6 +131,7 @@ export async function aggregateFiles(
           logger.warn(
             `Skipping ${file?.fileName ?? 'unknown'}: YAML file is empty`
           );
+          recordWarning('skipped_file', file?.fileName ?? 'unknown', 'YAML file is empty');
           return false;
         }
         return true;
@@ -149,6 +154,7 @@ export async function aggregateFiles(
                 logger.warn(
                   `Skipping ${relativePath}: MDX file is not AST parsable${validation.error ? `: ${validation.error}` : ''}`
                 );
+                recordWarning('skipped_file', relativePath, `MDX file is not AST parsable${validation.error ? `: ${validation.error}` : ''}`);
                 return null;
               }
             }
@@ -191,6 +197,7 @@ export async function aggregateFiles(
             logger.warn(
               `Skipping ${file?.fileName ?? 'unknown'}: File is empty after sanitization`
             );
+            recordWarning('skipped_file', file?.fileName ?? 'unknown', 'File is empty after sanitization');
             return false;
           }
           return true;

--- a/packages/cli/src/formats/files/translate.ts
+++ b/packages/cli/src/formats/files/translate.ts
@@ -59,7 +59,11 @@ export async function aggregateFiles(
             JSON.parse(content);
           } catch (e: any) {
             logger.warn(`Skipping ${relativePath}: JSON file is not parsable`);
-            recordWarning('skipped_file', relativePath, 'JSON file is not parsable');
+            recordWarning(
+              'skipped_file',
+              relativePath,
+              'JSON file is not parsable'
+            );
             return null;
           }
         }
@@ -106,7 +110,11 @@ export async function aggregateFiles(
             YAML.parse(content);
           } catch (e: any) {
             logger.warn(`Skipping ${relativePath}: YAML file is not parsable`);
-            recordWarning('skipped_file', relativePath, 'YAML file is not parsable');
+            recordWarning(
+              'skipped_file',
+              relativePath,
+              'YAML file is not parsable'
+            );
             return null;
           }
         }
@@ -131,7 +139,11 @@ export async function aggregateFiles(
           logger.warn(
             `Skipping ${file?.fileName ?? 'unknown'}: YAML file is empty`
           );
-          recordWarning('skipped_file', file?.fileName ?? 'unknown', 'YAML file is empty');
+          recordWarning(
+            'skipped_file',
+            file?.fileName ?? 'unknown',
+            'YAML file is empty'
+          );
           return false;
         }
         return true;
@@ -154,7 +166,11 @@ export async function aggregateFiles(
                 logger.warn(
                   `Skipping ${relativePath}: MDX file is not AST parsable${validation.error ? `: ${validation.error}` : ''}`
                 );
-                recordWarning('skipped_file', relativePath, `MDX file is not AST parsable${validation.error ? `: ${validation.error}` : ''}`);
+                recordWarning(
+                  'skipped_file',
+                  relativePath,
+                  `MDX file is not AST parsable${validation.error ? `: ${validation.error}` : ''}`
+                );
                 return null;
               }
             }
@@ -197,7 +213,11 @@ export async function aggregateFiles(
             logger.warn(
               `Skipping ${file?.fileName ?? 'unknown'}: File is empty after sanitization`
             );
-            recordWarning('skipped_file', file?.fileName ?? 'unknown', 'File is empty after sanitization');
+            recordWarning(
+              'skipped_file',
+              file?.fileName ?? 'unknown',
+              'File is empty after sanitization'
+            );
             return false;
           }
           return true;

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.6.11';
+export const PACKAGE_VERSION = '2.6.12';

--- a/packages/cli/src/state/translateWarnings.ts
+++ b/packages/cli/src/state/translateWarnings.ts
@@ -1,0 +1,33 @@
+export type WarningCategory =
+  | 'skipped_file'
+  | 'failed_move'
+  | 'failed_translation'
+  | 'failed_download';
+
+export type TranslateWarning = {
+  category: WarningCategory;
+  fileName: string;
+  reason: string;
+};
+
+const warnings: TranslateWarning[] = [];
+
+export function recordWarning(
+  category: WarningCategory,
+  fileName: string,
+  reason: string
+) {
+  warnings.push({ category, fileName, reason });
+}
+
+export function getWarnings(): TranslateWarning[] {
+  return warnings;
+}
+
+export function hasWarnings(): boolean {
+  return warnings.length > 0;
+}
+
+export function clearWarnings() {
+  warnings.length = 0;
+}

--- a/packages/cli/src/workflow/DownloadStep.ts
+++ b/packages/cli/src/workflow/DownloadStep.ts
@@ -8,6 +8,7 @@ import {
 } from '../api/downloadFileBatch.js';
 import { GT } from 'generaltranslation';
 import { Settings } from '../types/index.js';
+import { recordWarning } from '../state/translateWarnings.js';
 import { FileStatusTracker } from './PollJobsStep.js';
 
 export type DownloadTranslationsInput = {
@@ -128,6 +129,13 @@ export class DownloadTranslationsStep extends WorkflowStep<
           logger.warn(
             `Failed to download ${batchResult.failed.length} files: ${batchResult.failed.map((f) => f.inputPath).join('\n')}`
           );
+          for (const f of batchResult.failed) {
+            recordWarning(
+              'failed_download',
+              f.inputPath,
+              `Failed to download for locale ${f.locale}`
+            );
+          }
         }
       } else {
         this.spinner?.stop(chalk.green('No files to download'));

--- a/packages/cli/src/workflow/UploadSourcesStep.ts
+++ b/packages/cli/src/workflow/UploadSourcesStep.ts
@@ -1,6 +1,7 @@
 import type { FileToUpload } from 'generaltranslation/types';
 import { WorkflowStep } from './Workflow.js';
 import { logger } from '../console/logger.js';
+import { recordWarning } from '../state/translateWarnings.js';
 import { GT } from 'generaltranslation';
 import { Settings } from '../types/index.js';
 import chalk from 'chalk';
@@ -126,6 +127,16 @@ export class UploadSourcesStep extends WorkflowStep<
         logger.warn(
           `Failed to migrate ${failed} moved file${failed !== 1 ? 's' : ''}`
         );
+        for (const r of moveResult.results) {
+          if (!r.success) {
+            const move = moves.find((m) => m.newFileId === r.newFileId);
+            recordWarning(
+              'failed_move',
+              move?.newFileName ?? r.newFileId,
+              r.error ?? 'Unknown error'
+            );
+          }
+        }
       }
     }
 

--- a/packages/cli/src/workflow/download.ts
+++ b/packages/cli/src/workflow/download.ts
@@ -8,6 +8,7 @@ import { DownloadTranslationsStep } from './DownloadStep.js';
 import { BranchData } from '../types/branch.js';
 import { logErrorAndExit } from '../console/logging.js';
 import { logger } from '../console/logger.js';
+import { recordWarning } from '../state/translateWarnings.js';
 import { BranchStep } from './BranchStep.js';
 import { FileProperties } from '../types/files.js';
 import chalk from 'chalk';
@@ -115,6 +116,13 @@ export async function downloadTranslations(
           .map(([key, value]) => `- ${value.fileName}`)
           .join('\n')}`
       );
+      for (const [, value] of pollResult.fileTracker.failed) {
+        recordWarning(
+          'failed_translation',
+          value.fileName,
+          `Failed to translate for locale ${value.locale}`
+        );
+      }
     }
 
     if (!pollResult.success) {


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR implements a comprehensive warning tracking and display system for the CLI translate workflow. The changes introduce a centralized warning state manager (`translateWarnings.ts`) that collects warnings from various stages of the translation process, including file validation, upload moves, translation jobs, and downloads. At the end of each translate command, warnings are displayed in a grouped, categorized format to help users quickly identify issues.

Key improvements:
- **Centralized warning state**: Module-level state management for collecting warnings across the entire workflow
- **Four warning categories**: `skipped_file`, `failed_move`, `failed_translation`, and `failed_download`
- **Enhanced user feedback**: Warnings are grouped by category and displayed with file names and reasons after command completion
- **Proper lifecycle management**: Warnings are cleared after each translate command to prevent state leakage

The implementation follows good practices by using a simple in-memory store pattern and integrating seamlessly into existing error logging without disrupting the workflow.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge with no significant risk
- The implementation is straightforward and well-structured with no logical errors or security concerns. The warning state management uses a simple module-level array pattern that's appropriate for CLI usage. All warning recording is additive (no mutations to existing logic), and proper cleanup is implemented. The changes are purely additive for user experience improvement without affecting core functionality.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/cli/src/state/translateWarnings.ts | New module-level state management for tracking warnings during translation workflow |
| packages/cli/src/console/displayTranslateSummary.ts | New display function that groups and formats warnings by category for user output |
| packages/cli/src/cli/base.ts | Integrated warning summary display and cleanup after translate command completes |
| packages/cli/src/api/downloadFileBatch.ts | Added warning tracking for download failures (missing paths and save errors) |
| packages/cli/src/formats/files/translate.ts | Added warning tracking for file validation failures (unparsable, empty, invalid files) |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant BaseCLI
    participant Workflow
    participant WarningState
    participant DisplaySummary

    User->>BaseCLI: gtx translate
    BaseCLI->>Workflow: Start translation workflow
    
    alt File Validation
        Workflow->>Workflow: aggregateFiles()
        Workflow->>WarningState: recordWarning('skipped_file', ...)
    end
    
    alt File Upload with Moves
        Workflow->>Workflow: UploadSourcesStep
        Workflow->>WarningState: recordWarning('failed_move', ...)
    end
    
    alt Translation Jobs
        Workflow->>Workflow: PollTranslationJobsStep
        Workflow->>WarningState: recordWarning('failed_translation', ...)
    end
    
    alt File Download
        Workflow->>Workflow: DownloadTranslationsStep
        Workflow->>WarningState: recordWarning('failed_download', ...)
    end
    
    Workflow-->>BaseCLI: Workflow complete
    BaseCLI->>DisplaySummary: displayTranslateSummary()
    DisplaySummary->>WarningState: hasWarnings()
    WarningState-->>DisplaySummary: true/false
    
    opt Has Warnings
        DisplaySummary->>WarningState: getWarnings()
        WarningState-->>DisplaySummary: Warning list
        DisplaySummary->>DisplaySummary: Group by category
        DisplaySummary->>User: Display formatted warnings
    end
    
    BaseCLI->>WarningState: clearWarnings()
    BaseCLI->>User: Done!
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->