### PR TITLE
F/mint openapi node handling

### DIFF
--- a/.changeset/green-walls-listen.md
+++ b/.changeset/green-walls-listen.md
@@ -1,0 +1,5 @@
+---
+'gtx-cli': patch
+---
+
+Add handling of `openapi` field in group nodes for Mintlify docs

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.6.14';
+export const PACKAGE_VERSION = '2.6.16';

--- a/packages/cli/src/utils/processOpenApi.ts
+++ b/packages/cli/src/utils/processOpenApi.ts
@@ -251,8 +251,25 @@ function rewriteDocsJsonOpenApi(
       nextLocale = node.language;
     }
 
-    if (isRecord(node.openapi) && Array.isArray(node.pages)) {
-      const locale = nextLocale || localeHint || defaultLocale;
+    const locale = nextLocale || localeHint || defaultLocale;
+
+    if (typeof node.openapi === 'string') {
+      const sourceValue = node.openapi;
+      const localizedSource = localizeDocsJsonSpecPath(
+        sourceValue,
+        locale,
+        filePath,
+        specs,
+        fileMappingAbs,
+        fileMappingRel,
+        warnings,
+        configDir
+      );
+      if (localizedSource && localizedSource !== sourceValue) {
+        node.openapi = localizedSource;
+        changed = true;
+      }
+    } else if (isRecord(node.openapi)) {
       const openapiConfig = node.openapi as Record<string, unknown>;
       const sourceValue = openapiConfig.source;
       if (typeof sourceValue === 'string') {
@@ -271,7 +288,9 @@ function rewriteDocsJsonOpenApi(
           changed = true;
         }
       }
+    }
 
+    if (Array.isArray(node.pages)) {
       const pages = node.pages;
       for (let i = 0; i < pages.length; i += 1) {
         const page = pages[i];


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends the CLI’s Mintlify OpenAPI post-processing to also rewrite `docs.json` group nodes where `openapi` is provided as a string (instead of an object with `source`). It adds a regression test for the string-form group nodes and bumps the CLI version + changeset.

The changes integrate into the existing `processOpenApi` flow by expanding `rewriteDocsJsonOpenApi`’s JSON traversal: for each node, it now localizes either `node.openapi` (string) or `node.openapi.source` (object), and continues to strip locale prefixes from `pages` entries.

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

- This PR is not safe to merge until docs.json string `openapi` rewriting is constrained to the intended node types.
- Core behavior change is small and covered by a new test, but the current implementation rewrites any string-valued `openapi` field during JSON traversal, which can corrupt non-group nodes that legitimately use an `openapi` string for other semantics in Mintlify configs.
- packages/cli/src/utils/processOpenApi.ts
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .changeset/green-walls-listen.md | Adds a patch changeset noting Mintlify `openapi` field handling in group nodes. |
| packages/cli/src/generated/version.ts | Bumps generated CLI package version from 2.6.14 to 2.6.16. |
| packages/cli/src/utils/__tests__/processOpenApi.test.ts | Adds a test covering docs.json group nodes where `openapi` is a string; ensures locale-specific spec paths are written for non-default locales. |
| packages/cli/src/utils/processOpenApi.ts | Extends docs.json rewriting to handle group nodes where `openapi` is a string; however, the traversal now rewrites any string `openapi` field regardless of node type, which can corrupt non-group nodes that use `openapi` strings. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant CLI as gtx-cli
  participant FS as FileSystem
  participant POA as processOpenApi
  participant RJ as rewriteDocsJsonOpenApi
  participant LSP as localizeDocsJsonSpecPath

  CLI->>POA: processOpenApi(settings)
  POA->>FS: buildSpecAnalyses(openapi.files)
  POA->>FS: collectDocsJsonTargets(settings.files, fileMapping)
  loop each docs.json target
    POA->>FS: readFile(target.path)
    POA->>RJ: rewriteDocsJsonOpenApi(content, localeHint)
    RJ->>RJ: visitNode(json)
    alt node.openapi is string
      RJ->>LSP: localizeDocsJsonSpecPath(source, locale)
      LSP->>FS: existsSync(localized spec)
      LSP-->>RJ: localized path or original
      RJ-->>RJ: mutate node.openapi
    else node.openapi is object
      RJ->>LSP: localizeDocsJsonSpecPath(openapi.source, locale)
      LSP-->>RJ: localized path or original
      RJ-->>RJ: mutate openapi.source
    end
    opt node.pages exists
      RJ-->>RJ: stripLocaleFromOpenApiPage(pages[i], locale)
    end
    RJ-->>POA: updated content if changed
    POA->>FS: writeFile(target.path)
  end
```
</details>


<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - Remove console.log statements and debug logging from production code before merging. ([source](https://app.greptile.com/review/custom-context?memory=ea076fa4-7856-4d31-9266-35f86e49f4b6))
- Rule from `dashboard` - Move server actions and database-related functions to the 'node' package instead of keeping them in ... ([source](https://app.greptile.com/review/custom-context?memory=c8d8f4ee-3b53-426d-8c49-e9799df196c8))

<!-- /greptile_comment -->