### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@
 
 ## Getting Started
 
+```bash
+npx gt
+```
+
 General Translation is a fully integrated suite of internationalization (i18n) tools for React apps. Translate entire React components—not just strings—with a simple `<T>` wrapper. No refactoring into dictionaries. Just write your content and let GT handle the rest.
 
 - Visit our [documentation](https://generaltranslation.com/docs) to get started.


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `npx gt` quick-start command block to the "Getting Started" section of `README.md`, providing users with an immediate call-to-action at the top of the documentation. The change is minimal and low-risk.

However, there is a consistency issue: the new "Getting Started" command uses `npx gt` without a version tag, while the existing "Quick Start" section (line 52) uses `npx gt@latest`. To ensure users consistently get the latest version and avoid locally cached packages, both commands should use the same form (`npx gt@latest`).

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- Safe to merge with minor version-tag consistency fix applied.
- This PR is low-risk as it only modifies documentation. The single finding—a version tag inconsistency between the "Getting Started" command (`npx gt`) and the "Quick Start" command (`npx gt@latest`)—is valid and straightforward to address. Once the new command is updated to `npx gt@latest` for consistency, the change is safe to merge.
- README.md — update line 20 from `npx gt` to `npx gt@latest` for consistency with line 52.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User visits README] --> B[Getting Started section]
    B --> C["npx gt - should be npx gt@latest"]
    C --> D[Description paragraph]
    D --> E[Documentation & API key links]
    E --> F[Quick Start section]
    F --> G["npx gt@latest"]
    G -.->|consistency issue| C
```
</details>

<sub>Last reviewed commit: 367dd96</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->