### PR TITLE
F/cli file publish

### DIFF
--- a/.changeset/twenty-insects-share.md
+++ b/.changeset/twenty-insects-share.md
@@ -1,0 +1,6 @@
+---
+'gt': minor
+'generaltranslation': patch
+---
+
+Adding CDN publishing for all file types

--- a/packages/cli/src/api/saveLocalEdits.ts
+++ b/packages/cli/src/api/saveLocalEdits.ts
@@ -16,7 +16,7 @@ export async function saveLocalEdits(settings: Settings): Promise<void> {
   if (!settings.files) return;
 
   // Collect current files from config
-  const files = await aggregateFiles(settings);
+  const { files } = await aggregateFiles(settings);
   if (!files.length) return;
 
   // run branch query to get branch id

--- a/packages/cli/src/cli/base.ts
+++ b/packages/cli/src/cli/base.ts
@@ -271,7 +271,8 @@ export class BaseCLI {
           settings,
           results.fileVersionData,
           results.jobData,
-          results.branchData
+          results.branchData,
+          results.publishMap
         );
       }
     } else {

--- a/packages/cli/src/cli/commands/stage.ts
+++ b/packages/cli/src/cli/commands/stage.ts
@@ -25,12 +25,13 @@ export async function handleStage(
   fileVersionData: FileTranslationData | undefined;
   jobData: EnqueueFilesResult | undefined;
   branchData: BranchData | undefined;
+  publishMap: Map<string, boolean>;
 } | null> {
   if (!hasValidLocales(settings)) return exitSync(1);
   // Validate credentials if not in dry run
   if (!options.dryRun && !hasValidCredentials(settings)) return exitSync(1);
 
-  const { files: allFiles, reactComponents } = await collectFiles(
+  const { files: allFiles, reactComponents, publishMap } = await collectFiles(
     options,
     settings,
     library
@@ -85,5 +86,6 @@ export async function handleStage(
     fileVersionData,
     jobData,
     branchData,
+    publishMap,
   };
 }

--- a/packages/cli/src/cli/commands/stage.ts
+++ b/packages/cli/src/cli/commands/stage.ts
@@ -31,11 +31,11 @@ export async function handleStage(
   // Validate credentials if not in dry run
   if (!options.dryRun && !hasValidCredentials(settings)) return exitSync(1);
 
-  const { files: allFiles, reactComponents, publishMap } = await collectFiles(
-    options,
-    settings,
-    library
-  );
+  const {
+    files: allFiles,
+    reactComponents,
+    publishMap,
+  } = await collectFiles(options, settings, library);
 
   // Dry run
   if (options.dryRun) {

--- a/packages/cli/src/cli/commands/translate.ts
+++ b/packages/cli/src/cli/commands/translate.ts
@@ -60,6 +60,7 @@ export async function handleTranslate(
           versionId: data.versionId,
           branchId: branchData?.currentBranch.id,
           publish: publishMap.get(fileId) ?? false,
+          fileName: data.fileName,
         })
       );
       const publishStep = new PublishStep(gt);

--- a/packages/cli/src/cli/commands/translate.ts
+++ b/packages/cli/src/cli/commands/translate.ts
@@ -16,6 +16,8 @@ import localizeStaticImports from '../../utils/localizeStaticImports.js';
 import { BranchData } from '../../types/branch.js';
 import { getDownloadedMeta } from '../../state/recentDownloads.js';
 import { persistPostProcessHashes } from '../../utils/persistPostprocessHashes.js';
+import { PublishStep } from '../../workflows/steps/PublishStep.js';
+import { gt } from '../../utils/gt.js';
 
 // Downloads translations that were completed
 export async function handleTranslate(
@@ -23,7 +25,8 @@ export async function handleTranslate(
   settings: Settings,
   fileVersionData: FileTranslationData | undefined,
   jobData: EnqueueFilesResult | undefined,
-  branchData: BranchData | undefined
+  branchData: BranchData | undefined,
+  publishMap?: Map<string, boolean>
 ) {
   if (fileVersionData) {
     const { resolvedPaths, placeholderPaths, transformPaths } = settings.files;
@@ -48,6 +51,22 @@ export async function handleTranslate(
       forceRetranslation: options.force,
       forceDownload: options.forceDownload || options.force, // if force is true should also force download
     });
+
+    // Publish files after translations are downloaded
+    if (publishMap) {
+      const allFileRefs = Object.entries(fileVersionData).map(
+        ([fileId, data]) => ({
+          fileId,
+          versionId: data.versionId,
+          branchId: branchData?.currentBranch.id ?? '',
+          fileName: data.fileName,
+          fileFormat: 'JSON' as const, // not used by PublishStep
+        })
+      );
+      const publishStep = new PublishStep(gt, publishMap);
+      await publishStep.run(allFileRefs);
+      await publishStep.wait();
+    }
   }
 }
 

--- a/packages/cli/src/cli/commands/translate.ts
+++ b/packages/cli/src/cli/commands/translate.ts
@@ -58,12 +58,11 @@ export async function handleTranslate(
         ([fileId, data]) => ({
           fileId,
           versionId: data.versionId,
-          branchId: branchData?.currentBranch.id ?? '',
-          fileName: data.fileName,
-          fileFormat: 'JSON' as const, // not used by PublishStep
+          branchId: branchData?.currentBranch.id,
+          publish: publishMap.get(fileId) ?? false,
         })
       );
-      const publishStep = new PublishStep(gt, publishMap);
+      const publishStep = new PublishStep(gt);
       await publishStep.run(allFileRefs);
       await publishStep.wait();
     }

--- a/packages/cli/src/cli/commands/translate.ts
+++ b/packages/cli/src/cli/commands/translate.ts
@@ -52,8 +52,8 @@ export async function handleTranslate(
       forceDownload: options.forceDownload || options.force, // if force is true should also force download
     });
 
-    // Publish files after translations are downloaded
-    if (publishMap) {
+    // Publish/unpublish files after translations are downloaded
+    if (publishMap && Array.from(publishMap.values()).some(Boolean)) {
       const allFileRefs = Object.entries(fileVersionData).map(
         ([fileId, data]) => ({
           fileId,

--- a/packages/cli/src/cli/commands/translate.ts
+++ b/packages/cli/src/cli/commands/translate.ts
@@ -18,6 +18,7 @@ import { getDownloadedMeta } from '../../state/recentDownloads.js';
 import { persistPostProcessHashes } from '../../utils/persistPostprocessHashes.js';
 import { PublishStep } from '../../workflows/steps/PublishStep.js';
 import { gt } from '../../utils/gt.js';
+import { hasPublishConfig } from '../../utils/resolvePublish.js';
 
 // Downloads translations that were completed
 export async function handleTranslate(
@@ -53,16 +54,16 @@ export async function handleTranslate(
     });
 
     // Publish/unpublish files after translations are downloaded
-    if (publishMap && Array.from(publishMap.values()).some(Boolean)) {
-      const allFileRefs = Object.entries(fileVersionData).map(
-        ([fileId, data]) => ({
+    if (publishMap && hasPublishConfig(settings)) {
+      const allFileRefs = Object.entries(fileVersionData)
+        .filter(([fileId]) => publishMap.has(fileId))
+        .map(([fileId, data]) => ({
           fileId,
           versionId: data.versionId,
           branchId: branchData?.currentBranch.id,
-          publish: publishMap.get(fileId) ?? false,
+          publish: publishMap.get(fileId)!,
           fileName: data.fileName,
-        })
-      );
+        }));
       const publishStep = new PublishStep(gt);
       await publishStep.run(allFileRefs);
       await publishStep.wait();

--- a/packages/cli/src/config/generateSettings.ts
+++ b/packages/cli/src/config/generateSettings.ts
@@ -186,7 +186,13 @@ export async function generateSettings(
         cwd,
         compositePatterns
       )
-    : { resolvedPaths: {}, placeholderPaths: {}, transformPaths: {} };
+    : {
+        resolvedPaths: {},
+        placeholderPaths: {},
+        transformPaths: {},
+        publishPaths: new Set<string>(),
+        unpublishPaths: new Set<string>(),
+      };
 
   mergedOptions.options = {
     ...(mergedOptions.options || {}),

--- a/packages/cli/src/config/generateSettings.ts
+++ b/packages/cli/src/config/generateSettings.ts
@@ -192,6 +192,7 @@ export async function generateSettings(
         transformPaths: {},
         publishPaths: new Set<string>(),
         unpublishPaths: new Set<string>(),
+        gtJson: {},
       };
 
   mergedOptions.options = {

--- a/packages/cli/src/formats/files/__tests__/aggregateFiles.test.ts
+++ b/packages/cli/src/formats/files/__tests__/aggregateFiles.test.ts
@@ -88,7 +88,7 @@ describe('aggregateFiles - Empty File Handling', () => {
         .mockReturnValueOnce('') // empty file
         .mockReturnValueOnce('{"key": "value"}'); // valid file
 
-      const result = await aggregateFiles(settings as any);
+      const { files: result } = await aggregateFiles(settings as any);
 
       expect(mockLogWarning).toHaveBeenCalledWith(
         'Skipping empty.json: JSON file is not parsable'
@@ -113,7 +113,7 @@ describe('aggregateFiles - Empty File Handling', () => {
         .mockReturnValueOnce('   \n\t  ') // whitespace only
         .mockReturnValueOnce('{"key": "value"}'); // valid file
 
-      const result = await aggregateFiles(settings as any);
+      const { files: result } = await aggregateFiles(settings as any);
 
       expect(mockLogWarning).toHaveBeenCalledWith(
         'Skipping whitespace.json: JSON file is not parsable'
@@ -140,7 +140,7 @@ describe('aggregateFiles - Empty File Handling', () => {
 
       mockReadFile.mockReturnValueOnce('{ invalid json');
 
-      const result = await aggregateFiles(settings as any);
+      const { files: result } = await aggregateFiles(settings as any);
 
       expect(mockLogWarning).not.toHaveBeenCalled();
       expect(result).toHaveLength(1);
@@ -163,7 +163,7 @@ describe('aggregateFiles - Empty File Handling', () => {
         .mockReturnValueOnce(null as any) // null content
         .mockReturnValueOnce('{"key": "value"}'); // valid file
 
-      const result = await aggregateFiles(settings as any);
+      const { files: result } = await aggregateFiles(settings as any);
 
       expect(mockLogWarning).toHaveBeenCalledWith(
         'Skipping null.json: JSON file is empty'
@@ -189,7 +189,7 @@ describe('aggregateFiles - Empty File Handling', () => {
         .mockReturnValueOnce('') // empty file
         .mockReturnValueOnce('key: value'); // valid file
 
-      const result = await aggregateFiles(settings as any);
+      const { files: result } = await aggregateFiles(settings as any);
 
       expect(mockLogWarning).toHaveBeenCalledWith(
         'Skipping empty.yaml: YAML file is empty'
@@ -213,7 +213,7 @@ describe('aggregateFiles - Empty File Handling', () => {
         .mockReturnValueOnce('   \n\t  ') // whitespace only
         .mockReturnValueOnce('key: value'); // valid file
 
-      const result = await aggregateFiles(settings as any);
+      const { files: result } = await aggregateFiles(settings as any);
 
       expect(mockLogWarning).toHaveBeenCalledWith(
         'Skipping whitespace.yml: YAML file is empty'
@@ -239,7 +239,7 @@ describe('aggregateFiles - Empty File Handling', () => {
         .mockReturnValueOnce('') // empty file
         .mockReturnValueOnce('# Valid MDX'); // valid file
 
-      const result = await aggregateFiles(settings as any);
+      const { files: result } = await aggregateFiles(settings as any);
 
       expect(mockLogWarning).toHaveBeenCalledWith(
         'Skipping empty.mdx: File is empty after sanitization'
@@ -269,7 +269,7 @@ describe('aggregateFiles - Empty File Handling', () => {
         error: 'bad',
       });
 
-      const result = await aggregateFiles(settings as any);
+      const { files: result } = await aggregateFiles(settings as any);
 
       expect(mockIsValidMdx).not.toHaveBeenCalled();
       expect(mockLogWarning).not.toHaveBeenCalled();
@@ -298,7 +298,7 @@ describe('aggregateFiles - Empty File Handling', () => {
         '---\nsummary: "Hello"\n---\n\n# Content'
       );
 
-      const result = await aggregateFiles(settings as any);
+      const { files: result } = await aggregateFiles(settings as any);
 
       expect(result).toHaveLength(1);
       expect(result[0].content).toMatch(/title:\s*"?My File"?/);
@@ -330,7 +330,7 @@ describe('aggregateFiles - Empty File Handling', () => {
 
       mockReadFile.mockReturnValueOnce(content);
 
-      const result = await aggregateFiles(settings as any);
+      const { files: result } = await aggregateFiles(settings as any);
 
       expect(result).toHaveLength(1);
       expect(result[0].content).toBe(content);
@@ -357,7 +357,7 @@ describe('aggregateFiles - Empty File Handling', () => {
         '---\nsummary: "Hello"\n---\n\n# Content'
       );
 
-      const result = await aggregateFiles(settings as any);
+      const { files: result } = await aggregateFiles(settings as any);
 
       expect(result).toHaveLength(1);
       expect(result[0].content).toMatch(/title:\s*"?Getting Started"?/);
@@ -384,7 +384,7 @@ describe('aggregateFiles - Empty File Handling', () => {
         '---\nsummary: "Hello"\n---\n\n# Content'
       );
 
-      const result = await aggregateFiles(settings as any);
+      const { files: result } = await aggregateFiles(settings as any);
 
       expect(result).toHaveLength(1);
       expect(result[0].content).toMatch(/title:\s*"?Index"?/);
@@ -409,7 +409,7 @@ describe('aggregateFiles - Empty File Handling', () => {
         .mockReturnValueOnce('') // empty after sanitization
         .mockReturnValueOnce('# Valid content'); // valid after sanitization
 
-      const result = await aggregateFiles(settings as any);
+      const { files: result } = await aggregateFiles(settings as any);
 
       expect(mockLogWarning).toHaveBeenCalledWith(
         'Skipping sanitized-empty.md: File is empty after sanitization'
@@ -440,7 +440,7 @@ describe('aggregateFiles - Empty File Handling', () => {
         .mockReturnValueOnce('   \n\t  ') // whitespace only after sanitization
         .mockReturnValueOnce('export const Component = () => "Hello"'); // valid after sanitization
 
-      const result = await aggregateFiles(settings as any);
+      const { files: result } = await aggregateFiles(settings as any);
 
       expect(mockLogWarning).toHaveBeenCalledWith(
         'Skipping whitespace-after-sanitization.ts: File is empty after sanitization'
@@ -465,7 +465,7 @@ describe('aggregateFiles - Empty File Handling', () => {
 
       mockReadFile.mockReturnValueOnce('{"key": "value"}');
 
-      const result = await aggregateFiles(settings as any);
+      const { files: result } = await aggregateFiles(settings as any);
 
       expect(result).toHaveLength(1);
       expect(result[0].fileFormat).toBe('TWILIO_CONTENT_JSON');
@@ -492,7 +492,7 @@ describe('aggregateFiles - Empty File Handling', () => {
         .mockReturnValueOnce('') // empty file
         .mockReturnValueOnce('{"key": "value"}'); // valid file
 
-      const result = await aggregateFiles(settings as any);
+      const { files: result } = await aggregateFiles(settings as any);
 
       expect(mockLogWarning).toHaveBeenCalledWith(
         'Skipping empty.json: JSON file is not parsable'
@@ -515,7 +515,7 @@ describe('aggregateFiles - Empty File Handling', () => {
 
       mockReadFile.mockReturnValueOnce('{ invalid json');
 
-      const result = await aggregateFiles(settings as any);
+      const { files: result } = await aggregateFiles(settings as any);
 
       expect(mockLogWarning).toHaveBeenCalledWith(
         'Skipping invalid.json: JSON file is not parsable'
@@ -541,7 +541,7 @@ describe('aggregateFiles - Empty File Handling', () => {
 
       mockReadFile.mockReturnValueOnce('{ invalid json');
 
-      const result = await aggregateFiles(settings as any);
+      const { files: result } = await aggregateFiles(settings as any);
 
       expect(mockLogWarning).not.toHaveBeenCalled();
       expect(result).toHaveLength(1);
@@ -572,7 +572,7 @@ describe('aggregateFiles - Empty File Handling', () => {
         .mockReturnValueOnce('{"twilio": "content"}') // valid Twilio Content JSON
         .mockReturnValueOnce('# Valid markdown'); // valid MD
 
-      const result = await aggregateFiles(settings as any);
+      const { files: result } = await aggregateFiles(settings as any);
 
       // Check that warnings were logged for empty files
       expect(mockLogWarning).toHaveBeenCalledWith(
@@ -616,7 +616,7 @@ describe('aggregateFiles - Empty File Handling', () => {
         .mockReturnValueOnce('') // empty file 2 - will return null from map
         .mockReturnValueOnce('{"key": "value"}'); // valid file
 
-      const result = await aggregateFiles(settings as any);
+      const { files: result } = await aggregateFiles(settings as any);
 
       expect(mockLogWarning).toHaveBeenCalledWith(
         'Skipping empty1.json: JSON file is not parsable'
@@ -651,7 +651,7 @@ describe('aggregateFiles - Empty File Handling', () => {
         .mockReturnValueOnce('') // empty after parsing - gets filtered out
         .mockReturnValueOnce('parsed content'); // valid after parsing
 
-      const result = await aggregateFiles(settings as any);
+      const { files: result } = await aggregateFiles(settings as any);
 
       expect(result).toHaveLength(1);
       expect(result[0].fileName).toBe('valid.json');

--- a/packages/cli/src/formats/files/aggregateFiles.ts
+++ b/packages/cli/src/formats/files/aggregateFiles.ts
@@ -57,6 +57,17 @@ export async function aggregateFiles(
   const { resolvedPaths: filePaths } = settings.files;
   const skipValidation = settings.options?.skipFileValidation;
 
+  // Build publish map upfront from resolved paths
+  for (const fileType of SUPPORTED_FILE_EXTENSIONS) {
+    if (filePaths[fileType]) {
+      for (const absolutePath of filePaths[fileType]) {
+        const relativePath = getRelative(absolutePath);
+        const fileId = hashStringSync(relativePath);
+        publishMap.set(fileId, shouldPublishFile(absolutePath, settings));
+      }
+    }
+  }
+
   // Process JSON files
   if (filePaths.json) {
     const { library, additionalModules } = determineLibrary();
@@ -372,31 +383,6 @@ export async function aggregateFiles(
     logger.error(
       'No files to translate were found. Check your configuration and try again.'
     );
-  }
-
-  // Build a reverse map of fileId -> absolute path for publish resolution
-  // fileId = hashStringSync(relativePath), relativePath = getRelative(absolutePath)
-  // So we can rebuild it from the resolved paths
-  const fileIdToAbsolutePath = new Map<string, string>();
-  for (const fileType of SUPPORTED_FILE_EXTENSIONS) {
-    if (filePaths[fileType]) {
-      for (const absolutePath of filePaths[fileType]) {
-        const relativePath = getRelative(absolutePath);
-        const fileId = hashStringSync(relativePath);
-        fileIdToAbsolutePath.set(fileId, absolutePath);
-      }
-    }
-  }
-
-  // Build publish map using per-file resolution logic
-  for (const file of allFiles) {
-    const absolutePath = fileIdToAbsolutePath.get(file.fileId);
-    if (absolutePath) {
-      publishMap.set(file.fileId, shouldPublishFile(absolutePath, settings));
-    } else {
-      // For files without a resolved path (e.g. gtjson template), use global setting
-      publishMap.set(file.fileId, settings.publish);
-    }
   }
 
   return { files: allFiles, publishMap };

--- a/packages/cli/src/formats/files/aggregateFiles.ts
+++ b/packages/cli/src/formats/files/aggregateFiles.ts
@@ -385,5 +385,13 @@ export async function aggregateFiles(
     );
   }
 
+  // Remove stale entries for files that were skipped during validation
+  const validFileIds = new Set(allFiles.map((f) => f.fileId));
+  for (const fileId of publishMap.keys()) {
+    if (!validFileIds.has(fileId)) {
+      publishMap.delete(fileId);
+    }
+  }
+
   return { files: allFiles, publishMap };
 }

--- a/packages/cli/src/formats/files/aggregateFiles.ts
+++ b/packages/cli/src/formats/files/aggregateFiles.ts
@@ -44,14 +44,14 @@ export async function aggregateFiles(
   settings: Settings
 ): Promise<{ files: FileToUpload[]; publishMap: Map<string, boolean> }> {
   // Aggregate all files to translate
-  const allFiles: FileToUpload[] = [];
+  const files: FileToUpload[] = [];
   const publishMap = new Map<string, boolean>();
   if (
     !settings.files ||
     (Object.keys(settings.files.placeholderPaths).length === 1 &&
       settings.files.placeholderPaths.gt)
   ) {
-    return { files: allFiles, publishMap };
+    return { files, publishMap };
   }
 
   const { resolvedPaths: filePaths } = settings.files;
@@ -177,7 +177,7 @@ export async function aggregateFiles(
         }
         return true;
       });
-    allFiles.push(...jsonFiles.filter((file) => file !== null));
+    files.push(...jsonFiles.filter((file) => file !== null));
   }
 
   // Process YAML files
@@ -268,7 +268,7 @@ export async function aggregateFiles(
         }
         return true;
       });
-    allFiles.push(...yamlFiles.filter((file) => file !== null));
+    files.push(...yamlFiles.filter((file) => file !== null));
   }
 
   // Process Twilio Content JSON files
@@ -319,7 +319,7 @@ export async function aggregateFiles(
         }
         return true;
       });
-    allFiles.push(...twilioContentJsonFiles.filter((file) => file !== null));
+    files.push(...twilioContentJsonFiles.filter((file) => file !== null));
   }
 
   for (const fileType of SUPPORTED_FILE_EXTENSIONS) {
@@ -330,7 +330,7 @@ export async function aggregateFiles(
     )
       continue;
     if (filePaths[fileType]) {
-      const files = filePaths[fileType]
+      const parsed = filePaths[fileType]
         .map((filePath) => {
           const content = readFile(filePath);
           const relativePath = getRelative(filePath);
@@ -375,23 +375,23 @@ export async function aggregateFiles(
           }
           return true;
         });
-      allFiles.push(...files.filter((file) => file !== null));
+      files.push(...parsed.filter((file) => file !== null));
     }
   }
 
-  if (allFiles.length === 0 && !settings.publish) {
+  if (files.length === 0 && !settings.publish) {
     logger.error(
       'No files to translate were found. Check your configuration and try again.'
     );
   }
 
   // Remove stale entries for files that were skipped during validation
-  const validFileIds = new Set(allFiles.map((f) => f.fileId));
+  const validFileIds = new Set(files.map((f) => f.fileId));
   for (const fileId of publishMap.keys()) {
     if (!validFileIds.has(fileId)) {
       publishMap.delete(fileId);
     }
   }
 
-  return { files: allFiles, publishMap };
+  return { files, publishMap };
 }

--- a/packages/cli/src/formats/files/aggregateFiles.ts
+++ b/packages/cli/src/formats/files/aggregateFiles.ts
@@ -17,6 +17,7 @@ import {
   parseKeyedMetadata,
   type KeyedMetadata,
 } from '../parseKeyedMetadata.js';
+import { shouldPublishFile } from '../../utils/resolvePublish.js';
 
 /**
  * Checks if a file path is a metadata companion file (e.g. foo.metadata.json)
@@ -41,15 +42,16 @@ export const SUPPORTED_DATA_FORMATS = ['JSX', 'ICU', 'I18NEXT'];
 
 export async function aggregateFiles(
   settings: Settings
-): Promise<FileToUpload[]> {
+): Promise<{ files: FileToUpload[]; publishMap: Map<string, boolean> }> {
   // Aggregate all files to translate
   const allFiles: FileToUpload[] = [];
+  const publishMap = new Map<string, boolean>();
   if (
     !settings.files ||
     (Object.keys(settings.files.placeholderPaths).length === 1 &&
       settings.files.placeholderPaths.gt)
   ) {
-    return allFiles;
+    return { files: allFiles, publishMap };
   }
 
   const { resolvedPaths: filePaths } = settings.files;
@@ -372,5 +374,30 @@ export async function aggregateFiles(
     );
   }
 
-  return allFiles;
+  // Build a reverse map of fileId -> absolute path for publish resolution
+  // fileId = hashStringSync(relativePath), relativePath = getRelative(absolutePath)
+  // So we can rebuild it from the resolved paths
+  const fileIdToAbsolutePath = new Map<string, string>();
+  for (const fileType of SUPPORTED_FILE_EXTENSIONS) {
+    if (filePaths[fileType]) {
+      for (const absolutePath of filePaths[fileType]) {
+        const relativePath = getRelative(absolutePath);
+        const fileId = hashStringSync(relativePath);
+        fileIdToAbsolutePath.set(fileId, absolutePath);
+      }
+    }
+  }
+
+  // Build publish map using per-file resolution logic
+  for (const file of allFiles) {
+    const absolutePath = fileIdToAbsolutePath.get(file.fileId);
+    if (absolutePath) {
+      publishMap.set(file.fileId, shouldPublishFile(absolutePath, settings));
+    } else {
+      // For files without a resolved path (e.g. gtjson template), use global setting
+      publishMap.set(file.fileId, settings.publish);
+    }
+  }
+
+  return { files: allFiles, publishMap };
 }

--- a/packages/cli/src/formats/files/collectFiles.ts
+++ b/packages/cli/src/formats/files/collectFiles.ts
@@ -11,14 +11,19 @@ import type { FileToUpload, JsxChildren } from 'generaltranslation/types';
 import { hashStringSync } from '../../utils/hash.js';
 import { TEMPLATE_FILE_NAME, TEMPLATE_FILE_ID } from '../../utils/constants.js';
 import { isInlineLibrary } from '../../types/libraries.js';
+import { shouldPublishGt } from '../../utils/resolvePublish.js';
 
 export async function collectFiles(
   options: TranslateFlags,
   settings: Settings,
   library: SupportedLibraries
-): Promise<{ files: FileToUpload[]; reactComponents: number }> {
+): Promise<{
+  files: FileToUpload[];
+  reactComponents: number;
+  publishMap: Map<string, boolean>;
+}> {
   // Aggregate files
-  const allFiles = await aggregateFiles(settings);
+  const { files: allFiles, publishMap } = await aggregateFiles(settings);
 
   // Parse for React components
   let reactComponents = 0;
@@ -49,16 +54,18 @@ export async function collectFiles(
         }
       }
       reactComponents = updates.length;
+      const templateFileId = TEMPLATE_FILE_ID;
       allFiles.push({
         fileName: TEMPLATE_FILE_NAME,
         content: JSON.stringify(fileData),
         fileFormat: 'GTJSON',
         formatMetadata: fileMetadata,
-        fileId: TEMPLATE_FILE_ID,
+        fileId: templateFileId,
         versionId: hashStringSync(JSON.stringify(Object.keys(fileData).sort())),
         locale: settings.defaultLocale,
       } satisfies FileToUpload);
+      publishMap.set(templateFileId, shouldPublishGt(settings));
     }
   }
-  return { files: allFiles, reactComponents };
+  return { files: allFiles, reactComponents, publishMap };
 }

--- a/packages/cli/src/formats/files/collectFiles.ts
+++ b/packages/cli/src/formats/files/collectFiles.ts
@@ -23,7 +23,7 @@ export async function collectFiles(
   publishMap: Map<string, boolean>;
 }> {
   // Aggregate files
-  const { files: allFiles, publishMap } = await aggregateFiles(settings);
+  const { files, publishMap } = await aggregateFiles(settings);
 
   // Parse for React components
   let reactComponents = 0;
@@ -54,7 +54,7 @@ export async function collectFiles(
         }
       }
       reactComponents = updates.length;
-      allFiles.push({
+      files.push({
         fileName: TEMPLATE_FILE_NAME,
         content: JSON.stringify(fileData),
         fileFormat: 'GTJSON',
@@ -66,5 +66,5 @@ export async function collectFiles(
       publishMap.set(TEMPLATE_FILE_ID, shouldPublishGt(settings));
     }
   }
-  return { files: allFiles, reactComponents, publishMap };
+  return { files, reactComponents, publishMap };
 }

--- a/packages/cli/src/formats/files/collectFiles.ts
+++ b/packages/cli/src/formats/files/collectFiles.ts
@@ -54,17 +54,16 @@ export async function collectFiles(
         }
       }
       reactComponents = updates.length;
-      const templateFileId = TEMPLATE_FILE_ID;
       allFiles.push({
         fileName: TEMPLATE_FILE_NAME,
         content: JSON.stringify(fileData),
         fileFormat: 'GTJSON',
         formatMetadata: fileMetadata,
-        fileId: templateFileId,
+        fileId: TEMPLATE_FILE_ID,
         versionId: hashStringSync(JSON.stringify(Object.keys(fileData).sort())),
         locale: settings.defaultLocale,
       } satisfies FileToUpload);
-      publishMap.set(templateFileId, shouldPublishGt(settings));
+      publishMap.set(TEMPLATE_FILE_ID, shouldPublishGt(settings));
     }
   }
   return { files: allFiles, reactComponents, publishMap };

--- a/packages/cli/src/fs/config/parseFilesConfig.ts
+++ b/packages/cli/src/fs/config/parseFilesConfig.ts
@@ -129,27 +129,30 @@ export function resolveFiles(
       placeholderResult[fileType] = filePaths.placeholderPaths;
 
       // Match resolved paths against publish/unpublish patterns
+      // Use POSIX paths for micromatch (which expects forward slashes)
+      // but store platform-native paths in the sets for downstream lookups
       if (publishPatterns.length > 0 || unpublishPatterns.length > 0) {
         const resolvedAbsolute = filePaths.resolvedPaths;
+        const posixPaths = resolvedAbsolute.map(toPosixPath);
         const toAbsoluteGlob = (p: string) =>
-          path.resolve(cwd, p.replace(/\[locale\]/g, locale));
+          toPosixPath(path.resolve(cwd, p.replace(/\[locale\]/g, locale)));
 
         for (const pubPattern of publishPatterns) {
-          const matches = micromatch(
-            resolvedAbsolute,
-            toAbsoluteGlob(pubPattern)
-          );
-          for (const p of matches) {
-            publishPaths.add(p);
+          const matched = micromatch(posixPaths, toAbsoluteGlob(pubPattern));
+          const matchedSet = new Set(matched);
+          for (let i = 0; i < posixPaths.length; i++) {
+            if (matchedSet.has(posixPaths[i])) {
+              publishPaths.add(resolvedAbsolute[i]);
+            }
           }
         }
         for (const unpubPattern of unpublishPatterns) {
-          const matches = micromatch(
-            resolvedAbsolute,
-            toAbsoluteGlob(unpubPattern)
-          );
-          for (const p of matches) {
-            unpublishPaths.add(p);
+          const matched = micromatch(posixPaths, toAbsoluteGlob(unpubPattern));
+          const matchedSet = new Set(matched);
+          for (let i = 0; i < posixPaths.length; i++) {
+            if (matchedSet.has(posixPaths[i])) {
+              unpublishPaths.add(resolvedAbsolute[i]);
+            }
           }
         }
       }

--- a/packages/cli/src/fs/config/parseFilesConfig.ts
+++ b/packages/cli/src/fs/config/parseFilesConfig.ts
@@ -129,34 +129,16 @@ export function resolveFiles(
       result[fileType] = filePaths.resolvedPaths;
       placeholderResult[fileType] = filePaths.placeholderPaths;
 
-      // Match resolved paths against publish/unpublish patterns
-      // Use POSIX paths for micromatch (which expects forward slashes)
-      // but store platform-native paths in the sets for downstream lookups
-      if (publishPatterns.length > 0 || unpublishPatterns.length > 0) {
-        const resolvedAbsolute = filePaths.resolvedPaths;
-        const posixPaths = resolvedAbsolute.map(toPosixPath);
-        const toAbsoluteGlob = (p: string) =>
-          toPosixPath(path.resolve(cwd, p.replace(/\[locale\]/g, locale)));
-
-        for (const pubPattern of publishPatterns) {
-          const matched = micromatch(posixPaths, toAbsoluteGlob(pubPattern));
-          const matchedSet = new Set(matched);
-          for (let i = 0; i < posixPaths.length; i++) {
-            if (matchedSet.has(posixPaths[i])) {
-              publishPaths.add(resolvedAbsolute[i]);
-            }
-          }
-        }
-        for (const unpubPattern of unpublishPatterns) {
-          const matched = micromatch(posixPaths, toAbsoluteGlob(unpubPattern));
-          const matchedSet = new Set(matched);
-          for (let i = 0; i < posixPaths.length; i++) {
-            if (matchedSet.has(posixPaths[i])) {
-              unpublishPaths.add(resolvedAbsolute[i]);
-            }
-          }
-        }
-      }
+      // Classify resolved paths into publish/unpublish sets
+      classifyPublishPaths(
+        filePaths.resolvedPaths,
+        publishPatterns,
+        unpublishPatterns,
+        cwd,
+        locale,
+        publishPaths,
+        unpublishPaths
+      );
     }
   }
 
@@ -317,4 +299,43 @@ function buildPlaceholderPathFromPattern(
 
 function toPosixPath(value: string): string {
   return value.split(path.sep).join(path.posix.sep);
+}
+
+/**
+ * Classifies resolved file paths into publish/unpublish sets by matching
+ * them against the given glob patterns. Uses POSIX paths for micromatch
+ * compatibility but stores platform-native paths in the output sets.
+ */
+function classifyPublishPaths(
+  resolvedPaths: string[],
+  publishPatterns: string[],
+  unpublishPatterns: string[],
+  cwd: string,
+  locale: string,
+  publishPaths: Set<string>,
+  unpublishPaths: Set<string>
+): void {
+  if (publishPatterns.length === 0 && unpublishPatterns.length === 0) return;
+
+  const posixPaths = resolvedPaths.map(toPosixPath);
+  const toAbsoluteGlob = (p: string) =>
+    toPosixPath(path.resolve(cwd, p.replace(/\[locale\]/g, locale)));
+
+  for (const pattern of publishPatterns) {
+    const matched = new Set(micromatch(posixPaths, toAbsoluteGlob(pattern)));
+    for (let i = 0; i < posixPaths.length; i++) {
+      if (matched.has(posixPaths[i])) {
+        publishPaths.add(resolvedPaths[i]);
+      }
+    }
+  }
+
+  for (const pattern of unpublishPatterns) {
+    const matched = new Set(micromatch(posixPaths, toAbsoluteGlob(pattern)));
+    for (let i = 0; i < posixPaths.length; i++) {
+      if (matched.has(posixPaths[i])) {
+        unpublishPaths.add(resolvedPaths[i]);
+      }
+    }
+  }
 }

--- a/packages/cli/src/fs/config/parseFilesConfig.ts
+++ b/packages/cli/src/fs/config/parseFilesConfig.ts
@@ -135,13 +135,19 @@ export function resolveFiles(
           path.resolve(cwd, p.replace(/\[locale\]/g, locale));
 
         for (const pubPattern of publishPatterns) {
-          const matches = micromatch(resolvedAbsolute, toAbsoluteGlob(pubPattern));
+          const matches = micromatch(
+            resolvedAbsolute,
+            toAbsoluteGlob(pubPattern)
+          );
           for (const p of matches) {
             publishPaths.add(p);
           }
         }
         for (const unpubPattern of unpublishPatterns) {
-          const matches = micromatch(resolvedAbsolute, toAbsoluteGlob(unpubPattern));
+          const matches = micromatch(
+            resolvedAbsolute,
+            toAbsoluteGlob(unpubPattern)
+          );
           for (const p of matches) {
             unpublishPaths.add(p);
           }

--- a/packages/cli/src/fs/config/parseFilesConfig.ts
+++ b/packages/cli/src/fs/config/parseFilesConfig.ts
@@ -86,7 +86,7 @@ export function resolveFiles(
   transformPaths: TransformFiles;
   publishPaths: Set<string>;
   unpublishPaths: Set<string>;
-  gtJson?: {
+  gtJson: {
     publish?: boolean;
     includeSourceCodeContext?: boolean;
   };
@@ -150,14 +150,10 @@ export function resolveFiles(
     transformPaths: transformPaths,
     publishPaths,
     unpublishPaths,
-    gtJson:
-      files.gt?.publish !== undefined ||
-      files.gt?.includeSourceCodeContext !== undefined
-        ? {
-            publish: files.gt?.publish,
-            includeSourceCodeContext: files.gt?.includeSourceCodeContext,
-          }
-        : undefined,
+    gtJson: {
+      publish: files.gt?.publish,
+      includeSourceCodeContext: files.gt?.includeSourceCodeContext,
+    },
   };
 }
 

--- a/packages/cli/src/fs/config/parseFilesConfig.ts
+++ b/packages/cli/src/fs/config/parseFilesConfig.ts
@@ -54,11 +54,11 @@ export function normalizeIncludePatterns(patterns: IncludePattern[]): {
     if (typeof pattern === 'string') {
       paths.push(pattern);
     } else {
-      paths.push(pattern.path);
+      paths.push(pattern.pattern);
       if (pattern.publish === true) {
-        publishPatterns.push(pattern.path);
+        publishPatterns.push(pattern.pattern);
       } else if (pattern.publish === false) {
-        unpublishPatterns.push(pattern.path);
+        unpublishPatterns.push(pattern.pattern);
       }
     }
   }
@@ -86,8 +86,10 @@ export function resolveFiles(
   transformPaths: TransformFiles;
   publishPaths: Set<string>;
   unpublishPaths: Set<string>;
-  gtPublish?: boolean;
-  includeSourceCodeContext?: boolean;
+  gtJson?: {
+    publish?: boolean;
+    includeSourceCodeContext?: boolean;
+  };
 } {
   // Initialize result object with empty arrays for each file type
   const result: ResolvedFiles = {};
@@ -148,8 +150,14 @@ export function resolveFiles(
     transformPaths: transformPaths,
     publishPaths,
     unpublishPaths,
-    gtPublish: files.gt?.publish,
-    includeSourceCodeContext: files.gt?.includeSourceCodeContext,
+    gtJson:
+      files.gt?.publish !== undefined ||
+      files.gt?.includeSourceCodeContext !== undefined
+        ? {
+            publish: files.gt?.publish,
+            includeSourceCodeContext: files.gt?.includeSourceCodeContext,
+          }
+        : undefined,
   };
 }
 

--- a/packages/cli/src/fs/config/parseFilesConfig.ts
+++ b/packages/cli/src/fs/config/parseFilesConfig.ts
@@ -38,14 +38,6 @@ export function resolveLocaleFiles(
   return result;
 }
 /**
- * Resolves the files from the files object
- * Performs glob pattern expansion on the files
- * Replaces [locale] with the actual locale in the files
- *
- * @param files - The files object
- * @returns The resolved files
- */
-/**
  * Normalizes include patterns into plain path strings and tracks which
  * patterns have explicit publish flags.
  */

--- a/packages/cli/src/fs/config/parseFilesConfig.ts
+++ b/packages/cli/src/fs/config/parseFilesConfig.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 import {
   FilesOptions,
+  IncludePattern,
   ResolvedFiles,
   TransformFiles,
   TransformOption,
@@ -44,6 +45,35 @@ export function resolveLocaleFiles(
  * @param files - The files object
  * @returns The resolved files
  */
+/**
+ * Normalizes include patterns into plain path strings and tracks which
+ * patterns have explicit publish flags.
+ */
+export function normalizeIncludePatterns(patterns: IncludePattern[]): {
+  paths: string[];
+  publishPatterns: string[];
+  unpublishPatterns: string[];
+} {
+  const paths: string[] = [];
+  const publishPatterns: string[] = [];
+  const unpublishPatterns: string[] = [];
+
+  for (const pattern of patterns) {
+    if (typeof pattern === 'string') {
+      paths.push(pattern);
+    } else {
+      paths.push(pattern.path);
+      if (pattern.publish === true) {
+        publishPatterns.push(pattern.path);
+      } else if (pattern.publish === false) {
+        unpublishPatterns.push(pattern.path);
+      }
+    }
+  }
+
+  return { paths, publishPatterns, unpublishPatterns };
+}
+
 export function resolveFiles(
   files: FilesOptions,
   locale: string,
@@ -54,11 +84,16 @@ export function resolveFiles(
   resolvedPaths: ResolvedFiles;
   placeholderPaths: ResolvedFiles;
   transformPaths: TransformFiles;
+  publishPaths: Set<string>;
+  unpublishPaths: Set<string>;
+  gtPublish?: boolean;
 } {
   // Initialize result object with empty arrays for each file type
   const result: ResolvedFiles = {};
   const placeholderResult: ResolvedFiles = {};
   const transformPaths: TransformFiles = {};
+  const publishPaths = new Set<string>();
+  const unpublishPaths = new Set<string>();
 
   // Process GT files
   if (files.gt?.output) {
@@ -78,9 +113,12 @@ export function resolveFiles(
     }
     // ==== PLACEHOLDERS ==== //
     if (files[fileType]?.include) {
+      const { paths, publishPatterns, unpublishPatterns } =
+        normalizeIncludePatterns(files[fileType].include);
+
       const filePaths = expandGlobPatterns(
         cwd,
-        files[fileType].include,
+        paths,
         files[fileType]?.exclude || [],
         locale,
         locales,
@@ -89,6 +127,36 @@ export function resolveFiles(
       );
       result[fileType] = filePaths.resolvedPaths;
       placeholderResult[fileType] = filePaths.placeholderPaths;
+
+      // Track which resolved paths came from publish/unpublish patterns
+      for (const pubPattern of publishPatterns) {
+        const pubPaths = expandGlobPatterns(
+          cwd,
+          [pubPattern],
+          files[fileType]?.exclude || [],
+          locale,
+          locales,
+          transformPaths[fileType] || undefined,
+          compositePatterns
+        );
+        for (const p of pubPaths.resolvedPaths) {
+          publishPaths.add(p);
+        }
+      }
+      for (const unpubPattern of unpublishPatterns) {
+        const unpubPaths = expandGlobPatterns(
+          cwd,
+          [unpubPattern],
+          files[fileType]?.exclude || [],
+          locale,
+          locales,
+          transformPaths[fileType] || undefined,
+          compositePatterns
+        );
+        for (const p of unpubPaths.resolvedPaths) {
+          unpublishPaths.add(p);
+        }
+      }
     }
   }
 
@@ -96,6 +164,9 @@ export function resolveFiles(
     resolvedPaths: result,
     placeholderPaths: placeholderResult,
     transformPaths: transformPaths,
+    publishPaths,
+    unpublishPaths,
+    gtPublish: files.gt?.publish,
   };
 }
 

--- a/packages/cli/src/fs/config/parseFilesConfig.ts
+++ b/packages/cli/src/fs/config/parseFilesConfig.ts
@@ -66,6 +66,14 @@ export function normalizeIncludePatterns(patterns: IncludePattern[]): {
   return { paths, publishPatterns, unpublishPatterns };
 }
 
+/**
+ * Resolves the files from the files object.
+ * Performs glob pattern expansion on the files.
+ * Replaces [locale] with the actual locale in the files.
+ *
+ * @param files - The files object
+ * @returns The resolved files
+ */
 export function resolveFiles(
   files: FilesOptions,
   locale: string,

--- a/packages/cli/src/fs/config/parseFilesConfig.ts
+++ b/packages/cli/src/fs/config/parseFilesConfig.ts
@@ -128,33 +128,23 @@ export function resolveFiles(
       result[fileType] = filePaths.resolvedPaths;
       placeholderResult[fileType] = filePaths.placeholderPaths;
 
-      // Track which resolved paths came from publish/unpublish patterns
-      for (const pubPattern of publishPatterns) {
-        const pubPaths = expandGlobPatterns(
-          cwd,
-          [pubPattern],
-          files[fileType]?.exclude || [],
-          locale,
-          locales,
-          transformPaths[fileType] || undefined,
-          compositePatterns
-        );
-        for (const p of pubPaths.resolvedPaths) {
-          publishPaths.add(p);
+      // Match resolved paths against publish/unpublish patterns
+      if (publishPatterns.length > 0 || unpublishPatterns.length > 0) {
+        const resolvedAbsolute = filePaths.resolvedPaths;
+        const toAbsoluteGlob = (p: string) =>
+          path.resolve(cwd, p.replace(/\[locale\]/g, locale));
+
+        for (const pubPattern of publishPatterns) {
+          const matches = micromatch(resolvedAbsolute, toAbsoluteGlob(pubPattern));
+          for (const p of matches) {
+            publishPaths.add(p);
+          }
         }
-      }
-      for (const unpubPattern of unpublishPatterns) {
-        const unpubPaths = expandGlobPatterns(
-          cwd,
-          [unpubPattern],
-          files[fileType]?.exclude || [],
-          locale,
-          locales,
-          transformPaths[fileType] || undefined,
-          compositePatterns
-        );
-        for (const p of unpubPaths.resolvedPaths) {
-          unpublishPaths.add(p);
+        for (const unpubPattern of unpublishPatterns) {
+          const matches = micromatch(resolvedAbsolute, toAbsoluteGlob(unpubPattern));
+          for (const p of matches) {
+            unpublishPaths.add(p);
+          }
         }
       }
     }

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.10.4';
+export const PACKAGE_VERSION = '2.10.7';

--- a/packages/cli/src/translation/stage.ts
+++ b/packages/cli/src/translation/stage.ts
@@ -32,7 +32,7 @@ export async function aggregateInlineTranslations(
     library,
     false,
     settings.parsingOptions,
-    settings.files?.gtJson?.includeSourceCodeContext ?? false
+    settings.files?.gtJson.includeSourceCodeContext ?? false
   );
 
   if (warnings.length > 0) {

--- a/packages/cli/src/translation/stage.ts
+++ b/packages/cli/src/translation/stage.ts
@@ -32,7 +32,7 @@ export async function aggregateInlineTranslations(
     library,
     false,
     settings.parsingOptions,
-    settings.files?.includeSourceCodeContext ?? false
+    settings.files?.gtJson?.includeSourceCodeContext ?? false
   );
 
   if (warnings.length > 0) {

--- a/packages/cli/src/translation/validate.ts
+++ b/packages/cli/src/translation/validate.ts
@@ -32,7 +32,7 @@ async function runValidation(
       true,
       files,
       settings.parsingOptions,
-      settings.files?.includeSourceCodeContext ?? false
+      settings.files?.gtJson?.includeSourceCodeContext ?? false
     );
   }
 
@@ -56,7 +56,7 @@ async function runValidation(
     pkg,
     true,
     settings.parsingOptions,
-    settings.files?.includeSourceCodeContext ?? false
+    settings.files?.gtJson?.includeSourceCodeContext ?? false
   );
 }
 

--- a/packages/cli/src/translation/validate.ts
+++ b/packages/cli/src/translation/validate.ts
@@ -32,7 +32,7 @@ async function runValidation(
       true,
       files,
       settings.parsingOptions,
-      settings.files?.gtJson?.includeSourceCodeContext ?? false
+      settings.files?.gtJson.includeSourceCodeContext ?? false
     );
   }
 
@@ -56,7 +56,7 @@ async function runValidation(
     pkg,
     true,
     settings.parsingOptions,
-    settings.files?.gtJson?.includeSourceCodeContext ?? false
+    settings.files?.gtJson.includeSourceCodeContext ?? false
   );
 }
 

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -175,7 +175,7 @@ export type TransformFiles = {
 };
 
 // Include patterns can be plain strings or objects with a publish flag
-export type IncludePattern = string | { path: string; publish?: boolean };
+export type IncludePattern = string | { pattern: string; publish?: boolean };
 
 // Update FilesOptions to fix the error
 export type FilesOptions = {
@@ -209,8 +209,10 @@ export type Settings = {
     transformPaths: TransformFiles; // Absolute transform paths for all locales containing [locale]
     publishPaths: Set<string>; // Absolute paths explicitly opted IN to publishing
     unpublishPaths: Set<string>; // Absolute paths explicitly opted OUT of publishing
-    gtPublish?: boolean; // if true, publish gtjson translations to the CDN
-    includeSourceCodeContext?: boolean; // Include surrounding source code lines as context for translations (default: false)
+    gtJson?: {
+      publish?: boolean; // if true, publish gtjson translations to the CDN
+      includeSourceCodeContext?: boolean; // Include surrounding source code lines as context for translations (default: false)
+    };
   };
   stageTranslations: boolean; // if true, always stage the project during translate command
   publish: boolean; // if true, publish the translations to the CDN

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -174,16 +174,20 @@ export type TransformFiles = {
   [K in SupportedFileExtension]?: TransformOption | string | TransformOption[]; // if a string, only transform the file name
 };
 
+// Include patterns can be plain strings or objects with a publish flag
+export type IncludePattern = string | { path: string; publish?: boolean };
+
 // Update FilesOptions to fix the error
 export type FilesOptions = {
   [K in SupportedFileExtension]?: {
-    include: string[];
+    include: IncludePattern[];
     exclude?: string[];
     transform?: string | TransformOption | TransformOption[];
   };
 } & {
   gt?: {
     output: string; // Output glob: /path/[locale].json
+    publish?: boolean; // if true, publish gtjson translations to the CDN
   };
 };
 
@@ -202,6 +206,9 @@ export type Settings = {
     resolvedPaths: ResolvedFiles; // Absolute resolved paths for the default locale
     placeholderPaths: ResolvedFiles; // Absolute placeholder paths for all locales containing [locale]
     transformPaths: TransformFiles; // Absolute transform paths for all locales containing [locale]
+    publishPaths: Set<string>; // Absolute paths explicitly opted IN to publishing
+    unpublishPaths: Set<string>; // Absolute paths explicitly opted OUT of publishing
+    gtPublish?: boolean; // if true, publish gtjson translations to the CDN
   };
   stageTranslations: boolean; // if true, always stage the project during translate command
   publish: boolean; // if true, publish the translations to the CDN

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -209,7 +209,7 @@ export type Settings = {
     transformPaths: TransformFiles; // Absolute transform paths for all locales containing [locale]
     publishPaths: Set<string>; // Absolute paths explicitly opted IN to publishing
     unpublishPaths: Set<string>; // Absolute paths explicitly opted OUT of publishing
-    gtJson?: {
+    gtJson: {
       publish?: boolean; // if true, publish gtjson translations to the CDN
       includeSourceCodeContext?: boolean; // Include surrounding source code lines as context for translations (default: false)
     };

--- a/packages/cli/src/utils/resolvePublish.ts
+++ b/packages/cli/src/utils/resolvePublish.ts
@@ -1,0 +1,44 @@
+import { Settings } from '../types/index.js';
+
+/**
+ * Determines whether a file should be published based on the publish resolution logic:
+ * - If the file is explicitly opted OUT (unpublishPaths), never publish
+ * - If the file is explicitly opted IN (publishPaths), always publish
+ * - Otherwise, fall back to the global publish setting
+ */
+export function shouldPublishFile(
+  resolvedPath: string,
+  settings: Settings
+): boolean {
+  if (settings.files.unpublishPaths?.has(resolvedPath)) return false;
+  if (settings.files.publishPaths?.has(resolvedPath)) return true;
+  return settings.publish ?? false;
+}
+
+/**
+ * Determines whether gtjson content should be published.
+ * Uses the gt-specific publish flag if set, otherwise falls back to global.
+ */
+export function shouldPublishGt(settings: Settings): boolean {
+  if (settings.files.gtPublish === false) return false;
+  if (settings.files.gtPublish === true) return true;
+  return settings.publish;
+}
+
+/**
+ * Builds a map of fileId -> shouldPublish for a set of files.
+ */
+export function buildPublishMap(
+  files: { fileId: string; resolvedPath?: string }[],
+  settings: Settings
+): Map<string, boolean> {
+  const map = new Map<string, boolean>();
+  for (const file of files) {
+    if (file.resolvedPath) {
+      map.set(file.fileId, shouldPublishFile(file.resolvedPath, settings));
+    } else {
+      map.set(file.fileId, settings.publish);
+    }
+  }
+  return map;
+}

--- a/packages/cli/src/utils/resolvePublish.ts
+++ b/packages/cli/src/utils/resolvePublish.ts
@@ -24,4 +24,3 @@ export function shouldPublishGt(settings: Settings): boolean {
   if (settings.files.gtPublish === true) return true;
   return settings.publish;
 }
-

--- a/packages/cli/src/utils/resolvePublish.ts
+++ b/packages/cli/src/utils/resolvePublish.ts
@@ -22,7 +22,7 @@ export function shouldPublishFile(
 export function hasPublishConfig(settings: Settings): boolean {
   return (
     settings.publish ||
-    settings.files.gtPublish !== undefined ||
+    settings.files.gtJson?.publish !== undefined ||
     (settings.files.publishPaths?.size ?? 0) > 0 ||
     (settings.files.unpublishPaths?.size ?? 0) > 0
   );
@@ -33,7 +33,7 @@ export function hasPublishConfig(settings: Settings): boolean {
  * Uses the gt-specific publish flag if set, otherwise falls back to global.
  */
 export function shouldPublishGt(settings: Settings): boolean {
-  if (settings.files.gtPublish === false) return false;
-  if (settings.files.gtPublish === true) return true;
+  if (settings.files.gtJson?.publish === false) return false;
+  if (settings.files.gtJson?.publish === true) return true;
   return settings.publish;
 }

--- a/packages/cli/src/utils/resolvePublish.ts
+++ b/packages/cli/src/utils/resolvePublish.ts
@@ -22,7 +22,7 @@ export function shouldPublishFile(
 export function hasPublishConfig(settings: Settings): boolean {
   return (
     settings.publish ||
-    settings.files.gtJson?.publish !== undefined ||
+    settings.files.gtJson.publish !== undefined ||
     (settings.files.publishPaths?.size ?? 0) > 0 ||
     (settings.files.unpublishPaths?.size ?? 0) > 0
   );
@@ -33,7 +33,7 @@ export function hasPublishConfig(settings: Settings): boolean {
  * Uses the gt-specific publish flag if set, otherwise falls back to global.
  */
 export function shouldPublishGt(settings: Settings): boolean {
-  if (settings.files.gtJson?.publish === false) return false;
-  if (settings.files.gtJson?.publish === true) return true;
+  if (settings.files.gtJson.publish === false) return false;
+  if (settings.files.gtJson.publish === true) return true;
   return settings.publish;
 }

--- a/packages/cli/src/utils/resolvePublish.ts
+++ b/packages/cli/src/utils/resolvePublish.ts
@@ -16,6 +16,19 @@ export function shouldPublishFile(
 }
 
 /**
+ * Returns true if the user has any explicit publish configuration —
+ * global flag, gt-specific flag, or per-file publish/unpublish patterns.
+ */
+export function hasPublishConfig(settings: Settings): boolean {
+  return (
+    settings.publish ||
+    settings.files.gtPublish !== undefined ||
+    (settings.files.publishPaths?.size ?? 0) > 0 ||
+    (settings.files.unpublishPaths?.size ?? 0) > 0
+  );
+}
+
+/**
  * Determines whether gtjson content should be published.
  * Uses the gt-specific publish flag if set, otherwise falls back to global.
  */

--- a/packages/cli/src/utils/resolvePublish.ts
+++ b/packages/cli/src/utils/resolvePublish.ts
@@ -25,20 +25,3 @@ export function shouldPublishGt(settings: Settings): boolean {
   return settings.publish;
 }
 
-/**
- * Builds a map of fileId -> shouldPublish for a set of files.
- */
-export function buildPublishMap(
-  files: { fileId: string; resolvedPath?: string }[],
-  settings: Settings
-): Map<string, boolean> {
-  const map = new Map<string, boolean>();
-  for (const file of files) {
-    if (file.resolvedPath) {
-      map.set(file.fileId, shouldPublishFile(file.resolvedPath, settings));
-    } else {
-      map.set(file.fileId, settings.publish);
-    }
-  }
-  return map;
-}

--- a/packages/cli/src/workflows/steps/EnqueueStep.ts
+++ b/packages/cli/src/workflows/steps/EnqueueStep.ts
@@ -27,7 +27,6 @@ export class EnqueueStep extends WorkflowStep<
     this.result = await this.gt.enqueueFiles(files, {
       sourceLocale: this.settings.defaultLocale,
       targetLocales: this.settings.locales,
-      publish: this.settings.publish,
       requireApproval: this.settings.stageTranslations,
       modelProvider: this.settings.modelProvider,
       force: this.force,

--- a/packages/cli/src/workflows/steps/PublishStep.ts
+++ b/packages/cli/src/workflows/steps/PublishStep.ts
@@ -12,42 +12,30 @@ export class PublishStep extends WorkflowStep<PublishFileEntry[], void> {
   }
 
   async run(files: PublishFileEntry[]): Promise<void> {
-    const filesToPublish = files.filter((f) => f.publish);
+    if (files.length === 0) return;
 
-    if (filesToPublish.length === 0) return;
-
-    this.spinner.start(
-      `Publishing ${filesToPublish.length} file${filesToPublish.length !== 1 ? 's' : ''} to CDN...`
-    );
+    this.spinner.start('Updating CDN...');
 
     try {
-      const result = await this.gt.publishFiles(filesToPublish);
+      const result = await this.gt.publishFiles(files);
 
       const failed = result.results.filter(
         (r: { success: boolean; error?: string }) => !r.success
       );
       if (failed.length > 0) {
-        this.spinner.stop(
-          chalk.yellow(
-            `Published ${filesToPublish.length - failed.length}/${filesToPublish.length} files (${failed.length} failed)`
-          )
-        );
+        this.spinner.stop(chalk.yellow('CDN updated with errors'));
         for (const f of failed) {
-          const file = filesToPublish.find((p) => p.fileId === f.fileId);
+          const file = files.find((p) => p.fileId === f.fileId);
           const name = file?.fileName ?? f.fileId;
           logger.warn(
-            `Failed to publish ${name}: ${f.error ?? 'unknown error'}`
+            `Failed to update ${name}: ${f.error ?? 'unknown error'}`
           );
         }
       } else {
-        this.spinner.stop(
-          chalk.green(
-            `${filesToPublish.length} file${filesToPublish.length !== 1 ? 's' : ''} published to CDN`
-          )
-        );
+        this.spinner.stop(chalk.green('CDN updated'));
       }
     } catch (err) {
-      this.spinner.stop(chalk.red('Failed to publish files to CDN'));
+      this.spinner.stop(chalk.red('Failed to update CDN'));
       logger.warn(
         `Publish error: ${err instanceof Error ? err.message : String(err)}`
       );

--- a/packages/cli/src/workflows/steps/PublishStep.ts
+++ b/packages/cli/src/workflows/steps/PublishStep.ts
@@ -33,8 +33,10 @@ export class PublishStep extends WorkflowStep<PublishFileEntry[], void> {
           )
         );
         for (const f of failed) {
+          const file = filesToPublish.find((p) => p.fileId === f.fileId);
+          const name = file?.fileName ?? f.fileId;
           logger.warn(
-            `Failed to publish ${f.fileId}: ${f.error ?? 'unknown error'}`
+            `Failed to publish ${name}: ${f.error ?? 'unknown error'}`
           );
         }
       } else {

--- a/packages/cli/src/workflows/steps/PublishStep.ts
+++ b/packages/cli/src/workflows/steps/PublishStep.ts
@@ -1,23 +1,18 @@
 import { WorkflowStep } from './WorkflowStep.js';
 import { logger } from '../../console/logger.js';
 import { GT } from 'generaltranslation';
-import type { FileReference } from 'generaltranslation/types';
+import type { PublishFileEntry } from 'generaltranslation/types';
 import chalk from 'chalk';
 
-export class PublishStep extends WorkflowStep<FileReference[], void> {
+export class PublishStep extends WorkflowStep<PublishFileEntry[], void> {
   private spinner = logger.createSpinner('dots');
 
-  constructor(
-    private gt: GT,
-    private publishMap: Map<string, boolean>
-  ) {
+  constructor(private gt: GT) {
     super();
   }
 
-  async run(files: FileReference[]): Promise<void> {
-    const filesToPublish = files.filter(
-      (f) => this.publishMap.get(f.fileId) === true
-    );
+  async run(files: PublishFileEntry[]): Promise<void> {
+    const filesToPublish = files.filter((f) => f.publish);
 
     if (filesToPublish.length === 0) return;
 
@@ -25,32 +20,34 @@ export class PublishStep extends WorkflowStep<FileReference[], void> {
       `Publishing ${filesToPublish.length} file${filesToPublish.length !== 1 ? 's' : ''} to CDN...`
     );
 
-    const result = await this.gt.publishFiles(
-      filesToPublish.map((f) => ({
-        fileId: f.fileId,
-        versionId: f.versionId,
-        branchId: f.branchId,
-        publish: true,
-      }))
-    );
+    try {
+      const result = await this.gt.publishFiles(filesToPublish);
 
-    const failed = result.results.filter(
-      (r: { success: boolean; error?: string }) => !r.success
-    );
-    if (failed.length > 0) {
-      this.spinner.stop(
-        chalk.yellow(
-          `Published ${filesToPublish.length - failed.length}/${filesToPublish.length} files (${failed.length} failed)`
-        )
+      const failed = result.results.filter(
+        (r: { success: boolean; error?: string }) => !r.success
       );
-      for (const f of failed) {
-        logger.warn(`Failed to publish ${f.fileId}: ${f.error}`);
+      if (failed.length > 0) {
+        this.spinner.stop(
+          chalk.yellow(
+            `Published ${filesToPublish.length - failed.length}/${filesToPublish.length} files (${failed.length} failed)`
+          )
+        );
+        for (const f of failed) {
+          logger.warn(
+            `Failed to publish ${f.fileId}: ${f.error ?? 'unknown error'}`
+          );
+        }
+      } else {
+        this.spinner.stop(
+          chalk.green(
+            `${filesToPublish.length} file${filesToPublish.length !== 1 ? 's' : ''} published to CDN`
+          )
+        );
       }
-    } else {
-      this.spinner.stop(
-        chalk.green(
-          `${filesToPublish.length} file${filesToPublish.length !== 1 ? 's' : ''} published to CDN`
-        )
+    } catch (err) {
+      this.spinner.stop(chalk.red('Failed to publish files to CDN'));
+      logger.warn(
+        `Publish error: ${err instanceof Error ? err.message : String(err)}`
       );
     }
   }

--- a/packages/cli/src/workflows/steps/PublishStep.ts
+++ b/packages/cli/src/workflows/steps/PublishStep.ts
@@ -4,10 +4,7 @@ import { GT } from 'generaltranslation';
 import type { FileReference } from 'generaltranslation/types';
 import chalk from 'chalk';
 
-export class PublishStep extends WorkflowStep<
-  FileReference[],
-  void
-> {
+export class PublishStep extends WorkflowStep<FileReference[], void> {
   private spinner = logger.createSpinner('dots');
 
   constructor(

--- a/packages/cli/src/workflows/steps/PublishStep.ts
+++ b/packages/cli/src/workflows/steps/PublishStep.ts
@@ -1,0 +1,64 @@
+import { WorkflowStep } from './WorkflowStep.js';
+import { logger } from '../../console/logger.js';
+import { GT } from 'generaltranslation';
+import type { FileReference } from 'generaltranslation/types';
+import chalk from 'chalk';
+
+export class PublishStep extends WorkflowStep<
+  FileReference[],
+  void
+> {
+  private spinner = logger.createSpinner('dots');
+
+  constructor(
+    private gt: GT,
+    private publishMap: Map<string, boolean>
+  ) {
+    super();
+  }
+
+  async run(files: FileReference[]): Promise<void> {
+    const filesToPublish = files.filter(
+      (f) => this.publishMap.get(f.fileId) === true
+    );
+
+    if (filesToPublish.length === 0) return;
+
+    this.spinner.start(
+      `Publishing ${filesToPublish.length} file${filesToPublish.length !== 1 ? 's' : ''} to CDN...`
+    );
+
+    const result = await this.gt.publishFiles(
+      filesToPublish.map((f) => ({
+        fileId: f.fileId,
+        versionId: f.versionId,
+        branchId: f.branchId,
+        publish: true,
+      }))
+    );
+
+    const failed = result.results.filter(
+      (r: { success: boolean; error?: string }) => !r.success
+    );
+    if (failed.length > 0) {
+      this.spinner.stop(
+        chalk.yellow(
+          `Published ${filesToPublish.length - failed.length}/${filesToPublish.length} files (${failed.length} failed)`
+        )
+      );
+      for (const f of failed) {
+        logger.warn(`Failed to publish ${f.fileId}: ${f.error}`);
+      }
+    } else {
+      this.spinner.stop(
+        chalk.green(
+          `${filesToPublish.length} file${filesToPublish.length !== 1 ? 's' : ''} published to CDN`
+        )
+      );
+    }
+  }
+
+  async wait(): Promise<void> {
+    return;
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -107,6 +107,10 @@ import _processFileMoves, {
 import _getOrphanedFiles, {
   type GetOrphanedFilesResult,
 } from './translate/getOrphanedFiles';
+import _publishFiles, {
+  type PublishFileEntry,
+  type PublishFilesResult,
+} from './translate/publishFiles';
 import { CutoffFormatOptions } from './formatting/custom-formats/CutoffFormat/types';
 import { TranslateOptions } from './types-dir/api/entry';
 import { API_VERSION as _API_VERSION } from './translate/api';
@@ -496,6 +500,19 @@ export class GT {
       mergedOptions,
       this._getTranslationConfig()
     );
+  }
+
+  /**
+   * Publishes or unpublishes files on the CDN.
+   *
+   * @param {PublishFileEntry[]} files - Array of file entries with publish flags
+   * @returns {Promise<PublishFilesResult>} Result containing per-file success/failure
+   */
+  async publishFiles(
+    files: PublishFileEntry[]
+  ): Promise<PublishFilesResult> {
+    this._validateAuth('publishFiles');
+    return await _publishFiles(files, this._getTranslationConfig());
   }
 
   /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -508,9 +508,7 @@ export class GT {
    * @param {PublishFileEntry[]} files - Array of file entries with publish flags
    * @returns {Promise<PublishFilesResult>} Result containing per-file success/failure
    */
-  async publishFiles(
-    files: PublishFileEntry[]
-  ): Promise<PublishFilesResult> {
+  async publishFiles(files: PublishFileEntry[]): Promise<PublishFilesResult> {
     this._validateAuth('publishFiles');
     return await _publishFiles(files, this._getTranslationConfig());
   }

--- a/packages/core/src/translate/__tests__/enqueueFiles.test.ts
+++ b/packages/core/src/translate/__tests__/enqueueFiles.test.ts
@@ -29,7 +29,6 @@ describe('_enqueueFiles', () => {
   ): EnqueueOptions => ({
     sourceLocale: 'en',
     targetLocales: ['es', 'fr'],
-    publish: true,
     ...overrides,
   });
 
@@ -87,7 +86,6 @@ describe('_enqueueFiles', () => {
           ],
           targetLocales: ['es', 'fr'],
           sourceLocale: 'en',
-          publish: true,
           requireApproval: undefined,
           modelProvider: undefined,
           force: undefined,
@@ -131,7 +129,6 @@ describe('_enqueueFiles', () => {
   it('should handle all optional parameters', async () => {
     const mockFiles = [createMockFile()];
     const mockOptions = createMockOptions({
-      publish: false,
       requireApproval: true,
       modelProvider: 'openai',
       force: true,
@@ -164,7 +161,6 @@ describe('_enqueueFiles', () => {
       expect.any(String),
       expect.objectContaining({
         body: expect.objectContaining({
-          publish: false,
           requireApproval: true,
           modelProvider: 'openai',
           force: true,

--- a/packages/core/src/translate/enqueueFiles.ts
+++ b/packages/core/src/translate/enqueueFiles.ts
@@ -6,7 +6,6 @@ import { processBatches } from './utils/batch';
 export type EnqueueOptions = {
   sourceLocale: string;
   targetLocales: string[];
-  publish?: boolean;
   requireApproval?: boolean;
   modelProvider?: string;
   force?: boolean;
@@ -38,7 +37,6 @@ export default async function _enqueueFiles(
         })),
         targetLocales: options.targetLocales,
         sourceLocale: options.sourceLocale,
-        publish: options.publish,
         requireApproval: options.requireApproval,
         modelProvider: options.modelProvider,
         force: options.force,

--- a/packages/core/src/translate/publishFiles.ts
+++ b/packages/core/src/translate/publishFiles.ts
@@ -1,0 +1,38 @@
+import { TranslationRequestConfig } from '../types';
+import apiRequest from './utils/apiRequest';
+
+export type PublishFileEntry = {
+  fileId: string;
+  versionId: string;
+  branchId?: string;
+  publish: boolean;
+};
+
+export type PublishFilesResult = {
+  results: {
+    fileId: string;
+    versionId: string;
+    success: boolean;
+    error?: string;
+  }[];
+};
+
+/**
+ * @internal
+ * Publishes or unpublishes files on the CDN.
+ * @param files - Array of file entries with publish flags
+ * @param config - The configuration for the API call
+ * @returns The result of the API call
+ */
+export default async function _publishFiles(
+  files: PublishFileEntry[],
+  config: TranslationRequestConfig
+): Promise<PublishFilesResult> {
+  return await apiRequest<PublishFilesResult>(
+    config,
+    '/v2/project/files/publish',
+    {
+      body: { files },
+    }
+  );
+}

--- a/packages/core/src/translate/publishFiles.ts
+++ b/packages/core/src/translate/publishFiles.ts
@@ -6,6 +6,7 @@ export type PublishFileEntry = {
   versionId: string;
   branchId?: string;
   publish: boolean;
+  fileName?: string;
 };
 
 export type PublishFilesResult = {

--- a/packages/core/src/types-dir/api/enqueueFiles.ts
+++ b/packages/core/src/types-dir/api/enqueueFiles.ts
@@ -20,7 +20,6 @@ export type Updates = ({
 
 /**
  * Options for enqueueing files
- * @param publish - Whether to publish the files
  * @param requireApproval - Whether to require approval for the files
  * @param description - Optional description for the project
  * @param sourceLocale - The project's source locale

--- a/packages/core/src/types-dir/api/enqueueFiles.ts
+++ b/packages/core/src/types-dir/api/enqueueFiles.ts
@@ -30,7 +30,6 @@ export type Updates = ({
  * @param modelProvider - Optional model provider to use
  */
 export type EnqueueFilesOptions = {
-  publish?: boolean;
   requireApproval?: boolean;
   description?: string; // @deprecated Will be removed in v8.0.0
   sourceLocale?: string;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -69,6 +69,10 @@ export type {
   EnqueueEntriesResult,
 } from './types-dir/api/enqueueEntries';
 export type { FileReference } from './types-dir/api/file';
+export type {
+  PublishFileEntry,
+  PublishFilesResult,
+} from './translate/publishFiles';
 export type { DownloadedFile } from './types-dir/api/downloadFileBatch';
 export type { DownloadFileOptions } from './types-dir/api/downloadFile';
 export type { FileFormat } from './types-dir/api/file';


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a CLI file publish/unpublish feature that allows users to control whether translated files are pushed to the CDN after a `translate` run. It adds per-file `publish` flags in `IncludePattern`, a global `gt.publish` option, and a new `PublishStep` workflow step that calls the new `GT.publishFiles()` core API method.

**Key changes:**
- `IncludePattern` type now supports `{ path: string; publish?: boolean }` objects alongside plain strings, resolved into `publishPaths`/`unpublishPaths` sets during config parsing.
- `aggregateFiles` and `collectFiles` now return a `publishMap: Map<string, boolean>` alongside the file list, threaded through `handleStage` → `base.ts` → `handleTranslate`.
- After translations are downloaded, `handleTranslate` builds a `PublishFileEntry[]` from `fileVersionData` filtered by the publishMap and calls `PublishStep.run`.
- `PublishStep` wraps the API call with a spinner, graceful error handling, and per-file failure warnings.
- `hasPublishConfig` guards the publish step but returns `true` whenever `gtPublish` is defined (even `false`), meaning a pure opt-out config (`gtPublish: false`) will still trigger an API call to "unpublish" on every run.
- Files not re-staged in the current run are absent from `fileVersionData` and therefore silently skipped by the publish step, even if they carry an explicit `publish: true` flag.

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

- Mergeable with awareness — logic issues in hasPublishConfig and silent publish skipping for unchanged files may produce confusing behavior in production.
- The overall architecture is sound and the happy path works correctly. Two logic concerns lower the score: (1) hasPublishConfig returns true for pure opt-out configs (gtPublish: false), causing an unnecessary API call on every run; (2) files not re-staged in the current run are silently excluded from the publish step even when explicitly configured to publish. These won't cause crashes but will produce confusing behaviour for users. The rest of the changes — type additions, pattern matching, PublishStep error handling — are clean.
- packages/cli/src/utils/resolvePublish.ts (hasPublishConfig logic) and packages/cli/src/cli/commands/translate.ts (silent skip of unchanged files)
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/core/src/translate/publishFiles.ts | New internal API function that POSTs to `/v2/project/files/publish` with an array of `PublishFileEntry` objects. Clean, minimal, and well-typed. |
| packages/cli/src/utils/resolvePublish.ts | New utility exposing `shouldPublishFile`, `shouldPublishGt`, and `hasPublishConfig`. `hasPublishConfig` returns `true` whenever `gtPublish` is defined (even `false`), potentially triggering unnecessary CDN API calls on every translate run for pure opt-out configurations. |
| packages/cli/src/workflows/steps/PublishStep.ts | New workflow step wrapping `gt.publishFiles`. Correctly handles errors with try/catch ensuring the spinner always stops, and falls back to a user-friendly error message when `f.error` is absent. |
| packages/cli/src/cli/commands/translate.ts | Adds publish step after translation download. `branchId` correctly uses optional chaining. However, files not re-staged in the current run are silently excluded from the publish call even if they have an explicit `publish: true` config. |
| packages/cli/src/formats/files/aggregateFiles.ts | Return type changed to include `publishMap`. Map is built upfront and stale entries cleaned up at end. Deletes from the Map while iterating its own `.keys()` iterator — safe but unconventional. |
| packages/cli/src/fs/config/parseFilesConfig.ts | Adds `normalizeIncludePatterns` to extract publish/unpublish patterns from `IncludePattern[]`. Uses micromatch to resolve matched absolute paths into `publishPaths`/`unpublishPaths` sets — POSIX conversion looks correct. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant CLI as CLI (base.ts)
    participant Stage as handleStage
    participant Collect as collectFiles / aggregateFiles
    participant Translate as handleTranslate
    participant Publish as PublishStep
    participant API as GT Core API

    User->>CLI: gt translate
    CLI->>Stage: handleStage(options, settings, library)
    Stage->>Collect: collectFiles(options, settings, library)
    Collect->>Collect: aggregateFiles(settings)<br/>→ { files, publishMap }
    Collect->>Collect: publishMap.set(TEMPLATE_FILE_ID, shouldPublishGt)
    Collect-->>Stage: { files, reactComponents, publishMap }
    Stage-->>CLI: { fileVersionData, jobData, branchData, publishMap }
    CLI->>Translate: handleTranslate(options, settings, fileVersionData, jobData, branchData, publishMap)
    Translate->>Translate: runDownloadWorkflow(...)
    alt publishMap && hasPublishConfig(settings)
        Translate->>Translate: filter fileVersionData by publishMap keys
        Translate->>Publish: publishStep.run(allFileRefs)
        Publish->>API: POST /v2/project/files/publish
        API-->>Publish: PublishFilesResult
        alt failures exist
            Publish->>User: warn per failed file
        else success
            Publish->>User: CDN updated ✓
        end
    end
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (9)</h3></summary>

1. `packages/cli/src/cli/base.ts`, line 278-280 ([link](https://github.com/generaltranslation/gt/blob/284d73a4311d4bdce5f20003f341e5695437ac1e/packages/cli/src/cli/base.ts#L278-L280)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Publish step not triggered in `stageTranslations` path**

   When `settings.stageTranslations` is `true`, the code takes the `handleDownload` branch and never calls `handleTranslate`, meaning the `PublishStep` is never invoked. Any per-file publish flags (via `publishPaths` / `unpublishPaths`) or the global `settings.publish` flag will be silently ignored for users in this mode. If this is intentional, a comment explaining why publish is skipped in the staging-only flow would help future readers. If not, consider running the publish step after `handleDownload` as well.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/cli/src/cli/base.ts
   Line: 278-280

   Comment:
   **Publish step not triggered in `stageTranslations` path**

   When `settings.stageTranslations` is `true`, the code takes the `handleDownload` branch and never calls `handleTranslate`, meaning the `PublishStep` is never invoked. Any per-file publish flags (via `publishPaths` / `unpublishPaths`) or the global `settings.publish` flag will be silently ignored for users in this mode. If this is intentional, a comment explaining why publish is skipped in the staging-only flow would help future readers. If not, consider running the publish step after `handleDownload` as well.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `packages/cli/src/workflows/steps/PublishStep.ts`, line 15 ([link](https://github.com/generaltranslation/gt/blob/cf2433efbc3e210906e53ae098a8d1271d9c592a/packages/cli/src/workflows/steps/PublishStep.ts#L15)) 

   **Explicitly opted-out files are never unpublished from CDN**

   `PublishStep.run()` filters entries down to `files.filter((f) => f.publish)` before calling the API. The internal `_publishFiles` docstring says the endpoint "Publishes **or unpublishes** files on the CDN" and `PublishFileEntry.publish` is typed as `boolean`, strongly implying `publish: false` is a supported, meaningful value.

   With the current filter, a file that was previously published and is now placed in `unpublishPaths` (i.e. `shouldPublishFile` returns `false`) will never have a `publish: false` payload sent to the API — the file stays live on the CDN indefinitely.

   If selective unpublishing is intended for a future iteration, at minimum a code comment should document this limitation. If it should work today, the filter needs to also forward entries whose `publish` value is `false`:

   ```typescript
   // Only entries explicitly opted-in are published; opted-out entries are
   // currently not forwarded to the API, so previously-published files are
   // NOT unpublished. Revisit if unpublish support is needed.
   const filesToPublish = files.filter((f) => f.publish);
   ```

3. `packages/cli/src/cli/commands/translate.ts`, line 56-68 ([link](https://github.com/generaltranslation/gt/blob/03bbacfd728b9687a8c530dbf54b6e62ce5286e9/packages/cli/src/cli/commands/translate.ts#L56-L68)) 

   **Publish API called on every run, even when nothing should be published**

   `publishMap` is always a `Map` instance (truthy), so `if (publishMap)` is always `true`. When `settings.publish` is `false` and no per-file publish flags are set, every entry in `allFileRefs` will have `publish: false`, but `publishStep.run()` is still called and sends all of them to the CDN API. For users who have never opted into CDN publishing, this results in:
   1. An unnecessary API call after every translation run.
   2. A potential hard error if the user lacks CDN publish permissions.
   3. Files that were previously published being explicitly marked as unpublished.

   The guard `if (publishMap)` was clearly intended to be a skip condition, but it never fires because `handleStage` always returns a `Map`. Add a check that at least one entry opts in before hitting the API:

4. `packages/cli/src/cli/commands/translate.ts`, line 57-65 ([link](https://github.com/generaltranslation/gt/blob/1cf0b9bdb6e698f85156e54e9b08e181e84523dc/packages/cli/src/cli/commands/translate.ts#L57-L65)) 

   **All `fileVersionData` files sent to publish API, not just relevant ones**

   `allFileRefs` is built from every entry in `fileVersionData`, then the `publish` flag is looked up in `publishMap`. Files that have `publish: false` in the map (i.e., they're not meant to be published) are still included in the payload and sent to the API. If the API interprets `publish: false` as an **unpublish** directive, this will unintentionally unpublish files that were never published in the current run.

   Consider filtering to only include files that either (a) should be published (`publish: true`) or (b) are explicitly in `unpublishPaths` (explicit opt-out, meaning they were previously published and should now be removed):

   ```typescript
   const allFileRefs = Object.entries(fileVersionData)
     .filter(([fileId]) => {
       const shouldPublish = publishMap.get(fileId) ?? false;
       // include if publishing, or if explicitly marked to unpublish
       return shouldPublish || settings.files.unpublishPaths?.has(fileId);
     })
     .map(([fileId, data]) => ({
       fileId,
       versionId: data.versionId,
       branchId: branchData?.currentBranch.id,
       publish: publishMap.get(fileId) ?? false,
       fileName: data.fileName,
     }));
   ```

5. `packages/cli/src/fs/config/parseFilesConfig.ts`, line 126-150 ([link](https://github.com/generaltranslation/gt/blob/1cf0b9bdb6e698f85156e54e9b08e181e84523dc/packages/cli/src/fs/config/parseFilesConfig.ts#L126-L150)) 

   **Publish path matching uses default locale, breaking multi-locale patterns**

   `toAbsoluteGlob` replaces `[locale]` with the single `locale` argument passed into `resolveFiles`. The `resolvedPaths` from `expandGlobPatterns` are also scoped to that locale (default locale). This means patterns like `[locale]/**/*.json` work correctly when the user includes the default locale, but the resolved absolute paths stored in `publishPaths` / `unpublishPaths` only cover **one locale** — the default.

   In `shouldPublishFile` (called from `aggregateFiles.ts`), the absolute path of each file is checked against these sets. Since `aggregateFiles` operates on `settings.files.resolvedPaths`, which contains default-locale paths, the lookup will match. But if any code downstream were to check publish status for non-default locale paths, those paths would not be in the set and would silently fall back to the global publish flag. This is worth documenting at minimum to avoid future regressions.

6. `packages/cli/src/cli/commands/translate.ts`, line 56 ([link](https://github.com/generaltranslation/gt/blob/0da1f3c0d4596dd8410cb41dbdcc0803c7ca6aec/packages/cli/src/cli/commands/translate.ts#L56)) 

   **`some(Boolean)` guard silently skips explicit unpublish-only operations**

   The condition `Array.from(publishMap.values()).some(Boolean)` only triggers the publish API when at least one file has `publish: true`. This breaks the explicit unpublish scenario:

   1. User configures `settings.publish: true` globally.
   2. Files are published on the CDN via a prior run.
   3. User changes their config to explicitly opt **all** files out: `{ path: "...", publish: false }` in their include patterns.
   4. `shouldPublishFile` returns `false` for every file (they are all in `unpublishPaths`).
   5. `publishMap` contains only `false` values → `some(Boolean)` is `false` → API call never made → files remain published on the CDN despite the explicit opt-out.

   The fix is to also trigger when there are any files in `unpublishPaths`:

   

   This ensures the API is called whenever there are explicit unpublish intentions, not only when at least one file is being published.

7. `packages/cli/src/cli/commands/translate.ts`, line 57-65 ([link](https://github.com/generaltranslation/gt/blob/0da1f3c0d4596dd8410cb41dbdcc0803c7ca6aec/packages/cli/src/cli/commands/translate.ts#L57-L65)) 

   **`allFileRefs` sends every translated file to the publish API, including files with no explicit CDN intent**

   `Object.entries(fileVersionData)` iterates over **all** staged files, and `publishMap.get(fileId) ?? false` defaults to `false` for any file absent from the map. This means files that the user never intended to manage on the CDN (and that may not even be in `publishPaths`/`unpublishPaths`) will be sent with `publish: false` to the endpoint — effectively issuing an active unpublish request for them.

   For the more common mixed scenario (global `publish: false`, some files explicitly `publish: true`), every other translated file will receive a spurious `publish: false` in the same batch call.

   Filtering `allFileRefs` to only include files that are actually represented in the `publishMap` (which is already trimmed of stale/skipped entries by `aggregateFiles`) would prevent this:

   ```ts
   const allFileRefs = Object.entries(fileVersionData)
     .filter(([fileId]) => publishMap.has(fileId))
     .map(([fileId, data]) => ({
       fileId,
       versionId: data.versionId,
       branchId: branchData?.currentBranch.id,
       publish: publishMap.get(fileId)!,
       fileName: data.fileName,
     }));
   ```

8. `packages/cli/src/cli/commands/translate.ts`, line 57-70 ([link](https://github.com/generaltranslation/gt/blob/3479a7900ba64de6cf774659ccda3197903676be/packages/cli/src/cli/commands/translate.ts#L57-L70)) 

   **Files not re-staged in the current run are silently skipped for publish**

   `fileVersionData` only contains entries for files that were staged in the current run. If a file's content hasn't changed (so it isn't re-staged), it won't appear in `fileVersionData` and will be silently filtered out here — even if the user explicitly configured `publish: true` for that file.

   This means a first-time `translate` run that doesn't upload any changes won't publish those files to the CDN, leaving the user wondering why their publish config had no effect. Consider whether files with an explicit `publish: true` flag that are absent from `fileVersionData` should still be sent to the publish API using the version IDs from a previous download/cache.


9. `packages/cli/src/utils/resolvePublish.ts`, line 22-28 ([link](https://github.com/generaltranslation/gt/blob/3479a7900ba64de6cf774659ccda3197903676be/packages/cli/src/utils/resolvePublish.ts#L22-L28)) 

   **`hasPublishConfig` returns `true` for explicit opt-outs, triggering unnecessary API calls**

   When only `gt.publish: false` is set (no `publish: true` anywhere), `gtPublish !== undefined` is `true`, so `hasPublishConfig` returns `true`. This causes the publish step to fire and call the API with `publish: false` for every file — even if the files have never been published to the CDN. For a pure opt-out / default-off configuration this generates a pointless API round-trip on every translate run.

   Consider tightening the guard so that it returns `true` only when at least one file would be published (i.e., when `publish === true`, `gtPublish === true`, or `publishPaths.size > 0`), and that unpublish paths/flags are only actionable when there is concrete evidence a prior publish was performed (e.g. a local state file).

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/cli/src/formats/files/aggregateFiles.ts
Line: 374-379

Comment:
**Mutating a Map while iterating its own keys iterator**

Deleting entries from a `Map` while iterating over `map.keys()` is technically safe in JavaScript (deleted-but-not-yet-visited entries are skipped), but it's an unusual pattern that can surprise readers and may trip up some static-analysis tools. A simple spread avoids the ambiguity:

```suggestion
  const validFileIds = new Set(allFiles.map((f) => f.fileId));
  for (const fileId of [...publishMap.keys()]) {
    if (!validFileIds.has(fileId)) {
      publishMap.delete(fileId);
    }
  }
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/cli/src/cli/commands/translate.ts
Line: 57-70

Comment:
**Files not re-staged in the current run are silently skipped for publish**

`fileVersionData` only contains entries for files that were staged in the current run. If a file's content hasn't changed (so it isn't re-staged), it won't appear in `fileVersionData` and will be silently filtered out here — even if the user explicitly configured `publish: true` for that file.

This means a first-time `translate` run that doesn't upload any changes won't publish those files to the CDN, leaving the user wondering why their publish config had no effect. Consider whether files with an explicit `publish: true` flag that are absent from `fileVersionData` should still be sent to the publish API using the version IDs from a previous download/cache.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/cli/src/utils/resolvePublish.ts
Line: 22-28

Comment:
**`hasPublishConfig` returns `true` for explicit opt-outs, triggering unnecessary API calls**

When only `gt.publish: false` is set (no `publish: true` anywhere), `gtPublish !== undefined` is `true`, so `hasPublishConfig` returns `true`. This causes the publish step to fire and call the API with `publish: false` for every file — even if the files have never been published to the CDN. For a pure opt-out / default-off configuration this generates a pointless API round-trip on every translate run.

Consider tightening the guard so that it returns `true` only when at least one file would be published (i.e., when `publish === true`, `gtPublish === true`, or `publishPaths.size > 0`), and that unpublish paths/flags are only actionable when there is concrete evidence a prior publish was performed (e.g. a local state file).

```suggestion
export function hasPublishConfig(settings: Settings): boolean {
  return (
    settings.publish === true ||
    settings.files.gtPublish === true ||
    (settings.files.publishPaths?.size ?? 0) > 0 ||
    (settings.files.unpublishPaths?.size ?? 0) > 0
  );
}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["fix: publishing chec..."](https://github.com/generaltranslation/gt/commit/3479a7900ba64de6cf774659ccda3197903676be)</sub>

<!-- /greptile_comment -->