### PR TITLE
feat(cli): Edit key creation wizard

### DIFF
--- a/.changeset/bright-phones-exist.md
+++ b/.changeset/bright-phones-exist.md
@@ -1,5 +1,6 @@
 ---
 'gt': patch
+'generaltranslation': patch
 ---
 
 feat: Auth wizard supports both types of key creation

--- a/.changeset/bright-phones-exist.md
+++ b/.changeset/bright-phones-exist.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+feat: Auth wizard supports both types of key creation

--- a/packages/cli/src/cli/base.ts
+++ b/packages/cli/src/cli/base.ts
@@ -78,6 +78,7 @@ export type UploadOptions = {
 };
 
 export type LoginOptions = {
+  config?: string;
   keyType?: 'development' | 'production' | 'all';
 };
 
@@ -680,7 +681,7 @@ See https://generaltranslation.com/en/docs/next/guides/local-tx`
     }
   }
   protected async handleLoginCommand(options: LoginOptions): Promise<void> {
-    const settings = await generateSettings({});
+    const settings = await generateSettings({ config: options.config });
     const keyType = options.keyType || 'all';
     const credentials = await retrieveCredentials(settings, keyType);
     await setCredentials(credentials, settings.framework);

--- a/packages/cli/src/cli/base.ts
+++ b/packages/cli/src/cli/base.ts
@@ -78,7 +78,7 @@ export type UploadOptions = {
 };
 
 export type LoginOptions = {
-  keyType?: 'development' | 'production';
+  keyType?: 'development' | 'production' | 'all';
 };
 
 export class BaseCLI {
@@ -313,7 +313,7 @@ export class BaseCLI {
   protected setupLoginCommand(): void {
     this.program
       .command('auth')
-      .description('Generate a General Translation API key and project ID')
+      .description('Generate General Translation API keys and project ID')
       .option(
         '-c, --config <path>',
         'Filepath to config file, by default gt.config.json',
@@ -321,33 +321,36 @@ export class BaseCLI {
       )
       .option(
         '-t, --key-type <type>',
-        'Type of key to generate, production | development'
+        'Type of key to generate, production | development | all'
       )
       .action(async (options: LoginOptions) => {
         displayHeader('Authenticating with General Translation...');
         if (!options.keyType) {
-          const packageJson = await searchForPackageJson();
-          if (
-            packageJson &&
-            INLINE_LIBRARIES.some((lib) => isPackageInstalled(lib, packageJson))
-          ) {
-            options.keyType = 'development';
-          } else {
-            options.keyType = 'production';
-          }
+          options.keyType = await promptSelect<
+            'development' | 'production' | 'all'
+          >({
+            message: 'What type of API key would you like to generate?',
+            options: [
+              { value: 'development', label: 'Development' },
+              { value: 'production', label: 'Production' },
+              { value: 'all', label: 'Both' },
+            ],
+            defaultValue: 'all',
+          });
         } else {
           if (
             options.keyType !== 'development' &&
-            options.keyType !== 'production'
+            options.keyType !== 'production' &&
+            options.keyType !== 'all'
           ) {
             logErrorAndExit(
-              'Invalid key type, must be development or production'
+              'Invalid key type, must be development, production, or all'
             );
           }
         }
         await this.handleLoginCommand(options);
         logger.endCommand(
-          `Done! A ${options.keyType} key has been generated and saved to your .env.local file.`
+          `Done! ${options.keyType} keys have been generated and saved to your .env.local file.`
         );
       });
   }
@@ -654,24 +657,33 @@ See https://generaltranslation.com/en/docs/next/guides/local-tx`
       const loginQuestion = useDefaults
         ? true
         : await promptConfirm({
-            message: `Would you like the wizard to automatically generate a ${
-              isUsingGT ? 'development' : 'production'
-            } API key and project ID for you?`,
+            message:
+              'Would you like the wizard to automatically generate API keys and a project ID for you?',
             defaultValue: true,
           });
       if (loginQuestion) {
         const settings = await generateSettings({});
-        const keyType = isUsingGT ? 'development' : 'production';
+        const keyType = useDefaults
+          ? 'all'
+          : await promptSelect<'development' | 'production' | 'all'>({
+              message: 'What type of API key would you like to generate?',
+              options: [
+                { value: 'development', label: 'Development' },
+                { value: 'production', label: 'Production' },
+                { value: 'all', label: 'Both' },
+              ],
+              defaultValue: 'all',
+            });
         const credentials = await retrieveCredentials(settings, keyType);
-        await setCredentials(credentials, keyType, settings.framework);
+        await setCredentials(credentials, settings.framework);
       }
     }
   }
   protected async handleLoginCommand(options: LoginOptions): Promise<void> {
     const settings = await generateSettings({});
-    const keyType = options.keyType || 'production';
+    const keyType = options.keyType || 'all';
     const credentials = await retrieveCredentials(settings, keyType);
-    await setCredentials(credentials, keyType, settings.framework);
+    await setCredentials(credentials, settings.framework);
   }
 
   protected setupUpdateInstructionsCommand(): void {

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.6.30';
+export const PACKAGE_VERSION = '2.7.0';

--- a/packages/cli/src/utils/credentials.ts
+++ b/packages/cli/src/utils/credentials.ts
@@ -4,16 +4,22 @@ import path from 'node:path';
 import fs from 'node:fs';
 import { Settings, SupportedFrameworks } from '../types/index.js';
 import chalk from 'chalk';
+import apiRequest from './fetch.js';
 // Type for credentials returned from the dashboard
 type Credentials = {
-  apiKey: string;
+  apiKeys: ApiKey[];
   projectId: string;
+};
+
+type ApiKey = {
+  key: string;
+  type: 'development' | 'production';
 };
 
 // Fetches project ID and API key by opening the dashboard in the browser
 export async function retrieveCredentials(
   settings: Settings,
-  keyType: 'development' | 'production'
+  keyType: 'development' | 'production' | 'all'
 ): Promise<Credentials> {
   // Generate a session ID
   const { sessionId } = await generateCredentialsSession(
@@ -42,18 +48,17 @@ export async function retrieveCredentials(
       const interval = setInterval(async () => {
         // Ping the dashboard to see if the credentials are set
         try {
-          const res = await fetch(
-            `${settings.baseUrl}/cli/wizard/${sessionId}`,
-            {
-              method: 'GET',
-            }
+          const res = await apiRequest(
+            settings.baseUrl,
+            `/cli/wizard/${sessionId}`,
+            { method: 'GET' }
           );
           if (res.status === 200) {
             const data = await res.json();
             resolve(data as Credentials);
             clearInterval(interval);
             clearTimeout(timeout);
-            fetch(`${settings.baseUrl}/cli/wizard/${sessionId}`, {
+            apiRequest(settings.baseUrl, `/cli/wizard/${sessionId}`, {
               method: 'DELETE',
             });
           }
@@ -78,18 +83,12 @@ export async function retrieveCredentials(
 
 export async function generateCredentialsSession(
   url: string,
-  keyType: 'development' | 'production'
+  keyType: 'development' | 'production' | 'all'
 ): Promise<{
   sessionId: string;
 }> {
-  const res = await fetch(`${url}/cli/wizard/session`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      keyType,
-    }),
+  const res = await apiRequest(url, '/cli/wizard/session', {
+    body: { keyType },
   });
   if (!res.ok) {
     logErrorAndExit('Failed to generate credentials session');
@@ -99,13 +98,15 @@ export async function generateCredentialsSession(
 
 // Checks if the credentials are set in the environment variables
 export function areCredentialsSet() {
-  return process.env.GT_PROJECT_ID && process.env.GT_API_KEY;
+  return (
+    process.env.GT_PROJECT_ID &&
+    (process.env.GT_API_KEY || process.env.GT_DEV_API_KEY)
+  );
 }
 
 // Sets the credentials in .env.local file
 export async function setCredentials(
   credentials: Credentials,
-  type: 'development' | 'production',
   framework?: SupportedFrameworks,
   cwd: string = process.cwd()
 ) {
@@ -151,10 +152,13 @@ export async function setCredentials(
   }
 
   envContent += `\n${prefix}GT_PROJECT_ID=${credentials.projectId}\n`;
-  if (type === 'development') {
-    envContent += `${prefix || ''}GT_DEV_API_KEY=${credentials.apiKey}\n`;
-  } else {
-    envContent += `GT_API_KEY=${credentials.apiKey}\n`;
+
+  for (const apiKey of credentials.apiKeys) {
+    if (apiKey.type === 'development') {
+      envContent += `${prefix || ''}GT_DEV_API_KEY=${apiKey.key}\n`;
+    } else {
+      envContent += `${prefix || ''}GT_API_KEY=${apiKey.key}\n`;
+    }
   }
 
   // Ensure we don't have excessive newlines

--- a/packages/cli/src/utils/fetch.ts
+++ b/packages/cli/src/utils/fetch.ts
@@ -1,0 +1,33 @@
+const API_VERSION = '2026-03-06.v1';
+
+/**
+ * @internal
+ *
+ * Makes an API request to the General Translation API.
+ *
+ * Encapsulates URL construction, headers, and JSON parsing.
+ */
+export default async function apiRequest<T>(
+  baseUrl: string,
+  endpoint: string,
+  options?: {
+    body?: unknown;
+    method?: 'GET' | 'POST' | 'DELETE';
+  }
+): Promise<Response> {
+  const method = options?.method ?? 'POST';
+
+  const requestInit: RequestInit = {
+    method,
+    headers: {
+      'Content-Type': 'application/json',
+      'gt-api-version': API_VERSION,
+    },
+  };
+
+  if (options?.body !== undefined) {
+    requestInit.body = JSON.stringify(options.body);
+  }
+
+  return fetch(`${baseUrl}${endpoint}`, requestInit);
+}

--- a/packages/cli/src/utils/fetch.ts
+++ b/packages/cli/src/utils/fetch.ts
@@ -1,4 +1,4 @@
-const API_VERSION = '2026-03-06.v1';
+import { API_VERSION } from 'generaltranslation';
 
 /**
  * @internal

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -106,6 +106,7 @@ import _getOrphanedFiles, {
 } from './translate/getOrphanedFiles';
 import { CutoffFormatOptions } from './formatting/custom-formats/CutoffFormat/types';
 import { TranslateOptions } from './types-dir/api/entry';
+import { API_VERSION as _API_VERSION } from './translate/api';
 
 // ============================================================ //
 //                        Core Class                            //
@@ -1996,3 +1997,5 @@ export function isSupersetLocale(
 ): boolean {
   return _isSupersetLocale(superLocale, subLocale);
 }
+
+export const API_VERSION = _API_VERSION;

--- a/packages/core/src/translate/api.ts
+++ b/packages/core/src/translate/api.ts
@@ -1,1 +1,1 @@
-export const API_VERSION = '2026-02-18.v1';
+export const API_VERSION = '2026-03-06.v1';


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR upgrades the `auth` / `init` wizard in the CLI to let users explicitly choose which type of API key to generate (`development`, `production`, or `all`/both), replacing the previous automatic detection heuristic. It also introduces a centralized `apiRequest` utility (`fetch.ts`) that standardises URL construction and shared headers (including a new `gt-api-version` header) across all credential-related requests.

Key changes:
- **New `fetch.ts` helper**: Wraps all CLI→API calls with shared headers (`Content-Type`, `gt-api-version`) and a default POST method. Contains an unused generic type parameter `T` that should be removed.
- **`credentials.ts` refactor**: `Credentials` now carries an `ApiKey[]` array instead of a single `apiKey` string, allowing multiple keys to be returned and written in one session. `setCredentials` no longer requires a `type` argument; key type is read from each `ApiKey` object. `areCredentialsSet()` now accepts either `GT_API_KEY` or `GT_DEV_API_KEY`.
- **`base.ts` wizard flow**: Auto-detection logic removed; an interactive `promptSelect` is shown instead. The `'all'` option generates both keys in one browser session. The success message uses incorrect plural wording for single-key selections.
- **Version bump**: `2.6.30` → `2.7.0`.

The logic changes are well-scoped and internally consistent. Main items to address: remove the unused generic type parameter, and fix the grammar in the success message.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- This PR is safe to merge with minor polish — an unused generic type and a grammar issue in user-facing text.
- The logic changes are well-scoped, internally consistent, and the new apiRequest helper is straightforward. The credential flow properly supports multiple keys. Two issues remain: an unused TypeScript generic that will generate a compilation warning, and a minor user-facing grammar error in the success message that should be corrected before merge.
- packages/cli/src/utils/fetch.ts (remove unused generic T) and packages/cli/src/cli/base.ts (fix plural/singular in success message)
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant CLI (base.ts)
    participant credentials.ts
    participant fetch.ts (apiRequest)
    participant GT API

    User->>CLI (base.ts): gt auth (or init wizard)
    CLI (base.ts)->>User: promptSelect — key type?
    User-->>CLI (base.ts): development | production | all
    CLI (base.ts)->>credentials.ts: retrieveCredentials(settings, keyType)
    credentials.ts->>fetch.ts (apiRequest): POST /cli/wizard/session {keyType}
    fetch.ts (apiRequest)->>GT API: POST /cli/wizard/session
    GT API-->>fetch.ts (apiRequest): { sessionId }
    fetch.ts (apiRequest)-->>credentials.ts: Response
    credentials.ts->>User: Open browser → dashboard/cli/wizard/:sessionId
    loop Poll every 2 s
        credentials.ts->>fetch.ts (apiRequest): GET /cli/wizard/:sessionId
        fetch.ts (apiRequest)->>GT API: GET /cli/wizard/:sessionId
        GT API-->>fetch.ts (apiRequest): 200 { apiKeys: ApiKey[], projectId }
        fetch.ts (apiRequest)-->>credentials.ts: Response
    end
    credentials.ts->>fetch.ts (apiRequest): DELETE /cli/wizard/:sessionId
    credentials.ts-->>CLI (base.ts): Credentials { apiKeys[], projectId }
    CLI (base.ts)->>credentials.ts: setCredentials(credentials, framework)
    credentials.ts->>credentials.ts: Write GT_PROJECT_ID + GT_DEV_API_KEY / GT_API_KEY to .env.local
```
</details>

<sub>Last reviewed commit: 4f413db</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->