### PR TITLE
fix: apply style guide to error messages and warnings

### DIFF
--- a/packages/core/src/logging/warnings.ts
+++ b/packages/core/src/logging/warnings.ts
@@ -1,5 +1,5 @@
 export const formatI18nextWarning =
-  'Warning: formatI18next is not currently supported but will be implemented in a future version. Use _formatMessage for current ICU message format support.';
+  'Warning: formatI18next is not currently supported. Use _formatMessage for ICU message format support.';
 
 export const formatJsxWarning =
-  'Warning: formatJsx is not currently supported but will be implemented in a future version. Use _formatMessage for current ICU message format support.';
+  'Warning: formatJsx is not currently supported. Use _formatMessage for ICU message format support.';

--- a/packages/next/src/errors/createErrors.ts
+++ b/packages/next/src/errors/createErrors.ts
@@ -60,17 +60,16 @@ export const conflictingConfigurationBuildError = (conflicts: string[]) =>
     '\n'
   )}`;
 
-export const typesFileError = `gt-next Error: There is no scenario in which you should be seeing this error.`;
+export const typesFileError = `gt-next Error: Unexpected error in types file. This should not occur.`;
 
 export const gtProviderUseClientError =
-  `You're attempting to import the Next.js <GTProvider> in a client component. ` +
-  `Are you sure you want to do this? It's better to import <GTProvider> in a file not marked 'use client' so that it can fetch translations on the server. ` +
-  `If you really need to put <GTProvider> on the client, import <GTClientProvider> from 'gt-next/client' instead (discouraged when using the Next.js App Router).`;
+  `You are importing the Next.js <GTProvider> in a client component. ` +
+  `Import <GTProvider> in a file not marked 'use client' so it can fetch translations on the server. ` +
+  `If you need <GTProvider> on the client, import <GTClientProvider> from 'gt-next/client' instead (discouraged when using the Next.js App Router).`;
 
 export const txUseClientError =
-  `You're attempting to use the <Tx> runtime translation component in a client component. ` +
-  `This is currently unsupported. Please use <T> with variables, ` +
-  `or make sure <Tx> rendered on the server only. `;
+  `The <Tx> runtime translation component is not supported in client components. ` +
+  `Use <T> with variables, or ensure <Tx> renders on the server only.`;
 
 export const missingVariablesError = (variables: string[], message: string) =>
   `gt-next Error: missing variables: "${variables.join('", "')}" in message: "${message}"`;
@@ -129,9 +128,8 @@ export const createMismatchingHashWarning = (
 export const projectIdMissingWarn = `gt-next: Project ID missing! Set projectId as GT_PROJECT_ID in your environment or by passing the projectId parameter to withGTConfig(). Find your project ID: generaltranslation.com/dashboard.`;
 
 export const noInitGTWarn =
-  `gt-next: You are running General Translation without the withGTConfig() plugin. ` +
-  `This means that you are not translating your app. To activate translation, add the withGTConfig() plugin to your app, ` +
-  `and set the projectId and apiKey in your environment. ` +
+  `gt-next: General Translation is running without the withGTConfig() plugin. ` +
+  `Your app is not being translated. Add withGTConfig() to your app and set projectId and apiKey in your environment. ` +
   `For more information, visit https://generaltranslation.com/docs/next/tutorials/quickstart`;
 
 export const APIKeyMissingWarn =
@@ -151,20 +149,20 @@ export const createTranslationLoadingWarning = ({
   `[DEV ONLY] Warning: gt-next created translation "${source}" -> "${translation}"` +
   (id ? ` for id "${id}"` : '') +
   `. ` +
-  `In development, hot-reloaded translations may not be be displayed until the page is refreshed. ` +
+  `In development, hot-reloaded translations may not be displayed until the page is refreshed. ` +
   `In production, translations will be preloaded and there won't be a warning.`;
 
 export const runtimeTranslationTimeoutWarning = `gt-next: Runtime translation timed out.`;
 
-export const dictionaryNotFoundWarning = `gt-next: Dictionary not found. Make sure you have added a dictionary to your project (either dictionary.js or [defaultLocale].json), and you have added the withGTConfig() plugin.`;
+export const dictionaryNotFoundWarning = `gt-next: Dictionary not found. Add a dictionary to your project (either dictionary.js or [defaultLocale].json) and add the withGTConfig() plugin.`;
 
 export const standardizedLocalesWarning = (locales: string[]) =>
-  `gt-next: You are using The following locales were standardized: ${locales.join(', ')}.`;
+  `gt-next: The following locales were standardized: ${locales.join(', ')}.`;
 
 export const standardizedCanonicalLocalesWarning = (locales: string[]) =>
-  `gt-next: You are using The following canonical locales were standardized: ${locales.join(', ')}.`;
+  `gt-next: The following canonical locales were standardized: ${locales.join(', ')}.`;
 
-export const deprecatedLocaleMappingWarning = `gt-next: You are using the deprecated localeMapping configuration. Please move "customMapping" to your gt.config.json file.`;
+export const deprecatedLocaleMappingWarning = `gt-next: The localeMapping configuration is deprecated. Move "customMapping" to your gt.config.json file.`;
 
 export const createGTCompilerUnresolvedWarning = (type: 'babel' | 'swc') =>
   `gt-next (plugin): The GT ${type} compiler could not be resolved. Skipping compiler optimizations.`;

--- a/packages/next/src/errors/ssg.ts
+++ b/packages/next/src/errors/ssg.ts
@@ -10,7 +10,7 @@ export const ssgMissingGetStaticLocaleFunctionError =
 
 // This was (1) triggered by SSG without running middleware, or (2) triggered by a request with no locale headers (also no middleware).
 export const noLocalesCouldBeDeterminedWarning =
-  'gt-next: no locales could be determined for this request. If you are using SSG, make sure to follow set up instructions here: https://generaltranslation.com/en/docs/next/guides/ssg#ssg-custom-get-locale';
+  'gt-next: no locales could be determined for this request. If you are using SSG, make sure to follow setup instructions here: https://generaltranslation.com/en/docs/next/guides/ssg#ssg-custom-get-locale';
 
 const createCustomSSGFunctionSuffix = (functionName: StaticRequestFunctions) =>
   `If you wish to use ${functionName.replace('Static', '')} during SSG, please define a custom ${functionName.replace('Static', '')}() function for SSG. For more information, visit https://generaltranslation.com/en/docs/next/guides/ssg. To disable this warning, set "disableSSGWarnings" to true.`;
@@ -38,15 +38,15 @@ export const createSsrFunctionDuringSsgWarning = (
 ) =>
   process.env._GENERALTRANSLATION_DISABLE_SSG_WARNINGS === 'true'
     ? ''
-    : `gt-next: ${functionName}() was invoked during SSG. Rendering will like fallback to SSR behavior`;
+    : `gt-next: ${functionName}() was invoked during SSG. Rendering will likely fall back to SSR behavior.`;
 
 export const ssrDetectionFailedWarning =
   'gt-next: Unable to determine if runtime is SSR or SSG. Falling back to SSR behavior.';
 
 export const deprecatedExperimentalEnableSSGWarning =
-  'gt-next: You are using the deprecated experimentalEnableSSG configuration. This will be removed in a future version.';
+  'gt-next: The experimentalEnableSSG configuration is deprecated and will be removed in a future version.';
 
 export const createDeprecatedGetStaticLocaleFunctionWarning = (
   functionName: keyof typeof DEPRECATED_REQUEST_FUNCTION_TO_CONFIG_KEY
 ) =>
-  `gt-next: You are using the deprecated ${functionName} function. Please use ${functionName.replace('Static', '')} instead.`;
+  `gt-next: ${functionName} is deprecated. Use ${functionName.replace('Static', '')} instead.`;

--- a/packages/react-core/src/errors-dir/createErrors.ts
+++ b/packages/react-core/src/errors-dir/createErrors.ts
@@ -135,7 +135,7 @@ export const createUnsupportedLocaleWarning = (
   );
 };
 
-export const dictionaryMissingWarning = `${PACKAGE_NAME} Warning: No dictionary was found. Ensure you are either passing your dictionary to the <GTProvider>.`;
+export const dictionaryMissingWarning = `${PACKAGE_NAME} Warning: No dictionary found. Ensure you are passing your dictionary to <GTProvider>.`;
 
 export const createStringRenderWarning = (
   message: string,


### PR DESCRIPTION
Applies the docs style guide to error messages and warning strings across packages.

## Changes

### Bug fixes
- Fix typo: `may not be be displayed` → `may not be displayed`
- Fix broken message: `You are using The following locales were standardized` → `The following locales were standardized`
- Fix typo: `will like fallback` → `will likely fall back`
- Fix incomplete sentence in `dictionaryMissingWarning` (dangling "either..." with no "or")

### Style guide compliance
- Fix grammar: `set up instructions` → `setup instructions` (noun form)
- Use direct, active voice: remove indirect phrasing like "You're attempting to", "Are you sure you want to"
- Remove filler words and unnecessary verbosity
- Use present tense instead of future tense (`will be implemented`)
- Simplify verbose error/warning messages while preserving meaning

### Files changed
- `packages/next/src/errors/createErrors.ts`
- `packages/next/src/errors/ssg.ts`
- `packages/react-core/src/errors-dir/createErrors.ts`
- `packages/core/src/logging/warnings.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated error and warning messages across multiple packages for improved clarity and consistency.
  * Refined wording in user-facing messages to reduce ambiguity and improve readability.
  * Improved guidance messaging for configuration, dependency usage, and resource loading.
  * Fixed minor grammatical issues in user-facing text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR applies style guide compliance to user-facing error messages and warnings across four packages, fixing genuine bugs while simplifying messaging.

**Key changes:**
- **Bug fixes:** Removes duplicate word in `"may not be be displayed"`, fixes malformed sentence `"You are using The following locales were standardized"` → `"The following locales were standardized"`, corrects typo `"will like fallback"` → `"will likely fall back"`, and resolves dangling conditional in `dictionaryMissingWarning`
- **Style improvements:** Converts indirect phrasing (`"You're attempting to"`, `"Are you sure you want to"`) to direct active voice, removes filler words, and simplifies verbose messaging while preserving critical information
- **No behavior changes:** All modifications are limited to string literals in error/warning files; no logic or runtime behavior is affected

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- All changes are limited to string literals in error/warning message files with no logic, control flow, or runtime behavior modifications. Safe to merge.
- This PR is safe to merge with a confidence score of 5/5. All four changed files contain only exported string constants or template-literal functions with no functional logic modified. The bug fixes (typos, broken sentences) are demonstrably correct, and the style improvements reduce verbosity without removing critical information. String-literal-only changes pose minimal risk.
- No files require special attention. All changes are straightforward message text improvements.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Developer Action] --> B{Error/Warning Type}
    B --> C[Build-time Error\ncreatErrors.ts]
    B --> D[SSG/SSR Warning\nssg.ts]
    B --> E[Runtime Warning\nwarnings.ts]
    B --> F[React Core Warning\nreact-core/createErrors.ts]

    C --> C1[typesFileError]
    C --> C2[gtProviderUseClientError]
    C --> C3[txUseClientError]
    C --> C4[standardizedLocalesWarning]
    C --> C5[noInitGTWarn]

    D --> D1[noLocalesCouldBeDeterminedWarning]
    D --> D2[createSsrFunctionDuringSsgWarning]
    D --> D3[deprecatedExperimentalEnableSSGWarning]
    D --> D4[createDeprecatedGetStaticLocaleFunctionWarning]

    E --> E1[formatI18nextWarning]
    E --> E2[formatJsxWarning]

    F --> F1[dictionaryMissingWarning]

    C1 & C2 & C3 & C4 & C5 --> G[Console Output to Developer]
    D1 & D2 & D3 & D4 --> G
    E1 & E2 --> G
    F1 --> G
```
</details>

<sub>Last reviewed commit: fcfd322</sub>

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->