### PR TITLE
F/move source code

### DIFF
--- a/.changeset/plenty-brooms-hug.md
+++ b/.changeset/plenty-brooms-hug.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+Move includeSourceCodeContext flag into files.gt

--- a/assets/config-schema.json
+++ b/assets/config-schema.json
@@ -107,6 +107,11 @@
                 "public/i18n/[locale].json",
                 "translations/[locale].json"
               ]
+            },
+            "includeSourceCodeContext": {
+              "type": "boolean",
+              "description": "Include surrounding source code lines as context for translations. Only applies to library users that send GT JSON for translation.",
+              "default": false
             }
           },
           "required": ["output"],

--- a/packages/cli/src/fs/config/parseFilesConfig.ts
+++ b/packages/cli/src/fs/config/parseFilesConfig.ts
@@ -54,6 +54,7 @@ export function resolveFiles(
   resolvedPaths: ResolvedFiles;
   placeholderPaths: ResolvedFiles;
   transformPaths: TransformFiles;
+  includeSourceCodeContext?: boolean;
 } {
   // Initialize result object with empty arrays for each file type
   const result: ResolvedFiles = {};
@@ -96,6 +97,7 @@ export function resolveFiles(
     resolvedPaths: result,
     placeholderPaths: placeholderResult,
     transformPaths: transformPaths,
+    includeSourceCodeContext: files.gt?.includeSourceCodeContext,
   };
 }
 

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.10.4';
+export const PACKAGE_VERSION = '2.10.7';

--- a/packages/cli/src/translation/stage.ts
+++ b/packages/cli/src/translation/stage.ts
@@ -32,7 +32,7 @@ export async function aggregateInlineTranslations(
     library,
     false,
     settings.parsingOptions,
-    settings.options?.includeSourceCodeContext ?? false
+    settings.files?.includeSourceCodeContext ?? false
   );
 
   if (warnings.length > 0) {

--- a/packages/cli/src/translation/validate.ts
+++ b/packages/cli/src/translation/validate.ts
@@ -32,7 +32,7 @@ async function runValidation(
       true,
       files,
       settings.parsingOptions,
-      settings.options?.includeSourceCodeContext ?? false
+      settings.files?.includeSourceCodeContext ?? false
     );
   }
 
@@ -56,7 +56,7 @@ async function runValidation(
     pkg,
     true,
     settings.parsingOptions,
-    settings.options?.includeSourceCodeContext ?? false
+    settings.files?.includeSourceCodeContext ?? false
   );
 }
 

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -184,6 +184,7 @@ export type FilesOptions = {
 } & {
   gt?: {
     output: string; // Output glob: /path/[locale].json
+    includeSourceCodeContext?: boolean; // Include surrounding source code lines as context for translations (default: false)
   };
 };
 
@@ -202,6 +203,7 @@ export type Settings = {
     resolvedPaths: ResolvedFiles; // Absolute resolved paths for the default locale
     placeholderPaths: ResolvedFiles; // Absolute placeholder paths for all locales containing [locale]
     transformPaths: TransformFiles; // Absolute transform paths for all locales containing [locale]
+    includeSourceCodeContext?: boolean; // Include surrounding source code lines as context for translations (default: false)
   };
   stageTranslations: boolean; // if true, always stage the project during translate command
   publish: boolean; // if true, publish the translations to the CDN
@@ -263,7 +265,6 @@ export type AdditionalOptions = {
     replace: string; // replacement prefix, can include [locale] or [defaultLocale]
   }>;
   experimentalCanonicalLocaleKeys?: boolean; // For composite JSON schemas with locale keys, force canonical locale even when alias provided
-  includeSourceCodeContext?: boolean; // Include surrounding source code lines as context for translations (default: false)
 };
 
 export type SharedStaticAssetsConfig = {


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR relocates the `includeSourceCodeContext` configuration flag from `AdditionalOptions` (the `options` block in the config file) into `FilesOptions.gt` (the `files.gt` block), making it logically co-located with the other GT-specific file settings. The wiring is updated consistently across `parseFilesConfig.ts`, `stage.ts`, and `validate.ts`, and the JSON config schema is kept in sync.

**Key changes:**
- `includeSourceCodeContext` added to `FilesOptions.gt` and `Settings.files`; removed from `AdditionalOptions`
- `resolveFiles()` now surfaces the flag from `files.gt?.includeSourceCodeContext` in its return value
- All call sites in `stage.ts` and `validate.ts` updated from `settings.options?.includeSourceCodeContext` → `settings.files?.includeSourceCodeContext`
- JSON schema updated to document the new location under `files.gt`
- **Concern:** Any existing user who had `options.includeSourceCodeContext: true` in their config will silently lose the setting with no warning or migration path — this is a breaking change that is misclassified as a `patch` in the changeset.

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

- Safe to merge functionally, but the breaking config change and incorrect semver bump should be addressed first.
- The code changes themselves are correct and consistent — the flag is properly threaded from config parsing through to the call sites. The risk is the silent breaking change: users with `options.includeSourceCodeContext: true` in their config will have the feature silently disabled after upgrading, and the changeset is incorrectly classified as a patch rather than a minor or major bump.
- `packages/cli/src/types/index.ts` and `.changeset/plenty-brooms-hug.md` need attention for the missing migration/deprecation path and incorrect semver classification.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .changeset/plenty-brooms-hug.md | Changeset marks this as a patch, but the change removes a user-facing config option from its previous location (options.includeSourceCodeContext) — this is a potentially breaking change that should be at least a minor bump. |
| packages/cli/src/types/index.ts | Moves includeSourceCodeContext from AdditionalOptions to FilesOptions.gt and Settings.files. The structural change is correct, but silently breaks existing configs that used the old options path without a deprecation warning. |
| packages/cli/src/fs/config/parseFilesConfig.ts | Correctly threads includeSourceCodeContext through resolveFiles() return value from files.gt?.includeSourceCodeContext. |
| packages/cli/src/translation/stage.ts | Correctly updates the lookup path from settings.options?.includeSourceCodeContext to settings.files?.includeSourceCodeContext. |
| packages/cli/src/translation/validate.ts | Correctly updates both call sites from settings.options?.includeSourceCodeContext to settings.files?.includeSourceCodeContext. |
| assets/config-schema.json | Adds includeSourceCodeContext to the files.gt JSON schema definition, keeping the schema in sync with the type changes. |
| packages/cli/src/generated/version.ts | Auto-generated version bump from 2.10.4 to 2.10.7, skipping two patch versions — likely reflects other changes merged concurrently; low risk. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["gt.config file\n(files.gt.includeSourceCodeContext)"] -->|parsed by| B["resolveFiles()\nparseFilesConfig.ts"]
    B -->|returns includeSourceCodeContext| C["Settings.files.includeSourceCodeContext"]
    C -->|read by| D["aggregateInlineTranslations()\nstage.ts"]
    C -->|read by| E["runValidation()\nvalidate.ts"]
    D -->|passed to| F["createUpdates()"]
    E -->|passed to| G["createUpdates() / createInlineUpdates()"]

    style A fill:#f9f,stroke:#333
    style C fill:#bbf,stroke:#333
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/cli/src/types/index.ts
Line: 265

Comment:
**Silent breaking change for existing `options.includeSourceCodeContext` users**

The `includeSourceCodeContext` flag has been removed from `AdditionalOptions` (i.e., the `options` block in the config file) and moved to `files.gt`. Any user who previously configured this as:

```json
{
  "options": {
    "includeSourceCodeContext": true
  }
}
```

will now silently have the feature disabled after upgrading, because the old field is gone and there is no backward-compatibility shim or deprecation warning. The value `settings.options?.includeSourceCodeContext` will now be `undefined` everywhere, defaulting to `false`. Consider adding a config-parse-time warning that reads the old `options.includeSourceCodeContext` path and instructs the user to migrate to `files.gt.includeSourceCodeContext`.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .changeset/plenty-brooms-hug.md
Line: 2

Comment:
**Breaking change misclassified as a patch**

Removing `includeSourceCodeContext` from `AdditionalOptions` and moving it to `files.gt` is a breaking change for any existing user who had the option set under `options` in their config. Changesets that remove or relocate a user-facing configuration key should typically be bumped to at least a `minor` (or `major` if the package follows semver strictly for config API changes), not a `patch`.

```suggestion
---
'gt': minor
---

Move includeSourceCodeContext flag into files.gt
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["chore: changeset"](https://github.com/generaltranslation/gt/commit/98843a82586c0cd6488cbda024f5e78002b85942)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->