### PR TITLE
F/bump timeout

### DIFF
--- a/.changeset/cool-owls-know.md
+++ b/.changeset/cool-owls-know.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+Bumping CLI timeouts

--- a/packages/cli/src/cli/flags.ts
+++ b/packages/cli/src/cli/flags.ts
@@ -2,7 +2,7 @@ import { Command } from 'commander';
 import findFilepath from '../fs/findFilepath.js';
 import { DEFAULT_GIT_REMOTE_NAME } from '../utils/constants.js';
 
-const DEFAULT_TIMEOUT = 600;
+const DEFAULT_TIMEOUT = 900;
 
 export function attachSharedFlags(command: Command) {
   command

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.6.30';
+export const PACKAGE_VERSION = '2.7.0';

--- a/packages/cli/src/utils/calculateTimeoutMs.ts
+++ b/packages/cli/src/utils/calculateTimeoutMs.ts
@@ -1,0 +1,12 @@
+import { DEFAULT_TIMEOUT_SECONDS } from './constants.js';
+
+/**
+ * Calculate timeout in ms with validation
+ */
+export function calculateTimeoutMs(
+  timeout: string | number | undefined
+): number {
+  const value =
+    timeout !== undefined ? Number(timeout) : DEFAULT_TIMEOUT_SECONDS;
+  return (Number.isFinite(value) ? value : DEFAULT_TIMEOUT_SECONDS) * 1000;
+}

--- a/packages/cli/src/utils/constants.ts
+++ b/packages/cli/src/utils/constants.ts
@@ -8,3 +8,5 @@ export const TEMPLATE_FILE_NAME = '__INTERNAL_GT_TEMPLATE_NAME__';
 export const TEMPLATE_FILE_ID = hashStringSync(TEMPLATE_FILE_NAME);
 
 export const DEFAULT_GIT_REMOTE_NAME = 'origin';
+
+export const DEFAULT_TIMEOUT_SECONDS = 900;

--- a/packages/cli/src/workflows/setupProject.ts
+++ b/packages/cli/src/workflows/setupProject.ts
@@ -7,14 +7,7 @@ import { SetupStep } from './steps/SetupStep.js';
 import { BranchStep } from './steps/BranchStep.js';
 import { BranchData } from '../types/branch.js';
 import { logCollectedFiles } from '../console/logging.js';
-
-/**
- * Helper: Calculate timeout with validation
- */
-function calculateTimeout(timeout: string | number | undefined): number {
-  const value = timeout !== undefined ? Number(timeout) : 900;
-  return (Number.isFinite(value) ? value : 900) * 1000;
-}
+import { calculateTimeoutMs } from '../utils/calculateTimeoutMs.js';
 
 /**
  * Sets up a project by uploading files running the setup step
@@ -35,7 +28,7 @@ export async function runSetupProjectWorkflow(
     logCollectedFiles(files);
 
     // Calculate timeout for setup step
-    const timeoutMs = calculateTimeout(options.timeout);
+    const timeoutMs = calculateTimeoutMs(options.timeout);
 
     // Create workflow with steps
     const branchStep = new BranchStep(gt, settings);

--- a/packages/cli/src/workflows/setupProject.ts
+++ b/packages/cli/src/workflows/setupProject.ts
@@ -12,8 +12,8 @@ import { logCollectedFiles } from '../console/logging.js';
  * Helper: Calculate timeout with validation
  */
 function calculateTimeout(timeout: string | number | undefined): number {
-  const value = timeout !== undefined ? Number(timeout) : 600;
-  return (Number.isFinite(value) ? value : 600) * 1000;
+  const value = timeout !== undefined ? Number(timeout) : 900;
+  return (Number.isFinite(value) ? value : 900) * 1000;
 }
 
 /**

--- a/packages/cli/src/workflows/stage.ts
+++ b/packages/cli/src/workflows/stage.ts
@@ -13,8 +13,8 @@ import { BranchData } from '../types/branch.js';
  * Helper: Calculate timeout with validation
  */
 function calculateTimeout(timeout: string | number | undefined): number {
-  const value = timeout !== undefined ? Number(timeout) : 600;
-  return (Number.isFinite(value) ? value : 600) * 1000;
+  const value = timeout !== undefined ? Number(timeout) : 900;
+  return (Number.isFinite(value) ? value : 900) * 1000;
 }
 
 /**

--- a/packages/cli/src/workflows/stage.ts
+++ b/packages/cli/src/workflows/stage.ts
@@ -8,14 +8,7 @@ import { EnqueueStep } from './steps/EnqueueStep.js';
 import { BranchStep } from './steps/BranchStep.js';
 import { UserEditDiffsStep } from './steps/UserEditDiffsStep.js';
 import { BranchData } from '../types/branch.js';
-
-/**
- * Helper: Calculate timeout with validation
- */
-function calculateTimeout(timeout: string | number | undefined): number {
-  const value = timeout !== undefined ? Number(timeout) : 900;
-  return (Number.isFinite(value) ? value : 900) * 1000;
-}
+import { calculateTimeoutMs } from '../utils/calculateTimeoutMs.js';
 
 /**
  * Sends multiple files for translation to the API using a workflow pattern
@@ -41,7 +34,7 @@ export async function runStageFilesWorkflow({
     logCollectedFiles(files);
 
     // Calculate timeout for setup step
-    const timeoutMs = calculateTimeout(options.timeout);
+    const timeoutMs = calculateTimeoutMs(options.timeout);
 
     // Create workflow with steps
     const branchStep = new BranchStep(gt, settings);


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps the default CLI translation wait timeout from **600 seconds (10 minutes)** to **900 seconds (15 minutes)** across all relevant locations in the CLI package, and cuts a new `2.7.0` release.

**Changes:**
- `packages/cli/src/cli/flags.ts`: `DEFAULT_TIMEOUT` constant updated from `600` → `900`; used as the default value for the `--timeout` CLI flag
- `packages/cli/src/workflows/setupProject.ts`: fallback in `calculateTimeout` updated from `600` → `900`
- `packages/cli/src/workflows/stage.ts`: fallback in `calculateTimeout` updated from `600` → `900`
- `packages/cli/src/generated/version.ts`: auto-generated version bumped to `2.7.0`
- `.changeset/cool-owls-know.md`: changeset entry added for the timeout bump

**Observations:**
- The three timeout values are updated consistently — no stale `600` values remain in `packages/cli/src/`
- The `calculateTimeout` helper function is duplicated verbatim between `setupProject.ts` and `stage.ts`; this PR was a natural opportunity to consolidate it into a shared utility to avoid future drift

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge — it is a minimal, consistent change bumping a single default value across three locations with no behavioral side effects.
- All three timeout default values are updated consistently (600 → 900), no old values remain in the codebase, and no logic is altered. The only non-critical observation is a pre-existing code duplication of `calculateTimeout` that this PR could have cleaned up but didn't.
- No files require special attention
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .changeset/cool-owls-know.md | New changeset entry documenting the CLI timeout bump as a patch change |
| packages/cli/src/cli/flags.ts | DEFAULT_TIMEOUT constant bumped from 600 to 900 seconds; cleanly used as the default value for the --timeout CLI flag |
| packages/cli/src/generated/version.ts | Auto-generated version file bumped from 2.6.30 to 2.7.0 |
| packages/cli/src/workflows/setupProject.ts | Timeout fallback in calculateTimeout updated from 600 to 900, consistent with flags.ts; duplicate of the same function in stage.ts |
| packages/cli/src/workflows/stage.ts | Timeout fallback in calculateTimeout updated from 600 to 900, consistent with flags.ts; duplicate of the same function in setupProject.ts |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    CLI["CLI --timeout flag\n(default: 900s via DEFAULT_TIMEOUT)"]
    CT1["calculateTimeout()\nstage.ts\nfallback: 900s"]
    CT2["calculateTimeout()\nsetupProject.ts\nfallback: 900s"]
    Stage["runStageFilesWorkflow\nEnqueueStep + SetupStep"]
    Setup["runSetupProjectWorkflow\nSetupStep"]
    API["Translation API\n(timeoutMs applied)"]

    CLI -->|"options.timeout"| CT1
    CLI -->|"options.timeout"| CT2
    CT1 -->|"timeoutMs (ms)"| Stage
    CT2 -->|"timeoutMs (ms)"| Setup
    Stage --> API
    Setup --> API
```
</details>

<sub>Last reviewed commit: e0a03b7</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->