### PR TITLE
fix: add nn

### DIFF
--- a/.changeset/stupid-turtles-end.md
+++ b/.changeset/stupid-turtles-end.md
@@ -1,0 +1,5 @@
+---
+'@generaltranslation/supported-locales': patch
+---
+
+fix: add nn

--- a/packages/supported-locales/src/supportedLocales.ts
+++ b/packages/supported-locales/src/supportedLocales.ts
@@ -110,6 +110,11 @@ const supportedLocales = {
     'no',
     'no-NO', // Norway
   ],
+  nn: [
+    // Norwegian Nynorsk
+    'nn',
+    'nn-NO', // Norway
+  ],
   pa: ['pa'], // Punjabi
   pl: ['pl'], // Polish
   pt: [


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Norwegian Nynorsk (`nn` and `nn-NO`) as a supported locale in the `@generaltranslation/supported-locales` package. This follows the same pattern as the recently added Norwegian Bokmål (`nb`) entry in PR #1027.

- Adds `nn` key to `supportedLocales` with `'nn'` and `'nn-NO'` variants
- Includes a changeset for a patch version bump
- No issues found — the change is minimal, correct, and follows existing conventions

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge — it's a minimal, additive-only data change with no logic modifications.
- The change only adds a new entry to a static locale map object. It follows the exact same pattern as all other entries in the file. No logic, imports, or control flow are modified. `nn` (Norwegian Nynorsk) is a valid ISO 639-1 language code.
- No files require special attention.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/supported-locales/src/supportedLocales.ts | Adds Norwegian Nynorsk (`nn` and `nn-NO`) to the supported locales map, following the same pattern as existing Norwegian entries (`nb`, `no`). |
| .changeset/stupid-turtles-end.md | Standard changeset file declaring a patch version bump for `@generaltranslation/supported-locales`. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
flowchart TD
    A["User provides locale string<br/>(e.g. 'nn', 'nn-NO')"] --> B["getSupportedLocale()"]
    B --> C["Validate & standardize locale"]
    C --> D["Extract languageCode<br/>(e.g. 'nn')"]
    D --> E{"supportedLocales['nn']<br/>exists?"}
    E -- "Yes (NEW)" --> F["Match against<br/>['nn', 'nn-NO']"]
    F --> G["Return matched locale"]
    E -- "No" --> H["Return null"]
```
</details>


<sub>Last reviewed commit: 5b0b9c9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->