### PR TITLE
F/publish on save upload

### DIFF
--- a/.changeset/dry-coats-brake.md
+++ b/.changeset/dry-coats-brake.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+Extending publish step to save-local and upload commands

--- a/packages/cli/src/api/collectUserEditDiffs.ts
+++ b/packages/cli/src/api/collectUserEditDiffs.ts
@@ -44,8 +44,8 @@ const findLatestDownloadedVersion = (
 export async function collectAndSendUserEditDiffs(
   files: FileReference[],
   settings: Settings
-) {
-  if (!settings.files) return;
+): Promise<boolean> {
+  if (!settings.files) return false;
 
   const { resolvedPaths, placeholderPaths, transformPaths } = settings.files;
   const fileMapping = createFileMapping(
@@ -226,4 +226,6 @@ export async function collectAndSendUserEditDiffs(
   if (collectedDiffs.length > 0) {
     await gt.submitUserEditDiffs({ diffs: collectedDiffs });
   }
+
+  return collectedDiffs.length > 0;
 }

--- a/packages/cli/src/api/saveLocalEdits.ts
+++ b/packages/cli/src/api/saveLocalEdits.ts
@@ -7,6 +7,7 @@ import { logErrorAndExit } from '../console/logging.js';
 import { logger } from '../console/logger.js';
 import type { FileReference } from 'generaltranslation/types';
 import chalk from 'chalk';
+import { runPublishWorkflow } from '../workflows/publish.js';
 
 /**
  * Uploads current source files to obtain file references, then collects and sends
@@ -16,7 +17,7 @@ export async function saveLocalEdits(settings: Settings): Promise<void> {
   if (!settings.files) return;
 
   // Collect current files from config
-  const { files } = await aggregateFiles(settings);
+  const { files, publishMap } = await aggregateFiles(settings);
   if (!files.length) return;
 
   // run branch query to get branch id
@@ -39,6 +40,11 @@ export async function saveLocalEdits(settings: Settings): Promise<void> {
   const spinner = logger.createSpinner('dots');
   spinner.start('Saving local edits...');
 
-  await collectAndSendUserEditDiffs(uploads, settings);
+  const hadDiffs = await collectAndSendUserEditDiffs(uploads, settings);
   spinner.stop(chalk.green('Local edits saved successfully'));
+
+  // Publish files to CDN if diffs were detected and publish config exists
+  if (hadDiffs) {
+    await runPublishWorkflow(files, publishMap, branchResult.currentBranch.id, settings);
+  }
 }

--- a/packages/cli/src/api/saveLocalEdits.ts
+++ b/packages/cli/src/api/saveLocalEdits.ts
@@ -45,6 +45,11 @@ export async function saveLocalEdits(settings: Settings): Promise<void> {
 
   // Publish files to CDN if diffs were detected and publish config exists
   if (hadDiffs) {
-    await runPublishWorkflow(files, publishMap, branchResult.currentBranch.id, settings);
+    await runPublishWorkflow(
+      files,
+      publishMap,
+      branchResult.currentBranch.id,
+      settings
+    );
   }
 }

--- a/packages/cli/src/cli/base.ts
+++ b/packages/cli/src/cli/base.ts
@@ -197,7 +197,9 @@ export class BaseCLI {
         .description(
           'Save local edits for all configured files by sending diffs (no translation enqueued)'
         )
-    ).action(async (initOptions: SharedFlags) => {
+    )
+      .option('--publish', 'Publish translations to the CDN', false)
+      .action(async (initOptions: SharedFlags) => {
       displayHeader('Saving local edits...');
       const settings = await generateSettings(initOptions);
       await saveLocalEdits(settings);

--- a/packages/cli/src/cli/base.ts
+++ b/packages/cli/src/cli/base.ts
@@ -200,11 +200,11 @@ export class BaseCLI {
     )
       .option('--publish', 'Publish translations to the CDN', false)
       .action(async (initOptions: SharedFlags) => {
-      displayHeader('Saving local edits...');
-      const settings = await generateSettings(initOptions);
-      await saveLocalEdits(settings);
-      logger.endCommand('Saved local edits');
-    });
+        displayHeader('Saving local edits...');
+        const settings = await generateSettings(initOptions);
+        await saveLocalEdits(settings);
+        logger.endCommand('Saved local edits');
+      });
   }
 
   protected async handleSetupProject(

--- a/packages/cli/src/cli/commands/translate.ts
+++ b/packages/cli/src/cli/commands/translate.ts
@@ -58,7 +58,12 @@ export async function handleTranslate(
         versionId: data.versionId,
         fileName: data.fileName,
       }));
-      await runPublishWorkflow(files, publishMap, branchData?.currentBranch.id ?? '', settings);
+      await runPublishWorkflow(
+        files,
+        publishMap,
+        branchData?.currentBranch.id ?? '',
+        settings
+      );
     }
   }
 }

--- a/packages/cli/src/cli/commands/translate.ts
+++ b/packages/cli/src/cli/commands/translate.ts
@@ -16,9 +16,7 @@ import localizeStaticImports from '../../utils/localizeStaticImports.js';
 import { BranchData } from '../../types/branch.js';
 import { getDownloadedMeta } from '../../state/recentDownloads.js';
 import { persistPostProcessHashes } from '../../utils/persistPostprocessHashes.js';
-import { PublishStep } from '../../workflows/steps/PublishStep.js';
-import { gt } from '../../utils/gt.js';
-import { hasPublishConfig } from '../../utils/resolvePublish.js';
+import { runPublishWorkflow } from '../../workflows/publish.js';
 
 // Downloads translations that were completed
 export async function handleTranslate(
@@ -54,19 +52,13 @@ export async function handleTranslate(
     });
 
     // Publish/unpublish files after translations are downloaded
-    if (publishMap && hasPublishConfig(settings)) {
-      const allFileRefs = Object.entries(fileVersionData)
-        .filter(([fileId]) => publishMap.has(fileId))
-        .map(([fileId, data]) => ({
-          fileId,
-          versionId: data.versionId,
-          branchId: branchData?.currentBranch.id,
-          publish: publishMap.get(fileId)!,
-          fileName: data.fileName,
-        }));
-      const publishStep = new PublishStep(gt);
-      await publishStep.run(allFileRefs);
-      await publishStep.wait();
+    if (publishMap) {
+      const files = Object.entries(fileVersionData).map(([fileId, data]) => ({
+        fileId,
+        versionId: data.versionId,
+        fileName: data.fileName,
+      }));
+      await runPublishWorkflow(files, publishMap, branchData?.currentBranch.id ?? '', settings);
     }
   }
 }

--- a/packages/cli/src/cli/commands/translate.ts
+++ b/packages/cli/src/cli/commands/translate.ts
@@ -52,7 +52,7 @@ export async function handleTranslate(
     });
 
     // Publish/unpublish files after translations are downloaded
-    if (publishMap) {
+    if (publishMap && branchData?.currentBranch.id) {
       const files = Object.entries(fileVersionData).map(([fileId, data]) => ({
         fileId,
         versionId: data.versionId,
@@ -61,7 +61,7 @@ export async function handleTranslate(
       await runPublishWorkflow(
         files,
         publishMap,
-        branchData?.currentBranch.id ?? '',
+        branchData.currentBranch.id,
         settings
       );
     }

--- a/packages/cli/src/cli/commands/upload.ts
+++ b/packages/cli/src/cli/commands/upload.ts
@@ -251,11 +251,19 @@ export async function upload(
 
   try {
     // Send all files in a single API call
-    const result = await runUploadFilesWorkflow({ files: uploadData, options: settings });
+    const result = await runUploadFilesWorkflow({
+      files: uploadData,
+      options: settings,
+    });
 
     // Publish files to CDN if publish config exists
     const publishMap = buildPublishMap(filePaths, settings);
-    await runPublishWorkflow(allFiles, publishMap, result.branchData.currentBranch.id, settings);
+    await runPublishWorkflow(
+      allFiles,
+      publishMap,
+      result.branchData.currentBranch.id,
+      settings
+    );
   } catch (error) {
     logErrorAndExit(`Error uploading files: ${error}`);
   }

--- a/packages/cli/src/cli/commands/upload.ts
+++ b/packages/cli/src/cli/commands/upload.ts
@@ -20,6 +20,8 @@ import parseYaml from '../../formats/yaml/parseYaml.js';
 import type { FileToUpload } from 'generaltranslation/types';
 import { hashStringSync } from '../../utils/hash.js';
 import { hasValidCredentials } from './utils/validation.js';
+import { buildPublishMap } from '../../utils/resolvePublish.js';
+import { runPublishWorkflow } from '../../workflows/publish.js';
 
 const SUPPORTED_DATA_FORMATS = ['JSX', 'ICU', 'I18NEXT'];
 
@@ -249,7 +251,11 @@ export async function upload(
 
   try {
     // Send all files in a single API call
-    await runUploadFilesWorkflow({ files: uploadData, options: settings });
+    const result = await runUploadFilesWorkflow({ files: uploadData, options: settings });
+
+    // Publish files to CDN if publish config exists
+    const publishMap = buildPublishMap(filePaths, settings);
+    await runPublishWorkflow(allFiles, publishMap, result.branchData.currentBranch.id, settings);
   } catch (error) {
     logErrorAndExit(`Error uploading files: ${error}`);
   }

--- a/packages/cli/src/cli/commands/upload.ts
+++ b/packages/cli/src/cli/commands/upload.ts
@@ -251,7 +251,7 @@ export async function upload(
 
   try {
     // Send all files in a single API call
-    const result = await runUploadFilesWorkflow({
+    const { branchData } = await runUploadFilesWorkflow({
       files: uploadData,
       options: settings,
     });
@@ -261,7 +261,7 @@ export async function upload(
     await runPublishWorkflow(
       allFiles,
       publishMap,
-      result.branchData.currentBranch.id,
+      branchData.currentBranch.id,
       settings
     );
   } catch (error) {

--- a/packages/cli/src/formats/files/aggregateFiles.ts
+++ b/packages/cli/src/formats/files/aggregateFiles.ts
@@ -17,7 +17,7 @@ import {
   parseKeyedMetadata,
   type KeyedMetadata,
 } from '../parseKeyedMetadata.js';
-import { shouldPublishFile } from '../../utils/resolvePublish.js';
+import { buildPublishMap } from '../../utils/resolvePublish.js';
 
 /**
  * Checks if a file path is a metadata companion file (e.g. foo.metadata.json)
@@ -45,37 +45,19 @@ export async function aggregateFiles(
 ): Promise<{ files: FileToUpload[]; publishMap: Map<string, boolean> }> {
   // Aggregate all files to translate
   const files: FileToUpload[] = [];
-  const publishMap = new Map<string, boolean>();
   if (
     !settings.files ||
     (Object.keys(settings.files.placeholderPaths).length === 1 &&
       settings.files.placeholderPaths.gt)
   ) {
-    return { files, publishMap };
+    return { files, publishMap: new Map<string, boolean>() };
   }
 
   const { resolvedPaths: filePaths } = settings.files;
   const skipValidation = settings.options?.skipFileValidation;
 
   // Build publish map upfront from resolved paths.
-  // Only include files that have an explicit publish config or when a global
-  // publish flag is defined. Files without any config are left out of the map
-  // so the publish endpoint is never called for them.
-  const hasGlobalPublish = settings.publish !== undefined;
-  for (const fileType of SUPPORTED_FILE_EXTENSIONS) {
-    if (filePaths[fileType]) {
-      for (const absolutePath of filePaths[fileType]) {
-        const hasExplicitConfig =
-          settings.files.publishPaths?.has(absolutePath) ||
-          settings.files.unpublishPaths?.has(absolutePath);
-        if (hasGlobalPublish || hasExplicitConfig) {
-          const relativePath = getRelative(absolutePath);
-          const fileId = hashStringSync(relativePath);
-          publishMap.set(fileId, shouldPublishFile(absolutePath, settings));
-        }
-      }
-    }
-  }
+  const publishMap = buildPublishMap(filePaths, settings);
 
   // Process JSON files
   if (filePaths.json) {

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.11.1';
+export const PACKAGE_VERSION = '2.11.2';

--- a/packages/cli/src/utils/resolvePublish.ts
+++ b/packages/cli/src/utils/resolvePublish.ts
@@ -1,4 +1,7 @@
-import { Settings } from '../types/index.js';
+import { Settings, ResolvedFiles } from '../types/index.js';
+import { SUPPORTED_FILE_EXTENSIONS } from '../formats/files/supportedFiles.js';
+import { getRelative } from '../fs/findFilepath.js';
+import { hashStringSync } from './hash.js';
 
 /**
  * Determines whether a file should be published based on the publish resolution logic:
@@ -13,6 +16,35 @@ export function shouldPublishFile(
   if (settings.files.unpublishPaths?.has(resolvedPath)) return false;
   if (settings.files.publishPaths?.has(resolvedPath)) return true;
   return settings.publish ?? false;
+}
+
+/**
+ * Builds a publish map from resolved file paths.
+ * Only includes files that have an explicit publish config or when a global
+ * publish flag is defined. Files without any config are left out of the map
+ * so the publish endpoint is never called for them.
+ */
+export function buildPublishMap(
+  filePaths: ResolvedFiles,
+  settings: Settings
+): Map<string, boolean> {
+  const publishMap = new Map<string, boolean>();
+  const hasGlobalPublish = settings.publish !== undefined;
+  for (const fileType of SUPPORTED_FILE_EXTENSIONS) {
+    if (filePaths[fileType]) {
+      for (const absolutePath of filePaths[fileType]) {
+        const hasExplicitConfig =
+          settings.files.publishPaths?.has(absolutePath) ||
+          settings.files.unpublishPaths?.has(absolutePath);
+        if (hasGlobalPublish || hasExplicitConfig) {
+          const relativePath = getRelative(absolutePath);
+          const fileId = hashStringSync(relativePath);
+          publishMap.set(fileId, shouldPublishFile(absolutePath, settings));
+        }
+      }
+    }
+  }
+  return publishMap;
 }
 
 /**

--- a/packages/cli/src/workflows/publish.ts
+++ b/packages/cli/src/workflows/publish.ts
@@ -26,6 +26,7 @@ export async function runPublishWorkflow(
         publish: publishMap.get(file.fileId)!,
         fileName: file.fileName,
       }));
+    if (allFileRefs.length === 0) return;
     const publishStep = new PublishStep(gt);
     await publishStep.run(allFileRefs);
     await publishStep.wait();

--- a/packages/cli/src/workflows/publish.ts
+++ b/packages/cli/src/workflows/publish.ts
@@ -1,0 +1,37 @@
+import { Settings } from '../types/index.js';
+import { PublishStep } from './steps/PublishStep.js';
+import { gt } from '../utils/gt.js';
+import { hasPublishConfig } from '../utils/resolvePublish.js';
+import { logger } from '../console/logger.js';
+
+/**
+ * Publishes files to the CDN if publish config exists and the publishMap is non-empty.
+ * Shared by translate, upload, and save-local commands.
+ */
+export async function runPublishWorkflow(
+  files: { fileId: string; versionId: string; fileName: string }[],
+  publishMap: Map<string, boolean>,
+  branchId: string,
+  settings: Settings
+): Promise<void> {
+  if (publishMap.size === 0 || !hasPublishConfig(settings)) return;
+
+  try {
+    const allFileRefs = files
+      .filter((file) => publishMap.has(file.fileId))
+      .map((file) => ({
+        fileId: file.fileId,
+        versionId: file.versionId,
+        branchId,
+        publish: publishMap.get(file.fileId)!,
+        fileName: file.fileName,
+      }));
+    const publishStep = new PublishStep(gt);
+    await publishStep.run(allFileRefs);
+    await publishStep.wait();
+  } catch (error) {
+    logger.warn(
+      `Failed to publish files: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+}

--- a/packages/cli/src/workflows/upload.ts
+++ b/packages/cli/src/workflows/upload.ts
@@ -7,6 +7,7 @@ import { BranchStep } from './steps/BranchStep.js';
 import { UploadSourcesStep } from './steps/UploadSourcesStep.js';
 import { UploadTranslationsStep } from './steps/UploadTranslationsStep.js';
 import type { FileToUpload } from 'generaltranslation/types';
+import { BranchData } from '../types/branch.js';
 
 /**
  * Uploads multiple files to the API using a workflow pattern
@@ -23,7 +24,7 @@ export async function runUploadFilesWorkflow({
     translations: FileToUpload[];
   }[];
   options: Settings;
-}) {
+}): Promise<{ branchData: BranchData }> {
   try {
     logger.message(
       chalk.cyan('Files to upload:') +
@@ -65,6 +66,7 @@ export async function runUploadFilesWorkflow({
     }
 
     logger.success('All files uploaded successfully');
+    return { branchData };
   } catch (error) {
     return logErrorAndExit('Failed to upload files. ' + error);
   }

--- a/packages/cli/src/workflows/upload.ts
+++ b/packages/cli/src/workflows/upload.ts
@@ -13,7 +13,7 @@ import { BranchData } from '../types/branch.js';
  * Uploads multiple files to the API using a workflow pattern
  * @param files - Array of file objects to upload
  * @param options - The options for the API call
- * @returns The uploaded content or version ID
+ * @returns The branch data resolved during the workflow
  */
 export async function runUploadFilesWorkflow({
   files,


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds "publish on save/upload" behaviour to the CLI by introducing a shared `runPublishWorkflow` function in `packages/cli/src/workflows/publish.ts` and wiring it into the `translate`, `upload`, and `save-local` commands. It also extracts `buildPublishMap` into `resolvePublish.ts` to eliminate duplicated logic, updates `collectAndSendUserEditDiffs` to return `boolean` (indicating whether diffs were found), and updates `runUploadFilesWorkflow` to surface `branchData` to its callers.

Key changes:
- **New `runPublishWorkflow` helper** centralises CDN publish logic with proper early-return guards (`publishMap.size === 0`, `!hasPublishConfig`) and internal error handling.
- **`buildPublishMap` extracted** from `aggregateFiles.ts` into `resolvePublish.ts` and shared across all three command paths.
- **`translate` command** now delegates to `runPublishWorkflow` instead of inline `PublishStep` usage, and correctly guards against a missing `branchData.currentBranch.id`.
- **`upload` command** now calls `runPublishWorkflow` after every successful upload unconditionally — this may be surprising for users who have per-file publish config but did not explicitly opt in to CDN publication for that run.
- **`save-local` command** triggers publish only when diffs were detected, which is the correct gating behaviour.
- **`--publish` flag** added to `save-local` in `base.ts` but `SharedFlags` type is not updated to include it, creating a minor TypeScript type gap (works at runtime).

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

- The core refactoring is sound, but the unconditional publish triggered by every `upload` run warrants intentional design review before merging.
- The `runPublishWorkflow` abstraction is well-structured and the `translate`/`save-local` paths look correct. The main concern is that `upload` now always calls `runPublishWorkflow` after a successful upload with no opt-in guard, which is a behaviour change for any user who has per-file `publishPaths` in their config. There is also a minor TypeScript type gap with `SharedFlags` not including `publish`.
- Pay close attention to `packages/cli/src/cli/commands/upload.ts` — the unconditional publish call and its interaction with existing per-file publish configs.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/workflows/publish.ts | New shared `runPublishWorkflow` function that centralises publish-to-CDN logic, with correct early-return guards and internal error handling via `logger.warn`. |
| packages/cli/src/workflows/upload.ts | Return type updated to `Promise<{ branchData: BranchData }>`. Safe because failure paths call `logErrorAndExit` (typed `never`), guaranteeing `branchData` is always defined when the function returns. |
| packages/cli/src/cli/commands/upload.ts | Integrates `runPublishWorkflow` after upload. Unconditional publish call (no guard on user opt-in) could surprise users with existing per-file publish config who didn't intend to publish on this run. |
| packages/cli/src/api/saveLocalEdits.ts | Wires up `runPublishWorkflow` after detecting diffs; only triggers publish when `hadDiffs` is true, which is correct. |
| packages/cli/src/cli/base.ts | Adds `--publish` option to `save-local` command, but `SharedFlags` type doesn't include `publish`, creating a minor type gap (works at runtime via `generateSettings`). |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant translate as translate command
    participant upload as upload command
    participant save as save-local command
    participant PW as runPublishWorkflow
    participant PS as PublishStep

    User->>translate: gt translate
    translate->>translate: runDownloadWorkflow
    translate->>translate: guard: publishMap && branchData?.currentBranch.id
    translate->>PW: runPublishWorkflow(files, publishMap, branchId, settings)
    PW->>PW: guard: publishMap.size > 0 && hasPublishConfig
    PW->>PS: publishStep.run(allFileRefs)
    PS-->>PW: done
    PW-->>translate: void

    User->>upload: gt upload
    upload->>upload: runUploadFilesWorkflow → { branchData }
    upload->>upload: buildPublishMap(filePaths, settings)
    upload->>PW: runPublishWorkflow(allFiles, publishMap, branchId, settings)
    PW->>PW: guard: publishMap.size > 0 && hasPublishConfig
    PW->>PS: publishStep.run(allFileRefs)
    PS-->>PW: done
    PW-->>upload: void

    User->>save: gt save-local [--publish]
    save->>save: aggregateFiles → { files, publishMap }
    save->>save: collectAndSendUserEditDiffs → hadDiffs: boolean
    alt hadDiffs === true
        save->>PW: runPublishWorkflow(files, publishMap, branchId, settings)
        PW->>PW: guard: publishMap.size > 0 && hasPublishConfig
        PW->>PS: publishStep.run(allFileRefs)
        PS-->>PW: done
        PW-->>save: void
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/cli/src/cli/base.ts
Line: 201

Comment:
**`publish` missing from `SharedFlags` type**

The `--publish` option is registered on the `save-local` command but `SharedFlags` only declares `config`, `apiKey`, and `projectId`. At runtime, Commander.js correctly populates `initOptions.publish` and `generateSettings` (accepting `Record<string, any>`) passes it through to `settings.publish` — so the flag does work. However, TypeScript won't enforce or surface the `publish` field at the type level, and any future code that tries to access `initOptions.publish` directly will get a type error.

Consider either extending `SharedFlags` with `publish?: boolean`, or typing the action callback parameter with an intersection type:

```suggestion
      .action(async (initOptions: SharedFlags & { publish?: boolean }) => {
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/cli/src/cli/commands/upload.ts
Line: 253-269

Comment:
**Publish runs unconditionally even without `--publish` flag on upload**

`runPublishWorkflow` is now always called after every successful upload, including for users who have never configured any publish settings. While `runPublishWorkflow` safely returns early when `publishMap.size === 0 || !hasPublishConfig(settings)`, `buildPublishMap` can still produce a non-empty map if the user has per-file `publishPaths`/`unpublishPaths` in their config, even if they did not pass `--publish` for this particular run.

In contrast, `saveLocalEdits` only publishes when `hadDiffs` is true. The `upload` command has no equivalent "only publish if something new was actually uploaded" guard or "only if the user opted in via `--publish`" guard.

If the intent is that `upload` should always trigger a CDN publish when publish config is present, this is fine — but it should be explicitly documented. Otherwise, consider mirroring the `translate` command's approach and guarding this behind an explicit condition (e.g. checking `options.publish` or a similar intent flag before calling `runPublishWorkflow`).

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["fix: guards"](https://github.com/generaltranslation/gt/commit/47491ab0f35324b5f5a6effda07409f160d1e543)</sub>

<!-- /greptile_comment -->