### PR TITLE
chore(mcp): fix docs tools

### DIFF
--- a/.changeset/neat-pianos-push.md
+++ b/.changeset/neat-pianos-push.md
@@ -1,0 +1,5 @@
+---
+'@generaltranslation/mcp': patch
+---
+
+Fix docs URLs

--- a/packages/mcp/src/resources/docs.ts
+++ b/packages/mcp/src/resources/docs.ts
@@ -35,7 +35,7 @@ export async function addDocsResource(server: McpServer) {
   // Resource for llms-full.txt
   server.resource('llms-full.txt', 'llms://llms-full.txt', async (uri) => {
     try {
-      const content = await fetchDocContent('llms-full.txt', false);
+      const content = await fetchDocContent('llms-full.txt');
 
       return {
         contents: [
@@ -61,7 +61,7 @@ export async function addDocsResource(server: McpServer) {
   // Resource for llms.txt
   server.resource('llms.txt', 'llms://llms.txt', async (uri) => {
     try {
-      const content = await fetchDocContent('llms.txt', false);
+      const content = await fetchDocContent('llms.txt');
 
       return {
         contents: [
@@ -90,8 +90,8 @@ export function startCacheRefreshJob() {
   const refreshCache = async () => {
     try {
       console.error('Refreshing MCP resources cache...');
-      await fetchDocContent('llms.txt', false);
-      await fetchDocContent('llms-full.txt', false);
+      await fetchDocContent('llms.txt');
+      await fetchDocContent('llms-full.txt');
       console.error('Cache refresh complete');
     } catch (error) {
       console.error('Error refreshing cache:', error);

--- a/packages/mcp/src/tools/docs.ts
+++ b/packages/mcp/src/tools/docs.ts
@@ -10,7 +10,7 @@ export function addDocsTools(server: McpServer) {
       path: z
         .string()
         .describe(
-          'The path to the documentation file (e.g., "/en-US/docs/cli/auth.mdx" or "/en-US/docs/react/introduction.mdx")'
+          'The path to the documentation file (e.g., "en-US/docs/cli/auth.mdx" or "en-US/docs/react/introduction.mdx")'
         ),
     },
     async ({ path }) => {

--- a/packages/mcp/src/tools/docs.ts
+++ b/packages/mcp/src/tools/docs.ts
@@ -10,7 +10,7 @@ export function addDocsTools(server: McpServer) {
       path: z
         .string()
         .describe(
-          'The path to the documentation file (e.g., "platform/index.mdx" or "react/introduction.mdx")'
+          'The path to the documentation file (e.g., "/en-US/docs/cli/auth.mdx" or "/en-US/docs/react/introduction.mdx")'
         ),
     },
     async ({ path }) => {
@@ -65,7 +65,7 @@ export function addDocsTools(server: McpServer) {
     async ({ type }) => {
       try {
         const filename = type === 'full' ? 'llms-full.txt' : 'llms.txt';
-        const content = await fetchDocContent(filename, false);
+        const content = await fetchDocContent(filename);
 
         if (!content) {
           return {

--- a/packages/mcp/src/utils/getDocs.ts
+++ b/packages/mcp/src/utils/getDocs.ts
@@ -1,9 +1,17 @@
 const BASE_URL = 'https://generaltranslation.com';
 
-export const DOCS_URL = `${BASE_URL}/docs`;
+/**
+ * Strips incorrect prefixes from doc paths.
+ * e.g. "/en-US/docs/node/api/initialize-gt" -> "node/api/initialize-gt"
+ */
+function sanitizeDocPath(path: string): string {
+  // Remove leading slash
+  const sanitized = path.replace(/^\/+/, '');
+  return sanitized;
+}
 
 export const getDocs = async (path: string) => {
-  const url = `${DOCS_URL}/${path}`;
+  const url = `${BASE_URL}/${sanitizeDocPath(path)}`;
   console.error(`Fetching document from: ${url}`);
 
   try {
@@ -29,10 +37,7 @@ export const CACHE_TTL = 5 * 60 * 1000; // 5 minutes in milliseconds
  * Fetches content from the docs URL with caching
  * Refreshes cache every 5 minutes
  */
-export async function fetchDocContent(
-  path: string,
-  includeDocsPath: boolean = true
-): Promise<string> {
+export async function fetchDocContent(path: string): Promise<string> {
   const now = Date.now();
 
   // Check if we have a valid cached entry
@@ -41,7 +46,7 @@ export async function fetchDocContent(
   }
 
   // Fetch fresh content
-  const url = includeDocsPath ? `${DOCS_URL}/${path}` : `${BASE_URL}/${path}`;
+  const url = `${BASE_URL}/${path}`;
   console.error(`Fetching document from: ${url}`);
 
   try {

--- a/packages/mcp/src/utils/getDocs.ts
+++ b/packages/mcp/src/utils/getDocs.ts
@@ -2,7 +2,7 @@ const BASE_URL = 'https://generaltranslation.com';
 
 /**
  * Strips incorrect prefixes from doc paths.
- * e.g. "/en-US/docs/node/api/initialize-gt" -> "node/api/initialize-gt"
+ * e.g. "/en-US/docs/node/api/initialize-gt" -> "en-US/docs/node/api/initialize-gt"
  */
 function sanitizeDocPath(path: string): string {
   // Remove leading slash


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes incorrect documentation URL construction in the MCP package by removing the now-unnecessary `DOCS_URL` constant (`${BASE_URL}/docs`) and the `includeDocsPath` boolean parameter from `fetchDocContent`, simplifying all URL building to use `BASE_URL` directly. It also adds a `sanitizeDocPath` helper to strip leading slashes from user-supplied paths in `getDocs`, and updates the `fetch-docs` tool description with more accurate path examples (`en-US/docs/...`).

**Key changes:**
- Removed `DOCS_URL` export and the `includeDocsPath` parameter from `fetchDocContent`, eliminating a source of incorrect URL generation
- Added `sanitizeDocPath` to defensively strip leading slashes from user-provided paths before URL construction in `getDocs`
- Updated the `fetch-docs` tool's path description to reflect the real URL structure
- Minor inconsistency: `sanitizeDocPath` is applied in `getDocs` but not in `fetchDocContent`, which uses the same URL pattern — worth applying consistently for robustness

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- This PR is safe to merge — it corrects broken doc URLs with a straightforward simplification and minimal risk.
- The change is small and well-scoped: it removes a parameter that was causing incorrect URL construction and adds a defensive path sanitizer. All existing call sites are updated consistently. The only minor concern is that `sanitizeDocPath` is not applied in `fetchDocContent`, creating a small inconsistency, but since `fetchDocContent` is currently only called with hardcoded, slash-free paths, there is no immediate bug.
- packages/mcp/src/utils/getDocs.ts — minor inconsistency between `getDocs` (uses `sanitizeDocPath`) and `fetchDocContent` (does not)
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/mcp/src/utils/getDocs.ts | Core URL-building logic simplified: removes `includeDocsPath` param and the exported `DOCS_URL` constant, adds `sanitizeDocPath` helper. Minor inconsistency: `sanitizeDocPath` is used in `getDocs` but not in `fetchDocContent`. |
| packages/mcp/src/tools/docs.ts | Updated path example in tool description to reflect the actual URL structure (`en-US/docs/...`), and dropped the now-removed `false` second argument from `fetchDocContent` calls. No issues. |
| packages/mcp/src/resources/docs.ts | Removed `false` second argument from all `fetchDocContent` calls to match the simplified signature. No issues. |
| .changeset/neat-pianos-push.md | Standard patch-level changeset entry for the `@generaltranslation/mcp` package. No issues. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[MCP Tool: fetch-docs\npath: 'en-US/docs/cli/auth.mdx'] --> B[getDocs path]
    B --> C[sanitizeDocPath\nremove leading slashes]
    C --> D["URL: BASE_URL + '/' + sanitized path\nhttps://generaltranslation.com/en-US/docs/cli/auth.mdx"]
    D --> E[fetch & return text]

    F[MCP Tool: list-docs\ntype: 'full' or 'short'] --> G["fetchDocContent\n'llms-full.txt' or 'llms.txt'"]
    H[MCP Resource: llms.txt / llms-full.txt] --> G
    I[Cache Refresh Job] --> G
    G --> J{Cache valid?}
    J -- Yes --> K[Return cached content]
    J -- No --> L["URL: BASE_URL + '/' + path\nhttps://generaltranslation.com/llms.txt"]
    L --> M[fetch, update cache & return]
```
</details>

<sub>Last reviewed commit: 7be3969</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed documentation URL references
  * Enhanced error handling when fetching documentation with improved fallback to cached content

* **Documentation**
  * Updated documentation path examples to clarify locale-prefixed path structure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->