### PR TITLE
fix: add missing test/example packages to changeset ignore list

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,7 +5,7 @@
     { "repo": "generaltranslation/gt" }
   ],
   "commit": false,
-  "fixed": [["gt", "gtx-cli"]],
+  "fixed": [],
   "linked": [],
   "access": "public",
   "baseBranch": "main",
@@ -13,11 +13,13 @@
   "ignore": [
     "base",
     "general-cases",
+    "gt-next-middleware-e2e",
     "create-react-app",
     "ai-chatbot",
     "next-create-app",
     "next-starter",
     "next-pages-router",
+    "next-ssg",
     "vite-create-app",
     "cli-test-app"
   ]


### PR DESCRIPTION
The changeset config was missing `next-ssg` and `gt-next-middleware-e2e` from the ignore list, causing test/example packages to appear in changesets.

This adds those two packages so only packages inside `packages/` are tracked by changesets.

**Full ignore list now covers all non-`packages/` workspace packages:**
- `tests/apps/next/base` → `base`
- `tests/apps/next/general-cases` → `general-cases`
- `tests/apps/next/middleware` → `gt-next-middleware-e2e` *(new)*
- `tests/apps/cli-test-app` → `cli-test-app`
- `examples/next-ssg` → `next-ssg` *(new)*
- `examples/next-chatbot` → `ai-chatbot`
- `examples/next-create-app` → `next-create-app`
- `examples/next-gt-starter` → `next-starter`
- `examples/next-pages-router` → `next-pages-router`
- `examples/create-react-app` → `create-react-app`
- `examples/vite-create-app` → `vite-create-app`