### PR TITLE
F/cli optimization

### DIFF
--- a/.changeset/late-mugs-marry.md
+++ b/.changeset/late-mugs-marry.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+Optimizing CLI download on composite JSONs

--- a/packages/cli/src/formats/json/flattenJson.ts
+++ b/packages/cli/src/formats/json/flattenJson.ts
@@ -34,7 +34,11 @@ function tryFastFlatten(
     }
 
     if (valid) {
-      const pointer = '/' + pointerParts.map((p) => p.replace(/~/g, '~0').replace(/\//g, '~1')).join('/');
+      const pointer =
+        '/' +
+        pointerParts
+          .map((p) => p.replace(/~/g, '~0').replace(/\//g, '~1'))
+          .join('/');
       result[pointer] = value;
     }
   }

--- a/packages/cli/src/formats/json/flattenJson.ts
+++ b/packages/cli/src/formats/json/flattenJson.ts
@@ -2,6 +2,47 @@ import { JSONPath } from 'jsonpath-plus';
 import { logger } from '../../console/logger.js';
 
 /**
+ * Fast path for simple wildcard JSONPath patterns like `$.*.prop` or `$.*`.
+ * Returns null if the pattern is too complex for the fast path.
+ */
+function tryFastFlatten(
+  json: any,
+  jsonPath: string
+): Record<string, any> | null {
+  // Match patterns like $.* or $.*.prop or $.*.prop.nested
+  const match = jsonPath.match(/^\$\.\*(?:\.(.+))?$/);
+  if (!match || typeof json !== 'object' || json === null) {
+    return null;
+  }
+
+  const subPath = match[1]; // e.g. "translations" or "prop.nested" or undefined
+  const parts = subPath ? subPath.split('.') : [];
+  const result: Record<string, any> = {};
+
+  for (const key of Object.keys(json)) {
+    let value = json[key];
+    const pointerParts = [key];
+
+    let valid = true;
+    for (const part of parts) {
+      if (typeof value !== 'object' || value === null || !(part in value)) {
+        valid = false;
+        break;
+      }
+      value = value[part];
+      pointerParts.push(part);
+    }
+
+    if (valid) {
+      const pointer = '/' + pointerParts.map((p) => p.replace(/~/g, '~0').replace(/\//g, '~1')).join('/');
+      result[pointer] = value;
+    }
+  }
+
+  return result;
+}
+
+/**
  * Flattens a JSON object according to a list of JSON paths.
  * @param json - The JSON object to flatten
  * @param jsonPaths - The list of JSON paths to flatten
@@ -13,6 +54,13 @@ export function flattenJson(
 ): Record<string, any> {
   const extractedJson: Record<string, any> = {};
   for (const jsonPath of jsonPaths) {
+    // Try fast path for simple wildcard patterns (avoids JSONPath overhead on large objects)
+    const fastResult = tryFastFlatten(json, jsonPath);
+    if (fastResult) {
+      Object.assign(extractedJson, fastResult);
+      continue;
+    }
+
     try {
       const results = JSONPath({
         json,

--- a/packages/cli/src/formats/json/mergeJson.ts
+++ b/packages/cli/src/formats/json/mergeJson.ts
@@ -355,10 +355,7 @@ export function mergeJson(
         // The API returns flattened pointers where "" (root) holds the value.
         if (isPrimitiveSourceItem) {
           let translatedValue: any = targetItems;
-          if (
-            typeof targetItems === 'object' &&
-            targetItems !== null
-          ) {
+          if (typeof targetItems === 'object' && targetItems !== null) {
             translatedValue =
               targetItems[''] ??
               Object.values(targetItems)[0] ??

--- a/packages/cli/src/formats/json/mergeJson.ts
+++ b/packages/cli/src/formats/json/mergeJson.ts
@@ -356,10 +356,7 @@ export function mergeJson(
         if (isPrimitiveSourceItem) {
           let translatedValue: any = targetItems;
           if (typeof targetItems === 'object' && targetItems !== null) {
-            translatedValue =
-              targetItems[''] ??
-              Object.values(targetItems)[0] ??
-              defaultLocaleSourceItem;
+            translatedValue = targetItems[''] ?? defaultLocaleSourceItem;
           }
           sourceObjectValue[mutateSourceItemKey] = translatedValue;
           continue;

--- a/packages/cli/src/formats/json/mergeJson.ts
+++ b/packages/cli/src/formats/json/mergeJson.ts
@@ -92,6 +92,12 @@ export function mergeJson(
   // Create a deep copy of the original JSON to avoid mutations
   const mergedJson = structuredClone(originalJson);
 
+  // Pre-parse all target contents ONCE (avoid re-parsing per pointer)
+  const parsedTargets = targets.map((target) => ({
+    targetLocale: target.targetLocale,
+    parsedContent: JSON.parse(target.translatedContent),
+  }));
+
   // Create mapping of sourceObjectPointer to SourceObjectOptions
   const sourceObjectPointers: Record<
     string,
@@ -145,9 +151,8 @@ export function mergeJson(
       // 10. Remove all items for the target locale (they can be identified by the key)
       const indiciesToRemove = new Set<number>();
       const itemsToAdd: any[] = [];
-      for (const target of targets) {
-        const targetJson = JSON.parse(target.translatedContent);
-        let targetItems = targetJson[sourceObjectPointer];
+      for (const parsedTarget of parsedTargets) {
+        let targetItems = parsedTarget.parsedContent[sourceObjectPointer];
         // 1. Get the target items
         if (!targetItems) {
           // If no translation can be found, a transformation may need to happen still
@@ -157,8 +162,8 @@ export function mergeJson(
         // 2. Track all array indecies to remove (will be overwritten)
         const targetItemsToRemove = findMatchingItemArray(
           useCanonicalLocaleKeys
-            ? gt.resolveCanonicalLocale(target.targetLocale)
-            : target.targetLocale,
+            ? gt.resolveCanonicalLocale(parsedTarget.targetLocale)
+            : parsedTarget.targetLocale,
           sourceObjectOptions,
           sourceObjectPointer,
           sourceObjectValue
@@ -193,7 +198,7 @@ export function mergeJson(
         // 4. Validate that the mergedItems is not empty
         if (Object.keys(mergedItems).length === 0) {
           logger.warn(
-            `Translated JSON for locale: ${target.targetLocale} does not have a valid sourceObjectPointer: ${sourceObjectPointer}. Skipping this target`
+            `Translated JSON for locale: ${parsedTarget.targetLocale} does not have a valid sourceObjectPointer: ${sourceObjectPointer}. Skipping this target`
           );
           continue;
         }
@@ -218,8 +223,8 @@ export function mergeJson(
           const { identifyingLocaleProperty: targetLocaleKeyProperty } =
             getSourceObjectOptionsArray(
               useCanonicalLocaleKeys
-                ? gt.resolveCanonicalLocale(target.targetLocale)
-                : target.targetLocale,
+                ? gt.resolveCanonicalLocale(parsedTarget.targetLocale)
+                : parsedTarget.targetLocale,
               sourceObjectPointer,
               sourceObjectOptions
             );
@@ -258,7 +263,7 @@ export function mergeJson(
           applyTransformations(
             mutatedSourceItem,
             sourceObjectOptions.transform,
-            target.targetLocale,
+            parsedTarget.targetLocale,
             defaultLocale
           );
 
@@ -315,6 +320,9 @@ export function mergeJson(
         return exitSync(1);
       }
       const { sourceItem: defaultLocaleSourceItem } = matchingDefaultLocaleItem;
+      const isPrimitiveSourceItem =
+        typeof defaultLocaleSourceItem !== 'object' ||
+        defaultLocaleSourceItem === null;
 
       // For each target:
       // 1. Get the target items
@@ -324,10 +332,9 @@ export function mergeJson(
       // 5. Override the source item with the translated values
       // 6. Apply additional mutations to the sourceItem
       // 7. Merge the source item with the original JSON (if the source item is not a new item)
-      for (const target of targets) {
-        const targetJson = JSON.parse(target.translatedContent);
+      for (const parsedTarget of parsedTargets) {
         // 1. Get the target items
-        let targetItems = targetJson[sourceObjectPointer];
+        let targetItems = parsedTarget.parsedContent[sourceObjectPointer];
         if (!targetItems) {
           targetItems = {};
         }
@@ -335,16 +342,35 @@ export function mergeJson(
         // 2. Find the source item for the target locale
         const matchingTargetItem = findMatchingItemObject(
           useCanonicalLocaleKeys
-            ? gt.resolveCanonicalLocale(target.targetLocale)
-            : target.targetLocale,
+            ? gt.resolveCanonicalLocale(parsedTarget.targetLocale)
+            : parsedTarget.targetLocale,
           sourceObjectPointer,
           sourceObjectOptions,
           sourceObjectValue
         );
+        const mutateSourceItemKey = matchingTargetItem.keyParentProperty;
+
+        // For primitive source items (e.g. translations: {"en": "simple string"}),
+        // JSONPointer operations can't mutate a primitive, so assign directly.
+        // The API returns flattened pointers where "" (root) holds the value.
+        if (isPrimitiveSourceItem) {
+          let translatedValue: any = targetItems;
+          if (
+            typeof targetItems === 'object' &&
+            targetItems !== null
+          ) {
+            translatedValue =
+              targetItems[''] ??
+              Object.values(targetItems)[0] ??
+              defaultLocaleSourceItem;
+          }
+          sourceObjectValue[mutateSourceItemKey] = translatedValue;
+          continue;
+        }
+
         // If the target locale has a matching source item, use it to mutate the source item
         // Otherwise, fallback to the default locale source item
         const mutateSourceItem = structuredClone(defaultLocaleSourceItem);
-        const mutateSourceItemKey = matchingTargetItem.keyParentProperty;
 
         // 3. Merge the target items with the source item (if there are transformations to perform)
         const mergedItems = {
@@ -355,7 +381,7 @@ export function mergeJson(
         // 4. Validate that the mergedItems is not empty
         if (Object.keys(mergedItems).length === 0) {
           logger.warn(
-            `Translated JSON for locale: ${target.targetLocale} does not have a valid sourceObjectPointer: ${sourceObjectPointer}. Skipping this target`
+            `Translated JSON for locale: ${parsedTarget.targetLocale} does not have a valid sourceObjectPointer: ${sourceObjectPointer}. Skipping this target`
           );
           continue;
         }
@@ -384,7 +410,7 @@ export function mergeJson(
         applyTransformations(
           mutateSourceItem,
           sourceObjectOptions.transform,
-          target.targetLocale,
+          parsedTarget.targetLocale,
           defaultLocale
         );
 
@@ -454,22 +480,36 @@ function sortByLocaleOrder(
       )
     );
 
-    const orderedItems: any[] = [];
-    const remainingItems = [...itemsWithLocale];
-
-    for (const localeValue of localeOrderValues) {
-      for (let i = 0; i < remainingItems.length; ) {
-        const entry = remainingItems[i];
-        if (entry.localeValue === localeValue) {
-          orderedItems.push(entry.item);
-          remainingItems.splice(i, 1);
-          continue;
+    // Use a Map for O(n) grouping instead of O(n²) splice
+    const localeGroups = new Map<string, any[]>();
+    const ungrouped: any[] = [];
+    for (const entry of itemsWithLocale) {
+      if (entry.localeValue) {
+        let group = localeGroups.get(entry.localeValue);
+        if (!group) {
+          group = [];
+          localeGroups.set(entry.localeValue, group);
         }
-        i += 1;
+        group.push(entry.item);
+      } else {
+        ungrouped.push(entry.item);
       }
     }
 
-    remainingItems.forEach((entry) => orderedItems.push(entry.item));
+    const orderedItems: any[] = [];
+    for (const localeValue of localeOrderValues) {
+      const group = localeGroups.get(localeValue);
+      if (group) {
+        orderedItems.push(...group);
+      }
+    }
+    // Add any locale groups not in localeOrderValues
+    for (const [localeValue, group] of localeGroups) {
+      if (!localeOrderValues.includes(localeValue)) {
+        orderedItems.push(...group);
+      }
+    }
+    orderedItems.push(...ungrouped);
 
     return orderedItems;
   }

--- a/packages/cli/src/formats/json/mergeJson.ts
+++ b/packages/cli/src/formats/json/mergeJson.ts
@@ -354,11 +354,8 @@ export function mergeJson(
         // JSONPointer operations can't mutate a primitive, so assign directly.
         // The API returns flattened pointers where "" (root) holds the value.
         if (isPrimitiveSourceItem) {
-          let translatedValue: any = targetItems;
-          if (typeof targetItems === 'object' && targetItems !== null) {
-            translatedValue = targetItems[''] ?? defaultLocaleSourceItem;
-          }
-          sourceObjectValue[mutateSourceItemKey] = translatedValue;
+          sourceObjectValue[mutateSourceItemKey] =
+            targetItems?.[''] ?? defaultLocaleSourceItem;
           continue;
         }
 

--- a/packages/cli/src/formats/json/mergeJson.ts
+++ b/packages/cli/src/formats/json/mergeJson.ts
@@ -477,7 +477,6 @@ function sortByLocaleOrder(
       )
     );
 
-    // Use a Map for O(n) grouping instead of O(n²) splice
     const localeGroups = new Map<string, any[]>();
     const ungrouped: any[] = [];
     for (const entry of itemsWithLocale) {

--- a/packages/cli/src/formats/json/mergeJson.ts
+++ b/packages/cli/src/formats/json/mergeJson.ts
@@ -354,8 +354,10 @@ export function mergeJson(
         // JSONPointer operations can't mutate a primitive, so assign directly.
         // The API returns flattened pointers where "" (root) holds the value.
         if (isPrimitiveSourceItem) {
-          sourceObjectValue[mutateSourceItemKey] =
-            targetItems?.[''] ?? defaultLocaleSourceItem;
+          const translatedValue = targetItems?.[''];
+          if (translatedValue !== undefined) {
+            sourceObjectValue[mutateSourceItemKey] = translatedValue;
+          }
           continue;
         }
 

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.10.0';
+export const PACKAGE_VERSION = '2.10.1';


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR delivers three performance optimisations and one bug fix for the CLI's composite JSON merge pipeline:

- **Fast-path flatten** (`flattenJson.ts`): A new `tryFastFlatten` helper handles simple `$.*` and `$.*.prop` JSONPath patterns with a direct `Object.keys` iteration instead of invoking `jsonpath-plus`, producing identical RFC 6901 JSON Pointers (with correct `~0`/`~1` escaping) and correctly falling back to the full JSONPath engine for anything more complex.
- **Pre-parse translated content** (`mergeJson.ts`): `JSON.parse(target.translatedContent)` was previously called inside nested loops over every `sourceObjectPointer`. It is now called once per target up-front, eliminating redundant parsing.
- **O(n) sort** (`mergeJson.ts`): The `sortByLocaleOrder` 'locales' mode replaced an O(n²) splice loop with a `Map`-based grouping strategy. This is correct for the common case, but introduces a subtle ordering difference for edge cases (see inline comment).
- **Primitive source item fix** (`mergeJson.ts`): A new `isPrimitiveSourceItem` guard correctly short-circuits the JSONPointer mutation path for locale objects whose value is a primitive (string/number/boolean/null), assigning the translated value directly. Previously, spreading a primitive into the `mergedItems` object would silently corrupt the result.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- Safe to merge with low risk; one minor behavioural edge case in experimental sort ordering should be verified.
- The optimisations are straightforward and the fast-path logic is provably equivalent to JSONPath for the patterns it covers. The primitive source item fix addresses a real bug. The only concern is the subtle reordering of locale-less items vs. unrecognised-locale items in the experimental `sortByLocaleOrder` refactor, which may differ from the old behaviour in edge cases but is unlikely to affect production workloads given its experimental status.
- packages/cli/src/formats/json/mergeJson.ts — specifically the `sortByLocaleOrder` refactor around lines 503-509.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/formats/json/flattenJson.ts | Adds a O(n) fast path (`tryFastFlatten`) for simple `$.*` and `$.*.prop` patterns, correctly generating RFC 6901 JSON Pointers (with `~0`/`~1` escaping) and falling back to `jsonpath-plus` for any pattern it cannot handle. Logic is functionally equivalent to the JSONPath slow path for the patterns it covers. |
| packages/cli/src/formats/json/mergeJson.ts | Two optimizations (pre-parse target JSON once; O(n) Map-based sort) plus a new `isPrimitiveSourceItem` branch that fixes handling of primitive locale values. The sort refactor has a minor behavioural difference: items without a `localeValue` are now always ordered after items with unrecognised locales, whereas previously they were interleaved in original order. |
| packages/cli/src/generated/version.ts | Auto-generated version bump from 2.10.0 to 2.10.1 — no issues. |
| .changeset/late-mugs-marry.md | New changeset entry for the CLI optimisation patch — correct and complete. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[flattenJson called with jsonPath] --> B{tryFastFlatten matches simple wildcard?}
    B -- Yes --> C[Object.keys iteration and RFC 6901 pointer generation]
    C --> D{Any matches found?}
    D -- Yes --> E[Return result map]
    D -- No --> F[Return empty map]
    B -- No --> G[jsonpath-plus full engine]
    G --> H[Return pointer to value map]
    E --> I[Object.assign into extractedJson]
    F --> I
    H --> I

    subgraph mergeJson composite path
    J[Parse originalContent] --> K[structuredClone into mergedJson]
    K --> L[Pre-parse ALL targets ONCE into parsedTargets]
    L --> M[generateSourceObjectPointers via flattenJson]
    M --> N{sourceObjectOptions type?}
    N -- array --> O[Loop parsedTargets and build itemsToAdd and indiciesToRemove]
    N -- object --> P{isPrimitiveSourceItem?}
    P -- Yes --> Q[Assign translatedValue directly from targetItems root or first value]
    P -- No --> R[structuredClone and JSONPointer mutations]
    Q --> S[JSONPointer.set into mergedJson]
    R --> S
    O --> T[sortByLocaleOrder using Map grouping]
    T --> S
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/cli/src/formats/json/mergeJson.ts
Line: 503-509

Comment:
**Ordering of ungrouped items changed vs. original behaviour**

Before this refactor, `remainingItems` held all items that did NOT match any `localeOrderValues` entry — including items with an unrecognised `localeValue` **and** items whose `localeValue` was `undefined`/`null` — and they were appended in their **original relative order**.

The new Map-based implementation separates these two categories:
1. Items with an unrecognised locale are grouped in `localeGroups` and flushed first (lines 503-507).
2. Items with a falsy `localeValue` are in `ungrouped` and always appended last (line 509).

This means if the original array had, for example, `[{localeValue: undefined}, {localeValue: "zh"}]` where `"zh"` is not in `localeOrderValues`, the old code would produce `[…, {undefined}, {zh}]` while the new code produces `[…, {zh}, {undefined}]`. The relative position of locale-less items and unrecognised-locale items is now reversed compared to the original ordering.

Although this path is gated behind `experimentalSort: 'locales'` and is an edge case, the reordering is silently different from the old behaviour and could surprise users who have both locale-less items and extra-locale items in their composite JSON arrays.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ad020d5</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->