### PR TITLE
fix: branch fallback behavior

### DIFF
--- a/.changeset/crazy-clocks-slide.md
+++ b/.changeset/crazy-clocks-slide.md
@@ -1,0 +1,5 @@
+---
+'gtx-cli': patch
+---
+
+fix: default branch fallback

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.6.18';
+export const PACKAGE_VERSION = '2.6.19';


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR refines the branch fallback behavior in the CLI's branch resolution workflow. The key changes include:

- Improved initialization of `autoDetectFailed` to correctly track when auto-detection is disabled from the start (not just when it fails at runtime)
- Moved the fallback warning to only display when auto-detection actually fails, preventing spurious warnings when auto-detection is intentionally disabled
- Simplified the `checkedOutBranch` fallback logic to always use the default branch when no checked-out branch is detected, removing complex conditional logic that could lead to inconsistent behavior

These changes align with the existing test suite and improve the user experience by reducing unnecessary warnings while maintaining proper fallback behavior to avoid retranslation.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- This PR is safe to merge with low risk
- The changes simplify complex branching logic and align with existing test coverage. The core logic change (always falling back to default branch for `checkedOutBranch`) is well-commented and appears intentional to avoid retranslation. The warning message placement improvement prevents user confusion. However, the simplified conditional on line 178 removes several checks that may have been defensive - worth verifying this doesn't introduce edge cases not covered by tests.
- Verify that the simplified fallback logic in `packages/cli/src/workflow/BranchStep.ts:177-180` handles all edge cases, particularly when `currentBranch` is the same as `defaultBranch`
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/cli/src/workflow/BranchStep.ts | Refactored branch fallback logic to always use default branch for `checkedOutBranch` when not detected, and improved warning message placement |

</details>


</details>


<sub>Last reviewed commit: eaf6910</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->