### PR TITLE
F/keyed metadata

### DIFF
--- a/.changeset/large-foxes-lose.md
+++ b/.changeset/large-foxes-lose.md
@@ -1,0 +1,5 @@
+---
+'gt': minor
+---
+
+Adding metadata support for keyed file types

--- a/packages/cli/src/formats/files/aggregateFiles.ts
+++ b/packages/cli/src/formats/files/aggregateFiles.ts
@@ -12,7 +12,7 @@ import { hashStringSync } from '../../utils/hash.js';
 import { preprocessContent } from './preprocessContent.js';
 import {
   parseKeyedMetadata,
-  type MetadataObject,
+  type KeyedMetadata,
 } from '../parseKeyedMetadata.js';
 
 /**
@@ -99,7 +99,7 @@ export async function aggregateFiles(
         );
 
         // Detect companion metadata file
-        let keyedMetadata: MetadataObject | undefined;
+        let keyedMetadata: KeyedMetadata | undefined;
         try {
           keyedMetadata = parseKeyedMetadata(filePath, JSON.parse(content));
         } catch {
@@ -161,7 +161,7 @@ export async function aggregateFiles(
         );
 
         // Detect companion metadata file
-        let keyedMetadata: MetadataObject | undefined;
+        let keyedMetadata: KeyedMetadata | undefined;
         try {
           keyedMetadata = parseKeyedMetadata(filePath, YAML.parse(content));
         } catch {

--- a/packages/cli/src/formats/files/aggregateFiles.ts
+++ b/packages/cli/src/formats/files/aggregateFiles.ts
@@ -118,9 +118,7 @@ export async function aggregateFiles(
 
             // Filter metadata to only keep keys that exist in the transformed source
             // This prevents misaligned entries from wide JSONPath patterns
-            const sourceKeys = new Set(
-              Object.keys(JSON.parse(parsedJson))
-            );
+            const sourceKeys = new Set(Object.keys(JSON.parse(parsedJson)));
             const filtered = Object.fromEntries(
               Object.entries(transformedMetadata).filter(([k]) =>
                 sourceKeys.has(k)

--- a/packages/cli/src/formats/files/aggregateFiles.ts
+++ b/packages/cli/src/formats/files/aggregateFiles.ts
@@ -105,24 +105,16 @@ export async function aggregateFiles(
           const parsed = JSON.parse(content);
           const rawMetadata = parseKeyedMetadata(filePath, parsed);
           if (rawMetadata) {
-            const jsonSchema = validateJsonSchema(
+            // Run metadata through the same include/composite schema as the source
+            // so key paths align at translation time
+            const transformed = parseJson(
+              JSON.stringify(rawMetadata),
+              filePath,
               settings.options || {},
-              filePath
+              settings.defaultLocale,
+              false
             );
-            if (jsonSchema?.include && !jsonSchema?.composite) {
-              // Run metadata through the same include schema as the source
-              // so key paths align at translation time
-              const transformed = parseJson(
-                JSON.stringify(rawMetadata),
-                filePath,
-                settings.options || {},
-                settings.defaultLocale,
-                false
-              );
-              keyedMetadata = JSON.parse(transformed) as KeyedMetadata;
-            } else {
-              keyedMetadata = rawMetadata;
-            }
+            keyedMetadata = JSON.parse(transformed) as KeyedMetadata;
           }
         } catch {
           // Content not parsable or no metadata — skip

--- a/packages/cli/src/formats/files/aggregateFiles.ts
+++ b/packages/cli/src/formats/files/aggregateFiles.ts
@@ -10,6 +10,24 @@ import YAML from 'yaml';
 import { determineLibrary } from '../../fs/determineFramework/index.js';
 import { hashStringSync } from '../../utils/hash.js';
 import { preprocessContent } from './preprocessContent.js';
+import { parseKeyedMetadata, type MetadataObject } from '../parseKeyedMetadata.js';
+
+/**
+ * Checks if a file path is a metadata companion file (e.g. foo.metadata.json)
+ * AND its corresponding source file (e.g. foo.json) exists in the file list.
+ * If both conditions are true, the metadata file should be skipped as a translation source.
+ */
+function isCompanionMetadataFile(
+  filePath: string,
+  allFilePaths: string[]
+): boolean {
+  const metadataPattern = /\.metadata\.(json|yaml|yml)$/;
+  if (!metadataPattern.test(filePath)) return false;
+
+  // Derive the source file path: foo.metadata.json -> foo.json
+  const sourceFilePath = filePath.replace('.metadata.', '.');
+  return allFilePaths.includes(sourceFilePath);
+}
 export const SUPPORTED_DATA_FORMATS = ['JSX', 'ICU', 'I18NEXT'];
 
 export async function aggregateFiles(
@@ -47,6 +65,7 @@ export async function aggregateFiles(
     }
 
     const jsonFiles = filePaths.json
+      .filter((filePath) => !isCompanionMetadataFile(filePath, filePaths.json!))
       .map((filePath) => {
         const content = readFile(filePath);
         const relativePath = getRelative(filePath);
@@ -73,6 +92,14 @@ export async function aggregateFiles(
           settings.defaultLocale
         );
 
+        // Detect companion metadata file
+        let keyedMetadata: MetadataObject | undefined;
+        try {
+          keyedMetadata = parseKeyedMetadata(filePath, JSON.parse(content));
+        } catch {
+          // Content not parsable as JSON — skip metadata detection
+        }
+
         return {
           fileId: hashStringSync(relativePath),
           versionId: hashStringSync(parsedJson),
@@ -81,6 +108,9 @@ export async function aggregateFiles(
           fileFormat: 'JSON' as const,
           dataFormat,
           locale: settings.defaultLocale,
+          ...(keyedMetadata && {
+            formatMetadata: { keyedMetadata },
+          }),
         } satisfies FileToUpload;
       })
       .filter((file) => {
@@ -98,6 +128,7 @@ export async function aggregateFiles(
   // Process YAML files
   if (filePaths.yaml) {
     const yamlFiles = filePaths.yaml
+      .filter((filePath) => !isCompanionMetadataFile(filePath, filePaths.yaml!))
       .map((filePath) => {
         const content = readFile(filePath);
         const relativePath = getRelative(filePath);
@@ -123,6 +154,12 @@ export async function aggregateFiles(
           settings.options || {}
         );
 
+        // Detect companion metadata file
+        const keyedMetadata = parseKeyedMetadata(
+          filePath,
+          YAML.parse(content)
+        );
+
         return {
           content: parsedYaml,
           fileName: relativePath,
@@ -130,6 +167,9 @@ export async function aggregateFiles(
           fileId: hashStringSync(relativePath),
           versionId: hashStringSync(parsedYaml),
           locale: settings.defaultLocale,
+          ...(keyedMetadata && {
+            formatMetadata: { keyedMetadata },
+          }),
         } satisfies FileToUpload;
       })
       .filter((file) => {

--- a/packages/cli/src/formats/files/aggregateFiles.ts
+++ b/packages/cli/src/formats/files/aggregateFiles.ts
@@ -28,7 +28,7 @@ function isCompanionMetadataFile(
   if (!metadataPattern.test(filePath)) return false;
 
   // Derive the source file path: foo.metadata.json -> foo.json
-  const sourceFilePath = filePath.replace('.metadata.', '.');
+  const sourceFilePath = filePath.replace(/\.metadata\.(json|yaml|yml)$/, '.$1');
   return allFilePaths.includes(sourceFilePath);
 }
 export const SUPPORTED_DATA_FORMATS = ['JSX', 'ICU', 'I18NEXT'];
@@ -158,7 +158,12 @@ export async function aggregateFiles(
         );
 
         // Detect companion metadata file
-        const keyedMetadata = parseKeyedMetadata(filePath, YAML.parse(content));
+        let keyedMetadata: MetadataObject | undefined;
+        try {
+          keyedMetadata = parseKeyedMetadata(filePath, YAML.parse(content));
+        } catch {
+          // Content not parsable as YAML — skip metadata detection
+        }
 
         return {
           content: parsedYaml,

--- a/packages/cli/src/formats/files/aggregateFiles.ts
+++ b/packages/cli/src/formats/files/aggregateFiles.ts
@@ -101,9 +101,22 @@ export async function aggregateFiles(
         // Detect companion metadata file
         let keyedMetadata: KeyedMetadata | undefined;
         try {
-          keyedMetadata = parseKeyedMetadata(filePath, JSON.parse(content));
+          const parsed = JSON.parse(content);
+          const rawMetadata = parseKeyedMetadata(filePath, parsed);
+          if (rawMetadata) {
+            // Run metadata through the same composite/include schema as the source
+            // so key paths align at translation time
+            const transformed = parseJson(
+              JSON.stringify(rawMetadata),
+              filePath,
+              settings.options || {},
+              settings.defaultLocale,
+              false
+            );
+            keyedMetadata = JSON.parse(transformed) as KeyedMetadata;
+          }
         } catch {
-          // Content not parsable as JSON — skip metadata detection
+          // Content not parsable or no metadata — skip
         }
 
         return {

--- a/packages/cli/src/formats/files/aggregateFiles.ts
+++ b/packages/cli/src/formats/files/aggregateFiles.ts
@@ -28,7 +28,10 @@ function isCompanionMetadataFile(
   if (!metadataPattern.test(filePath)) return false;
 
   // Derive the source file path: foo.metadata.json -> foo.json
-  const sourceFilePath = filePath.replace(/\.metadata\.(json|yaml|yml)$/, '.$1');
+  const sourceFilePath = filePath.replace(
+    /\.metadata\.(json|yaml|yml)$/,
+    '.$1'
+  );
   return allFilePaths.includes(sourceFilePath);
 }
 export const SUPPORTED_DATA_FORMATS = ['JSX', 'ICU', 'I18NEXT'];

--- a/packages/cli/src/formats/files/aggregateFiles.ts
+++ b/packages/cli/src/formats/files/aggregateFiles.ts
@@ -114,14 +114,21 @@ export async function aggregateFiles(
               settings.defaultLocale,
               false
             );
-            const parsed = JSON.parse(transformed) as KeyedMetadata;
-            // Discard if schema transformation produced an empty object
-            if (
-              Array.isArray(parsed)
-                ? parsed.length > 0
-                : Object.keys(parsed).length > 0
-            ) {
-              keyedMetadata = parsed;
+            const transformedMetadata = JSON.parse(transformed);
+
+            // Filter metadata to only keep keys that exist in the transformed source
+            // This prevents misaligned entries from wide JSONPath patterns
+            const sourceKeys = new Set(
+              Object.keys(JSON.parse(parsedJson))
+            );
+            const filtered = Object.fromEntries(
+              Object.entries(transformedMetadata).filter(([k]) =>
+                sourceKeys.has(k)
+              )
+            ) as KeyedMetadata;
+
+            if (Object.keys(filtered).length > 0) {
+              keyedMetadata = filtered;
             }
           }
         } catch {

--- a/packages/cli/src/formats/files/aggregateFiles.ts
+++ b/packages/cli/src/formats/files/aggregateFiles.ts
@@ -8,6 +8,7 @@ import { parseJson } from '../json/parseJson.js';
 import parseYaml from '../yaml/parseYaml.js';
 import { validateYamlSchema } from '../yaml/utils.js';
 import { flattenJson } from '../json/flattenJson.js';
+import type { JSONObject } from '../../types/data/json.js';
 import YAML from 'yaml';
 import { determineLibrary } from '../../fs/determineFramework/index.js';
 import { hashStringSync } from '../../utils/hash.js';
@@ -102,9 +103,14 @@ export async function aggregateFiles(
 
         // Detect companion metadata file
         let keyedMetadata: KeyedMetadata | undefined;
+        let parsedContent: JSONObject | undefined;
         try {
-          const parsed = JSON.parse(content);
-          const rawMetadata = parseKeyedMetadata(filePath, parsed);
+          parsedContent = JSON.parse(content) as JSONObject;
+        } catch {
+          // Content not parsable — skip metadata detection
+        }
+        if (parsedContent) {
+          const rawMetadata = parseKeyedMetadata(filePath, parsedContent);
           if (rawMetadata) {
             // Run metadata through the same include/composite schema as the source
             // so key paths align at translation time
@@ -134,8 +140,6 @@ export async function aggregateFiles(
               );
             }
           }
-        } catch {
-          // Content not parsable or no metadata — skip
         }
 
         return {

--- a/packages/cli/src/formats/files/aggregateFiles.ts
+++ b/packages/cli/src/formats/files/aggregateFiles.ts
@@ -128,6 +128,10 @@ export async function aggregateFiles(
 
             if (Object.keys(filtered).length > 0) {
               keyedMetadata = filtered;
+            } else {
+              logger.warn(
+                `Companion metadata found for ${relativePath} but no keys aligned with the JSON schema — metadata was not attached`
+              );
             }
           }
         } catch {

--- a/packages/cli/src/formats/files/aggregateFiles.ts
+++ b/packages/cli/src/formats/files/aggregateFiles.ts
@@ -5,8 +5,9 @@ import { Settings } from '../../types/index.js';
 import type { FileFormat, DataFormat, FileToUpload } from '../../types/data.js';
 import { SUPPORTED_FILE_EXTENSIONS } from './supportedFiles.js';
 import { parseJson } from '../json/parseJson.js';
-import { validateJsonSchema } from '../json/utils.js';
 import parseYaml from '../yaml/parseYaml.js';
+import { validateYamlSchema } from '../yaml/utils.js';
+import { flattenJson } from '../json/flattenJson.js';
 import YAML from 'yaml';
 import { determineLibrary } from '../../fs/determineFramework/index.js';
 import { hashStringSync } from '../../utils/hash.js';
@@ -190,7 +191,33 @@ export async function aggregateFiles(
         // Detect companion metadata file
         let keyedMetadata: KeyedMetadata | undefined;
         try {
-          keyedMetadata = parseKeyedMetadata(filePath, YAML.parse(content));
+          const parsedYamlContent = YAML.parse(content);
+          const rawMetadata = parseKeyedMetadata(filePath, parsedYamlContent);
+          if (rawMetadata) {
+            const yamlSchema = validateYamlSchema(
+              settings.options || {},
+              filePath
+            );
+            if (yamlSchema?.include) {
+              // Flatten metadata through the same include schema as the source
+              const flattened = flattenJson(
+                rawMetadata,
+                yamlSchema.include
+              );
+              // Filter to only keep keys that exist in the transformed source
+              const sourceKeys = new Set(
+                Object.keys(JSON.parse(parsedYaml))
+              );
+              const filtered = Object.fromEntries(
+                Object.entries(flattened).filter(([k]) => sourceKeys.has(k))
+              ) as KeyedMetadata;
+              if (Object.keys(filtered).length > 0) {
+                keyedMetadata = filtered;
+              }
+            } else {
+              keyedMetadata = rawMetadata;
+            }
+          }
         } catch {
           // Content not parsable as YAML — skip metadata detection
         }

--- a/packages/cli/src/formats/files/aggregateFiles.ts
+++ b/packages/cli/src/formats/files/aggregateFiles.ts
@@ -5,6 +5,7 @@ import { Settings } from '../../types/index.js';
 import type { FileFormat, DataFormat, FileToUpload } from '../../types/data.js';
 import { SUPPORTED_FILE_EXTENSIONS } from './supportedFiles.js';
 import { parseJson } from '../json/parseJson.js';
+import { validateJsonSchema } from '../json/utils.js';
 import parseYaml from '../yaml/parseYaml.js';
 import YAML from 'yaml';
 import { determineLibrary } from '../../fs/determineFramework/index.js';
@@ -104,16 +105,24 @@ export async function aggregateFiles(
           const parsed = JSON.parse(content);
           const rawMetadata = parseKeyedMetadata(filePath, parsed);
           if (rawMetadata) {
-            // Run metadata through the same composite/include schema as the source
-            // so key paths align at translation time
-            const transformed = parseJson(
-              JSON.stringify(rawMetadata),
-              filePath,
+            const jsonSchema = validateJsonSchema(
               settings.options || {},
-              settings.defaultLocale,
-              false
+              filePath
             );
-            keyedMetadata = JSON.parse(transformed) as KeyedMetadata;
+            if (jsonSchema?.include && !jsonSchema?.composite) {
+              // Run metadata through the same include schema as the source
+              // so key paths align at translation time
+              const transformed = parseJson(
+                JSON.stringify(rawMetadata),
+                filePath,
+                settings.options || {},
+                settings.defaultLocale,
+                false
+              );
+              keyedMetadata = JSON.parse(transformed) as KeyedMetadata;
+            } else {
+              keyedMetadata = rawMetadata;
+            }
           }
         } catch {
           // Content not parsable or no metadata — skip

--- a/packages/cli/src/formats/files/aggregateFiles.ts
+++ b/packages/cli/src/formats/files/aggregateFiles.ts
@@ -10,7 +10,10 @@ import YAML from 'yaml';
 import { determineLibrary } from '../../fs/determineFramework/index.js';
 import { hashStringSync } from '../../utils/hash.js';
 import { preprocessContent } from './preprocessContent.js';
-import { parseKeyedMetadata, type MetadataObject } from '../parseKeyedMetadata.js';
+import {
+  parseKeyedMetadata,
+  type MetadataObject,
+} from '../parseKeyedMetadata.js';
 
 /**
  * Checks if a file path is a metadata companion file (e.g. foo.metadata.json)
@@ -155,10 +158,7 @@ export async function aggregateFiles(
         );
 
         // Detect companion metadata file
-        const keyedMetadata = parseKeyedMetadata(
-          filePath,
-          YAML.parse(content)
-        );
+        const keyedMetadata = parseKeyedMetadata(filePath, YAML.parse(content));
 
         return {
           content: parsedYaml,

--- a/packages/cli/src/formats/files/aggregateFiles.ts
+++ b/packages/cli/src/formats/files/aggregateFiles.ts
@@ -200,14 +200,9 @@ export async function aggregateFiles(
             );
             if (yamlSchema?.include) {
               // Flatten metadata through the same include schema as the source
-              const flattened = flattenJson(
-                rawMetadata,
-                yamlSchema.include
-              );
+              const flattened = flattenJson(rawMetadata, yamlSchema.include);
               // Filter to only keep keys that exist in the transformed source
-              const sourceKeys = new Set(
-                Object.keys(JSON.parse(parsedYaml))
-              );
+              const sourceKeys = new Set(Object.keys(JSON.parse(parsedYaml)));
               const filtered = Object.fromEntries(
                 Object.entries(flattened).filter(([k]) => sourceKeys.has(k))
               ) as KeyedMetadata;

--- a/packages/cli/src/formats/files/aggregateFiles.ts
+++ b/packages/cli/src/formats/files/aggregateFiles.ts
@@ -212,6 +212,10 @@ export async function aggregateFiles(
               ) as KeyedMetadata;
               if (Object.keys(filtered).length > 0) {
                 keyedMetadata = filtered;
+              } else {
+                logger.warn(
+                  `Companion metadata found for ${relativePath} but no keys aligned with the YAML schema — metadata was not attached`
+                );
               }
             } else {
               keyedMetadata = rawMetadata;

--- a/packages/cli/src/formats/files/aggregateFiles.ts
+++ b/packages/cli/src/formats/files/aggregateFiles.ts
@@ -114,7 +114,15 @@ export async function aggregateFiles(
               settings.defaultLocale,
               false
             );
-            keyedMetadata = JSON.parse(transformed) as KeyedMetadata;
+            const parsed = JSON.parse(transformed) as KeyedMetadata;
+            // Discard if schema transformation produced an empty object
+            if (
+              Array.isArray(parsed)
+                ? parsed.length > 0
+                : Object.keys(parsed).length > 0
+            ) {
+              keyedMetadata = parsed;
+            }
           }
         } catch {
           // Content not parsable or no metadata — skip

--- a/packages/cli/src/formats/json/parseJson.ts
+++ b/packages/cli/src/formats/json/parseJson.ts
@@ -28,8 +28,11 @@ export function parseJson(
   try {
     json = JSON.parse(content);
   } catch {
-    logger.error(`Invalid JSON file: ${filePath}`);
-    return exitSync(1);
+    if (filterStrings) {
+      logger.error(`Invalid JSON file: ${filePath}`);
+      return exitSync(1);
+    }
+    return content;
   }
 
   if (jsonSchema.structuralTransform && jsonSchema.composite) {
@@ -48,8 +51,11 @@ export function parseJson(
   }
 
   if (!jsonSchema.composite) {
-    logger.error('No composite property found in JSON schema');
-    return exitSync(1);
+    if (filterStrings) {
+      logger.error('No composite property found in JSON schema');
+      return exitSync(1);
+    }
+    return content;
   }
 
   // Construct lvl 1
@@ -78,10 +84,13 @@ export function parseJson(
     if (sourceObjectOptions.type === 'array') {
       // Validate type
       if (!Array.isArray(sourceObjectValue)) {
-        logger.error(
-          `Source object value is not an array at path: ${sourceObjectPointer}`
-        );
-        return exitSync(1);
+        if (filterStrings) {
+          logger.error(
+            `Source object value is not an array at path: ${sourceObjectPointer}`
+          );
+          return exitSync(1);
+        }
+        continue;
       }
 
       // Find matching source items
@@ -92,10 +101,13 @@ export function parseJson(
         sourceObjectValue
       );
       if (!Object.keys(matchingItems).length) {
-        logger.error(
-          `Matching sourceItem not found at path: ${sourceObjectPointer} for locale: ${defaultLocale}. Check your JSON schema`
-        );
-        return exitSync(1);
+        if (filterStrings) {
+          logger.error(
+            `Matching sourceItem not found at path: ${sourceObjectPointer} for locale: ${defaultLocale}. Check your JSON schema`
+          );
+          return exitSync(1);
+        }
+        continue;
       }
       // Construct lvl 3
       const sourceItemsToTranslate: Record<string, Record<string, string>> = {};
@@ -141,10 +153,13 @@ export function parseJson(
       // Object: use the key in this object with the matching locale property
       // Validate type
       if (typeof sourceObjectValue !== 'object' || sourceObjectValue === null) {
-        logger.error(
-          `Source object value is not an object at path: ${sourceObjectPointer}`
-        );
-        return exitSync(1);
+        if (filterStrings) {
+          logger.error(
+            `Source object value is not an object at path: ${sourceObjectPointer}`
+          );
+          return exitSync(1);
+        }
+        continue;
       }
 
       // Validate localeProperty
@@ -156,10 +171,13 @@ export function parseJson(
       );
       // Validate source item exists
       if (!matchingItem.sourceItem) {
-        logger.error(
-          `Source item not found at path: ${sourceObjectPointer}. You must specify a source item where its key matches the default locale`
-        );
-        return exitSync(1);
+        if (filterStrings) {
+          logger.error(
+            `Source item not found at path: ${sourceObjectPointer}. You must specify a source item where its key matches the default locale`
+          );
+          return exitSync(1);
+        }
+        continue;
       }
       const { sourceItem } = matchingItem;
 

--- a/packages/cli/src/formats/json/parseJson.ts
+++ b/packages/cli/src/formats/json/parseJson.ts
@@ -165,10 +165,7 @@ export function parseJson(
 
       // Get the fields to translate from the includes
       const flatten = filterStrings ? flattenJsonWithStringFilter : flattenJson;
-      const itemsToTranslate = flatten(
-        sourceItem,
-        sourceObjectOptions.include
-      );
+      const itemsToTranslate = flatten(sourceItem, sourceObjectOptions.include);
 
       // Add the items to translate to the result
       sourceObjectsToTranslate[sourceObjectPointer] = itemsToTranslate;

--- a/packages/cli/src/formats/json/parseJson.ts
+++ b/packages/cli/src/formats/json/parseJson.ts
@@ -28,11 +28,8 @@ export function parseJson(
   try {
     json = JSON.parse(content);
   } catch {
-    if (filterStrings) {
-      logger.error(`Invalid JSON file: ${filePath}`);
-      return exitSync(1);
-    }
-    return content;
+    logger.error(`Invalid JSON file: ${filePath}`);
+    return exitSync(1);
   }
 
   if (jsonSchema.structuralTransform && jsonSchema.composite) {
@@ -51,11 +48,8 @@ export function parseJson(
   }
 
   if (!jsonSchema.composite) {
-    if (filterStrings) {
-      logger.error('No composite property found in JSON schema');
-      return exitSync(1);
-    }
-    return content;
+    logger.error('No composite property found in JSON schema');
+    return exitSync(1);
   }
 
   // Construct lvl 1
@@ -84,13 +78,10 @@ export function parseJson(
     if (sourceObjectOptions.type === 'array') {
       // Validate type
       if (!Array.isArray(sourceObjectValue)) {
-        if (filterStrings) {
-          logger.error(
-            `Source object value is not an array at path: ${sourceObjectPointer}`
-          );
-          return exitSync(1);
-        }
-        continue;
+        logger.error(
+          `Source object value is not an array at path: ${sourceObjectPointer}`
+        );
+        return exitSync(1);
       }
 
       // Find matching source items
@@ -101,13 +92,10 @@ export function parseJson(
         sourceObjectValue
       );
       if (!Object.keys(matchingItems).length) {
-        if (filterStrings) {
-          logger.error(
-            `Matching sourceItem not found at path: ${sourceObjectPointer} for locale: ${defaultLocale}. Check your JSON schema`
-          );
-          return exitSync(1);
-        }
-        continue;
+        logger.error(
+          `Matching sourceItem not found at path: ${sourceObjectPointer} for locale: ${defaultLocale}. Check your JSON schema`
+        );
+        return exitSync(1);
       }
       // Construct lvl 3
       const sourceItemsToTranslate: Record<string, Record<string, string>> = {};
@@ -153,13 +141,10 @@ export function parseJson(
       // Object: use the key in this object with the matching locale property
       // Validate type
       if (typeof sourceObjectValue !== 'object' || sourceObjectValue === null) {
-        if (filterStrings) {
-          logger.error(
-            `Source object value is not an object at path: ${sourceObjectPointer}`
-          );
-          return exitSync(1);
-        }
-        continue;
+        logger.error(
+          `Source object value is not an object at path: ${sourceObjectPointer}`
+        );
+        return exitSync(1);
       }
 
       // Validate localeProperty
@@ -171,13 +156,10 @@ export function parseJson(
       );
       // Validate source item exists
       if (!matchingItem.sourceItem) {
-        if (filterStrings) {
-          logger.error(
-            `Source item not found at path: ${sourceObjectPointer}. You must specify a source item where its key matches the default locale`
-          );
-          return exitSync(1);
-        }
-        continue;
+        logger.error(
+          `Source item not found at path: ${sourceObjectPointer}. You must specify a source item where its key matches the default locale`
+        );
+        return exitSync(1);
       }
       const { sourceItem } = matchingItem;
 

--- a/packages/cli/src/formats/json/parseJson.ts
+++ b/packages/cli/src/formats/json/parseJson.ts
@@ -1,5 +1,5 @@
 import { AdditionalOptions, SourceObjectOptions } from '../../types/index.js';
-import { flattenJsonWithStringFilter } from './flattenJson.js';
+import { flattenJson, flattenJsonWithStringFilter } from './flattenJson.js';
 import { JSONPath } from 'jsonpath-plus';
 import { exitSync } from '../../console/logging.js';
 import { logger } from '../../console/logger.js';
@@ -16,7 +16,8 @@ export function parseJson(
   content: string,
   filePath: string,
   options: AdditionalOptions,
-  defaultLocale: string
+  defaultLocale: string,
+  filterStrings: boolean = true
 ): string {
   const jsonSchema = validateJsonSchema(options, filePath);
   if (!jsonSchema) {
@@ -41,7 +42,8 @@ export function parseJson(
 
   // Handle include
   if (jsonSchema.include) {
-    const flattenedJson = flattenJsonWithStringFilter(json, jsonSchema.include);
+    const flatten = filterStrings ? flattenJsonWithStringFilter : flattenJson;
+    const flattenedJson = flatten(json, jsonSchema.include);
     return JSON.stringify(flattenedJson);
   }
 
@@ -162,7 +164,8 @@ export function parseJson(
       const { sourceItem } = matchingItem;
 
       // Get the fields to translate from the includes
-      const itemsToTranslate = flattenJsonWithStringFilter(
+      const flatten = filterStrings ? flattenJsonWithStringFilter : flattenJson;
+      const itemsToTranslate = flatten(
         sourceItem,
         sourceObjectOptions.include
       );

--- a/packages/cli/src/formats/parseKeyedMetadata.ts
+++ b/packages/cli/src/formats/parseKeyedMetadata.ts
@@ -33,9 +33,7 @@ function validateMetadataStructure(
     const keyPath = [...currentPath, key];
 
     if (sourceValue === undefined) {
-      errors.push(
-        `Key "${keyPath.join('.')}" does not exist in source`
-      );
+      errors.push(`Key "${keyPath.join('.')}" does not exist in source`);
       continue;
     }
 

--- a/packages/cli/src/formats/parseKeyedMetadata.ts
+++ b/packages/cli/src/formats/parseKeyedMetadata.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import YAML from 'yaml';
 import { logger } from '../console/logger.js';
 import type { SourceCode } from '../react/jsx/utils/extractSourceCode.js';
+import type { JSONObject } from '../types/data/json.js';
 
 export type MetadataLeaf = {
   context?: string;
@@ -14,24 +15,13 @@ export type MetadataObject = { [key: string]: MetadataLeaf | MetadataObject };
 export type MetadataArray = (MetadataLeaf | MetadataObject)[];
 export type KeyedMetadata = MetadataObject | MetadataArray;
 
-// JSON/YAML parsed content
-type ParsedContent = {
-  [key: string]:
-    | string
-    | number
-    | boolean
-    | null
-    | ParsedContent
-    | ParsedContent[];
-};
-
 /**
  * Validates that the metadata key structure is a subset of the source key structure.
  * Uses the source to determine whether a metadata value is a leaf (source value is a string)
  * or a nested object (source value is an object).
  */
 function validateMetadataStructure(
-  source: ParsedContent,
+  source: JSONObject,
   metadata: MetadataObject,
   currentPath: string[] = []
 ): string[] {
@@ -63,7 +53,7 @@ function validateMetadataStructure(
       } else if (typeof metaValue === 'object' && metaValue !== null) {
         errors.push(
           ...validateMetadataStructure(
-            sourceValue as ParsedContent,
+            sourceValue as JSONObject,
             metaValue as MetadataObject,
             keyPath
           )
@@ -91,14 +81,14 @@ function validateMetadataStructure(
  */
 export function parseKeyedMetadata(
   sourceFilePath: string,
-  sourceContent: ParsedContent | ParsedContent[]
+  sourceContent: JSONObject | JSONObject[]
 ): KeyedMetadata | undefined {
   const ext = path.extname(sourceFilePath);
   const baseName = sourceFilePath.slice(0, -ext.length);
 
   // Determine companion file path and parser
   let metadataFilePath: string | undefined;
-  let parse: ((content: string) => ParsedContent) | undefined;
+  let parse: ((content: string) => JSONObject) | undefined;
 
   if (ext === '.json') {
     metadataFilePath = `${baseName}.metadata.json`;

--- a/packages/cli/src/formats/parseKeyedMetadata.ts
+++ b/packages/cli/src/formats/parseKeyedMetadata.ts
@@ -60,10 +60,7 @@ function validateMetadataStructure(
         errors.push(
           `Metadata key "${keyPath.join('.')}" is an array but source is an object`
         );
-      } else if (
-        typeof metaValue === 'object' &&
-        metaValue !== null
-      ) {
+      } else if (typeof metaValue === 'object' && metaValue !== null) {
         errors.push(
           ...validateMetadataStructure(
             sourceValue as ParsedContent,

--- a/packages/cli/src/formats/parseKeyedMetadata.ts
+++ b/packages/cli/src/formats/parseKeyedMetadata.ts
@@ -68,6 +68,10 @@ function validateMetadataStructure(
             keyPath
           )
         );
+      } else {
+        errors.push(
+          `Metadata key "${keyPath.join('.')}" is a primitive but source is an object`
+        );
       }
     }
   }

--- a/packages/cli/src/formats/parseKeyedMetadata.ts
+++ b/packages/cli/src/formats/parseKeyedMetadata.ts
@@ -94,7 +94,7 @@ export function parseKeyedMetadata(
 
   // Determine companion file path and parser
   let metadataFilePath: string | undefined;
-  let parse: (content: string) => ParsedContent;
+  let parse: ((content: string) => ParsedContent) | undefined;
 
   if (ext === '.json') {
     metadataFilePath = `${baseName}.metadata.json`;
@@ -110,7 +110,7 @@ export function parseKeyedMetadata(
     parse = YAML.parse;
   }
 
-  if (!metadataFilePath || !parse!) {
+  if (!metadataFilePath || !parse) {
     return undefined;
   }
 
@@ -134,6 +134,15 @@ export function parseKeyedMetadata(
   } catch {
     const relativePath = path.relative(process.cwd(), metadataFilePath);
     logger.warn(`Skipping metadata file ${relativePath}: file is not parsable`);
+    return undefined;
+  }
+
+  // Reject if root types don't match (array vs object)
+  if (Array.isArray(metadataContent) !== Array.isArray(sourceContent)) {
+    const relativePath = path.relative(process.cwd(), metadataFilePath);
+    logger.warn(
+      `Skipping metadata file ${relativePath}: root type (array vs object) does not match source`
+    );
     return undefined;
   }
 

--- a/packages/cli/src/formats/parseKeyedMetadata.ts
+++ b/packages/cli/src/formats/parseKeyedMetadata.ts
@@ -1,0 +1,150 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import YAML from 'yaml';
+import { logger } from '../console/logger.js';
+import type { SourceCode } from '../react/jsx/utils/extractSourceCode.js';
+
+export type MetadataLeaf = {
+  context?: string;
+  maxChars?: number;
+  sourceCode?: Record<string, SourceCode[]>;
+};
+
+export type MetadataObject = { [key: string]: MetadataLeaf | MetadataObject };
+
+// JSON/YAML parsed content
+type ParsedContent = {
+  [key: string]:
+    | string
+    | number
+    | boolean
+    | null
+    | ParsedContent
+    | ParsedContent[];
+};
+
+/**
+ * Validates that the metadata key structure is a subset of the source key structure.
+ * Uses the source to determine whether a metadata value is a leaf (source value is a string)
+ * or a nested object (source value is an object).
+ */
+function validateMetadataStructure(
+  source: ParsedContent,
+  metadata: MetadataObject,
+  currentPath: string[] = []
+): string[] {
+  const errors: string[] = [];
+
+  for (const key of Object.keys(metadata)) {
+    const sourceValue = source[key];
+    const keyPath = [...currentPath, key];
+
+    if (sourceValue === undefined) {
+      errors.push(
+        `Metadata key "${keyPath.join('.')}" does not exist in source`
+      );
+      continue;
+    }
+
+    // If the source value is a string, this is a translatable leaf — metadata should be a MetadataLeaf
+    // If the source value is a nested object, recurse
+    if (
+      typeof sourceValue === 'object' &&
+      sourceValue !== null &&
+      !Array.isArray(sourceValue)
+    ) {
+      const metaValue = metadata[key];
+      if (
+        typeof metaValue === 'object' &&
+        metaValue !== null &&
+        !Array.isArray(metaValue)
+      ) {
+        errors.push(
+          ...validateMetadataStructure(
+            sourceValue as ParsedContent,
+            metaValue as MetadataObject,
+            keyPath
+          )
+        );
+      }
+    }
+  }
+
+  return errors;
+}
+
+/**
+ * Detects and parses a companion metadata file for a given source file.
+ *
+ * For `translations.json`, looks for `translations.metadata.json`.
+ * For `translations.yaml` or `translations.yml`, looks for `translations.metadata.yaml` or `.yml`.
+ *
+ * @param sourceFilePath - Absolute path to the source file
+ * @param sourceContent - Parsed source content (object) for structure validation
+ * @returns Parsed metadata object, or undefined if no companion file exists
+ */
+export function parseKeyedMetadata(
+  sourceFilePath: string,
+  sourceContent: ParsedContent
+): MetadataObject | undefined {
+  const ext = path.extname(sourceFilePath);
+  const baseName = sourceFilePath.slice(0, -ext.length);
+
+  // Determine companion file path and parser
+  let metadataFilePath: string | undefined;
+  let parse: (content: string) => ParsedContent;
+
+  if (ext === '.json') {
+    metadataFilePath = `${baseName}.metadata.json`;
+    parse = JSON.parse;
+  } else if (ext === '.yaml' || ext === '.yml') {
+    const yamlPath = `${baseName}.metadata.yaml`;
+    const ymlPath = `${baseName}.metadata.yml`;
+    if (fs.existsSync(yamlPath)) {
+      metadataFilePath = yamlPath;
+    } else if (fs.existsSync(ymlPath)) {
+      metadataFilePath = ymlPath;
+    }
+    parse = YAML.parse;
+  }
+
+  if (!metadataFilePath || !parse!) {
+    return undefined;
+  }
+
+  if (!fs.existsSync(metadataFilePath)) {
+    return undefined;
+  }
+
+  // Read and parse
+  let metadataContent: MetadataObject;
+  try {
+    const raw = fs.readFileSync(metadataFilePath, 'utf8');
+    const parsed = parse(raw);
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      const relativePath = path.relative(process.cwd(), metadataFilePath);
+      logger.warn(
+        `Skipping metadata file ${relativePath}: expected an object`
+      );
+      return undefined;
+    }
+    metadataContent = parsed as MetadataObject;
+  } catch {
+    const relativePath = path.relative(process.cwd(), metadataFilePath);
+    logger.warn(
+      `Skipping metadata file ${relativePath}: file is not parsable`
+    );
+    return undefined;
+  }
+
+  // Validate structure against source
+  const errors = validateMetadataStructure(sourceContent, metadataContent);
+  if (errors.length > 0) {
+    const relativePath = path.relative(process.cwd(), metadataFilePath);
+    for (const error of errors) {
+      logger.warn(`Metadata file ${relativePath}: ${error}`);
+    }
+  }
+
+  return metadataContent;
+}

--- a/packages/cli/src/formats/parseKeyedMetadata.ts
+++ b/packages/cli/src/formats/parseKeyedMetadata.ts
@@ -56,10 +56,13 @@ function validateMetadataStructure(
       !Array.isArray(sourceValue)
     ) {
       const metaValue = metadata[key];
-      if (
+      if (Array.isArray(metaValue)) {
+        errors.push(
+          `Metadata key "${keyPath.join('.')}" is an array but source is an object`
+        );
+      } else if (
         typeof metaValue === 'object' &&
-        metaValue !== null &&
-        !Array.isArray(metaValue)
+        metaValue !== null
       ) {
         errors.push(
           ...validateMetadataStructure(

--- a/packages/cli/src/formats/parseKeyedMetadata.ts
+++ b/packages/cli/src/formats/parseKeyedMetadata.ts
@@ -11,6 +11,8 @@ export type MetadataLeaf = {
 };
 
 export type MetadataObject = { [key: string]: MetadataLeaf | MetadataObject };
+export type MetadataArray = (MetadataLeaf | MetadataObject)[];
+export type KeyedMetadata = MetadataObject | MetadataArray;
 
 // JSON/YAML parsed content
 type ParsedContent = {
@@ -85,8 +87,8 @@ function validateMetadataStructure(
  */
 export function parseKeyedMetadata(
   sourceFilePath: string,
-  sourceContent: ParsedContent
-): MetadataObject | undefined {
+  sourceContent: ParsedContent | ParsedContent[]
+): KeyedMetadata | undefined {
   const ext = path.extname(sourceFilePath);
   const baseName = sourceFilePath.slice(0, -ext.length);
 
@@ -117,34 +119,32 @@ export function parseKeyedMetadata(
   }
 
   // Read and parse
-  let metadataContent: MetadataObject;
+  let metadataContent: KeyedMetadata;
   try {
     const raw = fs.readFileSync(metadataFilePath, 'utf8');
     const parsed = parse(raw);
-    if (
-      typeof parsed !== 'object' ||
-      parsed === null ||
-      Array.isArray(parsed)
-    ) {
+    if (typeof parsed !== 'object' || parsed === null) {
       const relativePath = path.relative(process.cwd(), metadataFilePath);
-      logger.warn(`Skipping metadata file ${relativePath}: expected an object`);
+      logger.warn(`Skipping metadata file ${relativePath}: expected an object or array`);
       return undefined;
     }
-    metadataContent = parsed as MetadataObject;
+    metadataContent = parsed as KeyedMetadata;
   } catch {
     const relativePath = path.relative(process.cwd(), metadataFilePath);
     logger.warn(`Skipping metadata file ${relativePath}: file is not parsable`);
     return undefined;
   }
 
-  // Validate structure against source
-  const errors = validateMetadataStructure(sourceContent, metadataContent);
-  if (errors.length > 0) {
-    const relativePath = path.relative(process.cwd(), metadataFilePath);
-    for (const error of errors) {
-      logger.warn(`Metadata file ${relativePath}: ${error}`);
+  // Validate structure against source (only for object-rooted files)
+  if (!Array.isArray(metadataContent) && !Array.isArray(sourceContent)) {
+    const errors = validateMetadataStructure(sourceContent, metadataContent);
+    if (errors.length > 0) {
+      const relativePath = path.relative(process.cwd(), metadataFilePath);
+      for (const error of errors) {
+        logger.warn(`Metadata file ${relativePath}: ${error}`);
+      }
+      return undefined;
     }
-    return undefined;
   }
 
   return metadataContent;

--- a/packages/cli/src/formats/parseKeyedMetadata.ts
+++ b/packages/cli/src/formats/parseKeyedMetadata.ts
@@ -121,19 +121,19 @@ export function parseKeyedMetadata(
   try {
     const raw = fs.readFileSync(metadataFilePath, 'utf8');
     const parsed = parse(raw);
-    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      Array.isArray(parsed)
+    ) {
       const relativePath = path.relative(process.cwd(), metadataFilePath);
-      logger.warn(
-        `Skipping metadata file ${relativePath}: expected an object`
-      );
+      logger.warn(`Skipping metadata file ${relativePath}: expected an object`);
       return undefined;
     }
     metadataContent = parsed as MetadataObject;
   } catch {
     const relativePath = path.relative(process.cwd(), metadataFilePath);
-    logger.warn(
-      `Skipping metadata file ${relativePath}: file is not parsable`
-    );
+    logger.warn(`Skipping metadata file ${relativePath}: file is not parsable`);
     return undefined;
   }
 

--- a/packages/cli/src/formats/parseKeyedMetadata.ts
+++ b/packages/cli/src/formats/parseKeyedMetadata.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import YAML from 'yaml';
 import { logger } from '../console/logger.js';
+import { exitSync } from '../console/logging.js';
 import type { SourceCode } from '../react/jsx/utils/extractSourceCode.js';
 import type { JSONObject } from '../types/data/json.js';
 
@@ -33,7 +34,7 @@ function validateMetadataStructure(
 
     if (sourceValue === undefined) {
       errors.push(
-        `Metadata key "${keyPath.join('.')}" does not exist in source`
+        `Key "${keyPath.join('.')}" does not exist in source`
       );
       continue;
     }
@@ -48,7 +49,7 @@ function validateMetadataStructure(
       const metaValue = metadata[key];
       if (Array.isArray(metaValue)) {
         errors.push(
-          `Metadata key "${keyPath.join('.')}" is an array but source is an object`
+          `Key "${keyPath.join('.')}" is an array but source is an object`
         );
       } else if (typeof metaValue === 'object' && metaValue !== null) {
         errors.push(
@@ -60,7 +61,7 @@ function validateMetadataStructure(
         );
       } else {
         errors.push(
-          `Metadata key "${keyPath.join('.')}" is a primitive but source is an object`
+          `Key "${keyPath.join('.')}" is a primitive but source is an object`
         );
       }
     }
@@ -119,25 +120,25 @@ export function parseKeyedMetadata(
     const parsed = parse(raw);
     if (typeof parsed !== 'object' || parsed === null) {
       const relativePath = path.relative(process.cwd(), metadataFilePath);
-      logger.warn(
-        `Skipping metadata file ${relativePath}: expected an object or array`
+      logger.error(
+        `Metadata file ${relativePath}: Expected an object or array`
       );
-      return undefined;
+      return exitSync(1);
     }
     metadataContent = parsed as KeyedMetadata;
   } catch {
     const relativePath = path.relative(process.cwd(), metadataFilePath);
-    logger.warn(`Skipping metadata file ${relativePath}: file is not parsable`);
-    return undefined;
+    logger.error(`Metadata file ${relativePath}: File is not parsable`);
+    return exitSync(1);
   }
 
   // Reject if root types don't match (array vs object)
   if (Array.isArray(metadataContent) !== Array.isArray(sourceContent)) {
     const relativePath = path.relative(process.cwd(), metadataFilePath);
-    logger.warn(
-      `Skipping metadata file ${relativePath}: root type (array vs object) does not match source`
+    logger.error(
+      `Metadata file ${relativePath}: Root type (array vs object) does not match source`
     );
-    return undefined;
+    return exitSync(1);
   }
 
   // Validate structure against source (only for object-rooted files)
@@ -146,8 +147,9 @@ export function parseKeyedMetadata(
     if (errors.length > 0) {
       const relativePath = path.relative(process.cwd(), metadataFilePath);
       for (const error of errors) {
-        logger.warn(`Metadata file ${relativePath}: ${error}`);
+        logger.error(`Metadata file ${relativePath}: ${error}`);
       }
+      return exitSync(1);
     }
   }
 

--- a/packages/cli/src/formats/parseKeyedMetadata.ts
+++ b/packages/cli/src/formats/parseKeyedMetadata.ts
@@ -154,7 +154,6 @@ export function parseKeyedMetadata(
       for (const error of errors) {
         logger.warn(`Metadata file ${relativePath}: ${error}`);
       }
-      return undefined;
     }
   }
 

--- a/packages/cli/src/formats/parseKeyedMetadata.ts
+++ b/packages/cli/src/formats/parseKeyedMetadata.ts
@@ -125,7 +125,9 @@ export function parseKeyedMetadata(
     const parsed = parse(raw);
     if (typeof parsed !== 'object' || parsed === null) {
       const relativePath = path.relative(process.cwd(), metadataFilePath);
-      logger.warn(`Skipping metadata file ${relativePath}: expected an object or array`);
+      logger.warn(
+        `Skipping metadata file ${relativePath}: expected an object or array`
+      );
       return undefined;
     }
     metadataContent = parsed as KeyedMetadata;

--- a/packages/cli/src/formats/parseKeyedMetadata.ts
+++ b/packages/cli/src/formats/parseKeyedMetadata.ts
@@ -144,6 +144,7 @@ export function parseKeyedMetadata(
     for (const error of errors) {
       logger.warn(`Metadata file ${relativePath}: ${error}`);
     }
+    return undefined;
   }
 
   return metadataContent;


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces keyed metadata support for JSON and YAML source files in the CLI, allowing users to place a companion `*.metadata.json` / `*.metadata.yaml` / `*.metadata.yml` file alongside a source file to attach per-key `context`, `maxChars`, and `sourceCode` hints that are forwarded to the translation API.

Key changes:
- New `parseKeyedMetadata.ts` — detects and parses companion metadata files, validates structural alignment with the source, and guards against root type mismatches.
- `aggregateFiles.ts` — filters companion metadata files from the translation source queue via `isCompanionMetadataFile`, then reads and attaches metadata to the `formatMetadata.keyedMetadata` field of each `FileToUpload`. For JSON, metadata is run through `parseJson` with the same schema transforms as the source to align pointer keys; for YAML with an `include` schema, `flattenJson` is used similarly.
- `parseJson.ts` — adds a `filterStrings` flag (default `true`) that replaces fatal `exitSync` calls with `continue`/early-return so that metadata content can safely traverse the same transform pipeline as source content.
- One inconsistency worth addressing: the YAML `include`-schema path silently drops companion metadata when all keys are filtered out, while the equivalent JSON path emits a `logger.warn`. This leaves users with no feedback when their YAML metadata file is ignored.

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

- Merging is moderately risky — the metadata pipeline has several edge-case gaps that can silently drop or misalign metadata without informing the user, though no data is corrupted or lost.
- The core happy path is well-structured and the existing previous-round feedback addressed the most critical crashes and type mismatches. The remaining concern is the inconsistent warning behaviour between the JSON and YAML include-schema paths: the YAML path silently drops metadata with no user feedback, making it hard to diagnose misconfiguration. All other identified issues are soft (metadata silently ignored rather than incorrect data sent) and do not cause runtime crashes in the common case.
- packages/cli/src/formats/files/aggregateFiles.ts (YAML include-schema metadata silently dropped with no warning) and packages/cli/src/formats/parseKeyedMetadata.ts (validation errors warn but metadata is still returned to caller)
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .changeset/large-foxes-lose.md | Standard changeset entry marking a minor version bump for the `gt` package to add keyed metadata support. |
| packages/cli/src/formats/parseKeyedMetadata.ts | New file that detects and parses companion metadata files (.metadata.json/.yaml/.yml). Has a root-type mismatch guard and structural validation, but validation errors only warn and still return metadata to the caller; also has YAML `parse` assigned regardless of whether a companion file was found. |
| packages/cli/src/formats/files/aggregateFiles.ts | Adds companion metadata detection for JSON and YAML source files, filtering them from translation sources via `isCompanionMetadataFile`. Several edge cases exist: YAML with no-include schema uses metadata directly without any key-alignment step, and missing user warning when YAML include-schema metadata is fully filtered out. |
| packages/cli/src/formats/json/parseJson.ts | Adds optional `filterStrings` parameter (default `true`) so metadata content can be run through the same schema transforms as source content without triggering fatal exits on type mismatches; error paths are gated on `filterStrings` and now `continue` instead of calling `exitSync`. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant AF as aggregateFiles
    participant PKM as parseKeyedMetadata
    participant FS as fs (filesystem)
    participant PJ as parseJson / flattenJson
    participant API as FileToUpload

    AF->>AF: filter companion files via isCompanionMetadataFile
    AF->>PJ: parseJson(content, filePath, ...) → parsedJson/parsedYaml
    AF->>PKM: parseKeyedMetadata(filePath, parsedContent)
    PKM->>FS: existsSync(*.metadata.json / .yaml / .yml)
    FS-->>PKM: path found
    PKM->>FS: readFileSync(metadataFilePath)
    PKM->>PKM: parse + root-type mismatch guard
    PKM->>PKM: validateMetadataStructure (warns on errors)
    PKM-->>AF: KeyedMetadata | undefined

    alt JSON file with schema
        AF->>PJ: parseJson(stringify(rawMetadata), ..., filterStrings=false)
        PJ-->>AF: transformed pointer-keyed metadata
        AF->>AF: filter keys to intersection with parsedJson keys
    else YAML file with include schema
        AF->>PJ: flattenJson(rawMetadata, yamlSchema.include)
        PJ-->>AF: flattened pointer-keyed metadata
        AF->>AF: filter keys to intersection with parsedYaml keys
    else YAML file without include schema
        AF->>AF: use rawMetadata as-is
    end

    AF->>API: FileToUpload { formatMetadata: { keyedMetadata } }
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/cli/src/formats/files/aggregateFiles.ts
Line: 213-215

Comment:
**Missing user warning when YAML metadata is fully filtered out**

When a YAML file with an `include` schema has a companion metadata file, but none of the flattened metadata keys align with the transformed source keys, `keyedMetadata` is silently left `undefined` with no diagnostic message. This is inconsistent with the identical scenario in the JSON section (lines 129–134), which explicitly emits a `logger.warn` to inform the user their metadata was ignored.

A user who adds `translations.metadata.yaml` for a `translations.yaml` file configured with an `include` schema and gets zero key matches will see no indication that their metadata file was dropped entirely.

Consider adding the same warning here:

```suggestion
              if (Object.keys(filtered).length > 0) {
                keyedMetadata = filtered;
              } else {
                logger.warn(
                  `Companion metadata found for ${relativePath} but no keys aligned with the YAML schema — metadata was not attached`
                );
              }
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: 971b3c4</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->