### PR TITLE
fix: avoid object spread in TranslationManager.setTranslations

### DIFF
--- a/.changeset/fix-translation-manager-perf.md
+++ b/.changeset/fix-translation-manager-perf.md
@@ -1,0 +1,5 @@
+---
+'gt-next': patch
+---
+
+fix: avoid object spread in TranslationManager.setTranslations for better performance

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.6.25';
+export const PACKAGE_VERSION = '2.6.27';

--- a/packages/next/src/config-dir/TranslationManager.ts
+++ b/packages/next/src/config-dir/TranslationManager.ts
@@ -148,10 +148,12 @@ export class TranslationManager {
   ) {
     if (!(locale && hash && translation)) return false;
     const reference = this._standardizeLocale(locale);
-    this.translationsMap.set(reference, {
-      ...(this.translationsMap.get(reference) || {}),
-      [hash]: translation,
-    });
+    let existing = this.translationsMap.get(reference);
+    if (!existing) {
+      existing = {};
+      this.translationsMap.set(reference, existing);
+    }
+    existing[hash] = translation;
   }
 }
 

--- a/packages/next/src/config-dir/__tests__/TranslationManager.test.ts
+++ b/packages/next/src/config-dir/__tests__/TranslationManager.test.ts
@@ -1,0 +1,54 @@
+import { TranslationManager } from '../TranslationManager';
+
+describe('TranslationManager', () => {
+  let manager: TranslationManager;
+
+  beforeEach(() => {
+    manager = new TranslationManager();
+  });
+
+  describe('setTranslations', () => {
+    it('should set a translation entry', () => {
+      manager.setTranslations('en', 'hash1', 'Hello');
+      const translations = manager.getRecentTranslations('en');
+      expect(translations).toEqual({ hash1: 'Hello' });
+    });
+
+    it('should accumulate translations for the same locale', () => {
+      manager.setTranslations('en', 'hash1', 'Hello');
+      manager.setTranslations('en', 'hash2', 'World');
+      const translations = manager.getRecentTranslations('en');
+      expect(translations).toEqual({ hash1: 'Hello', hash2: 'World' });
+    });
+
+    it('should overwrite an existing hash', () => {
+      manager.setTranslations('en', 'hash1', 'Hello');
+      manager.setTranslations('en', 'hash1', 'Hi');
+      const translations = manager.getRecentTranslations('en');
+      expect(translations).toEqual({ hash1: 'Hi' });
+    });
+
+    it('should return false for invalid inputs', () => {
+      expect(manager.setTranslations('', 'hash1', 'Hello')).toBe(false);
+      expect(manager.setTranslations('en', '', 'Hello')).toBe(false);
+    });
+
+    it('should keep separate translations per locale', () => {
+      manager.setTranslations('en', 'hash1', 'Hello');
+      manager.setTranslations('fr', 'hash1', 'Bonjour');
+      expect(manager.getRecentTranslations('en')).toEqual({ hash1: 'Hello' });
+      expect(manager.getRecentTranslations('fr')).toEqual({
+        hash1: 'Bonjour',
+      });
+    });
+
+    it('should mutate in place (not create new objects)', () => {
+      manager.setTranslations('en', 'hash1', 'Hello');
+      const ref1 = manager.getRecentTranslations('en');
+      manager.setTranslations('en', 'hash2', 'World');
+      const ref2 = manager.getRecentTranslations('en');
+      // Same object reference means mutation in place
+      expect(ref1).toBe(ref2);
+    });
+  });
+});


### PR DESCRIPTION
## Problem

In `TranslationManager.setTranslations()`, every new translation entry triggers object spread:

```ts
this.translationsMap.set(reference, {
  ...(this.translationsMap.get(reference) || {}),
  [hash]: translation,
});
```

This creates a new object on every call, copying all existing translations for that locale. For apps with many translation keys, this is **O(n) per insertion**, making bulk loading O(n²).

## Fix

Mutate the existing object directly since we own the reference:

```ts
let existing = this.translationsMap.get(reference);
if (!existing) {
  existing = {};
  this.translationsMap.set(reference, existing);
}
existing[hash] = translation;
```

This makes each insertion **O(1)**.

## Testing

Added tests for `TranslationManager.setTranslations`:
- Setting a translation works
- Multiple translations for the same locale accumulate correctly
- Overwriting an existing hash works
- Separate locales stay isolated
- Object reference is preserved (verifies in-place mutation)

All 197 existing tests pass.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Performance optimization that replaces object spread with direct mutation in `TranslationManager.setTranslations()`, reducing bulk loading complexity from O(n²) to O(n).

- Changed from creating a new object on each insertion to mutating existing object in-place
- Maintains correctness while significantly improving performance for apps with many translation keys
- Added comprehensive test coverage including reference equality checks to verify mutation behavior
- All 197 existing tests pass

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge with minimal risk
- The change is a well-isolated performance optimization with clear correctness guarantees, comprehensive test coverage including mutation behavior validation, and all existing tests passing
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/next/src/config-dir/TranslationManager.ts | Optimized setTranslations to mutate in-place instead of using object spread, changing from O(n) to O(1) per insertion |
| packages/next/src/config-dir/__tests__/TranslationManager.test.ts | Added comprehensive test coverage for setTranslations including mutation behavior validation |

</details>


</details>


<sub>Last reviewed commit: 6da8ba4</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->