### PR TITLE
fix: composite json uploads

### DIFF
--- a/.changeset/eleven-adults-clean.md
+++ b/.changeset/eleven-adults-clean.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+fix: upload supporting composite json

--- a/packages/cli/src/cli/commands/__tests__/upload.test.ts
+++ b/packages/cli/src/cli/commands/__tests__/upload.test.ts
@@ -1,0 +1,307 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { upload } from '../upload';
+import type { ResolvedFiles, Settings, TransformFiles } from '../../../types/index.js';
+import type { UploadOptions } from '../../base.js';
+
+vi.mock('../../../console/logger.js');
+vi.mock('../../../console/logging.js', () => ({
+  exitSync: vi.fn(() => {
+    throw new Error('Process exit called');
+  }),
+  logErrorAndExit: vi.fn(),
+}));
+vi.mock('../../../fs/findFilepath.js', () => ({
+  readFile: vi.fn((filePath: string) => {
+    const files = (vi as any).__mockFiles;
+    return files?.[filePath] ?? '';
+  }),
+  getRelative: vi.fn((filePath: string) => filePath),
+}));
+vi.mock('../../../workflows/upload.js', () => ({
+  runUploadFilesWorkflow: vi.fn(),
+}));
+vi.mock('../../../formats/files/fileMapping.js', () => ({
+  createFileMapping: vi.fn(() => ({})),
+}));
+vi.mock('../../../utils/hash.js', () => ({
+  hashStringSync: vi.fn((s: string) => `hash_${s.slice(0, 16)}`),
+}));
+vi.mock('./utils/validation.js', () => ({
+  hasValidCredentials: vi.fn(() => true),
+}));
+
+// Mock node:fs for existsSync/readFileSync (translation file reads)
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn(() => false),
+  readFileSync: vi.fn(() => ''),
+}));
+
+import { readFile } from '../../../fs/findFilepath.js';
+import { runUploadFilesWorkflow } from '../../../workflows/upload.js';
+import { createFileMapping } from '../../../formats/files/fileMapping.js';
+import { existsSync, readFileSync } from 'node:fs';
+
+function setMockFiles(files: Record<string, string>) {
+  (vi as any).__mockFiles = files;
+  vi.mocked(readFile).mockImplementation((filePath: string) => {
+    return files[filePath] ?? '';
+  });
+}
+
+function makeSettings(
+  overrides: Partial<Settings & UploadOptions> = {}
+): Settings & UploadOptions {
+  return {
+    defaultLocale: 'en',
+    locales: ['es', 'fr'],
+    projectId: 'test-project',
+    apiKey: 'test-key',
+    ...overrides,
+  } as Settings & UploadOptions;
+}
+
+describe('upload - composite JSON', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(createFileMapping).mockReturnValue({});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should extract translations from composite array JSON', async () => {
+    const compositeContent = JSON.stringify({
+      items: [
+        { locale: 'en', title: 'Hello', desc: 'World' },
+        { locale: 'es', title: 'Hola', desc: 'Mundo' },
+        { locale: 'fr', title: 'Bonjour', desc: 'Monde' },
+      ],
+    });
+
+    setMockFiles({ 'source.json': compositeContent });
+
+    const filePaths: ResolvedFiles = { json: ['source.json'] };
+    const settings = makeSettings({
+      locales: ['es', 'fr'],
+      options: {
+        jsonSchema: {
+          '**/*.json': {
+            composite: {
+              '$.items': {
+                type: 'array',
+                include: ['$.title', '$.desc'],
+                key: '$.locale',
+              },
+            },
+          },
+        },
+      },
+    });
+
+    await upload(filePaths, {}, {} as TransformFiles, 'JSX', settings);
+
+    expect(runUploadFilesWorkflow).toHaveBeenCalledTimes(1);
+    const call = vi.mocked(runUploadFilesWorkflow).mock.calls[0][0];
+    const fileData = call.files[0];
+
+    // Source should be the parsed composite (default locale extracted)
+    expect(fileData.source.locale).toBe('en');
+
+    // Should have 2 translations extracted from the same file
+    expect(fileData.translations).toHaveLength(2);
+    expect(fileData.translations[0].locale).toBe('es');
+    expect(fileData.translations[1].locale).toBe('fr');
+
+    // Verify extracted content contains translated values
+    const esContent = JSON.parse(fileData.translations[0].content);
+    expect(esContent['/items']['/0']['/title']).toBe('Hola');
+    expect(esContent['/items']['/0']['/desc']).toBe('Mundo');
+
+    const frContent = JSON.parse(fileData.translations[1].content);
+    expect(frContent['/items']['/0']['/title']).toBe('Bonjour');
+    expect(frContent['/items']['/0']['/desc']).toBe('Monde');
+  });
+
+  it('should extract translations from composite object JSON', async () => {
+    const compositeContent = JSON.stringify({
+      translations: {
+        en: { title: 'Hello', desc: 'World' },
+        es: { title: 'Hola', desc: 'Mundo' },
+      },
+    });
+
+    setMockFiles({ 'source.json': compositeContent });
+
+    const filePaths: ResolvedFiles = { json: ['source.json'] };
+    const settings = makeSettings({
+      locales: ['es'],
+      options: {
+        jsonSchema: {
+          '**/*.json': {
+            composite: {
+              '$.translations': {
+                type: 'object',
+                include: ['$.title', '$.desc'],
+              },
+            },
+          },
+        },
+      },
+    });
+
+    await upload(filePaths, {}, {} as TransformFiles, 'JSX', settings);
+
+    expect(runUploadFilesWorkflow).toHaveBeenCalledTimes(1);
+    const call = vi.mocked(runUploadFilesWorkflow).mock.calls[0][0];
+    const fileData = call.files[0];
+
+    expect(fileData.translations).toHaveLength(1);
+    expect(fileData.translations[0].locale).toBe('es');
+
+    const esContent = JSON.parse(fileData.translations[0].content);
+    expect(esContent['/translations']['/title']).toBe('Hola');
+    expect(esContent['/translations']['/desc']).toBe('Mundo');
+  });
+
+  it('should skip locale when extractJson returns null (locale not in file)', async () => {
+    const compositeContent = JSON.stringify({
+      items: [
+        { locale: 'en', title: 'Hello' },
+        { locale: 'es', title: 'Hola' },
+      ],
+    });
+
+    setMockFiles({ 'source.json': compositeContent });
+
+    const filePaths: ResolvedFiles = { json: ['source.json'] };
+    const settings = makeSettings({
+      locales: ['es', 'fr'], // fr is not in the file
+      options: {
+        jsonSchema: {
+          '**/*.json': {
+            composite: {
+              '$.items': {
+                type: 'array',
+                include: ['$.title'],
+                key: '$.locale',
+              },
+            },
+          },
+        },
+      },
+    });
+
+    await upload(filePaths, {}, {} as TransformFiles, 'JSX', settings);
+
+    const call = vi.mocked(runUploadFilesWorkflow).mock.calls[0][0];
+    const fileData = call.files[0];
+
+    // es should be extracted with content, fr gets an empty composite result
+    expect(fileData.translations).toHaveLength(2);
+    expect(fileData.translations[0].locale).toBe('es');
+    expect(fileData.translations[1].locale).toBe('fr');
+
+    // es has real content
+    const esContent = JSON.parse(fileData.translations[0].content);
+    expect(esContent['/items']['/0']['/title']).toBe('Hola');
+
+    // fr has empty composite result
+    const frContent = JSON.parse(fileData.translations[1].content);
+    expect(frContent).toEqual({});
+  });
+
+  it('should use fileMapping for non-composite JSON files', async () => {
+    const plainContent = JSON.stringify({ title: 'Hello' });
+    const translatedContent = JSON.stringify({ title: 'Hola' });
+
+    setMockFiles({ 'source.json': plainContent });
+
+    // No jsonSchema = no composite detection
+    const filePaths: ResolvedFiles = { json: ['source.json'] };
+    const settings = makeSettings({
+      locales: ['es'],
+      options: {},
+    });
+
+    vi.mocked(createFileMapping).mockReturnValue({
+      es: { 'source.json': 'es/source.json' },
+    });
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(translatedContent);
+
+    await upload(filePaths, {}, {} as TransformFiles, 'JSX', settings);
+
+    const call = vi.mocked(runUploadFilesWorkflow).mock.calls[0][0];
+    const fileData = call.files[0];
+
+    // Should use fileMapping to find separate translation file
+    expect(fileData.translations).toHaveLength(1);
+    expect(fileData.translations[0].locale).toBe('es');
+    expect(fileData.translations[0].content).toBe(translatedContent);
+  });
+
+  it('should handle mix of composite and non-composite JSON files', async () => {
+    const compositeContent = JSON.stringify({
+      items: [
+        { locale: 'en', title: 'Hello' },
+        { locale: 'es', title: 'Hola' },
+      ],
+    });
+    const plainContent = JSON.stringify({ greeting: 'Hi' });
+    const translatedPlain = JSON.stringify({ greeting: 'Hola' });
+
+    setMockFiles({
+      'composite.json': compositeContent,
+      'plain.json': plainContent,
+    });
+
+    const filePaths: ResolvedFiles = {
+      json: ['composite.json', 'plain.json'],
+    };
+    const settings = makeSettings({
+      locales: ['es'],
+      options: {
+        jsonSchema: {
+          'composite.json': {
+            composite: {
+              '$.items': {
+                type: 'array',
+                include: ['$.title'],
+                key: '$.locale',
+              },
+            },
+          },
+        },
+      },
+    });
+
+    vi.mocked(createFileMapping).mockReturnValue({
+      es: { 'plain.json': 'es/plain.json' },
+    });
+    vi.mocked(existsSync).mockImplementation(
+      (p) => p === 'es/plain.json'
+    );
+    vi.mocked(readFileSync).mockReturnValue(translatedPlain);
+
+    await upload(filePaths, {}, {} as TransformFiles, 'JSX', settings);
+
+    const call = vi.mocked(runUploadFilesWorkflow).mock.calls[0][0];
+
+    // composite.json: translations extracted from same file
+    const compositeFile = call.files.find(
+      (f) => f.source.fileName === 'composite.json'
+    );
+    expect(compositeFile?.translations).toHaveLength(1);
+    expect(compositeFile?.translations[0].locale).toBe('es');
+    const esContent = JSON.parse(compositeFile!.translations[0].content);
+    expect(esContent['/items']['/0']['/title']).toBe('Hola');
+
+    // plain.json: translations from separate file via fileMapping
+    const plainFile = call.files.find(
+      (f) => f.source.fileName === 'plain.json'
+    );
+    expect(plainFile?.translations).toHaveLength(1);
+    expect(plainFile?.translations[0].content).toBe(translatedPlain);
+  });
+});

--- a/packages/cli/src/cli/commands/__tests__/upload.test.ts
+++ b/packages/cli/src/cli/commands/__tests__/upload.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { upload } from '../upload';
-import type { ResolvedFiles, Settings, TransformFiles } from '../../../types/index.js';
+import type {
+  ResolvedFiles,
+  Settings,
+  TransformFiles,
+} from '../../../types/index.js';
 import type { UploadOptions } from '../../base.js';
 
 vi.mock('../../../console/logger.js');
@@ -279,9 +283,7 @@ describe('upload - composite JSON', () => {
     vi.mocked(createFileMapping).mockReturnValue({
       es: { 'plain.json': 'es/plain.json' },
     });
-    vi.mocked(existsSync).mockImplementation(
-      (p) => p === 'es/plain.json'
-    );
+    vi.mocked(existsSync).mockImplementation((p) => p === 'es/plain.json');
     vi.mocked(readFileSync).mockReturnValue(translatedPlain);
 
     await upload(filePaths, {}, {} as TransformFiles, 'JSX', settings);

--- a/packages/cli/src/cli/commands/upload.ts
+++ b/packages/cli/src/cli/commands/upload.ts
@@ -11,6 +11,8 @@ import { SUPPORTED_FILE_EXTENSIONS } from '../../formats/files/supportedFiles.js
 import { UploadOptions } from '../base.js';
 import sanitizeFileContent from '../../utils/sanitizeFileContent.js';
 import { parseJson } from '../../formats/json/parseJson.js';
+import { extractJson } from '../../formats/json/extractJson.js';
+import { validateJsonSchema } from '../../formats/json/utils.js';
 import { runUploadFilesWorkflow } from '../../workflows/upload.js';
 import { existsSync, readFileSync } from 'node:fs';
 import { createFileMapping } from '../../formats/files/fileMapping.js';
@@ -40,6 +42,10 @@ export async function upload(
   // Collect all files to translate
   const allFiles: FileToUpload[] = [];
   const additionalOptions = settings.options || {};
+  const compositeJsonFiles = new Map<
+    string,
+    { filePath: string; content: string }
+  >();
 
   // Process JSON files
   if (filePaths.json) {
@@ -58,6 +64,12 @@ export async function upload(
       );
 
       const relativePath = getRelative(filePath);
+
+      const jsonSchema = validateJsonSchema(additionalOptions, filePath);
+      if (jsonSchema?.composite) {
+        compositeJsonFiles.set(relativePath, { filePath, content });
+      }
+
       return {
         content: parsedJson,
         fileName: relativePath,
@@ -155,19 +167,44 @@ export async function upload(
     };
 
     const translations: FileToUpload[] = [];
+    const compositeInfo = compositeJsonFiles.get(file.fileName);
+
     for (const locale of locales) {
-      const translatedFileName = fileMapping[locale][file.fileName];
-      if (translatedFileName && existsSync(translatedFileName)) {
-        const translatedContent = readFileSync(translatedFileName, 'utf8');
-        translations.push({
-          content: translatedContent,
-          fileName: file.fileName,
-          fileFormat: file.fileFormat,
-          dataFormat: file.dataFormat,
+      if (compositeInfo) {
+        // Composite JSON: extract translations from the same source file
+        const extracted = extractJson(
+          compositeInfo.content,
+          compositeInfo.filePath,
+          additionalOptions,
           locale,
-          fileId: file.fileId,
-          versionId: file.versionId,
-        });
+          settings.defaultLocale
+        );
+        if (extracted) {
+          translations.push({
+            content: extracted,
+            fileName: file.fileName,
+            fileFormat: file.fileFormat,
+            dataFormat: file.dataFormat,
+            locale,
+            fileId: file.fileId,
+            versionId: file.versionId,
+          });
+        }
+      } else {
+        // Non-composite: look for separate translation files
+        const translatedFileName = fileMapping[locale]?.[file.fileName];
+        if (translatedFileName && existsSync(translatedFileName)) {
+          const translatedContent = readFileSync(translatedFileName, 'utf8');
+          translations.push({
+            content: translatedContent,
+            fileName: file.fileName,
+            fileFormat: file.fileFormat,
+            dataFormat: file.dataFormat,
+            locale,
+            fileId: file.fileId,
+            versionId: file.versionId,
+          });
+        }
       }
     }
     return {

--- a/packages/cli/src/formats/json/utils.ts
+++ b/packages/cli/src/formats/json/utils.ts
@@ -216,6 +216,13 @@ export function generateSourceObjectPointers(
   return sourceObjectPointers;
 }
 
+/**
+ * Validate the json schema for composite or include schemas
+ * @param options - Additional options containing jsonSchema config
+ * @param filePath - The path to the file (used for matching jsonSchema)
+ * @returns The json schema, or null if no schema is found
+ * @returns exitSync(1) if the json schema is invalid
+ */
 export function validateJsonSchema(
   options: AdditionalOptions,
   filePath: string


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes composite JSON uploads in the CLI by detecting composite-schema JSON files during the source-file processing pass, storing their raw content in a `compositeJsonFiles` map, and then using `extractJson` to derive per-locale translations from the single source file rather than looking for separate translated files via `fileMapping`.

Key changes:
- **`upload.ts`**: Two-phase handling — composite JSON files are identified with `validateJsonSchema` early in the pipeline, and per-locale translation content is later extracted inline via `extractJson`. Non-composite files retain the existing `fileMapping`-based path. Also includes a useful optional-chain fix (`fileMapping[locale]?.[file.fileName]`).
- **`utils.ts`**: Adds a JSDoc comment to the existing `validateJsonSchema` function.
- **`upload.test.ts`**: New test suite covering composite array, composite object, missing-locale, plain, and mixed scenarios. Contains two correctness issues: the `vi.mock('./utils/validation.js')` path resolves to a non-existent file (should be `'../utils/validation.js'`), and one test's description says it "should skip" a missing locale while the assertions confirm the locale is still included with empty content — exposing that `extractJson` never returns `null` for composite schemas and the `if (extracted)` guard is effectively dead code.

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

- The core composite upload logic is sound, but the guard against empty translations is ineffective and the new test suite has a broken mock path that leaves credential validation untested.
- The main feature (composite JSON extraction) works correctly for the happy path. However, the `if (extracted)` guard in `upload.ts` is never `false` for composite schemas because `extractJson` always returns a truthy string, which means locales absent from a composite file are still uploaded as empty `{}` payloads — this could cause unexpected API behaviour. Additionally, the new test file has a mock at the wrong path (`./utils/validation.js` instead of `../utils/validation.js`), meaning `hasValidCredentials` is never actually mocked; tests pass only because the test data happens to have valid credentials.
- `packages/cli/src/cli/commands/__tests__/upload.test.ts` (broken mock path, contradictory test name/assertions) and `packages/cli/src/cli/commands/upload.ts` (ineffective `if (extracted)` guard for composite schemas).
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/cli/commands/upload.ts | Adds composite JSON upload support by detecting composite files early and extracting per-locale translations from a single source file; includes a useful `?.` optional-chain fix for `fileMapping[locale]`. The `if (extracted)` guard is effectively dead code for composite schemas because `extractJson` always returns a truthy string, meaning empty-locale translations are always pushed. |
| packages/cli/src/cli/commands/__tests__/upload.test.ts | New test suite for composite JSON upload; has two issues: (1) the `vi.mock('./utils/validation.js')` path resolves to a non-existent `__tests__/utils/validation.js` instead of `../utils/validation.js`, so `hasValidCredentials` is never actually mocked; (2) the test named "should skip locale when extractJson returns null" contradicts its own assertions by verifying the locale is *included* with empty content. |
| packages/cli/src/formats/json/utils.ts | Only adds a JSDoc comment to the existing `validateJsonSchema` function; a `@returns` tag is used to document a side-effect (process exit) which is non-standard but harmless. |
| .changeset/eleven-adults-clean.md | Standard changeset file describing a patch-level fix for composite JSON upload support. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[upload called] --> B{JSON files present?}
    B -- yes --> C[Parse each JSON file]
    C --> D[validateJsonSchema]
    D --> E{composite schema?}
    E -- yes --> F[Add to compositeJsonFiles map]
    E -- no --> G[No composite tracking]
    F --> H[Add to allFiles]
    G --> H
    B -- no --> I[Process YAML and other types]
    I --> H
    H --> J[createFileMapping for all locales]
    J --> K[Map each file to upload object]
    K --> L{File is composite JSON?}
    L -- yes --> M[extractJson per locale\nfrom raw source]
    M --> N{extracted is truthy?\nnote: always true\nfor composite schemas}
    N -- yes --> O[Push translation]
    N -- no --> P[Skip locale]
    L -- no --> Q[Look up fileMapping per locale]
    Q --> R{Translated file exists?}
    R -- yes --> S[Read file and push translation]
    R -- no --> T[Skip locale]
    O --> U[Assemble source plus translations]
    S --> U
    U --> V[runUploadFilesWorkflow]
```
</details>

<sub>Last reviewed commit: e063411</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->