### PR TITLE
A/reexport msg functions gt next server

### DIFF
--- a/.changeset/forty-chicken-buy.md
+++ b/.changeset/forty-chicken-buy.md
@@ -1,0 +1,5 @@
+---
+'gt-next': patch
+---
+
+Re-export msg and related functions from gt-next/server in order to improve dev experience when using getMessages

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -17,7 +17,8 @@
     "@generaltranslation/compiler": "workspace:*",
     "@generaltranslation/next-internal": "workspace:*",
     "generaltranslation": "workspace:*",
-    "gt-react": "workspace:*"
+    "gt-react": "workspace:*",
+    "gt-i18n": "workspace:*"
   },
   "scripts": {
     "patch": "pnpm version patch",

--- a/packages/next/src/server.ts
+++ b/packages/next/src/server.ts
@@ -31,7 +31,14 @@ export function getLocales(): string[] {
   return getI18NConfig().getLocales();
 }
 
-export { msg, decodeMsg, decodeOptions, declareStatic, declareVar, decodeVars } from 'gt-i18n';
+export {
+  msg,
+  decodeMsg,
+  decodeOptions,
+  declareStatic,
+  declareVar,
+  decodeVars,
+} from 'gt-i18n';
 
 export {
   GTProvider,
@@ -43,5 +50,5 @@ export {
   Tx,
   getLocale,
   getRegion,
-  getLocaleDirection
+  getLocaleDirection,
 };

--- a/packages/next/src/server.ts
+++ b/packages/next/src/server.ts
@@ -31,6 +31,8 @@ export function getLocales(): string[] {
   return getI18NConfig().getLocales();
 }
 
+export { msg, decodeMsg, decodeOptions, declareStatic, declareVar, decodeVars } from 'gt-i18n';
+
 export {
   GTProvider,
   T,
@@ -41,5 +43,5 @@ export {
   Tx,
   getLocale,
   getRegion,
-  getLocaleDirection,
+  getLocaleDirection
 };

--- a/packages/next/tsconfig.json
+++ b/packages/next/tsconfig.json
@@ -28,6 +28,9 @@
     },
     {
       "path": "../supported-locales"
+    },
+    {
+      "path": "../i18n"
     }
   ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -505,6 +505,9 @@ importers:
       generaltranslation:
         specifier: workspace:*
         version: link:../core
+      gt-i18n:
+        specifier: workspace:*
+        version: link:../i18n
       gt-react:
         specifier: workspace:*
         version: link:../react


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR improves the `gt-next/server` developer experience by re-exporting `msg` and related helper functions from `gt-i18n`, so consumers can import them directly alongside other server utilities (e.g. `getMessages`). To support this, it adds `gt-i18n` as a `gt-next` dependency and includes `packages/i18n` in the `gt-next` TypeScript project references; the lockfile and a changeset are updated accordingly.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge with minimal risk.
- Changes are limited to adding a dependency and re-exporting already-existing gt-i18n APIs from gt-next/server, plus the required TS project reference and lockfile/changeset updates. No behavioral logic changes or risky runtime paths were introduced.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .changeset/forty-chicken-buy.md | Adds a changeset to publish a gt-next patch for re-exporting msg-related helpers. |
| packages/next/package.json | Adds gt-i18n as a dependency of gt-next so server re-exports can resolve at build/runtime. |
| packages/next/src/server.ts | Re-exports msg/decoder/declare helpers from gt-i18n via gt-next/server for improved DX. |
| packages/next/tsconfig.json | Adds a TypeScript project reference to packages/i18n to support local workspace typechecking/build. |
| pnpm-lock.yaml | Updates lockfile to include gt-i18n workspace dependency for gt-next. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant NextServer as packages/next/src/server.ts
    participant GtNextServer as gt-next/server

    User->>NextServer: import { msg, t, ... }
    NextServer->>GtNextServer: re-export msg, t, related fns
    GtNextServer-->>User: provide translation API
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->