### PR TITLE
fix: opt in for publishing

### DIFF
--- a/.changeset/solid-turkeys-jam.md
+++ b/.changeset/solid-turkeys-jam.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+Make CDN unpublish behavior opt-in

--- a/packages/cli/src/config/generateSettings.ts
+++ b/packages/cli/src/config/generateSettings.ts
@@ -166,8 +166,16 @@ export async function generateSettings(
   // For human review, always stage the project
   mergedOptions.stageTranslations = mergedOptions.stageTranslations ?? false;
 
-  // Add publish if not provided
-  mergedOptions.publish = (gtConfig.publish || flags.publish) ?? false;
+  // Add publish — only set if explicitly configured or passed via flag.
+  // When neither is set, leave undefined so the publish step knows
+  // there is no global publish intent.
+  if (flags.publish) {
+    mergedOptions.publish = true;
+  } else if (gtConfig.publish !== undefined) {
+    mergedOptions.publish = gtConfig.publish;
+  } else {
+    mergedOptions.publish = undefined;
+  }
 
   // Don't default src here — each pipeline (JS/Python) has its own defaults.
   // Only set src if the user explicitly provided it via flags or config.

--- a/packages/cli/src/formats/files/aggregateFiles.ts
+++ b/packages/cli/src/formats/files/aggregateFiles.ts
@@ -57,13 +57,22 @@ export async function aggregateFiles(
   const { resolvedPaths: filePaths } = settings.files;
   const skipValidation = settings.options?.skipFileValidation;
 
-  // Build publish map upfront from resolved paths
+  // Build publish map upfront from resolved paths.
+  // Only include files that have an explicit publish config or when a global
+  // publish flag is defined. Files without any config are left out of the map
+  // so the publish endpoint is never called for them.
+  const hasGlobalPublish = settings.publish !== undefined;
   for (const fileType of SUPPORTED_FILE_EXTENSIONS) {
     if (filePaths[fileType]) {
       for (const absolutePath of filePaths[fileType]) {
-        const relativePath = getRelative(absolutePath);
-        const fileId = hashStringSync(relativePath);
-        publishMap.set(fileId, shouldPublishFile(absolutePath, settings));
+        const hasExplicitConfig =
+          settings.files.publishPaths?.has(absolutePath) ||
+          settings.files.unpublishPaths?.has(absolutePath);
+        if (hasGlobalPublish || hasExplicitConfig) {
+          const relativePath = getRelative(absolutePath);
+          const fileId = hashStringSync(relativePath);
+          publishMap.set(fileId, shouldPublishFile(absolutePath, settings));
+        }
       }
     }
   }

--- a/packages/cli/src/formats/files/collectFiles.ts
+++ b/packages/cli/src/formats/files/collectFiles.ts
@@ -63,7 +63,11 @@ export async function collectFiles(
         versionId: hashStringSync(JSON.stringify(Object.keys(fileData).sort())),
         locale: settings.defaultLocale,
       } satisfies FileToUpload);
-      publishMap.set(TEMPLATE_FILE_ID, shouldPublishGt(settings));
+      // Only add GT JSON to publishMap if there's an explicit publish config
+      const gtPublishValue = shouldPublishGt(settings);
+      if (gtPublishValue !== undefined) {
+        publishMap.set(TEMPLATE_FILE_ID, gtPublishValue);
+      }
     }
   }
   return { files, reactComponents, publishMap };

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.10.8';
+export const PACKAGE_VERSION = '2.11.1';

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -215,7 +215,7 @@ export type Settings = {
     };
   };
   stageTranslations: boolean; // if true, always stage the project during translate command
-  publish: boolean; // if true, publish the translations to the CDN
+  publish?: boolean; // if true, publish the translations to the CDN; undefined means no global publish intent
   _versionId?: string; // internal use only
   _branchId?: string; // internal use only
   version?: string; // for specifying a custom version id to use. Should be unique

--- a/packages/cli/src/utils/resolvePublish.ts
+++ b/packages/cli/src/utils/resolvePublish.ts
@@ -21,7 +21,7 @@ export function shouldPublishFile(
  */
 export function hasPublishConfig(settings: Settings): boolean {
   return (
-    settings.publish ||
+    settings.publish !== undefined ||
     settings.files.gtJson.publish !== undefined ||
     (settings.files.publishPaths?.size ?? 0) > 0 ||
     (settings.files.unpublishPaths?.size ?? 0) > 0
@@ -31,8 +31,9 @@ export function hasPublishConfig(settings: Settings): boolean {
 /**
  * Determines whether gtjson content should be published.
  * Uses the gt-specific publish flag if set, otherwise falls back to global.
+ * Returns undefined when there is no explicit config at any level.
  */
-export function shouldPublishGt(settings: Settings): boolean {
+export function shouldPublishGt(settings: Settings): boolean | undefined {
   if (settings.files.gtJson.publish === false) return false;
   if (settings.files.gtJson.publish === true) return true;
   return settings.publish;


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes the `publish` setting from an opt-out boolean (defaulting to `false`) to an opt-in optional (`boolean | undefined`), so that files are never sent to the publish endpoint unless publishing is explicitly configured via a CLI flag, config file entry, or per-file `publishPaths`/`unpublishPaths` pattern.

Key changes:
- `Settings.publish` type widened from `boolean` to `boolean?`; `undefined` now means "no global publish intent"
- `generateSettings.ts`: `publish` is left `undefined` when neither `flags.publish` nor `gtConfig.publish` is set, replacing the old `?? false` default
- `aggregateFiles.ts`: `publishMap` entries are only created when `settings.publish !== undefined` (global intent) or the file has an explicit per-file config
- `collectFiles.ts`: GTJSON publish entry is only added to `publishMap` when `shouldPublishGt` returns a non-`undefined` value
- `resolvePublish.ts`: `shouldPublishGt` return type broadened to `boolean | undefined`; `hasPublishConfig` updated to check `!== undefined`

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

- Safe to merge with one logic concern: explicit CLI `--no-publish` can be silently overridden by a config file value due to a falsy rather than strict-`undefined` check.
- The opt-in publish model is correctly threaded through all relevant call sites. The one issue is in `generateSettings.ts` where `if (flags.publish)` cannot distinguish between "flag not provided" and "flag explicitly set to false", which could cause `gtConfig.publish = true` to override an intentional `--no-publish` CLI invocation.
- packages/cli/src/config/generateSettings.ts — the `flags.publish` falsy check at lines 172-178
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/config/generateSettings.ts | Introduces opt-in publish logic by leaving `mergedOptions.publish` as `undefined` when neither flag nor config is set; falsy check on `flags.publish` can't distinguish "not provided" from an explicit `--no-publish` flag, potentially letting config override CLI intent. |
| packages/cli/src/formats/files/aggregateFiles.ts | Correctly guards `publishMap` population behind `hasGlobalPublish || hasExplicitConfig`, preventing the publish endpoint from being called for files with no publish intent. |
| packages/cli/src/formats/files/collectFiles.ts | Correctly gates GTJSON publish-map registration on `shouldPublishGt` returning a non-`undefined` value, consistent with the new opt-in model. |
| packages/cli/src/utils/resolvePublish.ts | `shouldPublishGt` return type widened to `boolean | undefined`; `hasPublishConfig` correctly uses `!== undefined` for the global flag check; `shouldPublishFile` correctly defaults to `false` via `?? false` when called within the already-guarded context. |
| packages/cli/src/types/index.ts | `publish` field changed from required `boolean` to optional `boolean?`, correctly reflecting the new opt-in semantics. |
| packages/cli/src/generated/version.ts | Auto-generated version bump from `2.10.8` to `2.11.1`; no logic concerns. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[generateSettings] --> B{flags.publish truthy?}
    B -- Yes --> C[publish = true]
    B -- No --> D{gtConfig.publish !== undefined?}
    D -- Yes --> E[publish = gtConfig.publish]
    D -- No --> F[publish = undefined]

    C & E & F --> G[collectFiles / aggregateFiles]

    G --> H{settings.publish !== undefined OR file in publishPaths/unpublishPaths?}
    H -- No --> I[Skip: file NOT added to publishMap]
    H -- Yes --> J[shouldPublishFile / shouldPublishGt]

    J --> K{file in unpublishPaths?}
    K -- Yes --> L[publishMap: false]
    K -- No --> M{file in publishPaths?}
    M -- Yes --> N[publishMap: true]
    M -- No --> O[publishMap: settings.publish ?? false]

    L & N & O --> P[handleTranslate]
    P --> Q{publishMap present AND hasPublishConfig?}
    Q -- Yes --> R[PublishStep.run]
    Q -- No --> S[Skip publish step]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/cli/src/config/generateSettings.ts
Line: 172-178

Comment:
**CLI `--no-publish` flag silently overridden by config**

When the CLI framework represents an explicit `--no-publish` flag as `flags.publish = false` (a falsy value), the first branch is skipped and the code falls through to `else if (gtConfig.publish !== undefined)`. If `gtConfig.publish = true` is set in the config file, the explicit `--no-publish` flag is silently discarded and publishing proceeds anyway.

To distinguish "flag not provided" (`undefined`) from "flag explicitly set to false", the condition should check strictly for `undefined`:

```suggestion
  if (flags.publish === true) {
    mergedOptions.publish = true;
  } else if (flags.publish === false) {
    mergedOptions.publish = false;
  } else if (gtConfig.publish !== undefined) {
    mergedOptions.publish = gtConfig.publish;
  } else {
    mergedOptions.publish = undefined;
  }
```

This ensures the CLI flag always takes precedence over the config file when explicitly provided, which is the typical expected precedence order.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["chore: changeset"](https://github.com/generaltranslation/gt/commit/4de0ba9a35c3176f018d12ff48d48f1271e409b8)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->