### PR TITLE
fix: branch for vercel deployments

### DIFF
--- a/.changeset/lazy-ravens-work.md
+++ b/.changeset/lazy-ravens-work.md
@@ -1,0 +1,5 @@
+---
+'gtx-cli': patch
+---
+
+fix: branch detection vercel

--- a/packages/cli/src/config/generateSettings.ts
+++ b/packages/cli/src/config/generateSettings.ts
@@ -247,8 +247,11 @@ export async function generateSettings(
 
   // Add branch options if not provided
   const branchOptions = mergedOptions.branchOptions || {};
+  // If --branch is set, enable branching
   branchOptions.enabled =
-    flags.enableBranching ?? gtConfig.branchOptions?.enabled ?? false;
+    flags.enableBranching ??
+    gtConfig.branchOptions?.enabled ??
+    (flags.branch ? true : false);
   branchOptions.currentBranch =
     flags.branch ?? gtConfig.branchOptions?.currentBranch ?? undefined;
   branchOptions.autoDetectBranches = flags.disableBranchDetection

--- a/packages/cli/src/workflow/BranchStep.ts
+++ b/packages/cli/src/workflow/BranchStep.ts
@@ -74,7 +74,7 @@ export class BranchStep extends WorkflowStep<null, BranchData | null> {
         useDefaultBranch = false;
       } else {
         logger.warn(
-          'Banch auto-detection failed. Falling back to the default branch. Use --branch to specify a branch manually.'
+          'Branch auto-detection failed. Falling back to the default branch. Use --branch to specify a branch manually.'
         );
       }
     }

--- a/packages/cli/src/workflow/BranchStep.ts
+++ b/packages/cli/src/workflow/BranchStep.ts
@@ -173,7 +173,7 @@ export class BranchStep extends WorkflowStep<null, BranchData | null> {
         })
         .filter((b) => b !== null)[0] ?? null;
 
-    // When --branch is set manually without git, assume it was checked out from default
+    // When --branch is set manually or auto-detection failed, assume it was checked out from default
     if (
       (this.settings.branchOptions.currentBranch || autoDetectFailed) &&
       (!this.settings.branchOptions.autoDetectBranches || autoDetectFailed) &&

--- a/packages/cli/src/workflow/__tests__/BranchStep.test.ts
+++ b/packages/cli/src/workflow/__tests__/BranchStep.test.ts
@@ -48,11 +48,13 @@ const mockGt = {
 const defaultBranch = { id: 'default-id', name: 'main' };
 const featureBranch = { id: 'feature-id', name: 'feature-x' };
 
-function makeSettings(overrides: {
-  enabled?: boolean;
-  autoDetectBranches?: boolean;
-  currentBranch?: string;
-} = {}) {
+function makeSettings(
+  overrides: {
+    enabled?: boolean;
+    autoDetectBranches?: boolean;
+    currentBranch?: string;
+  } = {}
+) {
   return {
     branchOptions: {
       enabled: overrides.enabled ?? true,
@@ -240,7 +242,10 @@ describe('BranchStep', () => {
         branchName: 'new-branch',
         defaultBranch: false,
       });
-      expect(result?.currentBranch).toEqual({ id: 'new-id', name: 'new-branch' });
+      expect(result?.currentBranch).toEqual({
+        id: 'new-id',
+        name: 'new-branch',
+      });
     });
   });
 });

--- a/packages/cli/src/workflow/__tests__/BranchStep.test.ts
+++ b/packages/cli/src/workflow/__tests__/BranchStep.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { BranchStep } from '../BranchStep.js';
+
+// Mock git branch detection
+vi.mock('../../git/branches.js', () => ({
+  getCurrentBranch: vi.fn(),
+  getIncomingBranches: vi.fn(),
+  getCheckedOutBranches: vi.fn(),
+}));
+
+// Mock logger
+vi.mock('../../console/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    createSpinner: () => ({
+      start: vi.fn(),
+      stop: vi.fn(),
+      message: vi.fn(),
+    }),
+  },
+}));
+
+// Mock logErrorAndExit to throw instead of process.exit
+vi.mock('../../console/logging.js', () => ({
+  logErrorAndExit: vi.fn((msg: string) => {
+    throw new Error(msg);
+  }),
+}));
+
+import {
+  getCurrentBranch,
+  getIncomingBranches,
+  getCheckedOutBranches,
+} from '../../git/branches.js';
+import { logger } from '../../console/logger.js';
+
+const mockGetCurrentBranch = vi.mocked(getCurrentBranch);
+const mockGetIncomingBranches = vi.mocked(getIncomingBranches);
+const mockGetCheckedOutBranches = vi.mocked(getCheckedOutBranches);
+
+const mockGt = {
+  queryBranchData: vi.fn(),
+  createBranch: vi.fn(),
+};
+
+const defaultBranch = { id: 'default-id', name: 'main' };
+const featureBranch = { id: 'feature-id', name: 'feature-x' };
+
+function makeSettings(overrides: {
+  enabled?: boolean;
+  autoDetectBranches?: boolean;
+  currentBranch?: string;
+} = {}) {
+  return {
+    branchOptions: {
+      enabled: overrides.enabled ?? true,
+      autoDetectBranches: overrides.autoDetectBranches ?? true,
+      remoteName: 'origin',
+      currentBranch: overrides.currentBranch,
+    },
+  } as any;
+}
+
+describe('BranchStep', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...originalEnv };
+    delete process.env.VERCEL_GIT_COMMIT_REF;
+
+    mockGetIncomingBranches.mockResolvedValue([]);
+    mockGetCheckedOutBranches.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe('git auto-detection succeeds', () => {
+    it('should use the detected branch', async () => {
+      mockGetCurrentBranch.mockResolvedValue({
+        currentBranchName: 'feature-x',
+        defaultBranch: false,
+        defaultBranchName: 'main',
+      });
+      mockGt.queryBranchData.mockResolvedValue({
+        branches: [featureBranch],
+        defaultBranch,
+      });
+
+      const step = new BranchStep(mockGt as any, makeSettings());
+      const result = await step.run();
+
+      expect(result?.currentBranch).toEqual(featureBranch);
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('git detection fails, no VERCEL_GIT_COMMIT_REF, no --branch', () => {
+    it('should warn and fall back to default branch', async () => {
+      mockGetCurrentBranch.mockResolvedValue(null);
+      mockGt.queryBranchData.mockResolvedValue({
+        branches: [],
+        defaultBranch,
+      });
+
+      const step = new BranchStep(mockGt as any, makeSettings());
+      const result = await step.run();
+
+      expect(result?.currentBranch).toEqual(defaultBranch);
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('auto-detection failed')
+      );
+    });
+  });
+
+  describe('git detection fails, VERCEL_GIT_COMMIT_REF set', () => {
+    it('should use the Vercel env var branch', async () => {
+      process.env.VERCEL_GIT_COMMIT_REF = 'feature-x';
+      mockGetCurrentBranch.mockResolvedValue(null);
+      mockGt.queryBranchData.mockResolvedValue({
+        branches: [featureBranch],
+        defaultBranch,
+      });
+
+      const step = new BranchStep(mockGt as any, makeSettings());
+      const result = await step.run();
+
+      expect(result?.currentBranch).toEqual(featureBranch);
+    });
+
+    it('should set checkedOutBranch to default for non-default Vercel branch', async () => {
+      process.env.VERCEL_GIT_COMMIT_REF = 'feature-x';
+      mockGetCurrentBranch.mockResolvedValue(null);
+      mockGt.queryBranchData.mockResolvedValue({
+        branches: [featureBranch],
+        defaultBranch,
+      });
+
+      const step = new BranchStep(mockGt as any, makeSettings());
+      const result = await step.run();
+
+      expect(result?.checkedOutBranch).toEqual(defaultBranch);
+    });
+  });
+
+  describe('git detection fails, --branch specified', () => {
+    it('should use the manual branch', async () => {
+      mockGetCurrentBranch.mockResolvedValue(null);
+      mockGt.queryBranchData.mockResolvedValue({
+        branches: [featureBranch],
+        defaultBranch,
+      });
+
+      const step = new BranchStep(
+        mockGt as any,
+        makeSettings({ currentBranch: 'feature-x' })
+      );
+      const result = await step.run();
+
+      expect(result?.currentBranch).toEqual(featureBranch);
+    });
+
+    it('should set checkedOutBranch to default', async () => {
+      mockGetCurrentBranch.mockResolvedValue(null);
+      mockGt.queryBranchData.mockResolvedValue({
+        branches: [featureBranch],
+        defaultBranch,
+      });
+
+      const step = new BranchStep(
+        mockGt as any,
+        makeSettings({ currentBranch: 'feature-x' })
+      );
+      const result = await step.run();
+
+      expect(result?.checkedOutBranch).toEqual(defaultBranch);
+    });
+  });
+
+  describe('auto-detect disabled, --branch specified', () => {
+    it('should use the manual branch and set checkedOutBranch to default', async () => {
+      mockGt.queryBranchData.mockResolvedValue({
+        branches: [featureBranch],
+        defaultBranch,
+      });
+
+      const step = new BranchStep(
+        mockGt as any,
+        makeSettings({ autoDetectBranches: false, currentBranch: 'feature-x' })
+      );
+      const result = await step.run();
+
+      expect(result?.currentBranch).toEqual(featureBranch);
+      expect(result?.checkedOutBranch).toEqual(defaultBranch);
+      expect(mockGetCurrentBranch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('branching disabled', () => {
+    it('should fall back to default branch', async () => {
+      mockGt.queryBranchData.mockResolvedValue({
+        branches: [],
+        defaultBranch,
+      });
+
+      const step = new BranchStep(
+        mockGt as any,
+        makeSettings({ enabled: false })
+      );
+      const result = await step.run();
+
+      expect(result?.currentBranch).toEqual(defaultBranch);
+      expect(mockGetCurrentBranch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('new branch creation', () => {
+    it('should create a new branch when not found on server', async () => {
+      mockGetCurrentBranch.mockResolvedValue({
+        currentBranchName: 'new-branch',
+        defaultBranch: false,
+        defaultBranchName: 'main',
+      });
+      mockGt.queryBranchData.mockResolvedValue({
+        branches: [],
+        defaultBranch,
+      });
+      mockGt.createBranch.mockResolvedValue({
+        branch: { id: 'new-id', name: 'new-branch' },
+      });
+
+      const step = new BranchStep(mockGt as any, makeSettings());
+      const result = await step.run();
+
+      expect(mockGt.createBranch).toHaveBeenCalledWith({
+        branchName: 'new-branch',
+        defaultBranch: false,
+      });
+      expect(result?.currentBranch).toEqual({ id: 'new-id', name: 'new-branch' });
+    });
+  });
+});


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates the CLI branch-resolution workflow to better support Vercel deployments by falling back to `process.env.VERCEL_GIT_COMMIT_REF` when git-based branch auto-detection can’t determine the current branch. It also adds a heuristic to set `checkedOutBranch` to the default branch when branch selection was manual (or auto-detect failed) and no checked-out branch could be determined.

A patch changeset is included for `gtx-cli` to release the fix.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- This PR is safe to merge after fixing a small user-facing logging typo.
- The behavioral change is narrowly scoped to branch detection fallback in non-git environments (Vercel) and a post-resolution heuristic for `checkedOutBranch`. No evidence of new security or correctness regressions was found in the updated control flow, but the introduced warning message typo should be corrected before release.
- packages/cli/src/workflow/BranchStep.ts
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .changeset/lazy-ravens-work.md | Adds a patch changeset for `gtx-cli` describing a fix for Vercel branch detection; no functional code changes. |
| packages/cli/src/workflow/BranchStep.ts | Adds Vercel env var fallback for branch autodetection and a post-processing step to infer `checkedOutBranch` when autodetect is disabled/failed; contains a warning message typo that affects user-facing output. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant CLI as gtx-cli
  participant BranchStep
  participant Git as git helpers
  participant Env as process.env
  participant API as GT API

  CLI->>BranchStep: run()
  BranchStep->>Git: getCurrentBranch(remote)
  BranchStep->>Git: getIncomingBranches(remote)
  BranchStep->>Git: getCheckedOutBranches(remote)
  alt git current branch found
    BranchStep->>API: queryBranchData(branchNames)
  else git current branch missing
    BranchStep->>Env: read VERCEL_GIT_COMMIT_REF
    alt Vercel env var present
      BranchStep->>API: queryBranchData([vercelBranch]+incoming+checkedOut)
    else no env fallback
      BranchStep->>API: queryBranchData(incoming+checkedOut)
      BranchStep->>BranchStep: warn + use default branch
    end
  end

  alt use default branch
    BranchStep->>API: createBranch(defaultBranch=true) if needed
  else use detected/manual branch
    BranchStep->>API: createBranch(defaultBranch=false) if missing
    opt plan doesn't allow branching (403)
      BranchStep->>API: createBranch(defaultBranch=true)
    end
  end

  BranchStep->>BranchStep: resolve incomingBranch/checkedOutBranch
  opt autodetect disabled/failed
    BranchStep->>BranchStep: infer checkedOutBranch = defaultBranch
  end
  BranchStep-->>CLI: BranchData
```
</details>


<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - Remove console.log statements and debug logging from production code before merging. ([source](https://app.greptile.com/review/custom-context?memory=ea076fa4-7856-4d31-9266-35f86e49f4b6))

<!-- /greptile_comment -->