### PR TITLE
chore: ignore rollup cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ dist/
 .claude/
 tsconfig.tsbuildinfo
 target/
+.rollup.cache


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `.rollup.cache` to `.gitignore` to prevent Rollup's cache files from being tracked in version control. This is a standard practice since cache files are build artifacts that should be regenerated locally and don't need to be committed.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is completely safe to merge with no risk
- This is a trivial configuration change that only adds a cache file pattern to .gitignore. It follows standard best practices for ignoring build artifacts and has no impact on code execution or functionality.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .gitignore | Added .rollup.cache to gitignore to exclude Rollup build cache files |

</details>


</details>


<sub>Last reviewed commit: 7d5df05</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->