### PR TITLE
F/flag all tx failures

### DIFF
--- a/.changeset/curvy-plums-shave.md
+++ b/.changeset/curvy-plums-shave.md
@@ -1,0 +1,5 @@
+---
+'gtx-cli': patch
+---
+
+Handle case where all jobs fail

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.6.29';
+export const PACKAGE_VERSION = '2.6.30';

--- a/packages/cli/src/workflows/download.ts
+++ b/packages/cli/src/workflows/download.ts
@@ -137,6 +137,11 @@ export async function runDownloadWorkflow({
           `Failed to translate for locale ${value.locale}`
         );
       }
+
+      // If all files failed translation, exit early
+      if (pollResult.fileTracker.completed.size === 0) {
+        return false;
+      }
     }
 
     // Even if polling timed out, still download whatever completed successfully


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a defensive early-exit path in `runDownloadWorkflow` so that when all polled translation jobs fail (i.e. `failed.size > 0` and `completed.size === 0`) the function returns `false` immediately instead of proceeding to the (no-op) download step. It also bumps the `gtx-cli` package version to `2.6.30` and adds the corresponding changeset entry.

**Key changes:**
- `packages/cli/src/workflows/download.ts`: New guard at lines 142–144 exits early when failures are recorded and no files completed, avoiding a pointless download call.
- `packages/cli/src/generated/version.ts`: Auto-generated version bump `2.6.29` → `2.6.30`.
- `.changeset/curvy-plums-shave.md`: Patch changeset entry describing the fix.

**Concern:**
- The early-exit condition `pollResult.fileTracker.completed.size === 0` does not account for the `skipped` bucket in `FileStatusTracker`. If some files were skipped (already translated, no new job required) and others failed, `completed.size` is still `0` and the function returns `false` prematurely — skipping the download of those already-available translations. The same gap exists in the pre-existing `return false` inside the `!pollResult.success` branch.

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

- Safe in the common all-fail case, but risks silently skipping valid downloads when skipped files coexist with failed ones.
- The change is small and addresses a real edge case, but the guard condition is subtly incomplete — it treats "no completions" as equivalent to "all failed" without accounting for the skipped state, which could cause the workflow to bail out even when downloadable translations exist.
- packages/cli/src/workflows/download.ts — review the early-exit guard and the parallel guard in the !pollResult.success branch for the same skipped-files gap.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/workflows/download.ts | Adds an early-exit guard when all polled translation jobs fail (completed.size === 0 within the failed.size > 0 block); the guard may incorrectly return false when some files were skipped (already-translated) rather than failed, potentially skipping valid downloads. |
| .changeset/curvy-plums-shave.md | New changeset entry marking a patch bump for gtx-cli to handle the case where all translation jobs fail — no issues. |
| packages/cli/src/generated/version.ts | Auto-generated version bump from 2.6.29 to 2.6.30 — no issues. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[runDownloadWorkflow called] --> B{jobData exists?}
    B -- No --> C[Mark all files as completed\n staging mode]
    B -- Yes --> D[PollTranslationJobsStep.run]
    D --> E{failed.size > 0?}
    E -- Yes --> F[Log failures\nrecordWarning for each]
    F --> G{completed.size === 0?\n NEW CHECK}
    G -- Yes --> H[return false ❌\n early exit]
    G -- No --> I{pollResult.success?}
    E -- No --> I
    I -- No timeout --> J[pollTimedOut = true]
    J --> K{completed.size > 0?}
    K -- No --> L[return false ❌]
    K -- Yes --> M[Warn: partial success\ncontinue to download]
    I -- Yes --> N[DownloadTranslationsStep.run]
    C --> N
    M --> N
    N --> O{pollTimedOut?}
    O -- Yes --> P[return false ❌]
    O -- No --> Q[return downloadResult ✅]
```
</details>

<sub>Last reviewed commit: 1987e5d</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced download workflow to exit early when all translation jobs fail, preventing unnecessary processing and improving system efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->