### PR TITLE
fix: handle data prop injection

### DIFF
--- a/.changeset/tangy-apples-trade.md
+++ b/.changeset/tangy-apples-trade.md
@@ -1,0 +1,9 @@
+---
+'@generaltranslation/react-core-linter': patch
+'@generaltranslation/react-core': patch
+'@generaltranslation/compiler': patch
+'gt-next': patch
+'gtx-cli': patch
+---
+
+fix: runtime calculation for the injection of 'data-' attribute in jsx

--- a/packages/cli/src/console/index.ts
+++ b/packages/cli/src/console/index.ts
@@ -1,3 +1,4 @@
+import { BRANCH_COMPONENT } from '../react/jsx/utils/constants.js';
 import {
   colorizeFilepath,
   colorizeComponent,
@@ -233,6 +234,17 @@ export const warnInvalidStaticInitSync = (
 Example: ${colorizeContent(`const ${colorizeFunctionName(functionName)} = () => { ... }`)}
 Invalid: ${colorizeContent(`const ${colorizeFunctionName(functionName)} = [() => { ... }][0]`)}`
     ),
+    location
+  );
+
+export const warnDataAttrOnBranch = (
+  file: string,
+  attrName: string,
+  location?: string
+): string =>
+  withLocation(
+    file,
+    `${colorizeComponent(`<${BRANCH_COMPONENT}>`)} component ignores attributes prefixed with ${colorizeIdString('"data-"')}. Found ${colorizeIdString(attrName)}. Remove it or use a different attribute name.`,
     location
   );
 

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.6.27';
+export const PACKAGE_VERSION = '2.6.29';

--- a/packages/cli/src/react/jsx/utils/constants.ts
+++ b/packages/cli/src/react/jsx/utils/constants.ts
@@ -7,6 +7,7 @@ export const INLINE_MESSAGE_HOOK = 'useMessages';
 export const INLINE_MESSAGE_HOOK_ASYNC = 'getMessages';
 export const TRANSLATION_COMPONENT = 'T';
 export const STATIC_COMPONENT = 'Static';
+export const BRANCH_COMPONENT = 'Branch';
 
 // GT translation functions
 export const GT_TRANSLATION_FUNCS = [
@@ -23,7 +24,7 @@ export const GT_TRANSLATION_FUNCS = [
   'DateTime',
   'Currency',
   'Num',
-  'Branch',
+  BRANCH_COMPONENT,
   'Plural',
 ];
 // Valid variable components
@@ -47,3 +48,6 @@ export const GT_ATTRIBUTES = [
   'maxChars',
   ...GT_ATTRIBUTES_WITH_SUGAR,
 ] as const;
+
+// Data attribute prefix injected by build tools
+export const DATA_ATTR_PREFIX = 'data-' as const;

--- a/packages/cli/src/react/jsx/utils/jsxParsing/__tests__/addGTIdentifierToSyntaxTree.test.ts
+++ b/packages/cli/src/react/jsx/utils/jsxParsing/__tests__/addGTIdentifierToSyntaxTree.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import addGTIdentifierToSyntaxTree from '../addGTIdentifierToSyntaxTree.js';
+import type { MultipliedTreeNode } from '../types.js';
+
+describe('addGTIdentifierToSyntaxTree', () => {
+  describe('Branch data-* attribute filtering', () => {
+    it('should filter out data-* attributes from Branch props', () => {
+      const tree: MultipliedTreeNode = {
+        nodeType: 'element',
+        type: 'Branch',
+        props: {
+          children: 'fallback',
+          branch: 'status',
+          active: 'Active content',
+          inactive: 'Inactive content',
+          'data-testid': 'branch-test',
+        },
+      } as any;
+
+      const result = addGTIdentifierToSyntaxTree(tree);
+
+      // The result should be a JsxElement with a 'd' (GTProp) field
+      expect(result).toBeDefined();
+      const element = result as any;
+      expect(element.d).toBeDefined();
+      expect(element.d.t).toBe('b');
+      expect(element.d.b).toBeDefined();
+
+      // Branch props should include 'active' and 'inactive'
+      expect(element.d.b).toHaveProperty('active');
+      expect(element.d.b).toHaveProperty('inactive');
+
+      // data-testid should NOT be in the branches
+      expect(element.d.b).not.toHaveProperty('data-testid');
+    });
+
+    it('should preserve Branch props when no data-* attributes are present', () => {
+      const tree: MultipliedTreeNode = {
+        nodeType: 'element',
+        type: 'Branch',
+        props: {
+          children: 'fallback',
+          branch: 'status',
+          active: 'Active content',
+          inactive: 'Inactive content',
+        },
+      } as any;
+
+      const result = addGTIdentifierToSyntaxTree(tree);
+
+      const element = result as any;
+      expect(element.d).toBeDefined();
+      expect(element.d.t).toBe('b');
+      expect(element.d.b).toHaveProperty('active');
+      expect(element.d.b).toHaveProperty('inactive');
+    });
+  });
+});

--- a/packages/cli/src/react/jsx/utils/jsxParsing/addGTIdentifierToSyntaxTree.ts
+++ b/packages/cli/src/react/jsx/utils/jsxParsing/addGTIdentifierToSyntaxTree.ts
@@ -11,6 +11,7 @@ import {
 } from '../../../utils/getVariableName.js';
 import { isAcceptedPluralForm, JsxChild } from 'generaltranslation/internal';
 import { MultipliedTreeNode } from './types.js';
+import { DATA_ATTR_PREFIX } from '../constants.js';
 
 /**
  * Construct the data-_gt prop
@@ -54,7 +55,13 @@ function constructGTProp(
     // Branch
   } else if (type === 'Branch') {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
-    const { children, branch, ...branches } = props;
+    const { children, branch, ...allBranches } = props;
+    // Filter out data-* attributes injected by build tools
+    const branches = Object.fromEntries(
+      Object.entries(allBranches).filter(
+        ([key]) => !key.startsWith(DATA_ATTR_PREFIX)
+      )
+    );
     const resultBranches = Object.entries(branches).reduce(
       (acc: Record<string, JsxChildren>, [branchName, branch]) => {
         acc[branchName] = addGTIdentifierToSyntaxTree(branch, id);

--- a/packages/cli/src/react/jsx/utils/jsxParsing/parseJsx.ts
+++ b/packages/cli/src/react/jsx/utils/jsxParsing/parseJsx.ts
@@ -300,6 +300,12 @@ function buildJSXTree({
             ? attr.name.name
             : attr.name.name.name;
         let attrValue = null;
+        if (elementIsBranch && attrName.startsWith(DATA_ATTR_PREFIX)) {
+          const location = `${attr.loc?.start?.line}:${attr.loc?.start?.column}`;
+          output.errors.push(
+            warnDataAttrOnBranch(config.file, attrName, location)
+          );
+        }
         if (attr.value) {
           if (t.isStringLiteral(attr.value)) {
             attrValue = attr.value.value;
@@ -356,13 +362,6 @@ function buildJSXTree({
                 attrValue = staticAnalysis.value;
               }
               // Otherwise attrValue stays null and won't be included
-            }
-
-            if (elementIsBranch && attrName.startsWith('data-')) {
-              const location = `${attr.loc?.start?.line}:${attr.loc?.start?.column}`;
-              output.errors.push(
-                warnDataAttrOnBranch(config.file, attrName, location)
-              );
             }
           }
         }

--- a/packages/cli/src/react/jsx/utils/jsxParsing/parseJsx.ts
+++ b/packages/cli/src/react/jsx/utils/jsxParsing/parseJsx.ts
@@ -16,10 +16,12 @@ import {
   warnDuplicateFunctionDefinitionSync,
   warnInvalidStaticInitSync,
   warnRecursiveFunctionCallSync,
+  warnDataAttrOnBranch,
 } from '../../../../console/index.js';
 import { isAcceptedPluralForm, JsxChildren } from 'generaltranslation/internal';
 import { isStaticExpression } from '../../evaluateJsx.js';
 import {
+  DATA_ATTR_PREFIX,
   STATIC_COMPONENT,
   TRANSLATION_COMPONENT,
   VARIABLE_COMPONENTS,
@@ -313,7 +315,9 @@ function buildJSXTree({
             // If its a plural or branch prop
             if (
               (elementIsPlural && isAcceptedPluralForm(attrName as string)) ||
-              (elementIsBranch && attrName !== 'branch')
+              (elementIsBranch &&
+                attrName !== 'branch' &&
+                !attrName.startsWith(DATA_ATTR_PREFIX))
             ) {
               // Make sure that variable strings like {`I have ${count} book`} are invalid!
               if (
@@ -352,6 +356,13 @@ function buildJSXTree({
                 attrValue = staticAnalysis.value;
               }
               // Otherwise attrValue stays null and won't be included
+            }
+
+            if (elementIsBranch && attrName.startsWith('data-')) {
+              const location = `${attr.loc?.start?.line}:${attr.loc?.start?.column}`;
+              output.errors.push(
+                warnDataAttrOnBranch(config.file, attrName, location)
+              );
             }
           }
         }

--- a/packages/compiler/src/transform/jsx-children/utils/__tests__/getBranchComponentParameters.test.ts
+++ b/packages/compiler/src/transform/jsx-children/utils/__tests__/getBranchComponentParameters.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import * as t from '@babel/types';
+import { getBranchComponentParameters } from '../getBranchComponentParameters';
+import { GT_COMPONENT_TYPES } from '../../../../utils/constants/gt/constants';
+
+function makeObjectExpression(
+  props: Record<string, string>
+): t.ObjectExpression {
+  const properties = Object.entries(props).map(([key, value]) =>
+    t.objectProperty(t.stringLiteral(key), t.stringLiteral(value))
+  );
+  return t.objectExpression(properties);
+}
+
+describe('getBranchComponentParameters', () => {
+  it('should filter out branch and data-* attributes for Branch components', () => {
+    const expression = makeObjectExpression({
+      'data-testid': 'my-test',
+      'data-track': 'click',
+      branch: 'someBranch',
+      morning: 'Good morning',
+      evening: 'Good evening',
+    });
+
+    const result = getBranchComponentParameters(
+      expression,
+      GT_COMPONENT_TYPES.Branch
+    );
+
+    const keys = result.map(([key]) => key);
+    expect(keys).toEqual(['morning', 'evening']);
+  });
+
+  it('should NOT filter data-* attributes for Plural components', () => {
+    const expression = makeObjectExpression({
+      'data-testid': 'my-test',
+      'data-track': 'click',
+      n: '5',
+      one: 'One item',
+      other: 'Many items',
+    });
+
+    const result = getBranchComponentParameters(
+      expression,
+      GT_COMPONENT_TYPES.Plural
+    );
+
+    const keys = result.map(([key]) => key);
+    expect(keys).toEqual(['data-testid', 'data-track', 'one', 'other']);
+  });
+
+  it('should filter out children for any component type', () => {
+    const expression = makeObjectExpression({
+      children: 'child content',
+      morning: 'Good morning',
+    });
+
+    const result = getBranchComponentParameters(
+      expression,
+      GT_COMPONENT_TYPES.Branch
+    );
+
+    const keys = result.map(([key]) => key);
+    expect(keys).toEqual(['morning']);
+  });
+});

--- a/packages/compiler/src/transform/jsx-children/utils/getBranchComponentParameters.ts
+++ b/packages/compiler/src/transform/jsx-children/utils/getBranchComponentParameters.ts
@@ -33,6 +33,14 @@ export function getBranchComponentParameters(
         return null;
       }
 
+      // Filter out data-* attributes for Branch components
+      if (
+        canonicalName === GT_COMPONENT_TYPES.Branch &&
+        propertyName.startsWith('data-')
+      ) {
+        return null;
+      }
+
       // Filter by branch component type
       if (
         canonicalName === GT_COMPONENT_TYPES.Branch &&

--- a/packages/next/src/branches/Branch.tsx
+++ b/packages/next/src/branches/Branch.tsx
@@ -30,8 +30,11 @@ function Branch({
   branch?: string | number | boolean;
   [key: string]: any;
 }): React.JSX.Element {
-  // const { 'data-_gt': generaltranslation, ...branches } = props;
   branch = branch?.toString();
+  // ignore data-* attributes
+  if (typeof branch === 'string' && branch.startsWith('data-')) {
+    branch = undefined;
+  }
   const renderedBranch =
     branch && typeof branches[branch] !== 'undefined'
       ? branches[branch]

--- a/packages/next/swc-plugin/src/ast/traversal.rs
+++ b/packages/next/swc-plugin/src/ast/traversal.rs
@@ -535,7 +535,7 @@ impl<'a> JsxTraversal<'a> {
           let prop_name = name_ident.sym.as_ref();
 
           // Skip special props
-          if matches!(prop_name, "branch") {
+          if matches!(prop_name, "branch") || prop_name.starts_with("data-") {
             continue;
           }
 
@@ -1290,7 +1290,7 @@ mod tests {
     fn test_calculate_element_hash_consistency() {
       let visitor = create_test_visitor();
       let mut traversal = JsxTraversal::new(&visitor);
-      
+
       let element1 = create_jsx_element_with_children("T", vec![
         create_jsx_text_child("Hello world")
       ]);
@@ -1300,10 +1300,90 @@ mod tests {
 
       let (hash1, _) = traversal.calculate_element_hash(&element1);
       let (hash2, _) = traversal.calculate_element_hash(&element2);
-      
+
       // Same content should produce same hash
       assert_eq!(hash1, hash2, "Same content should produce same hash");
       assert!(!hash1.is_empty(), "Hash should not be empty for identical content");
+    }
+  }
+
+  mod extract_branch_props_tests {
+    use super::*;
+
+    // Helper to create a JSX string attribute
+    fn create_jsx_attr(name: &str, value: &str) -> JSXAttrOrSpread {
+      JSXAttrOrSpread::JSXAttr(JSXAttr {
+        span: DUMMY_SP,
+        name: JSXAttrName::Ident(IdentName {
+          span: DUMMY_SP,
+          sym: Atom::new(name),
+        }),
+        value: Some(JSXAttrValue::Str(Str {
+          span: DUMMY_SP,
+          value: Atom::new(value).into(),
+          raw: None,
+        })),
+      })
+    }
+
+    #[test]
+    fn filters_data_attributes() {
+      let visitor = create_test_visitor();
+      let mut traversal = JsxTraversal::new(&visitor);
+
+      let attrs = vec![
+        create_jsx_attr("branch", "val"),
+        create_jsx_attr("data-testid", "test"),
+        create_jsx_attr("data-track", "track"),
+        create_jsx_attr("morning", "Good morning"),
+        create_jsx_attr("evening", "Good evening"),
+      ];
+
+      let result = traversal.extract_branch_props(&attrs);
+      assert!(result.is_some());
+      let branches = result.unwrap();
+
+      // Should only contain morning and evening, not branch or data-*
+      assert_eq!(branches.len(), 2);
+      assert!(branches.contains_key("morning"));
+      assert!(branches.contains_key("evening"));
+      assert!(!branches.contains_key("branch"));
+      assert!(!branches.contains_key("data-testid"));
+      assert!(!branches.contains_key("data-track"));
+    }
+
+    #[test]
+    fn returns_none_when_only_data_and_branch_attrs() {
+      let visitor = create_test_visitor();
+      let mut traversal = JsxTraversal::new(&visitor);
+
+      let attrs = vec![
+        create_jsx_attr("branch", "val"),
+        create_jsx_attr("data-testid", "test"),
+      ];
+
+      let result = traversal.extract_branch_props(&attrs);
+      assert!(result.is_none(), "Should return None when no valid branch props remain");
+    }
+
+    #[test]
+    fn allows_non_data_prefixed_attrs() {
+      let visitor = create_test_visitor();
+      let mut traversal = JsxTraversal::new(&visitor);
+
+      let attrs = vec![
+        create_jsx_attr("database", "postgres"),
+        create_jsx_attr("dataSource", "api"),
+      ];
+
+      let result = traversal.extract_branch_props(&attrs);
+      assert!(result.is_some());
+      let branches = result.unwrap();
+
+      // "database" and "dataSource" don't start with "data-", so they should be kept
+      assert_eq!(branches.len(), 2);
+      assert!(branches.contains_key("database"));
+      assert!(branches.contains_key("dataSource"));
     }
   }
 }

--- a/packages/react-core-linter/src/index.ts
+++ b/packages/react-core-linter/src/index.ts
@@ -7,6 +7,7 @@
  */
 
 import type { ESLint, Rule } from 'eslint';
+import { noDataAttrsOnBranch } from './rules/no-data-attrs-on-branch/index.js';
 import { staticJsx } from './rules/static-jsx/index.js';
 import { staticString } from './rules/static-string/index.js';
 
@@ -16,6 +17,8 @@ const plugin: ESLint.Plugin = {
     version: '0.0.0',
   },
   rules: {
+    'no-data-attrs-on-branch':
+      noDataAttrsOnBranch as unknown as Rule.RuleModule,
     'static-jsx': staticJsx as unknown as Rule.RuleModule,
     'static-string': staticString as unknown as Rule.RuleModule,
   },
@@ -23,6 +26,8 @@ const plugin: ESLint.Plugin = {
     recommended: {
       plugins: ['@generaltranslation/react-core-linter'],
       rules: {
+        '@generaltranslation/react-core-linter/no-data-attrs-on-branch':
+          'error',
         '@generaltranslation/react-core-linter/static-jsx': 'error',
         '@generaltranslation/react-core-linter/static-string': 'error',
       },
@@ -34,6 +39,7 @@ plugin.configs = {
   recommended: {
     plugins: { '@generaltranslation/react-core-linter': plugin },
     rules: {
+      '@generaltranslation/react-core-linter/no-data-attrs-on-branch': 'error',
       '@generaltranslation/react-core-linter/static-jsx': 'error',
       '@generaltranslation/react-core-linter/static-string': 'error',
     },

--- a/packages/react-core-linter/src/rules/no-data-attrs-on-branch/__tests__/no-data-attrs-on-branch.test.ts
+++ b/packages/react-core-linter/src/rules/no-data-attrs-on-branch/__tests__/no-data-attrs-on-branch.test.ts
@@ -1,0 +1,114 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { describe, it } from 'vitest';
+import { noDataAttrsOnBranch } from '../index.js';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2020,
+    sourceType: 'module',
+    parserOptions: {
+      ecmaFeatures: {
+        jsx: true,
+      },
+    },
+  },
+});
+
+describe('no-data-attrs-on-branch rule', () => {
+  it('should allow Branch with normal props and no data-* attributes', () => {
+    ruleTester.run('no-data-attrs-on-branch', noDataAttrsOnBranch, {
+      valid: [
+        {
+          code: `
+            import { Branch } from 'gt-react';
+            function Component() {
+              const val = 'morning';
+              return <Branch branch={val} morning={<p>morning</p>}>default</Branch>;
+            }
+          `,
+          options: [{ libs: ['gt-react'] }],
+        },
+      ],
+      invalid: [],
+    });
+  });
+
+  it('should allow data-* attributes on non-Branch components', () => {
+    ruleTester.run('no-data-attrs-on-branch', noDataAttrsOnBranch, {
+      valid: [
+        {
+          code: `
+            function Component() {
+              return <div data-testid="x">hello</div>;
+            }
+          `,
+          options: [{ libs: ['gt-react'] }],
+        },
+      ],
+      invalid: [],
+    });
+  });
+
+  it('should allow data-* attributes on Plural component', () => {
+    ruleTester.run('no-data-attrs-on-branch', noDataAttrsOnBranch, {
+      valid: [
+        {
+          code: `
+            import { Plural } from 'gt-react';
+            function Component() {
+              return <Plural data-testid="x" n={1} singular={<p>one</p>}>default</Plural>;
+            }
+          `,
+          options: [{ libs: ['gt-react'] }],
+        },
+      ],
+      invalid: [],
+    });
+  });
+
+  it('should report error for data-* attributes on Branch', () => {
+    ruleTester.run('no-data-attrs-on-branch', noDataAttrsOnBranch, {
+      valid: [],
+      invalid: [
+        {
+          code: `
+            import { Branch } from 'gt-react';
+            function Component() {
+              const val = 'morning';
+              return <Branch data-testid="x" branch={val} morning={<p>morning</p>}>default</Branch>;
+            }
+          `,
+          options: [{ libs: ['gt-react'] }],
+          errors: [
+            {
+              messageId: 'noDataAttrsOnBranch',
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('should report error for data-* attributes on aliased Branch', () => {
+    ruleTester.run('no-data-attrs-on-branch', noDataAttrsOnBranch, {
+      valid: [],
+      invalid: [
+        {
+          code: `
+            import { Branch as B } from 'gt-next';
+            function Component() {
+              const val = 'morning';
+              return <B data-track="y" branch={val} morning={<p>morning</p>}>default</B>;
+            }
+          `,
+          options: [{ libs: ['gt-next'] }],
+          errors: [
+            {
+              messageId: 'noDataAttrsOnBranch',
+            },
+          ],
+        },
+      ],
+    });
+  });
+});

--- a/packages/react-core-linter/src/rules/no-data-attrs-on-branch/index.ts
+++ b/packages/react-core-linter/src/rules/no-data-attrs-on-branch/index.ts
@@ -1,0 +1,70 @@
+import { ESLintUtils, TSESTree } from '@typescript-eslint/utils';
+import { GT_LIBRARIES, RULE_URL } from '../../utils/constants.js';
+import { isBranchComponent } from '../../utils/isGTFunction.js';
+
+const createRule = ESLintUtils.RuleCreator((name) => `${RULE_URL}${name}`);
+
+export const noDataAttrsOnBranch = createRule({
+  name: 'no-data-attrs-on-branch',
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'The Branch component ignores any attributes prefixed with "data-".',
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          libs: {
+            type: 'array',
+            items: {
+              type: 'string',
+            },
+            description:
+              'List of library modules to check for translation components',
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    hasSuggestions: false,
+    messages: {
+      noDataAttrsOnBranch:
+        "The Branch component ignores any attributes prefixed with 'data-'. Remove data-* attributes from Branch.",
+    },
+  },
+  defaultOptions: [{ libs: GT_LIBRARIES }],
+  create(context, [options]) {
+    const { libs = GT_LIBRARIES } = options;
+
+    return {
+      JSXAttribute(node: TSESTree.JSXAttribute) {
+        // Check if the attribute name starts with "data-"
+        if (
+          node.name.type !== TSESTree.AST_NODE_TYPES.JSXIdentifier ||
+          !node.name.name.startsWith('data-')
+        ) {
+          return;
+        }
+
+        // Walk up to the parent JSXOpeningElement
+        const parent = node.parent;
+        if (
+          !parent ||
+          parent.type !== TSESTree.AST_NODE_TYPES.JSXOpeningElement
+        ) {
+          return;
+        }
+
+        // Check if the parent is a Branch component
+        if (isBranchComponent({ context, node: parent, libs })) {
+          context.report({
+            node,
+            messageId: 'noDataAttrsOnBranch',
+          });
+        }
+      },
+    };
+  },
+});

--- a/packages/react-core/src/branches/Branch.tsx
+++ b/packages/react-core/src/branches/Branch.tsx
@@ -32,6 +32,10 @@ function Branch({
   [key: string]: any;
 }): React.JSX.Element {
   branch = branch?.toString();
+  // ignore data-* attributes
+  if (typeof branch === 'string' && branch.startsWith('data-')) {
+    branch = undefined;
+  }
   const renderedBranch =
     branch && typeof branches[branch] !== 'undefined'
       ? branches[branch]

--- a/packages/react-core/src/internal/addGTIdentifier.tsx
+++ b/packages/react-core/src/internal/addGTIdentifier.tsx
@@ -65,7 +65,11 @@ export default function addGTIdentifier(
       if (transformationParts[0] === 'branch') {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
         const { children, branch, ...branches } = props;
-        const resultBranches = Object.entries(branches).reduce(
+        // Filter out data-* attributes injected by build tools
+        const filteredBranches = Object.fromEntries(
+          Object.entries(branches).filter(([key]) => !key.startsWith('data-'))
+        );
+        const resultBranches = Object.entries(filteredBranches).reduce(
           (acc, [branchName, branch]) => {
             (acc as Record<string, TaggedChildren>)[branchName] =
               addGTIdentifier(branch as ReactNode, index);


### PR DESCRIPTION
Many build tools will inject attributes into JSX for tracking. Almost always, you can identify these injected tag with their name `data-...`. Unfortunately, we were including these in our hash calculations for the `Branch` component during runtime. This component was particularly vulnerable because it accepts arbitrary attributes from the user. These arbitrary props are then added to the hash calculation at runtime. However, at build time, these props do not yet exist, so the registration tool never adds these to the hash. This creates a disparity between the two hashes.

The fix was quite simple. All we had to do was make the hash calculation more strict about what attributes it accepts. Other small changes included enforcement in the CLI tool and linter, so users will not try to use `data-...` fields explicitly. Additionally, the compilers were updated to emulate this runtime behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * data-* attributes on Branch components are now ignored at runtime, preventing them from being treated as branch keys.

* **New Features**
  * ESLint rule added to flag data-* attributes on Branch components.
  * CLI now emits a warning when data-* attributes are used on Branch.

* **Tests**
  * Added test suites covering Branch/Plural handling and the new lint rule.

* **Chores**
  * Changeset and patch version bumps across multiple packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes hash mismatches between build-time registration and runtime calculation in the `Branch` component caused by build tools injecting `data-` prefixed attributes. The fix filters `data-*` keys across all pipeline layers (runtime, CLI, compiler, linter) to ensure consistent hashing.

The core fix is sound: `addGTIdentifier.tsx` correctly filters `data-*` keys from branch props before hash computation, and equivalent filters are applied at build time (`addGTIdentifierToSyntaxTree.ts`, `getBranchComponentParameters.ts`, `traversal.rs`), build guardrails (new `no-data-attrs-on-branch` linter rule), and runtime safety (Branch.tsx guard).

However, two issues reduce confidence:

1. **Incomplete warning coverage in CLI** (`parseJsx.ts`): The `warnDataAttrOnBranch` call is positioned inside the expression-container type check, causing boolean and string-literal `data-*` attributes to skip the warning. Only expression-type attributes trigger the warning, leaving a developer-experience gap.

2. **Misleading comment in Branch.tsx**: Both `react-core` and `next` versions have a comment "ignore data-* attributes" that doesn't accurately describe the code, which checks whether the branch **selector value** starts with "data-", not whether injected prop keys are present. The comment should clarify that this guard prevents selection of keys filtered from the hash.

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

- Safe to merge with minor fixes — the core hash-fix logic is sound, but CLI warning coverage is incomplete and Branch.tsx comments are misleading.
- The primary fix in `addGTIdentifier.tsx` and build-tool equivalents is correct and well-tested across all pipeline layers. The ESLint rule is properly structured. Score is reduced from 5 because: (1) the `warnDataAttrOnBranch` warning in `parseJsx.ts` is nested inside the expression-container type check and will silently miss boolean and string-literal `data-*` attributes, creating a developer-experience gap where some patterns won't be warned about; and (2) the comment in both `Branch.tsx` files is misleading and doesn't accurately describe what the guard does, making the code harder to maintain and understand.
- `packages/cli/src/react/jsx/utils/jsxParsing/parseJsx.ts` (warning placement must catch all attribute value types) and `packages/react-core/src/branches/Branch.tsx` / `packages/next/src/branches/Branch.tsx` (comment clarity).
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["JSX Source Code\n&lt;Branch branch='x' morning={...} data-testid='t'&gt;"]

    subgraph BUILD["Build Time"]
        B["CLI / Compiler\nparseJsx.ts / addGTIdentifierToSyntaxTree.ts\ngetBranchComponentParameters.ts / traversal.rs"]
        C["Filter: drop data-* keys\nfrom branch props"]
        D["Hash computed WITHOUT data-*\n→ Registered in translation table"]
    end

    subgraph ESLINT["Lint Time"]
        E["ESLint no-data-attrs-on-branch rule"]
        F["Error reported if data-*\nattribute found on Branch"]
    end

    subgraph RUNTIME["Runtime"]
        G["addGTIdentifier.tsx\ncomputes hash"]
        H["Filter: drop data-* keys\nfrom branches spread"]
        I["Hash computed WITHOUT data-*\n→ Matches registered hash ✓"]
        J["Branch.tsx render\nbranch value check"]
        K{"branch value\nstarts with 'data-'?"}
        L["Set branch = undefined\n→ render fallback children"]
        M["Render branches[branch]"]
    end

    A --> BUILD
    A --> ESLINT
    A --> RUNTIME
    B --> C --> D
    E --> F
    G --> H --> I
    J --> K
    K -- Yes --> L
    K -- No --> M
```
</details>


<sub>Last reviewed commit: d938584</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->