### PR TITLE
fix: bench mark triggers

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -10,6 +10,7 @@ on:
 permissions:
   contents: write
   deployments: write
+  pull-requests: write
 
 concurrency:
   group: benchmark-${{ github.event.pull_request.number || github.run_id }}
@@ -167,7 +168,6 @@ jobs:
           fail-on-alert: false
           alert-comment-cc-users: '@generaltranslation/core'
           summary-always: true
-          # Data persistence — only save/push on release dispatches, NEVER on PRs
-          # (security: PRs from forks could store malicious data to gh-pages)
-          save-data-file: ${{ github.event_name != 'pull_request' }}
-          auto-push: ${{ github.event_name != 'pull_request' }}
+          # Data persistence — only save/push on release dispatches
+          save-data-file: ${{ github.event_name == 'repository_dispatch' }}
+          auto-push: ${{ github.event_name == 'repository_dispatch' }}


### PR DESCRIPTION
fix benchmark behaviors
- allow to write warnings to PRs
- fix triggers

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the benchmark workflow triggers by making two configuration changes: adding the `pull-requests: write` permission required for the benchmark action to post comments, and restricting benchmark data persistence to only occur on automated `repository_dispatch` events (releases). The previous logic used `!= 'pull_request'` which also allowed manual `workflow_dispatch` triggers to persist data, while the new logic explicitly allows only `repository_dispatch` events.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge with no risk - it's a simple workflow configuration fix
- The changes are minimal and well-scoped: adding a required permission and making the persistence logic more restrictive (only on releases). Both changes improve the workflow's behavior and security posture without introducing any risks
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/benchmark.yml | Added PR comment permission and restricted benchmark persistence to only automated release dispatches |

</details>


</details>


<sub>Last reviewed commit: 0a121fc</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->