### PR TITLE
New Function to get Files Skipped

### DIFF
--- a/packages/cli/src/formats/files/__tests__/checkFiles.test.ts
+++ b/packages/cli/src/formats/files/__tests__/checkFiles.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { checkFiles } from '../checkFiles.js';
+import { aggregateFiles } from '../aggregateFiles.js';
+import {
+  clearWarnings,
+  getWarnings,
+} from '../../../state/translateWarnings.js';
+
+vi.mock('../aggregateFiles.js');
+vi.mock('../../../state/translateWarnings.js');
+
+const mockAggregateFiles = vi.mocked(aggregateFiles);
+const mockClearWarnings = vi.mocked(clearWarnings);
+const mockGetWarnings = vi.mocked(getWarnings);
+
+describe('checkFiles', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return valid files with no skipped files', async () => {
+    mockAggregateFiles.mockResolvedValue([
+      { fileName: 'en/common.json' } as any,
+      { fileName: 'en/home.json' } as any,
+    ]);
+    mockGetWarnings.mockReturnValue([]);
+
+    const result = await checkFiles({} as any);
+
+    expect(result.validFiles).toEqual(['en/common.json', 'en/home.json']);
+    expect(result.skippedFiles).toEqual([]);
+    expect(result.summary).toEqual({ total: 2, valid: 2, skipped: 0 });
+  });
+
+  it('should capture skipped_file warnings as skippedFiles', async () => {
+    mockAggregateFiles.mockResolvedValue([
+      { fileName: 'en/valid.json' } as any,
+    ]);
+    mockGetWarnings.mockReturnValue([
+      {
+        category: 'skipped_file',
+        fileName: 'en/broken.json',
+        reason: 'JSON file is not parsable',
+      },
+    ]);
+
+    const result = await checkFiles({} as any);
+
+    expect(result.validFiles).toEqual(['en/valid.json']);
+    expect(result.skippedFiles).toEqual([
+      { fileName: 'en/broken.json', reason: 'JSON file is not parsable' },
+    ]);
+    expect(result.summary).toEqual({ total: 2, valid: 1, skipped: 1 });
+  });
+
+  it('should handle all files being skipped', async () => {
+    mockAggregateFiles.mockResolvedValue([]);
+    mockGetWarnings.mockReturnValue([
+      {
+        category: 'skipped_file',
+        fileName: 'a.json',
+        reason: 'JSON file is not parsable',
+      },
+      {
+        category: 'skipped_file',
+        fileName: 'b.yaml',
+        reason: 'YAML file is empty',
+      },
+    ]);
+
+    const result = await checkFiles({} as any);
+
+    expect(result.validFiles).toEqual([]);
+    expect(result.skippedFiles).toHaveLength(2);
+    expect(result.summary).toEqual({ total: 2, valid: 0, skipped: 2 });
+  });
+
+  it('should filter out non-skipped_file warnings', async () => {
+    mockAggregateFiles.mockResolvedValue([
+      { fileName: 'en/valid.json' } as any,
+    ]);
+    mockGetWarnings.mockReturnValue([
+      {
+        category: 'skipped_file',
+        fileName: 'en/broken.json',
+        reason: 'JSON file is not parsable',
+      },
+      {
+        category: 'failed_translation',
+        fileName: 'en/other.json',
+        reason: 'Translation failed',
+      },
+    ]);
+
+    const result = await checkFiles({} as any);
+
+    expect(result.skippedFiles).toEqual([
+      { fileName: 'en/broken.json', reason: 'JSON file is not parsable' },
+    ]);
+    expect(result.summary).toEqual({ total: 2, valid: 1, skipped: 1 });
+  });
+
+  it('should clear warnings before and after aggregation', async () => {
+    mockAggregateFiles.mockResolvedValue([]);
+    mockGetWarnings.mockReturnValue([]);
+
+    await checkFiles({} as any);
+
+    expect(mockClearWarnings).toHaveBeenCalledTimes(2);
+    // First call before aggregateFiles, second after reading warnings
+    expect(mockClearWarnings.mock.invocationCallOrder[0]).toBeLessThan(
+      mockAggregateFiles.mock.invocationCallOrder[0]
+    );
+  });
+
+  it('should handle mixed file types with various skip reasons', async () => {
+    mockAggregateFiles.mockResolvedValue([
+      { fileName: 'en/valid.json' } as any,
+      { fileName: 'docs/page.mdx' } as any,
+    ]);
+    mockGetWarnings.mockReturnValue([
+      {
+        category: 'skipped_file',
+        fileName: 'en/broken.json',
+        reason: 'JSON file is not parsable',
+      },
+      {
+        category: 'skipped_file',
+        fileName: 'config.yaml',
+        reason: 'YAML file is empty',
+      },
+      {
+        category: 'skipped_file',
+        fileName: 'docs/bad.mdx',
+        reason: 'MDX file is not AST parsable: Unexpected token',
+      },
+    ]);
+
+    const result = await checkFiles({} as any);
+
+    expect(result.validFiles).toEqual(['en/valid.json', 'docs/page.mdx']);
+    expect(result.skippedFiles).toHaveLength(3);
+    expect(result.skippedFiles[0].reason).toBe('JSON file is not parsable');
+    expect(result.skippedFiles[1].reason).toBe('YAML file is empty');
+    expect(result.skippedFiles[2].reason).toContain(
+      'MDX file is not AST parsable'
+    );
+    expect(result.summary).toEqual({ total: 5, valid: 2, skipped: 3 });
+  });
+
+  it('should return empty result when no files configured', async () => {
+    mockAggregateFiles.mockResolvedValue([]);
+    mockGetWarnings.mockReturnValue([]);
+
+    const result = await checkFiles({} as any);
+
+    expect(result.validFiles).toEqual([]);
+    expect(result.skippedFiles).toEqual([]);
+    expect(result.summary).toEqual({ total: 0, valid: 0, skipped: 0 });
+  });
+});

--- a/packages/cli/src/formats/files/checkFiles.ts
+++ b/packages/cli/src/formats/files/checkFiles.ts
@@ -1,0 +1,35 @@
+import { Settings } from '../../types/index.js';
+import { clearWarnings, getWarnings } from '../../state/translateWarnings.js';
+import { aggregateFiles } from './aggregateFiles.js';
+
+export type SkippedFileInfo = { fileName: string; reason: string };
+
+export type TranslateCheckResult = {
+  validFiles: string[];
+  skippedFiles: SkippedFileInfo[];
+  summary: { total: number; valid: number; skipped: number };
+};
+
+export async function checkFiles(
+  settings: Settings
+): Promise<TranslateCheckResult> {
+  clearWarnings();
+
+  const files = await aggregateFiles(settings);
+
+  const warnings = getWarnings();
+  const skippedFiles: SkippedFileInfo[] = warnings
+    .filter((w) => w.category === 'skipped_file')
+    .map((w) => ({ fileName: w.fileName, reason: w.reason }));
+
+  const validFiles = files.map((f) => f.fileName);
+
+  clearWarnings();
+
+  const total = validFiles.length + skippedFiles.length;
+  return {
+    validFiles,
+    skippedFiles,
+    summary: { total, valid: validFiles.length, skipped: skippedFiles.length },
+  };
+}

--- a/packages/cli/src/functions.ts
+++ b/packages/cli/src/functions.ts
@@ -9,6 +9,11 @@ export type {
   ValidationMessage,
   ValidationLevel,
 } from './translation/validate.js';
+export { getTranslateCheckJson } from './translation/translateCheck.js';
+export type {
+  TranslateCheckResult,
+  SkippedFileInfo,
+} from './translation/translateCheck.js';
 export {
   Libraries,
   GTLibrary,

--- a/packages/cli/src/translation/__tests__/translateCheck.test.ts
+++ b/packages/cli/src/translation/__tests__/translateCheck.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getTranslateCheckJson } from '../translateCheck.js';
+import { generateSettings } from '../../config/generateSettings.js';
+import { checkFiles } from '../../formats/files/checkFiles.js';
+import type { TranslateCheckResult } from '../../formats/files/checkFiles.js';
+
+vi.mock('../../config/generateSettings.js');
+vi.mock('../../formats/files/checkFiles.js');
+
+const mockGenerateSettings = vi.mocked(generateSettings);
+const mockCheckFiles = vi.mocked(checkFiles);
+
+describe('getTranslateCheckJson', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should resolve settings and delegate to checkFiles', async () => {
+    const fakeSettings = { defaultLocale: 'en' } as any;
+    const fakeResult: TranslateCheckResult = {
+      validFiles: ['en/common.json'],
+      skippedFiles: [],
+      summary: { total: 1, valid: 1, skipped: 0 },
+    };
+    mockGenerateSettings.mockResolvedValue(fakeSettings);
+    mockCheckFiles.mockResolvedValue(fakeResult);
+
+    const result = await getTranslateCheckJson({ config: 'gt.config.json' });
+
+    expect(mockGenerateSettings).toHaveBeenCalledWith({
+      config: 'gt.config.json',
+    });
+    expect(mockCheckFiles).toHaveBeenCalledWith(fakeSettings);
+    expect(result).toEqual(fakeResult);
+  });
+
+  it('should pass empty object when no options provided', async () => {
+    const fakeSettings = {} as any;
+    const fakeResult: TranslateCheckResult = {
+      validFiles: [],
+      skippedFiles: [],
+      summary: { total: 0, valid: 0, skipped: 0 },
+    };
+    mockGenerateSettings.mockResolvedValue(fakeSettings);
+    mockCheckFiles.mockResolvedValue(fakeResult);
+
+    await getTranslateCheckJson();
+
+    expect(mockGenerateSettings).toHaveBeenCalledWith({});
+  });
+
+  it('should forward defaultLocale option to generateSettings', async () => {
+    const fakeSettings = { defaultLocale: 'fr' } as any;
+    const fakeResult: TranslateCheckResult = {
+      validFiles: [],
+      skippedFiles: [],
+      summary: { total: 0, valid: 0, skipped: 0 },
+    };
+    mockGenerateSettings.mockResolvedValue(fakeSettings);
+    mockCheckFiles.mockResolvedValue(fakeResult);
+
+    await getTranslateCheckJson({ defaultLocale: 'fr' });
+
+    expect(mockGenerateSettings).toHaveBeenCalledWith({ defaultLocale: 'fr' });
+  });
+
+  it('should return skipped files from checkFiles', async () => {
+    const fakeSettings = {} as any;
+    const fakeResult: TranslateCheckResult = {
+      validFiles: ['valid.json'],
+      skippedFiles: [
+        { fileName: 'broken.json', reason: 'JSON file is not parsable' },
+      ],
+      summary: { total: 2, valid: 1, skipped: 1 },
+    };
+    mockGenerateSettings.mockResolvedValue(fakeSettings);
+    mockCheckFiles.mockResolvedValue(fakeResult);
+
+    const result = await getTranslateCheckJson();
+
+    expect(result.skippedFiles).toHaveLength(1);
+    expect(result.skippedFiles[0].fileName).toBe('broken.json');
+    expect(result.summary.skipped).toBe(1);
+  });
+});

--- a/packages/cli/src/translation/translateCheck.ts
+++ b/packages/cli/src/translation/translateCheck.ts
@@ -1,0 +1,15 @@
+import { generateSettings } from '../config/generateSettings.js';
+import { checkFiles } from '../formats/files/checkFiles.js';
+
+export type {
+  TranslateCheckResult,
+  SkippedFileInfo,
+} from '../formats/files/checkFiles.js';
+
+export async function getTranslateCheckJson(options?: {
+  config?: string;
+  defaultLocale?: string;
+}): Promise<import('../formats/files/checkFiles.js').TranslateCheckResult> {
+  const settings = await generateSettings(options ?? {});
+  return checkFiles(settings);
+}


### PR DESCRIPTION
# What

Added a Programmatic API to return files skipped from running `gtx-cli translate`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a programmatic API to retrieve files that were skipped during translation validation. The implementation creates `checkFiles()` that wraps `aggregateFiles()` and captures `skipped_file` warnings to return structured results containing valid files, skipped files with reasons, and a summary. The new `getTranslateCheckJson()` function is exported via `gtx-cli/functions` for programmatic use.

**Changes:**
- New `checkFiles()` function filters warnings by category `skipped_file` and returns structured results
- New `getTranslateCheckJson()` wrapper generates settings and calls `checkFiles()`
- Exports added to `functions.ts` for external consumption
- Comprehensive test coverage with 11 total test cases across both new functions

**Architecture:**
The implementation follows the existing pattern established by `getValidateJson()` in `validate.ts`, providing a programmatic alternative to CLI commands. It leverages the existing warning system (`translateWarnings.ts`) used by `aggregateFiles()` to track file processing issues.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge with no issues found
- Clean implementation with comprehensive test coverage, follows existing patterns, no breaking changes, and all custom rules satisfied (no console.log statements, code is in correct package)
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/cli/src/formats/files/checkFiles.ts | New function to check and classify files as valid or skipped by analyzing warnings from `aggregateFiles` |
| packages/cli/src/translation/translateCheck.ts | Thin wrapper function that generates settings and delegates to `checkFiles`, provides programmatic API |
| packages/cli/src/functions.ts | Added exports for `getTranslateCheckJson`, `TranslateCheckResult`, and `SkippedFileInfo` types |

</details>


</details>


<sub>Last reviewed commit: 8ebc5f8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->