### PR TITLE
fix: update logo URLs to /brand/ path

### DIFF
--- a/.changeset/fix-logo-urls.md
+++ b/.changeset/fix-logo-urls.md
@@ -1,0 +1,21 @@
+---
+"gt": patch
+"gtx-cli": patch
+"@generaltranslation/compiler": patch
+"generaltranslation": patch
+"gt-i18n": patch
+"locadex": patch
+"@generaltranslation/mcp": patch
+"@generaltranslation/next-internal": patch
+"@generaltranslation/gt-next-lint": patch
+"gt-next": patch
+"@generaltranslation/react-core-linter": patch
+"@generaltranslation/react-core": patch
+"gt-react": patch
+"gt-remark": patch
+"gt-sanity": patch
+"@generaltranslation/supported-locales": patch
+"gt-tanstack-start": patch
+---
+
+Fix logo URLs in README files (updated to `/brand/gt-logo-*.svg`)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <div align="center">
   <a href="https://generaltranslation.com">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://generaltranslation.com/gt-logo-dark.svg">
-      <img alt="General Translation" src="https://generaltranslation.com/gt-logo-light.svg" height="128">
+      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/brand/gt-logo-light.svg">
+      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-dark.svg" height="128">
     </picture>
   </a>
   <h1>General Translation</h1>

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://generaltranslation.com" target="_blank">
-    <img src="https://generaltranslation.com/gt-logo-light.svg" alt="General Translation" width="100" height="100">
+    <img src="https://generaltranslation.com/brand/gt-logo-light.svg" alt="General Translation" width="100" height="100">
   </a>
 </p>
 
@@ -15,7 +15,7 @@ Use this template for each example app's README:
 ```markdown
 <p align="center">
   <a href="https://generaltranslation.com" target="_blank">
-    <img src="https://generaltranslation.com/gt-logo-light.svg" alt="General Translation" width="100" height="100">
+    <img src="https://generaltranslation.com/brand/gt-logo-light.svg" alt="General Translation" width="100" height="100">
   </a>
 </p>
 

--- a/examples/create-react-app/README.md
+++ b/examples/create-react-app/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://generaltranslation.com" target="_blank">
-    <img src="https://generaltranslation.com/gt-logo-light.svg" alt="General Translation" width="100" height="100">
+    <img src="https://generaltranslation.com/brand/gt-logo-light.svg" alt="General Translation" width="100" height="100">
   </a>
 </p>
 

--- a/examples/next-chatbot/README.md
+++ b/examples/next-chatbot/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://generaltranslation.com" target="_blank">
-    <img src="https://generaltranslation.com/gt-logo-light.svg" alt="General Translation" width="100" height="100">
+    <img src="https://generaltranslation.com/brand/gt-logo-light.svg" alt="General Translation" width="100" height="100">
   </a>
 </p>
 

--- a/examples/next-create-app/README.md
+++ b/examples/next-create-app/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://generaltranslation.com" target="_blank">
-    <img src="https://generaltranslation.com/gt-logo-light.svg" alt="General Translation" width="100" height="100">
+    <img src="https://generaltranslation.com/brand/gt-logo-light.svg" alt="General Translation" width="100" height="100">
   </a>
 </p>
 

--- a/examples/next-gt-starter/README.md
+++ b/examples/next-gt-starter/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://generaltranslation.com" target="_blank">
-    <img src="https://generaltranslation.com/gt-logo-light.svg" alt="General Translation" width="100" height="100">
+    <img src="https://generaltranslation.com/brand/gt-logo-light.svg" alt="General Translation" width="100" height="100">
   </a>
 </p>
 

--- a/examples/next-pages-router/README.md
+++ b/examples/next-pages-router/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://generaltranslation.com" target="_blank">
-    <img src="https://generaltranslation.com/gt-logo-light.svg" alt="General Translation" width="100" height="100">
+    <img src="https://generaltranslation.com/brand/gt-logo-light.svg" alt="General Translation" width="100" height="100">
   </a>
 </p>
 

--- a/examples/next-ssg/README.md
+++ b/examples/next-ssg/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://generaltranslation.com" target="_blank">
-    <img src="https://generaltranslation.com/gt-logo-light.svg" alt="General Translation" width="100" height="100">
+    <img src="https://generaltranslation.com/brand/gt-logo-light.svg" alt="General Translation" width="100" height="100">
   </a>
 </p>
 

--- a/examples/vite-create-app/README.md
+++ b/examples/vite-create-app/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://generaltranslation.com" target="_blank">
-    <img src="https://generaltranslation.com/gt-logo-light.svg" alt="General Translation" width="100" height="100">
+    <img src="https://generaltranslation.com/brand/gt-logo-light.svg" alt="General Translation" width="100" height="100">
   </a>
 </p>
 

--- a/packages/README.md
+++ b/packages/README.md
@@ -12,9 +12,8 @@ When creating a new package, use this README template:
 <p align="center">
   <a href="https://generaltranslation.com/docs/PACKAGE_NAME">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://generaltranslation.com/gt-logo-dark.svg">
-      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/gt-logo-light.svg">
-      <img alt="General Translation" src="https://generaltranslation.com/gt-logo-light.svg" width="100" height="100">
+      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/brand/gt-logo-light.svg">
+      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-dark.svg" width="100" height="100">
     </picture>
   </a>
 </p>

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,9 +1,8 @@
 <p align="center">
   <a href="https://generaltranslation.com/docs/cli">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://generaltranslation.com/gt-logo-dark.svg">
-      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/gt-logo-light.svg">
-      <img alt="General Translation" src="https://generaltranslation.com/gt-logo-light.svg" width="100" height="100">
+      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/brand/gt-logo-light.svg">
+      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-dark.svg" width="100" height="100">
     </picture>
   </a>
 </p>

--- a/packages/compiler/README.md
+++ b/packages/compiler/README.md
@@ -1,9 +1,8 @@
 <p align="center">
   <a href="https://generaltranslation.com/docs">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://generaltranslation.com/gt-logo-dark.svg">
-      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/gt-logo-light.svg">
-      <img alt="General Translation" src="https://generaltranslation.com/gt-logo-light.svg" width="100" height="100">
+      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/brand/gt-logo-light.svg">
+      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-dark.svg" width="100" height="100">
     </picture>
   </a>
 </p>

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,9 +1,8 @@
 <p align="center">
   <a href="https://generaltranslation.com/docs">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://generaltranslation.com/gt-logo-dark.svg">
-      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/gt-logo-light.svg">
-      <img alt="General Translation" src="https://generaltranslation.com/gt-logo-light.svg" width="100" height="100">
+      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/brand/gt-logo-light.svg">
+      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-dark.svg" width="100" height="100">
     </picture>
   </a>
 </p>

--- a/packages/gtx-cli/README.md
+++ b/packages/gtx-cli/README.md
@@ -1,9 +1,8 @@
 <p align="center">
   <a href="https://generaltranslation.com/docs/cli">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://generaltranslation.com/gt-logo-dark.svg">
-      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/gt-logo-light.svg">
-      <img alt="General Translation" src="https://generaltranslation.com/gt-logo-light.svg" width="100" height="100">
+      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/brand/gt-logo-light.svg">
+      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-dark.svg" width="100" height="100">
     </picture>
   </a>
 </p>

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -1,9 +1,8 @@
 <p align="center">
   <a href="https://generaltranslation.com/docs/i18n">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://generaltranslation.com/gt-logo-dark.svg">
-      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/gt-logo-light.svg">
-      <img alt="General Translation" src="https://generaltranslation.com/gt-logo-light.svg" width="100" height="100">
+      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/brand/gt-logo-light.svg">
+      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-dark.svg" width="100" height="100">
     </picture>
   </a>
 </p>

--- a/packages/locadex/README.md
+++ b/packages/locadex/README.md
@@ -1,9 +1,8 @@
 <p align="center">
   <a href="https://generaltranslation.com/docs/locadex">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://generaltranslation.com/gt-logo-dark.svg">
-      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/gt-logo-light.svg">
-      <img alt="General Translation" src="https://generaltranslation.com/gt-logo-light.svg" width="100" height="100">
+      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/brand/gt-logo-light.svg">
+      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-dark.svg" width="100" height="100">
     </picture>
   </a>
 </p>

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,9 +1,8 @@
 <p align="center">
   <a href="https://generaltranslation.com/docs">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://generaltranslation.com/gt-logo-dark.svg">
-      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/gt-logo-light.svg">
-      <img alt="General Translation" src="https://generaltranslation.com/gt-logo-light.svg" width="100" height="100">
+      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/brand/gt-logo-light.svg">
+      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-dark.svg" width="100" height="100">
     </picture>
   </a>
 </p>

--- a/packages/next-internal/README.md
+++ b/packages/next-internal/README.md
@@ -1,9 +1,8 @@
 <p align="center">
   <a href="https://generaltranslation.com/docs/next">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://generaltranslation.com/gt-logo-dark.svg">
-      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/gt-logo-light.svg">
-      <img alt="General Translation" src="https://generaltranslation.com/gt-logo-light.svg" width="100" height="100">
+      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/brand/gt-logo-light.svg">
+      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-dark.svg" width="100" height="100">
     </picture>
   </a>
 </p>

--- a/packages/next-lint/README.md
+++ b/packages/next-lint/README.md
@@ -1,9 +1,8 @@
 <p align="center">
   <a href="https://generaltranslation.com/docs/next">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://generaltranslation.com/gt-logo-dark.svg">
-      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/gt-logo-light.svg">
-      <img alt="General Translation" src="https://generaltranslation.com/gt-logo-light.svg" width="100" height="100">
+      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/brand/gt-logo-light.svg">
+      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-dark.svg" width="100" height="100">
     </picture>
   </a>
 </p>

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -1,9 +1,8 @@
 <p align="center">
   <a href="https://generaltranslation.com/docs/next">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://generaltranslation.com/gt-logo-dark.svg">
-      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/gt-logo-light.svg">
-      <img alt="General Translation" src="https://generaltranslation.com/gt-logo-light.svg" width="100" height="100">
+      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/brand/gt-logo-light.svg">
+      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-dark.svg" width="100" height="100">
     </picture>
   </a>
 </p>

--- a/packages/react-core-linter/README.md
+++ b/packages/react-core-linter/README.md
@@ -1,9 +1,8 @@
 <p align="center">
   <a href="https://generaltranslation.com/docs/react-core-linter">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://generaltranslation.com/gt-logo-dark.svg">
-      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/gt-logo-light.svg">
-      <img alt="General Translation" src="https://generaltranslation.com/gt-logo-light.svg" width="100" height="100">
+      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/brand/gt-logo-light.svg">
+      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-dark.svg" width="100" height="100">
     </picture>
   </a>
 </p>

--- a/packages/react-core/README.md
+++ b/packages/react-core/README.md
@@ -1,9 +1,8 @@
 <p align="center">
   <a href="https://generaltranslation.com/docs/react">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://generaltranslation.com/gt-logo-dark.svg">
-      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/gt-logo-light.svg">
-      <img alt="General Translation" src="https://generaltranslation.com/gt-logo-light.svg" width="100" height="100">
+      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/brand/gt-logo-light.svg">
+      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-dark.svg" width="100" height="100">
     </picture>
   </a>
 </p>

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,9 +1,8 @@
 <p align="center">
   <a href="https://generaltranslation.com/docs/react">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://generaltranslation.com/gt-logo-dark.svg">
-      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/gt-logo-light.svg">
-      <img alt="General Translation" src="https://generaltranslation.com/gt-logo-light.svg" width="100" height="100">
+      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/brand/gt-logo-light.svg">
+      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-dark.svg" width="100" height="100">
     </picture>
   </a>
 </p>

--- a/packages/remark/README.md
+++ b/packages/remark/README.md
@@ -1,9 +1,8 @@
 <p align="center">
   <a href="https://generaltranslation.com/docs">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://generaltranslation.com/gt-logo-dark.svg">
-      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/gt-logo-light.svg">
-      <img alt="General Translation" src="https://generaltranslation.com/gt-logo-light.svg" width="100" height="100">
+      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/brand/gt-logo-light.svg">
+      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-dark.svg" width="100" height="100">
     </picture>
   </a>
 </p>

--- a/packages/sanity/README.md
+++ b/packages/sanity/README.md
@@ -1,9 +1,8 @@
 <p align="center">
   <a href="https://generaltranslation.com/docs/sanity">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://generaltranslation.com/gt-logo-dark.svg">
-      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/gt-logo-light.svg">
-      <img alt="General Translation" src="https://generaltranslation.com/gt-logo-light.svg" width="100" height="100">
+      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/brand/gt-logo-light.svg">
+      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-dark.svg" width="100" height="100">
     </picture>
   </a>
 </p>

--- a/packages/supported-locales/README.md
+++ b/packages/supported-locales/README.md
@@ -1,9 +1,8 @@
 <p align="center">
   <a href="https://generaltranslation.com/docs">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://generaltranslation.com/gt-logo-dark.svg">
-      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/gt-logo-light.svg">
-      <img alt="General Translation" src="https://generaltranslation.com/gt-logo-light.svg" width="100" height="100">
+      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/brand/gt-logo-light.svg">
+      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-dark.svg" width="100" height="100">
     </picture>
   </a>
 </p>

--- a/packages/tanstack-start/README.md
+++ b/packages/tanstack-start/README.md
@@ -1,9 +1,8 @@
 <p align="center">
   <a href="https://generaltranslation.com/docs/tanstack-start">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://generaltranslation.com/gt-logo-dark.svg">
-      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/gt-logo-light.svg">
-      <img alt="General Translation" src="https://generaltranslation.com/gt-logo-light.svg" width="100" height="100">
+      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/brand/gt-logo-light.svg">
+      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-dark.svg" width="100" height="100">
     </picture>
   </a>
 </p>


### PR DESCRIPTION
Updates all README logo URLs from `generaltranslation.com/gt-logo-*.svg` to `generaltranslation.com/brand/gt-logo-*.svg`.

Also fixes the `<picture>` tag logic so the light logo shows in light mode and dark logo is the default (matching #1111).

**27 files updated** across root, packages, and examples.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates all README logo URLs from `generaltranslation.com/gt-logo-*.svg` to `generaltranslation.com/brand/gt-logo-*.svg` across 27 files. It also streamlines the `<picture>` element used in package READMEs — replacing the previous two-`<source>` approach with a single light-mode `<source>` and a dark logo as the `<img>` fallback (making dark the default, matching #1111).

**Key changes:**
- All logo `src`/`srcset` URLs moved to the `/brand/` sub-path.
- Package READMEs now use one `<source media="(prefers-color-scheme: light)">` and the dark logo as the `<img>` default, so dark-mode and "no-preference" environments both display the dark logo.
- Example READMEs continue to use a plain `<img>` with the light logo URL (pre-existing pattern, no dark-mode support in examples — this appears intentional).
- `packages/react-core-linter/README.md` gains a trailing newline (minor cleanup).
- All 27 files are updated consistently with no missed occurrences.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge — all changes are purely documentation/markdown with no production code impact.
- Changes are limited to README files updating static image URLs and simplifying `<picture>` tag markup. The pattern is applied consistently across all 27 files, matches the stated intent (dark logo as default per #1111), and carries zero risk of runtime regressions.
- No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Root README updated: logo URL moved to `/brand/` path and `<picture>` logic switched to one `<source>` (light mode) with dark logo as the `<img>` fallback. |
| packages/README.md | Package template README updated: two `<source>` elements collapsed to one (light-mode only), dark logo set as default `<img>` fallback, URLs moved to `/brand/` path. |
| packages/next/README.md | Package README: logo URL updated to `/brand/` path and `<picture>` tag simplified to single light-mode source with dark fallback — consistent with all other package READMEs. |
| examples/README.md | Example template README: simple `<img>` URL updated to `/brand/` path; no `<picture>` element — examples intentionally use a static light logo (pre-existing pattern, unchanged by this PR). |
| packages/react-core-linter/README.md | Logo URL updated to `/brand/` path, `<picture>` tag simplified; also adds a trailing newline at end-of-file (minor cleanup). |
| packages/cli/README.md | Logo URL updated to `/brand/` path and `<picture>` tag simplified; change is consistent with all other package READMEs. |
| packages/react/README.md | Logo URL updated to `/brand/` path and `<picture>` tag simplified; consistent with all other package READMEs. |
| examples/create-react-app/README.md | Logo URL updated to `/brand/` path; uses simple `<img>` (no `<picture>`), consistent with the examples pattern. |
| examples/next-chatbot/README.md | Logo URL updated to `/brand/` path; simple `<img>` tag, consistent with examples pattern. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Browser renders README] --> B{Supports picture element?}
    B -- No --> C[Show dark logo fallback\ngt-logo-dark.svg]
    B -- Yes --> D{prefers-color-scheme?}
    D -- light --> E[Show light logo\n/brand/gt-logo-light.svg]
    D -- dark --> C
    D -- no-preference --> C
    style C fill:#2d2d2d,color:#fff
    style E fill:#f5f5f5,color:#000
```
</details>

<sub>Last reviewed commit: ["fix: update logo URL..."](https://github.com/generaltranslation/gt/commit/1e964a2de5be8ddfdde07db6e9323e2e7c2317d5)</sub>

<!-- /greptile_comment -->