### PR TITLE
feat: adding ha ig yo

### DIFF
--- a/.changeset/shaky-books-wink.md
+++ b/.changeset/shaky-books-wink.md
@@ -1,0 +1,5 @@
+---
+'@generaltranslation/supported-locales': patch
+---
+
+Adding ha, ig, yo

--- a/packages/supported-locales/src/supportedLocales.ts
+++ b/packages/supported-locales/src/supportedLocales.ts
@@ -67,12 +67,14 @@ const supportedLocales = {
     'fr-SN', // Senegal
   ],
   gu: ['gu'], // Gujarati
+  ha: ['ha'], // Hausa
   hi: ['hi'], // Hindi
   he: ['he'], // Hebrew
   hr: ['hr'], // Croatian
   hu: ['hu'], // Hungarian
   hy: ['hy'], // Armenian
   id: ['id'], // Indonesian
+  ig: ['ig'], // Igbo
   is: ['is'], // Icelandic
   it: [
     // Italian
@@ -146,6 +148,7 @@ const supportedLocales = {
   ur: ['ur'], // Urdu
   uz: ['uz'], // Uzbek
   vi: ['vi'], // Vietnamese
+  yo: ['yo'], // Yoruba
   zh: [
     // Chinese
     'zh',


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds support for three West African languages — Hausa (`ha`), Igbo (`ig`), and Yoruba (`yo`) — to the supported locales registry. Each is a valid ISO 639-1 / BCP 47 language code and has been inserted in the correct alphabetical position within the `supportedLocales` object.

- Added `ha: ['ha']` (Hausa) between `gu` and `hi`
- Added `ig: ['ig']` (Igbo) between `id` and `is`
- Added `yo: ['yo']` (Yoruba) between `vi` and `zh`

The changes are minimal, correct, and consistent with the existing patterns in the file.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge — it is a straightforward, additive data-only change.
- All three new locale codes (`ha`, `ig`, `yo`) are valid BCP 47 / ISO 639-1 language tags, correctly named, and placed in proper alphabetical order. No logic, types, or existing entries are modified.
- No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/supported-locales/src/supportedLocales.ts | Adds three new locale entries — Hausa (`ha`), Igbo (`ig`), and Yoruba (`yo`) — each with valid BCP 47 language codes, inserted in their correct alphabetical positions. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Locale Request] --> B{Is base language in supportedLocales?}
    B -- No --> C[Unsupported]
    B -- Yes --> D{Does the full locale tag exist in variants array?}
    D -- Yes --> E[Return exact match\ne.g. 'ha', 'ig', 'yo']
    D -- No --> F[Fall back to base language\ne.g. 'ha', 'ig', 'yo']
    E --> G[Resolved Locale]
    F --> G
```
</details>

<sub>Last reviewed commit: ["chore: changeset"](https://github.com/generaltranslation/gt/commit/9fed6da8907a09eab8e91706a3a73c659e44220a)</sub>

<!-- /greptile_comment -->