### PR TITLE
fix: nb support

### DIFF
--- a/.changeset/better-bees-flash.md
+++ b/.changeset/better-bees-flash.md
@@ -1,0 +1,5 @@
+---
+'@generaltranslation/supported-locales': patch
+---
+
+fix: add nb locale support

--- a/packages/core/src/locales/getLocaleEmoji.ts
+++ b/packages/core/src/locales/getLocaleEmoji.ts
@@ -1,11 +1,10 @@
 import { intlCache } from '../cache/IntlCache';
 import {
   CustomMapping,
-  FullCustomMapping,
   getCustomProperty,
   shouldUseCanonicalLocale,
 } from './customLocaleMapping';
-import { _isValidLocale, _standardizeLocale } from './isValidLocale';
+import { _standardizeLocale } from './isValidLocale';
 
 /**
  * @internal

--- a/packages/supported-locales/src/supportedLocales.ts
+++ b/packages/supported-locales/src/supportedLocales.ts
@@ -100,15 +100,15 @@ const supportedLocales = {
     'nl-NL', // Netherlands
     'nl-BE', // Belgium
   ],
-  no: [
-    // Norwegian
-    'no',
-    'no-NO', // Norway
-  ],
   nb: [
     // Norwegian Bokmål
     'nb',
     'nb-NO', // Norway
+  ],
+  no: [
+    // Norwegian
+    'no',
+    'no-NO', // Norway
   ],
   pa: ['pa'], // Punjabi
   pl: ['pl'], // Polish

--- a/packages/supported-locales/src/supportedLocales.ts
+++ b/packages/supported-locales/src/supportedLocales.ts
@@ -100,7 +100,16 @@ const supportedLocales = {
     'nl-NL', // Netherlands
     'nl-BE', // Belgium
   ],
-  no: ['no'], // Norwegian
+  no: [
+    // Norwegian
+    'no',
+    'no-NO', // Norway
+  ],
+  nb: [
+    // Norwegian Bokmål
+    'nb',
+    'nb-NO', // Norway
+  ],
   pa: ['pa'], // Punjabi
   pl: ['pl'], // Polish
   pt: [


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds support for Norwegian Bokmål (`nb`) locale in the supported locales list, and also expands the existing `no` (Norwegian) entry with an explicit `no-NO` region variant. An additional minor cleanup removes two unused imports (`FullCustomMapping` and `_isValidLocale`) from `getLocaleEmoji.ts` in the core package.

- **`packages/supported-locales/src/supportedLocales.ts`**: Adds `nb: ['nb', 'nb-NO']` as a new top-level language entry and extends `no: ['no']` to include `no-NO`. Both are valid BCP 47 locale codes that resolve correctly via `Intl.Locale`.
- **`packages/core/src/locales/getLocaleEmoji.ts`**: Removes two dead imports (`FullCustomMapping`, `_isValidLocale`) that were imported but never used in this file. This is a no-op cleanup.
- **`.changeset/better-bees-flash.md`**: Bumps `@generaltranslation/supported-locales` as a patch. The `generaltranslation` (core) package is not listed, which is appropriate since its change is a dead-import removal with no behavioral impact.
- Norwegian Nynorsk (`nn`) is not included in this PR; this appears to be an intentional scope decision rather than an error.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge — it adds valid BCP 47 locale entries and removes dead code with no behavioral risk.
- The changes are minimal and well-scoped: adding two locale entries (`nb`, `nb-NO`) that are valid BCP 47 tags and expanding `no-NO` under the existing `no` key. The only other change is removing unused imports in a utility file, which carries zero risk. No logic changes, no API surface changes beyond the supported locale list.
- No files require special attention.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .changeset/better-bees-flash.md | Changeset for @generaltranslation/supported-locales patch bump; correctly documents the nb locale fix but omits a changeset entry for the `generaltranslation` (core) package, which also has a change (unused import cleanup in getLocaleEmoji.ts). Since the core change is a no-op code cleanup with no behavior change, omitting it is likely acceptable. |
| packages/core/src/locales/getLocaleEmoji.ts | Removes two unused imports: `FullCustomMapping` and `_isValidLocale`. Neither symbol appears anywhere in the file body, confirming these are dead imports. Clean, no-behavior-change refactor. |
| packages/supported-locales/src/supportedLocales.ts | Adds Norwegian Bokmål (`nb`, `nb-NO`) as a new entry and expands the existing `no` entry to include `no-NO`. Both locale codes are valid BCP 47 tags. Norwegian Nynorsk (`nn`) is not added in this PR, which may be an intentional scope decision. No logic errors found. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
flowchart TD
    A["Input locale string\n(e.g. 'nb', 'nb-NO', 'no', 'no-NO')"] --> B["isValidLocale(locale)"]
    B -->|Invalid| C["return null"]
    B -->|Valid| D["standardizeLocale(locale)"]
    D --> E["getLocaleProperties(locale)\nextract languageCode"]
    E --> F{"supportedLocales[languageCode]\nexists?"}
    F -->|"No match\n(e.g. languageCode='nb' → before this PR)"| G["return null ❌"]
    F -->|"Match found\n(e.g. languageCode='nb' → after this PR)"| H["Look up exact locales\nunder that language key"]
    H --> I{"Exact or partial\nmatch found?"}
    I -->|Yes| J["return matched locale ✅\n(e.g. 'nb' or 'nb-NO')"]
    I -->|No| K["return null"]

    style G fill:#f99,stroke:#c00
    style J fill:#9f9,stroke:#090
```
</details>


<sub>Last reviewed commit: 5ef3b8d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->