### PR TITLE
F/mint text url preprocessing

### DIFF
--- a/.changeset/tasty-rockets-rule.md
+++ b/.changeset/tasty-rockets-rule.md
@@ -1,0 +1,5 @@
+---
+'gtx-cli': patch
+---
+
+Wrapping text node URLs for Mintlify MDX to align with their parser

--- a/packages/cli/src/formats/files/__tests__/aggregateFiles.test.ts
+++ b/packages/cli/src/formats/files/__tests__/aggregateFiles.test.ts
@@ -286,6 +286,7 @@ describe('aggregateFiles - Empty File Handling', () => {
           placeholderPaths: {},
         },
         defaultLocale: 'en',
+        framework: 'mintlify',
         options: {
           mintlify: {
             inferTitleFromFilename: true,
@@ -312,6 +313,7 @@ describe('aggregateFiles - Empty File Handling', () => {
           placeholderPaths: {},
         },
         defaultLocale: 'en',
+        framework: 'mintlify',
         options: {
           mintlify: {
             inferTitleFromFilename: true,
@@ -343,6 +345,7 @@ describe('aggregateFiles - Empty File Handling', () => {
           placeholderPaths: {},
         },
         defaultLocale: 'en',
+        framework: 'mintlify',
         options: {
           mintlify: {
             inferTitleFromFilename: true,
@@ -369,6 +372,7 @@ describe('aggregateFiles - Empty File Handling', () => {
           placeholderPaths: {},
         },
         defaultLocale: 'es',
+        framework: 'mintlify',
         options: {
           mintlify: {
             inferTitleFromFilename: true,

--- a/packages/cli/src/formats/files/aggregateFiles.ts
+++ b/packages/cli/src/formats/files/aggregateFiles.ts
@@ -12,6 +12,7 @@ import { determineLibrary } from '../../fs/determineFramework.js';
 import { isValidMdx } from '../../utils/validateMdx.js';
 import { hashStringSync } from '../../utils/hash.js';
 import { applyMintlifyTitleFallback } from '../../utils/mintlifyTitleFallback.js';
+import wrapPlainUrls from '../../utils/wrapPlainUrls.js';
 export const SUPPORTED_DATA_FORMATS = ['JSX', 'ICU', 'I18NEXT'];
 
 export async function aggregateFiles(
@@ -189,6 +190,13 @@ export async function aggregateFiles(
             );
             processedContent = result.content;
             addedMintlifyTitle = result.addedTitle;
+          }
+
+          if (
+            (fileType === 'md' || fileType === 'mdx') &&
+            settings.framework === 'mintlify'
+          ) {
+            processedContent = wrapPlainUrls(processedContent);
           }
 
           const sanitizedContent = sanitizeFileContent(processedContent);

--- a/packages/cli/src/formats/files/aggregateFiles.ts
+++ b/packages/cli/src/formats/files/aggregateFiles.ts
@@ -4,15 +4,12 @@ import { getRelative, readFile } from '../../fs/findFilepath.js';
 import { Settings } from '../../types/index.js';
 import type { FileFormat, DataFormat, FileToUpload } from '../../types/data.js';
 import { SUPPORTED_FILE_EXTENSIONS } from './supportedFiles.js';
-import sanitizeFileContent from '../../utils/sanitizeFileContent.js';
 import { parseJson } from '../json/parseJson.js';
 import parseYaml from '../yaml/parseYaml.js';
 import YAML from 'yaml';
 import { determineLibrary } from '../../fs/determineFramework.js';
-import { isValidMdx } from '../../utils/validateMdx.js';
 import { hashStringSync } from '../../utils/hash.js';
-import { applyMintlifyTitleFallback } from '../../utils/mintlifyTitleFallback.js';
-import wrapPlainUrls from '../../utils/wrapPlainUrls.js';
+import { preprocessContent } from './preprocessContent.js';
 export const SUPPORTED_DATA_FORMATS = ['JSX', 'ICU', 'I18NEXT'];
 
 export async function aggregateFiles(
@@ -160,55 +157,25 @@ export async function aggregateFiles(
           const content = readFile(filePath);
           const relativePath = getRelative(filePath);
 
-          if (fileType === 'mdx') {
-            if (!skipValidation?.mdx) {
-              const validation = isValidMdx(content, filePath);
-              if (!validation.isValid) {
-                logger.warn(
-                  `Skipping ${relativePath}: MDX file is not AST parsable${validation.error ? `: ${validation.error}` : ''}`
-                );
-                recordWarning(
-                  'skipped_file',
-                  relativePath,
-                  `MDX file is not AST parsable${validation.error ? `: ${validation.error}` : ''}`
-                );
-                return null;
-              }
-            }
-          }
+          const processed = preprocessContent(
+            content,
+            relativePath,
+            fileType,
+            settings
+          );
 
-          let processedContent = content;
-          let addedMintlifyTitle = false;
-          if (
-            fileType === 'mdx' &&
-            settings.options?.mintlify?.inferTitleFromFilename
-          ) {
-            const result = applyMintlifyTitleFallback(
-              processedContent,
-              relativePath,
-              settings.defaultLocale
-            );
-            processedContent = result.content;
-            addedMintlifyTitle = result.addedTitle;
+          if (typeof processed !== 'string') {
+            logger.warn(`Skipping ${relativePath}: ${processed.skip}`);
+            recordWarning('skipped_file', relativePath, processed.skip);
+            return null;
           }
-
-          if (
-            (fileType === 'md' || fileType === 'mdx') &&
-            settings.framework === 'mintlify'
-          ) {
-            processedContent = wrapPlainUrls(processedContent);
-          }
-
-          const sanitizedContent = sanitizeFileContent(processedContent);
-          // Always hash original content for versionId
-          const computedVersionId = hashStringSync(content);
 
           return {
-            content: sanitizedContent,
+            content: processed,
             fileName: relativePath,
             fileFormat: fileType.toUpperCase() as FileFormat,
             fileId: hashStringSync(relativePath),
-            versionId: computedVersionId,
+            versionId: hashStringSync(content),
             locale: settings.defaultLocale,
           } satisfies FileToUpload;
         })

--- a/packages/cli/src/formats/files/preprocess/mdx.ts
+++ b/packages/cli/src/formats/files/preprocess/mdx.ts
@@ -1,0 +1,20 @@
+import { Settings } from '../../../types/index.js';
+import { isValidMdx } from '../../../utils/validateMdx.js';
+
+/**
+ * Runs MDX-specific preprocessing. Returns a skip reason if the file
+ * should be skipped, or null if validation passed.
+ */
+export function preprocessMdx(
+  content: string,
+  filePath: string,
+  settings: Settings
+): string | null {
+  if (!settings.options?.skipFileValidation?.mdx) {
+    const validation = isValidMdx(content, filePath);
+    if (!validation.isValid) {
+      return `MDX file is not AST parsable${validation.error ? `: ${validation.error}` : ''}`;
+    }
+  }
+  return null;
+}

--- a/packages/cli/src/formats/files/preprocess/mintlify.ts
+++ b/packages/cli/src/formats/files/preprocess/mintlify.ts
@@ -11,12 +11,11 @@ export function preprocessMintlify(
   fileType: string,
   settings: Settings
 ): string {
+  if (fileType !== 'mdx') return content;
+
   let result = content;
 
-  if (
-    fileType === 'mdx' &&
-    settings.options?.mintlify?.inferTitleFromFilename
-  ) {
+  if (settings.options?.mintlify?.inferTitleFromFilename) {
     result = applyMintlifyTitleFallback(
       result,
       filePath,
@@ -24,9 +23,7 @@ export function preprocessMintlify(
     ).content;
   }
 
-  if (fileType === 'mdx') {
-    result = wrapPlainUrls(result);
-  }
+  result = wrapPlainUrls(result);
 
   return result;
 }

--- a/packages/cli/src/formats/files/preprocess/mintlify.ts
+++ b/packages/cli/src/formats/files/preprocess/mintlify.ts
@@ -13,8 +13,15 @@ export function preprocessMintlify(
 ): string {
   let result = content;
 
-  if (fileType === 'mdx' && settings.options?.mintlify?.inferTitleFromFilename) {
-    result = applyMintlifyTitleFallback(result, filePath, settings.defaultLocale).content;
+  if (
+    fileType === 'mdx' &&
+    settings.options?.mintlify?.inferTitleFromFilename
+  ) {
+    result = applyMintlifyTitleFallback(
+      result,
+      filePath,
+      settings.defaultLocale
+    ).content;
   }
 
   if (fileType === 'mdx') {

--- a/packages/cli/src/formats/files/preprocess/mintlify.ts
+++ b/packages/cli/src/formats/files/preprocess/mintlify.ts
@@ -1,0 +1,25 @@
+import { Settings } from '../../../types/index.js';
+import { applyMintlifyTitleFallback } from '../../../utils/mintlifyTitleFallback.js';
+import wrapPlainUrls from '../../../utils/wrapPlainUrls.js';
+
+/**
+ * Runs all Mintlify-specific preprocessing on file content.
+ */
+export function preprocessMintlify(
+  content: string,
+  filePath: string,
+  fileType: string,
+  settings: Settings
+): string {
+  let result = content;
+
+  if (fileType === 'mdx' && settings.options?.mintlify?.inferTitleFromFilename) {
+    result = applyMintlifyTitleFallback(result, filePath, settings.defaultLocale).content;
+  }
+
+  if (fileType === 'mdx') {
+    result = wrapPlainUrls(result);
+  }
+
+  return result;
+}

--- a/packages/cli/src/formats/files/preprocessContent.ts
+++ b/packages/cli/src/formats/files/preprocessContent.ts
@@ -1,0 +1,33 @@
+import { Settings } from '../../types/index.js';
+import { preprocessMdx } from './preprocess/mdx.js';
+import { preprocessMintlify } from './preprocess/mintlify.js';
+import sanitizeFileContent from '../../utils/sanitizeFileContent.js';
+
+/**
+ * Preprocesses file content before upload. Returns the processed content,
+ * or { skip: reason } if the file should be skipped.
+ */
+export function preprocessContent(
+  content: string,
+  filePath: string,
+  fileType: string,
+  settings: Settings
+): string | { skip: string } {
+  let result = content;
+
+  // File-type-specific
+  if (fileType === 'mdx') {
+    const skipReason = preprocessMdx(result, filePath, settings);
+    if (skipReason) return { skip: skipReason };
+  }
+
+  // Framework-specific
+  if (settings.framework === 'mintlify') {
+    result = preprocessMintlify(result, filePath, fileType, settings);
+  }
+
+  // Universal
+  result = sanitizeFileContent(result);
+
+  return result;
+}

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.6.27';
+export const PACKAGE_VERSION = '2.6.29';

--- a/packages/cli/src/utils/__tests__/wrapPlainUrls.test.ts
+++ b/packages/cli/src/utils/__tests__/wrapPlainUrls.test.ts
@@ -245,6 +245,15 @@ describe('wrapPlainUrls', () => {
     expect(wrapPlainUrls(input)).toBe(input);
   });
 
+  // --- URL with parentheses in path ---
+  it('wraps URLs with parentheses in the path', () => {
+    const input =
+      'See https://en.wikipedia.org/wiki/Unix_(operating_system) for details.';
+    const expected =
+      'See [https://en.wikipedia.org/wiki/Unix_(operating_system)](https://en.wikipedia.org/wiki/Unix_(operating_system)) for details.';
+    expect(wrapPlainUrls(input)).toBe(expected);
+  });
+
   // --- URL with fragment ---
   it('wraps URL with hash fragment', () => {
     const input = 'See https://example.com/docs#section for details.';

--- a/packages/cli/src/utils/__tests__/wrapPlainUrls.test.ts
+++ b/packages/cli/src/utils/__tests__/wrapPlainUrls.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect } from 'vitest';
+import wrapPlainUrls from '../wrapPlainUrls.js';
+
+describe('wrapPlainUrls', () => {
+  // --- Basic wrapping ---
+  it('wraps a plain URL in markdown link syntax', () => {
+    const input = 'Visit https://www.anthropic.com for more info.';
+    const expected =
+      'Visit [https://www.anthropic.com](https://www.anthropic.com) for more info.';
+    expect(wrapPlainUrls(input)).toBe(expected);
+  });
+
+  it('wraps multiple plain URLs on the same line', () => {
+    const input = 'See https://a.com and https://b.com for details.';
+    const expected =
+      'See [https://a.com](https://a.com) and [https://b.com](https://b.com) for details.';
+    expect(wrapPlainUrls(input)).toBe(expected);
+  });
+
+  it('wraps URLs with paths and query strings', () => {
+    const input = 'Go to https://example.com/docs?page=1&lang=en for help.';
+    const expected =
+      'Go to [https://example.com/docs?page=1&lang=en](https://example.com/docs?page=1&lang=en) for help.';
+    expect(wrapPlainUrls(input)).toBe(expected);
+  });
+
+  it('wraps http URLs', () => {
+    const input = 'Visit http://example.com today.';
+    const expected =
+      'Visit [http://example.com](http://example.com) today.';
+    expect(wrapPlainUrls(input)).toBe(expected);
+  });
+
+  // --- Trailing punctuation ---
+  it('excludes trailing period from the URL', () => {
+    const input = 'Visit https://example.com.';
+    const expected = 'Visit [https://example.com](https://example.com).';
+    expect(wrapPlainUrls(input)).toBe(expected);
+  });
+
+  it('excludes trailing comma from the URL', () => {
+    const input = 'See https://example.com, then continue.';
+    const expected =
+      'See [https://example.com](https://example.com), then continue.';
+    expect(wrapPlainUrls(input)).toBe(expected);
+  });
+
+  // --- Skip existing markdown links ---
+  it('does not modify URLs already in markdown link syntax', () => {
+    const input = 'Click [here](https://example.com) for info.';
+    expect(wrapPlainUrls(input)).toBe(input);
+  });
+
+  it('does not modify URLs that are both display text and href', () => {
+    const input =
+      'Visit [https://example.com](https://example.com) for info.';
+    expect(wrapPlainUrls(input)).toBe(input);
+  });
+
+  it('does not modify markdown image links', () => {
+    const input = '![alt](https://example.com/image.png)';
+    expect(wrapPlainUrls(input)).toBe(input);
+  });
+
+  // --- Skip angle bracket autolinks ---
+  it('does not modify angle bracket autolinks', () => {
+    const input = 'See <https://example.com> for info.';
+    expect(wrapPlainUrls(input)).toBe(input);
+  });
+
+  // --- Skip inline code ---
+  it('does not modify URLs inside inline code', () => {
+    const input = 'Run `curl https://example.com/api` to test.';
+    expect(wrapPlainUrls(input)).toBe(input);
+  });
+
+  // --- Skip fenced code blocks ---
+  it('does not modify URLs inside fenced code blocks (backticks)', () => {
+    const input = [
+      'Some text',
+      '```',
+      'https://example.com/in-code',
+      '```',
+      'https://example.com/outside-code',
+    ].join('\n');
+    const expected = [
+      'Some text',
+      '```',
+      'https://example.com/in-code',
+      '```',
+      '[https://example.com/outside-code](https://example.com/outside-code)',
+    ].join('\n');
+    expect(wrapPlainUrls(input)).toBe(expected);
+  });
+
+  it('does not modify URLs inside fenced code blocks (tildes)', () => {
+    const input = [
+      '~~~',
+      'https://example.com/in-code',
+      '~~~',
+      'https://example.com/outside',
+    ].join('\n');
+    const expected = [
+      '~~~',
+      'https://example.com/in-code',
+      '~~~',
+      '[https://example.com/outside](https://example.com/outside)',
+    ].join('\n');
+    expect(wrapPlainUrls(input)).toBe(expected);
+  });
+
+  it('handles code blocks with language specifier', () => {
+    const input = [
+      '```python',
+      'url = "https://example.com/api"',
+      '```',
+      'Visit https://example.com for more.',
+    ].join('\n');
+    const expected = [
+      '```python',
+      'url = "https://example.com/api"',
+      '```',
+      'Visit [https://example.com](https://example.com) for more.',
+    ].join('\n');
+    expect(wrapPlainUrls(input)).toBe(expected);
+  });
+
+  // --- Skip YAML frontmatter ---
+  it('does not modify URLs inside YAML frontmatter', () => {
+    const input = [
+      '---',
+      'canonical: https://example.com/page',
+      '---',
+      '',
+      'Visit https://example.com for more.',
+    ].join('\n');
+    const expected = [
+      '---',
+      'canonical: https://example.com/page',
+      '---',
+      '',
+      'Visit [https://example.com](https://example.com) for more.',
+    ].join('\n');
+    expect(wrapPlainUrls(input)).toBe(expected);
+  });
+
+  // --- Skip TOML frontmatter ---
+  it('does not modify URLs inside TOML frontmatter', () => {
+    const input = [
+      '+++',
+      'canonical = "https://example.com/page"',
+      '+++',
+      '',
+      'Visit https://example.com for more.',
+    ].join('\n');
+    const expected = [
+      '+++',
+      'canonical = "https://example.com/page"',
+      '+++',
+      '',
+      'Visit [https://example.com](https://example.com) for more.',
+    ].join('\n');
+    expect(wrapPlainUrls(input)).toBe(expected);
+  });
+
+  // --- Idempotency ---
+  it('is idempotent — running twice produces the same result', () => {
+    const input = 'Visit https://example.com for more info.';
+    const once = wrapPlainUrls(input);
+    const twice = wrapPlainUrls(once);
+    expect(twice).toBe(once);
+  });
+
+  // --- No URLs ---
+  it('returns content unchanged when there are no URLs', () => {
+    const input = 'Just some text without any links.';
+    expect(wrapPlainUrls(input)).toBe(input);
+  });
+
+  // --- Empty content ---
+  it('handles empty string', () => {
+    expect(wrapPlainUrls('')).toBe('');
+  });
+
+  // --- Real-world Mintlify example ---
+  it('handles the Korean translation edge case', () => {
+    const input =
+      '1. Sign up for an account at https://www.anthropic.com';
+    const expected =
+      '1. Sign up for an account at [https://www.anthropic.com](https://www.anthropic.com)';
+    expect(wrapPlainUrls(input)).toBe(expected);
+  });
+
+  // --- Mixed content ---
+  it('handles lines with both plain and wrapped URLs', () => {
+    const input =
+      'See https://plain.com and [wrapped](https://wrapped.com) together.';
+    const expected =
+      'See [https://plain.com](https://plain.com) and [wrapped](https://wrapped.com) together.';
+    expect(wrapPlainUrls(input)).toBe(expected);
+  });
+
+  // --- URL at start of line ---
+  it('wraps URL at the start of a line', () => {
+    const input = 'https://example.com is a great site.';
+    const expected =
+      '[https://example.com](https://example.com) is a great site.';
+    expect(wrapPlainUrls(input)).toBe(expected);
+  });
+
+  // --- Nested markdown links (image inside a link) ---
+  it('does not modify URLs in nested markdown links like [![alt](img)](url)', () => {
+    const input =
+      '[![arXiv](https://img.shields.io/badge/arXiv-2309.04269-b31b1b.svg)](https://arxiv.org/abs/2309.04269)';
+    expect(wrapPlainUrls(input)).toBe(input);
+  });
+
+  // --- HTML/JSX attributes ---
+  it('does not modify URLs inside HTML anchor tags', () => {
+    const input = '<a href="https://example.com">click here</a>';
+    expect(wrapPlainUrls(input)).toBe(input);
+  });
+
+  it('does not modify URLs inside JSX component props', () => {
+    const input = '<Component url="https://example.com/api" />';
+    expect(wrapPlainUrls(input)).toBe(input);
+  });
+
+  it('does not modify URLs inside img src attributes', () => {
+    const input = '<img src="https://example.com/image.png" alt="photo" />';
+    expect(wrapPlainUrls(input)).toBe(input);
+  });
+
+  // --- HTML comments ---
+  it('does not modify URLs inside HTML comments', () => {
+    const input = '<!-- see https://example.com for reference -->';
+    expect(wrapPlainUrls(input)).toBe(input);
+  });
+
+  // --- Reference-style links ---
+  it('does not modify reference-style link definitions', () => {
+    const input = '[1]: https://example.com/docs';
+    expect(wrapPlainUrls(input)).toBe(input);
+  });
+
+  it('does not modify reference-style link definitions with labels', () => {
+    const input = '[example-link]: https://example.com/page';
+    expect(wrapPlainUrls(input)).toBe(input);
+  });
+
+  // --- URL with fragment ---
+  it('wraps URL with hash fragment', () => {
+    const input = 'See https://example.com/docs#section for details.';
+    const expected =
+      'See [https://example.com/docs#section](https://example.com/docs#section) for details.';
+    expect(wrapPlainUrls(input)).toBe(expected);
+  });
+});

--- a/packages/cli/src/utils/__tests__/wrapPlainUrls.test.ts
+++ b/packages/cli/src/utils/__tests__/wrapPlainUrls.test.ts
@@ -26,8 +26,7 @@ describe('wrapPlainUrls', () => {
 
   it('wraps http URLs', () => {
     const input = 'Visit http://example.com today.';
-    const expected =
-      'Visit [http://example.com](http://example.com) today.';
+    const expected = 'Visit [http://example.com](http://example.com) today.';
     expect(wrapPlainUrls(input)).toBe(expected);
   });
 
@@ -52,8 +51,7 @@ describe('wrapPlainUrls', () => {
   });
 
   it('does not modify URLs that are both display text and href', () => {
-    const input =
-      'Visit [https://example.com](https://example.com) for info.';
+    const input = 'Visit [https://example.com](https://example.com) for info.';
     expect(wrapPlainUrls(input)).toBe(input);
   });
 
@@ -184,8 +182,7 @@ describe('wrapPlainUrls', () => {
 
   // --- Real-world Mintlify example ---
   it('handles the Korean translation edge case', () => {
-    const input =
-      '1. Sign up for an account at https://www.anthropic.com';
+    const input = '1. Sign up for an account at https://www.anthropic.com';
     const expected =
       '1. Sign up for an account at [https://www.anthropic.com](https://www.anthropic.com)';
     expect(wrapPlainUrls(input)).toBe(expected);

--- a/packages/cli/src/utils/wrapPlainUrls.ts
+++ b/packages/cli/src/utils/wrapPlainUrls.ts
@@ -11,12 +11,8 @@ const URL_REGEX = /https?:\/\/[^\s<>\[\]()]*[^\s<>\[\]().,;:!?'")\]}>]/g;
  * Wraps plain URLs in markdown link syntax [url](url) so that
  * translation pipelines preserve the URL separately from surrounding text.
  *
- * Uses remark AST parsing to identify URLs that appear in text nodes only —
- * URLs inside code, frontmatter, JSX attributes, link hrefs, etc. are
- * inherently different node types and are never touched.
+ * Uses remark AST parsing to identify URLs that appear in text nodes only.
  *
- * Applies replacements to the original string using AST positions so that
- * no formatting changes are introduced by remark-stringify.
  */
 export default function wrapPlainUrls(content: string): string {
   let ast: Root;

--- a/packages/cli/src/utils/wrapPlainUrls.ts
+++ b/packages/cli/src/utils/wrapPlainUrls.ts
@@ -5,8 +5,7 @@ import remarkFrontmatter from 'remark-frontmatter';
 import { visit } from 'unist-util-visit';
 import type { Root, Text } from 'mdast';
 
-const URL_REGEX =
-  /https?:\/\/[^\s<>\[\]()]*[^\s<>\[\]().,;:!?'")\]}>]/g;
+const URL_REGEX = /https?:\/\/[^\s<>\[\]()]*[^\s<>\[\]().,;:!?'")\]}>]/g;
 
 /**
  * Wraps plain URLs in markdown link syntax [url](url) so that
@@ -67,8 +66,7 @@ export default function wrapPlainUrls(content: string): string {
   let result = content;
   for (let i = replacements.length - 1; i >= 0; i--) {
     const { start, end, url } = replacements[i];
-    result =
-      result.slice(0, start) + `[${url}](${url})` + result.slice(end);
+    result = result.slice(0, start) + `[${url}](${url})` + result.slice(end);
   }
 
   return result;

--- a/packages/cli/src/utils/wrapPlainUrls.ts
+++ b/packages/cli/src/utils/wrapPlainUrls.ts
@@ -1,0 +1,75 @@
+import { unified } from 'unified';
+import remarkParse from 'remark-parse';
+import remarkMdx from 'remark-mdx';
+import remarkFrontmatter from 'remark-frontmatter';
+import { visit } from 'unist-util-visit';
+import type { Root, Text } from 'mdast';
+
+const URL_REGEX =
+  /https?:\/\/[^\s<>\[\]()]*[^\s<>\[\]().,;:!?'")\]}>]/g;
+
+/**
+ * Wraps plain URLs in markdown link syntax [url](url) so that
+ * translation pipelines preserve the URL separately from surrounding text.
+ *
+ * Uses remark AST parsing to identify URLs that appear in text nodes only —
+ * URLs inside code, frontmatter, JSX attributes, link hrefs, etc. are
+ * inherently different node types and are never touched.
+ *
+ * Applies replacements to the original string using AST positions so that
+ * no formatting changes are introduced by remark-stringify.
+ */
+export default function wrapPlainUrls(content: string): string {
+  let ast: Root;
+  try {
+    const processor = unified()
+      .use(remarkParse)
+      .use(remarkFrontmatter, ['yaml', 'toml'])
+      .use(remarkMdx);
+
+    ast = processor.parse(content);
+    ast = processor.runSync(ast) as Root;
+  } catch {
+    // If parsing fails, return content unchanged
+    return content;
+  }
+
+  // Collect all URL replacements from text nodes with their positions
+  const replacements: { start: number; end: number; url: string }[] = [];
+
+  visit(ast, 'text', (node: Text, _index, parent) => {
+    // Skip text nodes inside links — those are already display text for a link
+    if (parent && parent.type === 'link') return;
+
+    const pos = node.position;
+    if (!pos) return;
+
+    const value = node.value;
+    URL_REGEX.lastIndex = 0;
+    let match: RegExpExecArray | null;
+
+    while ((match = URL_REGEX.exec(value)) !== null) {
+      const url = match[0];
+      const nodeStartOffset = pos.start.offset;
+      if (nodeStartOffset === undefined) continue;
+
+      // Calculate the absolute offset in the original content
+      const urlStart = nodeStartOffset + match.index;
+      const urlEnd = urlStart + url.length;
+
+      replacements.push({ start: urlStart, end: urlEnd, url });
+    }
+  });
+
+  if (replacements.length === 0) return content;
+
+  // Apply replacements in reverse order to preserve positions
+  let result = content;
+  for (let i = replacements.length - 1; i >= 0; i--) {
+    const { start, end, url } = replacements[i];
+    result =
+      result.slice(0, start) + `[${url}](${url})` + result.slice(end);
+  }
+
+  return result;
+}

--- a/packages/cli/src/utils/wrapPlainUrls.ts
+++ b/packages/cli/src/utils/wrapPlainUrls.ts
@@ -5,8 +5,6 @@ import remarkFrontmatter from 'remark-frontmatter';
 import { visit } from 'unist-util-visit';
 import type { Root, Text } from 'mdast';
 
-const URL_REGEX = /https?:\/\/[^\s<>\[\]()]*[^\s<>\[\]().,;:!?'")\]}>]/g;
-
 /**
  * Wraps plain URLs in markdown link syntax [url](url) so that
  * translation pipelines preserve the URL separately from surrounding text.
@@ -15,6 +13,7 @@ const URL_REGEX = /https?:\/\/[^\s<>\[\]()]*[^\s<>\[\]().,;:!?'")\]}>]/g;
  *
  */
 export default function wrapPlainUrls(content: string): string {
+  const URL_REGEX = /https?:\/\/[^\s<>\[\]]*[^\s<>\[\].,;:!?'"\]}>]/g;
   let ast: Root;
   try {
     const processor = unified()
@@ -40,13 +39,25 @@ export default function wrapPlainUrls(content: string): string {
     if (!pos) return;
 
     const value = node.value;
-    URL_REGEX.lastIndex = 0;
     let match: RegExpExecArray | null;
 
     while ((match = URL_REGEX.exec(value)) !== null) {
-      const url = match[0];
+      let url = match[0];
       const nodeStartOffset = pos.start.offset;
       if (nodeStartOffset === undefined) continue;
+
+      // Trim unbalanced trailing ')' so that prose like "(see https://example.com)"
+      // doesn't absorb the surrounding paren, while Wikipedia-style URLs with
+      // balanced parens (e.g. /wiki/Unix_(operating_system)) are kept intact.
+      while (url.endsWith(')')) {
+        const open = url.split('(').length - 1;
+        const close = url.split(')').length - 1;
+        if (close > open) {
+          url = url.slice(0, -1);
+        } else {
+          break;
+        }
+      }
 
       // Calculate the absolute offset in the original content
       const urlStart = nodeStartOffset + match.index;


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a `wrapPlainUrls` preprocessing step for the `gtx-cli` tool that converts bare URLs in text into Markdown link syntax (`[url](url)`) before uploading Mintlify MDX/MD files for translation. The transformation is applied only when `framework === 'mintlify'` and uses AST-based parsing (via `remark`/`remark-mdx`/`remark-frontmatter`) to target text nodes exclusively, correctly skipping URLs in code blocks, frontmatter, JSX attributes, existing markdown links, and HTML comments.

Key changes:
- **New utility** `packages/cli/src/utils/wrapPlainUrls.ts`: AST-driven URL wrapper with fallback to original content on parse failure and reverse-order replacement to preserve character positions.
- **Integration in `aggregateFiles.ts`**: URL wrapping is gated on `fileType === 'md' || fileType === 'mdx'` and `settings.framework === 'mintlify'`, applied after `applyMintlifyTitleFallback` and before `sanitizeFileContent`.
- **Comprehensive test suite** with 25 cases covering frontmatter, code blocks, JSX, idempotency, and mixed content.
- **Notable gap**: The URL regex character class `[^\s<>\[\]()]*` excludes `(` from the middle of URL paths, causing URLs with parentheses (e.g. Wikipedia-style `https://en.wikipedia.org/wiki/Unix_(operating_system)`) to be silently truncated. Because the function already uses AST parsing to ensure it only matches text nodes (never link hrefs), excluding `(` from the *middle* class is overly conservative and not required for correctness.

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

- Safe to merge for most content, but URLs with parentheses in paths will be silently truncated, producing malformed wrapped links in translated output.
- The overall architecture is clean and well-tested. The AST-based approach is the right abstraction and the integration in `aggregateFiles.ts` is minimal and correctly scoped. However, the URL regex excludes `(` in the middle character class, which will incorrectly truncate valid URLs like Wikipedia links. Since this produces silently wrong output (a broken URL rather than a parse error), it warrants attention before merging to production Mintlify users who may have such links in their docs.
- `packages/cli/src/utils/wrapPlainUrls.ts` — the `URL_REGEX` on line 8 needs the parentheses exclusion revisited in its middle character class.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/cli/src/utils/wrapPlainUrls.ts | Core new utility: AST-based URL wrapping for Mintlify MDX. Logic is sound but the URL regex excludes `(` from the middle character class, causing URLs with parentheses in paths (e.g. Wikipedia links) to be truncated; module-level mutable regex with `g` flag also introduces subtle shared-state risk. |
| packages/cli/src/utils/__tests__/wrapPlainUrls.test.ts | Comprehensive test suite covering the main happy paths, edge cases (frontmatter, code blocks, JSX attributes, idempotency). Missing coverage for URLs with parentheses in paths, which is a known gap tied to the regex issue. |
| packages/cli/src/formats/files/aggregateFiles.ts | URL wrapping is applied only for `md`/`mdx` files with `framework === 'mintlify'`, correctly after the title-fallback step and before sanitization. Integration looks clean. |
| .changeset/tasty-rockets-rule.md | Patch-level changeset entry for `gtx-cli` describing the new Mintlify URL preprocessing step. Accurate and correctly scoped. |
| packages/cli/src/generated/version.ts | Auto-generated version bump from 2.6.27 → 2.6.29. No issues. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[aggregateFiles called] --> B{fileType is md or mdx?}
    B -- No --> G[sanitizeFileContent]
    B -- Yes --> C{framework === mintlify?}
    C -- No --> G
    C -- Yes --> D[wrapPlainUrls]

    subgraph wrapPlainUrls
        D --> E[Parse content with remark + remark-mdx + remark-frontmatter]
        E --> F{Parse succeeded?}
        F -- No --> R[Return content unchanged]
        F -- Yes --> H[visit AST text nodes]
        H --> I{Parent is link node?}
        I -- Yes --> J[Skip — already wrapped]
        I -- No --> K[Run URL_REGEX against node value]
        K --> L{Match found?}
        L -- Yes --> M[Record start/end offset + url]
        M --> K
        L -- No --> N[All text nodes visited]
        N --> O[Apply replacements in reverse offset order]
        O --> P[Return wrapped content]
    end

    P --> G[sanitizeFileContent]
    G --> Q[Upload FileToUpload with versionId from original content]
```
</details>


<sub>Last reviewed commit: d058d69</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Plain URLs in Mintlify MDX are now automatically wrapped as Markdown links for better parser compatibility.

* **New Features**
  * Unified content preprocessing before upload: MDX validation with clear skip reasons, Mintlify-specific transformations (optional title inference) and universal sanitization; framework-aware processing for Mintlify.

* **Tests**
  * Extensive test suite validating URL-wrapping across many edge cases and content scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->