### PR TITLE
fix: remove window.location.reload on locale change

### DIFF
--- a/.changeset/nasty-rocks-switch.md
+++ b/.changeset/nasty-rocks-switch.md
@@ -1,0 +1,6 @@
+---
+'gt-react': patch
+'gt-next': patch
+---
+
+fix: remove window.location.reload on locale change for gt-next

--- a/packages/next/src/provider/ClientProviderWrapper.tsx
+++ b/packages/next/src/provider/ClientProviderWrapper.tsx
@@ -2,7 +2,7 @@
 import { ClientProvider } from 'gt-react/client';
 import { ClientProviderProps } from 'gt-react/internal';
 import { usePathname } from 'next/navigation';
-import { useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { GT, standardizeLocale } from 'generaltranslation';
 import { useRouter } from 'next/navigation';
 
@@ -34,9 +34,9 @@ export default function ClientProviderWrapper(
   /**
    * Reloads server components
    */
-  const reloadServer = () => {
+  const reloadServer = useCallback(() => {
     router.refresh();
-  };
+  }, [router]);
 
   const gt = useMemo(
     () =>

--- a/packages/next/src/provider/ClientProviderWrapper.tsx
+++ b/packages/next/src/provider/ClientProviderWrapper.tsx
@@ -1,21 +1,23 @@
 'use client';
-import { ClientProvider as _ClientProvider } from 'gt-react/client';
+import { ClientProvider } from 'gt-react/client';
 import { ClientProviderProps } from 'gt-react/internal';
 import { usePathname } from 'next/navigation';
 import { useEffect, useMemo } from 'react';
 import { GT, standardizeLocale } from 'generaltranslation';
+import { useRouter } from 'next/navigation';
 
 function extractLocale(pathname: string, gt: GT): string | null {
   const matches = pathname.match(/^\/([^\/]+)(?:\/|$)/);
   return matches ? gt.resolveAliasLocale(matches[1]) : null;
 }
 
-export default function ClientProvider(
-  props: ClientProviderProps & {
+export default function ClientProviderWrapper(
+  props: Omit<ClientProviderProps, 'reloadServer'> & {
     localeRoutingEnabledCookieName: string;
     referrerLocaleCookieName: string;
   }
 ) {
+  const router = useRouter();
   const {
     locale,
     locales,
@@ -28,6 +30,13 @@ export default function ClientProvider(
     runtimeUrl,
     customMapping,
   } = props;
+
+  /**
+   * Reloads server components
+   */
+  const reloadServer = () => {
+    router.refresh();
+  };
 
   const gt = useMemo(
     () =>
@@ -80,7 +89,7 @@ export default function ClientProvider(
         document.cookie = `${localeRoutingEnabledCookieName}=;path=/`;
 
         // reload page
-        window.location.reload();
+        reloadServer();
       }
     }
   }, [
@@ -91,7 +100,8 @@ export default function ClientProvider(
     gtServicesEnabled,
     referrerLocaleCookieName,
     localeRoutingEnabledCookieName,
+    reloadServer,
   ]);
 
-  return <_ClientProvider {...props} />;
+  return <ClientProvider {...props} reloadServer={reloadServer} />;
 }

--- a/packages/next/src/provider/ClientProviderWrapper.tsx
+++ b/packages/next/src/provider/ClientProviderWrapper.tsx
@@ -33,6 +33,7 @@ export default function ClientProviderWrapper(
 
   /**
    * Reloads server components
+   * Must pass as a callback so the refresh function does not lose access to the router instance
    */
   const reloadServer = useCallback(() => {
     router.refresh();

--- a/packages/next/src/provider/GTProvider.tsx
+++ b/packages/next/src/provider/GTProvider.tsx
@@ -5,7 +5,7 @@ import { getLocale } from '../request/getLocale';
 import getDictionary, { getDictionaryEntry } from '../dictionary/getDictionary';
 import { Dictionary, Translations } from 'gt-react/internal';
 import { createDictionarySubsetError } from '../errors/createErrors';
-import ClientProvider from './ClientProviderWrapper';
+import ClientProviderWrapper from './ClientProviderWrapper';
 import { GTProviderProps } from '../utils/types';
 import { getRegion } from '../request/getRegion';
 
@@ -74,7 +74,7 @@ export default async function GTProvider({
   const translations = await cachedTranslationsPromise;
 
   return (
-    <ClientProvider
+    <ClientProviderWrapper
       dictionary={dictionary}
       dictionaryTranslations={dictionaryTranslations}
       translations={translations}
@@ -93,6 +93,6 @@ export default async function GTProvider({
       {...I18NConfig.getClientSideConfig()}
     >
       {children}
-    </ClientProvider>
+    </ClientProviderWrapper>
   );
 }

--- a/packages/react/src/internal.ts
+++ b/packages/react/src/internal.ts
@@ -62,7 +62,6 @@ import {
   CustomLoader,
   _Message,
   _Messages,
-  GTContextType,
   GTProp,
 } from '@generaltranslation/react-core/types';
 
@@ -79,7 +78,6 @@ export type {
   Entry,
   TranslatedChildren,
   Translations,
-  GTContextType,
   ClientProviderProps,
   GTProviderProps,
   DictionaryTranslationOptions,

--- a/packages/react/src/provider/ClientProvider.tsx
+++ b/packages/react/src/provider/ClientProvider.tsx
@@ -42,6 +42,7 @@ export default function ClientProvider({
   environment,
   reloadServer,
 }: ClientProviderProps): React.JSX.Element {
+  const didMount = useRef(false);
   // ----- TRANSLATIONS STATE ----- //
 
   const [translations, setTranslations] = useState<Translations | null>(
@@ -50,13 +51,9 @@ export default function ClientProvider({
   );
 
   // Update the translations object when _translations changes
-  const didMountTranslations = useRef(false);
   useEffect(() => {
     // Skip on mount to avoid an extra set state after first render
-    if (!didMountTranslations.current) {
-      didMountTranslations.current = true;
-      return;
-    }
+    if (!didMount.current) return;
     // Translations must override to avoid situation where we maintain stale dev translations from other languages
     // for example { abc123: '你好!', def456: 'bonjour' }
     setTranslations(_translations);
@@ -90,14 +87,15 @@ export default function ClientProvider({
   const [dictionary, setDictionary] = useState<Dictionary>(_dictionary || {});
 
   // Update the dictionary translations when locale changes (see useEffect for _translations above)
-  const didMountDict = useRef(false);
   useEffect(() => {
-    if (!didMountDict.current) {
-      didMountDict.current = true;
-      return;
-    }
+    if (!didMount.current) return;
     setDictionaryTranslations(_dictionaryTranslations);
   }, [_dictionaryTranslations]);
+
+  useEffect(() => {
+    if (!didMount.current) return;
+    setDictionary(_dictionary);
+  }, [_dictionary]);
 
   // ----- REGION STATE ----- //
 
@@ -225,6 +223,11 @@ export default function ClientProvider({
 
   // Block rendering until all translations are resolved (IF YOU REMOVE THIS YOU WILL BE FIRED)
   const display = !!(!translationRequired || translations) && locale;
+
+  // Update didMount ref
+  useEffect(() => {
+    didMount.current = true;
+  }, []);
 
   return (
     <GTContext.Provider

--- a/packages/react/src/provider/ClientProvider.tsx
+++ b/packages/react/src/provider/ClientProvider.tsx
@@ -50,11 +50,11 @@ export default function ClientProvider({
   );
 
   // Update the translations object when _translations changes
-  const didMount = useRef(false);
+  const didMountTranslations = useRef(false);
   useEffect(() => {
     // Skip on mount to avoid an extra set state after first render
-    if (!didMount.current) {
-      didMount.current = true;
+    if (!didMountTranslations.current) {
+      didMountTranslations.current = true;
       return;
     }
     // Translations must override to avoid situation where we maintain stale dev translations from other languages
@@ -90,8 +90,12 @@ export default function ClientProvider({
   const [dictionary, setDictionary] = useState<Dictionary>(_dictionary || {});
 
   // Update the dictionary translations when locale changes (see useEffect for _translations above)
+  const didMountDict = useRef(false);
   useEffect(() => {
-    if (!didMount.current) return;
+    if (!didMountDict.current) {
+      didMountDict.current = true;
+      return;
+    }
     setDictionaryTranslations(_dictionaryTranslations);
   }, [_dictionaryTranslations]);
 

--- a/packages/react/src/types/config.ts
+++ b/packages/react/src/types/config.ts
@@ -38,6 +38,7 @@ export type ClientProviderProps = {
   regionCookieName?: string;
   customMapping?: CustomMapping;
   environment: 'development' | 'production' | 'test';
+  reloadServer: () => void;
 };
 
 export type GTProviderProps = {


### PR DESCRIPTION
Previously, `<ClientProvider>` used `window.location.reload` as a catch all to prevent drift between `locale` + `translations` on the server and `locale` + `translations` on the client. It was useful because it effectively forces an entire state reset, triggering whenever the locale changed. For example, in `ClientProvider.tsx`, the `translations` object would only sync with the `_translations` parameter passed to `<ClientProvider>` upon initialization:

```tsx
const [translations, setTranslations] = useState(_translations);
```
Instead of checking the `_translations` object for updates, the `<ClientProvider>` would simply just reload the page forcing `translations` to reinitialize.

The issue is that an entire page reload is very much not optimal. Ideally, only server components need to be reloaded, and client components only need a state update and to be passed the corresponding translations from the server.

Two changes were made here:

1. A `useEffect` now checks `_translations` for changes and updates the `translations` object accordingly
2. Switched from `window.location.reload` to a `router.refresh`


This fix was inspired by [this discord message](https://discord.com/channels/1337588892672725085/1337588892672725088/1473551040723947688) from Mark L.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the full page reload (`window.location.reload`) with Next.js's `router.refresh()` when the locale changes, allowing server components to re-render without unmounting client components. The implementation adds `useEffect` hooks to sync translation props with state when they change, ensuring translations stay current without forcing a complete page reload.

**Key changes:**
- Added `useEffect` hooks in `ClientProvider.tsx` to watch for changes in `_translations`, `_dictionaryTranslations`, and `_dictionary` props and update state accordingly
- Replaced `window.location.reload()` with `router.refresh()` in both `ClientProviderWrapper.tsx` and `ClientProvider.tsx`
- Wrapped `reloadServer` callback in `useCallback` to prevent unnecessary re-renders
- Renamed internal component from `ClientProvider` to `ClientProviderWrapper` for clarity
- Added `reloadServer` as a required prop to `ClientProviderProps`

The implementation correctly uses a `didMount` ref guard to prevent unnecessary state updates on initial mount. All `useEffect` hooks check this flag before updating state, and a final effect sets it to `true` after mount completes.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge with minimal risk
- The changes are well-architected and follow established patterns in the codebase. The replacement of `window.location.reload` with `router.refresh()` is a significant improvement that maintains functionality while providing better UX. The `useCallback` wrapper prevents unnecessary re-renders, and the `useEffect` hooks correctly sync prop changes with state. All previous review concerns have been addressed.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/next/src/provider/ClientProviderWrapper.tsx | Wraps `reloadServer` in `useCallback`, replaces `window.location.reload` with `router.refresh()` - clean implementation |
| packages/react/src/provider/ClientProvider.tsx | Adds `useEffect` hooks to sync prop changes with state, replaces `window.location.reload` with `reloadServer()` callback - correct implementation |
| packages/react/src/types/config.ts | Adds required `reloadServer` prop to `ClientProviderProps` - type definition only |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant ClientProvider
    participant ClientProviderWrapper
    participant NextRouter
    participant Server

    User->>ClientProvider: setLocale(newLocale)
    ClientProvider->>ClientProvider: Validate & resolve locale
    ClientProvider->>ClientProvider: Set locale cookie
    ClientProvider->>ClientProvider: _setLocale(newLocale)
    ClientProvider->>ClientProviderWrapper: reloadServer()
    ClientProviderWrapper->>NextRouter: router.refresh()
    NextRouter->>Server: Request server components
    Server-->>NextRouter: Fresh server components with new locale
    NextRouter-->>ClientProviderWrapper: Updated props (_translations, _dictionary)
    
    Note over ClientProvider: useEffect detects _translations change
    ClientProvider->>ClientProvider: setTranslations(_translations)
    
    Note over ClientProvider: useEffect detects _dictionary change
    ClientProvider->>ClientProvider: setDictionary(_dictionary)
    
    Note over ClientProvider: useEffect detects _dictionaryTranslations change
    ClientProvider->>ClientProvider: setDictionaryTranslations(_dictionaryTranslations)
    
    ClientProvider->>User: UI re-renders with new translations
```
</details>


<sub>Last reviewed commit: 581acb9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->