### PR TITLE
fix(cli): Fix composite JSON

### DIFF
--- a/.changeset/smart-bobcats-cheat.md
+++ b/.changeset/smart-bobcats-cheat.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+Fix string behavior

--- a/packages/cli/src/formats/json/__tests__/extractJson.test.ts
+++ b/packages/cli/src/formats/json/__tests__/extractJson.test.ts
@@ -819,6 +819,40 @@ describe('extractJson', () => {
       );
     });
 
+    it('should handle string sourceItem in object composite schema', () => {
+      const localContent = JSON.stringify({
+        content: {
+          en: 'Contact name, phone number, email, 2',
+          es: 'Nombre del contacto, número de teléfono, email, 2',
+        },
+      });
+
+      const result = extractJson(
+        localContent,
+        'test.json',
+        {
+          jsonSchema: {
+            '**/*.json': {
+              composite: {
+                '$.content': {
+                  type: 'object',
+                  include: ['$.*'],
+                },
+              },
+            },
+          },
+        },
+        'es',
+        'en'
+      );
+
+      expect(result).not.toBeNull();
+      const parsed = JSON.parse(result!);
+      expect(parsed['/content']).toBe(
+        'Nombre del contacto, número de teléfono, email, 2'
+      );
+    });
+
     it('should handle empty translations object', () => {
       const localContent = JSON.stringify({
         translations: {},

--- a/packages/cli/src/formats/json/__tests__/mergeJson.test.ts
+++ b/packages/cli/src/formats/json/__tests__/mergeJson.test.ts
@@ -534,6 +534,48 @@ describe('mergeJson', () => {
       expect(parsed.translations.fr.desc).toBe('Description Française');
     });
 
+    it('should merge string sourceItem in object composite schema', () => {
+      const originalContent = JSON.stringify({
+        content: {
+          en: 'Contact name, phone number, email, 2',
+        },
+      });
+
+      const targets = [
+        {
+          translatedContent: JSON.stringify({
+            '/content': 'Nombre del contacto, número de teléfono, email, 2',
+          }),
+          targetLocale: 'es',
+        },
+      ];
+
+      const result = mergeJson(
+        originalContent,
+        'test.json',
+        {
+          jsonSchema: {
+            '**/*.json': {
+              composite: {
+                '$.content': {
+                  type: 'object',
+                  include: ['$.*'],
+                },
+              },
+            },
+          },
+        },
+        targets,
+        'en'
+      );
+
+      const parsed = JSON.parse(result[0]);
+      expect(parsed.content.en).toBe('Contact name, phone number, email, 2');
+      expect(parsed.content.es).toBe(
+        'Nombre del contacto, número de teléfono, email, 2'
+      );
+    });
+
     it('should use existing target locale object when available', () => {
       const originalContent = JSON.stringify({
         translations: {

--- a/packages/cli/src/formats/json/__tests__/parseJson.test.ts
+++ b/packages/cli/src/formats/json/__tests__/parseJson.test.ts
@@ -1249,6 +1249,36 @@ describe('parseJson', () => {
       expect(mockExit).toHaveBeenCalledWith(1);
     });
 
+    it('should handle string sourceItem in object composite schema', () => {
+      const json = JSON.stringify({
+        content: {
+          en: 'Contact name, phone number, email, 2',
+          fr: 'Nom du contact, numéro de téléphone, email, 2',
+        },
+      });
+
+      const result = parseJson(
+        json,
+        path.join(__dirname, '../__mocks__', 'test.json'),
+        {
+          jsonSchema: {
+            '**/*.json': {
+              composite: {
+                '$.content': {
+                  type: 'object',
+                  include: ['$.*'],
+                },
+              },
+            },
+          },
+        },
+        'en'
+      );
+
+      const parsed = JSON.parse(result);
+      expect(parsed['/content']).toBe('Contact name, phone number, email, 2');
+    });
+
     it('should preserve original formatting for non-matching files', () => {
       const originalJson = `{
   "formatted": {

--- a/packages/cli/src/formats/json/__tests__/structuralTransform.test.ts
+++ b/packages/cli/src/formats/json/__tests__/structuralTransform.test.ts
@@ -199,9 +199,8 @@ describe('structuralTransform', () => {
       );
 
       const parsed = JSON.parse(result);
-      // Source text extracted with empty-string pointer (value is a string, not an object)
-      expect(parsed['/btn_save/i18n']).toEqual({ '': 'Save changes' });
-      expect(parsed['/btn_cancel/i18n']).toEqual({ '': 'Cancel' });
+      expect(parsed['/btn_save/i18n']).toEqual('Save changes');
+      expect(parsed['/btn_cancel/i18n']).toEqual('Cancel');
     });
   });
 
@@ -307,8 +306,8 @@ describe('structuralTransform', () => {
 
       expect(result).not.toBeNull();
       const extracted = JSON.parse(result!);
-      expect(extracted['/btn_save/i18n']).toEqual({ '': 'Guardar cambios' });
-      expect(extracted['/btn_cancel/i18n']).toEqual({ '': 'Cancelar' });
+      expect(extracted['/btn_save/i18n']).toEqual('Guardar cambios');
+      expect(extracted['/btn_cancel/i18n']).toEqual('Cancelar');
     });
   });
 });

--- a/packages/cli/src/formats/json/extractJson.ts
+++ b/packages/cli/src/formats/json/extractJson.ts
@@ -165,6 +165,12 @@ export function extractJson(
         continue;
       }
 
+      // If the source item is a string, use it directly
+      if (typeof matchingTargetItem.sourceItem === 'string') {
+        compositeResult[sourceObjectPointer] = matchingTargetItem.sourceItem;
+        continue;
+      }
+
       // Extract values at the include paths
       const extractedValues = flattenJsonWithStringFilter(
         matchingTargetItem.sourceItem,

--- a/packages/cli/src/formats/json/mergeJson.ts
+++ b/packages/cli/src/formats/json/mergeJson.ts
@@ -92,6 +92,12 @@ export function mergeJson(
   // Create a deep copy of the original JSON to avoid mutations
   const mergedJson = structuredClone(originalJson);
 
+  // Pre-parse all target contents ONCE (avoid re-parsing per pointer)
+  const parsedTargets = targets.map((target) => ({
+    ...target,
+    parsedContent: JSON.parse(target.translatedContent),
+  }));
+
   // Create mapping of sourceObjectPointer to SourceObjectOptions
   const sourceObjectPointers: Record<
     string,
@@ -145,9 +151,8 @@ export function mergeJson(
       // 10. Remove all items for the target locale (they can be identified by the key)
       const indiciesToRemove = new Set<number>();
       const itemsToAdd: any[] = [];
-      for (const target of targets) {
-        const targetJson = JSON.parse(target.translatedContent);
-        let targetItems = targetJson[sourceObjectPointer];
+      for (const target of parsedTargets) {
+        let targetItems = target.parsedContent[sourceObjectPointer];
         // 1. Get the target items
         if (!targetItems) {
           // If no translation can be found, a transformation may need to happen still
@@ -324,10 +329,9 @@ export function mergeJson(
       // 5. Override the source item with the translated values
       // 6. Apply additional mutations to the sourceItem
       // 7. Merge the source item with the original JSON (if the source item is not a new item)
-      for (const target of targets) {
-        const targetJson = JSON.parse(target.translatedContent);
+      for (const target of parsedTargets) {
         // 1. Get the target items
-        let targetItems = targetJson[sourceObjectPointer];
+        let targetItems = target.parsedContent[sourceObjectPointer];
         if (!targetItems) {
           targetItems = {};
         }

--- a/packages/cli/src/formats/json/mergeJson.ts
+++ b/packages/cli/src/formats/json/mergeJson.ts
@@ -341,10 +341,21 @@ export function mergeJson(
           sourceObjectOptions,
           sourceObjectValue
         );
+        const mutateSourceItemKey = matchingTargetItem.keyParentProperty;
+
+        // If the source item is a string, use the translated string directly
+        if (typeof defaultLocaleSourceItem === 'string') {
+          const translatedValue =
+            typeof targetItems === 'string'
+              ? targetItems
+              : defaultLocaleSourceItem;
+          sourceObjectValue[mutateSourceItemKey] = translatedValue;
+          continue;
+        }
+
         // If the target locale has a matching source item, use it to mutate the source item
         // Otherwise, fallback to the default locale source item
         const mutateSourceItem = structuredClone(defaultLocaleSourceItem);
-        const mutateSourceItemKey = matchingTargetItem.keyParentProperty;
 
         // 3. Merge the target items with the source item (if there are transformations to perform)
         const mergedItems = {

--- a/packages/cli/src/formats/json/mergeJson.ts
+++ b/packages/cli/src/formats/json/mergeJson.ts
@@ -332,7 +332,7 @@ export function mergeJson(
       for (const target of parsedTargets) {
         // 1. Get the target items
         let targetItems = target.parsedContent[sourceObjectPointer];
-        if (!targetItems) {
+        if (targetItems == null) {
           targetItems = {};
         }
 
@@ -349,11 +349,10 @@ export function mergeJson(
 
         // If the source item is a string, use the translated string directly
         if (typeof defaultLocaleSourceItem === 'string') {
-          const translatedValue =
-            typeof targetItems === 'string'
-              ? targetItems
-              : defaultLocaleSourceItem;
-          sourceObjectValue[mutateSourceItemKey] = translatedValue;
+          if (typeof targetItems === 'string') {
+            sourceObjectValue[mutateSourceItemKey] = targetItems;
+          }
+          // If no translation found, leave the locale slot unchanged
           continue;
         }
 

--- a/packages/cli/src/formats/json/parseJson.ts
+++ b/packages/cli/src/formats/json/parseJson.ts
@@ -62,7 +62,7 @@ export function parseJson(
   // Construct lvl 2
   const sourceObjectsToTranslate: Record<
     string,
-    Record<string, Record<string, string>>
+    Record<string, Record<string, string>> | string
   > = {};
   for (const [
     sourceObjectPointer,
@@ -162,6 +162,12 @@ export function parseJson(
         return exitSync(1);
       }
       const { sourceItem } = matchingItem;
+
+      // If the source item is a string, use it directly
+      if (typeof sourceItem === 'string') {
+        sourceObjectsToTranslate[sourceObjectPointer] = sourceItem;
+        continue;
+      }
 
       // Get the fields to translate from the includes
       const flatten = filterStrings ? flattenJsonWithStringFilter : flattenJson;

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.10.0';
+export const PACKAGE_VERSION = '2.10.1';


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug in the composite JSON pipeline (`parseJson` → `mergeJson` → `extractJson`) where locale-keyed values that are plain strings (e.g. `{ "en": "Hello", "fr": "Bonjour" }`) were not handled correctly — the code previously tried to flatten or object-merge them via JSONPath, which silently produced empty results. The fix adds a type guard at each stage of the pipeline to short-circuit into a string-direct path when the source/target item is a `string`.

**Key changes:**
- `parseJson.ts`: stores a string `sourceItem` directly in `sourceObjectsToTranslate` instead of calling `flattenJson`; type signature updated to `Record<string, Record<string, Record<string, string>> | string>`.
- `mergeJson.ts`: when `defaultLocaleSourceItem` is a string, uses the translated string directly instead of cloning and applying object-level JSONPointer merges. `mutateSourceItemKey` declaration moved before the new guard.
- `extractJson.ts`: stores a string `sourceItem` directly in `compositeResult` instead of calling `flattenJsonWithStringFilter`.

**Issues found:**
- In `mergeJson.ts`, the existing `!targetItems → {}` coercion (line 331–333) runs *before* the new string check. Because `!""` is `true`, an empty-string translation is silently replaced with `{}`, causing the new guard to fall back to the default-locale string rather than the (intentionally empty) translation.
- No test cases were added for the string-valued composite path across any of the three files, leaving the bug fix without a regression test.

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

- Safe to merge for the common case; one edge-case with empty-string translations and missing test coverage lower confidence.
- The core fix is logically correct and consistent across all three pipeline stages. However, the upstream `!targetItems → {}` coercion in `mergeJson.ts` quietly swallows empty-string translated values before the new string guard can inspect them, which is a subtle correctness gap. Additionally, there are no new tests covering the string-valued composite path, so regressions in this flow would not be caught automatically.
- `packages/cli/src/formats/json/mergeJson.ts` — the `!targetItems` null-coercion on lines 331–333 interacts poorly with the new string path.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/formats/json/parseJson.ts | Adds string shortcut in composite object-type path: if `sourceItem` is a plain string, it's stored directly in `sourceObjectsToTranslate` instead of being flattened. Type of `sourceObjectsToTranslate` updated accordingly. No new tests cover this path. |
| packages/cli/src/formats/json/mergeJson.ts | Adds string shortcut in composite object-type path: if `defaultLocaleSourceItem` is a string, the translated string is used directly instead of object-merging. Has a subtle edge-case: the upstream `!targetItems → {}` coercion silently discards empty-string translations before the new string check runs. |
| packages/cli/src/formats/json/extractJson.ts | Adds string shortcut in composite object-type path: if the matched target item's `sourceItem` is a plain string, it's stored directly in `compositeResult` instead of being flattened. Logic is straightforward and consistent with the other two files. |
| .changeset/smart-bobcats-cheat.md | Patch-level changeset for the `gt` package. Description is minimal ("Fix string behavior") but package version bump and changeset type are appropriate. |
| packages/cli/src/generated/version.ts | Auto-generated version bump from 2.10.0 to 2.10.1, consistent with the patch changeset. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Composite JSON file\ne.g. {en: 'Hello', fr: 'Bonjour'}"] --> B["parseJson()"]

    B --> C{sourceItem\ntype?}
    C -- "string (NEW)" --> D["Store string directly\nsourceObjectsToTranslate[ptr] = sourceItem"]
    C -- "object" --> E["Flatten via JSONPath\nsourceObjectsToTranslate[ptr] = flattenJson(...)"]

    D --> F["Serialised payload\nsent to translation API"]
    E --> F

    F --> G["mergeJson()"]

    G --> H{defaultLocaleSourceItem\ntype?}
    H -- "string (NEW)" --> I{"targetItems\ntype?"}
    I -- "string" --> J["Use translated string\nsourceObjectValue[key] = targetItems"]
    I -- "other (or empty string coerced to {})" --> K["Fallback to default\nsourceObjectValue[key] = defaultLocaleSourceItem"]
    H -- "object" --> L["Object merge path\n(clone + JSONPointer.set)"]

    J --> M["JSONPointer.set(mergedJson, ptr, sourceObjectValue)"]
    K --> M
    L --> M

    M --> N["extractJson()"]

    N --> O{matchingTargetItem\n.sourceItem type?}
    O -- "string (NEW)" --> P["Store string directly\ncompositeResult[ptr] = sourceItem"]
    O -- "object" --> Q["Flatten via flattenJsonWithStringFilter"]

    P --> R["Final composite JSON output"]
    Q --> R
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/cli/src/formats/json/mergeJson.ts
Line: 347-354

Comment:
**`targetItems` replaced before string check**

The `!targetItems` guard on line 331–333 replaces a falsy `targetItems` with `{}` before the new string path is reached. An empty-string translation (`""`) is falsy, so it gets silently overwritten with `{}`, causing `typeof targetItems === 'string'` to be `false` and the code to fall back to `defaultLocaleSourceItem`. This means an empty translated string in the source map (intentional or otherwise) is silently discarded and replaced with the default-locale value.

```ts
let targetItems = targetJson[sourceObjectPointer];
if (!targetItems) {
  targetItems = {};
}
```

Consider tightening the guard to only replace `null`/`undefined`, not empty strings:

```suggestion
        // If the source item is a string, use the translated string directly
        if (typeof defaultLocaleSourceItem === 'string') {
          const translatedValue =
            typeof targetItems === 'string'
              ? targetItems
              : defaultLocaleSourceItem;
          sourceObjectValue[mutateSourceItemKey] = translatedValue;
          continue;
        }
```

The real fix belongs at the `!targetItems` initialisation (line 331):
```ts
// Before (replaces "" with {}):
if (!targetItems) { targetItems = {}; }

// After (only replaces null/undefined):
if (targetItems == null) { targetItems = {}; }
```
This keeps `""` as a string so the downstream `typeof targetItems === 'string'` check works correctly.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/cli/src/formats/json/parseJson.ts
Line: 63-66

Comment:
**No tests for new string handling**

There are no test cases in `parseJson.test.ts`, `mergeJson.test.ts`, or `extractJson.test.ts` covering the new string-value composite path (e.g. `{ translations: { en: "Hello", fr: "Bonjour" } }`). Since this PR is specifically fixing a bug in this code path, a regression test covering the full parse → merge → extract round-trip for string-valued composite schemas would significantly improve confidence in the fix.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: 9925731</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->