### PR TITLE
A/copy change

### DIFF
--- a/.changeset/calm-spies-build.md
+++ b/.changeset/calm-spies-build.md
@@ -2,4 +2,4 @@
 'generaltranslation': patch
 ---
 
-fix: language direction browser compatability
+fix: language direction browser compatibility

--- a/.changeset/calm-spies-build.md
+++ b/.changeset/calm-spies-build.md
@@ -1,0 +1,5 @@
+---
+'generaltranslation': patch
+---
+
+fix: language direction browser compatability

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -611,7 +611,7 @@
 
 ### Patch Changes
 
-- [#767](https://github.com/generaltranslation/gt/pull/767) [`b27a947`](https://github.com/generaltranslation/gt/commit/b27a947a46d2ad802278d79d45d25cdccd7193d5) Thanks [@brian-lou](https://github.com/brian-lou)! - Fix monorepo in-line string resolution
+- [#767](https://github.com/generaltranslation/gt/pull/767) [`b27a947`](https://github.com/generaltranslation/gt/commit/b27a947a46d2ad802278d79d45d25cdccd7193d5) Thanks [@brian-lou](https://github.com/brian-lou)! - Fix monorepo inline string resolution
 
 ## 2.4.6
 

--- a/packages/cli/src/translation/stage.ts
+++ b/packages/cli/src/translation/stage.ts
@@ -72,7 +72,7 @@ export async function aggregateInlineTranslations(
   if (updates.length == 0) {
     logger.error(
       chalk.red(
-        `No in-line content or dictionaries were found for ${chalk.green(
+        `No translation functions or dictionaries were found for ${chalk.green(
           library
         )}. Are you sure you're running this command in the right directory?`
       )

--- a/packages/cli/src/translation/validate.ts
+++ b/packages/cli/src/translation/validate.ts
@@ -164,7 +164,7 @@ export async function validateProject(
   if (updates.length === 0) {
     logger.error(
       chalk.red(
-        `No in-line content or dictionaries were found for ${chalk.green(
+        `No translation functions or dictionaries were found for ${chalk.green(
           pkg
         )}. Are you sure you're running this command in the right directory?`
       )

--- a/packages/core/src/locales/__tests__/getLocaleDirection.browser.test.ts
+++ b/packages/core/src/locales/__tests__/getLocaleDirection.browser.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment node
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { _getLocaleDirection } from '../getLocaleDirection';
+import { intlCache } from '../../cache/IntlCache';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/**
+ * Mocks intlCache.get so that 'Locale' calls return a real Intl.Locale
+ * with textInfo stripped, simulating browser environments where the
+ * textInfo property is not supported. All other calls (DisplayNames, etc.)
+ * pass through to the real implementation.
+ *
+ * Note: jsdom/happy-dom inherit Node's Intl implementation, so textInfo
+ * must be manually stripped even when using a browser-like vitest environment.
+ */
+function mockLocaleWithoutTextInfo() {
+  const originalGet = intlCache.get.bind(intlCache);
+  vi.spyOn(intlCache, 'get').mockImplementation(
+    (...args: Parameters<typeof intlCache.get>) => {
+      if (args[0] === 'Locale') {
+        const locale = new Intl.Locale(args[1] as string);
+        Object.defineProperty(locale, 'textInfo', {
+          value: undefined,
+          configurable: true,
+        });
+        return locale as ReturnType<typeof intlCache.get>;
+      }
+      return originalGet(...args);
+    }
+  );
+}
+
+/**
+ * Browser environment tests for _getLocaleDirection.
+ *
+ * Simulates browsers where Intl.Locale does not expose the textInfo
+ * property, forcing the function to fall back to script and language
+ * heuristics via _getLocaleProperties.
+ */
+describe.sequential('_getLocaleDirection (browser)', () => {
+  it('should detect rtl script when Intl.Locale lacks textInfo support', () => {
+    mockLocaleWithoutTextInfo();
+    expect(_getLocaleDirection('az-Arab')).toBe('rtl');
+  });
+
+  it('should detect ltr script when Intl.Locale lacks textInfo support', () => {
+    mockLocaleWithoutTextInfo();
+    expect(_getLocaleDirection('az-Latn')).toBe('ltr');
+  });
+
+  it('should fall back to known rtl languages when Intl.Locale is not available', () => {
+    vi.spyOn(intlCache, 'get').mockImplementation(() => {
+      throw new Error('Intl.Locale not supported');
+    });
+
+    expect(_getLocaleDirection('ar')).toBe('rtl');
+  });
+
+  it('should fall back to ltr for unknown languages when Intl.Locale is not available', () => {
+    vi.spyOn(intlCache, 'get').mockImplementation(() => {
+      throw new Error('Intl.Locale not supported');
+    });
+
+    expect(_getLocaleDirection('en')).toBe('ltr');
+  });
+});

--- a/packages/core/src/locales/__tests__/getLocaleDirection.node.test.ts
+++ b/packages/core/src/locales/__tests__/getLocaleDirection.node.test.ts
@@ -1,0 +1,42 @@
+// @vitest-environment node
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { _getLocaleDirection } from '../getLocaleDirection';
+import { intlCache } from '../../cache/IntlCache';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/**
+ * Node.js environment tests for _getLocaleDirection.
+ *
+ * In Node.js, Intl.Locale supports the textInfo property natively,
+ * so direction can be resolved directly without fallback heuristics.
+ */
+describe.sequential('_getLocaleDirection (node)', () => {
+  it('should use Intl.Locale.textInfo direction when available', () => {
+    const browserLocale = {
+      textInfo: { direction: 'rtl' as const },
+      language: 'en',
+      maximize: vi.fn(),
+    } as unknown as Intl.Locale;
+
+    vi.spyOn(intlCache, 'get').mockReturnValue(browserLocale);
+
+    expect(_getLocaleDirection('en-US')).toBe('rtl');
+    expect(browserLocale.maximize).not.toHaveBeenCalled();
+  });
+
+  it('should prioritize textInfo direction over script heuristics', () => {
+    const browserLocale = {
+      textInfo: { direction: 'ltr' as const },
+      language: 'ar',
+      maximize: vi.fn(() => ({ script: 'Arab' as const })),
+    } as unknown as Intl.Locale;
+
+    vi.spyOn(intlCache, 'get').mockReturnValue(browserLocale);
+
+    expect(_getLocaleDirection('ar-Arab')).toBe('ltr');
+    expect(browserLocale.maximize).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/locales/__tests__/getLocaleDirection.node.test.ts
+++ b/packages/core/src/locales/__tests__/getLocaleDirection.node.test.ts
@@ -15,28 +15,28 @@ afterEach(() => {
  */
 describe.sequential('_getLocaleDirection (node)', () => {
   it('should use Intl.Locale.textInfo direction when available', () => {
-    const browserLocale = {
+    const mockLocale = {
       textInfo: { direction: 'rtl' as const },
       language: 'en',
       maximize: vi.fn(),
     } as unknown as Intl.Locale;
 
-    vi.spyOn(intlCache, 'get').mockReturnValue(browserLocale);
+    vi.spyOn(intlCache, 'get').mockReturnValue(mockLocale);
 
     expect(_getLocaleDirection('en-US')).toBe('rtl');
-    expect(browserLocale.maximize).not.toHaveBeenCalled();
+    expect(mockLocale.maximize).not.toHaveBeenCalled();
   });
 
   it('should prioritize textInfo direction over script heuristics', () => {
-    const browserLocale = {
+    const mockLocale = {
       textInfo: { direction: 'ltr' as const },
       language: 'ar',
       maximize: vi.fn(() => ({ script: 'Arab' as const })),
     } as unknown as Intl.Locale;
 
-    vi.spyOn(intlCache, 'get').mockReturnValue(browserLocale);
+    vi.spyOn(intlCache, 'get').mockReturnValue(mockLocale);
 
     expect(_getLocaleDirection('ar-Arab')).toBe('ltr');
-    expect(browserLocale.maximize).not.toHaveBeenCalled();
+    expect(mockLocale.maximize).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/locales/__tests__/getLocaleDirection.test.ts
+++ b/packages/core/src/locales/__tests__/getLocaleDirection.test.ts
@@ -1,10 +1,5 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { _getLocaleDirection } from '../getLocaleDirection';
-import { intlCache } from '../../cache/IntlCache';
-
-afterEach(() => {
-  vi.restoreAllMocks();
-});
 
 describe('_getLocaleDirection', () => {
   it('should return ltr for left-to-right languages', () => {
@@ -73,11 +68,8 @@ describe('_getLocaleDirection', () => {
   });
 
   it('should handle edge cases and special locales', () => {
-    // Test some edge cases
     expect(_getLocaleDirection('root')).toBe('ltr');
     expect(_getLocaleDirection('und')).toBe('ltr');
-
-    // Test mixed scripts - should default to ltr if parsing fails
     expect(_getLocaleDirection('mixed-script-locale')).toBe('ltr');
   });
 
@@ -120,56 +112,5 @@ describe('_getLocaleDirection', () => {
       const result = _getLocaleDirection(locale);
       expect(['ltr', 'rtl']).toContain(result);
     }
-  });
-
-  describe('browser environments', () => {
-    it('should use Intl.Locale.textInfo direction when available', () => {
-      const browserLocale = {
-        textInfo: { direction: 'rtl' as const },
-        language: 'en',
-        maximize: vi.fn(),
-      } as unknown as Intl.Locale;
-
-      vi.spyOn(intlCache, 'get').mockReturnValue(browserLocale);
-
-      expect(_getLocaleDirection('en-US')).toBe('rtl');
-      expect(browserLocale.maximize).not.toHaveBeenCalled();
-    });
-
-    it('should prioritize textInfo direction over script heuristics', () => {
-      const browserLocale = {
-        textInfo: { direction: 'ltr' as const },
-        language: 'ar',
-        maximize: vi.fn(() => ({ script: 'Arab' as const })),
-      } as unknown as Intl.Locale;
-
-      vi.spyOn(intlCache, 'get').mockReturnValue(browserLocale);
-
-      expect(_getLocaleDirection('ar-Arab')).toBe('ltr');
-      expect(browserLocale.maximize).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('node environments', () => {
-    it('should use script detection when Intl.Locale lacks textInfo', () => {
-      const maximize = vi.fn(() => ({ script: 'Arab' as const }));
-      const fakeLocale = {
-        language: 'az',
-        maximize,
-      } as unknown as Intl.Locale;
-
-      vi.spyOn(intlCache, 'get').mockReturnValue(fakeLocale);
-
-      expect(_getLocaleDirection('az-Arab')).toBe('rtl');
-      expect(maximize).toHaveBeenCalled();
-    });
-
-    it('should fall back to known rtl languages when Intl.Locale is not available', () => {
-      vi.spyOn(intlCache, 'get').mockImplementation(() => {
-        throw new Error('Intl.Locale not supported');
-      });
-
-      expect(_getLocaleDirection('ar')).toBe('rtl');
-    });
   });
 });

--- a/packages/core/src/locales/__tests__/getLocaleDirection.test.ts
+++ b/packages/core/src/locales/__tests__/getLocaleDirection.test.ts
@@ -122,24 +122,54 @@ describe('_getLocaleDirection', () => {
     }
   });
 
-  it('should use script detection when textInfo is unavailable', () => {
-    const maximize = vi.fn(() => ({ script: 'Arab' as const }));
-    const fakeLocale = {
-      language: 'az',
-      maximize,
-    } as unknown as Intl.Locale;
+  describe('browser environments', () => {
+    it('should use Intl.Locale.textInfo direction when available', () => {
+      const browserLocale = {
+        textInfo: { direction: 'rtl' as const },
+        language: 'en',
+        maximize: vi.fn(),
+      } as unknown as Intl.Locale;
 
-    vi.spyOn(intlCache, 'get').mockReturnValue(fakeLocale);
+      vi.spyOn(intlCache, 'get').mockReturnValue(browserLocale);
 
-    expect(_getLocaleDirection('az-Arab')).toBe('rtl');
-    expect(maximize).toHaveBeenCalled();
-  });
-
-  it('should fall back to known rtl languages when Intl.Locale is not available', () => {
-    vi.spyOn(intlCache, 'get').mockImplementation(() => {
-      throw new Error('Intl.Locale not supported');
+      expect(_getLocaleDirection('en-US')).toBe('rtl');
+      expect(browserLocale.maximize).not.toHaveBeenCalled();
     });
 
-    expect(_getLocaleDirection('ar')).toBe('rtl');
+    it('should prioritize textInfo direction over script heuristics', () => {
+      const browserLocale = {
+        textInfo: { direction: 'ltr' as const },
+        language: 'ar',
+        maximize: vi.fn(() => ({ script: 'Arab' as const })),
+      } as unknown as Intl.Locale;
+
+      vi.spyOn(intlCache, 'get').mockReturnValue(browserLocale);
+
+      expect(_getLocaleDirection('ar-Arab')).toBe('ltr');
+      expect(browserLocale.maximize).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('node environments', () => {
+    it('should use script detection when Intl.Locale lacks textInfo', () => {
+      const maximize = vi.fn(() => ({ script: 'Arab' as const }));
+      const fakeLocale = {
+        language: 'az',
+        maximize,
+      } as unknown as Intl.Locale;
+
+      vi.spyOn(intlCache, 'get').mockReturnValue(fakeLocale);
+
+      expect(_getLocaleDirection('az-Arab')).toBe('rtl');
+      expect(maximize).toHaveBeenCalled();
+    });
+
+    it('should fall back to known rtl languages when Intl.Locale is not available', () => {
+      vi.spyOn(intlCache, 'get').mockImplementation(() => {
+        throw new Error('Intl.Locale not supported');
+      });
+
+      expect(_getLocaleDirection('ar')).toBe('rtl');
+    });
   });
 });

--- a/packages/core/src/locales/__tests__/getLocaleDirection.test.ts
+++ b/packages/core/src/locales/__tests__/getLocaleDirection.test.ts
@@ -1,5 +1,10 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { _getLocaleDirection } from '../getLocaleDirection';
+import { intlCache } from '../../cache/IntlCache';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe('_getLocaleDirection', () => {
   it('should return ltr for left-to-right languages', () => {
@@ -115,5 +120,26 @@ describe('_getLocaleDirection', () => {
       const result = _getLocaleDirection(locale);
       expect(['ltr', 'rtl']).toContain(result);
     }
+  });
+
+  it('should use script detection when textInfo is unavailable', () => {
+    const maximize = vi.fn(() => ({ script: 'Arab' as const }));
+    const fakeLocale = {
+      language: 'az',
+      maximize,
+    } as unknown as Intl.Locale;
+
+    vi.spyOn(intlCache, 'get').mockReturnValue(fakeLocale);
+
+    expect(_getLocaleDirection('az-Arab')).toBe('rtl');
+    expect(maximize).toHaveBeenCalled();
+  });
+
+  it('should fall back to known rtl languages when Intl.Locale is not available', () => {
+    vi.spyOn(intlCache, 'get').mockImplementation(() => {
+      throw new Error('Intl.Locale not supported');
+    });
+
+    expect(_getLocaleDirection('ar')).toBe('rtl');
   });
 });

--- a/packages/core/src/locales/getLocaleDirection.ts
+++ b/packages/core/src/locales/getLocaleDirection.ts
@@ -8,6 +8,8 @@ import { intlCache } from '../cache/IntlCache';
  * @internal
  */
 export function _getLocaleDirection(code: string): 'ltr' | 'rtl' {
+  console.log('--------------------------------');
+  console.log('getLocaleDirection', code);
   let script: string | undefined, language: string | undefined;
   try {
     const locale = intlCache.get('Locale', code);
@@ -30,8 +32,8 @@ export function _getLocaleDirection(code: string): 'ltr' | 'rtl' {
   language ||= extractLanguage(code);
 
   // Handle RTL script or language
-  if (isRtlScript(script)) return 'rtl';
-  if (isRtlLanguage(language)) return 'rtl';
+  if (script) return isRtlScript(script) ? 'rtl' : 'ltr';
+  if (language) return isRtlLanguage(language) ? 'rtl' : 'ltr';
 
   return 'ltr';
 }
@@ -135,9 +137,13 @@ function getLikelyScript(locale: Intl.Locale): string | undefined {
 }
 
 function isRtlScript(script: string | undefined): boolean {
-  return script ? RTL_SCRIPTS.has(script.toLowerCase()) : false;
+  const result = script ? RTL_SCRIPTS.has(script.toLowerCase()) : false;
+  console.log('isRtlScript', script, result);
+  return result;
 }
 
 function isRtlLanguage(language: string | undefined): boolean {
-  return language ? RTL_LANGUAGES.has(language.toLowerCase()) : false;
+  const result = language ? RTL_LANGUAGES.has(language.toLowerCase()) : false;
+  console.log('isRtlLanguage', language, result);
+  return result;
 }

--- a/packages/core/src/locales/getLocaleDirection.ts
+++ b/packages/core/src/locales/getLocaleDirection.ts
@@ -41,6 +41,7 @@ const RTL_SCRIPTS = new Set([
   'samr',
   'syrc',
   'thaa',
+  'yezi',
 ]);
 
 const RTL_LANGUAGES = new Set([

--- a/packages/core/src/locales/getLocaleDirection.ts
+++ b/packages/core/src/locales/getLocaleDirection.ts
@@ -83,7 +83,6 @@ function extractDirectionWithTextInfo(
     typeof locale.textInfo === 'object' &&
     locale.textInfo !== null &&
     'direction' in locale.textInfo &&
-    locale.textInfo?.direction &&
     (locale.textInfo?.direction === 'rtl' ||
       locale.textInfo?.direction === 'ltr')
   ) {

--- a/packages/core/src/locales/getLocaleDirection.ts
+++ b/packages/core/src/locales/getLocaleDirection.ts
@@ -8,12 +8,136 @@ import { intlCache } from '../cache/IntlCache';
  * @internal
  */
 export function _getLocaleDirection(code: string): 'ltr' | 'rtl' {
+  let script: string | undefined, language: string | undefined;
   try {
     const locale = intlCache.get('Locale', code);
-    // Return 'rtl' if the text direction of the language is right-to-left, otherwise 'ltr'
-    return (locale as any)?.textInfo?.direction === 'rtl' ? 'rtl' : 'ltr';
+
+    // Extract via textInfo property
+    const textInfoDirection = extractDirectionWithTextInfo(locale);
+    if (textInfoDirection) {
+      return textInfoDirection;
+    }
+
+    // Extract via script and language properties
+    script = getLikelyScript(locale);
+    language = locale.language;
   } catch {
-    // If the code is invalid or causes an error, fallback to 'ltr'
-    return 'ltr';
+    // silent
   }
+
+  // Fallback to simple heuristics
+  script ||= extractScript(code);
+  language ||= extractLanguage(code);
+
+  // Handle RTL script or language
+  if (isRtlScript(script)) return 'rtl';
+  if (isRtlLanguage(language)) return 'rtl';
+
+  return 'ltr';
+}
+
+// ===== HELPER CONSTANTS ===== //
+
+const RTL_SCRIPTS = new Set([
+  'arab',
+  'adlm',
+  'hebr',
+  'nkoo',
+  'rohg',
+  'samr',
+  'syrc',
+  'thaa',
+]);
+
+const RTL_LANGUAGES = new Set([
+  'ar',
+  'arc',
+  'ckb',
+  'dv',
+  'fa',
+  'he',
+  'iw',
+  'ku',
+  'lrc',
+  'nqo',
+  'ps',
+  'pnb',
+  'sd',
+  'syr',
+  'ug',
+  'ur',
+  'yi',
+]);
+
+// ===== HELPER FUNCTIONS ===== //
+
+/**
+ * Handles extracting direction via textInfo property
+ * @param Locale - Intl.Locale object
+ * @returns {'ltr' | 'rtl'} - The direction of the locale
+ *
+ * Intl.Locale.prototype.getTextInfo() / textInfo property incorporated in ES2024 Specification.
+ * This is not supported by all browsers yet.
+ * See: {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getTextInfo#browser_compatibility}
+ */
+function extractDirectionWithTextInfo(
+  locale: Intl.Locale
+): 'ltr' | 'rtl' | undefined {
+  if (
+    'textInfo' in locale &&
+    typeof locale.textInfo === 'object' &&
+    locale.textInfo !== null &&
+    'direction' in locale.textInfo &&
+    locale.textInfo?.direction &&
+    (locale.textInfo?.direction === 'rtl' ||
+      locale.textInfo?.direction === 'ltr')
+  ) {
+    return locale.textInfo?.direction;
+  }
+
+  return undefined;
+}
+
+function extractLanguage(code: string): string | undefined {
+  return code?.split(/[-_]/)[0]?.toLowerCase();
+}
+
+/**
+ * Handles extracting direction via script property
+ * @param code - The locale code to extract the script from
+ * @returns {string | undefined} - The script of the locale
+ *
+ * Script segment guaranteed to be 4 characters long.
+ * Filter by letters to avoid variant: https://datatracker.ietf.org/doc/html/rfc5646#section-2.2.5
+ */
+function extractScript(code: string): string | undefined {
+  return code
+    ?.split(/[-_]/)
+    .find((segment) => segment.length === 4 && /^[a-zA-Z]+$/.test(segment))
+    ?.toLowerCase();
+}
+
+function getLikelyScript(locale: Intl.Locale): string | undefined {
+  // Check for script property directly
+  if (locale?.script) {
+    return locale.script.toLowerCase();
+  }
+
+  // Check for script property via maximize()
+  if (typeof locale?.maximize === 'function') {
+    const maximized = locale.maximize();
+    if (maximized?.script) {
+      return maximized.script.toLowerCase();
+    }
+  }
+
+  return undefined;
+}
+
+function isRtlScript(script: string | undefined): boolean {
+  return script ? RTL_SCRIPTS.has(script.toLowerCase()) : false;
+}
+
+function isRtlLanguage(language: string | undefined): boolean {
+  return language ? RTL_LANGUAGES.has(language.toLowerCase()) : false;
 }

--- a/packages/core/src/locales/getLocaleDirection.ts
+++ b/packages/core/src/locales/getLocaleDirection.ts
@@ -1,4 +1,5 @@
 import { intlCache } from '../cache/IntlCache';
+import _getLocaleProperties from './getLocaleProperties';
 
 /**
  * Get the text direction for a given locale code using the Intl.Locale API.
@@ -8,9 +9,6 @@ import { intlCache } from '../cache/IntlCache';
  * @internal
  */
 export function _getLocaleDirection(code: string): 'ltr' | 'rtl' {
-  console.log('--------------------------------');
-  console.log('getLocaleDirection', code);
-  let script: string | undefined, language: string | undefined;
   try {
     const locale = intlCache.get('Locale', code);
 
@@ -19,21 +17,16 @@ export function _getLocaleDirection(code: string): 'ltr' | 'rtl' {
     if (textInfoDirection) {
       return textInfoDirection;
     }
-
-    // Extract via script and language properties
-    script = getLikelyScript(locale);
-    language = locale.language;
   } catch {
     // silent
   }
 
   // Fallback to simple heuristics
-  script ||= extractScript(code);
-  language ||= extractLanguage(code);
+  const { scriptCode, languageCode } = _getLocaleProperties(code);
 
   // Handle RTL script or language
-  if (script) return isRtlScript(script) ? 'rtl' : 'ltr';
-  if (language) return isRtlLanguage(language) ? 'rtl' : 'ltr';
+  if (scriptCode) return isRtlScript(scriptCode) ? 'rtl' : 'ltr';
+  if (languageCode) return isRtlLanguage(languageCode) ? 'rtl' : 'ltr';
 
   return 'ltr';
 }
@@ -100,50 +93,10 @@ function extractDirectionWithTextInfo(
   return undefined;
 }
 
-function extractLanguage(code: string): string | undefined {
-  return code?.split(/[-_]/)[0]?.toLowerCase();
-}
-
-/**
- * Handles extracting direction via script property
- * @param code - The locale code to extract the script from
- * @returns {string | undefined} - The script of the locale
- *
- * Script segment guaranteed to be 4 characters long.
- * Filter by letters to avoid variant: https://datatracker.ietf.org/doc/html/rfc5646#section-2.2.5
- */
-function extractScript(code: string): string | undefined {
-  return code
-    ?.split(/[-_]/)
-    .find((segment) => segment.length === 4 && /^[a-zA-Z]+$/.test(segment))
-    ?.toLowerCase();
-}
-
-function getLikelyScript(locale: Intl.Locale): string | undefined {
-  // Check for script property directly
-  if (locale?.script) {
-    return locale.script.toLowerCase();
-  }
-
-  // Check for script property via maximize()
-  if (typeof locale?.maximize === 'function') {
-    const maximized = locale.maximize();
-    if (maximized?.script) {
-      return maximized.script.toLowerCase();
-    }
-  }
-
-  return undefined;
-}
-
 function isRtlScript(script: string | undefined): boolean {
-  const result = script ? RTL_SCRIPTS.has(script.toLowerCase()) : false;
-  console.log('isRtlScript', script, result);
-  return result;
+  return script ? RTL_SCRIPTS.has(script.toLowerCase()) : false;
 }
 
 function isRtlLanguage(language: string | undefined): boolean {
-  const result = language ? RTL_LANGUAGES.has(language.toLowerCase()) : false;
-  console.log('isRtlLanguage', language, result);
-  return result;
+  return language ? RTL_LANGUAGES.has(language.toLowerCase()) : false;
 }

--- a/packages/core/src/locales/getLocaleDirection.ts
+++ b/packages/core/src/locales/getLocaleDirection.ts
@@ -9,10 +9,9 @@ import _getLocaleProperties from './getLocaleProperties';
  * @internal
  */
 export function _getLocaleDirection(code: string): 'ltr' | 'rtl' {
+  // Extract via textInfo property
   try {
     const locale = intlCache.get('Locale', code);
-
-    // Extract via textInfo property
     const textInfoDirection = extractDirectionWithTextInfo(locale);
     if (textInfoDirection) {
       return textInfoDirection;


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves browser compatibility for the `_getLocaleDirection` utility and updates CLI user-facing copy. The core change refactors `getLocaleDirection.ts` from a single-step `textInfo` lookup (which fails silently on browsers that don't support it) into a two-stage approach: it first tries the `Intl.Locale.textInfo` property, and if unavailable, falls back to script- and language-code heuristics via `_getLocaleProperties`. New test files cover both the Node.js (textInfo available) and browser (textInfo absent) scenarios. The CLI `stage.ts` and `validate.ts` error messages are updated from "No in-line content" to "No translation functions" for clarity, with the changelog corrected to match.

**Key changes:**
- `getLocaleDirection.ts`: Adds `RTL_SCRIPTS` / `RTL_LANGUAGES` sets and fallback heuristics; introduces `extractDirectionWithTextInfo` guard to safely detect browser support
- `getLocaleDirection.browser.test.ts` / `getLocaleDirection.node.test.ts`: New test suites covering the two resolution paths
- `stage.ts` / `validate.ts`: Error message copy updated to say "No translation functions or dictionaries were found"
- `CHANGELOG.md`: Minor copy fix ("in-line" → "inline")
- `extractDirectionWithTextInfo` only checks the `textInfo` property; the newer `getTextInfo()` method (Firefox 126+, Chrome 130+) is not handled, so those runtimes always use the heuristic path rather than the Intl API

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- This PR is safe to merge — it improves browser compatibility with well-tested heuristic fallbacks, and the only gap (getTextInfo() method) is non-critical.
- The logic is sound, the two-stage resolution is well-designed, and the new tests provide good coverage. The one gap — not handling Firefox's getTextInfo() method — is mitigated by the heuristic fallback producing correct results for all common RTL languages and scripts.
- packages/core/src/locales/getLocaleDirection.ts — the extractDirectionWithTextInfo function could be extended to also call getTextInfo() for full spec coverage.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/locales/getLocaleDirection.ts | Major refactor adding a two-stage direction resolution: Intl.Locale.textInfo first, then script/language heuristics as fallback for browser compatibility. Logic is correct but the getTextInfo() method (Firefox 126+) is not handled, meaning Firefox always falls through to heuristics. |
| packages/core/src/locales/__tests__/getLocaleDirection.browser.test.ts | New test file simulating browser environments that lack the textInfo property; correctly mocks intlCache.get and verifies both the script-based and language-based heuristic fallbacks. |
| packages/core/src/locales/__tests__/getLocaleDirection.node.test.ts | New test file verifying that textInfo is used when available in Node.js, and that it is correctly prioritized over script heuristics. Tests are well-structured and cover the key cases. |
| packages/core/src/locales/__tests__/getLocaleDirection.test.ts | Minor cleanup of inline comments from existing tests; no behavioral changes. |
| packages/cli/src/translation/stage.ts | Error message copy updated from "No in-line content" to "No translation functions" for clarity; straightforward change. |
| packages/cli/src/translation/validate.ts | Same error message copy update as stage.ts; consistent change across both CLI commands. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["_getLocaleDirection(code)"] --> B["intlCache.get('Locale', code)"]
    B -->|success| C["extractDirectionWithTextInfo(locale)"]
    B -->|throws| F["_getLocaleProperties(code)"]
    C -->|"'ltr' or 'rtl'"| Z["return direction"]
    C -->|"undefined (textInfo not available)"| F
    F --> G{scriptCode?}
    G -->|yes| H["isRtlScript(scriptCode)"]
    G -->|no| I{languageCode?}
    H --> Z
    I -->|yes| J["isRtlLanguage(languageCode)"]
    I -->|no| K["return 'ltr'"]
    J --> Z
```
</details>

<sub>Last reviewed commit: ba318a8</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved language direction detection with fallback support for environments where certain locale APIs are unavailable.
  * Updated CLI error messages for clarity on missing translation content.

* **Tests**
  * Added comprehensive test coverage for locale direction detection across browser and Node.js environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->