### PR TITLE
Configured local translation loading

### DIFF
--- a/packages/i18n/rollup.config.mjs
+++ b/packages/i18n/rollup.config.mjs
@@ -10,6 +10,8 @@ const external = [
   'generaltranslation/internal',
   'generaltranslation/id',
   '@generaltranslation/supported-locales',
+  'fs',
+  'path',
 ];
 
 export default [

--- a/packages/i18n/src/config/types.ts
+++ b/packages/i18n/src/config/types.ts
@@ -45,6 +45,9 @@ export type GTConfig = {
   runtimeUrl?: string | null;
   modelProvider?: string;
 
+  // local translations
+  translationOutputPath?: string;
+
   // other
   localeCookieName?: string;
 };

--- a/packages/i18n/src/i18n-manager/translations-manager/TranslationsManager.ts
+++ b/packages/i18n/src/i18n-manager/translations-manager/TranslationsManager.ts
@@ -7,6 +7,7 @@ import {
 import { Translations, TranslationsMap } from './utils/types/translation-data';
 import { TranslationsManagerConstructorParams } from './utils/types/translations-manager';
 import { createRemoteTranslationLoader } from './translations-loaders/createRemoteTranslationLoader';
+import { createLocalTranslationLoader } from './translations-loaders/createLocalTranslationLoader';
 import { createFallbackTranslationLoader } from './translations-loaders/createFallbackTranslationLoader';
 import {
   getLoadTranslationsType,
@@ -137,6 +138,7 @@ function determineTranslationLoader(config: {
   _versionId?: string;
   _branchId?: string;
   loadTranslations?: TranslationsLoader;
+  translationOutputPath?: string;
   customMapping?: CustomMapping;
 }): TranslationsLoader {
   const loadTranslationsType = getLoadTranslationsType(config);
@@ -153,6 +155,11 @@ function determineTranslationLoader(config: {
         projectId: config.projectId!,
         _versionId: config._versionId,
         _branchId: config._branchId,
+        customMapping: config.customMapping,
+      });
+    case LoadTranslationsType.LOCAL:
+      return createLocalTranslationLoader({
+        translationOutputPath: config.translationOutputPath!,
         customMapping: config.customMapping,
       });
     case LoadTranslationsType.CUSTOM:

--- a/packages/i18n/src/i18n-manager/translations-manager/translations-loaders/__tests__/createLocalTranslationLoader.test.ts
+++ b/packages/i18n/src/i18n-manager/translations-manager/translations-loaders/__tests__/createLocalTranslationLoader.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createLocalTranslationLoader } from '../createLocalTranslationLoader';
+
+vi.mock('fs', () => ({
+  promises: {
+    readFile: vi.fn(),
+  },
+}));
+
+describe('createLocalTranslationLoader', () => {
+  it('returns loader function', () => {
+    const loader = createLocalTranslationLoader({
+      translationOutputPath: 'public/_gt/[locale].json',
+    });
+    expect(typeof loader).toBe('function');
+  });
+
+  it('reads translations from local file', async () => {
+    const mockTranslations = { greeting: 'Hola, mundo!' };
+    const fs = await import('fs');
+    (fs.promises.readFile as any).mockResolvedValueOnce(
+      JSON.stringify(mockTranslations)
+    );
+
+    const loader = createLocalTranslationLoader({
+      translationOutputPath: 'public/_gt/[locale].json',
+    });
+
+    const result = await loader('es');
+    expect(fs.promises.readFile).toHaveBeenCalledWith(
+      'public/_gt/es.json',
+      'utf-8'
+    );
+    expect(result).toEqual(mockTranslations);
+  });
+
+  it('throws on file read failure', async () => {
+    const fs = await import('fs');
+    (fs.promises.readFile as any).mockRejectedValueOnce(
+      new Error('ENOENT: no such file or directory')
+    );
+
+    const loader = createLocalTranslationLoader({
+      translationOutputPath: 'public/_gt/[locale].json',
+    });
+
+    await expect(loader('fr')).rejects.toThrow('ENOENT');
+  });
+});

--- a/packages/i18n/src/i18n-manager/translations-manager/translations-loaders/createLocalTranslationLoader.ts
+++ b/packages/i18n/src/i18n-manager/translations-manager/translations-loaders/createLocalTranslationLoader.ts
@@ -1,0 +1,28 @@
+import { resolveCanonicalLocale } from 'generaltranslation';
+import { TranslationsLoader } from './types';
+import { Translations } from '../utils/types/translation-data';
+import { CustomMapping } from 'generaltranslation/types';
+
+type CreateLocalTranslationLoaderParams = {
+  translationOutputPath: string;
+  customMapping?: CustomMapping;
+};
+
+/**
+ * Creates a translations loader that reads from local JSON files on the filesystem.
+ * The translationOutputPath should contain a [locale] placeholder that gets replaced
+ * with the target locale (e.g., "public/_gt/[locale].json").
+ */
+export function createLocalTranslationLoader(
+  params: CreateLocalTranslationLoaderParams
+): TranslationsLoader {
+  const loader: TranslationsLoader = async (locale: string) => {
+    locale = resolveCanonicalLocale(locale, params.customMapping);
+    const filePath = params.translationOutputPath.replace('[locale]', locale);
+    const { promises: fsPromises } = await import('fs');
+    const content = await fsPromises.readFile(filePath, 'utf-8');
+    return JSON.parse(content) as Translations;
+  };
+
+  return loader;
+}

--- a/packages/i18n/src/i18n-manager/translations-manager/utils/types/translations-manager.ts
+++ b/packages/i18n/src/i18n-manager/translations-manager/utils/types/translations-manager.ts
@@ -16,6 +16,7 @@ export type TranslationsManagerConfig = {
   _versionId?: string;
   _branchId?: string;
   customMapping?: CustomMapping;
+  translationOutputPath?: string;
   cacheExpiryTime: number;
 };
 
@@ -24,6 +25,7 @@ export type TranslationsManagerConfig = {
  *
  * @property {number} [cacheExpiryTime] - The cache expiry time in milliseconds.
  * @property {TranslationsLoader} [loadTranslations] - A custom translations loader function.
+ * @property {string} [translationOutputPath] - Path pattern with [locale] placeholder for local translation files.
  */
 export type TranslationsManagerConstructorParams = Partial<
   Pick<TranslationsManagerConfig, 'cacheExpiryTime'>

--- a/packages/i18n/src/i18n-manager/utils/getLoadTranslationsType.ts
+++ b/packages/i18n/src/i18n-manager/utils/getLoadTranslationsType.ts
@@ -6,26 +6,31 @@ import { defaultCacheUrl } from 'generaltranslation/internal';
  * - GT_REMOTE: use the default remote store URL {@link defaultCacheUrl}
  * - REMOTE: use a custom remote store URL
  * - CUSTOM: use a custom translations loader
+ * - LOCAL: load translations from local filesystem using translationOutputPath
  * - DISABLED: no translations loading
  */
 export enum LoadTranslationsType {
   GT_REMOTE = 'gt-remote',
   REMOTE = 'remote',
   CUSTOM = 'custom',
+  LOCAL = 'local',
   DISABLED = 'disabled',
 }
 
 /**
- * Based on the configurtion return the load translations type
+ * Based on the configuration return the load translations type
  *
  * cacheUrl = null means disabled
  */
 export function getLoadTranslationsType(config: {
   cacheUrl?: string | null;
   loadTranslations?: TranslationsLoader;
+  translationOutputPath?: string;
 }): LoadTranslationsType {
   if (config.loadTranslations) {
     return LoadTranslationsType.CUSTOM;
+  } else if (config.translationOutputPath) {
+    return LoadTranslationsType.LOCAL;
   } else if (config.cacheUrl) {
     return LoadTranslationsType.REMOTE;
   } else if (

--- a/packages/i18n/src/i18n-manager/validation/config-validation/validateLoadTranslations.ts
+++ b/packages/i18n/src/i18n-manager/validation/config-validation/validateLoadTranslations.ts
@@ -25,9 +25,10 @@ export function validateLoadTranslations(params: {
   projectId?: string;
   cacheUrl?: string | null;
   loadTranslations?: TranslationsLoader;
+  translationOutputPath?: string;
 }): ValidationResult[] {
   const results: ValidationResult[] = [];
-  const { projectId, loadTranslations } = params;
+  const { projectId, loadTranslations, translationOutputPath } = params;
 
   const loadTranslationsType = getLoadTranslationsType(params);
   switch (loadTranslationsType) {
@@ -47,6 +48,21 @@ export function validateLoadTranslations(params: {
           type: 'error',
           message:
             'loadTranslations is required when loading translations from a custom loader',
+        });
+      }
+      break;
+    case LoadTranslationsType.LOCAL:
+      if (!translationOutputPath) {
+        results.push({
+          type: 'error',
+          message:
+            'translationOutputPath is required when loading translations from local files',
+        });
+      } else if (!translationOutputPath.includes('[locale]')) {
+        results.push({
+          type: 'error',
+          message:
+            'translationOutputPath must contain a [locale] placeholder',
         });
       }
       break;

--- a/packages/i18n/src/i18n-manager/validation/config-validation/validateLoadTranslations.ts
+++ b/packages/i18n/src/i18n-manager/validation/config-validation/validateLoadTranslations.ts
@@ -61,8 +61,7 @@ export function validateLoadTranslations(params: {
       } else if (!translationOutputPath.includes('[locale]')) {
         results.push({
           type: 'error',
-          message:
-            'translationOutputPath must contain a [locale] placeholder',
+          message: 'translationOutputPath must contain a [locale] placeholder',
         });
       }
       break;

--- a/packages/next/src/config-dir/I18NConfiguration.ts
+++ b/packages/next/src/config-dir/I18NConfiguration.ts
@@ -30,7 +30,7 @@ type I18NConfigurationParams = {
   runtimeUrl: string | undefined;
   cacheUrl: string | null;
   cacheExpiryTime?: number;
-  loadTranslationsType: 'remote' | 'custom' | 'disabled';
+  loadTranslationsType: 'remote' | 'custom' | 'local' | 'disabled';
   loadDictionaryEnabled: boolean;
   defaultLocale: string;
   locales: string[];
@@ -154,7 +154,8 @@ export default class I18NConfiguration {
 
     // buildtime translation enabled
     this.translationEnabled = !!(
-      loadTranslationsType === 'custom' || // load local translation
+      loadTranslationsType === 'custom' || // load custom translation
+      loadTranslationsType === 'local' || // load from local files (files.gt.output)
       (loadTranslationsType === 'remote' &&
         this.projectId && // projectId required because it's part of the GET request
         this.cacheUrl) ||

--- a/packages/next/src/config-dir/TranslationManager.ts
+++ b/packages/next/src/config-dir/TranslationManager.ts
@@ -15,7 +15,8 @@ export type TranslationManagerConfig = {
   _versionId?: string;
   translationEnabled: boolean;
   cacheExpiryTime?: number;
-  loadTranslationsType?: 'remote' | 'custom' | 'disabled';
+  loadTranslationsType?: 'remote' | 'custom' | 'local' | 'disabled';
+  translationOutputPath?: string;
 };
 
 /**

--- a/packages/next/src/config-dir/loadTranslation.ts
+++ b/packages/next/src/config-dir/loadTranslation.ts
@@ -19,7 +19,7 @@ let loadTranslationsFunction: (
 
 /**
  * Loads the translations for the user's current locale.
- * Supports custom translation loaders.
+ * Supports custom translation loaders and local file loading.
  *
  * @returns {Promise<Translations | undefined>} The translation object or undefined if not found or errored
  *
@@ -45,6 +45,33 @@ export default async function loadTranslations(
         return await customLoadTranslations(_props.targetLocale);
       } catch (error) {
         console.error(customLoadTranslationsError(_props.targetLocale), error);
+        return undefined;
+      }
+    };
+  } else if (process.env._GENERALTRANSLATION_TRANSLATION_OUTPUT_PATH) {
+    // ----- USING LOCAL FILE LOADER ----- //
+
+    const translationOutputPath =
+      process.env._GENERALTRANSLATION_TRANSLATION_OUTPUT_PATH;
+
+    loadTranslationsFunction = async (
+      _props: RemoteLoadTranslationsInput
+    ): Promise<any> => {
+      try {
+        const gt = getI18NConfig().getGTClass();
+        const targetLocale = gt.resolveCanonicalLocale(_props.targetLocale);
+        const filePath = translationOutputPath.replace(
+          '[locale]',
+          targetLocale
+        );
+        const { promises: fsPromises } = await import('fs');
+        const content = await fsPromises.readFile(filePath, 'utf-8');
+        return JSON.parse(content);
+      } catch (error) {
+        console.error(
+          `Failed to load local translations for ${_props.targetLocale}:`,
+          error
+        );
         return undefined;
       }
     };

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -398,12 +398,17 @@ export function withGTConfig(
   // Run SSG checks
   ssgChecks(mergedConfig, requestFunctionPaths);
 
+  // Extract files.gt.output from the config for local translation loading
+  const filesGtOutput: string | undefined =
+    (mergedConfig as any).files?.gt?.output;
+
   // Run cache component checks
   cacheComponentsChecks({
     mergedConfig,
     nextConfig,
     requestFunctionPaths,
-    localTranslationsEnabled: !!customLoadTranslationsPath,
+    localTranslationsEnabled:
+      !!customLoadTranslationsPath || !!filesGtOutput,
     localDictionaryEnabled: !!customLoadDictionaryPath,
   });
 
@@ -424,6 +429,8 @@ export function withGTConfig(
   }
 
   // Local translations flag
+  let resolvedTranslationOutputPath: string | undefined;
+
   if (customLoadTranslationsPath) {
     // Check: file exists if provided
     if (!fs.existsSync(path.resolve(customLoadTranslationsPath))) {
@@ -433,6 +440,10 @@ export function withGTConfig(
     } else {
       mergedConfig.loadTranslationsType = 'custom';
     }
+  } else if (filesGtOutput) {
+    // Use local translation loading when files.gt.output is configured
+    mergedConfig.loadTranslationsType = 'local';
+    resolvedTranslationOutputPath = path.resolve(filesGtOutput);
   } else {
     mergedConfig.loadTranslationsType = 'remote';
   }
@@ -568,8 +579,13 @@ export function withGTConfig(
       _GENERALTRANSLATION_LOCAL_DICTIONARY_ENABLED:
         mergedConfig.loadDictionaryEnabled.toString(),
       _GENERALTRANSLATION_LOCAL_TRANSLATION_ENABLED: (
-        mergedConfig.loadTranslationsType === 'custom'
+        mergedConfig.loadTranslationsType === 'custom' ||
+        mergedConfig.loadTranslationsType === 'local'
       ).toString(),
+      ...(resolvedTranslationOutputPath && {
+        _GENERALTRANSLATION_TRANSLATION_OUTPUT_PATH:
+          resolvedTranslationOutputPath,
+      }),
       _GENERALTRANSLATION_DEFAULT_LOCALE: (
         mergedConfig.defaultLocale ||
         defaultWithGTConfigProps.defaultLocale ||

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -399,16 +399,15 @@ export function withGTConfig(
   ssgChecks(mergedConfig, requestFunctionPaths);
 
   // Extract files.gt.output from the config for local translation loading
-  const filesGtOutput: string | undefined =
-    (mergedConfig as any).files?.gt?.output;
+  const filesGtOutput: string | undefined = (mergedConfig as any).files?.gt
+    ?.output;
 
   // Run cache component checks
   cacheComponentsChecks({
     mergedConfig,
     nextConfig,
     requestFunctionPaths,
-    localTranslationsEnabled:
-      !!customLoadTranslationsPath || !!filesGtOutput,
+    localTranslationsEnabled: !!customLoadTranslationsPath || !!filesGtOutput,
     localDictionaryEnabled: !!customLoadDictionaryPath,
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implement automatic local translation loading based on `gt.config.json` to simplify local translation setup.

This change removes the need for users to provide a custom `loadTranslations` function for local files. Instead, the system now checks for the `files.gt.output` field in `gt.config.json`. If this field is present and valid (e.g., `public/_gt/[locale].json`), a new `createLocalTranslationLoader` is used to read translation files directly from the filesystem.

---
[Slack Thread](https://generaltranslation.slack.com/archives/C0AD4GVFGDS/p1772947079223079?thread_ts=1772947079.223079&cid=C0AD4GVFGDS)

<p><a href="https://cursor.com/agents/bc-4010b3ea-58fe-5a26-a7b5-245b2b41e187"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4010b3ea-58fe-5a26-a7b5-245b2b41e187"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->