### PR TITLE
chore(cli): Update pino transport

### DIFF
--- a/.changeset/ready-teams-shop.md
+++ b/.changeset/ready-teams-shop.md
@@ -1,0 +1,5 @@
+---
+'gtx-cli': patch
+---
+
+Change pino transport

--- a/packages/cli/src/console/logger.ts
+++ b/packages/cli/src/console/logger.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import { randomUUID } from 'node:crypto';
-import { pino, transport } from 'pino';
+import { pino, destination } from 'pino';
 import {
   log as clackLog,
   spinner,
@@ -120,25 +120,9 @@ class Logger {
 
     this.logFormat = format;
 
-    const transports: Array<{
-      level: string;
-      target: string;
-      options: Record<string, unknown>;
-    }> = [];
-
-    // Console output (stdout)
+    // Console output (stdout) - only for JSON format
+    // For 'default' format, we use @clack/prompts directly
     if (format === 'json') {
-      // JSON formatted console output
-      transports.push({
-        level: logLevel,
-        target: 'pino/file',
-        options: { destination: 1 }, // stdout
-      });
-    }
-    // For 'default' format, we don't add a console transport - we'll use @clack/prompts directly
-
-    // Create console logger if we have console transports
-    if (transports.length > 0) {
       this.pinoLogger = pino(
         {
           level: logLevel,
@@ -146,9 +130,7 @@ class Logger {
             logId: randomUUID(),
           }),
         },
-        transport({
-          targets: transports,
-        })
+        destination(1)
       );
     }
 
@@ -161,15 +143,7 @@ class Logger {
             logId: randomUUID(),
           }),
         },
-        transport({
-          targets: [
-            {
-              level: logLevel,
-              target: 'pino/file',
-              options: { destination: logFile },
-            },
-          ],
-        })
+        destination(logFile)
       );
     }
   }

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.6.12';
+export const PACKAGE_VERSION = '2.6.13';


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Updates the CLI logger to use pino `destination()` streams for stdout and file output, removing the prior `transport({ targets })` setup.
- Keeps `@clack/prompts` as the default human-readable console output path, and only uses pino for console when `GT_LOG_FORMAT=json`.
- Adds a changeset for a patch release and bumps the generated CLI package version.

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

- This PR is close to safe to merge, but there are a couple of logger API calls that will not work as written.
- The pino destination change itself is straightforward, but the Logger wrapper currently calls unsupported pino methods (`trace()` and `silent()`), which will break type-checking and/or at runtime when those methods are used.
- packages/cli/src/console/logger.ts
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .changeset/ready-teams-shop.md | Adds a changeset marking a patch release for gtx-cli to reflect the pino transport change. |
| packages/cli/src/console/logger.ts | Replaces pino transport targets with pino destination streams for stdout and file logging; verify flush/level APIs compatibility with destination-based loggers. |
| packages/cli/src/generated/version.ts | Bumps generated PACKAGE_VERSION from 2.6.12 to 2.6.13. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  autonumber
  participant CLI as CLI Command
  participant L as Logger.getInstance()
  participant C as @clack/prompts
  participant P as pino (stdout)
  participant F as pino (file)

  CLI->>L: construct (reads GT_LOG_FORMAT/LEVEL/FILE)
  alt GT_LOG_FORMAT = json
    L->>P: pino({level, mixin}, destination(1))
  else GT_LOG_FORMAT = default
    Note over L: No pino stdout logger
  end
  opt GT_LOG_FILE set
    L->>F: pino({level, mixin}, destination(logFile))
  end

  CLI->>L: info/warn/error/etc.
  alt default format
    L->>C: clackLog.*(message)
  else json format
    L->>P: logger.*(message)
  end
  opt file logger enabled
    L->>F: logger.*(message)
  end

  CLI->>L: flush()
  L->>P: flush()
  L->>F: flush()
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->