### PR TITLE
fix(core): remove requirement on branchId for enqueue

### DIFF
--- a/.changeset/olive-deer-cross.md
+++ b/.changeset/olive-deer-cross.md
@@ -1,0 +1,5 @@
+---
+'generaltranslation': patch
+---
+
+fix: remove required branchId field for enqueue

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -95,7 +95,10 @@ import type {
   CreateBranchResult,
 } from './translate/createBranch';
 import _createBranch from './translate/createBranch';
-import type { FileReference } from './types-dir/api/file';
+import type {
+  FileReference,
+  FileReferenceOptionalBranchId,
+} from './types-dir/api/file';
 import _processFileMoves, {
   type MoveMapping,
   type ProcessMovesResponse,
@@ -270,8 +273,7 @@ export class GT {
       this.reverseCustomMapping = Object.fromEntries(
         Object.entries(customMapping)
           .filter(
-            ([_, value]) =>
-              value && typeof value === 'object' && 'code' in value
+            ([, value]) => value && typeof value === 'object' && 'code' in value
           )
           .map(([key, value]) => [(value as { code: string }).code, key])
       );
@@ -451,7 +453,7 @@ export class GT {
    * @returns {Promise<EnqueueFilesResult>} Result containing job IDs, queue status, and processing information
    */
   async enqueueFiles(
-    files: FileReference[],
+    files: FileReferenceOptionalBranchId[],
     options: EnqueueOptions
   ): Promise<EnqueueFilesResult> {
     // Validation

--- a/packages/core/src/translate/enqueueFiles.ts
+++ b/packages/core/src/translate/enqueueFiles.ts
@@ -1,6 +1,6 @@
 import { TranslationRequestConfig, EnqueueFilesResult } from '../types';
 import apiRequest from './utils/apiRequest';
-import type { FileReference } from '../types-dir/api/file';
+import type { FileReferenceOptionalBranchId } from '../types-dir/api/file';
 import { processBatches } from './utils/batch';
 
 export type EnqueueOptions = {
@@ -22,7 +22,7 @@ export type EnqueueOptions = {
  * @returns The result of the API call
  */
 export default async function _enqueueFiles(
-  files: FileReference[],
+  files: FileReferenceOptionalBranchId[],
   options: EnqueueOptions,
   config: TranslationRequestConfig
 ): Promise<EnqueueFilesResult> {

--- a/packages/core/src/types-dir/api/file.ts
+++ b/packages/core/src/types-dir/api/file.ts
@@ -13,27 +13,36 @@ export type FileFormat =
   | 'TXT';
 
 /**
- * File object structure for uploading files
- * @param content - Content of the file
- * @param fileName - Unique identifier for the file (such as the file path + file name)
- * @param fileFormat - The format of the file (JSON, MDX, MD, etc.)
- * @param formatMetadata - Optional metadata for the file, specific to the format of the file
- * @param dataFormat - Optional format of the data within the file
+ * Metadata for files or entries
  */
-export type FileToUpload = {
+type FormatMetadata = Record<string, any> | Updates[number]['metadata'];
+
+/**
+ * File object structure for uploading files
+ * @see {@link FileReferenceOptionalBranchId}
+ * @property {string} content - Content of the file
+ * @property {string} locale - The locale of the file (e.g. 'en', 'de', 'es', etc.)
+ * @property {FormatMetadata} [formatMetadata] - Optional metadata for the file, specific to the format of the file
+ * @property {string} [incomingBranchId] - The ID of the incoming branch of the file
+ * @property {string} [checkedOutBranchId] - The ID of the checked out branch of the file
+ */
+export type FileToUpload = FileReferenceOptionalBranchId & {
   content: string;
-  formatMetadata?: Record<string, any> | Updates[number]['metadata'];
+  locale: string;
+  formatMetadata?: FormatMetadata;
   incomingBranchId?: string;
   checkedOutBranchId?: string;
-  locale: string;
-} & Omit<FileReference, 'branchId'> & { branchId?: string };
+};
 
 /**
  * File object structure for referencing files
- * @param fileId - The ID of the file
- * @param versionId - The ID of the version of the file
- * @param branchId - The ID of the branch of the file
- * @param locale - The locale of the file ()
+ * @property {string} fileId - The ID of the file
+ * @property {string} versionId - The ID of the version of the file
+ * @property {string} branchId - The ID of the branch of the file
+ * @property {string} locale - The locale of the file (e.g. 'en', 'de', 'es', etc.)
+ * @property {string} fileName - The name of the file
+ * @property {FileFormat} fileFormat - The format of the file (JSON, MDX, MD, etc.)
+ * @property {DataFormat} [dataFormat] - Optional format of the data within the file
  */
 export type FileReference = {
   fileId: string;
@@ -42,4 +51,13 @@ export type FileReference = {
   fileName: string;
   fileFormat: FileFormat;
   dataFormat?: DataFormat;
+};
+
+/**
+ * File reference object structure for referencing files
+ * @see {@link FileReference}
+ * @property {string} [branchId] - The ID of the branch of the file
+ */
+export type FileReferenceOptionalBranchId = Omit<FileReference, 'branchId'> & {
+  branchId?: string;
 };


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes `branchId` optional in the `enqueueFiles` API by introducing a new `FileReferenceOptionalBranchId` type that extends `FileReference` with `branchId?` instead of `branchId`. The change is applied consistently across the type definitions, the internal `_enqueueFiles` function, and the public `GT.enqueueFiles` method, allowing callers to enqueue file translation jobs without needing a branch ID.

**Key changes:**
- New `FileReferenceOptionalBranchId` type added in `file.ts` — a thin wrapper over `FileReference` that makes `branchId` optional
- `FileToUpload` refactored to extend `FileReferenceOptionalBranchId` instead of manually repeating the `Omit<FileReference, 'branchId'> & { branchId?: string }` pattern — logically equivalent, cleaner
- New `FormatMetadata` type alias extracted from the inline union to reduce duplication
- Minor cleanup in `index.ts`: unused destructured variable `_` replaced with the idiomatic `[, value]` syntax
- The JSDoc for `FileReference` introduced in this PR incorrectly documents a `locale` property that does not exist on the type

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge — the change is a non-breaking relaxation of a type constraint and the logic is straightforward.
- The core change is minimal and backward-compatible: making a previously required field optional. The refactored types are structurally equivalent to what they replaced, and `undefined` branch IDs are naturally omitted during JSON serialization before the API call. The only issue found is a minor JSDoc documentation error.
- Only `packages/core/src/types-dir/api/file.ts` needs a minor JSDoc fix; no other files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .changeset/olive-deer-cross.md | New patch-level changeset entry correctly describing the removal of the required `branchId` field from the enqueue API. |
| packages/core/src/types-dir/api/file.ts | Introduces `FileReferenceOptionalBranchId` and `FormatMetadata` types, and refactors `FileToUpload` to extend the new type. The JSDoc for `FileReference` incorrectly lists a `locale` property that does not exist on the type. |
| packages/core/src/translate/enqueueFiles.ts | Correctly updates the `files` parameter type from `FileReference[]` to `FileReferenceOptionalBranchId[]`, making `branchId` optional. The API request body handles `undefined` gracefully via JSON serialization. |
| packages/core/src/index.ts | Imports and applies `FileReferenceOptionalBranchId` for the `enqueueFiles` method parameter type. Also includes a minor cleanup of an unused destructured variable (`[_, value]` → `[, value]`). |

</details>

</details>

<details><summary><h3>Class Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
classDiagram
    class FileReference {
        +string fileId
        +string versionId
        +string branchId
        +string fileName
        +FileFormat fileFormat
        +DataFormat dataFormat?
    }

    class FileReferenceOptionalBranchId {
        +string fileId
        +string versionId
        +string branchId?
        +string fileName
        +FileFormat fileFormat
        +DataFormat dataFormat?
    }

    class FileToUpload {
        +string content
        +string locale
        +FormatMetadata formatMetadata?
        +string incomingBranchId?
        +string checkedOutBranchId?
    }

    FileReference <|-- FileReferenceOptionalBranchId : Omit branchId + branchId?
    FileReferenceOptionalBranchId <|-- FileToUpload : extends
```
</details>

<sub>Last reviewed commit: fe73996</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->