### PR TITLE
cli update-instructions --new flag

### DIFF
--- a/.changeset/strong-dingos-joke.md
+++ b/.changeset/strong-dingos-joke.md
@@ -1,0 +1,5 @@
+---
+'gtx-cli': patch
+---
+
+added flag to update-instructions add comments to ai files even if they weren't there before

--- a/packages/cli/src/cli/base.ts
+++ b/packages/cli/src/cli/base.ts
@@ -625,11 +625,29 @@ See https://generaltranslation.com/en/docs/next/guides/local-tx`
     this.program
       .command('update-instructions')
       .description('Update GT usage instructions in AI agent files')
-      .action(async () => {
-        const agentFiles = findAgentFilesWithInstructions();
+      .option(
+        '--new',
+        'Add instructions to all agent files, even those without existing GT instructions'
+      )
+      .action(async (options: { new?: boolean }) => {
+        const agentFiles = options.new
+          ? findAgentFiles()
+          : findAgentFilesWithInstructions();
+
+        if (
+          options.new &&
+          hasCursorRulesDir() &&
+          !agentFiles.includes(CURSOR_GT_RULES_FILE)
+        ) {
+          agentFiles.push(CURSOR_GT_RULES_FILE);
+        }
 
         if (agentFiles.length === 0) {
-          logger.warn('No agent files with GT instructions found.');
+          logger.warn(
+            options.new
+              ? 'No agent files found. Create a CLAUDE.md or similar agent file first.'
+              : 'No agent files with GT instructions found. Use --new to add instructions to existing agent files.'
+          );
           return;
         }
 


### PR DESCRIPTION
# What
Added a flag to add ai instructions on how to use gt even if there was no instructions there to begin with

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Added a `--new` flag to the `update-instructions` CLI command to enable adding GT usage instructions to all existing agent files, not just those that already contain GT instructions.

**Changes:**
- Added `--new` option to the `update-instructions` command with helpful description
- Modified the command action to conditionally call `findAgentFiles()` (all agent files) or `findAgentFilesWithInstructions()` (only files with existing GT instructions) based on the flag
- Added special handling for `.cursor/rules/gt-i18n.mdc` when `--new` is used and the `.cursor/rules/` directory exists
- Updated warning messages to be context-aware based on whether `--new` flag is used

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge with minimal risk
- The implementation is straightforward and follows existing patterns in the codebase. The change adds an optional flag with clear conditional logic, reuses existing helper functions, and maintains backward compatibility. The error messages are clear and guide users appropriately. No security concerns, breaking changes, or console.log statements were introduced.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .changeset/strong-dingos-joke.md | Added changeset documenting the new `--new` flag for the `update-instructions` command |
| packages/cli/src/cli/base.ts | Added `--new` flag to `update-instructions` command to add GT instructions to all agent files, including those without existing instructions |

</details>


</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->