### PR TITLE
chore(core): update publish return type

### DIFF
--- a/packages/core/src/translate/publishFiles.ts
+++ b/packages/core/src/translate/publishFiles.ts
@@ -13,6 +13,8 @@ export type PublishFilesResult = {
   results: {
     fileId: string;
     versionId: string;
+    locale?: string; // if locale is provided, it means this result is for a translation. Else it is for a source file.
+    branchId: string;
     success: boolean;
     error?: string;
   }[];


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the `PublishFilesResult` return type in `packages/core/src/translate/publishFiles.ts` to include two new fields in each result entry: `locale?: string` (optional, present only for translation file results) and `branchId: string` (required, always returned by the server).

- `locale?: string` is added with a clear comment explaining its semantics — present for translation results, absent for source file results.
- `branchId: string` is added as a required field. This is consistent with other response types in the codebase (e.g., `downloadFileBatch.ts`, `enqueueFiles.ts`) where the server always resolves and returns a `branchId` even when the input entry didn't supply one.
- The existing `PublishStep.ts` consumer in the CLI does not yet consume these new fields, but the type change is purely additive and non-breaking.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge — it is a purely additive type update with no runtime logic changes.
- The change only adds two new fields to an existing TypeScript return type. There is no change to runtime behaviour, API calls, or consuming code. The `branchId: string` (required) vs `branchId?: string` (optional in input) asymmetry is intentional and consistent with the established codebase pattern where the server always resolves a branch. No bugs, no regressions, no breaking changes.
- No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/translate/publishFiles.ts | Adds `locale?: string` and `branchId: string` fields to `PublishFilesResult.results`. Minor asymmetry exists: `PublishFileEntry.branchId` is optional (input), while `PublishFilesResult.results.branchId` is required (output), consistent with the rest of the codebase (server always resolves to a branch). |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller as Caller (PublishStep / CLI)
    participant GT as GT.publishFiles()
    participant API as /v2/project/files/publish

    Caller->>GT: publishFiles(files: PublishFileEntry[])
    Note over Caller,GT: Each entry: { fileId, versionId, branchId? (optional), publish, fileName? }
    GT->>API: POST with { files }
    API-->>GT: PublishFilesResult
    Note over API,GT: Each result now includes:<br/>fileId, versionId, branchId (required),<br/>locale? (optional — present for translations),<br/>success, error?
    GT-->>Caller: PublishFilesResult
```
</details>

<sub>Last reviewed commit: ["update"](https://github.com/generaltranslation/gt/commit/84e83605800b057f97882d9a37974821a5d0105d)</sub>

<!-- /greptile_comment -->