### PR TITLE
F/composite handling fix

### DIFF
--- a/.changeset/tasty-beans-shout.md
+++ b/.changeset/tasty-beans-shout.md
@@ -1,0 +1,5 @@
+---
+'gtx-cli': patch
+---
+
+Fix: Update composite JSONs when non-translatable content changes, fix bug where `save-local` update composite key index

--- a/packages/cli/src/api/downloadFileBatch.ts
+++ b/packages/cli/src/api/downloadFileBatch.ts
@@ -133,7 +133,12 @@ export async function downloadFileBatch(
           }
         }
 
-        if (!forceDownload && !sourceChanged && fileExists && downloadedVersion) {
+        if (
+          !forceDownload &&
+          !sourceChanged &&
+          fileExists &&
+          downloadedVersion
+        ) {
           result.skipped.push(requestedFile);
           continue;
         }

--- a/packages/cli/src/formats/json/__tests__/extractJson.test.ts
+++ b/packages/cli/src/formats/json/__tests__/extractJson.test.ts
@@ -156,11 +156,11 @@ describe('extractJson', () => {
 
       expect(result).not.toBeNull();
       const parsed = JSON.parse(result!);
-      // Should extract Spanish values at index 1
+      // Should extract Spanish values using default locale's key position (/0)
       expect(parsed['/items']).toBeDefined();
-      expect(parsed['/items']['/1']).toBeDefined();
-      expect(parsed['/items']['/1']['/title']).toBe('Título Español');
-      expect(parsed['/items']['/1']['/desc']).toBe('Descripción Española');
+      expect(parsed['/items']['/0']).toBeDefined();
+      expect(parsed['/items']['/0']['/title']).toBe('Título Español');
+      expect(parsed['/items']['/0']['/desc']).toBe('Descripción Española');
     });
 
     it('should extract array composite values when target locale is at index 0', () => {
@@ -197,11 +197,11 @@ describe('extractJson', () => {
 
       expect(result).not.toBeNull();
       const parsed = JSON.parse(result!);
-      // Should extract Spanish values at index 0
+      // Should extract Spanish values using default locale's key position (/1)
       expect(parsed['/items']).toBeDefined();
-      expect(parsed['/items']['/0']).toBeDefined();
-      expect(parsed['/items']['/0']['/title']).toBe('Título Español');
-      expect(parsed['/items']['/0']['/desc']).toBe('Descripción Española');
+      expect(parsed['/items']['/1']).toBeDefined();
+      expect(parsed['/items']['/1']['/title']).toBe('Título Español');
+      expect(parsed['/items']['/1']['/desc']).toBe('Descripción Española');
     });
 
     it('should extract multiple matching items for same locale', () => {
@@ -236,8 +236,9 @@ describe('extractJson', () => {
 
       expect(result).not.toBeNull();
       const parsed = JSON.parse(result!);
-      expect(parsed['/items']['/1']['/title']).toBe('Título Español 1');
-      expect(parsed['/items']['/3']['/title']).toBe('Título Español 2');
+      // Keys should use default locale positions (/0, /2)
+      expect(parsed['/items']['/0']['/title']).toBe('Título Español 1');
+      expect(parsed['/items']['/2']['/title']).toBe('Título Español 2');
     });
 
     it('should handle nested key paths in array type', () => {
@@ -270,7 +271,8 @@ describe('extractJson', () => {
 
       expect(result).not.toBeNull();
       const parsed = JSON.parse(result!);
-      expect(parsed['/items']['/1']['/title']).toBe('Título Español');
+      // Key should use default locale position (/0)
+      expect(parsed['/items']['/0']['/title']).toBe('Título Español');
     });
 
     it('should warn when no matching items found for locale', () => {
@@ -577,19 +579,19 @@ describe('extractJson', () => {
       expect(result).not.toBeNull();
       const parsed = JSON.parse(result!);
 
-      // pt-BR is at index 1 in the test file
+      // Should use default locale (en) key position (/0)
       expect(parsed['/navigation/languages']).toBeDefined();
-      expect(parsed['/navigation/languages']['/1']).toBeDefined();
+      expect(parsed['/navigation/languages']['/0']).toBeDefined();
       expect(
-        parsed['/navigation/languages']['/1']['/global/anchors/0/anchor']
+        parsed['/navigation/languages']['/0']['/global/anchors/0/anchor']
       ).toBe('Anúncios');
       expect(
-        parsed['/navigation/languages']['/1']['/global/anchors/1/anchor']
+        parsed['/navigation/languages']['/0']['/global/anchors/1/anchor']
       ).toBe('Status');
-      expect(parsed['/navigation/languages']['/1']['/tabs/0/tab']).toBe(
+      expect(parsed['/navigation/languages']['/0']['/tabs/0/tab']).toBe(
         'Introdução'
       );
-      expect(parsed['/navigation/languages']['/1']['/tabs/1/tab']).toBe(
+      expect(parsed['/navigation/languages']['/0']['/tabs/1/tab']).toBe(
         'Funcionalidades'
       );
     });
@@ -673,7 +675,8 @@ describe('extractJson', () => {
 
       expect(result).not.toBeNull();
       const parsed = JSON.parse(result!);
-      expect(parsed['/items']['/1']['/message']).toBe(
+      // Key should use default locale position (/0)
+      expect(parsed['/items']['/0']['/message']).toBe(
         'Mensaje con "comillas", \'apostrofes\', y\nnuevas líneas\tcon tabs'
       );
     });
@@ -728,11 +731,12 @@ describe('extractJson', () => {
 
       expect(result).not.toBeNull();
       const parsed = JSON.parse(result!);
+      // Key should use default locale position (/0)
       expect(
-        parsed['/data/pages']['/1']['/sections/header/nav/links/0/text']
+        parsed['/data/pages']['/0']['/sections/header/nav/links/0/text']
       ).toBe('Inicio');
       expect(
-        parsed['/data/pages']['/1']['/sections/header/nav/links/1/text']
+        parsed['/data/pages']['/0']['/sections/header/nav/links/1/text']
       ).toBe('Acerca de');
     });
   });
@@ -777,7 +781,8 @@ describe('extractJson', () => {
       expect(result).not.toBeNull();
       const parsed = JSON.parse(result!);
       // Should match fr-CA in the data using canonical locale lookup
-      expect(parsed['/items']['/1']['/title']).toBe('Titre Français Canadien');
+      // Key should use default locale position (/0)
+      expect(parsed['/items']['/0']['/title']).toBe('Titre Français Canadien');
     });
   });
 
@@ -875,6 +880,7 @@ describe('extractJson', () => {
       expect(result).not.toBeNull();
       const parsed = JSON.parse(result!);
       // Should only extract the item that has the locale field
+      // No default locale items found, so falls back to target key (/1)
       expect(parsed['/items']['/1']['/title']).toBe('Spanish');
       expect(parsed['/items']['/0']).toBeUndefined();
     });

--- a/packages/cli/src/fs/config/downloadedVersions.ts
+++ b/packages/cli/src/fs/config/downloadedVersions.ts
@@ -10,6 +10,7 @@ export type DownloadedVersionEntry = {
   fileName?: string;
   updatedAt?: string;
   postProcessHash?: string;
+  sourceHash?: string;
 };
 
 export type DownloadedVersions = {

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.6.21';
+export const PACKAGE_VERSION = '2.6.22';

--- a/packages/cli/src/workflow/download.ts
+++ b/packages/cli/src/workflow/download.ts
@@ -126,10 +126,7 @@ export async function downloadTranslations(
       }
     }
 
-    // Even if polling timed out, still download whatever completed successfully.
-    // This prevents catastrophic file loss when clearLocaleDirs already wiped
-    // the locale directories — without this, a timeout on even a single file
-    // would cause ALL successfully translated files to be lost.
+    // Even if polling timed out, still download whatever completed successfully
     if (!pollResult.success) {
       pollTimedOut = true;
       if (pollResult.fileTracker.completed.size > 0) {
@@ -161,8 +158,7 @@ export async function downloadTranslations(
   });
   await downloadStep.wait();
 
-  // If polling timed out, report failure even though we downloaded what we could.
-  // The caller needs to know that not all translations were retrieved.
+  // If polling timed out, report failure even though we downloaded what we could
   if (pollTimedOut) {
     return false;
   }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two critical bugs in composite JSON handling:

- **Source hash tracking**: Adds `sourceHash` to track non-translatable content changes in source files, ensuring translations are re-downloaded when structural changes occur (not just translatable content)
- **Key position fix**: Corrects the `save-local` bug where composite array indices were misaligned—now uses default locale positions consistently during extraction and merge operations
- **Graceful degradation**: Changes hard errors to warnings when key mismatches occur, with automatic remapping logic to handle single-item cases
- **Timeout resilience**: Downloads completed translations even when polling times out, preventing data loss after `clearLocaleDirs` has already wiped locale directories

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- This PR is safe to merge with moderate confidence—fixes critical bugs and adds resilience
- The changes fix legitimate bugs with composite JSON handling and add defensive logic. The error-to-warning changes improve resilience, and comprehensive test updates validate the behavior. Score is 4/5 due to the complexity of the key remapping logic and potential edge cases in multi-item scenarios
- Pay close attention to `packages/cli/src/formats/json/mergeJson.ts` for the key remapping logic, particularly the single-item fallback case
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/cli/src/api/downloadFileBatch.ts | Added source hash tracking to detect non-translatable content changes and trigger re-downloads |
| packages/cli/src/formats/json/extractJson.ts | Fixed composite key index bug by using default locale positions instead of target locale positions |
| packages/cli/src/formats/json/mergeJson.ts | Added key remapping logic to handle mismatched positional keys and changed errors to warnings for better resilience |
| packages/cli/src/workflow/download.ts | Added graceful timeout handling to download completed files even when polling times out, preventing data loss |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Download Translation] --> B{Source Hash Exists?}
    B -->|Yes| C[Read Current Source]
    B -->|No| D[Skip Hash Check]
    C --> E[Compare Hashes]
    E -->|Changed| F[Force Re-download]
    E -->|Same| G{File Exists?}
    D --> G
    G -->|Yes| H[Skip Download]
    G -->|No| F
    F --> I[Merge Composite JSON]
    I --> J{Has Composite Schema?}
    J -->|Yes| K[Extract with Default Locale Keys]
    J -->|No| L[Use Raw Translation]
    K --> M{Key Mismatch?}
    M -->|Yes| N[Remap to Source Position]
    M -->|No| O[Apply Translation]
    N --> O
    L --> O
    O --> P[Save to Disk]
    P --> Q[Update sourceHash in Lock]
```
</details>


<sub>Last reviewed commit: 2e925e7</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->