### PR TITLE
feat(core): Add await helper

### DIFF
--- a/.changeset/full-bags-hammer.md
+++ b/.changeset/full-bags-hammer.md
@@ -1,0 +1,5 @@
+---
+'generaltranslation': patch
+---
+
+Add new helper awaitJobs() function

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -775,9 +775,7 @@ export class GT {
       files: result.data.map((file) => ({
         ...file,
         ...(file.locale && {
-          locale: file.locale
-            ? this.resolveAliasLocale(file.locale)
-            : undefined,
+          locale: this.resolveAliasLocale(file.locale),
         }),
       })),
       count: result.count,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -85,6 +85,10 @@ import {
   _checkJobStatus,
   CheckJobStatusResult,
 } from './translate/checkJobStatus';
+import _awaitJobs, {
+  AwaitJobsOptions,
+  AwaitJobsResult,
+} from './translate/awaitJobs';
 import type { FileDataQuery, FileDataResult } from './translate/queryFileData';
 import _queryFileData from './translate/queryFileData';
 import type { BranchQuery } from './translate/queryBranchData';
@@ -95,10 +99,7 @@ import type {
   CreateBranchResult,
 } from './translate/createBranch';
 import _createBranch from './translate/createBranch';
-import type {
-  FileReference,
-  FileReferenceOptionalBranchId,
-} from './types-dir/api/file';
+import type { FileReference, FileReferenceIds } from './types-dir/api/file';
 import _processFileMoves, {
   type MoveMapping,
   type ProcessMovesResponse,
@@ -444,6 +445,25 @@ export class GT {
   }
 
   /**
+   * Polls job statuses until all jobs from enqueueFiles are finished or the timeout is reached.
+   *
+   * @param {EnqueueFilesResult} enqueueResult - The result returned from enqueueFiles
+   * @param {AwaitJobsOptions} [options] - Polling configuration (interval, timeout)
+   * @returns {Promise<AwaitJobsResult>} The final status of all jobs and whether they all completed
+   */
+  async awaitJobs(
+    enqueueResult: EnqueueFilesResult,
+    options?: AwaitJobsOptions
+  ): Promise<AwaitJobsResult> {
+    this._validateAuth('awaitJobs');
+    return await _awaitJobs(
+      enqueueResult,
+      options,
+      this._getTranslationConfig()
+    );
+  }
+
+  /**
    * Enqueues translation jobs for previously uploaded source files.
    *
    * This method creates translation jobs that will process existing source files
@@ -452,12 +472,12 @@ export class GT {
    * uploadSourceFiles. The translation jobs are queued for processing and will
    * generate translated content based on the source files and target locales provided.
    *
-   * @param {FileReference[]} files - Array of file references containing IDs of previously uploaded source files
+   * @param {FileReferenceIds[]} files - Array of file references containing IDs of previously uploaded source files
    * @param {EnqueueOptions} options - Configuration options including source locale, target locales, and job settings
    * @returns {Promise<EnqueueFilesResult>} Result containing job IDs, queue status, and processing information
    */
   async enqueueFiles(
-    files: FileReferenceOptionalBranchId[],
+    files: FileReferenceIds[],
     options: EnqueueOptions
   ): Promise<EnqueueFilesResult> {
     // Validation
@@ -702,14 +722,16 @@ export class GT {
         {
           fileId: file.fileId,
           branchId: file.branchId,
-          locale: this.resolveCanonicalLocale(file.locale),
+          locale: file.locale
+            ? this.resolveCanonicalLocale(file.locale)
+            : undefined,
           versionId: file.versionId,
         },
       ],
       options,
       this._getTranslationConfig()
     );
-    return result.data[0].data;
+    return result.data?.[0]?.data ?? '';
   }
 
   /**
@@ -737,7 +759,9 @@ export class GT {
 
     requests = requests.map((request) => ({
       ...request,
-      locale: this.resolveCanonicalLocale(request.locale),
+      locale: request.locale
+        ? this.resolveCanonicalLocale(request.locale)
+        : undefined,
     }));
 
     // Request the batch download
@@ -750,7 +774,11 @@ export class GT {
     return {
       files: result.data.map((file) => ({
         ...file,
-        ...(file.locale && { locale: this.resolveAliasLocale(file.locale) }),
+        ...(file.locale && {
+          locale: file.locale
+            ? this.resolveAliasLocale(file.locale)
+            : undefined,
+        }),
       })),
       count: result.count,
     };

--- a/packages/core/src/translate/__tests__/awaitJobs.test.ts
+++ b/packages/core/src/translate/__tests__/awaitJobs.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import _awaitJobs from '../awaitJobs';
+import { _checkJobStatus } from '../checkJobStatus';
+import { TranslationRequestConfig } from '../../types';
+import { EnqueueFilesResult } from '../../types-dir/api/enqueueFiles';
+
+vi.mock('../checkJobStatus');
+
+const mockConfig: TranslationRequestConfig = {
+  baseUrl: 'https://api.test.com',
+  projectId: 'test-project',
+  apiKey: 'test-api-key',
+};
+
+function makeEnqueueResult(jobIds: string[]): EnqueueFilesResult {
+  const jobData: EnqueueFilesResult['jobData'] = {};
+  for (const jobId of jobIds) {
+    jobData[jobId] = {
+      sourceFileId: 'src-1',
+      fileId: 'file-1',
+      versionId: 'v-1',
+      branchId: 'branch-1',
+      targetLocale: 'es',
+      projectId: 'test-project',
+      force: false,
+    };
+  }
+  return { jobData, locales: ['es'], message: 'ok' };
+}
+
+describe('_awaitJobs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  it('should return immediately for empty jobData', async () => {
+    const result = await _awaitJobs(
+      { jobData: {}, locales: [], message: 'ok' },
+      undefined,
+      mockConfig
+    );
+    expect(result).toEqual({ complete: true, jobs: [] });
+    expect(_checkJobStatus).not.toHaveBeenCalled();
+  });
+
+  it('should resolve when all jobs complete on first poll', async () => {
+    vi.mocked(_checkJobStatus).mockResolvedValueOnce([
+      { jobId: 'job-1', status: 'completed' },
+      { jobId: 'job-2', status: 'completed' },
+    ]);
+
+    const result = await _awaitJobs(
+      makeEnqueueResult(['job-1', 'job-2']),
+      { pollingIntervalSeconds: 1 },
+      mockConfig
+    );
+
+    expect(result.complete).toBe(true);
+    expect(result.jobs).toHaveLength(2);
+    expect(result.jobs.every((j) => j.status === 'completed')).toBe(true);
+    expect(_checkJobStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it('should poll until jobs complete', async () => {
+    vi.mocked(_checkJobStatus)
+      .mockResolvedValueOnce([{ jobId: 'job-1', status: 'processing' }])
+      .mockResolvedValueOnce([{ jobId: 'job-1', status: 'completed' }]);
+
+    const promise = _awaitJobs(
+      makeEnqueueResult(['job-1']),
+      { pollingIntervalSeconds: 1 },
+      mockConfig
+    );
+
+    // First poll returns processing, then we need to advance the timer
+    await vi.advanceTimersByTimeAsync(1000);
+
+    const result = await promise;
+
+    expect(result.complete).toBe(true);
+    expect(result.jobs).toEqual([{ jobId: 'job-1', status: 'completed' }]);
+    expect(_checkJobStatus).toHaveBeenCalledTimes(2);
+  });
+
+  it('should handle failed jobs as terminal', async () => {
+    vi.mocked(_checkJobStatus).mockResolvedValueOnce([
+      {
+        jobId: 'job-1',
+        status: 'failed',
+        error: { message: 'Translation failed' },
+      },
+    ]);
+
+    const result = await _awaitJobs(
+      makeEnqueueResult(['job-1']),
+      undefined,
+      mockConfig
+    );
+
+    expect(result.complete).toBe(true);
+    expect(result.jobs).toEqual([
+      {
+        jobId: 'job-1',
+        status: 'failed',
+        error: { message: 'Translation failed' },
+      },
+    ]);
+  });
+
+  it('should handle unknown jobs as terminal', async () => {
+    vi.mocked(_checkJobStatus).mockResolvedValueOnce([
+      { jobId: 'job-1', status: 'unknown' },
+    ]);
+
+    const result = await _awaitJobs(
+      makeEnqueueResult(['job-1']),
+      undefined,
+      mockConfig
+    );
+
+    expect(result.complete).toBe(true);
+    expect(result.jobs).toEqual([{ jobId: 'job-1', status: 'unknown' }]);
+  });
+
+  it('should stop polling completed jobs and continue polling pending ones', async () => {
+    vi.mocked(_checkJobStatus)
+      .mockResolvedValueOnce([
+        { jobId: 'job-1', status: 'completed' },
+        { jobId: 'job-2', status: 'processing' },
+      ])
+      .mockResolvedValueOnce([{ jobId: 'job-2', status: 'completed' }]);
+
+    const promise = _awaitJobs(
+      makeEnqueueResult(['job-1', 'job-2']),
+      { pollingIntervalSeconds: 1 },
+      mockConfig
+    );
+
+    await vi.advanceTimersByTimeAsync(1000);
+
+    const result = await promise;
+
+    expect(result.complete).toBe(true);
+    expect(result.jobs).toHaveLength(2);
+    // Second call should only include job-2
+    expect(vi.mocked(_checkJobStatus).mock.calls[1][0]).toEqual(['job-2']);
+  });
+
+  it('should respect timeout and return incomplete', async () => {
+    vi.mocked(_checkJobStatus).mockResolvedValue([
+      { jobId: 'job-1', status: 'processing' },
+    ]);
+
+    const promise = _awaitJobs(
+      makeEnqueueResult(['job-1']),
+      { pollingIntervalSeconds: 1, timeoutSeconds: 3 },
+      mockConfig
+    );
+
+    // Advance past the timeout
+    await vi.advanceTimersByTimeAsync(5000);
+
+    const result = await promise;
+
+    expect(result.complete).toBe(false);
+    expect(result.jobs).toEqual([{ jobId: 'job-1', status: 'processing' }]);
+  });
+
+  it('should use default 5s polling interval', async () => {
+    vi.mocked(_checkJobStatus)
+      .mockResolvedValueOnce([{ jobId: 'job-1', status: 'processing' }])
+      .mockResolvedValueOnce([{ jobId: 'job-1', status: 'completed' }]);
+
+    const promise = _awaitJobs(
+      makeEnqueueResult(['job-1']),
+      undefined,
+      mockConfig
+    );
+
+    // Advance less than 5s — should not trigger second poll
+    await vi.advanceTimersByTimeAsync(4000);
+    expect(_checkJobStatus).toHaveBeenCalledTimes(1);
+
+    // Advance to 5s — should trigger second poll
+    await vi.advanceTimersByTimeAsync(1000);
+
+    const result = await promise;
+
+    expect(result.complete).toBe(true);
+    expect(_checkJobStatus).toHaveBeenCalledTimes(2);
+  });
+
+  it('should propagate API errors', async () => {
+    vi.mocked(_checkJobStatus).mockRejectedValueOnce(
+      new Error('Network error')
+    );
+
+    await expect(
+      _awaitJobs(makeEnqueueResult(['job-1']), undefined, mockConfig)
+    ).rejects.toThrow('Network error');
+  });
+});

--- a/packages/core/src/translate/awaitJobs.ts
+++ b/packages/core/src/translate/awaitJobs.ts
@@ -5,7 +5,7 @@ import { _checkJobStatus, JobStatus } from './checkJobStatus';
 export type AwaitJobsOptions = {
   /** Polling interval in seconds. Defaults to 5. */
   pollingIntervalSeconds?: number;
-  /** Timeout in seconds. If reached, resolves with whatever status is current. */
+  /** Timeout in seconds. Defaults to 600 (10 minutes). If reached, resolves with whatever status is current. */
   timeoutSeconds?: number;
 };
 
@@ -35,9 +35,11 @@ export default async function _awaitJobs(
   config: TranslationRequestConfig
 ): Promise<AwaitJobsResult> {
   const pollingInterval = (options?.pollingIntervalSeconds ?? 5) * 1000;
-  const timeout = options?.timeoutSeconds
-    ? options.timeoutSeconds * 1000
-    : undefined;
+  const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
+  const timeout =
+    options?.timeoutSeconds !== undefined
+      ? options.timeoutSeconds * 1000
+      : DEFAULT_TIMEOUT_MS;
 
   const jobIds = Object.keys(enqueueResult.jobData);
 
@@ -46,7 +48,9 @@ export default async function _awaitJobs(
   }
 
   const startTime = Date.now();
-  const finalStatuses = new Map<string, JobResult>();
+  const finalStatuses = new Map<string, JobResult>(
+    jobIds.map((id) => [id, { jobId: id, status: 'unknown' as JobStatus }])
+  );
   const pendingJobIds = new Set(jobIds);
 
   while (pendingJobIds.size > 0) {
@@ -74,7 +78,7 @@ export default async function _awaitJobs(
 
     if (pendingJobIds.size === 0) break;
 
-    if (timeout && Date.now() - startTime >= timeout) break;
+    if (Date.now() - startTime >= timeout) break;
 
     await new Promise((resolve) => setTimeout(resolve, pollingInterval));
   }

--- a/packages/core/src/translate/awaitJobs.ts
+++ b/packages/core/src/translate/awaitJobs.ts
@@ -1,0 +1,86 @@
+import { EnqueueFilesResult } from '../types-dir/api/enqueueFiles';
+import { TranslationRequestConfig } from '../types';
+import { _checkJobStatus, JobStatus } from './checkJobStatus';
+
+export type AwaitJobsOptions = {
+  /** Polling interval in seconds. Defaults to 5. */
+  pollingIntervalSeconds?: number;
+  /** Timeout in seconds. If reached, resolves with whatever status is current. */
+  timeoutSeconds?: number;
+};
+
+export type JobResult = {
+  jobId: string;
+  status: JobStatus;
+  error?: { message: string };
+};
+
+export type AwaitJobsResult = {
+  /** Whether all jobs completed (none still in progress). */
+  complete: boolean;
+  jobs: JobResult[];
+};
+
+/**
+ * @internal
+ * Polls job statuses until all jobs are finished or the timeout is reached.
+ * @param enqueueResult - The result from enqueueFiles
+ * @param options - Polling configuration
+ * @param config - API credentials and configuration
+ * @returns The final status of all jobs
+ */
+export default async function _awaitJobs(
+  enqueueResult: EnqueueFilesResult,
+  options: AwaitJobsOptions | undefined,
+  config: TranslationRequestConfig
+): Promise<AwaitJobsResult> {
+  const pollingInterval = (options?.pollingIntervalSeconds ?? 5) * 1000;
+  const timeout = options?.timeoutSeconds
+    ? options.timeoutSeconds * 1000
+    : undefined;
+
+  const jobIds = Object.keys(enqueueResult.jobData);
+
+  if (jobIds.length === 0) {
+    return { complete: true, jobs: [] };
+  }
+
+  const startTime = Date.now();
+  const finalStatuses = new Map<string, JobResult>();
+  const pendingJobIds = new Set(jobIds);
+
+  while (pendingJobIds.size > 0) {
+    const statuses = await _checkJobStatus(Array.from(pendingJobIds), config);
+
+    for (const job of statuses) {
+      if (
+        job.status === 'completed' ||
+        job.status === 'failed' ||
+        job.status === 'unknown'
+      ) {
+        finalStatuses.set(job.jobId, {
+          jobId: job.jobId,
+          status: job.status,
+          ...(job.error ? { error: job.error } : {}),
+        });
+        pendingJobIds.delete(job.jobId);
+      } else {
+        finalStatuses.set(job.jobId, {
+          jobId: job.jobId,
+          status: job.status,
+        });
+      }
+    }
+
+    if (pendingJobIds.size === 0) break;
+
+    if (timeout && Date.now() - startTime >= timeout) break;
+
+    await new Promise((resolve) => setTimeout(resolve, pollingInterval));
+  }
+
+  return {
+    complete: pendingJobIds.size === 0,
+    jobs: Array.from(finalStatuses.values()),
+  };
+}

--- a/packages/core/src/translate/enqueueFiles.ts
+++ b/packages/core/src/translate/enqueueFiles.ts
@@ -1,10 +1,10 @@
 import { TranslationRequestConfig, EnqueueFilesResult } from '../types';
 import apiRequest from './utils/apiRequest';
-import type { FileReferenceOptionalBranchId } from '../types-dir/api/file';
+import type { FileReferenceIds } from '../types-dir/api/file';
 import { processBatches } from './utils/batch';
 
 export type EnqueueOptions = {
-  sourceLocale: string;
+  sourceLocale?: string;
   targetLocales: string[];
   requireApproval?: boolean;
   modelProvider?: string;
@@ -21,7 +21,7 @@ export type EnqueueOptions = {
  * @returns The result of the API call
  */
 export default async function _enqueueFiles(
-  files: FileReferenceOptionalBranchId[],
+  files: FileReferenceIds[],
   options: EnqueueOptions,
   config: TranslationRequestConfig
 ): Promise<EnqueueFilesResult> {

--- a/packages/core/src/types-dir/api/file.ts
+++ b/packages/core/src/types-dir/api/file.ts
@@ -62,3 +62,18 @@ export type FileReference = {
 export type FileReferenceOptionalBranchId = Omit<FileReference, 'branchId'> & {
   branchId?: string;
 };
+
+/**
+ * File reference object structure for referencing files
+ * @see {@link FileReference}
+ * @property {string} [branchId] - The ID of the branch of the file
+ */
+export type FileReferenceIds = Omit<
+  FileReference,
+  'branchId' | 'fileName' | 'fileFormat' | 'dataFormat'
+> & {
+  branchId?: string;
+  fileName?: string;
+  fileFormat?: FileFormat;
+  dataFormat?: DataFormat;
+};

--- a/packages/core/src/types-dir/api/file.ts
+++ b/packages/core/src/types-dir/api/file.ts
@@ -27,10 +27,11 @@ type FormatMetadata = Record<string, any> | Updates[number]['metadata'];
  * @property {string} [incomingBranchId] - The ID of the incoming branch of the file
  * @property {string} [checkedOutBranchId] - The ID of the checked out branch of the file
  */
-export type FileToUpload = FileReferenceOptionalBranchId & {
+export type FileToUpload = Omit<FileReference, 'branchId'> & {
   content: string;
   locale: string;
   formatMetadata?: FormatMetadata;
+  branchId?: string;
   incomingBranchId?: string;
   checkedOutBranchId?: string;
 };
@@ -52,15 +53,6 @@ export type FileReference = {
   fileName: string;
   fileFormat: FileFormat;
   dataFormat?: DataFormat;
-};
-
-/**
- * File reference object structure for referencing files
- * @see {@link FileReference}
- * @property {string} [branchId] - The ID of the branch of the file
- */
-export type FileReferenceOptionalBranchId = Omit<FileReference, 'branchId'> & {
-  branchId?: string;
 };
 
 /**

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -100,6 +100,11 @@ export type {
   CheckJobStatusResult,
 } from './translate/checkJobStatus';
 export type {
+  AwaitJobsOptions,
+  AwaitJobsResult,
+  JobResult,
+} from './translate/awaitJobs';
+export type {
   SubmitUserEditDiff,
   SubmitUserEditDiffsPayload,
 } from './translate/submitUserEditDiffs';


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an `awaitJobs` helper to the `GT` class that polls translation job statuses (via `_checkJobStatus`) until all jobs reach a terminal state or a configurable timeout is hit. It also introduces the `FileReferenceIds` type (making file-format fields optional for ID-only references), relaxes `sourceLocale` to optional in `EnqueueOptions`, and adds defensive optional-chaining in `downloadFile`.

Key points:
- `_awaitJobs` correctly initialises all job statuses to `'unknown'` upfront (addressing a previously flagged gap) and now ships with a sensible 10-minute default timeout.
- The `complete` field in `AwaitJobsResult` returns `true` when all jobs are in a terminal state — including `failed` and `unknown` — which does **not** imply success. The JSDoc currently says "Whether all jobs completed", which is ambiguous and could mislead callers into assuming success without inspecting individual job statuses.
- The test suite is thorough but is missing an `afterEach(() => vi.useRealTimers())` to pair with the `beforeEach(() => vi.useFakeTimers())` setup.
- The new `FileReferenceIds` type JSDoc only documents `branchId`, leaving `fileName`, `fileFormat`, and `dataFormat` (all now optional) undocumented.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- This PR is safe to merge with minor documentation and test-hygiene improvements recommended.
- The core polling logic is correct, well-tested, and addresses previously flagged issues (default timeout, initialising missing jobs as `'unknown'`). The only concerns are a misleading JSDoc on `complete`, an incomplete JSDoc on `FileReferenceIds`, and a missing `afterEach` timer teardown — none of these are runtime bugs.
- packages/core/src/translate/awaitJobs.ts — clarify `complete` field semantics in JSDoc; packages/core/src/translate/__tests__/awaitJobs.test.ts — add `afterEach` timer teardown.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/core/src/translate/awaitJobs.ts | New polling helper that awaits job completion; logic is sound with a sensible 10-minute default timeout and proper terminal-state tracking, but the `complete` field JSDoc is misleading for failed/unknown terminal states. |
| packages/core/src/translate/__tests__/awaitJobs.test.ts | Comprehensive test coverage for the new `_awaitJobs` function; missing `afterEach(() => vi.useRealTimers())` to complement the `vi.useFakeTimers()` setup. |
| packages/core/src/types-dir/api/file.ts | Adds `FileReferenceIds` type making format metadata fields optional for ID-based references; JSDoc only documents `branchId` while the other newly-optional fields (`fileName`, `fileFormat`, `dataFormat`) are undocumented. |
| packages/core/src/translate/enqueueFiles.ts | Switches parameter type from `FileReferenceOptionalBranchId` to `FileReferenceIds` and makes `sourceLocale` optional; the GT class correctly falls back to `this.sourceLocale` so there is no regression. |
| packages/core/src/index.ts | Exposes `awaitJobs` on the GT class, updates `enqueueFiles` to use `FileReferenceIds`, and adds defensive optional-chaining in `downloadFile`; changes are straightforward and correct. |
| packages/core/src/types.ts | Re-exports new types (`AwaitJobsOptions`, `AwaitJobsResult`, `JobResult`) from the public API surface; no issues. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant GT as GT.awaitJobs()
    participant Core as _awaitJobs()
    participant API as _checkJobStatus()

    Caller->>GT: awaitJobs(enqueueResult, options)
    GT->>Core: _awaitJobs(enqueueResult, options, config)
    Note over Core: Extract jobIds from enqueueResult.jobData<br/>Init finalStatuses map with 'unknown'<br/>Init pendingJobIds set

    loop while pendingJobIds.size > 0
        Core->>API: _checkJobStatus(pendingJobIds, config)
        API-->>Core: JobResult[]

        loop for each job in response
            alt status is completed / failed / unknown
                Core->>Core: finalStatuses.set(jobId, result)<br/>pendingJobIds.delete(jobId)
            else status is queued / processing
                Core->>Core: finalStatuses.set(jobId, result)<br/>(keep in pendingJobIds)
            end
        end

        alt pendingJobIds empty
            Core->>Core: break
        else timeout exceeded
            Core->>Core: break (complete = false)
        else
            Core->>Core: sleep(pollingInterval)
        end
    end

    Core-->>GT: AwaitJobsResult { complete, jobs }
    GT-->>Caller: AwaitJobsResult
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/core/src/types-dir/api/file.ts`, line 66-79 ([link](https://github.com/generaltranslation/gt/blob/7bc24f3d24777676b55fd6b94e37b87f2b1017f0/packages/core/src/types-dir/api/file.ts#L66-L79)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **JSDoc is incomplete for `FileReferenceIds`**

   The `@property` section only documents `branchId`, but the new type also makes `fileName`, `fileFormat`, and `dataFormat` optional (all were previously required via `FileReference`). Callers reading only the JSDoc won't know those fields are available.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/core/src/types-dir/api/file.ts
   Line: 66-79

   Comment:
   **JSDoc is incomplete for `FileReferenceIds`**

   The `@property` section only documents `branchId`, but the new type also makes `fileName`, `fileFormat`, and `dataFormat` optional (all were previously required via `FileReference`). Callers reading only the JSDoc won't know those fields are available.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/core/src/translate/awaitJobs.ts
Line: 18-20

Comment:
**Misleading `complete` semantics — includes `failed`/`unknown` jobs**

The JSDoc states `"Whether all jobs completed (none still in progress)"`, but `complete: true` is also returned when all jobs are `failed` or `unknown`. Callers who check `result.complete === true` may incorrectly assume every job succeeded, when in fact all jobs could have failed.

Consider clarifying the JSDoc to reflect the actual semantics:

```suggestion
export type AwaitJobsResult = {
  /** Whether all jobs have reached a terminal state (completed, failed, or unknown) — none are still queued or processing. */
  complete: boolean;
  jobs: JobResult[];
};
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/core/src/translate/__tests__/awaitJobs.test.ts
Line: 31-35

Comment:
**Missing `afterEach` to restore real timers**

`vi.useFakeTimers()` is called in `beforeEach` but there is no matching `afterEach(() => vi.useRealTimers())`. While Vitest isolates test files in separate workers, failing to restore real timers is still a known footgun — it can cause unexpected behaviour if the file is ever refactored or run in a different isolation mode, and suppresses timer-related warnings from Vitest.

```suggestion
  beforeEach(() => {
    vi.clearAllMocks();
    vi.useFakeTimers();
  });

  afterEach(() => {
    vi.useRealTimers();
  });
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/core/src/types-dir/api/file.ts
Line: 66-79

Comment:
**JSDoc is incomplete for `FileReferenceIds`**

The `@property` section only documents `branchId`, but the new type also makes `fileName`, `fileFormat`, and `dataFormat` optional (all were previously required via `FileReference`). Callers reading only the JSDoc won't know those fields are available.

```suggestion
/**
 * File reference object structure for referencing files by ID.
 * All metadata fields (`fileName`, `fileFormat`, `dataFormat`) are optional
 * and `branchId` is optional as well.
 * @see {@link FileReference}
 * @property {string} [branchId] - The ID of the branch of the file
 * @property {string} [fileName] - The name of the file
 * @property {FileFormat} [fileFormat] - The format of the file
 * @property {DataFormat} [dataFormat] - Optional format of the data within the file
 */
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["update types"](https://github.com/generaltranslation/gt/commit/7bc24f3d24777676b55fd6b94e37b87f2b1017f0)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->