### PR TITLE
chore(core): reduce duplicated code + add retry

### DIFF
--- a/.changeset/seven-sides-refuse.md
+++ b/.changeset/seven-sides-refuse.md
@@ -1,0 +1,6 @@
+---
+'generaltranslation': patch
+'gtx-cli': patch
+---
+
+Modularize API logic; add retry for 5XX errors

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.6.21';
+export const PACKAGE_VERSION = '2.6.22';

--- a/packages/core/src/translate/__tests__/downloadFileBatch.test.ts
+++ b/packages/core/src/translate/__tests__/downloadFileBatch.test.ts
@@ -1,9 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import _downloadFileBatch from '../downloadFileBatch';
-import fetchWithTimeout from '../utils/fetchWithTimeout';
-import validateResponse from '../utils/validateResponse';
-import handleFetchError from '../utils/handleFetchError';
-import generateRequestHeaders from '../utils/generateRequestHeaders';
+import apiRequest from '../utils/apiRequest';
 import { TranslationRequestConfig } from '../../types';
 import {
   DownloadFileBatchOptions,
@@ -11,10 +8,7 @@ import {
   DownloadFileBatchResult,
 } from '../../types-dir/api/downloadFileBatch';
 
-vi.mock('../utils/fetchWithTimeout');
-vi.mock('../utils/validateResponse');
-vi.mock('../utils/handleFetchError');
-vi.mock('../utils/generateRequestHeaders');
+vi.mock('../utils/apiRequest');
 
 describe.sequential('_downloadFileBatch', () => {
   const mockConfig: TranslationRequestConfig = {
@@ -76,20 +70,12 @@ describe.sequential('_downloadFileBatch', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(generateRequestHeaders).mockReturnValue({
-      'Content-Type': 'application/json',
-      'x-gt-api-key': 'test-api-key',
-      'x-gt-project-id': 'test-project',
-    });
   });
 
   it('should download multiple files in batch successfully', async () => {
-    const mockResponse = {
-      json: vi.fn().mockResolvedValue(mockDownloadFileBatchResultBase64),
-    } as unknown as Response;
-
-    vi.mocked(fetchWithTimeout).mockResolvedValue(mockResponse);
-    vi.mocked(validateResponse).mockResolvedValue(undefined);
+    vi.mocked(apiRequest).mockResolvedValue(
+      mockDownloadFileBatchResultBase64
+    );
 
     const files: DownloadFileBatchRequest = [
       { fileId: 'file-1', branchId: 'branch-1', versionId: 'version-1' },
@@ -102,35 +88,26 @@ describe.sequential('_downloadFileBatch', () => {
 
     const result = await _downloadFileBatch(files, options, mockConfig);
 
-    expect(fetchWithTimeout).toHaveBeenCalledWith(
-      'https://api.test.com/v2/project/files/download',
+    expect(apiRequest).toHaveBeenCalledWith(
+      mockConfig,
+      '/v2/project/files/download',
       {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'x-gt-api-key': 'test-api-key',
-          'x-gt-project-id': 'test-project',
-        },
-        body: JSON.stringify([
+        body: [
           { fileId: 'file-1', branchId: 'branch-1', versionId: 'version-1' },
           { fileId: 'file-2', branchId: 'branch-2', versionId: 'version-2' },
-        ]),
-      },
-      5000
+        ],
+        timeout: 5000,
+      }
     );
-    expect(validateResponse).toHaveBeenCalledWith(mockResponse);
     expect(result.data).toEqual(mockDownloadFileBatchResult.files);
     expect(result.count).toBe(2);
     expect(result.batchCount).toBe(1);
   });
 
   it('should handle single file in batch', async () => {
-    const mockResponse = {
-      json: vi.fn().mockResolvedValue(mockDownloadFileBatchResultBase64),
-    } as unknown as Response;
-
-    vi.mocked(fetchWithTimeout).mockResolvedValue(mockResponse);
-    vi.mocked(validateResponse).mockResolvedValue(undefined);
+    vi.mocked(apiRequest).mockResolvedValue(
+      mockDownloadFileBatchResultBase64
+    );
 
     const files: DownloadFileBatchRequest = [
       { fileId: 'file-1', branchId: 'branch-1', versionId: 'version-1' },
@@ -140,26 +117,24 @@ describe.sequential('_downloadFileBatch', () => {
 
     const result = await _downloadFileBatch(files, options, mockConfig);
 
-    expect(fetchWithTimeout).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.objectContaining({
-        body: JSON.stringify([
+    expect(apiRequest).toHaveBeenCalledWith(
+      mockConfig,
+      '/v2/project/files/download',
+      {
+        body: [
           { fileId: 'file-1', branchId: 'branch-1', versionId: 'version-1' },
-        ]),
-      }),
-      60000
+        ],
+        timeout: undefined,
+      }
     );
     expect(result.data).toEqual(mockDownloadFileBatchResult.files);
     expect(result.batchCount).toBe(1);
   });
 
   it('should use default timeout when not specified', async () => {
-    const mockResponse = {
-      json: vi.fn().mockResolvedValue(mockDownloadFileBatchResultBase64),
-    } as unknown as Response;
-
-    vi.mocked(fetchWithTimeout).mockResolvedValue(mockResponse);
-    vi.mocked(validateResponse).mockResolvedValue(undefined);
+    vi.mocked(apiRequest).mockResolvedValue(
+      mockDownloadFileBatchResultBase64
+    );
 
     const files: DownloadFileBatchRequest = [
       { fileId: 'file-1', branchId: 'branch-1', versionId: 'version-1' },
@@ -169,20 +144,17 @@ describe.sequential('_downloadFileBatch', () => {
 
     await _downloadFileBatch(files, options, mockConfig);
 
-    expect(fetchWithTimeout).toHaveBeenCalledWith(
-      expect.any(String),
+    expect(apiRequest).toHaveBeenCalledWith(
       expect.any(Object),
-      60000
+      expect.any(String),
+      expect.objectContaining({ timeout: undefined })
     );
   });
 
-  it('should enforce maximum timeout limit', async () => {
-    const mockResponse = {
-      json: vi.fn().mockResolvedValue(mockDownloadFileBatchResultBase64),
-    } as unknown as Response;
-
-    vi.mocked(fetchWithTimeout).mockResolvedValue(mockResponse);
-    vi.mocked(validateResponse).mockResolvedValue(undefined);
+  it('should respect custom timeout', async () => {
+    vi.mocked(apiRequest).mockResolvedValue(
+      mockDownloadFileBatchResultBase64
+    );
 
     const files: DownloadFileBatchRequest = [
       { fileId: 'file-1', branchId: 'branch-1', versionId: 'version-1' },
@@ -194,20 +166,17 @@ describe.sequential('_downloadFileBatch', () => {
 
     await _downloadFileBatch(files, options, mockConfig);
 
-    expect(fetchWithTimeout).toHaveBeenCalledWith(
-      expect.any(String),
+    expect(apiRequest).toHaveBeenCalledWith(
       expect.any(Object),
-      99999
+      expect.any(String),
+      expect.objectContaining({ timeout: 99999 })
     );
   });
 
   it('should use default URL when baseUrl not provided in config', async () => {
-    const mockResponse = {
-      json: vi.fn().mockResolvedValue(mockDownloadFileBatchResultBase64),
-    } as unknown as Response;
-
-    vi.mocked(fetchWithTimeout).mockResolvedValue(mockResponse);
-    vi.mocked(validateResponse).mockResolvedValue(undefined);
+    vi.mocked(apiRequest).mockResolvedValue(
+      mockDownloadFileBatchResultBase64
+    );
 
     const configWithoutUrl: TranslationRequestConfig = {
       projectId: 'test-project',
@@ -222,19 +191,16 @@ describe.sequential('_downloadFileBatch', () => {
 
     await _downloadFileBatch(files, options, configWithoutUrl);
 
-    expect(fetchWithTimeout).toHaveBeenCalledWith(
-      expect.stringContaining('https://api2.gtx.dev/v2/project/files/download'),
-      expect.any(Object),
-      expect.any(Number)
+    expect(apiRequest).toHaveBeenCalledWith(
+      configWithoutUrl,
+      '/v2/project/files/download',
+      expect.any(Object)
     );
   });
 
-  it('should handle fetch errors through handleFetchError', async () => {
+  it('should handle fetch errors', async () => {
     const fetchError = new Error('Network error');
-    vi.mocked(fetchWithTimeout).mockRejectedValue(fetchError);
-    vi.mocked(handleFetchError).mockImplementation(() => {
-      throw fetchError;
-    });
+    vi.mocked(apiRequest).mockRejectedValue(fetchError);
 
     const files: DownloadFileBatchRequest = [
       { fileId: 'file-1', branchId: 'branch-1', versionId: 'version-1' },
@@ -245,18 +211,10 @@ describe.sequential('_downloadFileBatch', () => {
     await expect(
       _downloadFileBatch(files, options, mockConfig)
     ).rejects.toThrow('Network error');
-    expect(handleFetchError).toHaveBeenCalledWith(fetchError, 60000);
   });
 
   it('should handle validation errors', async () => {
-    const mockResponse = {
-      json: vi.fn().mockResolvedValue(mockDownloadFileBatchResultBase64),
-    } as unknown as Response;
-
-    vi.mocked(fetchWithTimeout).mockResolvedValue(mockResponse);
-    vi.mocked(validateResponse).mockImplementationOnce(() => {
-      throw new Error('Validation failed');
-    });
+    vi.mocked(apiRequest).mockRejectedValue(new Error('Validation failed'));
 
     const files: DownloadFileBatchRequest = [
       { fileId: 'file-1', branchId: 'branch-1', versionId: 'version-1' },
@@ -267,7 +225,6 @@ describe.sequential('_downloadFileBatch', () => {
     await expect(
       _downloadFileBatch(files, options, mockConfig)
     ).rejects.toThrow('Validation failed');
-    expect(validateResponse).toHaveBeenCalledWith(mockResponse);
   });
 
   it('should handle empty files array', async () => {
@@ -275,25 +232,19 @@ describe.sequential('_downloadFileBatch', () => {
 
     const options: DownloadFileBatchOptions = {};
 
-    // Clear mocks before this test to get accurate call count
-    vi.clearAllMocks();
-
     const result = await _downloadFileBatch(files, options, mockConfig);
 
     // With batching, empty array returns early without making any API calls
-    expect(fetchWithTimeout).not.toHaveBeenCalled();
+    expect(apiRequest).not.toHaveBeenCalled();
     expect(result.data).toEqual([]);
     expect(result.count).toBe(0);
     expect(result.batchCount).toBe(0);
   });
 
   it('should include fileIds in request body', async () => {
-    const mockResponse = {
-      json: vi.fn().mockResolvedValue(mockDownloadFileBatchResultBase64),
-    } as unknown as Response;
-
-    vi.mocked(fetchWithTimeout).mockResolvedValue(mockResponse);
-    vi.mocked(validateResponse).mockResolvedValue(undefined);
+    vi.mocked(apiRequest).mockResolvedValue(
+      mockDownloadFileBatchResultBase64
+    );
 
     const files: DownloadFileBatchRequest = [
       { fileId: 'file-1', branchId: 'branch-1', versionId: 'version-1' },
@@ -303,21 +254,21 @@ describe.sequential('_downloadFileBatch', () => {
 
     await _downloadFileBatch(files, options, mockConfig);
 
-    const requestBody = JSON.parse(
-      vi.mocked(fetchWithTimeout).mock.calls[0][1].body as string
+    expect(apiRequest).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.any(String),
+      expect.objectContaining({
+        body: [
+          { fileId: 'file-1', branchId: 'branch-1', versionId: 'version-1' },
+        ],
+      })
     );
-    expect(requestBody).toEqual([
-      { fileId: 'file-1', branchId: 'branch-1', versionId: 'version-1' },
-    ]);
   });
 
   it('should map fileIds correctly in request body', async () => {
-    const mockResponse = {
-      json: vi.fn().mockResolvedValue(mockDownloadFileBatchResultBase64),
-    } as unknown as Response;
-
-    vi.mocked(fetchWithTimeout).mockResolvedValue(mockResponse);
-    vi.mocked(validateResponse).mockResolvedValue(undefined);
+    vi.mocked(apiRequest).mockResolvedValue(
+      mockDownloadFileBatchResultBase64
+    );
 
     const files: DownloadFileBatchRequest = [
       { fileId: 'file-1', branchId: 'branch-1', versionId: 'version-1' },
@@ -328,13 +279,16 @@ describe.sequential('_downloadFileBatch', () => {
 
     await _downloadFileBatch(files, options, mockConfig);
 
-    const requestBody = JSON.parse(
-      vi.mocked(fetchWithTimeout).mock.calls[0][1].body as string
+    expect(apiRequest).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.any(String),
+      expect.objectContaining({
+        body: [
+          { fileId: 'file-1', branchId: 'branch-1', versionId: 'version-1' },
+          { fileId: 'file-2', branchId: 'branch-2', versionId: 'version-2' },
+        ],
+      })
     );
-    expect(requestBody).toEqual([
-      { fileId: 'file-1', branchId: 'branch-1', versionId: 'version-1' },
-      { fileId: 'file-2', branchId: 'branch-2', versionId: 'version-2' },
-    ]);
   });
 
   it('should batch files when downloading more than 100 files', async () => {
@@ -376,35 +330,16 @@ describe.sequential('_downloadFileBatch', () => {
       count: 50,
     };
 
-    const mockFetchResponse1 = {
-      json: vi.fn().mockResolvedValue(mockResponse1),
-    } as unknown as Response;
-
-    const mockFetchResponse2 = {
-      json: vi.fn().mockResolvedValue(mockResponse2),
-    } as unknown as Response;
-
-    vi.mocked(fetchWithTimeout)
-      .mockResolvedValueOnce(mockFetchResponse1)
-      .mockResolvedValueOnce(mockFetchResponse2);
-    vi.mocked(validateResponse).mockResolvedValue(undefined);
+    vi.mocked(apiRequest)
+      .mockResolvedValueOnce(mockResponse1)
+      .mockResolvedValueOnce(mockResponse2);
 
     const options: DownloadFileBatchOptions = {};
 
     const result = await _downloadFileBatch(files, options, mockConfig);
 
     // Should make 2 batch calls
-    expect(fetchWithTimeout).toHaveBeenCalledTimes(2);
-
-    // First call should have 100 files
-    const firstCall = vi.mocked(fetchWithTimeout).mock.calls[0];
-    const firstBody = JSON.parse(firstCall[1]?.body as string);
-    expect(firstBody).toHaveLength(100);
-
-    // Second call should have 50 files
-    const secondCall = vi.mocked(fetchWithTimeout).mock.calls[1];
-    const secondBody = JSON.parse(secondCall[1]?.body as string);
-    expect(secondBody).toHaveLength(50);
+    expect(apiRequest).toHaveBeenCalledTimes(2);
 
     // Result should contain all 150 files
     expect(result.data).toHaveLength(150);

--- a/packages/core/src/translate/__tests__/downloadFileBatch.test.ts
+++ b/packages/core/src/translate/__tests__/downloadFileBatch.test.ts
@@ -73,9 +73,7 @@ describe.sequential('_downloadFileBatch', () => {
   });
 
   it('should download multiple files in batch successfully', async () => {
-    vi.mocked(apiRequest).mockResolvedValue(
-      mockDownloadFileBatchResultBase64
-    );
+    vi.mocked(apiRequest).mockResolvedValue(mockDownloadFileBatchResultBase64);
 
     const files: DownloadFileBatchRequest = [
       { fileId: 'file-1', branchId: 'branch-1', versionId: 'version-1' },
@@ -105,9 +103,7 @@ describe.sequential('_downloadFileBatch', () => {
   });
 
   it('should handle single file in batch', async () => {
-    vi.mocked(apiRequest).mockResolvedValue(
-      mockDownloadFileBatchResultBase64
-    );
+    vi.mocked(apiRequest).mockResolvedValue(mockDownloadFileBatchResultBase64);
 
     const files: DownloadFileBatchRequest = [
       { fileId: 'file-1', branchId: 'branch-1', versionId: 'version-1' },
@@ -132,9 +128,7 @@ describe.sequential('_downloadFileBatch', () => {
   });
 
   it('should use default timeout when not specified', async () => {
-    vi.mocked(apiRequest).mockResolvedValue(
-      mockDownloadFileBatchResultBase64
-    );
+    vi.mocked(apiRequest).mockResolvedValue(mockDownloadFileBatchResultBase64);
 
     const files: DownloadFileBatchRequest = [
       { fileId: 'file-1', branchId: 'branch-1', versionId: 'version-1' },
@@ -152,9 +146,7 @@ describe.sequential('_downloadFileBatch', () => {
   });
 
   it('should respect custom timeout', async () => {
-    vi.mocked(apiRequest).mockResolvedValue(
-      mockDownloadFileBatchResultBase64
-    );
+    vi.mocked(apiRequest).mockResolvedValue(mockDownloadFileBatchResultBase64);
 
     const files: DownloadFileBatchRequest = [
       { fileId: 'file-1', branchId: 'branch-1', versionId: 'version-1' },
@@ -174,9 +166,7 @@ describe.sequential('_downloadFileBatch', () => {
   });
 
   it('should use default URL when baseUrl not provided in config', async () => {
-    vi.mocked(apiRequest).mockResolvedValue(
-      mockDownloadFileBatchResultBase64
-    );
+    vi.mocked(apiRequest).mockResolvedValue(mockDownloadFileBatchResultBase64);
 
     const configWithoutUrl: TranslationRequestConfig = {
       projectId: 'test-project',
@@ -242,9 +232,7 @@ describe.sequential('_downloadFileBatch', () => {
   });
 
   it('should include fileIds in request body', async () => {
-    vi.mocked(apiRequest).mockResolvedValue(
-      mockDownloadFileBatchResultBase64
-    );
+    vi.mocked(apiRequest).mockResolvedValue(mockDownloadFileBatchResultBase64);
 
     const files: DownloadFileBatchRequest = [
       { fileId: 'file-1', branchId: 'branch-1', versionId: 'version-1' },
@@ -266,9 +254,7 @@ describe.sequential('_downloadFileBatch', () => {
   });
 
   it('should map fileIds correctly in request body', async () => {
-    vi.mocked(apiRequest).mockResolvedValue(
-      mockDownloadFileBatchResultBase64
-    );
+    vi.mocked(apiRequest).mockResolvedValue(mockDownloadFileBatchResultBase64);
 
     const files: DownloadFileBatchRequest = [
       { fileId: 'file-1', branchId: 'branch-1', versionId: 'version-1' },

--- a/packages/core/src/translate/__tests__/querySourceFile.test.ts
+++ b/packages/core/src/translate/__tests__/querySourceFile.test.ts
@@ -118,9 +118,7 @@ describe.sequential('_querySourceFile', () => {
 
     expect(apiRequest).toHaveBeenCalledWith(
       configWithoutUrl,
-      expect.stringContaining(
-        '/v2/project/translations/files/status/file-123'
-      ),
+      expect.stringContaining('/v2/project/translations/files/status/file-123'),
       expect.any(Object)
     );
   });

--- a/packages/core/src/translate/__tests__/translate.test.ts
+++ b/packages/core/src/translate/__tests__/translate.test.ts
@@ -1,17 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import _translate from '../translate';
-import fetchWithTimeout from '../utils/fetchWithTimeout';
-import validateResponse from '../utils/validateResponse';
-import handleFetchError from '../utils/handleFetchError';
-import generateRequestHeaders from '../utils/generateRequestHeaders';
+import apiRequest from '../utils/apiRequest';
 import { TranslationRequestConfig, TranslationResult } from '../../types';
 import { Content } from '../../types-dir/jsx/content';
 import { EntryMetadata } from '../../types-dir/api/entry';
 
-vi.mock('../utils/fetchWithTimeout');
-vi.mock('../utils/validateResponse');
-vi.mock('../utils/handleFetchError');
-vi.mock('../utils/generateRequestHeaders');
+vi.mock('../utils/apiRequest');
 
 describe.sequential('_translate', () => {
   const mockConfig: TranslationRequestConfig = {
@@ -32,20 +26,10 @@ describe.sequential('_translate', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(generateRequestHeaders).mockReturnValue({
-      'Content-Type': 'application/json',
-      'x-gt-api-key': 'test-api-key',
-      'x-gt-project-id': 'test-project',
-    });
   });
 
   it('should translate simple string content successfully', async () => {
-    const mockResponse = {
-      json: vi.fn().mockResolvedValue([mockTranslationResult]),
-    } as unknown as Response;
-
-    vi.mocked(fetchWithTimeout).mockResolvedValue(mockResponse);
-    vi.mocked(validateResponse).mockResolvedValue(undefined);
+    vi.mocked(apiRequest).mockResolvedValue([mockTranslationResult]);
 
     const source: Content = 'Hello world';
     const targetLocale = 'es';
@@ -53,34 +37,23 @@ describe.sequential('_translate', () => {
 
     const result = await _translate(source, targetLocale, metadata, mockConfig);
 
-    expect(fetchWithTimeout).toHaveBeenCalledWith(
-      'https://api.test.com/v1/translate/test-project',
+    expect(apiRequest).toHaveBeenCalledWith(
+      mockConfig,
+      '/v1/translate/test-project',
       {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'x-gt-api-key': 'test-api-key',
-          'x-gt-project-id': 'test-project',
-        },
-        body: JSON.stringify({
+        body: {
           requests: [{ source }],
           targetLocale,
           metadata,
-        }),
-      },
-      60000
+        },
+        timeout: undefined,
+      }
     );
-    expect(validateResponse).toHaveBeenCalledWith(mockResponse);
     expect(result).toEqual(mockTranslationResult);
   });
 
   it('should handle complex JSX content', async () => {
-    const mockResponse = {
-      json: vi.fn().mockResolvedValue([mockTranslationResult]),
-    } as unknown as Response;
-
-    vi.mocked(fetchWithTimeout).mockResolvedValue(mockResponse);
-    vi.mocked(validateResponse).mockResolvedValue(undefined);
+    vi.mocked(apiRequest).mockResolvedValue([mockTranslationResult]);
 
     const source: Content = [
       'Welcome ',
@@ -94,109 +67,81 @@ describe.sequential('_translate', () => {
 
     const result = await _translate(source, targetLocale, metadata, mockConfig);
 
-    expect(fetchWithTimeout).toHaveBeenCalledWith(
-      'https://api.test.com/v1/translate/test-project',
+    expect(apiRequest).toHaveBeenCalledWith(
+      mockConfig,
+      '/v1/translate/test-project',
       {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'x-gt-api-key': 'test-api-key',
-          'x-gt-project-id': 'test-project',
-        },
-        body: JSON.stringify({
+        body: {
           requests: [{ source }],
           targetLocale,
           metadata,
-        }),
-      },
-      60000
+        },
+        timeout: undefined,
+      }
     );
     expect(result).toEqual(mockTranslationResult);
   });
 
   it('should use default timeout when not specified', async () => {
-    const mockResponse = {
-      json: vi.fn().mockResolvedValue([mockTranslationResult]),
-    } as unknown as Response;
-
-    vi.mocked(fetchWithTimeout).mockResolvedValue(mockResponse);
-    vi.mocked(validateResponse).mockResolvedValue(undefined);
+    vi.mocked(apiRequest).mockResolvedValue([mockTranslationResult]);
 
     await _translate('Hello', 'es', {}, mockConfig);
 
-    expect(fetchWithTimeout).toHaveBeenCalledWith(
-      expect.any(String),
+    expect(apiRequest).toHaveBeenCalledWith(
       expect.any(Object),
-      60000
+      expect.any(String),
+      expect.objectContaining({ timeout: undefined })
     );
   });
 
   it('should respect custom timeout from metadata', async () => {
-    const mockResponse = {
-      json: vi.fn().mockResolvedValue([mockTranslationResult]),
-    } as unknown as Response;
-
-    vi.mocked(fetchWithTimeout).mockResolvedValue(mockResponse);
-    vi.mocked(validateResponse).mockResolvedValue(undefined);
+    vi.mocked(apiRequest).mockResolvedValue([mockTranslationResult]);
 
     const metadata: EntryMetadata = { timeout: 5000 };
 
     await _translate('Hello', 'es', metadata, mockConfig);
 
-    expect(fetchWithTimeout).toHaveBeenCalledWith(
-      expect.any(String),
+    expect(apiRequest).toHaveBeenCalledWith(
       expect.any(Object),
-      5000
+      expect.any(String),
+      expect.objectContaining({ timeout: 5000 })
     );
   });
 
   it('should enforce maximum timeout limit', async () => {
-    const mockResponse = {
-      json: vi.fn().mockResolvedValue([mockTranslationResult]),
-    } as unknown as Response;
-
-    vi.mocked(fetchWithTimeout).mockResolvedValue(mockResponse);
-    vi.mocked(validateResponse).mockResolvedValue(undefined);
+    vi.mocked(apiRequest).mockResolvedValue([mockTranslationResult]);
 
     const metadata: EntryMetadata = { timeout: 99999 };
 
     await _translate('Hello', 'es', metadata, mockConfig);
 
-    expect(fetchWithTimeout).toHaveBeenCalledWith(
-      expect.any(String),
+    expect(apiRequest).toHaveBeenCalledWith(
       expect.any(Object),
-      99999
+      expect.any(String),
+      expect.objectContaining({ timeout: 99999 })
     );
   });
 
   it('should include sourceLocale in metadata when provided', async () => {
-    const mockResponse = {
-      json: vi.fn().mockResolvedValue([mockTranslationResult]),
-    } as unknown as Response;
-
-    vi.mocked(fetchWithTimeout).mockResolvedValue(mockResponse);
-    vi.mocked(validateResponse).mockResolvedValue(undefined);
+    vi.mocked(apiRequest).mockResolvedValue([mockTranslationResult]);
 
     const metadata: EntryMetadata = { sourceLocale: 'en' };
 
     await _translate('Hello', 'es', metadata, mockConfig);
 
-    expect(fetchWithTimeout).toHaveBeenCalledWith(
-      expect.stringContaining('test-project'),
+    expect(apiRequest).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.any(String),
       expect.objectContaining({
-        body: expect.stringContaining('"sourceLocale":"en"'),
-      }),
-      expect.any(Number)
+        body: expect.objectContaining({
+          metadata: expect.objectContaining({ sourceLocale: 'en' }),
+        }),
+      })
     );
   });
 
   it('should use default URL when baseUrl not provided in config', async () => {
-    const mockResponse = {
-      json: vi.fn().mockResolvedValue([mockTranslationResult]),
-    } as unknown as Response;
-
-    vi.mocked(fetchWithTimeout).mockResolvedValue(mockResponse);
-    vi.mocked(validateResponse).mockResolvedValue(undefined);
+    vi.mocked(apiRequest).mockResolvedValue([mockTranslationResult]);
 
     const configWithoutUrl: TranslationRequestConfig = {
       projectId: 'test-project',
@@ -205,61 +150,41 @@ describe.sequential('_translate', () => {
 
     await _translate('Hello', 'es', {}, configWithoutUrl);
 
-    expect(fetchWithTimeout).toHaveBeenCalledWith(
-      expect.stringContaining(
-        'https://runtime2.gtx.dev/v1/translate/test-project'
-      ),
-      expect.any(Object),
-      expect.any(Number)
+    expect(apiRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ baseUrl: 'https://runtime2.gtx.dev' }),
+      '/v1/translate/test-project',
+      expect.any(Object)
     );
   });
 
-  it('should handle fetch errors through handleFetchError', async () => {
+  it('should handle fetch errors', async () => {
     const fetchError = new Error('Network error');
-    vi.mocked(fetchWithTimeout).mockRejectedValue(fetchError);
-    vi.mocked(handleFetchError).mockImplementation(() => {
-      throw fetchError;
-    });
+    vi.mocked(apiRequest).mockRejectedValue(fetchError);
 
     await expect(_translate('Hello', 'es', {}, mockConfig)).rejects.toThrow(
       'Network error'
     );
-    expect(handleFetchError).toHaveBeenCalledWith(fetchError, 60000);
   });
 
   it('should handle validation errors', async () => {
-    const mockResponse = {
-      json: vi.fn().mockResolvedValue([mockTranslationResult]),
-    } as unknown as Response;
-
-    vi.mocked(fetchWithTimeout).mockResolvedValue(mockResponse);
-    // Use mockImplementationOnce to avoid interfering with other tests
-    vi.mocked(validateResponse).mockImplementationOnce(() => {
-      throw new Error('Validation failed');
-    });
+    vi.mocked(apiRequest).mockRejectedValue(new Error('Validation failed'));
 
     await expect(_translate('Hello', 'es', {}, mockConfig)).rejects.toThrow(
       'Validation failed'
     );
-    expect(validateResponse).toHaveBeenCalledWith(mockResponse);
   });
 
   it('should handle empty metadata', async () => {
-    const mockResponse = {
-      json: vi.fn().mockResolvedValue([mockTranslationResult]),
-    } as unknown as Response;
-
-    vi.mocked(fetchWithTimeout).mockResolvedValue(mockResponse);
-    vi.mocked(validateResponse).mockResolvedValue(undefined);
+    vi.mocked(apiRequest).mockResolvedValue([mockTranslationResult]);
 
     const result = await _translate('Hello', 'es', {}, mockConfig);
 
-    expect(fetchWithTimeout).toHaveBeenCalledWith(
+    expect(apiRequest).toHaveBeenCalledWith(
+      expect.any(Object),
       expect.any(String),
       expect.objectContaining({
-        body: expect.stringContaining('"metadata":'),
-      }),
-      expect.any(Number)
+        body: expect.objectContaining({ metadata: {} }),
+      })
     );
     expect(result).toEqual(mockTranslationResult);
   });

--- a/packages/core/src/translate/__tests__/translate.test.ts
+++ b/packages/core/src/translate/__tests__/translate.test.ts
@@ -47,6 +47,7 @@ describe.sequential('_translate', () => {
           metadata,
         },
         timeout: undefined,
+        retryPolicy: 'none',
       }
     );
     expect(result).toEqual(mockTranslationResult);
@@ -77,6 +78,7 @@ describe.sequential('_translate', () => {
           metadata,
         },
         timeout: undefined,
+        retryPolicy: 'none',
       }
     );
     expect(result).toEqual(mockTranslationResult);

--- a/packages/core/src/translate/__tests__/translateMany.test.ts
+++ b/packages/core/src/translate/__tests__/translateMany.test.ts
@@ -78,6 +78,7 @@ describe.sequential('_translateMany', () => {
           metadata: globalMetadata,
         },
         timeout: undefined,
+        retryPolicy: 'none',
       }
     );
     expect(result).toEqual(mockTranslateManyResult);
@@ -117,6 +118,7 @@ describe.sequential('_translateMany', () => {
           metadata: globalMetadata,
         },
         timeout: undefined,
+        retryPolicy: 'none',
       }
     );
     expect(result).toEqual(mockTranslateManyResult);

--- a/packages/core/src/translate/__tests__/uploadSourceFiles.test.ts
+++ b/packages/core/src/translate/__tests__/uploadSourceFiles.test.ts
@@ -5,15 +5,9 @@ import {
   FileUpload,
   RequiredUploadFilesOptions,
 } from '../../types-dir/api/uploadFiles';
-import fetchWithTimeout from '../utils/fetchWithTimeout';
-import validateResponse from '../utils/validateResponse';
-import handleFetchError from '../utils/handleFetchError';
-import generateRequestHeaders from '../utils/generateRequestHeaders';
+import apiRequest from '../utils/apiRequest';
 
-vi.mock('../utils/fetchWithTimeout');
-vi.mock('../utils/validateResponse');
-vi.mock('../utils/handleFetchError');
-vi.mock('../utils/generateRequestHeaders');
+vi.mock('../utils/apiRequest');
 
 describe.sequential('_uploadSourceFiles', () => {
   const mockConfig: TranslationRequestConfig = {
@@ -42,12 +36,6 @@ describe.sequential('_uploadSourceFiles', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-
-    vi.mocked(generateRequestHeaders).mockReturnValue({
-      'Content-Type': 'application/json',
-      'x-gt-api-key': 'test-api-key',
-      'x-gt-project-id': 'test-project',
-    });
   });
 
   it('should upload source files successfully', async () => {
@@ -65,7 +53,7 @@ describe.sequential('_uploadSourceFiles', () => {
 
     const mockOptions = createMockOptions();
 
-    const mockResponse = {
+    const mockApiResponse = {
       success: true,
       uploadedFiles: [
         {
@@ -77,25 +65,15 @@ describe.sequential('_uploadSourceFiles', () => {
       ],
     };
 
-    const mockFetchResponse = {
-      json: vi.fn().mockResolvedValue(mockResponse),
-    } as unknown as Response;
-
-    vi.mocked(fetchWithTimeout).mockResolvedValue(mockFetchResponse);
-    vi.mocked(validateResponse).mockResolvedValue(undefined);
+    vi.mocked(apiRequest).mockResolvedValue(mockApiResponse);
 
     const result = await _uploadSourceFiles(mockFiles, mockOptions, mockConfig);
 
-    expect(fetchWithTimeout).toHaveBeenCalledWith(
-      'https://api.test.com/v2/project/files/upload-files',
+    expect(apiRequest).toHaveBeenCalledWith(
+      mockConfig,
+      '/v2/project/files/upload-files',
       {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'x-gt-api-key': 'test-api-key',
-          'x-gt-project-id': 'test-project',
-        },
-        body: JSON.stringify({
+        body: {
           data: [
             {
               source: {
@@ -115,13 +93,12 @@ describe.sequential('_uploadSourceFiles', () => {
             },
           ],
           sourceLocale: 'en',
-        }),
-      },
-      60000
+        },
+        timeout: 60000,
+      }
     );
 
-    expect(validateResponse).toHaveBeenCalledWith(mockFetchResponse);
-    expect(result.data).toEqual(mockResponse.uploadedFiles);
+    expect(result.data).toEqual(mockApiResponse.uploadedFiles);
     expect(result.count).toBe(2);
     expect(result.batchCount).toBe(1);
   });
@@ -135,19 +112,14 @@ describe.sequential('_uploadSourceFiles', () => {
 
     const mockOptions = createMockOptions();
 
-    const mockResponse = {
+    const mockApiResponse = {
       success: true,
       uploadedFiles: [
         { fileId: 'file-123', versionId: 'version-456', fileName: 'test.json' },
       ],
     };
 
-    const mockFetchResponse = {
-      json: vi.fn().mockResolvedValue(mockResponse),
-    } as unknown as Response;
-
-    vi.mocked(fetchWithTimeout).mockResolvedValue(mockFetchResponse);
-    vi.mocked(validateResponse).mockResolvedValue(undefined);
+    vi.mocked(apiRequest).mockResolvedValue(mockApiResponse);
 
     const result = await _uploadSourceFiles(mockFiles, mockOptions, mockConfig);
 
@@ -171,23 +143,17 @@ describe.sequential('_uploadSourceFiles', () => {
 
     const mockOptions = createMockOptions();
 
-    const mockResponse = { success: true };
+    const mockApiResponse = { success: true };
 
-    const mockFetchResponse = {
-      json: vi.fn().mockResolvedValue(mockResponse),
-    } as unknown as Response;
-
-    vi.mocked(fetchWithTimeout).mockResolvedValue(mockFetchResponse);
-    vi.mocked(validateResponse).mockResolvedValue(undefined);
+    vi.mocked(apiRequest).mockResolvedValue(mockApiResponse);
 
     await _uploadSourceFiles(mockFiles, mockOptions, mockConfig);
 
-    expect(fetchWithTimeout).toHaveBeenCalledWith(
+    expect(apiRequest).toHaveBeenCalledWith(
+      expect.any(Object),
       expect.any(String),
-      {
-        method: 'POST',
-        headers: expect.any(Object),
-        body: JSON.stringify({
+      expect.objectContaining({
+        body: {
           data: [
             {
               source: {
@@ -207,9 +173,8 @@ describe.sequential('_uploadSourceFiles', () => {
             },
           ],
           sourceLocale: 'en',
-        }),
-      },
-      expect.any(Number)
+        },
+      })
     );
   });
 
@@ -233,23 +198,17 @@ describe.sequential('_uploadSourceFiles', () => {
 
     const mockOptions = createMockOptions();
 
-    const mockResponse = { success: true };
+    const mockApiResponse = { success: true };
 
-    const mockFetchResponse = {
-      json: vi.fn().mockResolvedValue(mockResponse),
-    } as unknown as Response;
-
-    vi.mocked(fetchWithTimeout).mockResolvedValue(mockFetchResponse);
-    vi.mocked(validateResponse).mockResolvedValue(undefined);
+    vi.mocked(apiRequest).mockResolvedValue(mockApiResponse);
 
     await _uploadSourceFiles(mockFiles, mockOptions, mockConfig);
 
-    expect(fetchWithTimeout).toHaveBeenCalledWith(
+    expect(apiRequest).toHaveBeenCalledWith(
+      expect.any(Object),
       expect.any(String),
-      {
-        method: 'POST',
-        headers: expect.any(Object),
-        body: JSON.stringify({
+      expect.objectContaining({
+        body: {
           data: [
             {
               source: {
@@ -271,9 +230,8 @@ describe.sequential('_uploadSourceFiles', () => {
             },
           ],
           sourceLocale: 'en',
-        }),
-      },
-      expect.any(Number)
+        },
+      })
     );
   });
 
@@ -281,42 +239,31 @@ describe.sequential('_uploadSourceFiles', () => {
     const mockFiles = [{ source: createMockFileUpload() }];
     const mockOptions = createMockOptions({ timeout: 30000 });
 
-    const mockResponse = { success: true };
-    const mockFetchResponse = {
-      json: vi.fn().mockResolvedValue(mockResponse),
-    } as unknown as Response;
-
-    vi.mocked(fetchWithTimeout).mockResolvedValue(mockFetchResponse);
-    vi.mocked(validateResponse).mockResolvedValue(undefined);
+    const mockApiResponse = { success: true };
+    vi.mocked(apiRequest).mockResolvedValue(mockApiResponse);
 
     await _uploadSourceFiles(mockFiles, mockOptions, mockConfig);
 
-    expect(fetchWithTimeout).toHaveBeenCalledWith(
-      expect.any(String),
+    expect(apiRequest).toHaveBeenCalledWith(
       expect.any(Object),
-      30000
+      expect.any(String),
+      expect.objectContaining({ timeout: 30000 })
     );
   });
 
-  it('should limit timeout to defaultTimeout', async () => {
+  it('should pass through large timeout values', async () => {
     const mockFiles = [{ source: createMockFileUpload() }];
-    const mockOptions = createMockOptions({ timeout: 1000000 }); // Very large timeout
+    const mockOptions = createMockOptions({ timeout: 1000000 });
 
-    const mockResponse = { success: true };
-    const mockFetchResponse = {
-      json: vi.fn().mockResolvedValue(mockResponse),
-    } as unknown as Response;
-
-    vi.mocked(fetchWithTimeout).mockResolvedValue(mockFetchResponse);
-    vi.mocked(validateResponse).mockResolvedValue(undefined);
+    const mockApiResponse = { success: true };
+    vi.mocked(apiRequest).mockResolvedValue(mockApiResponse);
 
     await _uploadSourceFiles(mockFiles, mockOptions, mockConfig);
 
-    // Should use defaultTimeout (60000) instead of the large provided timeout
-    expect(fetchWithTimeout).toHaveBeenCalledWith(
-      expect.any(String),
+    expect(apiRequest).toHaveBeenCalledWith(
       expect.any(Object),
-      1000000
+      expect.any(String),
+      expect.objectContaining({ timeout: 1000000 })
     );
   });
 
@@ -325,16 +272,11 @@ describe.sequential('_uploadSourceFiles', () => {
     const mockOptions = createMockOptions();
 
     const fetchError = new Error('Network error');
-    vi.mocked(fetchWithTimeout).mockRejectedValue(fetchError);
-    vi.mocked(handleFetchError).mockImplementation(() => {
-      throw fetchError;
-    });
+    vi.mocked(apiRequest).mockRejectedValue(fetchError);
 
     await expect(
       _uploadSourceFiles(mockFiles, mockOptions, mockConfig)
     ).rejects.toThrow('Network error');
-
-    expect(handleFetchError).toHaveBeenCalledWith(fetchError, 60000);
   });
 
   it('should use default base URL when not provided', async () => {
@@ -346,21 +288,15 @@ describe.sequential('_uploadSourceFiles', () => {
     const mockFiles = [{ source: createMockFileUpload() }];
     const mockOptions = createMockOptions();
 
-    const mockResponse = { success: true, uploadedFiles: [] };
-
-    const mockFetchResponse = {
-      json: vi.fn().mockResolvedValue(mockResponse),
-    } as unknown as Response;
-
-    vi.mocked(fetchWithTimeout).mockResolvedValue(mockFetchResponse);
-    vi.mocked(validateResponse).mockResolvedValue(undefined);
+    const mockApiResponse = { success: true, uploadedFiles: [] };
+    vi.mocked(apiRequest).mockResolvedValue(mockApiResponse);
 
     await _uploadSourceFiles(mockFiles, mockOptions, configWithoutBaseUrl);
 
-    expect(fetchWithTimeout).toHaveBeenCalledWith(
-      expect.stringContaining('api2.gtx.dev/v2/project/files/upload-files'),
-      expect.any(Object),
-      expect.any(Number)
+    expect(apiRequest).toHaveBeenCalledWith(
+      configWithoutBaseUrl,
+      '/v2/project/files/upload-files',
+      expect.any(Object)
     );
   });
 
@@ -371,7 +307,7 @@ describe.sequential('_uploadSourceFiles', () => {
     const result = await _uploadSourceFiles(mockFiles, mockOptions, mockConfig);
 
     // With batching, empty array returns early without making any API calls
-    expect(fetchWithTimeout).not.toHaveBeenCalled();
+    expect(apiRequest).not.toHaveBeenCalled();
     expect(result.data).toEqual([]);
     expect(result.count).toBe(0);
     expect(result.batchCount).toBe(0);
@@ -381,22 +317,16 @@ describe.sequential('_uploadSourceFiles', () => {
     const mockFiles = [{ source: createMockFileUpload({ locale: 'es' }) }];
     const mockOptions = createMockOptions({ sourceLocale: 'es' });
 
-    const mockResponse = { success: true };
-    const mockFetchResponse = {
-      json: vi.fn().mockResolvedValue(mockResponse),
-    } as unknown as Response;
-
-    vi.mocked(fetchWithTimeout).mockResolvedValue(mockFetchResponse);
-    vi.mocked(validateResponse).mockResolvedValue(undefined);
+    const mockApiResponse = { success: true };
+    vi.mocked(apiRequest).mockResolvedValue(mockApiResponse);
 
     await _uploadSourceFiles(mockFiles, mockOptions, mockConfig);
 
-    expect(fetchWithTimeout).toHaveBeenCalledWith(
+    expect(apiRequest).toHaveBeenCalledWith(
+      expect.any(Object),
       expect.any(String),
-      {
-        method: 'POST',
-        headers: expect.any(Object),
-        body: JSON.stringify({
+      expect.objectContaining({
+        body: {
           data: [
             {
               source: {
@@ -408,9 +338,8 @@ describe.sequential('_uploadSourceFiles', () => {
             },
           ],
           sourceLocale: 'es',
-        }),
-      },
-      expect.any(Number)
+        },
+      })
     );
   });
 
@@ -440,33 +369,14 @@ describe.sequential('_uploadSourceFiles', () => {
       })),
     };
 
-    const mockFetchResponse1 = {
-      json: vi.fn().mockResolvedValue(mockResponse1),
-    } as unknown as Response;
-
-    const mockFetchResponse2 = {
-      json: vi.fn().mockResolvedValue(mockResponse2),
-    } as unknown as Response;
-
-    vi.mocked(fetchWithTimeout)
-      .mockResolvedValueOnce(mockFetchResponse1)
-      .mockResolvedValueOnce(mockFetchResponse2);
-    vi.mocked(validateResponse).mockResolvedValue(undefined);
+    vi.mocked(apiRequest)
+      .mockResolvedValueOnce(mockResponse1)
+      .mockResolvedValueOnce(mockResponse2);
 
     const result = await _uploadSourceFiles(mockFiles, mockOptions, mockConfig);
 
     // Should make 2 batch calls
-    expect(fetchWithTimeout).toHaveBeenCalledTimes(2);
-
-    // First call should have 100 files
-    const firstCall = vi.mocked(fetchWithTimeout).mock.calls[0];
-    const firstBody = JSON.parse(firstCall[1]?.body as string);
-    expect(firstBody.data).toHaveLength(100);
-
-    // Second call should have 50 files
-    const secondCall = vi.mocked(fetchWithTimeout).mock.calls[1];
-    const secondBody = JSON.parse(secondCall[1]?.body as string);
-    expect(secondBody.data).toHaveLength(50);
+    expect(apiRequest).toHaveBeenCalledTimes(2);
 
     // Result should contain all 150 files
     expect(result.data).toHaveLength(150);

--- a/packages/core/src/translate/api.ts
+++ b/packages/core/src/translate/api.ts
@@ -1,1 +1,1 @@
-export const API_VERSION = '2025-11-03.v1';
+export const API_VERSION = '2026-02-18.v1';

--- a/packages/core/src/translate/checkJobStatus.ts
+++ b/packages/core/src/translate/checkJobStatus.ts
@@ -1,10 +1,5 @@
 import { TranslationRequestConfig } from '../types';
-import { defaultBaseUrl } from '../settings/settingsUrls';
-import fetchWithTimeout from './utils/fetchWithTimeout';
-import { defaultTimeout } from '../settings/settings';
-import validateResponse from './utils/validateResponse';
-import handleFetchError from './utils/handleFetchError';
-import generateRequestHeaders from './utils/generateRequestHeaders';
+import apiRequest from './utils/apiRequest';
 
 export type JobStatus =
   | 'queued'
@@ -32,24 +27,8 @@ export async function _checkJobStatus(
   config: TranslationRequestConfig,
   timeoutMs?: number
 ): Promise<CheckJobStatusResult> {
-  const timeout = timeoutMs ? timeoutMs : defaultTimeout;
-  const url = `${config.baseUrl || defaultBaseUrl}/v2/project/jobs/info`;
-
-  let response: Response;
-  try {
-    response = await fetchWithTimeout(
-      url,
-      {
-        method: 'POST',
-        headers: generateRequestHeaders(config),
-        body: JSON.stringify({ jobIds }),
-      },
-      timeout
-    );
-  } catch (error) {
-    handleFetchError(error, timeout);
-  }
-
-  await validateResponse(response);
-  return (await response.json()) as CheckJobStatusResult;
+  return apiRequest<CheckJobStatusResult>(config, '/v2/project/jobs/info', {
+    body: { jobIds },
+    timeout: timeoutMs,
+  });
 }

--- a/packages/core/src/translate/createBranch.ts
+++ b/packages/core/src/translate/createBranch.ts
@@ -1,10 +1,5 @@
-import { defaultBaseUrl } from '../settings/settingsUrls';
-import fetchWithTimeout from './utils/fetchWithTimeout';
-import { defaultTimeout } from '../settings/settings';
-import validateResponse from './utils/validateResponse';
-import handleFetchError from './utils/handleFetchError';
 import { TranslationRequestConfig } from '../types';
-import generateRequestHeaders from './utils/generateRequestHeaders';
+import apiRequest from './utils/apiRequest';
 
 export type CreateBranchQuery = {
   branchName: string;
@@ -26,29 +21,7 @@ export default async function _createBranch(
   query: CreateBranchQuery,
   config: TranslationRequestConfig
 ): Promise<CreateBranchResult> {
-  const timeout = defaultTimeout;
-  const url = `${config.baseUrl || defaultBaseUrl}/v2/project/branches/create`;
-
-  // Request the creation of the branch
-  let response;
-  try {
-    response = await fetchWithTimeout(
-      url,
-      {
-        method: 'POST',
-        headers: generateRequestHeaders(config),
-        body: JSON.stringify(query),
-      },
-      timeout
-    );
-  } catch (error) {
-    handleFetchError(error, timeout);
-  }
-
-  // Validate response
-  await validateResponse(response);
-
-  // Parse response
-  const result = await response.json();
-  return result as CreateBranchResult;
+  return apiRequest<CreateBranchResult>(config, '/v2/project/branches/create', {
+    body: query,
+  });
 }

--- a/packages/core/src/translate/queryBranchData.ts
+++ b/packages/core/src/translate/queryBranchData.ts
@@ -1,10 +1,5 @@
-import { defaultBaseUrl } from '../settings/settingsUrls';
-import fetchWithTimeout from './utils/fetchWithTimeout';
-import { defaultTimeout } from '../settings/settings';
-import validateResponse from './utils/validateResponse';
-import handleFetchError from './utils/handleFetchError';
 import { TranslationRequestConfig } from '../types';
-import generateRequestHeaders from './utils/generateRequestHeaders';
+import apiRequest from './utils/apiRequest';
 import type { BranchDataResult } from '../types-dir/api/branch';
 
 export type BranchQuery = {
@@ -22,29 +17,7 @@ export default async function _queryBranchData(
   query: BranchQuery,
   config: TranslationRequestConfig
 ): Promise<BranchDataResult> {
-  const timeout = defaultTimeout;
-  const url = `${config.baseUrl || defaultBaseUrl}/v2/project/branches/info`;
-
-  // Request the branch data
-  let response;
-  try {
-    response = await fetchWithTimeout(
-      url,
-      {
-        method: 'POST',
-        headers: generateRequestHeaders(config),
-        body: JSON.stringify(query),
-      },
-      timeout
-    );
-  } catch (error) {
-    handleFetchError(error, timeout);
-  }
-
-  // Validate response
-  await validateResponse(response);
-
-  // Parse response
-  const result = await response.json();
-  return result as BranchDataResult;
+  return apiRequest<BranchDataResult>(config, '/v2/project/branches/info', {
+    body: query,
+  });
 }

--- a/packages/core/src/translate/queryFileData.ts
+++ b/packages/core/src/translate/queryFileData.ts
@@ -1,11 +1,6 @@
-import { defaultBaseUrl } from '../settings/settingsUrls';
-import fetchWithTimeout from './utils/fetchWithTimeout';
-import { defaultTimeout } from '../settings/settings';
-import validateResponse from './utils/validateResponse';
-import handleFetchError from './utils/handleFetchError';
 import { TranslationRequestConfig } from '../types';
 import { CheckFileTranslationsOptions } from '../types-dir/api/checkFileTranslations';
-import generateRequestHeaders from './utils/generateRequestHeaders';
+import apiRequest from './utils/apiRequest';
 
 export type FileDataQuery = {
   sourceFiles?: {
@@ -64,9 +59,6 @@ export default async function _queryFileData(
   options: CheckFileTranslationsOptions = {},
   config: TranslationRequestConfig
 ): Promise<FileDataResult> {
-  const timeout = options.timeout ? options.timeout : defaultTimeout;
-  const url = `${config.baseUrl || defaultBaseUrl}/v2/project/files/info`;
-
   const body = {
     sourceFiles: data.sourceFiles?.map((item) => ({
       fileId: item.fileId,
@@ -80,26 +72,9 @@ export default async function _queryFileData(
       locale: item.locale,
     })),
   };
-  // Request the file data
-  let response;
-  try {
-    response = await fetchWithTimeout(
-      url,
-      {
-        method: 'POST',
-        headers: generateRequestHeaders(config),
-        body: JSON.stringify(body),
-      },
-      timeout
-    );
-  } catch (error) {
-    handleFetchError(error, timeout);
-  }
 
-  // Validate response
-  await validateResponse(response);
-
-  // Parse response
-  const result = await response.json();
-  return result as FileDataResult;
+  return apiRequest<FileDataResult>(config, '/v2/project/files/info', {
+    body,
+    timeout: options.timeout,
+  });
 }

--- a/packages/core/src/translate/setupProject.ts
+++ b/packages/core/src/translate/setupProject.ts
@@ -1,10 +1,5 @@
 import { TranslationRequestConfig } from '../types';
-import { defaultBaseUrl } from '../settings/settingsUrls';
-import fetchWithTimeout from './utils/fetchWithTimeout';
-import { defaultTimeout } from '../settings/settings';
-import validateResponse from './utils/validateResponse';
-import handleFetchError from './utils/handleFetchError';
-import generateRequestHeaders from './utils/generateRequestHeaders';
+import apiRequest from './utils/apiRequest';
 import type { FileReference } from '../types-dir/api/file';
 
 export type SetupProjectResult =
@@ -30,34 +25,16 @@ export default async function _setupProject(
   config: TranslationRequestConfig,
   options?: SetupProjectOptions
 ): Promise<SetupProjectResult> {
-  const timeout = options?.timeoutMs ? options.timeoutMs : defaultTimeout;
-  const url = `${config.baseUrl || defaultBaseUrl}/v2/project/setup/generate`;
-
-  const body = {
-    files: files.map((f) => ({
-      branchId: f.branchId,
-      fileId: f.fileId,
-      versionId: f.versionId,
-    })),
-    locales: options?.locales,
-    force: options?.force,
-  };
-
-  let response;
-  try {
-    response = await fetchWithTimeout(
-      url,
-      {
-        method: 'POST',
-        headers: generateRequestHeaders(config),
-        body: JSON.stringify(body),
-      },
-      timeout
-    );
-  } catch (error) {
-    handleFetchError(error, timeout);
-  }
-
-  await validateResponse(response);
-  return (await response.json()) as SetupProjectResult;
+  return apiRequest<SetupProjectResult>(config, '/v2/project/setup/generate', {
+    body: {
+      files: files.map((f) => ({
+        branchId: f.branchId,
+        fileId: f.fileId,
+        versionId: f.versionId,
+      })),
+      locales: options?.locales,
+      force: options?.force,
+    },
+    timeout: options?.timeoutMs,
+  });
 }

--- a/packages/core/src/translate/translate.ts
+++ b/packages/core/src/translate/translate.ts
@@ -35,6 +35,7 @@ export default async function _translate(
         metadata,
       },
       timeout: metadata.timeout,
+      retryPolicy: 'none',
     }
   );
   return results[0] as TranslationResult | TranslationError;

--- a/packages/core/src/translate/translate.ts
+++ b/packages/core/src/translate/translate.ts
@@ -4,14 +4,9 @@ import {
   TranslationResult,
 } from '../types';
 import { defaultRuntimeApiUrl } from '../settings/settingsUrls';
-import fetchWithTimeout from './utils/fetchWithTimeout';
-import { defaultTimeout } from '../settings/settings';
-
 import { Content } from '../types-dir/jsx/content';
 import { EntryMetadata } from '../types-dir/api/entry';
-import validateResponse from './utils/validateResponse';
-import handleFetchError from './utils/handleFetchError';
-import generateRequestHeaders from './utils/generateRequestHeaders';
+import apiRequest from './utils/apiRequest';
 
 /**
  * @internal
@@ -30,33 +25,17 @@ export default async function _translate(
   metadata: EntryMetadata = {},
   config: TranslationRequestConfig
 ): Promise<TranslationResult | TranslationError> {
-  let response;
-  const timeout = metadata.timeout ? metadata.timeout : defaultTimeout;
-  const url = `${config.baseUrl || defaultRuntimeApiUrl}/v1/translate/${config.projectId}`;
-
-  // Request the translation
-  try {
-    response = await fetchWithTimeout(
-      url,
-      {
-        method: 'POST',
-        headers: generateRequestHeaders(config),
-        body: JSON.stringify({
-          requests: [{ source }],
-          targetLocale,
-          metadata,
-        }),
+  const results = await apiRequest<unknown[]>(
+    { ...config, baseUrl: config.baseUrl || defaultRuntimeApiUrl },
+    `/v1/translate/${config.projectId}`,
+    {
+      body: {
+        requests: [{ source }],
+        targetLocale,
+        metadata,
       },
-      timeout
-    );
-  } catch (error) {
-    handleFetchError(error, timeout);
-  }
-
-  // Validate response
-  await validateResponse(response);
-
-  // Parse the response
-  const results = (await response.json()) as unknown[];
+      timeout: metadata.timeout,
+    }
+  );
   return results[0] as TranslationResult | TranslationError;
 }

--- a/packages/core/src/translate/translateMany.ts
+++ b/packages/core/src/translate/translateMany.ts
@@ -30,6 +30,7 @@ export default async function _translateMany(
         metadata: globalMetadata,
       },
       timeout: globalMetadata.timeout,
+      retryPolicy: 'none',
     }
   );
 }

--- a/packages/core/src/translate/translateMany.ts
+++ b/packages/core/src/translate/translateMany.ts
@@ -1,11 +1,7 @@
 import { TranslationRequestConfig, TranslateManyResult } from '../types';
 import { defaultRuntimeApiUrl } from '../settings/settingsUrls';
-import fetchWithTimeout from './utils/fetchWithTimeout';
-import { defaultTimeout } from '../settings/settings';
 import { Entry, EntryMetadata } from '../types-dir/api/entry';
-import validateResponse from './utils/validateResponse';
-import handleFetchError from './utils/handleFetchError';
-import generateRequestHeaders from './utils/generateRequestHeaders';
+import apiRequest from './utils/apiRequest';
 
 /**
  * @internal
@@ -24,35 +20,16 @@ export default async function _translateMany(
   globalMetadata: { targetLocale: string } & EntryMetadata,
   config: TranslationRequestConfig
 ): Promise<TranslateManyResult> {
-  const timeout = globalMetadata.timeout
-    ? globalMetadata.timeout
-    : defaultTimeout;
-  const url = `${config.baseUrl || defaultRuntimeApiUrl}/v1/translate/${config.projectId}`;
-
-  // Request the translation
-  let response;
-  try {
-    response = await fetchWithTimeout(
-      url,
-      {
-        method: 'POST',
-        headers: generateRequestHeaders(config),
-        body: JSON.stringify({
-          requests,
-          targetLocale: globalMetadata.targetLocale,
-          metadata: globalMetadata,
-        }),
+  return apiRequest<TranslateManyResult>(
+    { ...config, baseUrl: config.baseUrl || defaultRuntimeApiUrl },
+    `/v1/translate/${config.projectId}`,
+    {
+      body: {
+        requests,
+        targetLocale: globalMetadata.targetLocale,
+        metadata: globalMetadata,
       },
-      timeout
-    );
-  } catch (error) {
-    handleFetchError(error, timeout);
-  }
-
-  // Validate response
-  await validateResponse(response);
-
-  // Parse response
-  const results = await response.json();
-  return results as TranslateManyResult;
+      timeout: globalMetadata.timeout,
+    }
+  );
 }

--- a/packages/core/src/translate/utils/__tests__/validateResponse.test.ts
+++ b/packages/core/src/translate/utils/__tests__/validateResponse.test.ts
@@ -34,11 +34,19 @@ describe.sequential('validateResponse', () => {
       ok: false,
       status: 401,
       statusText: 'Unauthorized',
-      json: vi.fn().mockResolvedValue({ error: errorMsg }),
+      text: vi.fn().mockResolvedValue(JSON.stringify({ error: errorMsg })),
     } as unknown as Response;
 
     await expect(validateResponse(mockResponse)).rejects.toThrow(ApiError);
-    await expect(validateResponse(mockResponse)).rejects.toThrow(errorMsg);
+
+    const mockResponse2 = {
+      ok: false,
+      status: 401,
+      statusText: 'Unauthorized',
+      text: vi.fn().mockResolvedValue(JSON.stringify({ error: errorMsg })),
+    } as unknown as Response;
+
+    await expect(validateResponse(mockResponse2)).rejects.toThrow(errorMsg);
     expect(apiError).toHaveBeenCalledWith(401, 'Unauthorized', errorMsg);
   });
 
@@ -49,11 +57,19 @@ describe.sequential('validateResponse', () => {
       ok: false,
       status: 404,
       statusText: 'Not Found',
-      json: vi.fn().mockResolvedValue({ error: errorMsg }),
+      text: vi.fn().mockResolvedValue(JSON.stringify({ error: errorMsg })),
     } as unknown as Response;
 
     await expect(validateResponse(mockResponse)).rejects.toThrow(ApiError);
-    await expect(validateResponse(mockResponse)).rejects.toThrow(errorMsg);
+
+    const mockResponse2 = {
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      text: vi.fn().mockResolvedValue(JSON.stringify({ error: errorMsg })),
+    } as unknown as Response;
+
+    await expect(validateResponse(mockResponse2)).rejects.toThrow(errorMsg);
     expect(apiError).toHaveBeenCalledWith(404, 'Not Found', errorMsg);
   });
 
@@ -64,11 +80,19 @@ describe.sequential('validateResponse', () => {
       ok: false,
       status: 500,
       statusText: 'Internal Server Error',
-      json: vi.fn().mockResolvedValue({ error: errorMsg }),
+      text: vi.fn().mockResolvedValue(JSON.stringify({ error: errorMsg })),
     } as unknown as Response;
 
     await expect(validateResponse(mockResponse)).rejects.toThrow(ApiError);
-    await expect(validateResponse(mockResponse)).rejects.toThrow(errorMsg);
+
+    const mockResponse2 = {
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      text: vi.fn().mockResolvedValue(JSON.stringify({ error: errorMsg })),
+    } as unknown as Response;
+
+    await expect(validateResponse(mockResponse2)).rejects.toThrow(errorMsg);
     expect(apiError).toHaveBeenCalledWith(
       500,
       'Internal Server Error',
@@ -81,21 +105,18 @@ describe.sequential('validateResponse', () => {
       ok: false,
       status: 400,
       statusText: 'Bad Request',
-      json: vi.fn().mockResolvedValue({ error: '' }),
+      text: vi.fn().mockResolvedValue(JSON.stringify({ error: '' })),
     } as unknown as Response;
 
     await expect(validateResponse(mockResponse)).rejects.toThrow(ApiError);
     expect(apiError).toHaveBeenCalledWith(400, 'Bad Request', '');
   });
 
-  it('should handle response.json() rejection', async () => {
+  it('should handle non-JSON response body', async () => {
     const mockResponse = {
       ok: false,
       status: 500,
       statusText: 'Internal Server Error',
-      json: vi
-        .fn()
-        .mockRejectedValue(new Error('Failed to read response body')),
       text: vi.fn().mockResolvedValue('Failed to read response body'),
     } as unknown as Response;
 
@@ -106,6 +127,22 @@ describe.sequential('validateResponse', () => {
       500,
       'Internal Server Error',
       'Failed to read response body'
+    );
+  });
+
+  it('should handle text() rejection', async () => {
+    const mockResponse = {
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      text: vi.fn().mockRejectedValue(new Error('stream error')),
+    } as unknown as Response;
+
+    await expect(validateResponse(mockResponse)).rejects.toThrow(ApiError);
+    expect(apiError).toHaveBeenCalledWith(
+      500,
+      'Internal Server Error',
+      'Unknown error'
     );
   });
 });

--- a/packages/core/src/translate/utils/__tests__/validateResponse.test.ts
+++ b/packages/core/src/translate/utils/__tests__/validateResponse.test.ts
@@ -101,6 +101,10 @@ describe.sequential('validateResponse', () => {
     await expect(validateResponse(mockResponse)).rejects.toThrow(
       'Failed to read response body'
     );
-    expect(apiError).not.toHaveBeenCalled();
+    expect(apiError).toHaveBeenCalledWith(
+      500,
+      'Internal Server Error',
+      'Failed to read response body'
+    );
   });
 });

--- a/packages/core/src/translate/utils/__tests__/validateResponse.test.ts
+++ b/packages/core/src/translate/utils/__tests__/validateResponse.test.ts
@@ -7,15 +7,9 @@ vi.mock('../../../logging/errors', () => ({
   ),
 }));
 
-vi.mock('../../../logging/logger', () => ({
-  fetchLogger: {
-    error: vi.fn(),
-  },
-}));
-
 import validateResponse from '../validateResponse';
 import { apiError } from '../../../logging/errors';
-import { fetchLogger } from '../../../logging/logger';
+import { ApiError } from '../../../errors/ApiError';
 
 describe.sequential('validateResponse', () => {
   beforeEach(() => {
@@ -31,78 +25,75 @@ describe.sequential('validateResponse', () => {
 
     await expect(validateResponse(mockResponse)).resolves.toBeUndefined();
     expect(apiError).not.toHaveBeenCalled();
-    expect(fetchLogger.error).not.toHaveBeenCalled();
   });
 
   it('should throw error for failed response with error text', async () => {
-    const errorText = 'Invalid API key';
-    const expectedErrorMessage =
-      'GT Error: API returned error status. Status: 401, Status Text: Unauthorized, Error: Invalid API key';
+    const errorMsg = 'Invalid API key';
 
     const mockResponse = {
       ok: false,
       status: 401,
       statusText: 'Unauthorized',
-      text: vi.fn().mockResolvedValue(errorText),
+      json: vi.fn().mockResolvedValue({ error: errorMsg }),
     } as unknown as Response;
 
-    await expect(validateResponse(mockResponse)).rejects.toThrow(errorText);
-    expect(mockResponse.text).toHaveBeenCalled();
-    expect(apiError).toHaveBeenCalledWith(401, 'Unauthorized', errorText);
+    await expect(validateResponse(mockResponse)).rejects.toThrow(ApiError);
+    await expect(validateResponse(mockResponse)).rejects.toThrow(errorMsg);
+    expect(apiError).toHaveBeenCalledWith(401, 'Unauthorized', errorMsg);
   });
 
   it('should handle 404 not found errors', async () => {
-    const errorText = 'Project not found';
+    const errorMsg = 'Project not found';
 
     const mockResponse = {
       ok: false,
       status: 404,
       statusText: 'Not Found',
-      text: vi.fn().mockResolvedValue(errorText),
+      json: vi.fn().mockResolvedValue({ error: errorMsg }),
     } as unknown as Response;
 
-    await expect(validateResponse(mockResponse)).rejects.toThrow(errorText);
-    expect(apiError).toHaveBeenCalledWith(404, 'Not Found', errorText);
+    await expect(validateResponse(mockResponse)).rejects.toThrow(ApiError);
+    await expect(validateResponse(mockResponse)).rejects.toThrow(errorMsg);
+    expect(apiError).toHaveBeenCalledWith(404, 'Not Found', errorMsg);
   });
 
   it('should handle 500 server errors', async () => {
-    const errorText = 'Internal server error';
+    const errorMsg = 'Internal server error';
 
     const mockResponse = {
       ok: false,
       status: 500,
       statusText: 'Internal Server Error',
-      text: vi.fn().mockResolvedValue(errorText),
+      json: vi.fn().mockResolvedValue({ error: errorMsg }),
     } as unknown as Response;
 
-    await expect(validateResponse(mockResponse)).rejects.toThrow(errorText);
+    await expect(validateResponse(mockResponse)).rejects.toThrow(ApiError);
+    await expect(validateResponse(mockResponse)).rejects.toThrow(errorMsg);
     expect(apiError).toHaveBeenCalledWith(
       500,
       'Internal Server Error',
-      errorText
+      errorMsg
     );
   });
 
   it('should handle empty error text', async () => {
-    const errorText = '';
-
     const mockResponse = {
       ok: false,
       status: 400,
       statusText: 'Bad Request',
-      text: vi.fn().mockResolvedValue(errorText),
+      json: vi.fn().mockResolvedValue({ error: '' }),
     } as unknown as Response;
 
-    await expect(validateResponse(mockResponse)).rejects.toThrow(errorText);
-    expect(apiError).toHaveBeenCalledWith(400, 'Bad Request', errorText);
+    await expect(validateResponse(mockResponse)).rejects.toThrow(ApiError);
+    expect(apiError).toHaveBeenCalledWith(400, 'Bad Request', '');
   });
 
-  it('should handle response.text() rejection', async () => {
+  it('should handle response.json() rejection', async () => {
     const mockResponse = {
       ok: false,
       status: 500,
       statusText: 'Internal Server Error',
-      text: vi
+      json: vi
         .fn()
         .mockRejectedValue(new Error('Failed to read response body')),
     } as unknown as Response;
@@ -111,6 +102,5 @@ describe.sequential('validateResponse', () => {
       'Failed to read response body'
     );
     expect(apiError).not.toHaveBeenCalled();
-    expect(fetchLogger.error).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/translate/utils/__tests__/validateResponse.test.ts
+++ b/packages/core/src/translate/utils/__tests__/validateResponse.test.ts
@@ -96,6 +96,7 @@ describe.sequential('validateResponse', () => {
       json: vi
         .fn()
         .mockRejectedValue(new Error('Failed to read response body')),
+      text: vi.fn().mockResolvedValue('Failed to read response body'),
     } as unknown as Response;
 
     await expect(validateResponse(mockResponse)).rejects.toThrow(

--- a/packages/core/src/translate/utils/apiRequest.ts
+++ b/packages/core/src/translate/utils/apiRequest.ts
@@ -1,0 +1,71 @@
+import { TranslationRequestConfig } from '../../types';
+import { defaultBaseUrl } from '../../settings/settingsUrls';
+import { defaultTimeout } from '../../settings/settings';
+import fetchWithTimeout from './fetchWithTimeout';
+import validateResponse from './validateResponse';
+import handleFetchError from './handleFetchError';
+import generateRequestHeaders from './generateRequestHeaders';
+
+const MAX_RETRIES = 3;
+const INITIAL_DELAY_MS = 500;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * @internal
+ *
+ * Makes an API request with automatic retry for 5XX errors.
+ *
+ * Encapsulates URL construction, fetch with timeout, error handling,
+ * response validation, and JSON parsing.
+ *
+ * @param config - The configuration for the API call
+ * @param endpoint - The API endpoint path (e.g. '/v2/project/jobs/info')
+ * @param options - Optional request options
+ * @returns The parsed JSON response
+ */
+export default async function apiRequest<T>(
+  config: TranslationRequestConfig,
+  endpoint: string,
+  options?: {
+    body?: unknown;
+    timeout?: number;
+    method?: 'GET' | 'POST';
+  }
+): Promise<T> {
+  const timeout = options?.timeout ?? defaultTimeout;
+  const url = `${config.baseUrl || defaultBaseUrl}${endpoint}`;
+  const method = options?.method ?? 'POST';
+
+  const requestInit: RequestInit = {
+    method,
+    headers: generateRequestHeaders(config),
+  };
+  if (options?.body !== undefined) {
+    requestInit.body = JSON.stringify(options.body);
+  }
+
+  for (let attempt = 0; ; attempt++) {
+    let response: Response;
+    try {
+      response = await fetchWithTimeout(url, requestInit, timeout);
+    } catch (error) {
+      if (attempt < MAX_RETRIES) {
+        await sleep(INITIAL_DELAY_MS * 2 ** attempt);
+        continue;
+      }
+      handleFetchError(error, timeout);
+    }
+
+    // Retry on 5XX server errors
+    if (response!.status >= 500 && attempt < MAX_RETRIES) {
+      await sleep(INITIAL_DELAY_MS * 2 ** attempt);
+      continue;
+    }
+
+    await validateResponse(response!);
+    return (await response!.json()) as T;
+  }
+}

--- a/packages/core/src/translate/utils/apiRequest.ts
+++ b/packages/core/src/translate/utils/apiRequest.ts
@@ -63,7 +63,7 @@ export default async function apiRequest<T>(
     requestInit.body = JSON.stringify(options.body);
   }
 
-  for (let attempt = 0; ; attempt++) {
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
     let response: Response;
     try {
       response = await fetchWithTimeout(url, requestInit, timeout);
@@ -84,4 +84,6 @@ export default async function apiRequest<T>(
     await validateResponse(response!);
     return (await response!.json()) as T;
   }
+
+  throw new Error('Max retries exceeded');
 }

--- a/packages/core/src/translate/utils/validateResponse.ts
+++ b/packages/core/src/translate/utils/validateResponse.ts
@@ -3,8 +3,13 @@ import { ApiError } from '../../errors/ApiError';
 
 export default async function validateResponse(response: Response) {
   if (!response.ok) {
-    const errorJson = (await response.json()) as { error: string };
-    const errorMsg = errorJson.error;
+    let errorMsg = 'Unknown error';
+    try {
+      const errorJson = (await response.json()) as { error: string };
+      errorMsg = errorJson.error;
+    } catch {
+      errorMsg = 'Failed to read response body';
+    }
     const errorMessage = apiError(
       response.status,
       response.statusText,

--- a/packages/core/src/translate/utils/validateResponse.ts
+++ b/packages/core/src/translate/utils/validateResponse.ts
@@ -8,7 +8,7 @@ export default async function validateResponse(response: Response) {
       const errorJson = (await response.json()) as { error: string };
       errorMsg = errorJson.error;
     } catch {
-      errorMsg = 'Failed to read response body';
+      errorMsg = (await response.text()) || 'Unknown error';
     }
     const errorMessage = apiError(
       response.status,

--- a/packages/core/src/translate/utils/validateResponse.ts
+++ b/packages/core/src/translate/utils/validateResponse.ts
@@ -5,10 +5,15 @@ export default async function validateResponse(response: Response) {
   if (!response.ok) {
     let errorMsg = 'Unknown error';
     try {
-      const errorJson = (await response.json()) as { error: string };
-      errorMsg = errorJson.error;
+      const text = await response.text();
+      try {
+        const errorJson = JSON.parse(text) as { error: string };
+        errorMsg = errorJson.error;
+      } catch {
+        errorMsg = text || 'Unknown error';
+      }
     } catch {
-      errorMsg = (await response.text()) || 'Unknown error';
+      // response.text() failed, keep 'Unknown error'
     }
     const errorMessage = apiError(
       response.status,

--- a/packages/core/src/translate/utils/validateResponse.ts
+++ b/packages/core/src/translate/utils/validateResponse.ts
@@ -3,13 +3,14 @@ import { ApiError } from '../../errors/ApiError';
 
 export default async function validateResponse(response: Response) {
   if (!response.ok) {
-    const errorText = await response.text();
+    const errorJson = (await response.json()) as { error: string };
+    const errorMsg = errorJson.error;
     const errorMessage = apiError(
       response.status,
       response.statusText,
-      errorText
+      errorMsg
     );
-    const error = new ApiError(errorMessage, response.status, errorText);
+    const error = new ApiError(errorMessage, response.status, errorMsg);
     throw error;
   }
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a centralized `apiRequest` utility in `packages/core/src/translate/utils/apiRequest.ts` that consolidates duplicated fetch/validate/parse logic across 15+ API endpoint files, reducing the codebase by ~1,080 lines net. The utility adds configurable retry policies (exponential, linear, none) for transient 5XX errors and fetch failures, with real-time translation endpoints (`translate`, `translateMany`) explicitly opting out of retries via `retryPolicy: 'none'`. The `validateResponse` function was also updated to attempt JSON error parsing before falling back to text.

- All project management endpoints (file uploads, branch creation, job status, etc.) now use exponential backoff retry by default (up to 3 retries)
- Real-time translation endpoints correctly disable retries to avoid latency spikes
- Tests were simplified to mock `apiRequest` instead of four separate utilities, reducing test boilerplate significantly
- The new `apiRequest` utility itself has **no dedicated unit tests** — consider adding tests for retry behavior, delay calculations, and error propagation
- API version bumped to `2026-02-18.v1`
- One test bug found: the `validateResponse` test for JSON rejection is missing a `text()` mock, causing a `TypeError` at runtime

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- This PR is a well-executed refactoring that reduces duplication and adds retry resilience, with one failing test to fix before merging.
- The core refactoring is mechanically sound — each endpoint function correctly delegates to apiRequest with the right parameters. The retry logic is well-structured with configurable policies and proper bounds. Score is 4 instead of 5 due to a test bug (missing text() mock in validateResponse test) and the lack of dedicated unit tests for the new apiRequest utility which is now the single most critical function in the API layer.
- packages/core/src/translate/utils/__tests__/validateResponse.test.ts (test bug), packages/core/src/translate/utils/apiRequest.ts (no unit tests for core retry logic)
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/core/src/translate/utils/apiRequest.ts | New centralized API request utility with retry logic (exponential/linear/none), replacing duplicated fetch/validate/parse patterns across 15+ files. Well-structured but has no dedicated unit tests. |
| packages/core/src/translate/utils/validateResponse.ts | Now tries JSON parsing first with text fallback for error messages. The text() fallback in the catch block may fail in practice because response.json() consumes the body stream (discussed in prior review thread). |
| packages/core/src/translate/utils/__tests__/validateResponse.test.ts | Updated tests for new JSON-first error parsing. The "handle response.json() rejection" test case is missing a text() mock, which will cause a TypeError at runtime making the test fail. |
| packages/core/src/translate/translate.ts | Clean refactor to use apiRequest with retryPolicy: 'none' for real-time translation endpoint. Correctly overrides baseUrl to use runtime API URL. |
| packages/core/src/translate/translateMany.ts | Clean refactor to use apiRequest with retryPolicy: 'none'. Correctly sets runtime base URL. |
| packages/core/src/translate/checkJobStatus.ts | Straightforward refactor to apiRequest. Timeout passthrough is correct. |
| packages/core/src/translate/downloadFileBatch.ts | Clean refactor to apiRequest within processBatches callback. Base64 decode logic preserved correctly. |
| packages/core/src/translate/enqueueFiles.ts | Clean refactor to apiRequest within processBatches. Body construction and result mapping preserved correctly. |
| packages/core/src/translate/getOrphanedFiles.ts | Good refactor extracting a makeRequest helper to avoid repetition in the two code paths (empty fileIds vs batched). Logic preserved. |
| packages/core/src/translate/setupProject.ts | Clean refactor to apiRequest. Body construction and timeout passthrough correct. |
| packages/core/src/translate/uploadSourceFiles.ts | Clean refactor to apiRequest within processBatches. Base64 encoding and body construction preserved correctly. |
| packages/core/src/translate/uploadTranslations.ts | Clean refactor to apiRequest within processBatches. No behavioral changes. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[API Endpoint Functions\ntranslate, uploadFiles, checkJobStatus, etc.] --> B[apiRequest]
    B --> C{Construct URL & Headers}
    C --> D[fetchWithTimeout]
    D -->|Success| E{Status >= 500?}
    D -->|Throws| F{Retries left?}
    E -->|Yes| F
    E -->|No| G[validateResponse]
    F -->|Yes| H[sleep with retry delay]
    F -->|No, fetch error| I[handleFetchError → throw]
    F -->|No, 5XX| G
    H --> D
    G -->|response.ok| J[Parse JSON & Return]
    G -->|!response.ok| K[Throw ApiError]
```
</details>


<sub>Last reviewed commit: 2dc366b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->