### PR TITLE
fix: temporarily address compatability issues

### DIFF
--- a/.changeset/tame-waves-fold.md
+++ b/.changeset/tame-waves-fold.md
@@ -1,0 +1,5 @@
+---
+'gtx-cli': patch
+---
+
+fix: compatability interface issue with types

--- a/packages/cli/src/functions.ts
+++ b/packages/cli/src/functions.ts
@@ -9,3 +9,13 @@ export type {
   ValidationMessage,
   ValidationLevel,
 } from './translation/validate.js';
+export {
+  Libraries,
+  GTLibrary,
+  InlineLibrary,
+  ReactLibrary,
+  GT_LIBRARIES,
+  INLINE_LIBRARIES,
+  REACT_LIBRARIES,
+  GT_LIBRARIES_UPSTREAM,
+} from './types/libraries.js';

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.6.20';
+export const PACKAGE_VERSION = '2.6.21';

--- a/packages/cli/src/next/parse/wrapContent.ts
+++ b/packages/cli/src/next/parse/wrapContent.ts
@@ -45,7 +45,7 @@ const IMPORT_MAP = {
  */
 export async function wrapContentNext(
   options: WrapOptions,
-  pkg: typeof Libraries.GT_NEXT,
+  pkg: `${typeof Libraries.GT_NEXT}`,
   errors: string[],
   warnings: string[]
 ): Promise<{ filesUpdated: string[] }> {

--- a/packages/cli/src/react/parse/wrapContent.ts
+++ b/packages/cli/src/react/parse/wrapContent.ts
@@ -39,7 +39,7 @@ const IMPORT_MAP = {
  */
 export async function wrapContentReact(
   options: WrapOptions,
-  pkg: typeof Libraries.GT_REACT,
+  pkg: `${typeof Libraries.GT_REACT}`,
   framework: SupportedFrameworks,
   errors: string[],
   warnings: string[]

--- a/packages/cli/src/translation/validate.ts
+++ b/packages/cli/src/translation/validate.ts
@@ -91,13 +91,11 @@ export async function getValidateJson(
   files?: string[]
 ): Promise<ValidationResult> {
   const validatedPkg: Framework =
-    pkg === Libraries.GT_REACT
-      ? Libraries.GT_REACT
-      : pkg === Libraries.GT_NEXT
-        ? Libraries.GT_NEXT
-        : pkg === Libraries.GT_REACT_NATIVE
-          ? Libraries.GT_REACT_NATIVE
-          : pkg;
+    pkg === Libraries.GT_NEXT
+      ? Libraries.GT_NEXT
+      : pkg === Libraries.GT_REACT_NATIVE
+        ? Libraries.GT_REACT_NATIVE
+        : Libraries.GT_REACT;
   const { errors, warnings } = await runValidation(
     settings,
     validatedPkg,

--- a/packages/cli/src/translation/validate.ts
+++ b/packages/cli/src/translation/validate.ts
@@ -6,7 +6,7 @@ import { logger } from '../console/logger.js';
 
 import { createUpdates } from './parse.js';
 import { createInlineUpdates } from '../react/parse/createInlineUpdates.js';
-import { InlineLibrary } from '../types/libraries.js';
+import { InlineLibrary, Libraries } from '../types/libraries.js';
 
 // Types for programmatic validation API
 export type ValidationLevel = 'error' | 'warning';
@@ -83,10 +83,26 @@ function parseFileFromMessage(msg: string): { file: string; message: string } {
  */
 export async function getValidateJson(
   settings: Options & Settings,
-  pkg: Framework,
+  // TODO: fix compatability more generally so do not have to do this
+  pkg:
+    | `${typeof Libraries.GT_REACT}`
+    | `${typeof Libraries.GT_NEXT}`
+    | `${typeof Libraries.GT_REACT_NATIVE}`,
   files?: string[]
 ): Promise<ValidationResult> {
-  const { errors, warnings } = await runValidation(settings, pkg, files);
+  const validatedPkg: Framework =
+    pkg === Libraries.GT_REACT
+      ? Libraries.GT_REACT
+      : pkg === Libraries.GT_NEXT
+        ? Libraries.GT_NEXT
+        : pkg === Libraries.GT_REACT_NATIVE
+          ? Libraries.GT_REACT_NATIVE
+          : pkg;
+  const { errors, warnings } = await runValidation(
+    settings,
+    validatedPkg,
+    files
+  );
 
   const result: ValidationResult = {};
 


### PR DESCRIPTION
refactor of cli from earlier breaks interface due to typing, eventually we want to move locadex-core types over to gtx-cli types, but this is a temporary fix for now

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses TypeScript compatibility issues by changing function parameter types from enum members to string template literals. The main changes include:

- Exports `Libraries` enum and related types from `functions.ts` to make them available to external consumers
- Modifies `wrapContentNext` and `wrapContentReact` to accept string template literal types instead of enum member types
- Adds runtime type conversion in `getValidateJson` to convert string template types back to enum values

The approach is marked as temporary with a TODO comment, indicating this is a workaround rather than a complete solution.

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

- Safe to merge but contains workaround logic that needs follow-up
- The changes successfully address the immediate type compatibility issue by accepting string template literals and converting them at runtime. However, the fallback case in the ternary chain has a type incompatibility that could cause issues if reached, and the PR itself acknowledges this is a temporary fix (TODO comment)
- Pay attention to `packages/cli/src/translation/validate.ts` - the fallback logic needs review
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/cli/src/functions.ts | Exports `Libraries` enum and related types for external consumers |
| packages/cli/src/next/parse/wrapContent.ts | Changes `pkg` parameter type from enum member to string template literal |
| packages/cli/src/react/parse/wrapContent.ts | Changes `pkg` parameter type from enum member to string template literal |
| packages/cli/src/translation/validate.ts | Adds runtime conversion from string template type to enum type with fallback issue |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
flowchart TD
    A[External Consumer] -->|calls| B[getValidateJson]
    B -->|accepts| C["`pkg: string template literal`"]
    C -->|runtime check| D{Match Libraries enum?}
    D -->|GT_REACT| E[Libraries.GT_REACT]
    D -->|GT_NEXT| F[Libraries.GT_NEXT]
    D -->|GT_REACT_NATIVE| G[Libraries.GT_REACT_NATIVE]
    D -->|no match| H[fallback: pkg]
    E --> I[runValidation]
    F --> I
    G --> I
    H -->|type error| I
    I --> J[ValidationResult]
```
</details>


<sub>Last reviewed commit: 123f3d4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->