### PR TITLE
F/extend publish actions

### DIFF
--- a/packages/cli/src/api/saveLocalEdits.ts
+++ b/packages/cli/src/api/saveLocalEdits.ts
@@ -7,6 +7,8 @@ import { logErrorAndExit } from '../console/logging.js';
 import { logger } from '../console/logger.js';
 import type { FileReference } from 'generaltranslation/types';
 import chalk from 'chalk';
+import { PublishStep } from '../workflows/steps/PublishStep.js';
+import { hasPublishConfig } from '../utils/resolvePublish.js';
 
 /**
  * Uploads current source files to obtain file references, then collects and sends
@@ -16,7 +18,7 @@ export async function saveLocalEdits(settings: Settings): Promise<void> {
   if (!settings.files) return;
 
   // Collect current files from config
-  const { files } = await aggregateFiles(settings);
+  const { files, publishMap } = await aggregateFiles(settings);
   if (!files.length) return;
 
   // run branch query to get branch id
@@ -41,4 +43,20 @@ export async function saveLocalEdits(settings: Settings): Promise<void> {
 
   await collectAndSendUserEditDiffs(uploads, settings);
   spinner.stop(chalk.green('Local edits saved successfully'));
+
+  // Publish/unpublish files after saving edits
+  if (hasPublishConfig(settings)) {
+    const allFileRefs = uploads
+      .filter((f) => publishMap.has(f.fileId))
+      .map((f) => ({
+        fileId: f.fileId,
+        versionId: f.versionId,
+        branchId: f.branchId,
+        publish: publishMap.get(f.fileId)!,
+        fileName: f.fileName,
+      }));
+    const publishStep = new PublishStep(gt);
+    await publishStep.run(allFileRefs);
+    await publishStep.wait();
+  }
 }

--- a/packages/cli/src/cli/commands/__tests__/upload.test.ts
+++ b/packages/cli/src/cli/commands/__tests__/upload.test.ts
@@ -60,6 +60,14 @@ function makeSettings(
     locales: ['es', 'fr'],
     projectId: 'test-project',
     apiKey: 'test-key',
+    files: {
+      resolvedPaths: {},
+      placeholderPaths: {},
+      transformPaths: {},
+      publishPaths: new Set<string>(),
+      unpublishPaths: new Set<string>(),
+      gtJson: {},
+    },
     ...overrides,
   } as Settings & UploadOptions;
 }

--- a/packages/cli/src/cli/commands/upload.ts
+++ b/packages/cli/src/cli/commands/upload.ts
@@ -20,7 +20,7 @@ import parseYaml from '../../formats/yaml/parseYaml.js';
 import type { FileToUpload } from 'generaltranslation/types';
 import { hashStringSync } from '../../utils/hash.js';
 import { hasValidCredentials } from './utils/validation.js';
-import { shouldPublishFile } from '../../utils/resolvePublish.js';
+import { buildPublishMap } from '../../utils/resolvePublish.js';
 
 const SUPPORTED_DATA_FORMATS = ['JSX', 'ICU', 'I18NEXT'];
 
@@ -249,16 +249,7 @@ export async function upload(
   });
 
   // Build publish map from resolved paths
-  const publishMap = new Map<string, boolean>();
-  for (const fileType of SUPPORTED_FILE_EXTENSIONS) {
-    if (filePaths[fileType]) {
-      for (const absolutePath of filePaths[fileType]) {
-        const relativePath = getRelative(absolutePath);
-        const fileId = hashStringSync(relativePath);
-        publishMap.set(fileId, shouldPublishFile(absolutePath, settings));
-      }
-    }
-  }
+  const publishMap = buildPublishMap(filePaths, settings);
 
   try {
     // Send all files in a single API call

--- a/packages/cli/src/cli/commands/upload.ts
+++ b/packages/cli/src/cli/commands/upload.ts
@@ -20,6 +20,7 @@ import parseYaml from '../../formats/yaml/parseYaml.js';
 import type { FileToUpload } from 'generaltranslation/types';
 import { hashStringSync } from '../../utils/hash.js';
 import { hasValidCredentials } from './utils/validation.js';
+import { shouldPublishFile } from '../../utils/resolvePublish.js';
 
 const SUPPORTED_DATA_FORMATS = ['JSX', 'ICU', 'I18NEXT'];
 
@@ -247,9 +248,25 @@ export async function upload(
     };
   });
 
+  // Build publish map from resolved paths
+  const publishMap = new Map<string, boolean>();
+  for (const fileType of SUPPORTED_FILE_EXTENSIONS) {
+    if (filePaths[fileType]) {
+      for (const absolutePath of filePaths[fileType]) {
+        const relativePath = getRelative(absolutePath);
+        const fileId = hashStringSync(relativePath);
+        publishMap.set(fileId, shouldPublishFile(absolutePath, settings));
+      }
+    }
+  }
+
   try {
     // Send all files in a single API call
-    await runUploadFilesWorkflow({ files: uploadData, options: settings });
+    await runUploadFilesWorkflow({
+      files: uploadData,
+      options: settings,
+      publishMap,
+    });
   } catch (error) {
     logErrorAndExit(`Error uploading files: ${error}`);
   }

--- a/packages/cli/src/config/generateSettings.ts
+++ b/packages/cli/src/config/generateSettings.ts
@@ -166,8 +166,14 @@ export async function generateSettings(
   // For human review, always stage the project
   mergedOptions.stageTranslations = mergedOptions.stageTranslations ?? false;
 
-  // Add publish if not provided
-  mergedOptions.publish = (gtConfig.publish || flags.publish) ?? false;
+  // Only set publish if explicitly provided in config or flags
+  // --publish flag is a boolean flag (true when passed, false as Commander default)
+  // so we only treat it as explicit when it's true
+  if (flags.publish) {
+    mergedOptions.publish = true;
+  } else if (gtConfig.publish !== undefined) {
+    mergedOptions.publish = gtConfig.publish;
+  }
 
   // Don't default src here — each pipeline (JS/Python) has its own defaults.
   // Only set src if the user explicitly provided it via flags or config.

--- a/packages/cli/src/formats/files/aggregateFiles.ts
+++ b/packages/cli/src/formats/files/aggregateFiles.ts
@@ -17,7 +17,7 @@ import {
   parseKeyedMetadata,
   type KeyedMetadata,
 } from '../parseKeyedMetadata.js';
-import { shouldPublishFile } from '../../utils/resolvePublish.js';
+import { buildPublishMap } from '../../utils/resolvePublish.js';
 
 /**
  * Checks if a file path is a metadata companion file (e.g. foo.metadata.json)
@@ -58,14 +58,9 @@ export async function aggregateFiles(
   const skipValidation = settings.options?.skipFileValidation;
 
   // Build publish map upfront from resolved paths
-  for (const fileType of SUPPORTED_FILE_EXTENSIONS) {
-    if (filePaths[fileType]) {
-      for (const absolutePath of filePaths[fileType]) {
-        const relativePath = getRelative(absolutePath);
-        const fileId = hashStringSync(relativePath);
-        publishMap.set(fileId, shouldPublishFile(absolutePath, settings));
-      }
-    }
+  const resolvedPublishMap = buildPublishMap(filePaths, settings);
+  for (const [fileId, shouldPublish] of resolvedPublishMap) {
+    publishMap.set(fileId, shouldPublish);
   }
 
   // Process JSON files

--- a/packages/cli/src/fs/__tests__/normalizeIncludePatterns.test.ts
+++ b/packages/cli/src/fs/__tests__/normalizeIncludePatterns.test.ts
@@ -31,9 +31,7 @@ describe('normalizeIncludePatterns', () => {
   });
 
   it('handles objects with no publish flag', () => {
-    const result = normalizeIncludePatterns([
-      { pattern: './docs/**/*.mdx' },
-    ]);
+    const result = normalizeIncludePatterns([{ pattern: './docs/**/*.mdx' }]);
     expect(result.paths).toEqual(['./docs/**/*.mdx']);
     expect(result.publishPatterns).toEqual([]);
     expect(result.unpublishPatterns).toEqual([]);

--- a/packages/cli/src/fs/__tests__/normalizeIncludePatterns.test.ts
+++ b/packages/cli/src/fs/__tests__/normalizeIncludePatterns.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeIncludePatterns } from '../config/parseFilesConfig.js';
+
+describe('normalizeIncludePatterns', () => {
+  it('handles plain string patterns', () => {
+    const result = normalizeIncludePatterns([
+      './docs/**/*.mdx',
+      './i18n/[locale].json',
+    ]);
+    expect(result.paths).toEqual(['./docs/**/*.mdx', './i18n/[locale].json']);
+    expect(result.publishPatterns).toEqual([]);
+    expect(result.unpublishPatterns).toEqual([]);
+  });
+
+  it('extracts pattern from objects with publish: true', () => {
+    const result = normalizeIncludePatterns([
+      { pattern: './marketing/**/*.mdx', publish: true },
+    ]);
+    expect(result.paths).toEqual(['./marketing/**/*.mdx']);
+    expect(result.publishPatterns).toEqual(['./marketing/**/*.mdx']);
+    expect(result.unpublishPatterns).toEqual([]);
+  });
+
+  it('extracts pattern from objects with publish: false', () => {
+    const result = normalizeIncludePatterns([
+      { pattern: './internal/**/*.json', publish: false },
+    ]);
+    expect(result.paths).toEqual(['./internal/**/*.json']);
+    expect(result.publishPatterns).toEqual([]);
+    expect(result.unpublishPatterns).toEqual(['./internal/**/*.json']);
+  });
+
+  it('handles objects with no publish flag', () => {
+    const result = normalizeIncludePatterns([
+      { pattern: './docs/**/*.mdx' },
+    ]);
+    expect(result.paths).toEqual(['./docs/**/*.mdx']);
+    expect(result.publishPatterns).toEqual([]);
+    expect(result.unpublishPatterns).toEqual([]);
+  });
+
+  it('handles mixed patterns', () => {
+    const result = normalizeIncludePatterns([
+      './docs/**/*.mdx',
+      { pattern: './marketing/**/*.mdx', publish: true },
+      { pattern: './internal/**/*.json', publish: false },
+      { pattern: './other/**/*.yaml' },
+    ]);
+    expect(result.paths).toEqual([
+      './docs/**/*.mdx',
+      './marketing/**/*.mdx',
+      './internal/**/*.json',
+      './other/**/*.yaml',
+    ]);
+    expect(result.publishPatterns).toEqual(['./marketing/**/*.mdx']);
+    expect(result.unpublishPatterns).toEqual(['./internal/**/*.json']);
+  });
+
+  it('handles empty array', () => {
+    const result = normalizeIncludePatterns([]);
+    expect(result.paths).toEqual([]);
+    expect(result.publishPatterns).toEqual([]);
+    expect(result.unpublishPatterns).toEqual([]);
+  });
+});

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -215,7 +215,7 @@ export type Settings = {
     };
   };
   stageTranslations: boolean; // if true, always stage the project during translate command
-  publish: boolean; // if true, publish the translations to the CDN
+  publish?: boolean; // if explicitly set, controls CDN publishing for all files
   _versionId?: string; // internal use only
   _branchId?: string; // internal use only
   version?: string; // for specifying a custom version id to use. Should be unique

--- a/packages/cli/src/utils/__tests__/resolvePublish.test.ts
+++ b/packages/cli/src/utils/__tests__/resolvePublish.test.ts
@@ -1,10 +1,18 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   shouldPublishFile,
   shouldPublishGt,
   hasPublishConfig,
+  buildPublishMap,
 } from '../resolvePublish.js';
 import { Settings } from '../../types/index.js';
+
+vi.mock('../../fs/findFilepath.js', () => ({
+  getRelative: vi.fn((p: string) => p),
+}));
+vi.mock('../hash.js', () => ({
+  hashStringSync: vi.fn((s: string) => `hash_${s}`),
+}));
 
 function createSettings(
   overrides: {
@@ -15,7 +23,7 @@ function createSettings(
   } = {}
 ): Settings {
   return {
-    publish: overrides.publish ?? false,
+    publish: overrides.publish,
     files: {
       resolvedPaths: {},
       placeholderPaths: {},
@@ -125,5 +133,72 @@ describe('hasPublishConfig', () => {
       unpublishPaths: new Set(['/abs/file.json']),
     });
     expect(hasPublishConfig(settings)).toBe(true);
+  });
+});
+
+describe('buildPublishMap', () => {
+  it('includes all files when global publish is true', () => {
+    const settings = createSettings({ publish: true });
+    const filePaths = { json: ['/abs/a.json', '/abs/b.json'] };
+    const map = buildPublishMap(filePaths, settings);
+    expect(map.size).toBe(2);
+    expect(map.get('hash_/abs/a.json')).toBe(true);
+    expect(map.get('hash_/abs/b.json')).toBe(true);
+  });
+
+  it('only includes explicitly configured files when no global flag', () => {
+    const settings = createSettings({
+      publishPaths: new Set(['/abs/a.json']),
+    });
+    const filePaths = { json: ['/abs/a.json', '/abs/b.json'] };
+    const map = buildPublishMap(filePaths, settings);
+    expect(map.size).toBe(1);
+    expect(map.get('hash_/abs/a.json')).toBe(true);
+    expect(map.has('hash_/abs/b.json')).toBe(false);
+  });
+
+  it('includes unpublish files when no global flag', () => {
+    const settings = createSettings({
+      unpublishPaths: new Set(['/abs/b.json']),
+    });
+    const filePaths = { json: ['/abs/a.json', '/abs/b.json'] };
+    const map = buildPublishMap(filePaths, settings);
+    expect(map.size).toBe(1);
+    expect(map.get('hash_/abs/b.json')).toBe(false);
+    expect(map.has('hash_/abs/a.json')).toBe(false);
+  });
+
+  it('global true with per-file opt-out', () => {
+    const settings = createSettings({
+      publish: true,
+      unpublishPaths: new Set(['/abs/b.json']),
+    });
+    const filePaths = { json: ['/abs/a.json', '/abs/b.json'] };
+    const map = buildPublishMap(filePaths, settings);
+    expect(map.size).toBe(2);
+    expect(map.get('hash_/abs/a.json')).toBe(true);
+    expect(map.get('hash_/abs/b.json')).toBe(false);
+  });
+
+  it('returns empty map when no files exist', () => {
+    const settings = createSettings({ publish: true });
+    const map = buildPublishMap({}, settings);
+    expect(map.size).toBe(0);
+  });
+
+  it('includes all files when global publish is explicitly false', () => {
+    const settings = createSettings({ publish: false });
+    const filePaths = { json: ['/abs/a.json', '/abs/b.json'] };
+    const map = buildPublishMap(filePaths, settings);
+    expect(map.size).toBe(2);
+    expect(map.get('hash_/abs/a.json')).toBe(false);
+    expect(map.get('hash_/abs/b.json')).toBe(false);
+  });
+
+  it('returns empty map when publish is unset and no explicit config', () => {
+    const settings = createSettings();
+    const filePaths = { json: ['/abs/a.json', '/abs/b.json'] };
+    const map = buildPublishMap(filePaths, settings);
+    expect(map.size).toBe(0);
   });
 });

--- a/packages/cli/src/utils/__tests__/resolvePublish.test.ts
+++ b/packages/cli/src/utils/__tests__/resolvePublish.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import {
+  shouldPublishFile,
+  shouldPublishGt,
+  hasPublishConfig,
+} from '../resolvePublish.js';
+import { Settings } from '../../types/index.js';
+
+function createSettings(
+  overrides: {
+    publish?: boolean;
+    publishPaths?: Set<string>;
+    unpublishPaths?: Set<string>;
+    gtJsonPublish?: boolean;
+  } = {}
+): Settings {
+  return {
+    publish: overrides.publish ?? false,
+    files: {
+      resolvedPaths: {},
+      placeholderPaths: {},
+      transformPaths: {},
+      publishPaths: overrides.publishPaths ?? new Set(),
+      unpublishPaths: overrides.unpublishPaths ?? new Set(),
+      gtJson: {
+        publish: overrides.gtJsonPublish,
+      },
+    },
+  } as Settings;
+}
+
+describe('shouldPublishFile', () => {
+  it('returns false when file is in unpublishPaths, even if global is true', () => {
+    const settings = createSettings({
+      publish: true,
+      unpublishPaths: new Set(['/abs/internal.json']),
+    });
+    expect(shouldPublishFile('/abs/internal.json', settings)).toBe(false);
+  });
+
+  it('returns true when file is in publishPaths, even if global is false', () => {
+    const settings = createSettings({
+      publish: false,
+      publishPaths: new Set(['/abs/marketing.json']),
+    });
+    expect(shouldPublishFile('/abs/marketing.json', settings)).toBe(true);
+  });
+
+  it('unpublishPaths takes priority over publishPaths', () => {
+    const settings = createSettings({
+      publishPaths: new Set(['/abs/file.json']),
+      unpublishPaths: new Set(['/abs/file.json']),
+    });
+    expect(shouldPublishFile('/abs/file.json', settings)).toBe(false);
+  });
+
+  it('falls back to global publish when file is in neither set', () => {
+    const settingsOn = createSettings({ publish: true });
+    const settingsOff = createSettings({ publish: false });
+    expect(shouldPublishFile('/abs/file.json', settingsOn)).toBe(true);
+    expect(shouldPublishFile('/abs/file.json', settingsOff)).toBe(false);
+  });
+
+  it('returns false when no config at all', () => {
+    const settings = createSettings();
+    expect(shouldPublishFile('/abs/file.json', settings)).toBe(false);
+  });
+});
+
+describe('shouldPublishGt', () => {
+  it('returns false when gtJson.publish is explicitly false', () => {
+    const settings = createSettings({
+      publish: true,
+      gtJsonPublish: false,
+    });
+    expect(shouldPublishGt(settings)).toBe(false);
+  });
+
+  it('returns true when gtJson.publish is explicitly true', () => {
+    const settings = createSettings({
+      publish: false,
+      gtJsonPublish: true,
+    });
+    expect(shouldPublishGt(settings)).toBe(true);
+  });
+
+  it('falls back to global publish when gtJson.publish is undefined', () => {
+    const settingsOn = createSettings({ publish: true });
+    const settingsOff = createSettings({ publish: false });
+    expect(shouldPublishGt(settingsOn)).toBe(true);
+    expect(shouldPublishGt(settingsOff)).toBe(false);
+  });
+});
+
+describe('hasPublishConfig', () => {
+  it('returns false when no publish config exists', () => {
+    const settings = createSettings();
+    expect(hasPublishConfig(settings)).toBe(false);
+  });
+
+  it('returns true when global publish is true', () => {
+    const settings = createSettings({ publish: true });
+    expect(hasPublishConfig(settings)).toBe(true);
+  });
+
+  it('returns true when gtJson.publish is explicitly set to true', () => {
+    const settings = createSettings({ gtJsonPublish: true });
+    expect(hasPublishConfig(settings)).toBe(true);
+  });
+
+  it('returns true when gtJson.publish is explicitly set to false', () => {
+    const settings = createSettings({ gtJsonPublish: false });
+    expect(hasPublishConfig(settings)).toBe(true);
+  });
+
+  it('returns true when publishPaths has entries', () => {
+    const settings = createSettings({
+      publishPaths: new Set(['/abs/file.json']),
+    });
+    expect(hasPublishConfig(settings)).toBe(true);
+  });
+
+  it('returns true when unpublishPaths has entries', () => {
+    const settings = createSettings({
+      unpublishPaths: new Set(['/abs/file.json']),
+    });
+    expect(hasPublishConfig(settings)).toBe(true);
+  });
+});

--- a/packages/cli/src/utils/resolvePublish.ts
+++ b/packages/cli/src/utils/resolvePublish.ts
@@ -44,15 +44,28 @@ export function shouldPublishGt(settings: Settings): boolean {
 /**
  * Builds a publish map from resolved file paths.
  * Maps fileId -> shouldPublish for each file.
+ *
+ * When a global publish flag is set, all files are included (global determines
+ * the default, per-file config overrides). When there's no global flag, only
+ * files with explicit per-pattern publish config are included.
  */
 export function buildPublishMap(
   filePaths: ResolvedFiles,
   settings: Settings
 ): Map<string, boolean> {
   const publishMap = new Map<string, boolean>();
+  const hasGlobal = settings.publish;
+
   for (const fileType of SUPPORTED_FILE_EXTENSIONS) {
     if (filePaths[fileType]) {
       for (const absolutePath of filePaths[fileType]) {
+        const isExplicit =
+          settings.files?.publishPaths?.has(absolutePath) ||
+          settings.files?.unpublishPaths?.has(absolutePath);
+
+        // Only include files with explicit config when there's no global flag
+        if (!hasGlobal && !isExplicit) continue;
+
         const relativePath = getRelative(absolutePath);
         const fileId = hashStringSync(relativePath);
         publishMap.set(fileId, shouldPublishFile(absolutePath, settings));

--- a/packages/cli/src/utils/resolvePublish.ts
+++ b/packages/cli/src/utils/resolvePublish.ts
@@ -1,4 +1,7 @@
-import { Settings } from '../types/index.js';
+import { ResolvedFiles, Settings } from '../types/index.js';
+import { SUPPORTED_FILE_EXTENSIONS } from '../formats/files/supportedFiles.js';
+import { getRelative } from '../fs/findFilepath.js';
+import { hashStringSync } from './hash.js';
 
 /**
  * Determines whether a file should be published based on the publish resolution logic:
@@ -36,4 +39,25 @@ export function shouldPublishGt(settings: Settings): boolean {
   if (settings.files.gtJson.publish === false) return false;
   if (settings.files.gtJson.publish === true) return true;
   return settings.publish;
+}
+
+/**
+ * Builds a publish map from resolved file paths.
+ * Maps fileId -> shouldPublish for each file.
+ */
+export function buildPublishMap(
+  filePaths: ResolvedFiles,
+  settings: Settings
+): Map<string, boolean> {
+  const publishMap = new Map<string, boolean>();
+  for (const fileType of SUPPORTED_FILE_EXTENSIONS) {
+    if (filePaths[fileType]) {
+      for (const absolutePath of filePaths[fileType]) {
+        const relativePath = getRelative(absolutePath);
+        const fileId = hashStringSync(relativePath);
+        publishMap.set(fileId, shouldPublishFile(absolutePath, settings));
+      }
+    }
+  }
+  return publishMap;
 }

--- a/packages/cli/src/utils/resolvePublish.ts
+++ b/packages/cli/src/utils/resolvePublish.ts
@@ -13,8 +13,8 @@ export function shouldPublishFile(
   resolvedPath: string,
   settings: Settings
 ): boolean {
-  if (settings.files?.unpublishPaths?.has(resolvedPath)) return false;
-  if (settings.files?.publishPaths?.has(resolvedPath)) return true;
+  if (settings.files.unpublishPaths?.has(resolvedPath)) return false;
+  if (settings.files.publishPaths?.has(resolvedPath)) return true;
   return settings.publish ?? false;
 }
 
@@ -25,9 +25,9 @@ export function shouldPublishFile(
 export function hasPublishConfig(settings: Settings): boolean {
   return (
     settings.publish ||
-    settings.files?.gtJson?.publish !== undefined ||
-    (settings.files?.publishPaths?.size ?? 0) > 0 ||
-    (settings.files?.unpublishPaths?.size ?? 0) > 0
+    settings.files.gtJson?.publish !== undefined ||
+    (settings.files.publishPaths?.size ?? 0) > 0 ||
+    (settings.files.unpublishPaths?.size ?? 0) > 0
   );
 }
 
@@ -36,8 +36,8 @@ export function hasPublishConfig(settings: Settings): boolean {
  * Uses the gt-specific publish flag if set, otherwise falls back to global.
  */
 export function shouldPublishGt(settings: Settings): boolean {
-  if (settings.files?.gtJson?.publish === false) return false;
-  if (settings.files?.gtJson?.publish === true) return true;
+  if (settings.files.gtJson?.publish === false) return false;
+  if (settings.files.gtJson?.publish === true) return true;
   return settings.publish;
 }
 
@@ -60,8 +60,8 @@ export function buildPublishMap(
     if (filePaths[fileType]) {
       for (const absolutePath of filePaths[fileType]) {
         const isExplicit =
-          settings.files?.publishPaths?.has(absolutePath) ||
-          settings.files?.unpublishPaths?.has(absolutePath);
+          settings.files.publishPaths?.has(absolutePath) ||
+          settings.files.unpublishPaths?.has(absolutePath);
 
         // Only include files with explicit config when there's no global flag
         if (!hasGlobal && !isExplicit) continue;

--- a/packages/cli/src/utils/resolvePublish.ts
+++ b/packages/cli/src/utils/resolvePublish.ts
@@ -13,8 +13,8 @@ export function shouldPublishFile(
   resolvedPath: string,
   settings: Settings
 ): boolean {
-  if (settings.files.unpublishPaths?.has(resolvedPath)) return false;
-  if (settings.files.publishPaths?.has(resolvedPath)) return true;
+  if (settings.files?.unpublishPaths?.has(resolvedPath)) return false;
+  if (settings.files?.publishPaths?.has(resolvedPath)) return true;
   return settings.publish ?? false;
 }
 
@@ -25,9 +25,9 @@ export function shouldPublishFile(
 export function hasPublishConfig(settings: Settings): boolean {
   return (
     settings.publish ||
-    settings.files.gtJson.publish !== undefined ||
-    (settings.files.publishPaths?.size ?? 0) > 0 ||
-    (settings.files.unpublishPaths?.size ?? 0) > 0
+    settings.files?.gtJson?.publish !== undefined ||
+    (settings.files?.publishPaths?.size ?? 0) > 0 ||
+    (settings.files?.unpublishPaths?.size ?? 0) > 0
   );
 }
 
@@ -36,8 +36,8 @@ export function hasPublishConfig(settings: Settings): boolean {
  * Uses the gt-specific publish flag if set, otherwise falls back to global.
  */
 export function shouldPublishGt(settings: Settings): boolean {
-  if (settings.files.gtJson.publish === false) return false;
-  if (settings.files.gtJson.publish === true) return true;
+  if (settings.files?.gtJson?.publish === false) return false;
+  if (settings.files?.gtJson?.publish === true) return true;
   return settings.publish;
 }
 

--- a/packages/cli/src/utils/resolvePublish.ts
+++ b/packages/cli/src/utils/resolvePublish.ts
@@ -24,7 +24,7 @@ export function shouldPublishFile(
  */
 export function hasPublishConfig(settings: Settings): boolean {
   return (
-    settings.publish ||
+    settings.publish !== undefined ||
     settings.files.gtJson?.publish !== undefined ||
     (settings.files.publishPaths?.size ?? 0) > 0 ||
     (settings.files.unpublishPaths?.size ?? 0) > 0
@@ -38,7 +38,7 @@ export function hasPublishConfig(settings: Settings): boolean {
 export function shouldPublishGt(settings: Settings): boolean {
   if (settings.files.gtJson?.publish === false) return false;
   if (settings.files.gtJson?.publish === true) return true;
-  return settings.publish;
+  return settings.publish ?? false;
 }
 
 /**
@@ -54,7 +54,8 @@ export function buildPublishMap(
   settings: Settings
 ): Map<string, boolean> {
   const publishMap = new Map<string, boolean>();
-  const hasGlobal = settings.publish;
+
+  const hasGlobal = settings.publish !== undefined;
 
   for (const fileType of SUPPORTED_FILE_EXTENSIONS) {
     if (filePaths[fileType]) {

--- a/packages/cli/src/workflows/upload.ts
+++ b/packages/cli/src/workflows/upload.ts
@@ -6,6 +6,8 @@ import { gt } from '../utils/gt.js';
 import { BranchStep } from './steps/BranchStep.js';
 import { UploadSourcesStep } from './steps/UploadSourcesStep.js';
 import { UploadTranslationsStep } from './steps/UploadTranslationsStep.js';
+import { PublishStep } from './steps/PublishStep.js';
+import { hasPublishConfig } from '../utils/resolvePublish.js';
 import type { FileToUpload } from 'generaltranslation/types';
 
 /**
@@ -17,12 +19,14 @@ import type { FileToUpload } from 'generaltranslation/types';
 export async function runUploadFilesWorkflow({
   files,
   options,
+  publishMap,
 }: {
   files: {
     source: FileToUpload;
     translations: FileToUpload[];
   }[];
   options: Settings;
+  publishMap?: Map<string, boolean>;
 }) {
   try {
     logger.message(
@@ -65,6 +69,22 @@ export async function runUploadFilesWorkflow({
     }
 
     logger.success('All files uploaded successfully');
+
+    // Publish/unpublish files after upload
+    if (publishMap && hasPublishConfig(options)) {
+      const allFileRefs = files
+        .filter((f) => publishMap.has(f.source.fileId))
+        .map((f) => ({
+          fileId: f.source.fileId,
+          versionId: f.source.versionId,
+          branchId: branchData.currentBranch.id,
+          publish: publishMap.get(f.source.fileId)!,
+          fileName: f.source.fileName,
+        }));
+      const publishStep = new PublishStep(gt);
+      await publishStep.run(allFileRefs);
+      await publishStep.wait();
+    }
   } catch (error) {
     return logErrorAndExit('Failed to upload files. ' + error);
   }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends the publish/unpublish pipeline so that per-file `publish` patterns (defined inline in `files.include` entries), a global `publish` flag, and the existing `gtJson.publish` flag all flow through a single shared `buildPublishMap` helper. The helper is called from both `aggregateFiles` and `cli/commands/upload`, eliminating the previously duplicated map-building loop. After a successful upload (or `saveLocalEdits`), a `PublishStep` is conditionally executed to push the resolved publish decisions to the API.

Key changes and concerns:

- **Breaking behaviour change in `hasPublishConfig`** — switching from `settings.publish ||` to `settings.publish !== undefined` means that `"publish": false` in `gt.config.json` now returns `true` from `hasPublishConfig` and causes **all files to be actively unpublished from the CDN** on every upload. Previously this setting was a no-op. Users upgrading with `"publish": false` in their config could silently lose published CDN content.
- **`buildPublishMap` correctly scopes the map** — when no global flag is set, only files with explicit per-pattern config are included, fixing the previous "filter is always true" no-op. This is a meaningful correctness improvement.
- **`gtJson`-only config edge case** — `hasPublishConfig` returns `true` when only `gtJson.publish` is set, but `buildPublishMap` never includes `gt` JSON entries, so `allFileRefs` will always be empty in that scenario, resulting in an unnecessary `publishStep.run([])` call in both `workflows/upload.ts` and `saveLocalEdits.ts`.
- **Missing test** — `hasPublishConfig` lacks a test case for `publish: false`, leaving the most impactful new behaviour path undocumented.


<details open><summary><h3>Confidence Score: 2/5</h3></summary>

- Not safe to merge without addressing the `publish: false` breaking behaviour change that would silently unpublish all CDN content for affected users.
- The `hasPublishConfig` change from `settings.publish ||` to `settings.publish !== undefined` is a silent, destructive breaking change for any user who currently has `"publish": false` in their `gt.config.json`. On their next `gt upload` all of their published CDN translations would be actively unpublished with no warning. The rest of the PR — `buildPublishMap` refactor, per-file pattern support, `Settings` type change — is well-structured and correct.
- `packages/cli/src/utils/resolvePublish.ts` (the `hasPublishConfig` condition) and `packages/cli/src/config/generateSettings.ts` (to confirm the intended semantics of `publish: false`).
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/cli/src/utils/resolvePublish.ts | New `buildPublishMap` helper and updated `hasPublishConfig`/`shouldPublishGt`. The `publish !== undefined` guard in `hasPublishConfig` silently introduces a breaking behaviour change: `publish: false` in `gt.config.json` now actively triggers unpublishing of all CDN content, whereas it was previously a no-op. |
| packages/cli/src/config/generateSettings.ts | Correctly avoids defaulting `publish` to `false` so that an absent flag leaves it `undefined`; pairs well with the intent of the new `hasPublishConfig` logic. The `flags.publish === false` (Commander default) bypass is clearly explained. |
| packages/cli/src/workflows/upload.ts | Publish step correctly gated on `publishMap && hasPublishConfig`, but an empty `allFileRefs` (possible with `gtJson`-only config) will still call `publishStep.run([])` unnecessarily. |
| packages/cli/src/api/saveLocalEdits.ts | Correctly calls `publishStep` after saving edits using the returned `publishMap`, but shares the same empty-`allFileRefs` risk when only `gtJson.publish` is configured. |
| packages/cli/src/utils/__tests__/resolvePublish.test.ts | Good coverage of `shouldPublishFile`, `shouldPublishGt`, and `buildPublishMap`, but `hasPublishConfig` is missing a test for the `publish: false` case, which is a newly significant behaviour path. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[gt upload / saveLocalEdits] --> B[generateSettings]
    B --> C{publish flag\nor config?}
    C -- "--publish flag" --> D[publish = true]
    C -- "config publish: true/false" --> E[publish = true/false]
    C -- "neither" --> F[publish = undefined]

    D & E & F --> G[resolveFiles\nbuildPublishMap]
    G --> H{hasGlobal?\npublish !== undefined}
    H -- yes --> I[All files added to map\nvalue = shouldPublishFile]
    H -- no --> J[Only explicit\npublishPaths/unpublishPaths\nadded to map]

    I & J --> K[publishMap\nfileId -> boolean]

    K --> L[runUploadFilesWorkflow\nor aggregateFiles]
    L --> M{publishMap &&\nhasPublishConfig?}
    M -- yes --> N[Build allFileRefs\nfrom map]
    N --> O{allFileRefs\nempty?}
    O -- no --> P[PublishStep.run\nallFileRefs]
    O -- yes --> Q[PublishStep.run empty\nno-op / wasteful]
    M -- no --> R[Skip publish step]

    style E fill:#f96,color:#000
    style Q fill:#f96,color:#000
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `packages/cli/src/utils/resolvePublish.ts`, line 22-29 ([link](https://github.com/generaltranslation/gt/blob/6f1fa0db11fc2d3a33d41784b70fe622352825ef/packages/cli/src/utils/resolvePublish.ts#L22-L29)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`hasPublishConfig` returns `true` when only `unpublishPaths` is set, causing silent mass-unpublish**

   When a user configures `unpublishPaths` for a few files (to explicitly opt them out) but has not set the global `publish` flag, `hasPublishConfig` correctly returns `true`. However, because `publishMap` is built for *all* resolved files (not just those in `publishPaths`/`unpublishPaths`), every file is then sent to `publishFiles()` with `publish: false` (from the global `settings.publish = false` fallback).

   Concretely: a user who only specifies `unpublishPaths: ['./internal/**']` will end up sending `publish: false` for **every other file** in their project via the CDN publish API call — which could silently un-publish files that should remain published.

   Consider restricting the publish-step call to files that have an explicit publish decision (files present in `publishPaths` or `unpublishPaths`), rather than all resolved files.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/cli/src/utils/resolvePublish.ts
   Line: 22-29

   Comment:
   **`hasPublishConfig` returns `true` when only `unpublishPaths` is set, causing silent mass-unpublish**

   When a user configures `unpublishPaths` for a few files (to explicitly opt them out) but has not set the global `publish` flag, `hasPublishConfig` correctly returns `true`. However, because `publishMap` is built for *all* resolved files (not just those in `publishPaths`/`unpublishPaths`), every file is then sent to `publishFiles()` with `publish: false` (from the global `settings.publish = false` fallback).

   Concretely: a user who only specifies `unpublishPaths: ['./internal/**']` will end up sending `publish: false` for **every other file** in their project via the CDN publish API call — which could silently un-publish files that should remain published.

   Consider restricting the publish-step call to files that have an explicit publish decision (files present in `publishPaths` or `unpublishPaths`), rather than all resolved files.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `packages/cli/src/utils/resolvePublish.ts`, line 25-32 ([link](https://github.com/generaltranslation/gt/blob/6ba0f420fe13163cc0c3b76875988aba31b9acd4/packages/cli/src/utils/resolvePublish.ts#L25-L32)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`publish: false` in config now silently unpublishes all CDN content**

   The old implementation used `settings.publish ||` (where `publish` was always `boolean`, defaulting to `false`). With the old code, having `"publish": false` in `gt.config.json` left `hasPublishConfig` returning `false`, so the publish step was never triggered — it was effectively a no-op.

   With the new implementation (`settings.publish !== undefined ||`), a user who has `"publish": false` in their `gt.config.json` will now get `hasPublishConfig` returning `true`, `buildPublishMap` will include every file with `publish: false`, and the publish step will actively **unpublish all CDN content** on every `gt upload` run.

   Any user who previously had `"publish": false` as a defensive default in their config will now have all their published translations wiped from the CDN the next time they upload. This is a silent, destructive breaking change.

   If the intent is for `"publish": false` in config to mean "actively unpublish everything", that should be clearly documented and gated with a warning. If the intent is only to support `"publish": true` and per-file patterns, the condition should exclude the `false` case:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/cli/src/utils/resolvePublish.ts
   Line: 25-32

   Comment:
   **`publish: false` in config now silently unpublishes all CDN content**

   The old implementation used `settings.publish ||` (where `publish` was always `boolean`, defaulting to `false`). With the old code, having `"publish": false` in `gt.config.json` left `hasPublishConfig` returning `false`, so the publish step was never triggered — it was effectively a no-op.

   With the new implementation (`settings.publish !== undefined ||`), a user who has `"publish": false` in their `gt.config.json` will now get `hasPublishConfig` returning `true`, `buildPublishMap` will include every file with `publish: false`, and the publish step will actively **unpublish all CDN content** on every `gt upload` run.

   Any user who previously had `"publish": false` as a defensive default in their config will now have all their published translations wiped from the CDN the next time they upload. This is a silent, destructive breaking change.

   If the intent is for `"publish": false` in config to mean "actively unpublish everything", that should be clearly documented and gated with a warning. If the intent is only to support `"publish": true` and per-file patterns, the condition should exclude the `false` case:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/cli/src/utils/resolvePublish.ts
Line: 25-32

Comment:
**`publish: false` in config now silently unpublishes all CDN content**

The old implementation used `settings.publish ||` (where `publish` was always `boolean`, defaulting to `false`). With the old code, having `"publish": false` in `gt.config.json` left `hasPublishConfig` returning `false`, so the publish step was never triggered — it was effectively a no-op.

With the new implementation (`settings.publish !== undefined ||`), a user who has `"publish": false` in their `gt.config.json` will now get `hasPublishConfig` returning `true`, `buildPublishMap` will include every file with `publish: false`, and the publish step will actively **unpublish all CDN content** on every `gt upload` run.

Any user who previously had `"publish": false` as a defensive default in their config will now have all their published translations wiped from the CDN the next time they upload. This is a silent, destructive breaking change.

If the intent is for `"publish": false` in config to mean "actively unpublish everything", that should be clearly documented and gated with a warning. If the intent is only to support `"publish": true` and per-file patterns, the condition should exclude the `false` case:

```suggestion
  return (
    settings.publish === true ||
    settings.files.gtJson?.publish !== undefined ||
    (settings.files.publishPaths?.size ?? 0) > 0 ||
    (settings.files.unpublishPaths?.size ?? 0) > 0
  );
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/cli/src/utils/__tests__/resolvePublish.test.ts
Line: 121-135

Comment:
**Missing `hasPublishConfig` test for `publish: false`**

The `hasPublishConfig` suite tests `publish: true`, `gtJsonPublish: true/false`, `publishPaths`, and `unpublishPaths`, but never `settings.publish = false`. Given that the new implementation uses `settings.publish !== undefined` (not `settings.publish === true`), `hasPublishConfig({ publish: false })` now returns `true` — a meaningful behaviour change from the previous `settings.publish ||` check. Without a test explicitly covering this case the behaviour is undocumented and the risk of a future regression is high.

```ts
it('returns true when global publish is explicitly false', () => {
  const settings = createSettings({ publish: false });
  expect(hasPublishConfig(settings)).toBe(true);
});
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/cli/src/api/saveLocalEdits.ts
Line: 47-61

Comment:
**Empty `allFileRefs` possible when `gtJson.publish` is the only active config**

`hasPublishConfig` returns `true` when `settings.files.gtJson?.publish !== undefined`, but `buildPublishMap` (which populates `publishMap`) only covers `SUPPORTED_FILE_EXTENSIONS` — it never adds entries for the `gt` JSON output path. If `gtJson.publish` is the only configured publish flag (i.e., no global `settings.publish`, no per-file paths), `publishMap` will be empty, the filter on line 50 will produce an empty array, and `publishStep.run([])` will be called unnecessarily.

Consider adding an early-exit guard:

```ts
if (hasPublishConfig(settings) && allFileRefs.length > 0) {
```

or restructuring so that `gtJson` publishing is handled separately (which it appears to be elsewhere via `shouldPublishGt`).

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/cli/src/workflows/upload.ts
Line: 73-87

Comment:
**Same empty-`allFileRefs` risk from `gtJson`-only publish config**

The same issue present in `saveLocalEdits.ts` exists here: if `hasPublishConfig(options)` returns `true` solely because `settings.files.gtJson?.publish !== undefined`, `publishMap` will be empty (it has no `gt` entries), `allFileRefs` will be an empty array, and `publishStep.run([])` will be invoked needlessly.

A simple guard resolves both sites:

```suggestion
    if (publishMap && hasPublishConfig(options) && allFileRefs.length > 0) {
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["fix: flag"](https://github.com/generaltranslation/gt/commit/6ba0f420fe13163cc0c3b76875988aba31b9acd4)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->