### PR TITLE
Cli branch handling

### DIFF
--- a/packages/cli/src/config/generateSettings.ts
+++ b/packages/cli/src/config/generateSettings.ts
@@ -247,8 +247,11 @@ export async function generateSettings(
 
   // Add branch options if not provided
   const branchOptions = mergedOptions.branchOptions || {};
+  // QoL: If --branch is specified, auto-enable branching
   branchOptions.enabled =
-    flags.enableBranching ?? gtConfig.branchOptions?.enabled ?? false;
+    flags.enableBranching ??
+    gtConfig.branchOptions?.enabled ??
+    (flags.branch ? true : false);
   branchOptions.currentBranch =
     flags.branch ?? gtConfig.branchOptions?.currentBranch ?? undefined;
   branchOptions.autoDetectBranches = flags.disableBranchDetection

--- a/packages/cli/src/workflow/BranchStep.ts
+++ b/packages/cli/src/workflow/BranchStep.ts
@@ -101,6 +101,12 @@ export class BranchStep extends WorkflowStep<null, BranchData | null> {
     });
 
     if (useDefaultBranch) {
+      // Log warning if we're falling back to default branch due to disabled/failed auto-detection
+      if (autoDetectionDisabledOrFailed) {
+        logger.warn(
+          'Branch auto-detection is disabled or failed. Using default branch.'
+        );
+      }
       if (!branchData.defaultBranch) {
         const createBranchResult = await this.gt.createBranch({
           branchName: 'main', // name doesn't matter for default branch

--- a/packages/cli/src/workflow/BranchStep.ts
+++ b/packages/cli/src/workflow/BranchStep.ts
@@ -47,6 +47,9 @@ export class BranchStep extends WorkflowStep<null, BranchData | null> {
     // Track whether we should assume the branch is checked out from the default branch
     // (when --branch is specified but auto-detection is disabled or failed)
     let assumeCheckedOutFromDefault: boolean = false;
+    // Track whether auto-detection was disabled or failed
+    let autoDetectionDisabledOrFailed: boolean =
+      !this.settings.branchOptions.autoDetectBranches;
 
     if (
       this.settings.branchOptions.enabled &&
@@ -65,6 +68,9 @@ export class BranchStep extends WorkflowStep<null, BranchData | null> {
       // If auto-detection succeeded, don't use default branch
       if (current !== null) {
         useDefaultBranch = false;
+      } else {
+        // Auto-detection failed (current is null)
+        autoDetectionDisabledOrFailed = true;
       }
       // If auto-detection failed but --branch is specified, we'll handle it below
       // If auto-detection failed and no --branch, useDefaultBranch remains true (fallback to default branch)
@@ -80,9 +86,8 @@ export class BranchStep extends WorkflowStep<null, BranchData | null> {
       };
       useDefaultBranch = false;
 
-      // If auto-detection is disabled or failed (checkedOut is empty), assume the branch
-      // is checked out from the default branch
-      if (checkedOut.length === 0) {
+      // Only assume branch is checked out from default if auto-detection was disabled or failed
+      if (autoDetectionDisabledOrFailed) {
         assumeCheckedOutFromDefault = true;
       }
     }

--- a/packages/cli/src/workflow/__tests__/BranchStep.test.ts
+++ b/packages/cli/src/workflow/__tests__/BranchStep.test.ts
@@ -1,0 +1,378 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { BranchStep } from '../BranchStep.js';
+
+// Mock the git/branches module
+vi.mock('../../git/branches.js', () => ({
+  getCurrentBranch: vi.fn(),
+  getIncomingBranches: vi.fn(),
+  getCheckedOutBranches: vi.fn(),
+}));
+
+// Mock the logger
+vi.mock('../../console/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    createSpinner: () => ({
+      start: vi.fn(),
+      stop: vi.fn(),
+      message: vi.fn(),
+    }),
+  },
+}));
+
+// Mock the logging module
+vi.mock('../../console/logging.js', () => ({
+  logErrorAndExit: vi.fn((msg) => {
+    throw new Error(msg);
+  }),
+}));
+
+import {
+  getCurrentBranch,
+  getIncomingBranches,
+  getCheckedOutBranches,
+} from '../../git/branches.js';
+import { logger } from '../../console/logger.js';
+
+// Mock the GT class
+const createMockGt = () => ({
+  queryBranchData: vi.fn(),
+  createBranch: vi.fn(),
+});
+
+describe('BranchStep', () => {
+  let mockGt: ReturnType<typeof createMockGt>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGt = createMockGt();
+  });
+
+  describe('when auto-detection is disabled', () => {
+    const createSettingsWithDisabledAutoDetect = () => ({
+      branchOptions: {
+        enabled: true,
+        autoDetectBranches: false,
+        remoteName: 'origin',
+        currentBranch: undefined as string | undefined,
+      },
+    });
+
+    it('should use default branch and log warning when --branch is not specified', async () => {
+      const settings = createSettingsWithDisabledAutoDetect();
+      settings.branchOptions.currentBranch = undefined;
+
+      mockGt.queryBranchData.mockResolvedValue({
+        branches: [],
+        defaultBranch: { id: 'default-branch-id', name: 'main' },
+      });
+
+      const step = new BranchStep(mockGt as any, settings as any);
+      const result = await step.run();
+
+      expect(result).not.toBeNull();
+      expect(result!.currentBranch).toEqual({
+        id: 'default-branch-id',
+        name: 'main',
+      });
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Branch auto-detection is disabled or failed. Using default branch.'
+      );
+      // Should not have called git detection functions
+      expect(getCurrentBranch).not.toHaveBeenCalled();
+    });
+
+    it('should use specified branch and set checkedOutBranch to default when --branch is specified', async () => {
+      const settings = createSettingsWithDisabledAutoDetect();
+      settings.branchOptions.currentBranch = 'feature-branch';
+
+      mockGt.queryBranchData.mockResolvedValue({
+        branches: [],
+        defaultBranch: { id: 'default-branch-id', name: 'main' },
+      });
+      mockGt.createBranch.mockResolvedValue({
+        branch: { id: 'feature-branch-id', name: 'feature-branch' },
+      });
+
+      const step = new BranchStep(mockGt as any, settings as any);
+      const result = await step.run();
+
+      expect(result).not.toBeNull();
+      expect(result!.currentBranch).toEqual({
+        id: 'feature-branch-id',
+        name: 'feature-branch',
+      });
+      expect(result!.checkedOutBranch).toEqual({
+        id: 'default-branch-id',
+        name: 'main',
+      });
+      expect(mockGt.createBranch).toHaveBeenCalledWith({
+        branchName: 'feature-branch',
+        defaultBranch: false,
+      });
+      // Should not log warning since we're using the specified branch
+      expect(logger.warn).not.toHaveBeenCalledWith(
+        'Branch auto-detection is disabled or failed. Using default branch.'
+      );
+    });
+  });
+
+  describe('when auto-detection fails', () => {
+    const createSettingsWithAutoDetect = () => ({
+      branchOptions: {
+        enabled: true,
+        autoDetectBranches: true,
+        remoteName: 'origin',
+        currentBranch: undefined as string | undefined,
+      },
+    });
+
+    it('should use default branch and log warning when detection fails and no --branch specified', async () => {
+      const settings = createSettingsWithAutoDetect();
+      settings.branchOptions.currentBranch = undefined;
+
+      // Auto-detection fails (returns null)
+      vi.mocked(getCurrentBranch).mockResolvedValue(null);
+      vi.mocked(getIncomingBranches).mockResolvedValue([]);
+      vi.mocked(getCheckedOutBranches).mockResolvedValue([]);
+
+      mockGt.queryBranchData.mockResolvedValue({
+        branches: [],
+        defaultBranch: { id: 'default-branch-id', name: 'main' },
+      });
+
+      const step = new BranchStep(mockGt as any, settings as any);
+      const result = await step.run();
+
+      expect(result).not.toBeNull();
+      expect(result!.currentBranch).toEqual({
+        id: 'default-branch-id',
+        name: 'main',
+      });
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Branch auto-detection is disabled or failed. Using default branch.'
+      );
+    });
+
+    it('should use specified branch and set checkedOutBranch to default when detection fails but --branch is specified', async () => {
+      const settings = createSettingsWithAutoDetect();
+      settings.branchOptions.currentBranch = 'my-feature';
+
+      // Auto-detection fails (returns null)
+      vi.mocked(getCurrentBranch).mockResolvedValue(null);
+      vi.mocked(getIncomingBranches).mockResolvedValue([]);
+      vi.mocked(getCheckedOutBranches).mockResolvedValue([]);
+
+      mockGt.queryBranchData.mockResolvedValue({
+        branches: [],
+        defaultBranch: { id: 'default-branch-id', name: 'main' },
+      });
+      mockGt.createBranch.mockResolvedValue({
+        branch: { id: 'my-feature-id', name: 'my-feature' },
+      });
+
+      const step = new BranchStep(mockGt as any, settings as any);
+      const result = await step.run();
+
+      expect(result).not.toBeNull();
+      expect(result!.currentBranch).toEqual({
+        id: 'my-feature-id',
+        name: 'my-feature',
+      });
+      expect(result!.checkedOutBranch).toEqual({
+        id: 'default-branch-id',
+        name: 'main',
+      });
+    });
+  });
+
+  describe('when auto-detection succeeds', () => {
+    const createSettingsWithAutoDetect = () => ({
+      branchOptions: {
+        enabled: true,
+        autoDetectBranches: true,
+        remoteName: 'origin',
+        currentBranch: undefined as string | undefined,
+      },
+    });
+
+    it('should use detected branch when auto-detection succeeds', async () => {
+      const settings = createSettingsWithAutoDetect();
+
+      vi.mocked(getCurrentBranch).mockResolvedValue({
+        currentBranchName: 'detected-branch',
+        defaultBranch: false,
+        defaultBranchName: 'main',
+      });
+      vi.mocked(getIncomingBranches).mockResolvedValue([]);
+      vi.mocked(getCheckedOutBranches).mockResolvedValue(['main']);
+
+      mockGt.queryBranchData.mockResolvedValue({
+        branches: [
+          { id: 'detected-branch-id', name: 'detected-branch' },
+          { id: 'main-id', name: 'main' },
+        ],
+        defaultBranch: { id: 'main-id', name: 'main' },
+      });
+
+      const step = new BranchStep(mockGt as any, settings as any);
+      const result = await step.run();
+
+      expect(result).not.toBeNull();
+      expect(result!.currentBranch).toEqual({
+        id: 'detected-branch-id',
+        name: 'detected-branch',
+      });
+      expect(result!.checkedOutBranch).toEqual({
+        id: 'main-id',
+        name: 'main',
+      });
+      // Should NOT log warning
+      expect(logger.warn).not.toHaveBeenCalledWith(
+        'Branch auto-detection is disabled or failed. Using default branch.'
+      );
+    });
+
+    it('should NOT assume checkedOutBranch is default when detection succeeds but checkedOut is empty', async () => {
+      const settings = createSettingsWithAutoDetect();
+      settings.branchOptions.currentBranch = 'override-branch';
+
+      // Detection succeeds (current is not null)
+      vi.mocked(getCurrentBranch).mockResolvedValue({
+        currentBranchName: 'detected-branch',
+        defaultBranch: false,
+        defaultBranchName: 'main',
+      });
+      vi.mocked(getIncomingBranches).mockResolvedValue([]);
+      // But checkedOut is empty (e.g., detached HEAD scenario)
+      vi.mocked(getCheckedOutBranches).mockResolvedValue([]);
+
+      mockGt.queryBranchData.mockResolvedValue({
+        branches: [],
+        defaultBranch: { id: 'default-branch-id', name: 'main' },
+      });
+      mockGt.createBranch.mockResolvedValue({
+        branch: { id: 'override-branch-id', name: 'override-branch' },
+      });
+
+      const step = new BranchStep(mockGt as any, settings as any);
+      const result = await step.run();
+
+      expect(result).not.toBeNull();
+      expect(result!.currentBranch).toEqual({
+        id: 'override-branch-id',
+        name: 'override-branch',
+      });
+      // Since detection succeeded (current !== null), we should NOT assume default
+      // checkedOutBranch should be null because checkedOut array was empty
+      expect(result!.checkedOutBranch).toBeNull();
+    });
+
+    it('should use detected current branch when on the default branch', async () => {
+      const settings = createSettingsWithAutoDetect();
+
+      vi.mocked(getCurrentBranch).mockResolvedValue({
+        currentBranchName: 'main',
+        defaultBranch: true,
+        defaultBranchName: 'main',
+      });
+      vi.mocked(getIncomingBranches).mockResolvedValue(['feature-1']);
+      vi.mocked(getCheckedOutBranches).mockResolvedValue([]);
+
+      // The query should include 'main' (current branch) and 'feature-1' (incoming)
+      mockGt.queryBranchData.mockResolvedValue({
+        branches: [
+          { id: 'main-id', name: 'main' },
+          { id: 'feature-1-id', name: 'feature-1' },
+        ],
+        defaultBranch: { id: 'main-id', name: 'main' },
+      });
+
+      const step = new BranchStep(mockGt as any, settings as any);
+      const result = await step.run();
+
+      expect(result).not.toBeNull();
+      // When detected branch is 'main' and it exists in branches, it should use that
+      expect(result!.currentBranch).toEqual({
+        id: 'main-id',
+        name: 'main',
+      });
+      expect(result!.incomingBranch).toEqual({
+        id: 'feature-1-id',
+        name: 'feature-1',
+      });
+      // queryBranchData should be called with the detected branch names
+      expect(mockGt.queryBranchData).toHaveBeenCalledWith({
+        branchNames: ['main', 'feature-1'],
+      });
+    });
+  });
+
+  describe('branch creation', () => {
+    it('should create default branch if it does not exist', async () => {
+      const settings = {
+        branchOptions: {
+          enabled: true,
+          autoDetectBranches: false,
+          remoteName: 'origin',
+          currentBranch: undefined,
+        },
+      };
+
+      mockGt.queryBranchData.mockResolvedValue({
+        branches: [],
+        defaultBranch: null, // No default branch exists
+      });
+      mockGt.createBranch.mockResolvedValue({
+        branch: { id: 'new-default-id', name: 'main' },
+      });
+
+      const step = new BranchStep(mockGt as any, settings as any);
+      const result = await step.run();
+
+      expect(result).not.toBeNull();
+      expect(mockGt.createBranch).toHaveBeenCalledWith({
+        branchName: 'main',
+        defaultBranch: true,
+      });
+      expect(result!.currentBranch).toEqual({
+        id: 'new-default-id',
+        name: 'main',
+      });
+    });
+
+    it('should create specified branch if it does not exist', async () => {
+      const settings = {
+        branchOptions: {
+          enabled: true,
+          autoDetectBranches: false,
+          remoteName: 'origin',
+          currentBranch: 'new-feature',
+        },
+      };
+
+      mockGt.queryBranchData.mockResolvedValue({
+        branches: [],
+        defaultBranch: { id: 'default-id', name: 'main' },
+      });
+      mockGt.createBranch.mockResolvedValue({
+        branch: { id: 'new-feature-id', name: 'new-feature' },
+      });
+
+      const step = new BranchStep(mockGt as any, settings as any);
+      const result = await step.run();
+
+      expect(result).not.toBeNull();
+      expect(mockGt.createBranch).toHaveBeenCalledWith({
+        branchName: 'new-feature',
+        defaultBranch: false,
+      });
+      expect(result!.currentBranch).toEqual({
+        id: 'new-feature-id',
+        name: 'new-feature',
+      });
+    });
+  });
+});


### PR DESCRIPTION
Improve CLI branch detection by auto-enabling branching when `--branch` is used and providing robust fallbacks when detection is disabled or fails.

---
[Slack Thread](https://generaltranslation.slack.com/archives/C0AD4GVFGDS/p1770511259887319?thread_ts=1770511259.887319&cid=C0AD4GVFGDS)

<p><a href="https://cursor.com/background-agent?bcId=bc-da26b38b-a830-5722-8bb2-de9a87636eda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-da26b38b-a830-5722-8bb2-de9a87636eda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts CLI branch handling in two places:

- `packages/cli/src/config/generateSettings.ts` now auto-enables `branchOptions.enabled` when the user passes `--branch`, so branch mode turns on without also needing `--enable-branching`.
- `packages/cli/src/workflow/BranchStep.ts` adds a fallback path so that when `--branch` is specified but branch auto-detection is disabled or can’t determine state, the workflow can still proceed by assuming the checked-out base is the default branch.

The main behavior change is in `BranchStep`, where git-derived branch metadata is used to populate `BranchData` before calling GT API methods (`queryBranchData` / `createBranch`) to resolve branch IDs.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- This PR is close to safe to merge, but it contains a logic edge case that can misreport branch relationships when `--branch` is used with partial git detection results.
- Core changes are small and localized, but `assumeCheckedOutFromDefault` is currently triggered by `checkedOut.length === 0`, which can occur even when auto-detection otherwise succeeded (e.g., detached HEAD), leading to incorrect `checkedOutBranch` reporting.
- packages/cli/src/workflow/BranchStep.ts
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/cli/src/config/generateSettings.ts | Auto-enables branching when `--branch` is provided by defaulting `branchOptions.enabled` to true in that case. |
| packages/cli/src/workflow/BranchStep.ts | Adds fallback logic to assume `checkedOutBranch` is the default branch when `--branch` is specified and auto-detection is disabled/failed; current implementation keys off `checkedOut.length === 0`, which can misclassify cases where detection otherwise succeeded. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant CLI as CLI
  participant GS as generateSettings
  participant BS as BranchStep.run
  participant Git as git/branches
  participant API as GT API

  CLI->>GS: parse flags/config
  GS-->>CLI: settings.branchOptions

  CLI->>BS: run(settings)
  alt branchOptions.enabled && autoDetectBranches
    par git detection
      BS->>Git: getCurrentBranch(remote)
      Git-->>BS: current
      BS->>Git: getIncomingBranches(remote)
      Git-->>BS: incoming
      BS->>Git: getCheckedOutBranches(remote)
      Git-->>BS: checkedOut
    end
  else auto-detect disabled
    Note over BS: skip git detection
  end

  opt --branch provided
    Note over BS: override current branch name
  end

  BS->>API: queryBranchData(branchNames)
  API-->>BS: branches + defaultBranch

  alt useDefaultBranch
    BS->>API: createBranch(defaultBranch=true)
    API-->>BS: currentBranch
  else current branch missing
    BS->>API: createBranch(branchName=current)
    API-->>BS: currentBranch
  end

  opt assumeCheckedOutFromDefault
    Note over BS: checkedOutBranch := defaultBranch
  end

  BS-->>CLI: BranchData
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->