### PR TITLE
feat(node): add locale utilities

### DIFF
--- a/.changeset/yellow-items-chew.md
+++ b/.changeset/yellow-items-chew.md
@@ -1,0 +1,6 @@
+---
+'gt-i18n': minor
+'gt-node': minor
+---
+
+feat: add locale utilities

--- a/packages/i18n/src/helpers/index.ts
+++ b/packages/i18n/src/helpers/index.ts
@@ -1,0 +1,1 @@
+export * from './locale';

--- a/packages/i18n/src/helpers/locale.ts
+++ b/packages/i18n/src/helpers/locale.ts
@@ -1,0 +1,57 @@
+import { getI18nManager } from '../i18n-manager/singleton-operations';
+
+/**
+ * Get the current locale
+ * @returns The current locale
+ *
+ * @example
+ * const locale = getLocale();
+ * console.log(locale); // 'en-US'
+ */
+export function getLocale() {
+  const i18nManager = getI18nManager();
+  return i18nManager.getLocale();
+}
+
+/**
+ * Get the current locales
+ * @returns The current locales
+ *
+ * @example
+ * const locales = getLocales();
+ * console.log(locales); // ['en-US', 'es-ES']
+ */
+export function getLocales() {
+  const i18nManager = getI18nManager();
+  return i18nManager.getLocales();
+}
+
+/**
+ * Get the default locale
+ * @returns The default locale
+ *
+ * @example
+ * const defaultLocale = getDefaultLocale();
+ * console.log(defaultLocale); // 'en-US'
+ */
+export function getDefaultLocale() {
+  const i18nManager = getI18nManager();
+  return i18nManager.getDefaultLocale();
+}
+
+/**
+ * Get the locale properties
+ * @param {string} [locale] - The locale to get the properties for. When not provided, uses the current locale.
+ * @returns The locale properties
+ *
+ * @example
+ * const localeProperties = getLocaleProperties();
+ *
+ * @example
+ * const localeProperties = getLocaleProperties('en-US');
+ */
+export function getLocaleProperties(locale: string) {
+  const i18nManager = getI18nManager();
+  const gtInstance = i18nManager.getGTClass();
+  return gtInstance.getLocaleProperties(locale);
+}

--- a/packages/i18n/src/helpers/locale.ts
+++ b/packages/i18n/src/helpers/locale.ts
@@ -50,7 +50,7 @@ export function getDefaultLocale() {
  * @example
  * const localeProperties = getLocaleProperties('en-US');
  */
-export function getLocaleProperties(locale: string) {
+export function getLocaleProperties(locale?: string) {
   const i18nManager = getI18nManager();
   const gtInstance = i18nManager.getGTClass();
   return gtInstance.getLocaleProperties(locale);

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -1,3 +1,4 @@
 export * from './translation-functions/msg';
 export * from './translation-functions/static';
 export * from './translation-functions/fallbacks';
+export * from './helpers';

--- a/packages/node/src/helpers/index.ts
+++ b/packages/node/src/helpers/index.ts
@@ -1,0 +1,7 @@
+// Locale Utilities
+export {
+  getLocale,
+  getLocales,
+  getDefaultLocale,
+  getLocaleProperties,
+} from 'gt-i18n';

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -1,2 +1,3 @@
 export * from './setup';
 export * from './translation-functions';
+export * from './helpers';


### PR DESCRIPTION
adds the following utilities to `gt-node` and `gt-i18n`:
- `getLocale()`
- `getDefaultLocale()`
- `getLocales()`
- `getLocaleProperties()`
This improves parity with our react libraries.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds four locale utility functions (`getLocale`, `getLocales`, `getDefaultLocale`, `getLocaleProperties`) to `gt-i18n` and re-exports them through `gt-node`, improving parity with the existing React libraries. The overall structure is clean and follows established patterns in the codebase (singleton `I18nManager` access, barrel re-exports).

**Key findings:**
- **Type/documentation mismatch in `getLocaleProperties`**: The JSDoc marks `locale` as optional (`[locale]`) and even provides an example calling the function with no arguments, but the TypeScript signature declares it as required (`locale: string`). Callers following the documented API will get a TypeScript compile error. The signature should be changed to `locale?: string` and a fallback to `i18nManager.getLocale()` should be added in the function body.
- The delegation pattern in `packages/node/src/helpers/index.ts` (re-exporting directly from `gt-i18n` rather than re-implementing) is clean and avoids duplication.
- Changeset versioning (`minor` for both packages) is appropriate for new exported APIs.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- Safe to merge with one fix: the `getLocaleProperties` parameter type must be made optional to match its documentation and usage examples.
- The PR is small, well-scoped, and follows existing patterns. The only real issue is a type/docs mismatch in `getLocaleProperties` — the signature requires `locale: string` but the JSDoc marks it as optional and provides a zero-argument call example. This will surface as a TypeScript error for any caller following the documented API. All other changes are trivial barrel exports with no logic concerns.
- packages/i18n/src/helpers/locale.ts — specifically the `getLocaleProperties` function signature
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/i18n/src/helpers/locale.ts | New locale utilities file. Contains a type/documentation mismatch: `getLocaleProperties` documents an optional `locale` parameter (with a no-arg usage example) but the TypeScript signature requires it, causing a compile error for callers following the docs. |
| packages/i18n/src/helpers/index.ts | Simple barrel file re-exporting everything from `./locale`. No issues. |
| packages/i18n/src/index.ts | Adds `export * from './helpers'` to surface the new locale utilities from the `gt-i18n` package entry point. No issues. |
| packages/node/src/helpers/index.ts | Re-exports the four locale utilities from `gt-i18n` into `gt-node`. Clean approach for maintaining parity without duplicating logic. |
| packages/node/src/index.ts | Adds `export * from './helpers'` to expose the locale utilities from the `gt-node` entry point. No issues. |
| .changeset/yellow-items-chew.md | Changeset entry marking both `gt-i18n` and `gt-node` as minor version bumps for the new locale utilities. Correct versioning intent. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant gt-node as gt-node (helpers/index.ts)
    participant gt-i18n as gt-i18n (helpers/locale.ts)
    participant Singleton as getI18nManager()
    participant I18nManager
    participant GT as GT instance

    Caller->>gt-node: getLocale() / getLocales() / getDefaultLocale()
    gt-node->>gt-i18n: re-export (no-op passthrough)
    gt-i18n->>Singleton: getI18nManager()
    Singleton-->>gt-i18n: I18nManager instance
    gt-i18n->>I18nManager: getLocale() / getLocales() / getDefaultLocale()
    I18nManager-->>Caller: string / string[]

    Caller->>gt-node: getLocaleProperties(locale)
    gt-node->>gt-i18n: re-export (no-op passthrough)
    gt-i18n->>Singleton: getI18nManager()
    Singleton-->>gt-i18n: I18nManager instance
    gt-i18n->>I18nManager: getGTClass()
    I18nManager-->>gt-i18n: GT instance
    gt-i18n->>GT: getLocaleProperties(locale)
    GT-->>Caller: locale properties object
```
</details>

<sub>Last reviewed commit: dbcdbde</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->