### PR TITLE
feat(cli): twilio content support

### DIFF
--- a/.changeset/every-cougars-send.md
+++ b/.changeset/every-cougars-send.md
@@ -1,0 +1,6 @@
+---
+'gt': minor
+'generaltranslation': patch
+---
+
+feat: add twilio json support for cli

--- a/packages/cli/src/cli/base.ts
+++ b/packages/cli/src/cli/base.ts
@@ -596,6 +596,10 @@ See https://generaltranslation.com/en/docs/next/guides/local-tx`
               { value: 'ts', label: FILE_EXT_TO_EXT_LABEL.ts },
               { value: 'js', label: FILE_EXT_TO_EXT_LABEL.js },
               { value: 'yaml', label: FILE_EXT_TO_EXT_LABEL.yaml },
+              {
+                value: 'twilioContentJson',
+                label: FILE_EXT_TO_EXT_LABEL.twilioContentJson,
+              },
             ],
             required: !isUsingGT,
           });

--- a/packages/cli/src/cli/commands/__tests__/upload.test.ts
+++ b/packages/cli/src/cli/commands/__tests__/upload.test.ts
@@ -64,6 +64,90 @@ function makeSettings(
   } as Settings & UploadOptions;
 }
 
+describe('upload - Twilio Content JSON', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(createFileMapping).mockReturnValue({});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should upload Twilio Content JSON files with TWILIO_CONTENT_JSON fileFormat', async () => {
+    const content = JSON.stringify({ body: 'Hello {{1}}' });
+    setMockFiles({ 'twilio/content.json': content });
+
+    const filePaths: ResolvedFiles = {
+      twilioContentJson: ['twilio/content.json'],
+    };
+    const settings = makeSettings({ options: {} });
+
+    await upload(filePaths, {}, {} as TransformFiles, 'JSX', settings);
+
+    expect(runUploadFilesWorkflow).toHaveBeenCalledTimes(1);
+    const call = vi.mocked(runUploadFilesWorkflow).mock.calls[0][0];
+    expect(call.files).toHaveLength(1);
+    expect(call.files[0].source.fileFormat).toBe('TWILIO_CONTENT_JSON');
+  });
+
+  it('should use fileMapping for Twilio Content JSON files (no composite)', async () => {
+    const content = JSON.stringify({ body: 'Hello' });
+    const translatedContent = JSON.stringify({ body: 'Hola' });
+    setMockFiles({ 'twilio/content.json': content });
+
+    const filePaths: ResolvedFiles = {
+      twilioContentJson: ['twilio/content.json'],
+    };
+    const settings = makeSettings({ locales: ['es'], options: {} });
+
+    vi.mocked(createFileMapping).mockReturnValue({
+      es: { 'twilio/content.json': 'twilio/es/content.json' },
+    });
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(translatedContent);
+
+    await upload(filePaths, {}, {} as TransformFiles, 'JSX', settings);
+
+    const call = vi.mocked(runUploadFilesWorkflow).mock.calls[0][0];
+    const fileData = call.files[0];
+
+    expect(fileData.translations).toHaveLength(1);
+    expect(fileData.translations[0].locale).toBe('es');
+    expect(fileData.translations[0].content).toBe(translatedContent);
+  });
+
+  it('should handle mix of regular JSON and Twilio Content JSON', async () => {
+    const jsonContent = JSON.stringify({ title: 'Hello' });
+    const twilioContent = JSON.stringify({ body: 'Hi {{1}}' });
+    setMockFiles({
+      'messages.json': jsonContent,
+      'twilio/content.json': twilioContent,
+    });
+
+    const filePaths: ResolvedFiles = {
+      json: ['messages.json'],
+      twilioContentJson: ['twilio/content.json'],
+    };
+    const settings = makeSettings({ locales: ['es'], options: {} });
+
+    await upload(filePaths, {}, {} as TransformFiles, 'JSX', settings);
+
+    const call = vi.mocked(runUploadFilesWorkflow).mock.calls[0][0];
+    expect(call.files).toHaveLength(2);
+
+    const jsonFile = call.files.find(
+      (f) => f.source.fileName === 'messages.json'
+    );
+    const twilioFile = call.files.find(
+      (f) => f.source.fileName === 'twilio/content.json'
+    );
+
+    expect(jsonFile?.source.fileFormat).toBe('JSON');
+    expect(twilioFile?.source.fileFormat).toBe('TWILIO_CONTENT_JSON');
+  });
+});
+
 describe('upload - composite JSON', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/packages/cli/src/cli/commands/upload.ts
+++ b/packages/cli/src/cli/commands/upload.ts
@@ -111,8 +111,42 @@ export async function upload(
     allFiles.push(...yamlFiles);
   }
 
+  // Process Twilio Content JSON files
+  if (filePaths.twilioContentJson) {
+    const twilioContentJsonFiles = filePaths.twilioContentJson.map(
+      (filePath) => {
+        const content = readFile(filePath);
+
+        const parsedJson = parseJson(
+          content,
+          filePath,
+          additionalOptions,
+          settings.defaultLocale
+        );
+
+        const relativePath = getRelative(filePath);
+
+        return {
+          content: parsedJson,
+          fileName: relativePath,
+          fileFormat: 'TWILIO_CONTENT_JSON' as const,
+          dataFormat,
+          locale: settings.defaultLocale,
+          fileId: hashStringSync(relativePath),
+          versionId: hashStringSync(parsedJson),
+        } satisfies FileToUpload;
+      }
+    );
+    allFiles.push(...twilioContentJsonFiles);
+  }
+
   for (const fileType of SUPPORTED_FILE_EXTENSIONS) {
-    if (fileType === 'json' || fileType === 'yaml') continue;
+    if (
+      fileType === 'json' ||
+      fileType === 'yaml' ||
+      fileType === 'twilioContentJson'
+    )
+      continue;
     if (filePaths[fileType]) {
       const files = filePaths[fileType].map((filePath) => {
         const content = readFile(filePath);

--- a/packages/cli/src/cli/commands/upload.ts
+++ b/packages/cli/src/cli/commands/upload.ts
@@ -130,7 +130,7 @@ export async function upload(
           content: parsedJson,
           fileName: relativePath,
           fileFormat: 'TWILIO_CONTENT_JSON' as const,
-          dataFormat,
+          dataFormat: 'STRING' as const,
           locale: settings.defaultLocale,
           fileId: hashStringSync(relativePath),
           versionId: hashStringSync(parsedJson),

--- a/packages/cli/src/formats/files/__tests__/aggregateFiles.test.ts
+++ b/packages/cli/src/formats/files/__tests__/aggregateFiles.test.ts
@@ -450,6 +450,105 @@ describe('aggregateFiles - Empty File Handling', () => {
     });
   });
 
+  describe('Twilio Content JSON files', () => {
+    it('should process valid Twilio Content JSON files with correct fileFormat', async () => {
+      const settings = {
+        files: {
+          resolvedPaths: {
+            twilioContentJson: ['/full/path/content.json'],
+          },
+          placeholderPaths: {},
+        },
+        options: {},
+        defaultLocale: 'en',
+      };
+
+      mockReadFile.mockReturnValueOnce('{"key": "value"}');
+
+      const result = await aggregateFiles(settings as any);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].fileFormat).toBe('TWILIO_CONTENT_JSON');
+      expect(result[0].dataFormat).toBe('STRING');
+      expect(result[0].fileName).toBe('content.json');
+    });
+
+    it('should skip empty Twilio Content JSON files and log warning', async () => {
+      const settings = {
+        files: {
+          resolvedPaths: {
+            twilioContentJson: [
+              '/full/path/empty.json',
+              '/full/path/valid.json',
+            ],
+          },
+          placeholderPaths: {},
+        },
+        options: {},
+        defaultLocale: 'en',
+      };
+
+      mockReadFile
+        .mockReturnValueOnce('') // empty file
+        .mockReturnValueOnce('{"key": "value"}'); // valid file
+
+      const result = await aggregateFiles(settings as any);
+
+      expect(mockLogWarning).toHaveBeenCalledWith(
+        'Skipping empty.json: JSON file is not parsable'
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0].fileName).toBe('valid.json');
+    });
+
+    it('should skip unparsable Twilio Content JSON files', async () => {
+      const settings = {
+        files: {
+          resolvedPaths: {
+            twilioContentJson: ['/full/path/invalid.json'],
+          },
+          placeholderPaths: {},
+        },
+        options: {},
+        defaultLocale: 'en',
+      };
+
+      mockReadFile.mockReturnValueOnce('{ invalid json');
+
+      const result = await aggregateFiles(settings as any);
+
+      expect(mockLogWarning).toHaveBeenCalledWith(
+        'Skipping invalid.json: JSON file is not parsable'
+      );
+      expect(result).toHaveLength(0);
+    });
+
+    it('should allow invalid JSON when validation is skipped', async () => {
+      const settings = {
+        files: {
+          resolvedPaths: {
+            twilioContentJson: ['/full/path/invalid.json'],
+          },
+          placeholderPaths: {},
+        },
+        options: {
+          skipFileValidation: {
+            json: true,
+          },
+        },
+        defaultLocale: 'en',
+      };
+
+      mockReadFile.mockReturnValueOnce('{ invalid json');
+
+      const result = await aggregateFiles(settings as any);
+
+      expect(mockLogWarning).not.toHaveBeenCalled();
+      expect(result).toHaveLength(1);
+      expect(result[0].fileName).toBe('invalid.json');
+    });
+  });
+
   describe('Mixed file types with empty files', () => {
     it('should skip empty files across all file types and process valid ones', async () => {
       const settings = {
@@ -457,6 +556,7 @@ describe('aggregateFiles - Empty File Handling', () => {
           resolvedPaths: {
             json: ['/full/path/empty.json', '/full/path/valid.json'],
             yaml: ['/full/path/empty.yaml'],
+            twilioContentJson: ['/full/path/valid-twilio.json'],
             md: ['/full/path/valid.md'],
           },
           placeholderPaths: {},
@@ -469,6 +569,7 @@ describe('aggregateFiles - Empty File Handling', () => {
         .mockReturnValueOnce('') // empty JSON
         .mockReturnValueOnce('{"key": "value"}') // valid JSON
         .mockReturnValueOnce('') // empty YAML
+        .mockReturnValueOnce('{"twilio": "content"}') // valid Twilio Content JSON
         .mockReturnValueOnce('# Valid markdown'); // valid MD
 
       const result = await aggregateFiles(settings as any);
@@ -481,12 +582,13 @@ describe('aggregateFiles - Empty File Handling', () => {
         'Skipping empty.yaml: YAML file is empty'
       );
 
-      // Should have 2 valid files
-      expect(result).toHaveLength(2);
+      // Should have 3 valid files
+      expect(result).toHaveLength(3);
 
-      // Check the file names are correct (JSON processed first, then MD after YAML)
+      // Check the file names are correct
       const fileNames = result.map((f) => f.fileName);
       expect(fileNames).toContain('valid.json');
+      expect(fileNames).toContain('valid-twilio.json');
       expect(fileNames).toContain('valid.md');
     });
   });

--- a/packages/cli/src/formats/files/aggregateFiles.ts
+++ b/packages/cli/src/formats/files/aggregateFiles.ts
@@ -149,8 +149,64 @@ export async function aggregateFiles(
     allFiles.push(...yamlFiles.filter((file) => file !== null));
   }
 
+  // Process Twilio Content JSON files
+  if (filePaths.twilioContentJson) {
+    const twilioContentJsonFiles = filePaths.twilioContentJson
+      .map((filePath) => {
+        const content = readFile(filePath);
+        const relativePath = getRelative(filePath);
+
+        // Pre-validate JSON parseability
+        if (!skipValidation?.json) {
+          try {
+            JSON.parse(content);
+          } catch {
+            logger.warn(`Skipping ${relativePath}: JSON file is not parsable`);
+            recordWarning(
+              'skipped_file',
+              relativePath,
+              'JSON file is not parsable'
+            );
+            return null;
+          }
+        }
+
+        const parsedJson = parseJson(
+          content,
+          filePath,
+          settings.options || {},
+          settings.defaultLocale
+        );
+
+        return {
+          fileId: hashStringSync(relativePath),
+          versionId: hashStringSync(parsedJson),
+          content: parsedJson,
+          fileName: relativePath,
+          fileFormat: 'TWILIO_CONTENT_JSON' as const,
+          dataFormat: 'STRING' as const,
+          locale: settings.defaultLocale,
+        } satisfies FileToUpload;
+      })
+      .filter((file) => {
+        if (!file) return false;
+        if (typeof file.content !== 'string' || !file.content.trim()) {
+          logger.warn(`Skipping ${file.fileName}: JSON file is empty`);
+          recordWarning('skipped_file', file.fileName, 'JSON file is empty');
+          return false;
+        }
+        return true;
+      });
+    allFiles.push(...twilioContentJsonFiles.filter((file) => file !== null));
+  }
+
   for (const fileType of SUPPORTED_FILE_EXTENSIONS) {
-    if (fileType === 'json' || fileType === 'yaml') continue;
+    if (
+      fileType === 'json' ||
+      fileType === 'yaml' ||
+      fileType === 'twilioContentJson'
+    )
+      continue;
     if (filePaths[fileType]) {
       const files = filePaths[fileType]
         .map((filePath) => {

--- a/packages/cli/src/formats/files/supportedFiles.ts
+++ b/packages/cli/src/formats/files/supportedFiles.ts
@@ -7,6 +7,7 @@ export const SUPPORTED_FILE_EXTENSIONS = [
   'yaml',
   'html',
   'txt',
+  'twilioContentJson',
 ] as const;
 
 export const FILE_EXT_TO_EXT_LABEL = {
@@ -18,4 +19,5 @@ export const FILE_EXT_TO_EXT_LABEL = {
   yaml: 'YAML',
   html: 'HTML',
   txt: 'Text',
+  twilioContentJson: 'Twilio Content JSON',
 };

--- a/packages/cli/src/fs/__tests__/parseFilesConfig.test.ts
+++ b/packages/cli/src/fs/__tests__/parseFilesConfig.test.ts
@@ -955,9 +955,7 @@ describe('parseFilesConfig', () => {
 
       const result = resolveLocaleFiles(files, 'fr');
 
-      expect(result.twilioContentJson).toEqual([
-        'src/fr/twilio/content.json',
-      ]);
+      expect(result.twilioContentJson).toEqual(['src/fr/twilio/content.json']);
     });
   });
 

--- a/packages/cli/src/fs/__tests__/parseFilesConfig.test.ts
+++ b/packages/cli/src/fs/__tests__/parseFilesConfig.test.ts
@@ -919,6 +919,48 @@ describe('parseFilesConfig', () => {
     });
   });
 
+  describe('resolveFiles - twilioContentJson', () => {
+    beforeEach(() => {
+      vi.mocked(fg.sync).mockReturnValue([]);
+    });
+
+    const defaultLocales = ['en', 'fr', 'es'];
+
+    it('should resolve twilioContentJson glob patterns', () => {
+      const files = {
+        twilioContentJson: {
+          include: ['src/[locale]/twilio/*.json'],
+        },
+      };
+
+      vi.mocked(fg.sync).mockReturnValue([
+        '/project/src/en/twilio/content.json',
+      ]);
+
+      const result = resolveFiles(files, 'en', defaultLocales, '/project');
+
+      expect(result.resolvedPaths.twilioContentJson).toEqual([
+        '/project/src/en/twilio/content.json',
+      ]);
+      expect(result.placeholderPaths.twilioContentJson).toEqual([
+        '/project/src/[locale]/twilio/content.json',
+      ]);
+    });
+
+    it('should replace [locale] in twilioContentJson paths', () => {
+      const files: ResolvedFiles = {
+        twilioContentJson: ['src/[locale]/twilio/content.json'],
+        gt: 'output/[locale].json',
+      };
+
+      const result = resolveLocaleFiles(files, 'fr');
+
+      expect(result.twilioContentJson).toEqual([
+        'src/fr/twilio/content.json',
+      ]);
+    });
+  });
+
   describe('resolveFiles - composite patterns', () => {
     beforeEach(() => {
       vi.mocked(fg.sync).mockReturnValue([]);

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.8.0';
+export const PACKAGE_VERSION = '2.8.2';

--- a/packages/core/src/types-dir/api/file.ts
+++ b/packages/core/src/types-dir/api/file.ts
@@ -10,7 +10,8 @@ export type FileFormat =
   | 'TS'
   | 'JS'
   | 'HTML'
-  | 'TXT';
+  | 'TXT'
+  | 'TWILIO_CONTENT_JSON';
 
 /**
  * Metadata for files or entries


### PR DESCRIPTION
add translation support for twilio content

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Twilio Content JSON (`twilioContentJson`) as a new supported file format for the GT CLI, enabling translation workflows for Twilio content template files. It registers the new type in `supportedFiles.ts`, adds it to the interactive `init` wizard in `base.ts`, extends the `FileFormat` type in `packages/core`, and implements processing logic in both `upload.ts` and `aggregateFiles.ts`. Tests are added for all major paths.

Key changes:
- New `'TWILIO_CONTENT_JSON'` value added to the `FileFormat` union type in `packages/core`
- `twilioContentJson` added to `SUPPORTED_FILE_EXTENSIONS` and skipped in the generic extension loop (processed separately, like `json` and `yaml`)
- `aggregateFiles.ts` correctly hardcodes `dataFormat: 'STRING'` for Twilio files; `upload.ts` inconsistently forwards the caller-supplied `dataFormat` (defaulting to `'JSX'`)
- The Twilio processing block in `upload.ts` is also missing the `SUPPORTED_DATA_FORMATS` validation guard that is present for the JSON and YAML blocks

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

- Safe to merge after addressing the `dataFormat` inconsistency in `upload.ts` — Twilio files will otherwise be tagged differently depending on which code path is invoked.
- The overall structure is solid, tests are thorough, and the `aggregateFiles.ts` path is correct. However, `upload.ts` forwards the caller-supplied `dataFormat` (defaulting to `'JSX'`) rather than hardcoding `'STRING'` as `aggregateFiles.ts` does, which creates a real behavioural inconsistency for the `gt upload` command path. The missing `SUPPORTED_DATA_FORMATS` guard in the same block is a secondary concern.
- packages/cli/src/cli/commands/upload.ts — `dataFormat` handling and missing validation guard for the Twilio Content JSON block.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/cli/commands/upload.ts | Adds Twilio Content JSON file processing, but uses the caller-supplied `dataFormat` instead of hardcoding `'STRING'` as done in `aggregateFiles.ts`, and is missing the `SUPPORTED_DATA_FORMATS` validation guard present for JSON and YAML blocks. |
| packages/cli/src/formats/files/aggregateFiles.ts | Adds Twilio Content JSON aggregation with `dataFormat: 'STRING'` hardcoded and proper null-filtering logic consistent with existing JSON and YAML handling. |
| packages/cli/src/formats/files/supportedFiles.ts | Registers `twilioContentJson` in the supported extensions list and label map. |
| packages/core/src/types-dir/api/file.ts | Adds `'TWILIO_CONTENT_JSON'` to the `FileFormat` union type — clean, minimal change. |
| packages/cli/src/cli/base.ts | Adds `twilioContentJson` option to the interactive file-type prompt. |
| packages/cli/src/cli/commands/__tests__/upload.test.ts | Adds three focused test cases covering Twilio Content JSON upload, file mapping, and mixed file type scenarios — good coverage. |
| packages/cli/src/formats/files/__tests__/aggregateFiles.test.ts | Comprehensive tests for Twilio Content JSON in `aggregateFiles`, including empty-file skipping, invalid JSON, and skip-validation flag. |
| packages/cli/src/fs/__tests__/parseFilesConfig.test.ts | Tests `twilioContentJson` glob resolution and `[locale]` placeholder replacement — straightforward additions. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CLI: gt upload / gt translate] --> B{File Type?}
    B --> C[JSON]
    B --> D[YAML]
    B --> E[twilioContentJson]
    B --> F[MD / MDX / TS / JS / HTML / TXT]

    C --> C1[Validate SUPPORTED_DATA_FORMATS]
    C1 --> C2[parseJson]
    C2 --> C3[FileFormat: JSON\ndataFormat: param]

    D --> D1[Validate SUPPORTED_DATA_FORMATS]
    D1 --> D2[parseYaml]
    D2 --> D3[FileFormat: YAML\ndataFormat: param]

    E --> E1{upload.ts path}
    E --> E2{aggregateFiles.ts path}

    E1 --> E1a[❌ No SUPPORTED_DATA_FORMATS check]
    E1a --> E1b[parseJson]
    E1b --> E1c[FileFormat: TWILIO_CONTENT_JSON\ndataFormat: param ⚠️ JSX by default]

    E2 --> E2a[Validate JSON parseability]
    E2a --> E2b[parseJson]
    E2b --> E2c[FileFormat: TWILIO_CONTENT_JSON\ndataFormat: STRING ✅]

    F --> F1[sanitizeFileContent / preprocessContent]
    F1 --> F2[FileFormat: uppercase extension\ndataFormat: param]

    C3 --> G[allFiles array]
    D3 --> G
    E1c --> G
    E2c --> G
    F2 --> G

    G --> H[runUploadFilesWorkflow API call]
```
</details>

<sub>Last reviewed commit: cfafaad</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->