### PR TITLE
A/add 419 emoji

### DIFF
--- a/.changeset/clean-pets-bathe.md
+++ b/.changeset/clean-pets-bathe.md
@@ -1,0 +1,5 @@
+---
+'generaltranslation': patch
+---
+
+added custom emoji for 419 region code

--- a/packages/core/src/locales/getLocaleEmoji.ts
+++ b/packages/core/src/locales/getLocaleEmoji.ts
@@ -320,4 +320,5 @@ export const emojis = {
   ZM: '🇿🇲', // Zambia
   ZW: '🇿🇼', // Zimbabwe,
   EU: '🇪🇺', // European Union (EU)
+  419: '🌎' // Latin America
 } as Record<string, string>;

--- a/packages/core/src/locales/getLocaleEmoji.ts
+++ b/packages/core/src/locales/getLocaleEmoji.ts
@@ -320,5 +320,5 @@ export const emojis = {
   ZM: '🇿🇲', // Zambia
   ZW: '🇿🇼', // Zimbabwe,
   EU: '🇪🇺', // European Union (EU)
-  419: '🌎' // Latin America
+  419: '🌎', // Latin America
 } as Record<string, string>;

--- a/packages/core/src/locales/getLocaleEmoji.ts
+++ b/packages/core/src/locales/getLocaleEmoji.ts
@@ -320,5 +320,5 @@ export const emojis = {
   ZM: '🇿🇲', // Zambia
   ZW: '🇿🇼', // Zimbabwe,
   EU: '🇪🇺', // European Union (EU)
-  419: '🌎', // Latin America
+  '419': '🌎', // Latin America
 } as Record<string, string>;


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a globe emoji (🌎) mapping for the UN M.49 region code `419` (Latin America) to the `emojis` lookup table in `getLocaleEmoji.ts`. This enables locales like `es-419` (Latin American Spanish) to resolve to a meaningful emoji instead of falling back to the default globe. The change is minimal and correct — `Intl.Locale('es-419').region` returns the string `"419"`, and JavaScript coerces the numeric object key to a string, so the lookup works as expected.

- Added `419: '🌎'` entry to the `emojis` object for Latin America region code
- Included a changeset for a patch release of `generaltranslation`

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge — it adds a single static data entry with no behavioral risk.
- The change is a one-line addition of a static key-value pair to a data mapping object. It introduces no new logic, no new dependencies, and no changes to control flow. The numeric key coercion behavior is well-defined in JavaScript and confirmed to work correctly with the Intl.Locale API.
- No files require special attention.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/core/src/locales/getLocaleEmoji.ts | Adds a `419: '🌎'` entry to the `emojis` map for the UN M.49 Latin America region code. The numeric key is coerced to a string at runtime, and lookups via `Intl.Locale.region` return `"419"` as a string, so this works correctly. |
| .changeset/clean-pets-bathe.md | Standard changeset file marking a patch release for the `generaltranslation` package. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
flowchart TD
    A["_getLocaleEmoji('es-419')"] --> B["_standardizeLocale('es-419')"]
    B --> C["Intl.Locale('es-419')"]
    C --> D{"region = '419'"}
    D -->|"emojis['419'] exists"| E["Return 🌎"]
    D -->|"No match"| F["maximize() locale"]
    F --> G{"extrapolated region?"}
    G -->|"Found"| H["Return emojis[region]"]
    G -->|"Not found"| I["Return defaultEmoji 🌍"]
```
</details>


<sub>Last reviewed commit: c8be23b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->