### PR TITLE
fi: add string datatype formatting

### DIFF
--- a/.changeset/chilly-cars-cross.md
+++ b/.changeset/chilly-cars-cross.md
@@ -1,0 +1,6 @@
+---
+'generaltranslation': patch
+'gt': patch
+---
+
+fix: add string datatype formatting

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.12.0';
+export const PACKAGE_VERSION = '2.13.0';

--- a/packages/core/src/formatting/format.ts
+++ b/packages/core/src/formatting/format.ts
@@ -71,7 +71,6 @@ export function _formatMessageICU(
  * @returns {string} The formatted message.
  * @internal
  *
- * Will fallback to an empty string
  * TODO: add this to custom formats
  */
 export function _formatMessageString(message: string): string {

--- a/packages/core/src/formatting/format.ts
+++ b/packages/core/src/formatting/format.ts
@@ -65,10 +65,10 @@ export function _formatMessageICU(
 }
 
 /**
- * Formats a message according to the specified locales and options.
+ * Returns the message as-is without any formatting.
  *
- * @param {string} message - The message to format.
- * @returns {string} The formatted message.
+ * @param {string} message - The message to return.
+ * @returns {string} The original message, unchanged.
  * @internal
  *
  * TODO: add this to custom formats

--- a/packages/core/src/formatting/format.ts
+++ b/packages/core/src/formatting/format.ts
@@ -55,13 +55,27 @@ export function _formatCutoff({
  * Will fallback to an empty string
  * TODO: add this to custom formats
  */
-export function _formatMessage(
+export function _formatMessageICU(
   message: string,
   locales: string | string[] = libraryDefaultLocale,
   variables: FormatVariables = {}
 ): string {
   const messageFormat = new IntlMessageFormat(message, locales);
   return messageFormat.format(variables)?.toString() ?? '';
+}
+
+/**
+ * Formats a message according to the specified locales and options.
+ *
+ * @param {string} message - The message to format.
+ * @returns {string} The formatted message.
+ * @internal
+ *
+ * Will fallback to an empty string
+ * TODO: add this to custom formats
+ */
+export function _formatMessageString(message: string): string {
+  return message;
 }
 
 /**
@@ -251,7 +265,7 @@ export function _formatRelativeTime({
 
 /**
  * @experimental This function is not currently supported but will be implemented in a future version.
- * Use {@link _formatMessage} for current ICU message format support.
+ * Use {@link _formatMessageICU} for current ICU message format support.
  * Formats an I18next message according to the specified locales and options.
  *
  * @param message - The I18next message to format.
@@ -270,7 +284,7 @@ export function _formatI18next(
 
 /**
  * @experimental This function is not currently supported but will be implemented in a future version.
- * Use {@link _formatMessage} for current ICU message format support.
+ * Use {@link _formatMessageICU} for current ICU message format support.
  * Formats a JSX message according to the specified locales and options.
  *
  * @param message - The JSX message to format.

--- a/packages/core/src/id/hashSource.ts
+++ b/packages/core/src/id/hashSource.ts
@@ -23,11 +23,11 @@ export function hashString(string: string): string {
  * Calculates a unique ID for the given children objects by hashing their sanitized JSON string representation.
  *
  * @param {any} childrenAsObjects - The children objects to be hashed.
- * @param {string} context - The context for the children
- * @param {string} id - The id for the JSX Children object
- * @param {number} maxChars - The maxChars for the JSX Children object
- * @param {string} dataFormat - The data format of the sources
- * @param {function} hashFunction custom hash function
+ * @param {string} [context] - The context for the children
+ * @param {string} [id] - The id for the JSX Children object
+ * @param {number} [maxChars] - The maxChars for the JSX Children object
+ * @param {string} [dataFormat] - The data format of the sources
+ * @param {function} [hashFunction] custom hash function
  * @returns {string} - The unique has of the children.
  */
 export function hashSource(
@@ -42,19 +42,20 @@ export function hashSource(
   } & HashMetadata,
   hashFunction: (string: string) => string = hashString
 ): string {
-  let sanitizedData: {
-    source?: SanitizedChildren;
-  } & HashMetadata = { dataFormat };
+  let sanitizedSource: SanitizedChildren | string;
   if (dataFormat === 'JSX') {
-    sanitizedData.source = sanitizeJsxChildren(source);
+    sanitizedSource = sanitizeJsxChildren(source);
   } else {
-    sanitizedData.source = source as string;
+    sanitizedSource = source as string;
   }
-  sanitizedData = {
-    ...sanitizedData,
+  const sanitizedData: {
+    source?: SanitizedChildren;
+  } & HashMetadata = {
+    source: sanitizedSource,
     ...(id && { id }),
     ...(context && { context }),
     ...(maxChars != null && { maxChars: Math.abs(maxChars) }),
+    ...(dataFormat && { dataFormat }),
   };
   const stringifiedData = stringify(sanitizedData);
   return hashFunction(stringifiedData);

--- a/packages/core/src/id/types.ts
+++ b/packages/core/src/id/types.ts
@@ -4,5 +4,5 @@ export type HashMetadata = {
   context?: string;
   id?: string;
   maxChars?: number;
-  dataFormat: DataFormat;
+  dataFormat?: DataFormat;
 };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,9 +11,10 @@ import {
   _formatList,
   _formatRelativeTime,
   _formatDateTime,
-  _formatMessage,
+  _formatMessageICU,
   _formatListToParts,
   _formatCutoff,
+  _formatMessageString,
 } from './formatting/format';
 import {
   CustomMapping,
@@ -115,6 +116,7 @@ import _publishFiles, {
 import { CutoffFormatOptions } from './formatting/custom-formats/CutoffFormat/types';
 import { TranslateOptions } from './types-dir/api/entry';
 import { API_VERSION as _API_VERSION } from './translate/api';
+import { StringFormat } from './types-dir/jsx/content';
 
 // ============================================================ //
 //                        Core Class                            //
@@ -1080,6 +1082,7 @@ export class GT {
    * @param {string} message - The message to format.
    * @param {string | string[]} [locales='en'] - The locales to use for formatting.
    * @param {FormatVariables} [variables={}] - The variables to use for formatting.
+   * @param {StringFormat} [dataFormat='ICU'] - The format of the message.
    * @returns {string} The formatted message.
    *
    * @example
@@ -1094,6 +1097,7 @@ export class GT {
     options?: {
       locales?: string | string[];
       variables?: FormatVariables;
+      dataFormat?: StringFormat;
     }
   ): string {
     return formatMessage(message, {
@@ -1642,6 +1646,7 @@ export function formatCutoff(
  * @param {string} message - The message to format.
  * @param {string | string[]} [locales='en'] - The locales to use for formatting.
  * @param {FormatVariables} [variables={}] - The variables to use for formatting.
+ * @param {StringFormat} [dataFormat='ICU'] - The format of the message.
  * @returns {string} The formatted message.
  *
  * @example
@@ -1656,9 +1661,15 @@ export function formatMessage(
   options?: {
     locales?: string | string[];
     variables?: FormatVariables;
+    dataFormat?: StringFormat;
   }
 ): string {
-  return _formatMessage(message, options?.locales, options?.variables);
+  switch (options?.dataFormat) {
+    case 'STRING':
+      return _formatMessageString(message);
+    default:
+      return _formatMessageICU(message, options?.locales, options?.variables);
+  }
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1646,7 +1646,7 @@ export function formatCutoff(
  * @param {string} message - The message to format.
  * @param {string | string[]} [locales='en'] - The locales to use for formatting.
  * @param {FormatVariables} [variables={}] - The variables to use for formatting.
- * @param {StringFormat} [dataFormat='ICU'] - The format of the message.
+ * @param {StringFormat} [dataFormat='ICU'] - The format of the message. (When STRING, the message is returned as is)
  * @returns {string} The formatted message.
  *
  * @example

--- a/packages/core/src/logging/warnings.ts
+++ b/packages/core/src/logging/warnings.ts
@@ -1,5 +1,5 @@
 export const formatI18nextWarning =
-  'Warning: formatI18next is not currently supported but will be implemented in a future version. Use _formatMessage for current ICU message format support.';
+  'Warning: formatI18next is not currently supported but will be implemented in a future version. Use _formatMessageICU for current ICU message format support.';
 
 export const formatJsxWarning =
-  'Warning: formatJsx is not currently supported but will be implemented in a future version. Use _formatMessage for current ICU message format support.';
+  'Warning: formatJsx is not currently supported but will be implemented in a future version. Use _formatMessageICU for current ICU message format support.';

--- a/packages/core/src/translate/translateMany.ts
+++ b/packages/core/src/translate/translateMany.ts
@@ -71,7 +71,6 @@ export default async function _translateMany(
       metadata?.hash ??
       hashSource({
         source,
-        dataFormat: metadata?.dataFormat ?? 'STRING',
         ...(metadata ?? {}),
       });
     hashOrder?.push(hash);

--- a/packages/core/src/translate/translateMany.ts
+++ b/packages/core/src/translate/translateMany.ts
@@ -71,6 +71,7 @@ export default async function _translateMany(
       metadata?.hash ??
       hashSource({
         source,
+        dataFormat: metadata?.dataFormat ?? 'STRING',
         ...(metadata ?? {}),
       });
     hashOrder?.push(hash);

--- a/packages/core/src/types-dir/jsx/content.ts
+++ b/packages/core/src/types-dir/jsx/content.ts
@@ -38,9 +38,14 @@ export type JsxElement = {
 export type JsxChild = string | JsxElement | Variable;
 
 /**
+ * The format of the string content
+ */
+export type StringFormat = 'ICU' | 'I18NEXT' | 'STRING';
+
+/**
  * The format of the content
  */
-export type DataFormat = 'JSX' | 'ICU' | 'I18NEXT' | 'STRING';
+export type DataFormat = 'JSX' | StringFormat;
 
 /**
  * A content type representing JSX, ICU, and I18next messages


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds first-class `'STRING'` datatype support to `formatMessage`, allowing callers to opt out of ICU parsing and receive the message string unchanged. It also renames the internal `_formatMessage` helper to `_formatMessageICU` throughout the codebase for clarity, and makes `dataFormat` optional in `HashMetadata` with a corresponding refactor in `hashSource`.

- **New `_formatMessageString`** — passthrough function (`return message`) added to `format.ts`; used in `formatMessage` when `dataFormat: 'STRING'` is passed.
- **Rename `_formatMessage` → `_formatMessageICU`** — purely internal (underscore-prefixed, not re-exported); no public API breakage.
- **`formatMessage` / `GT.formatMessage` gets `dataFormat?: StringFormat`** — switch dispatches to `_formatMessageString` for `'STRING'`, falls through to ICU for everything else (including `'I18NEXT'`, which still has no deprecation warning in this path).
- **`HashMetadata.dataFormat` made optional** — `hashSource` now conditionally spreads `dataFormat` only when truthy; since `fast-json-stable-stringify` already strips `undefined` keys, existing hashes for entries with an explicit `dataFormat` value are unchanged.
- **New `StringFormat` type** — `'ICU' | 'I18NEXT' | 'STRING'` extracted from `DataFormat`, giving `formatMessage` a tighter type that excludes `'JSX'`.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- Safe to merge with one minor doc fix; prior concerns about variables/I18NEXT are known and non-blocking for this patch.
- The core logic is straightforward and correct — the STRING passthrough is simple, the rename is purely internal, and the hashSource refactor is hash-stable for all existing callers with explicit dataFormat values. The one remaining new issue (inaccurate JSDoc first line on _formatMessageString) is P2/style only. Previously flagged concerns (silent variables drop for STRING, missing I18NEXT warning in switch, hash behaviour for callers defaulting dataFormat) are all acknowledged carry-forwards, not regressions introduced here.
- packages/core/src/index.ts (I18NEXT silently falls through to ICU in formatMessage switch) and packages/core/src/formatting/format.ts (minor JSDoc inaccuracy on _formatMessageString).
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/formatting/format.ts | Renames _formatMessage to _formatMessageICU for clarity and adds new _formatMessageString passthrough function; JSDoc first line is copy-pasted from the ICU version and mentions "locales and options" that do not exist on the function. |
| packages/core/src/id/hashSource.ts | Refactors hashSource to conditionally include dataFormat only when truthy; since fast-json-stable-stringify strips undefined keys, the hash output is stable for existing callers that passed explicit dataFormat values. |
| packages/core/src/id/types.ts | Makes dataFormat optional in HashMetadata, aligning the type with the updated hashSource implementation. |
| packages/core/src/index.ts | Adds dataFormat?: StringFormat option to both the GT class method and standalone formatMessage function; when 'STRING', variables are silently dropped (previously flagged); 'I18NEXT' falls through to ICU without a deprecation warning (previously flagged). GT.formatMessage correctly propagates dataFormat via ...options spread. |
| packages/core/src/logging/warnings.ts | Updates deprecation warning strings to reference _formatMessageICU instead of the removed _formatMessage; straightforward and correct. |
| packages/core/src/types-dir/jsx/content.ts | Introduces StringFormat = 'ICU' | 'I18NEXT' | 'STRING' and redefines DataFormat = 'JSX' | StringFormat; clean factoring with no issues. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["formatMessage(message, options)"] --> B{options?.dataFormat}
    B -- "'STRING'" --> C["_formatMessageString(message)\n→ returns message unchanged"]
    B -- "'ICU' / undefined" --> D["_formatMessageICU(message, locales, variables)\n→ IntlMessageFormat.format()"]
    B -- "'I18NEXT'" --> D
    D -->|"format error"| E["fallback: ''"]
    C --> F["Return string"]
    D --> F
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/core/src/formatting/format.ts
Line: 67-75

Comment:
**Inaccurate JSDoc first line**

The opening line of the JSDoc for `_formatMessageString` — "Formats a message according to the specified locales and options" — was copied from the ICU version and no longer matches the function signature. The function accepts only a single `message` parameter with no `locales` or `options` arguments.

```suggestion
/**
 * Returns the message as-is without any formatting.
 *
 * @param {string} message - The message to return.
 * @returns {string} The original message, unchanged.
 * @internal
 *
 * TODO: add this to custom formats
 */
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: greptile"](https://github.com/generaltranslation/gt/commit/2c450bcc1e2b033f5061d70892ca86eaaa0dce01) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26066874)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->