### PR TITLE
fix(i18n): declareVar support

### DIFF
--- a/.changeset/big-frogs-lay.md
+++ b/.changeset/big-frogs-lay.md
@@ -2,4 +2,4 @@
 'gt-i18n': patch
 ---
 
-fix: declare static support for gt-i18n
+fix: declareVar support for gt-i18n

--- a/.changeset/big-frogs-lay.md
+++ b/.changeset/big-frogs-lay.md
@@ -1,0 +1,5 @@
+---
+'gt-i18n': patch
+---
+
+fix: declare static support for gt-i18n

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.6.24';
+export const PACKAGE_VERSION = '2.6.25';

--- a/packages/i18n/src/translation-functions/fallbacks/__tests__/gtFallback.test.ts
+++ b/packages/i18n/src/translation-functions/fallbacks/__tests__/gtFallback.test.ts
@@ -21,4 +21,88 @@ describe('gtFallback', () => {
     const result = gtFallback(undefined as unknown as string);
     expect(result).toBeUndefined();
   });
+
+  describe('declareVar support', () => {
+    it('resolves declareVar in source-only (fallback) mode', () => {
+      // No $_fallback set, so extractVars('') returns {}.
+      // The unindexed select is resolved via _gt_: 'other'.
+      const result = gtFallback('Hello {_gt_, select, other {John}}!', {});
+      expect(result).toBe('Hello John!');
+    });
+
+    it('resolves multiple declareVars in source-only (fallback) mode', () => {
+      const result = gtFallback(
+        'I play with {_gt_, select, other {toys}} at the {_gt_, select, other {park}}',
+        {}
+      );
+      expect(result).toBe('I play with toys at the park');
+    });
+
+    it('resolves declareVar with $_fallback (translation mode)', () => {
+      // The source has the unindexed select with the value.
+      // The translation uses a simple indexed argument.
+      const source = 'Hello {_gt_, select, other {John}}!';
+      const translation = 'Bonjour {_gt_1} !';
+      const result = gtFallback(translation, { $_fallback: source });
+      expect(result).toBe('Bonjour John !');
+    });
+
+    it('resolves declareVar with indexed select in translation', () => {
+      // Translation may contain indexed select syntax: {_gt_1, select, other {}}
+      // condenseVars should simplify this to {_gt_1}
+      const source = 'Hello {_gt_, select, other {John}}!';
+      const translation = 'Bonjour {_gt_1, select, other {}} !';
+      const result = gtFallback(translation, { $_fallback: source });
+      expect(result).toBe('Bonjour John !');
+    });
+
+    it('resolves multiple declareVars with reordering in translation', () => {
+      const source =
+        'I play with {_gt_, select, other {toys}} at the {_gt_, select, other {park}}';
+      // Translation reorders the variables
+      const translation = 'Je joue au {_gt_2} avec des {_gt_1}';
+      const result = gtFallback(translation, { $_fallback: source });
+      expect(result).toBe('Je joue au park avec des toys');
+    });
+
+    it('resolves declareVar combined with user variables', () => {
+      const source =
+        'Hello {name}, welcome to {_gt_, select, other {the park}}!';
+      const translation = 'Bonjour {name}, bienvenue à {_gt_1} !';
+      const result = gtFallback(translation, {
+        name: 'Alice',
+        $_fallback: source,
+      });
+      expect(result).toBe('Bonjour Alice, bienvenue à the park !');
+    });
+
+    it('resolves multiple declareVars combined with user variables', () => {
+      const source =
+        '{name} bought {_gt_, select, other {3 apples}} and {_gt_, select, other {2 oranges}}';
+      const translation = '{name} a acheté {_gt_1} et {_gt_2}';
+      const result = gtFallback(translation, {
+        name: 'Bob',
+        $_fallback: source,
+      });
+      expect(result).toBe('Bob a acheté 3 apples et 2 oranges');
+    });
+
+    it('handles empty declareVar value', () => {
+      const source = 'Hello {_gt_, select, other {}}!';
+      const translation = 'Bonjour {_gt_1} !';
+      const result = gtFallback(translation, { $_fallback: source });
+      expect(result).toBe('Bonjour  !');
+    });
+
+    it('works when $_fallback has no declareVar markers', () => {
+      // $_fallback is set but has no _gt_ markers - should behave like normal interpolation
+      const source = 'Hello {name}!';
+      const translation = 'Bonjour {name} !';
+      const result = gtFallback(translation, {
+        name: 'Alice',
+        $_fallback: source,
+      });
+      expect(result).toBe('Bonjour Alice !');
+    });
+  });
 });

--- a/packages/i18n/src/translation-functions/internal/getGT.ts
+++ b/packages/i18n/src/translation-functions/internal/getGT.ts
@@ -38,7 +38,9 @@ export async function getGT(): Promise<GTFunctionType> {
     options?: InlineTranslationOptions
   ) => {
     const translation = resolveTranslation(message, options);
-    if (translation) message = translation;
+    if (translation) {
+      return gtFallback(translation, { ...options, $_fallback: message });
+    }
     return gtFallback(message, options);
   };
 

--- a/packages/i18n/src/translation-functions/types/options.ts
+++ b/packages/i18n/src/translation-functions/types/options.ts
@@ -13,6 +13,8 @@ export type InlineTranslationOptions = BaseTranslationOptions & {
   $id?: string;
   $_hash?: string;
   $maxChars?: number;
+  /** @internal Used to carry the original source when rendering a translation */
+  $_fallback?: string;
   /** @deprecated use {@link EncodedTranslationOptions} instead */
   $_source?: string;
 };

--- a/packages/i18n/src/translation-functions/utils/interpolateMessage.ts
+++ b/packages/i18n/src/translation-functions/utils/interpolateMessage.ts
@@ -54,9 +54,10 @@ export function interpolateMessage<T extends string | null | undefined>(
 
     // If formatting the translation failed and we have a fallback, try formatting the source instead
     if (source != null) {
-      return interpolateMessage(source, variables) as T extends string
-        ? string
-        : T;
+      return interpolateMessage(source, {
+        ...options,
+        $_fallback: undefined,
+      }) as T extends string ? string : T;
     }
 
     // Apply cutoff formatting

--- a/packages/i18n/src/translation-functions/utils/interpolateMessage.ts
+++ b/packages/i18n/src/translation-functions/utils/interpolateMessage.ts
@@ -1,6 +1,10 @@
 import { extractVariables } from '../../utils/extractVariables';
 import { formatMessage } from './formatMessage';
-import { VAR_IDENTIFIER } from 'generaltranslation/internal';
+import {
+  VAR_IDENTIFIER,
+  extractVars,
+  condenseVars,
+} from 'generaltranslation/internal';
 import { formatCutoff } from 'generaltranslation';
 import logger from '../../logs/logger';
 import { interpolationFailureMessage } from './messages';
@@ -21,11 +25,21 @@ export function interpolateMessage<T extends string | null | undefined>(
 
   // Remove any gt related options
   const variables = extractVariables(options);
+  const source = options.$_fallback;
 
   try {
+    // Extract declared variable values from the source/fallback
+    const declaredVars = extractVars(source || '');
+
+    // Condense indexed selects to arguments if declared vars exist
+    const message = Object.keys(declaredVars).length
+      ? condenseVars(encodedMsg)
+      : encodedMsg;
+
     // Interpolate the message
-    const interpolatedMessage = formatMessage(encodedMsg, {
+    const interpolatedMessage = formatMessage(message, {
       ...variables,
+      ...declaredVars,
       [VAR_IDENTIFIER]: 'other',
     });
     // Apply cutoff formatting

--- a/packages/i18n/src/utils/extractVariables.ts
+++ b/packages/i18n/src/utils/extractVariables.ts
@@ -16,7 +16,8 @@ export function extractVariables<T extends BaseTranslationOptions>(
         key !== '$maxChars' &&
         key !== '$hash' && // this is already being done in @gt/react-core
         key !== '$_hash' &&
-        key !== '$_source'
+        key !== '$_source' &&
+        key !== '$_fallback'
     )
   );
 }


### PR DESCRIPTION
adds support for declareVar in `gt-i18n`'s string interpolation

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds support for `declareVar` in `gt-i18n`'s string interpolation, enabling translations to reference variables declared in the source message using the `{_gt_, select, other {value}}` syntax. The implementation extracts declared variables from the source message via the new `$_fallback` option, condenses indexed select statements in translations to simple arguments, and provides graceful error handling that falls back to the source message when translation formatting fails. The changes are well-tested with comprehensive coverage for various scenarios including variable reordering, combination with user variables, and error handling.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- Safe to merge with one minor fix needed
- The implementation is well-designed and thoroughly tested, but the recursive fallback call in `interpolateMessage.ts` doesn't preserve the `$maxChars` option, which could lead to incorrect cutoff behavior when falling back to the source
- Review `interpolateMessage.ts:57` - ensure `$maxChars` is preserved in recursive call
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/i18n/src/utils/extractVariables.ts | Filters out `$_fallback` from variables to prevent it from being treated as user input |
| packages/i18n/src/translation-functions/internal/getGT.ts | Passes original message as `$_fallback` when translation exists to enable declareVar resolution |
| packages/i18n/src/translation-functions/utils/interpolateMessage.ts | Core implementation: extracts declareVars from fallback, condenses indexed selects, handles formatting errors with fallback retry |

</details>


</details>


<sub>Last reviewed commit: 35d1697</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->