### PR TITLE
fix: apply style guide to error messages and warnings (extended)

### DIFF
--- a/.changeset/style-guide-errors.md
+++ b/.changeset/style-guide-errors.md
@@ -1,0 +1,10 @@
+---
+"gt": patch
+"gt-next": patch
+"@generaltranslation/react-core": patch
+"@generaltranslation/compiler": patch
+"locadex": patch
+"gt-sanity": patch
+---
+
+Apply style guide to error messages and warnings: remove "Please", simplify verbose phrasing, fix `in-line` → `inline`.

--- a/packages/cli/src/cli/base.ts
+++ b/packages/cli/src/cli/base.ts
@@ -599,7 +599,7 @@ See https://generaltranslation.com/en/docs/next/guides/local-tx`
     const files: FilesOptions = {};
     for (const fileExtension of fileExtensions) {
       const paths = await promptText({
-        message: `${chalk.cyan(FILE_EXT_TO_EXT_LABEL[fileExtension])}: Please enter a space-separated list of glob patterns matching the location of the ${FILE_EXT_TO_EXT_LABEL[fileExtension]} files you would like to translate.\nMake sure to include [locale] in the patterns.\nSee https://generaltranslation.com/docs/cli/reference/config#include for more information.`,
+        message: `${chalk.cyan(FILE_EXT_TO_EXT_LABEL[fileExtension])}: Enter a space-separated list of glob patterns matching the location of the ${FILE_EXT_TO_EXT_LABEL[fileExtension]} files you would like to translate.\nMake sure to include [locale] in the patterns.\nSee https://generaltranslation.com/docs/cli/reference/config#include for more information.`,
         defaultValue: `./**/[locale]/*.${fileExtension}`,
       });
 

--- a/packages/cli/src/cli/commands/upload.ts
+++ b/packages/cli/src/cli/commands/upload.ts
@@ -122,7 +122,7 @@ export async function upload(
 
   if (allFiles.length === 0) {
     logger.error(
-      'No files to upload were found. Please check your configuration and try again.'
+      'No files to upload were found. Check your configuration and try again.'
     );
     return;
   }

--- a/packages/cli/src/cli/react.ts
+++ b/packages/cli/src/cli/react.ts
@@ -104,7 +104,7 @@ export class ReactCLI extends InlineCLI {
         filesUpdated.map((file) => `${chalk.green('-')} ${file}`).join('\n')
     );
     if (filesUpdated.length > 0) {
-      logger.step(chalk.green('Please verify the changes before committing.'));
+      logger.step(chalk.green('Verify the changes before committing.'));
     }
 
     if (warnings.length > 0) {

--- a/packages/cli/src/config/generateSettings.ts
+++ b/packages/cli/src/config/generateSettings.ts
@@ -73,7 +73,7 @@ export async function generateSettings(
     gtConfig.projectId !== flags.projectId
   ) {
     logErrorAndExit(
-      `Project ID mismatch between ${chalk.green(gtConfig.projectId)} and ${chalk.green(flags.projectId)}! Please use the same projectId in all configs.`
+      `Project ID mismatch between ${chalk.green(gtConfig.projectId)} and ${chalk.green(flags.projectId)}! Use the same projectId in all configs.`
     );
   } else if (
     gtConfig.projectId &&
@@ -81,7 +81,7 @@ export async function generateSettings(
     gtConfig.projectId !== projectIdEnv
   ) {
     logErrorAndExit(
-      `Project ID mismatch between ${chalk.green(gtConfig.projectId)} and ${chalk.green(projectIdEnv)}! Please use the same projectId in all configs.`
+      `Project ID mismatch between ${chalk.green(gtConfig.projectId)} and ${chalk.green(projectIdEnv)}! Use the same projectId in all configs.`
     );
   }
 

--- a/packages/cli/src/config/validateSettings.ts
+++ b/packages/cli/src/config/validateSettings.ts
@@ -35,7 +35,7 @@ export function validateSettings(settings: Settings) {
       isSupersetLocale(settings.defaultLocale, locale)
     );
     return logErrorAndExit(
-      `defaultLocale: ${settings.defaultLocale} is a superset of another locale (${locale})! Please change the defaultLocale to a more specific locale.`
+      `defaultLocale: ${settings.defaultLocale} is a superset of another locale (${locale})! Change the defaultLocale to a more specific locale.`
     );
   }
 }

--- a/packages/cli/src/console/index.ts
+++ b/packages/cli/src/console/index.ts
@@ -22,7 +22,7 @@ const withDeclareStaticError = (message: string): string =>
 export const warnApiKeyInConfigSync = (optionsFilepath: string): string =>
   `${colorizeFilepath(
     optionsFilepath
-  )}: Your API key is exposed! Please remove it from the file and include it as an environment variable.`;
+  )}: Your API key is exposed! Remove it from the file and include it as an environment variable.`;
 
 export const warnVariablePropSync = (
   file: string,
@@ -288,13 +288,13 @@ export const warnDeclareStaticNoResultsSync = (
   );
 
 // Re-export error messages
-export const noLocalesError = `No locales found! Please provide a list of locales for translation, or specify them in your gt.config.json file.`;
-export const noDefaultLocaleError = `No default locale found! Please provide a default locale, or specify it in your gt.config.json file.`;
-export const noFilesError = `Incorrect or missing files configuration! Please make sure your files are configured correctly in your gt.config.json file.`;
-export const noSourceFileError = `No source file found! Please double check your translations directory and default locale.`;
-export const noSupportedFormatError = `Unsupported data format! Please make sure your translationsDir parameter ends with a supported file extension.`;
-export const noApiKeyError = `No API key found! Please provide an API key using the --api-key flag or set the GT_API_KEY environment variable.`;
-export const devApiKeyError = `You are using a development API key. Please use a production API key to use the General Translation API.\nYou can generate a production API key with the command: npx gt auth -t production`;
-export const noProjectIdError = `No project ID found! Please provide a project ID using the --project-id flag, specify it in your gt.config.json file, or set the GT_PROJECT_ID environment variable.`;
-export const noVersionIdError = `No version ID found! Please provide a version ID using the --version-id flag or specify it in your gt.config.json file as the _versionId property.`;
-export const invalidConfigurationError = `Invalid files configuration! Please either provide a valid configuration to download local translations or set the --publish flag to true to upload translations to the CDN.`;
+export const noLocalesError = `No locales found! Provide a list of locales for translation, or specify them in your gt.config.json file.`;
+export const noDefaultLocaleError = `No default locale found! Provide a default locale, or specify it in your gt.config.json file.`;
+export const noFilesError = `Incorrect or missing files configuration! Make sure your files are configured correctly in your gt.config.json file.`;
+export const noSourceFileError = `No source file found! Double-check your translations directory and default locale.`;
+export const noSupportedFormatError = `Unsupported data format! Make sure your translationsDir parameter ends with a supported file extension.`;
+export const noApiKeyError = `No API key found! Provide an API key using the --api-key flag or set the GT_API_KEY environment variable.`;
+export const devApiKeyError = `Development API keys cannot be used with the General Translation API. Use a production API key instead.\nGenerate a production API key with: npx gt auth -t production`;
+export const noProjectIdError = `No project ID found! Provide a project ID using the --project-id flag, specify it in your gt.config.json file, or set the GT_PROJECT_ID environment variable.`;
+export const noVersionIdError = `No version ID found! Provide a version ID using the --version-id flag or specify it in your gt.config.json file as the _versionId property.`;
+export const invalidConfigurationError = `Invalid files configuration! Provide a valid configuration to download local translations or set the --publish flag to true to upload translations to the CDN.`;

--- a/packages/cli/src/console/logging.ts
+++ b/packages/cli/src/console/logging.ts
@@ -206,7 +206,7 @@ export function warnApiKeyInConfig(optionsFilepath: string) {
   logger.warn(
     `Found ${chalk.cyan('apiKey')} in "${chalk.green(optionsFilepath)}". ` +
       chalk.white(
-        'Your API key is exposed! Please remove it from the file and include it as an environment variable.'
+        'Your API key is exposed! Remove it from the file and include it as an environment variable.'
       )
   );
 }

--- a/packages/cli/src/formats/files/aggregateFiles.ts
+++ b/packages/cli/src/formats/files/aggregateFiles.ts
@@ -203,7 +203,7 @@ export async function aggregateFiles(
 
   if (allFiles.length === 0 && !settings.publish) {
     logger.error(
-      'No files to translate were found. Please check your configuration and try again.'
+      'No files to translate were found. Check your configuration and try again.'
     );
   }
 

--- a/packages/cli/src/formats/json/__tests__/parseJson.test.ts
+++ b/packages/cli/src/formats/json/__tests__/parseJson.test.ts
@@ -312,7 +312,7 @@ describe('parseJson', () => {
       }).toThrow('Process exit called');
 
       expect(mockLogError).toHaveBeenCalledWith(
-        'Matching sourceItem not found at path: /test for locale: en. Please check your JSON schema'
+        'Matching sourceItem not found at path: /test for locale: en. Check your JSON schema'
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });

--- a/packages/cli/src/formats/json/mergeJson.ts
+++ b/packages/cli/src/formats/json/mergeJson.ts
@@ -110,7 +110,7 @@ export function mergeJson(
       );
       if (!Object.keys(matchingDefaultLocaleItems).length) {
         logger.warn(
-          `Matching sourceItems not found at path: ${sourceObjectPointer}. Please check your JSON file includes the key field. Skipping this target`
+          `Matching sourceItems not found at path: ${sourceObjectPointer}. Check that your JSON file includes the key field. Skipping this target`
         );
         continue;
       }

--- a/packages/cli/src/formats/json/parseJson.ts
+++ b/packages/cli/src/formats/json/parseJson.ts
@@ -82,7 +82,7 @@ export function parseJson(
       );
       if (!Object.keys(matchingItems).length) {
         logger.error(
-          `Matching sourceItem not found at path: ${sourceObjectPointer} for locale: ${defaultLocale}. Please check your JSON schema`
+          `Matching sourceItem not found at path: ${sourceObjectPointer} for locale: ${defaultLocale}. Check your JSON schema`
         );
         return exitSync(1);
       }

--- a/packages/cli/src/fs/determineFramework.ts
+++ b/packages/cli/src/fs/determineFramework.ts
@@ -20,7 +20,7 @@ export function determineLibrary(): {
     if (!fs.existsSync(packageJsonPath)) {
       logger.warn(
         chalk.yellow(
-          'No package.json found in the current directory. Please run this command from the root of your project.'
+          'No package.json found in the current directory. Run this command from the root of your project.'
         )
       );
       return { library: 'base', additionalModules: [] };

--- a/packages/cli/src/locadex/setupFlow.ts
+++ b/packages/cli/src/locadex/setupFlow.ts
@@ -12,7 +12,7 @@ export async function setupLocadex(settings: Settings): Promise<void> {
 
   logger.message(
     `${chalk.dim(
-      `If the browser window didn't open automatically, please open the following link:`
+      `If the browser window didn't open automatically, open the following link:`
     )}\n\n${chalk.cyan(urlToOpen)}`
   );
 }

--- a/packages/cli/src/react/parse/addVitePlugin/__tests__/updateViteConfig.test.ts
+++ b/packages/cli/src/react/parse/addVitePlugin/__tests__/updateViteConfig.test.ts
@@ -469,7 +469,7 @@ describe('updateViteConfig', () => {
 
       expect(warnings).toHaveLength(1);
       expect(warnings[0]).toContain('Failed to add gt compiler plugin');
-      expect(warnings[0]).toContain('Please add the plugin manually');
+      expect(warnings[0]).toContain('Add the plugin manually');
       expect(filesUpdated).toContain('/path/to/vite.config.ts');
     });
 

--- a/packages/cli/src/react/parse/addVitePlugin/index.ts
+++ b/packages/cli/src/react/parse/addVitePlugin/index.ts
@@ -36,7 +36,7 @@ export async function addVitePlugin({
   ]);
   if (!viteConfigPath) {
     logger.error(
-      `No ${VITE_CONFIG_PATH_BASE}[js|ts|mjs|mts|cjs|cts] file found. Please add the @generaltranslation/compiler plugin to your vite configuration file:
+      `No ${VITE_CONFIG_PATH_BASE}[js|ts|mjs|mts|cjs|cts] file found. Add the @generaltranslation/compiler plugin to your vite configuration file:
       import { vite as gtCompiler } from '@generaltranslation/compiler';
       export default defineConfig({
         plugins: [gtCompiler()],

--- a/packages/cli/src/react/parse/addVitePlugin/updateViteConfig.ts
+++ b/packages/cli/src/react/parse/addVitePlugin/updateViteConfig.ts
@@ -143,7 +143,7 @@ async function updateViteConfigAst({
     success = addPluginInvocation({ ast, alias, namespaces });
     if (!success) {
       warnings.push(
-        `Failed to add gt compiler plugin to ${viteConfigPath}. Please add the plugin manually:
+        `Failed to add gt compiler plugin to ${viteConfigPath}. Add the plugin manually:
 import { vite as gtCompiler } from '@generaltranslation/compiler';
 export default defineConfig({
   plugins: [gtCompiler()],

--- a/packages/cli/src/setup/userInput.ts
+++ b/packages/cli/src/setup/userInput.ts
@@ -20,14 +20,14 @@ export async function getDesiredLocales(): Promise<{
     validate: (input) => {
       const localeList = input.split(' ');
       if (localeList.length === 0) {
-        return 'Please enter at least one locale';
+        return 'Enter at least one locale';
       }
       if (localeList.some((locale) => !locale.trim())) {
-        return 'Please enter a valid locale (e.g., es fr de)';
+        return 'Enter a valid locale (e.g., es fr de)';
       }
       for (const locale of localeList) {
         if (!gt.isValidLocale(locale)) {
-          return 'Please enter a valid locale (e.g., es fr de)';
+          return 'Enter a valid locale (e.g., es fr de)';
         }
       }
       return true;

--- a/packages/cli/src/setup/wizard.ts
+++ b/packages/cli/src/setup/wizard.ts
@@ -79,7 +79,7 @@ Please let us know what you would like to see added at https://github.com/genera
   if (!packageJson) {
     logger.error(
       chalk.red(
-        'No package.json found in the current directory. Please run this command from the root of your project.'
+        'No package.json found in the current directory. Run this command from the root of your project.'
       )
     );
     exitSync(1);

--- a/packages/cli/src/translation/stage.ts
+++ b/packages/cli/src/translation/stage.ts
@@ -72,7 +72,7 @@ export async function aggregateInlineTranslations(
   if (updates.length == 0) {
     logger.error(
       chalk.red(
-        `No in-line content or dictionaries were found for ${chalk.green(
+        `No inline content or dictionaries were found for ${chalk.green(
           library
         )}. Are you sure you're running this command in the right directory?`
       )

--- a/packages/cli/src/translation/validate.ts
+++ b/packages/cli/src/translation/validate.ts
@@ -164,7 +164,7 @@ export async function validateProject(
   if (updates.length === 0) {
     logger.error(
       chalk.red(
-        `No in-line content or dictionaries were found for ${chalk.green(
+        `No inline content or dictionaries were found for ${chalk.green(
           pkg
         )}. Are you sure you're running this command in the right directory?`
       )

--- a/packages/cli/src/utils/addExplicitAnchorIds.ts
+++ b/packages/cli/src/utils/addExplicitAnchorIds.ts
@@ -204,7 +204,7 @@ export function addExplicitAnchorIds(
     logger.warn(
       `Header count mismatch detected! ${sourceFile} has ${sourceHeadingMap.length} headers but ${translatedFile} has ${translatedHeadings.length} headers. ` +
         `This likely means your source file was edited after translation was requested, causing a mismatch between ` +
-        `the number of headers in your source file vs the translated file. Please re-translate this file to resolve the issue.`
+        `the number of headers in your source file vs the translated file. Re-translate this file to resolve the issue.`
     );
   }
 

--- a/packages/cli/src/utils/installPackage.ts
+++ b/packages/cli/src/utils/installPackage.ts
@@ -32,7 +32,7 @@ export async function installPackage(
     childProcess.on('error', (error) => {
       logger.error(chalk.red(`Installation error: ${error.message}`));
       logger.info(
-        `Please manually install ${packageName} with: ${packageManager.name} ${packageManager.installCommand} ${packageName}`
+        `Manually install ${packageName} with: ${packageManager.name} ${packageManager.installCommand} ${packageName}`
       );
       reject(error);
     });
@@ -46,7 +46,7 @@ export async function installPackage(
           logger.error(chalk.red(`Error details: ${errorOutput}`));
         }
         logger.info(
-          `Please manually install ${packageName} with: ${packageManager.name} ${packageManager.installCommand} ${packageName}`
+          `Manually install ${packageName} with: ${packageManager.name} ${packageManager.installCommand} ${packageName}`
         );
         reject(new Error(`Process exited with code ${code}`));
       }
@@ -80,7 +80,7 @@ export async function installPackageGlobal(
     childProcess.on('error', (error) => {
       logger.error(chalk.red(`Installation error: ${error.message}`));
       logger.info(
-        `Please manually install ${packageName} with: npm install -g ${packageName}`
+        `Manually install ${packageName} with: npm install -g ${packageName}`
       );
       reject(error);
     });
@@ -94,7 +94,7 @@ export async function installPackageGlobal(
           logger.error(chalk.red(`Error details: ${errorOutput}`));
         }
         logger.info(
-          `Please manually install ${packageName} with: npm install -g ${packageName}`
+          `Manually install ${packageName} with: npm install -g ${packageName}`
         );
         reject(new Error(`Process exited with code ${code}`));
       }

--- a/packages/cli/src/utils/packageManager.ts
+++ b/packages/cli/src/utils/packageManager.ts
@@ -300,7 +300,7 @@ export async function getPackageManager(
 
   const selectedPackageManager: PackageManager =
     await promptSelect<PackageManager>({
-      message: 'Please select your package manager.',
+      message: 'Select your package manager.',
       options: packageManagers.map((packageManager) => ({
         value: packageManager,
         label: packageManager.label,

--- a/packages/cli/src/workflows/steps/BranchStep.ts
+++ b/packages/cli/src/workflows/steps/BranchStep.ts
@@ -116,7 +116,7 @@ export class BranchStep extends WorkflowStep<null, BranchData | null> {
     } else {
       if (!current) {
         return logErrorAndExit(
-          'Failed to determine the current branch. Please specify a custom branch or enable automatic branch detection.'
+          'Failed to determine the current branch. Specify a custom branch or enable automatic branch detection.'
         );
       }
       const currentBranch = branchData.branches.find(
@@ -132,7 +132,7 @@ export class BranchStep extends WorkflowStep<null, BranchData | null> {
         } catch (error) {
           if (error instanceof ApiError && error.code === 403) {
             logger.warn(
-              'To enable translation branching, please upgrade your plan. Falling back to default branch.'
+              'To enable translation branching, upgrade your plan. Falling back to default branch.'
             );
             // retry with default branch
             try {
@@ -151,7 +151,7 @@ export class BranchStep extends WorkflowStep<null, BranchData | null> {
 
     if (this.branchData.currentBranch.id === '') {
       return logErrorAndExit(
-        'Something went wrong while resolving branch information. Please try again.'
+        'Something went wrong while resolving branch information. Try again.'
       );
     }
 

--- a/packages/compiler/src/state/StringCollector.ts
+++ b/packages/compiler/src/state/StringCollector.ts
@@ -71,7 +71,7 @@ export class StringCollector {
   pushTranslationContent(counterId: number, content: TranslationContent): void {
     if (counterId === -1) {
       throw new Error(
-        'Cannot have a counterId of -1. You are likely trying to register content from a namespace method invocation.'
+        'Cannot have a counterId of -1. This likely means you are trying to register content from a namespace method invocation.'
       );
     }
     // Get the agreggator

--- a/packages/locadex/src/logging/console.ts
+++ b/packages/locadex/src/logging/console.ts
@@ -78,7 +78,7 @@ function displayInitializingText() {
     `\n${chalk.bold.blue('General Translation, Inc.')}
 ${chalk.dim('https://generaltranslation.com/docs')}
 
-Locadex is in research preview and may make mistakes. Please report any bugs or issues to https://github.com/generaltranslation/gt/issues.
+Locadex is in research preview and may make mistakes. Report any bugs or issues to https://github.com/generaltranslation/gt/issues.
 `
   );
 }

--- a/packages/next/src/errors/cacheComponents.ts
+++ b/packages/next/src/errors/cacheComponents.ts
@@ -10,16 +10,16 @@ export const cacheComponentsMissingExperimentalLocaleResolutionWarning =
   'gt-next: cacheComponents is enabled, but experimentalLocaleResolution is not enabled. experimentalLocaleResolution must be enabled for i18n to work inside of cached components.';
 
 export const cacheComponentsExperimentalFeatureWarning =
-  'gt-next: You are using an experimental feature: experimentalLocaleResolution.';
+  'gt-next: experimentalLocaleResolution is an experimental feature.';
 
 export const cacheComponentsExperimentalFeatureDisableGetRequestFunctionWarning =
-  'gt-next: Because experimentalLocaleResolution is enabled, functions getRegion and getDomain are disabled.';
+  'gt-next: experimentalLocaleResolution is enabled. getRegion and getDomain are disabled.';
 
 export const cacheComponentsExperimentalLocaleResolutionDisableCustomGetLocaleWarning =
-  'gt-next: experimentalLocaleResolution is enabled. Your provided getLocale function will be ignored.';
+  'gt-next: experimentalLocaleResolution is enabled. The provided getLocale function will be ignored.';
 
 export const cacheComponentsNonLocalTranslationsWarning =
-  'gt-next Error: cacheComponents is enabled, but you are not storing translations locally. Prerendering step may fail. Please follow these instructions to store translations locally: https://generaltranslation.com/en-US/docs/next/guides/local-tx';
+  'gt-next Error: cacheComponents is enabled, but translations are not stored locally. Prerendering may fail. Store translations locally: https://generaltranslation.com/en-US/docs/next/guides/local-tx';
 
 export const experimentalLocaleResolutionWithoutCacheComponentsWarning =
-  'gt-next: experimentalLocaleResolution is enabled, but cacheComponents disabled. experimentalLocaleResolution is meant to be used with cacheComponents. If this is intentional, ignore this warning.';
+  'gt-next: experimentalLocaleResolution is enabled, but cacheComponents is disabled. experimentalLocaleResolution is meant to be used with cacheComponents. If this is intentional, ignore this warning.';

--- a/packages/next/src/errors/createErrors.ts
+++ b/packages/next/src/errors/createErrors.ts
@@ -7,10 +7,10 @@ export const remoteTranslationsError =
   'gt-next Error: fetching remote translation.';
 
 export const customLoadTranslationsError = (locale: string = '') =>
-  `gt-next Error: fetching locally stored translations. If you are using a custom loadTranslations("${locale}"), make sure it is correctly implemented.`;
+  `gt-next Error: Failed to fetch locally stored translations. If using a custom loadTranslations("${locale}"), make sure it is correctly implemented.`;
 
 export const customLoadDictionaryWarning = (locale: string = '') =>
-  `gt-next Warning: fetching locally stored translation dictionary. If you are using a custom loadDictionary("${locale}"), make sure it is correctly implemented.`;
+  `gt-next Warning: Failed to fetch locally stored translation dictionary. If using a custom loadDictionary("${locale}"), make sure it is correctly implemented.`;
 
 export const createUnresolvedNextVersionError = (error: Error) =>
   `gt-next Error: Unable to resolve next version. ${error.message}`;
@@ -31,14 +31,14 @@ export const createDictionaryTranslationError = (id: string) =>
   `gt-next Error: Dictionary translation entry with id: ${id} could not be found.`;
 
 export const createRequiredPrefixError = (id: string, requiredPrefix: string) =>
-  `gt-next Error: You are using <GTProvider> with a provided prefix id: "${requiredPrefix}", but one of the children of <GTProvider> has the id "${id}". Change the <GTProvider> id prop or your dictionary structure to proceed.`;
+  `gt-next Error: <GTProvider> has prefix id "${requiredPrefix}", but a child has id "${id}". Change the <GTProvider> id prop or your dictionary structure to proceed.`;
 
-export const devApiKeyIncludedInProductionError = `gt-next Error: You are attempting a production build using a development API key. Replace this API key with a production API key when you build your app for production.`;
+export const devApiKeyIncludedInProductionError = `gt-next Error: Production builds cannot use a development API key. Replace it with a production API key.`;
 
 export const createDictionarySubsetError = (id: string, functionName: string) =>
-  `gt-next Error: ${functionName} with id: "${id}". Invalid dictionary entry detected. Make sure you are navigating to the correct subroute of the dictionary with the ID you provide.`;
+  `gt-next Error: ${functionName} with id: "${id}". Invalid dictionary entry. Make sure the ID maps to the correct subroute of the dictionary.`;
 
-export const dictionaryDisabledError = `gt-next Error: You are trying to use a dictionary, but you have not added the withGTConfig() plugin to your app. You must add withGTConfig() to use dictionaries. For more information, visit generaltranslation.com/docs`;
+export const dictionaryDisabledError = `gt-next Error: Dictionaries require the withGTConfig() plugin. Add withGTConfig() to your app. For more information, visit generaltranslation.com/docs`;
 
 export const unresolvedCustomLoadDictionaryError = `gt-next Error: loadDictionary() was resolved by plug-in but could not be resolved at run time. This usually means that the file was found, but the loadDictionary() function itself could not be resolved.`;
 
@@ -56,7 +56,7 @@ export const unresolvedGetLocaleBuildError = (path: string) =>
 export const conflictingConfigurationBuildError = (conflicts: string[]) =>
   `gt-next Error: Conflicting configuration${
     conflicts.length > 1 ? 's' : ''
-  } detected. Please resolve the following conflicts before building your app:\n${conflicts.join(
+  } detected. Resolve the following conflicts before building your app:\n${conflicts.join(
     '\n'
   )}`;
 
@@ -82,12 +82,12 @@ export const createStringRenderError = (
   `gt-next Error: error rendering string ${id ? `for id: "${id}"` : ''} original message: "${message}"`;
 
 export const invalidLocalesError = (locales: string[]) =>
-  `gt-next Error: You are using invalid locale codes in your configuration. ` +
-  `You must either specify a list of valid locales or use "customMapping" to ` +
-  `specify aliases for the following invalid locales: ${locales.join(', ')}.`;
+  `gt-next Error: Invalid locale codes in your configuration. ` +
+  `Specify a list of valid locales or use "customMapping" to ` +
+  `define aliases for the following invalid locales: ${locales.join(', ')}.`;
 
 export const invalidCanonicalLocalesError = (locales: string[]) =>
-  `gt-next Error: You are using invalid canonical locale codes in your configuration: ${locales.join(', ')}.`;
+  `gt-next Error: Invalid canonical locale codes in your configuration: ${locales.join(', ')}.`;
 
 export const createInvalidIcuDictionaryEntryError = (id: string) =>
   `gt-next Error: Invalid ICU string dictionary entry found for id: "${id}"`;
@@ -98,7 +98,7 @@ export const createInvalidIcuDictionaryEntryWarning = (id: string) =>
   `gt-next: Invalid ICU string dictionary entry found for id: "${id}"`;
 
 export const createBadFilepathWarning = (filename: string, dir: string[]) =>
-  `gt-next: Found ${filename} in ${dir.join(' or ')} directory. This is not supported. Please move it to your root directory.`;
+  `gt-next: Found ${filename} in ${dir.join(' or ')} directory. This is not supported. Move it to your root directory.`;
 
 export const usingDefaultsWarning =
   'gt-next: Unable to access gt-next configuration. Using defaults.';
@@ -174,7 +174,7 @@ export const createGTCompilerUnavailableWarning = (type: 'babel' | 'swc') =>
     ? `gt-next (plugin): The GT swc compiler is compatible with < next@${SWC_PLUGIN_SUPPORT}. Skipping compiler optimizations.`
     : `gt-next (plugin): The GT babel compiler is compatible with turbopack or < react@${BABEL_PLUGIN_SUPPORT}. Skipping compiler optimizations.`;
 
-export const disablingCompileTimeHashWarning = `gt-next (plugin): You are disabling compile time hash. This will disable the compiler optimizations.`;
+export const disablingCompileTimeHashWarning = `gt-next (plugin): Compile-time hash is disabled. Compiler optimizations are inactive.`;
 
 export const createStringRenderWarning = (
   message: string,
@@ -182,4 +182,4 @@ export const createStringRenderWarning = (
 ) =>
   `gt-next: failed to render string ${id ? `for id: "${id}"` : ''} original message: "${message}"`;
 
-export const swcPluginCompatibilityChangeWarning = `gt-next (plugin): As of gt-next@6.12.4, SWC plugin support has been disabled for all versions of Next.js prior to ${SWC_PLUGIN_SUPPORT}. Please update to the latest version of Next.js.`;
+export const swcPluginCompatibilityChangeWarning = `gt-next (plugin): As of gt-next@6.12.4, SWC plugin support is disabled for Next.js versions prior to ${SWC_PLUGIN_SUPPORT}. Update to the latest version of Next.js.`;

--- a/packages/next/src/errors/ssg.ts
+++ b/packages/next/src/errors/ssg.ts
@@ -4,16 +4,16 @@ import { RequestFunctions, StaticRequestFunctions } from '../request/types';
 // ========== ERRORS ========== //
 
 export const ssgMissingGetStaticLocaleFunctionError =
-  'gt-next: You have enabled SSG, but you have not configured a custom getStaticLocale() function. Please visit https://generaltranslation.com/en/docs/next/guides/ssg to configure SSG.';
+  'gt-next: SSG is enabled, but no custom getStaticLocale() function is configured. Visit https://generaltranslation.com/en/docs/next/guides/ssg to configure SSG.';
 
 // ========== WARNINGS ========== //
 
 // This was (1) triggered by SSG without running middleware, or (2) triggered by a request with no locale headers (also no middleware).
 export const noLocalesCouldBeDeterminedWarning =
-  'gt-next: no locales could be determined for this request. If you are using SSG, make sure to follow set up instructions here: https://generaltranslation.com/en/docs/next/guides/ssg#ssg-custom-get-locale';
+  'gt-next: No locales could be determined for this request. If using SSG, follow setup instructions here: https://generaltranslation.com/en/docs/next/guides/ssg#ssg-custom-get-locale';
 
 const createCustomSSGFunctionSuffix = (functionName: StaticRequestFunctions) =>
-  `If you wish to use ${functionName.replace('Static', '')} during SSG, please define a custom ${functionName.replace('Static', '')}() function for SSG. For more information, visit https://generaltranslation.com/en/docs/next/guides/ssg. To disable this warning, set "disableSSGWarnings" to true.`;
+  `To use ${functionName.replace('Static', '')} during SSG, define a custom ${functionName.replace('Static', '')}() function. For more information, visit https://generaltranslation.com/en/docs/next/guides/ssg. To disable this warning, set "disableSSGWarnings" to true.`;
 
 export const createSsgMissingCustomFunctionWarning = (
   functionName: StaticRequestFunctions
@@ -23,7 +23,7 @@ export const createSsgMissingCustomFunctionWarning = (
     : `gt-next: ${functionName.replace('Static', '')}() was invoked during SSG. ${createCustomSSGFunctionSuffix(functionName)}`;
 
 export const invalidSSGConfigurationWarning =
-  'gt-next: You are using SSG, but you have not configured SSG in your withGTConfig() plugin. Please visit https://generaltranslation.com/en/docs/next/guides/ssg to configure SSG.';
+  'gt-next: SSG is in use, but not configured in withGTConfig(). Visit https://generaltranslation.com/en/docs/next/guides/ssg to configure SSG.';
 
 export const createGetRequestFunctionWarning = (
   functionName: RequestFunctions | StaticRequestFunctions
@@ -38,15 +38,15 @@ export const createSsrFunctionDuringSsgWarning = (
 ) =>
   process.env._GENERALTRANSLATION_DISABLE_SSG_WARNINGS === 'true'
     ? ''
-    : `gt-next: ${functionName}() was invoked during SSG. Rendering will like fallback to SSR behavior`;
+    : `gt-next: ${functionName}() was invoked during SSG. Rendering will likely fall back to SSR behavior.`;
 
 export const ssrDetectionFailedWarning =
   'gt-next: Unable to determine if runtime is SSR or SSG. Falling back to SSR behavior.';
 
 export const deprecatedExperimentalEnableSSGWarning =
-  'gt-next: You are using the deprecated experimentalEnableSSG configuration. This will be removed in a future version.';
+  'gt-next: The experimentalEnableSSG configuration is deprecated and will be removed in a future version.';
 
 export const createDeprecatedGetStaticLocaleFunctionWarning = (
   functionName: keyof typeof DEPRECATED_REQUEST_FUNCTION_TO_CONFIG_KEY
 ) =>
-  `gt-next: You are using the deprecated ${functionName} function. Please use ${functionName.replace('Static', '')} instead.`;
+  `gt-next: ${functionName} is deprecated. Use ${functionName.replace('Static', '')} instead.`;

--- a/packages/react-core/src/errors-dir/createErrors.ts
+++ b/packages/react-core/src/errors-dir/createErrors.ts
@@ -9,7 +9,7 @@ export const devApiKeyProductionError = `${PACKAGE_NAME} Error: Production envir
 
 export const apiKeyInProductionError = `${PACKAGE_NAME} Error: Production environments cannot include an api key.`;
 
-export const createNoAuthError = `${PACKAGE_NAME} Error: Configuration is missing a projectId and/or devApiKey. Please add these values to your environment or pass them to the <GTProvider> directly.`;
+export const createNoAuthError = `${PACKAGE_NAME} Error: Configuration is missing a projectId and/or devApiKey. Add these values to your environment or pass them to <GTProvider> directly.`;
 
 export const createPluralMissingError = (children: any) =>
   `${PACKAGE_NAME} Error: <Plural> component with children "${children}" requires "n" option.`;
@@ -37,10 +37,10 @@ export const createGenericRuntimeTranslationError = (
 export const runtimeTranslationError = `${PACKAGE_NAME} Error: Runtime translation failed: `;
 
 export const customLoadTranslationsError = (locale: string = '') =>
-  `${PACKAGE_NAME} Error: fetching locally stored translations. If you are using a custom loadTranslations(${locale}), make sure it is correctly implemented.`;
+  `${PACKAGE_NAME} Error: Failed to fetch locally stored translations. If using a custom loadTranslations(${locale}), make sure it is correctly implemented.`;
 
 export const customLoadDictionaryWarning = (locale: string = '') =>
-  `${PACKAGE_NAME} Error: fetching locally stored dictionary. If you are using a custom loadDictionary(${locale}), make sure it is correctly implemented.`;
+  `${PACKAGE_NAME} Error: Failed to fetch locally stored dictionary. If using a custom loadDictionary(${locale}), make sure it is correctly implemented.`;
 
 export const missingVariablesError = (variables: string[], message: string) =>
   `${PACKAGE_NAME} Error: missing variables: "${variables.join('", "')}" in message: "${message}"`;
@@ -61,12 +61,12 @@ export const createStringTranslationError = (
   } could not locate translation.`;
 
 export const invalidLocalesError = (locales: string[]) =>
-  `${PACKAGE_NAME} Error: You are using invalid locale codes in your configuration. ` +
-  `You must either specify a list of valid locales or use "customMapping" to ` +
-  `specify aliases for the following invalid locales: ${locales.join(', ')}.`;
+  `${PACKAGE_NAME} Error: Invalid locale codes in your configuration. ` +
+  `Specify a list of valid locales or use "customMapping" to ` +
+  `define aliases for the following invalid locales: ${locales.join(', ')}.`;
 
 export const invalidCanonicalLocalesError = (locales: string[]) =>
-  `${PACKAGE_NAME} Error: You are using invalid canonical locale codes in your configuration: ${locales.join(', ')}.`;
+  `${PACKAGE_NAME} Error: Invalid canonical locale codes in your configuration: ${locales.join(', ')}.`;
 
 export const createEmptyIdError = () =>
   `${PACKAGE_NAME} Error: You cannot provide an empty id to t.obj()`;
@@ -129,8 +129,8 @@ export const createUnsupportedLocaleWarning = (
   packageName: string = PACKAGE_NAME
 ) => {
   return (
-    `${packageName} Warning: You are trying to switch to "${newLocale}" which is not supported.  ` +
-    `Update the list of supported locales through your dashboard or your config.json file if you are using a config file. ` +
+    `${packageName} Warning: "${newLocale}" is not a supported locale. ` +
+    `Update supported locales in your dashboard or gt.config.json. ` +
     `Falling back to "${validatedLocale}".`
   );
 };

--- a/packages/sanity/src/serialization/serialize/index.ts
+++ b/packages/sanity/src/serialization/serialize/index.ts
@@ -145,7 +145,7 @@ export const BaseDocumentSerializer = (schemas: Schema) => {
     } catch (err) {
       //eslint-disable-next-line no-console -- this is a warning
       console.warn(
-        `Had issues serializing block of type "${obj._type}". Please specify a serialization method for this block in your serialization config. Received error: ${err}`
+        `Had issues serializing block of type "${obj._type}". Specify a serialization method for this block in your serialization config. Received error: ${err}`
       );
     }
 


### PR DESCRIPTION
Extends #1074 with a comprehensive pass across the entire monorepo.

## Changes

### Style guide compliance (29 files)
- Remove "Please" from all error/warning messages (direct voice)
- Remove "You are using/attempting" patterns (active voice)  
- `in-line` → `inline` in CLI messages
- Simplify verbose messages while preserving meaning
- Use present tense where appropriate

### Bug fixes (from main, not yet in #1074)
- `will like fallback` → `will likely fall back`
- Capitalize sentence starts (`no locales` → `No locales`)

### Packages touched
- `next` (errors/cacheComponents, errors/createErrors, errors/ssg)
- `react-core` (errors-dir/createErrors)
- `cli` (console/index, console/logging, setup, config, formats, workflows, utils)
- `compiler` (state/StringCollector)
- `locadex` (logging/console)
- `sanity` (serialization/serialize)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated user-facing messages throughout the CLI and SDK for improved clarity and consistency. Messages now use more direct phrasing by removing redundant words and adjusting wording for a cleaner tone. Minor text corrections, including spelling standardization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends #1074 with a comprehensive, monorepo-wide style guide pass across 29 files, applying direct voice to all error and warning messages (removing "Please", "You are using/attempting" patterns, `in-line` → `inline`) while also fixing two correctness issues from `main`: the typo `"will like fallback"` → `"will likely fall back"` and a missing sentence-start capitalisation in `ssg.ts`.

Key changes:
- **Style guide compliance** applied consistently across `packages/next`, `packages/react-core`, `packages/cli`, `packages/compiler`, `packages/locadex`, and `packages/sanity`
- **Bug fix**: `createSsrFunctionDuringSsgWarning` in `ssg.ts` corrects a long-standing typo and now ends with a period for consistency
- **Pre-existing inconsistency in react-core**: `customLoadDictionaryWarning` uses `Error:` prefix but should use `Warning:` to match the function name and align with the corresponding function in `packages/next`; since the file is touched by this PR it would be a low-cost fix to correct here

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- This PR is safe to merge. All changes are pure string literal modifications with no logic or type signature changes.
- Safe to merge with minor action item: one function in react-core named `customLoadDictionaryWarning` uses "Error:" prefix instead of "Warning:", which should be corrected while the file is open. The file is already being edited in this PR, making this a low-cost fix. All other style guide changes are correct and consistent.
- packages/react-core/src/errors-dir/createErrors.ts — change "Error:" to "Warning:" in `customLoadDictionaryWarning` to match function name and the corresponding function in `packages/next`
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph packages["Packages with updated messages"]
        CLI["packages/cli<br/>(console/index, logging,<br/>base, react, config,<br/>formats, fs, locadex,<br/>setup, translation,<br/>utils, workflows)"]
        NEXT["packages/next<br/>(errors/cacheComponents,<br/>errors/createErrors,<br/>errors/ssg)"]
        RC["packages/react-core<br/>(errors-dir/createErrors)"]
        COMP["packages/compiler<br/>(state/StringCollector)"]
        LOC["packages/locadex<br/>(logging/console)"]
        SAN["packages/sanity<br/>(serialization/serialize)"]
    end

    subgraph changes["Style Changes Applied"]
        P["Remove 'Please'"]
        Y["Remove 'You are using/attempting'"]
        IL["in-line → inline"]
        TF["Typo fix: 'will like fallback'<br/>→ 'will likely fall back'"]
        CAP["Capitalise sentence starts"]
    end

    CLI --> P & Y & IL
    NEXT --> P & Y & TF & CAP
    RC --> P & Y
    COMP --> Y
    LOC --> P
    SAN --> P
```
</details>

<sub>Last reviewed commit: 134fa69</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->