### PR TITLE
test(i18n): resolveTranslationSync

### DIFF
--- a/packages/i18n/src/i18n-manager/__tests__/resolveTranslationSync.test.ts
+++ b/packages/i18n/src/i18n-manager/__tests__/resolveTranslationSync.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { I18nManager } from '../I18nManager';
+import { hashMessage } from '../../utils/hashMessage';
+
+describe('I18nManager.resolveTranslationSync', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return undefined when no translations loaded for locale', () => {
+    const manager = new I18nManager({
+      defaultLocale: 'en',
+      locales: ['en', 'fr'],
+      loadTranslations: vi.fn(),
+    });
+    manager.setLocale('fr');
+
+    const result = manager.resolveTranslationSync('Hello');
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should return the correct translation via hash lookup after async getTranslations populates resolvedCache', async () => {
+    const message = 'Hello {name}!';
+    const options = { $context: 'greeting' };
+    const expectedHash = hashMessage(message, options);
+    const translatedString = 'Bonjour {name} !';
+
+    const mockTranslations = {
+      [expectedHash]: translatedString,
+    };
+
+    const manager = new I18nManager({
+      defaultLocale: 'en',
+      locales: ['en', 'fr'],
+      loadTranslations: vi.fn().mockResolvedValue(mockTranslations),
+    });
+    manager.setLocale('fr');
+
+    // Trigger async load to populate resolvedCache
+    await manager.getTranslations('fr');
+
+    const result = manager.resolveTranslationSync(message, options);
+
+    expect(result).toBe(translatedString);
+  });
+});

--- a/packages/i18n/src/translation-functions/internal/__tests__/resolveTranslationSync.test.ts
+++ b/packages/i18n/src/translation-functions/internal/__tests__/resolveTranslationSync.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { resolveTranslationSync } from '../resolveTranslationSync';
+import { getI18nManager } from '../../../i18n-manager/singleton-operations';
+import { gtFallback } from '../../fallbacks/gtFallback';
+
+vi.mock('../../../i18n-manager/singleton-operations');
+vi.mock('../../fallbacks/gtFallback');
+
+describe('resolveTranslationSync', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(gtFallback).mockReturnValue('fallback-result');
+  });
+
+  it('should call gtFallback with the translation and $_fallback set to original message when translation found', () => {
+    const mockManager = {
+      resolveTranslationSync: vi.fn().mockReturnValue('Bonjour {name} !'),
+    };
+    vi.mocked(getI18nManager).mockReturnValue(mockManager as any);
+
+    const message = 'Hello {name}!';
+    const options = { name: 'Alice' };
+
+    resolveTranslationSync(message, options);
+
+    expect(gtFallback).toHaveBeenCalledWith('Bonjour {name} !', {
+      name: 'Alice',
+      $_fallback: 'Hello {name}!',
+    });
+  });
+
+  it('should call gtFallback with original message and user options (no $_fallback) when no translation found', () => {
+    const mockManager = {
+      resolveTranslationSync: vi.fn().mockReturnValue(undefined),
+    };
+    vi.mocked(getI18nManager).mockReturnValue(mockManager as any);
+
+    const message = 'Hello {name}!';
+    const options = { name: 'Alice' };
+
+    resolveTranslationSync(message, options);
+
+    expect(gtFallback).toHaveBeenCalledWith('Hello {name}!', {
+      name: 'Alice',
+    });
+    // Verify $_fallback is NOT present
+    const callArgs = vi.mocked(gtFallback).mock.calls[0][1];
+    expect(callArgs).not.toHaveProperty('$_fallback');
+  });
+
+  it('should preserve user options alongside $_fallback when translation found', () => {
+    const mockManager = {
+      resolveTranslationSync: vi.fn().mockReturnValue('Translated'),
+    };
+    vi.mocked(getI18nManager).mockReturnValue(mockManager as any);
+
+    const message = 'Hello {name}!';
+    const options = { name: 'Bob', $context: 'greeting', $id: 'hello-msg' };
+
+    resolveTranslationSync(message, options);
+
+    expect(gtFallback).toHaveBeenCalledWith('Translated', {
+      name: 'Bob',
+      $context: 'greeting',
+      $id: 'hello-msg',
+      $_fallback: 'Hello {name}!',
+    });
+  });
+});


### PR DESCRIPTION
just a few unit tests

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds unit tests for the `resolveTranslationSync` functionality at two levels: the `I18nManager` class method and the internal `resolveTranslationSync` translation function. The tests are well-structured and cover the primary happy and unhappy paths.

Key observations:
- Tests correctly use `beforeEach(() => vi.clearAllMocks())` to prevent cross-test pollution
- The `I18nManager` tests accurately model the async-populate-then-sync-read pattern (loading translations via `getTranslations` first, then reading synchronously)
- The internal function tests properly isolate dependencies via `vi.mock` for both `getI18nManager` and `gtFallback`
- Missing edge-case coverage: (1) hash not found in already-loaded translations (file 1), (2) empty-string translation being silently treated as "not found" due to a truthy `if (translation)` check in the implementation (file 2), and (3) no return-value assertions in file 2 tests

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- Safe to merge — this PR only adds test files and introduces no changes to production code.
- The PR exclusively adds unit test files with no modifications to implementation code. The tests are logically correct and will pass against the existing implementation. The suggestions are coverage improvements, not bugs in the tests themselves.
- No files require special attention; both files are test-only additions.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/i18n/src/i18n-manager/__tests__/resolveTranslationSync.test.ts | New test file covering I18nManager.resolveTranslationSync. Two tests cover the "no translations loaded" and "cache populated via async getTranslations" happy paths. Missing a test for the case where translations are loaded but the specific hash is absent. |
| packages/i18n/src/translation-functions/internal/__tests__/resolveTranslationSync.test.ts | New test file for the internal resolveTranslationSync function. Three tests cover translation-found (with options), translation-not-found, and options-preservation. Missing return-value assertions and an edge-case test for empty-string translations. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Test
    participant resolveTranslationSync as resolveTranslationSync (internal)
    participant I18nManager
    participant TranslationsManager
    participant resolvedCache

    Note over Test,resolvedCache: Happy path — translation found
    Test->>resolveTranslationSync: resolveTranslationSync(message, options)
    resolveTranslationSync->>I18nManager: resolveTranslationSync(message, options)
    I18nManager->>TranslationsManager: getTranslationsSync(locale)
    TranslationsManager->>resolvedCache: get(locale)
    resolvedCache-->>TranslationsManager: Translations map
    TranslationsManager-->>I18nManager: Translations map
    I18nManager->>I18nManager: hashMessage(message, options)
    I18nManager-->>resolveTranslationSync: translatedString
    resolveTranslationSync->>resolveTranslationSync: gtFallback(translation, {...options, $_fallback: message})
    resolveTranslationSync-->>Test: interpolated result

    Note over Test,resolvedCache: Unhappy path — no translations loaded
    Test->>resolveTranslationSync: resolveTranslationSync(message, options)
    resolveTranslationSync->>I18nManager: resolveTranslationSync(message, options)
    I18nManager->>TranslationsManager: getTranslationsSync(locale)
    TranslationsManager->>resolvedCache: get(locale)
    resolvedCache-->>TranslationsManager: undefined
    TranslationsManager-->>I18nManager: undefined
    I18nManager-->>resolveTranslationSync: undefined
    resolveTranslationSync->>resolveTranslationSync: gtFallback(message, options)
    resolveTranslationSync-->>Test: interpolated fallback
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/i18n/src/translation-functions/internal/__tests__/resolveTranslationSync.test.ts
Line: 27-31

Comment:
**Missing return value assertions**

All three tests verify what `gtFallback` is called with, but none asserts the actual return value of `resolveTranslationSync`. Since `gtFallback` is mocked to return `'fallback-result'`, adding a simple return-value assertion would complete the contract check. For example, in each test:

```suggestion
    resolveTranslationSync(message, options);

    expect(gtFallback).toHaveBeenCalledWith('Bonjour {name} !', {
      name: 'Alice',
      $_fallback: 'Hello {name}!',
    });
    expect(resolveTranslationSync(message, options)).toBe('fallback-result');
```

Without this, the tests don't fully verify that the result of `gtFallback` is actually returned by `resolveTranslationSync`.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/i18n/src/translation-functions/internal/__tests__/resolveTranslationSync.test.ts
Line: 14-32

Comment:
**Missing edge case: empty string translation treated as "not found"**

The implementation uses a truthy check `if (translation)` (see `resolveTranslationSync.ts` line 17), which means an empty string translation (`''`) would fall through to the no-translation branch and call `gtFallback(message, options)` instead of `gtFallback('', { ...options, $_fallback: message })`. This is a potential silent misbehavior that is not tested here.

Consider adding a test that mocks `resolveTranslationSync` returning `''` and verifies the correct branch is taken — or, alternatively, change the implementation guard to `if (translation !== undefined)` to make the intent explicit.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/i18n/src/i18n-manager/__tests__/resolveTranslationSync.test.ts
Line: 1-47

Comment:
**Missing test: hash not found in loaded translations**

The two existing tests cover (1) no translations loaded at all, and (2) a matching hash found after loading. There is no test for the case where translations are loaded for the locale but the queried message hash does not exist in them. In that scenario `getTranslationsSync` returns the translations map but `translations[hash]` evaluates to `undefined`, which is then cast to `string` in the implementation (`return translations[hash] as string`).

This case can silently return `undefined` typed as `string`, which could propagate incorrectly in callers. Adding a third test that populates the cache with a different key and verifies the result is `undefined` would close this gap.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: 0e8f1ba</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->