### PR TITLE
fix(cli): Fix force behavior

### DIFF
--- a/.changeset/fine-shoes-care.md
+++ b/.changeset/fine-shoes-care.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+Fix --force behavior

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.9.0';
+export const PACKAGE_VERSION = '2.10.0';

--- a/packages/cli/src/workflows/steps/PollJobsStep.ts
+++ b/packages/cli/src/workflows/steps/PollJobsStep.ts
@@ -61,27 +61,31 @@ export class PollTranslationJobsStep extends WorkflowStep<
     });
 
     // Initial query to check which files already have translations
-    const initialFileData = await this.gt.queryFileData({
-      translatedFiles: fileQueryData.map((item) => ({
-        fileId: item.fileId,
-        versionId: item.versionId,
-        branchId: item.branchId,
-        locale: item.locale,
-      })),
-    });
-    const existingTranslations = initialFileData.translatedFiles || [];
+    // Skip when force retranslation is enabled, since the server
+    // no longer marks force-retranslated files as incomplete
+    if (!forceRetranslation) {
+      const initialFileData = await this.gt.queryFileData({
+        translatedFiles: fileQueryData.map((item) => ({
+          fileId: item.fileId,
+          versionId: item.versionId,
+          branchId: item.branchId,
+          locale: item.locale,
+        })),
+      });
+      const existingTranslations = initialFileData.translatedFiles || [];
 
-    // Mark all existing translations as completed
-    existingTranslations.forEach((translation) => {
-      if (!translation.completedAt) {
-        return;
-      }
-      const fileKey = `${translation.branchId}:${translation.fileId}:${translation.versionId}:${translation.locale}`;
-      const fileProperties = filePropertiesMap.get(fileKey);
-      if (fileProperties) {
-        fileTracker.completed.set(fileKey, fileProperties);
-      }
-    });
+      // Mark all existing translations as completed
+      existingTranslations.forEach((translation) => {
+        if (!translation.completedAt) {
+          return;
+        }
+        const fileKey = `${translation.branchId}:${translation.fileId}:${translation.versionId}:${translation.locale}`;
+        const fileProperties = filePropertiesMap.get(fileKey);
+        if (fileProperties) {
+          fileTracker.completed.set(fileKey, fileProperties);
+        }
+      });
+    }
 
     // Build a map of jobs for quick lookup:
     // branchId:fileId:versionId:locale -> job


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the `--force` flag behavior in the CLI's translation polling workflow by skipping the initial `queryFileData` pre-completion check when force retranslation is enabled. The fix addresses a server-side behavioral change where the server no longer marks force-retranslated files as incomplete, which previously caused files to be incorrectly pre-marked as completed before their retranslation jobs actually finished — effectively making `--force` a no-op.

Key changes:
- **`PollJobsStep.ts`**: The initial `queryFileData` call (used to detect already-translated files and skip polling them) is now gated behind `if (!forceRetranslation)`. This ensures that when `--force` is passed, all files are properly categorized as in-progress and the polling loop waits for the retranslation jobs to complete.
- **`version.ts`**: Version bumped from `2.9.0` to `2.10.0`, but this is an auto-generated file that should not be manually edited, and the bump is a *minor* version increment that contradicts the `'patch'` type declared in the accompanying changeset.

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

- The core logic fix is correct and safe, but the version/changeset inconsistency could disrupt the automated release pipeline.
- The fix to `PollJobsStep.ts` is well-reasoned and correctly addresses the described bug. However, `version.ts` is auto-generated and should not be manually edited. The declared changeset type (`'patch'`) would yield `2.9.1`, not `2.10.0`. If the changeset release tooling runs, it may overwrite the manually-set version or produce a conflicting release tag. This needs to be resolved before merging to avoid release pipeline confusion.
- `packages/cli/src/generated/version.ts` and `.changeset/fine-shoes-care.md` — the version bump and changeset type are inconsistent with each other.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/workflows/steps/PollJobsStep.ts | Core fix: wraps the initial `queryFileData` pre-completion check in `if (!forceRetranslation)` to prevent files from being wrongly marked as complete before retranslation jobs finish. Logic is correct and well-commented. |
| packages/cli/src/generated/version.ts | Auto-generated file manually edited to `2.10.0` (a minor bump), but the accompanying changeset declares `'patch'`, which should yield `2.9.1`. This is a version/changeset inconsistency. |
| .changeset/fine-shoes-care.md | New changeset for the force-retranslation fix, declared as `'patch'`. Inconsistent with the `2.10.0` minor version bump in `version.ts`. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PollTranslationJobsStep.run] --> B{forceRetranslation?}
    B -- No --> C[queryFileData: fetch existing translations]
    C --> D[Mark files with completedAt as completed]
    B -- Yes --> E[Skip initial query\n server no longer marks\n force files as incomplete]
    D --> F[Categorize remaining files]
    E --> F
    F --> G{file already in\nfileTracker.completed?}
    G -- Yes --> H[continue / skip]
    G -- No --> I{job exists\nin jobMap?}
    I -- Yes --> J[Mark inProgress]
    I -- No --> K[Mark skipped]
    J --> L{forceRetranslation\nOR inProgress > 0?}
    K --> L
    H --> L
    L -- forceRetranslation=true\nor still in progress --> M[Start polling loop\nevery 5s via setInterval]
    L -- Not force AND\ninProgress = 0 --> N[Return early:\nAll translations ready]
    M --> O[checkJobStatus]
    O --> P{job status?}
    P -- completed --> Q[Move to fileTracker.completed]
    P -- failed --> R[Move to fileTracker.failed]
    P -- unknown --> S[Move to fileTracker.skipped]
    Q --> T{inProgress = 0\nor timeout?}
    R --> T
    S --> T
    T -- No --> O
    T -- Yes --> U[Resolve promise with result]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/cli/src/generated/version.ts
Line: 2

Comment:
**Version bump inconsistent with changeset type**

The `version.ts` file is annotated as auto-generated (`// This file is auto-generated. Do not edit manually.`), but it was manually edited in this PR. More importantly, the accompanying changeset (`fine-shoes-care.md`) declares a `'patch'` bump, which should produce `2.9.0 → 2.9.1`. However, the version was manually set to `2.10.0`, which is a *minor* version increment.

If the changeset tooling runs again to cut a release, it may overwrite this file with the wrong value (e.g. `2.9.1`) based on the declared changeset type, or the release pipeline may behave unexpectedly. Either:
- The changeset type should be `'minor'` to match `2.10.0`, or
- The version here should be `2.9.1` to match the `'patch'` declaration.

```suggestion
export const PACKAGE_VERSION = '2.9.1';
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: 65c60fe</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->