### PR TITLE
fix(cli): disable branching by default

### DIFF
--- a/.changeset/slow-signs-win.md
+++ b/.changeset/slow-signs-win.md
@@ -1,0 +1,5 @@
+---
+'gtx-cli': patch
+---
+
+Disable branching by default

--- a/packages/cli/src/cli/flags.ts
+++ b/packages/cli/src/cli/flags.ts
@@ -103,7 +103,6 @@ export function attachTranslateFlags(command: Command) {
       false
     )
     .option('--enable-branching', 'Enable branching for the project')
-    .option('--no-enable-branching', 'Disable branching for the project')
     .option(
       '--remote-name <name>',
       'Specify a custom remote name to use for branch detection',

--- a/packages/cli/src/config/generateSettings.ts
+++ b/packages/cli/src/config/generateSettings.ts
@@ -248,7 +248,7 @@ export async function generateSettings(
   // Add branch options if not provided
   const branchOptions = mergedOptions.branchOptions || {};
   branchOptions.enabled =
-    flags.enableBranching ?? gtConfig.branchOptions?.enabled ?? true;
+    flags.enableBranching ?? gtConfig.branchOptions?.enabled ?? false;
   branchOptions.currentBranch =
     flags.branch ?? gtConfig.branchOptions?.currentBranch ?? undefined;
   branchOptions.autoDetectBranches = flags.disableBranchDetection

--- a/packages/cli/src/workflow/BranchStep.ts
+++ b/packages/cli/src/workflow/BranchStep.ts
@@ -107,8 +107,8 @@ export class BranchStep extends WorkflowStep<null, BranchData | null> {
           this.branchData.currentBranch = createBranchResult.branch;
         } catch (error) {
           if (error instanceof ApiError && error.code === 403) {
-            logger.error(
-              'Failed to create branch. To enable branching, please upgrade your plan.'
+            logger.warn(
+              'To enable translation branching, please upgrade your plan. Falling back to default branch.'
             );
             // retry with default branch
             try {

--- a/packages/cli/src/workflow/BranchStep.ts
+++ b/packages/cli/src/workflow/BranchStep.ts
@@ -107,6 +107,9 @@ export class BranchStep extends WorkflowStep<null, BranchData | null> {
           this.branchData.currentBranch = createBranchResult.branch;
         } catch (error) {
           if (error instanceof ApiError && error.code === 403) {
+            logger.error(
+              'Failed to create branch. To enable branching, please upgrade your plan.'
+            );
             // retry with default branch
             try {
               const createBranchResult = await this.gt.createBranch({


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Changes CLI settings generation so `branchOptions.enabled` defaults to `false` when neither CLI flags nor config specify it.
- Removes the explicit `--no-enable-branching` flag from the CLI flag definitions.
- Adds a changeset documenting the behavior change for `gtx-cli`.

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

- This PR is mostly safe to merge, but has a likely breaking CLI flag change that should be addressed or explicitly versioned.
- Core behavior change (default branching disabled) is straightforward and localized, but removing a previously supported CLI option can break existing scripts/automation via parse errors.
- packages/cli/src/cli/flags.ts
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .changeset/slow-signs-win.md | Adds a changeset noting branching is now disabled by default. |
| packages/cli/src/cli/flags.ts | Removes --no-enable-branching flag; may break existing invocations and also changes how commander default booleans are represented. |
| packages/cli/src/config/generateSettings.ts | Changes default for branchOptions.enabled from true to false when not specified in flags/config. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User as CLI User
    participant Flags as packages/cli/src/cli/flags.ts
    participant Gen as packages/cli/src/config/generateSettings.ts

    User->>Flags: Invoke CLI with args
    Flags->>Flags: Parse --branching / default flags
    Flags->>Gen: generateSettings(parsedFlags)
    Gen->>Gen: Apply defaults (branching disabled by default)
    Gen-->>Flags: Settings object
    Flags-->>User: CLI runs using settings
```
</details>


<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - Remove console.log statements and debug logging from production code before merging. ([source](https://app.greptile.com/review/custom-context?memory=ea076fa4-7856-4d31-9266-35f86e49f4b6))
- Rule from `dashboard` - Move server actions and database-related functions to the 'node' package instead of keeping them in ... ([source](https://app.greptile.com/review/custom-context?memory=c8d8f4ee-3b53-426d-8c49-e9799df196c8))

<!-- /greptile_comment -->