### PR TITLE
F/shared asset mirroring

### DIFF
--- a/.changeset/all-readers-add.md
+++ b/.changeset/all-readers-add.md
@@ -1,0 +1,5 @@
+---
+'gtx-cli': patch
+---
+
+Allow `sharedStaticAssets` configuration to mirror shared asset structure

--- a/assets/config-schema.json
+++ b/assets/config-schema.json
@@ -301,7 +301,7 @@
     },
     "sharedStaticAssets": {
       "type": "object",
-      "description": "Configuration for moving shared static assets to a single directory and rewriting references in source files.",
+      "description": "Configuration for moving shared static assets to a single directory and rewriting references in source files, or mirroring assets to each locale directory.",
       "properties": {
         "include": {
           "oneOf": [
@@ -316,15 +316,29 @@
         },
         "outDir": {
           "type": "string",
-          "description": "Repo-root relative output directory where assets will be placed (on disk). Examples: 'public/shared', 'static/img', 'shared'."
+          "description": "Repo-root relative output directory where assets will be placed (on disk). Examples: 'public/shared', 'static/img', 'shared'. Not required when mirrorToLocales is true."
         },
         "publicPath": {
           "type": "string",
           "description": "Public URL prefix to use in rewritten content. If omitted, it is derived from outDir (public/* → '/…', static/* → '/…', otherwise '/basename(outDir)').",
           "examples": ["/shared", "/img", "/assets"]
+        },
+        "mirrorToLocales": {
+          "type": "boolean",
+          "description": "When true, copy matched assets to the equivalent location in each locale directory instead of centralizing them. This preserves relative paths in translated files. outDir and publicPath are ignored.",
+          "default": false
         }
       },
-      "required": ["include", "outDir"],
+      "required": ["include"],
+      "if": {
+        "not": {
+          "properties": { "mirrorToLocales": { "const": true } },
+          "required": ["mirrorToLocales"]
+        }
+      },
+      "then": {
+        "required": ["outDir"]
+      },
       "additionalProperties": false
     },
     "options": {

--- a/packages/cli/src/cli/base.ts
+++ b/packages/cli/src/cli/base.ts
@@ -49,7 +49,7 @@ import { displayTranslateSummary } from '../console/displayTranslateSummary.js';
 import updateConfig from '../fs/config/updateConfig.js';
 import { createLoadTranslationsFile } from '../fs/createLoadTranslationsFile.js';
 import { saveLocalEdits } from '../api/saveLocalEdits.js';
-import processSharedStaticAssets from '../utils/sharedStaticAssets.js';
+import processSharedStaticAssets, { mirrorAssetsToLocales } from '../utils/sharedStaticAssets.js';
 import { setupLocadex } from '../locadex/setupFlow.js';
 import { detectFramework } from '../setup/detectFramework.js';
 import {
@@ -214,6 +214,8 @@ export class BaseCLI {
     if (include.size > 0) {
       await postProcessTranslations(settings, include);
     }
+    // Mirror assets after translations are downloaded and locale dirs are populated
+    await mirrorAssetsToLocales(settings);
     clearDownloaded();
     displayTranslateSummary();
     clearWarnings();

--- a/packages/cli/src/cli/base.ts
+++ b/packages/cli/src/cli/base.ts
@@ -49,7 +49,9 @@ import { displayTranslateSummary } from '../console/displayTranslateSummary.js';
 import updateConfig from '../fs/config/updateConfig.js';
 import { createLoadTranslationsFile } from '../fs/createLoadTranslationsFile.js';
 import { saveLocalEdits } from '../api/saveLocalEdits.js';
-import processSharedStaticAssets, { mirrorAssetsToLocales } from '../utils/sharedStaticAssets.js';
+import processSharedStaticAssets, {
+  mirrorAssetsToLocales,
+} from '../utils/sharedStaticAssets.js';
 import { setupLocadex } from '../locadex/setupFlow.js';
 import { detectFramework } from '../setup/detectFramework.js';
 import {

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.6.13';
+export const PACKAGE_VERSION = '2.6.14';

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -263,8 +263,9 @@ export type AdditionalOptions = {
 
 export type SharedStaticAssetsConfig = {
   include: string | string[];
-  outDir: string;
+  outDir?: string;
   publicPath?: string;
+  mirrorToLocales?: boolean;
 };
 
 export type JsonSchema = {

--- a/packages/cli/src/utils/__tests__/sharedStaticAssets.test.ts
+++ b/packages/cli/src/utils/__tests__/sharedStaticAssets.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import path from 'node:path';
 import fs from 'node:fs';
 import fg from 'fast-glob';
-import processSharedStaticAssets, { mirrorAssetsToLocales } from '../sharedStaticAssets';
+import processSharedStaticAssets, {
+  mirrorAssetsToLocales,
+} from '../sharedStaticAssets';
 import type { Settings } from '../../types/index.js';
 import { createFileMapping } from '../../formats/files/fileMapping.js';
 
@@ -900,10 +902,7 @@ describe('processSharedStaticAssets', () => {
 
       // Both source and target exist with same size
       vi.mocked(fs.promises.stat).mockImplementation((p) => {
-        if (
-          p === assetPath ||
-          p === '/project/i18n/fr/docs/images/pic.png'
-        ) {
+        if (p === assetPath || p === '/project/i18n/fr/docs/images/pic.png') {
           return Promise.resolve({ isFile: () => true, size: 1024 } as any);
         }
         return Promise.reject(new Error('Not found'));

--- a/packages/cli/src/utils/addExplicitAnchorIds.ts
+++ b/packages/cli/src/utils/addExplicitAnchorIds.ts
@@ -147,10 +147,7 @@ export function extractHeadingInfo(mdxContent: string): HeadingInfo[] {
 
     const ast = parseProcessor.parse(mdxContent);
     processedAst = parseProcessor.runSync(ast) as Root;
-  } catch (error) {
-    console.warn(
-      `Failed to parse MDX content: ${error instanceof Error ? error.message : String(error)}`
-    );
+  } catch {
     // Fallback: line-by-line extraction skipping fenced code blocks
     return extractHeadingsWithFallback(mdxContent);
   }
@@ -297,10 +294,7 @@ function applyInlineIds(
 
     const ast = parseProcessor.parse(translatedContent);
     processedAst = parseProcessor.runSync(ast) as Root;
-  } catch (error) {
-    console.warn(
-      `Failed to parse translated MDX content: ${error instanceof Error ? error.message : String(error)}`
-    );
+  } catch {
     return applyInlineIdsStringFallback(
       translatedContent,
       idMappings,
@@ -386,10 +380,7 @@ function applyInlineIds(
     }
 
     return content;
-  } catch (error) {
-    console.warn(
-      `Failed to stringify translated MDX content: ${error instanceof Error ? error.message : String(error)}`
-    );
+  } catch {
     return translatedContent;
   }
 }

--- a/packages/cli/src/utils/localizeStaticImports.ts
+++ b/packages/cli/src/utils/localizeStaticImports.ts
@@ -443,11 +443,7 @@ function transformMdxImports(
 
     const ast = parseProcessor.parse(mdxContent);
     processedAst = parseProcessor.runSync(ast) as Root;
-  } catch (error) {
-    console.warn(
-      `Failed to parse MDX content: ${error instanceof Error ? error.message : String(error)}`
-    );
-    console.warn('Falling back to string-based import localization.');
+  } catch {
     return transformImportsStringFallback(
       mdxContent,
       defaultLocale,

--- a/packages/cli/src/utils/localizeStaticUrls.ts
+++ b/packages/cli/src/utils/localizeStaticUrls.ts
@@ -359,12 +359,7 @@ function transformMdxUrls(
 
     const ast = parseProcessor.parse(mdxContent);
     processedAst = parseProcessor.runSync(ast) as Root;
-  } catch (error) {
-    console.warn(
-      `Failed to parse MDX content: ${error instanceof Error ? error.message : String(error)}`
-    );
-    console.warn('Returning original content unchanged due to parsing error.');
-
+  } catch {
     return {
       content: mdxContent,
       hasChanges: false,

--- a/packages/cli/src/utils/sharedStaticAssets.ts
+++ b/packages/cli/src/utils/sharedStaticAssets.ts
@@ -10,6 +10,8 @@ import { visit } from 'unist-util-visit';
 import type { Root } from 'mdast';
 import escapeHtmlInTextNodes from 'gt-remark';
 import type { Settings, SharedStaticAssetsConfig } from '../types/index.js';
+import { createFileMapping } from '../formats/files/fileMapping.js';
+import { TEMPLATE_FILE_NAME } from './constants.js';
 
 function derivePublicPath(outDir: string, provided?: string): string {
   if (provided) return provided;
@@ -203,24 +205,143 @@ function rewriteMdxContent(
   }
 }
 
+function resolveAssetPaths(
+  include: string[],
+  cwd: string
+): Set<string> {
+  const assetPaths = new Set<string>();
+  for (let pattern of include) {
+    if (pattern.startsWith('/')) pattern = pattern.slice(1);
+    const matches = fg.sync(path.resolve(cwd, pattern), { absolute: true });
+    for (const m of matches) assetPaths.add(path.normalize(m));
+  }
+  return assetPaths;
+}
+
+export async function mirrorAssetsToLocales(settings: Settings) {
+  const cfg: SharedStaticAssetsConfig | undefined =
+    settings.sharedStaticAssets as any;
+  if (!cfg?.mirrorToLocales) return;
+  if (!settings.files) return;
+
+  const cwd = process.cwd();
+  const include = toArray(cfg.include);
+  if (include.length === 0) return;
+
+  const assetPaths = resolveAssetPaths(include, cwd);
+  if (assetPaths.size === 0) return;
+
+  const { resolvedPaths, placeholderPaths, transformPaths } = settings.files;
+  const targetLocales = settings.locales.filter(
+    (l) => l !== settings.defaultLocale
+  );
+  if (targetLocales.length === 0) return;
+
+  const fileMapping = createFileMapping(
+    resolvedPaths,
+    placeholderPaths,
+    transformPaths,
+    targetLocales,
+    settings.defaultLocale
+  );
+
+  for (const locale of targetLocales) {
+    const filesMap = fileMapping[locale];
+    if (!filesMap) continue;
+
+    // Extract unique (sourceDir, targetDir) pairs from the file mapping
+    const dirPairs = new Map<string, string>();
+    for (const [sourcePath, targetPath] of Object.entries(filesMap)) {
+      if (sourcePath === TEMPLATE_FILE_NAME) continue;
+      const sourceDir = path.dirname(path.resolve(cwd, sourcePath));
+      const targetDir = path.dirname(path.resolve(cwd, targetPath));
+      if (sourceDir !== targetDir) {
+        dirPairs.set(sourceDir, targetDir);
+      }
+    }
+
+    if (dirPairs.size === 0) continue;
+
+    // Derive ancestor directory pairs by walking up from each known pair.
+    // e.g. if docs/guide → ja/docs/guide, infer docs → ja/docs.
+    // Stop at cwd or when an existing pair conflicts.
+    const ancestorPairs = new Map<string, string>();
+    for (const [sourceDir, targetDir] of dirPairs) {
+      let s = path.dirname(sourceDir);
+      let t = path.dirname(targetDir);
+      while (s.startsWith(cwd) && s !== cwd) {
+        const existing = dirPairs.get(s) ?? ancestorPairs.get(s);
+        if (existing !== undefined) {
+          if (existing !== t) break; // conflict — different transforms
+        } else {
+          ancestorPairs.set(s, t);
+        }
+        s = path.dirname(s);
+        t = path.dirname(t);
+      }
+    }
+    for (const [s, t] of ancestorPairs) {
+      dirPairs.set(s, t);
+    }
+
+    // Sort source dirs by length descending so longest prefix matches first
+    const sortedPairs = [...dirPairs.entries()].sort(
+      (a, b) => b[0].length - a[0].length
+    );
+
+    for (const assetAbs of assetPaths) {
+      // Find the directory pair whose sourceDir is the longest prefix of the asset
+      let bestSource: string | undefined;
+      let bestTarget: string | undefined;
+      for (const [sourceDir, targetDir] of sortedPairs) {
+        if (
+          assetAbs.startsWith(sourceDir + path.sep) ||
+          assetAbs.startsWith(sourceDir + '/')
+        ) {
+          bestSource = sourceDir;
+          bestTarget = targetDir;
+          break;
+        }
+      }
+      if (!bestSource || !bestTarget) continue;
+
+      const relFromSource = path.relative(bestSource, assetAbs);
+      const targetAsset = path.resolve(bestTarget, relFromSource);
+
+      // Skip if target already exists with same size
+      try {
+        const [srcStat, dstStat] = await Promise.all([
+          fs.promises.stat(assetAbs),
+          fs.promises.stat(targetAsset),
+        ]);
+        if (dstStat.isFile() && srcStat.size === dstStat.size) continue;
+      } catch {
+        // target doesn't exist, proceed with copy
+      }
+
+      await ensureDir(path.dirname(targetAsset));
+      await fs.promises.copyFile(assetAbs, targetAsset);
+    }
+  }
+}
+
 export default async function processSharedStaticAssets(settings: Settings) {
   const cfg: SharedStaticAssetsConfig | undefined =
     settings.sharedStaticAssets as any;
   if (!cfg) return;
+
+  // mirrorToLocales is handled separately after translations are downloaded
+  if (cfg.mirrorToLocales) return;
 
   const cwd = process.cwd();
   const include = toArray(cfg.include);
   if (include.length === 0) return;
 
   // Resolve assets
-  const assetPaths = new Set<string>();
-  for (let pattern of include) {
-    // Treat leading '/' as repo-relative, not filesystem root
-    if (pattern.startsWith('/')) pattern = pattern.slice(1);
-    const matches = fg.sync(path.resolve(cwd, pattern), { absolute: true });
-    for (const m of matches) assetPaths.add(path.normalize(m));
-  }
+  const assetPaths = resolveAssetPaths(include, cwd);
   if (assetPaths.size === 0) return;
+
+  if (!cfg.outDir) return;
 
   const outDirInput = cfg.outDir.startsWith('/')
     ? cfg.outDir.slice(1)

--- a/packages/cli/src/utils/sharedStaticAssets.ts
+++ b/packages/cli/src/utils/sharedStaticAssets.ts
@@ -205,10 +205,7 @@ function rewriteMdxContent(
   }
 }
 
-function resolveAssetPaths(
-  include: string[],
-  cwd: string
-): Set<string> {
+function resolveAssetPaths(include: string[], cwd: string): Set<string> {
   const assetPaths = new Set<string>();
   for (let pattern of include) {
     if (pattern.startsWith('/')) pattern = pattern.slice(1);


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new `mirrorToLocales` mode for the `sharedStaticAssets` configuration that allows assets to be copied to each locale directory instead of being centralized.

**Key Changes:**
- Added `mirrorToLocales` boolean flag to `sharedStaticAssets` config (default: `false`)
- Made `outDir` optional when `mirrorToLocales` is `true` (enforced via JSON schema conditional validation)
- Implemented `mirrorAssetsToLocales()` function that copies assets to locale directories after translations are downloaded
- Added ancestor directory inference algorithm to determine target paths for assets in sibling directories
- Extracted `resolveAssetPaths()` helper function to avoid code duplication
- Removed `console.warn` debug statements from error handlers in `addExplicitAnchorIds.ts`, `localizeStaticImports.ts`, and `localizeStaticUrls.ts` (aligns with custom rule **ea076fa4-7856-4d31-9266-35f86e49f4b6**)
- Added comprehensive test coverage for the new mirroring functionality

**How It Works:**
1. When `mirrorToLocales: true`, the existing `processSharedStaticAssets()` function returns early without moving assets
2. After translations are downloaded, `mirrorAssetsToLocales()` is called
3. The function uses `createFileMapping()` to understand the source→target directory structure
4. It infers ancestor directory pairs (e.g., if `docs/guide` → `ja/docs/guide`, then infer `docs` → `ja/docs`)
5. Assets are copied to their equivalent location in each locale directory, preserving relative paths

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- This PR is safe to merge with minor risk from the ancestor directory inference logic
- Score reflects well-tested implementation with comprehensive test coverage, but the ancestor directory inference algorithm (lines 262-282 in sharedStaticAssets.ts) adds complexity that could potentially cause issues in edge cases with conflicting directory transformations
- Pay close attention to `packages/cli/src/utils/sharedStaticAssets.ts` - the ancestor directory inference logic should be monitored in production
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| assets/config-schema.json | Schema updated to add `mirrorToLocales` property and make `outDir` optional with conditional validation |
| packages/cli/src/types/index.ts | Type definitions updated to reflect optional `outDir` and new `mirrorToLocales` boolean flag |
| packages/cli/src/cli/base.ts | Added call to `mirrorAssetsToLocales` after post-processing translations to copy assets to locale directories |
| packages/cli/src/utils/sharedStaticAssets.ts | Implements `mirrorAssetsToLocales` function with ancestor directory inference logic; extracts `resolveAssetPaths` helper; adds early return for mirror mode |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant CLI as BaseCLI
    participant Process as processSharedStaticAssets
    participant Mirror as mirrorAssetsToLocales
    participant FileMap as createFileMapping
    participant FS as File System

    User->>CLI: Run translate command
    Note over CLI: Before translations
    CLI->>Process: processSharedStaticAssets(settings)
    
    alt mirrorToLocales = false
        Process->>FS: Resolve asset paths via glob
        Process->>FS: Move assets to outDir
        Process->>FS: Rewrite MDX references
        Process-->>CLI: Assets centralized
    else mirrorToLocales = true
        Process-->>CLI: Skip (early return)
    end
    
    Note over CLI: Download translations
    CLI->>CLI: Download & write translated files
    
    Note over CLI: After translations
    CLI->>Mirror: mirrorAssetsToLocales(settings)
    
    alt mirrorToLocales = true
        Mirror->>FS: Resolve asset paths via glob
        Mirror->>FileMap: createFileMapping(...)
        FileMap-->>Mirror: Return locale file mappings
        
        loop For each locale
            Mirror->>Mirror: Extract dir pairs from file mapping
            Mirror->>Mirror: Infer ancestor dir pairs
            
            loop For each asset
                Mirror->>Mirror: Find best matching dir pair
                Mirror->>FS: Check if target exists (same size)
                alt Target missing or different
                    Mirror->>FS: Copy asset to locale dir
                end
            end
        end
        Mirror-->>CLI: Assets mirrored
    else mirrorToLocales = false
        Mirror-->>CLI: Skip (early return)
    end
    
    CLI-->>User: Translation complete
```
</details>


<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - Remove console.log statements and debug logging from production code before merging. ([source](https://app.greptile.com/review/custom-context?memory=ea076fa4-7856-4d31-9266-35f86e49f4b6))

<!-- /greptile_comment -->