### PR TITLE
chore: add format field

### DIFF
--- a/.changeset/tall-flowers-leave.md
+++ b/.changeset/tall-flowers-leave.md
@@ -1,0 +1,10 @@
+---
+'@generaltranslation/react-core': patch
+'@generaltranslation/compiler': patch
+'generaltranslation': patch
+'gt-i18n': patch
+'gt-next': patch
+'gt': patch
+---
+
+chore: add support for multiple format types

--- a/packages/cli/src/console/index.ts
+++ b/packages/cli/src/console/index.ts
@@ -125,6 +125,17 @@ export const warnInvalidMaxCharsSync = (
     location
   );
 
+export const warnInvalidFormatSync = (
+  file: string,
+  value: string,
+  location?: string
+): string =>
+  withLocation(
+    file,
+    `Found invalid $format value: ${colorizeContent(value)}. Must be one of: 'ICU', 'STRING', 'I18NEXT'.`,
+    location
+  );
+
 export const warnInvalidIcuSync = (
   file: string,
   value: string,

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.13.0';
+export const PACKAGE_VERSION = '2.13.1';

--- a/packages/cli/src/react/jsx/utils/constants.ts
+++ b/packages/cli/src/react/jsx/utils/constants.ts
@@ -66,6 +66,7 @@ export const GT_ATTRIBUTES_WITH_SUGAR = [
   '$id',
   '$context',
   '$maxChars',
+  '$format',
 ] as const;
 
 export const GT_ATTRIBUTES = [

--- a/packages/cli/src/react/jsx/utils/mapAttributeName.ts
+++ b/packages/cli/src/react/jsx/utils/mapAttributeName.ts
@@ -7,7 +7,9 @@ type MapAttributeName<T extends string> = T extends '$id'
     ? 'context'
     : T extends '$maxChars'
       ? 'maxChars'
-      : T;
+      : T extends '$format'
+        ? 'format'
+        : T;
 
 /**
  * Map the attribute name to the corresponding attribute name in the metadata
@@ -25,6 +27,8 @@ export function mapAttributeName(attrName: string): string {
       return 'context';
     case '$maxChars':
       return 'maxChars';
+    case '$format':
+      return 'format';
     default:
       return attrName;
   }

--- a/packages/cli/src/react/jsx/utils/stringParsing/derivation/index.ts
+++ b/packages/cli/src/react/jsx/utils/stringParsing/derivation/index.ts
@@ -1,5 +1,6 @@
 import { NodePath } from '@babel/traverse';
 import * as t from '@babel/types';
+import type { DataFormat } from 'generaltranslation/types';
 import { InlineMetadata } from '../processTranslationCall/extractStringEntryMetadata.js';
 import { ParsingConfig } from '../types.js';
 import { ParsingOutput } from '../types.js';
@@ -91,7 +92,7 @@ export function deriveExpression({
   const temporaryDeriveId = `derive-temp-id-${randomUUID()}`;
   for (const string of strings) {
     output.updates.push({
-      dataFormat: 'ICU',
+      dataFormat: (metadata.format || 'ICU') as DataFormat,
       source: string,
       metadata: {
         ...metadata,

--- a/packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/__tests__/processTranslationCall.test.ts
+++ b/packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/__tests__/processTranslationCall.test.ts
@@ -289,9 +289,7 @@ describe('$format option support', () => {
   });
 
   it('should still warn on invalid ICU when no $format specified', () => {
-    const output = runProcessTranslationCall(
-      `t("Hello {{plain}} string")`
-    );
+    const output = runProcessTranslationCall(`t("Hello {{plain}} string")`);
     expect(output.updates).toHaveLength(0);
     expect(output.warnings.size).toBeGreaterThan(0);
   });

--- a/packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/__tests__/processTranslationCall.test.ts
+++ b/packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/__tests__/processTranslationCall.test.ts
@@ -266,4 +266,33 @@ describe('$format option support', () => {
     expect(output.updates[0]).toMatchObject({ dataFormat: 'STRING' });
     expect(output.updates[1]).toMatchObject({ dataFormat: 'STRING' });
   });
+
+  it('should not warn on invalid ICU when $format is STRING', () => {
+    const output = runProcessTranslationCall(
+      `t("Hello {{plain}} string", { $format: "STRING" })`
+    );
+    expect(output.updates).toHaveLength(1);
+    expect(output.updates[0]).toMatchObject({
+      dataFormat: 'STRING',
+      source: 'Hello {{plain}} string',
+    });
+    expect(output.errors).toHaveLength(0);
+    expect(output.warnings.size).toBe(0);
+  });
+
+  it('should still warn on invalid ICU when $format is ICU', () => {
+    const output = runProcessTranslationCall(
+      `t("Hello {{plain}} string", { $format: "ICU" })`
+    );
+    expect(output.updates).toHaveLength(0);
+    expect(output.warnings.size).toBeGreaterThan(0);
+  });
+
+  it('should still warn on invalid ICU when no $format specified', () => {
+    const output = runProcessTranslationCall(
+      `t("Hello {{plain}} string")`
+    );
+    expect(output.updates).toHaveLength(0);
+    expect(output.warnings.size).toBeGreaterThan(0);
+  });
 });

--- a/packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/__tests__/processTranslationCall.test.ts
+++ b/packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/__tests__/processTranslationCall.test.ts
@@ -209,3 +209,61 @@ describe('processTranslationCall - array support', () => {
     expect(output.errors.length).toBeGreaterThan(0);
   });
 });
+
+describe('$format option support', () => {
+  it('should extract $format from options and set dataFormat', () => {
+    const output = runProcessTranslationCall(
+      `t("Hello", { $format: "STRING" })`
+    );
+    expect(output.updates).toHaveLength(1);
+    expect(output.updates[0]).toMatchObject({
+      dataFormat: 'STRING',
+      source: 'Hello',
+    });
+    expect(output.errors).toHaveLength(0);
+  });
+
+  it('should default to ICU when $format is not provided', () => {
+    const output = runProcessTranslationCall(`t("Hello")`);
+    expect(output.updates).toHaveLength(1);
+    expect(output.updates[0]).toMatchObject({
+      dataFormat: 'ICU',
+      source: 'Hello',
+    });
+  });
+
+  it('should extract $format alongside other metadata', () => {
+    const output = runProcessTranslationCall(
+      `t("Hello", { $id: "greeting", $context: "home", $format: "I18NEXT" })`
+    );
+    expect(output.updates).toHaveLength(1);
+    expect(output.updates[0]).toMatchObject({
+      dataFormat: 'I18NEXT',
+      source: 'Hello',
+      metadata: { id: 'greeting', context: 'home' },
+    });
+  });
+
+  it('should warn on invalid $format value', () => {
+    const output = runProcessTranslationCall(
+      `t("Hello", { $format: "INVALID" })`
+    );
+    expect(output.updates).toHaveLength(1);
+    // Invalid format should fall back to ICU
+    expect(output.updates[0]).toMatchObject({
+      dataFormat: 'ICU',
+      source: 'Hello',
+    });
+    // Should produce a warning
+    expect(output.warnings.size).toBeGreaterThan(0);
+  });
+
+  it('should extract $format for array of strings', () => {
+    const output = runProcessTranslationCall(
+      `t(["Hello", "World"], { $format: "STRING" })`
+    );
+    expect(output.updates).toHaveLength(2);
+    expect(output.updates[0]).toMatchObject({ dataFormat: 'STRING' });
+    expect(output.updates[1]).toMatchObject({ dataFormat: 'STRING' });
+  });
+});

--- a/packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/extractStringEntryMetadata.ts
+++ b/packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/extractStringEntryMetadata.ts
@@ -3,6 +3,7 @@ import { ParsingConfig } from '../types.js';
 import { ParsingOutput } from '../types.js';
 import { isStaticExpression } from '../../../evaluateJsx.js';
 import { warnInvalidMaxCharsSync } from '../../../../../console/index.js';
+import { warnInvalidFormatSync } from '../../../../../console/index.js';
 import { warnNonStaticExpressionSync } from '../../../../../console/index.js';
 import { GT_ATTRIBUTES_WITH_SUGAR } from '../../constants.js';
 import generateModule from '@babel/generator';
@@ -24,6 +25,7 @@ export type InlineMetadata = {
   context?: string;
   id?: string;
   hash?: string;
+  format?: string;
   filePaths?: string[];
   sourceCode?: Record<string, SourceCode[]>;
 };
@@ -155,6 +157,23 @@ function extractInlineMetadata({
               } else if (typeof result.value === 'string') {
                 // Add the maxChars value to the metadata
                 metadata[mappedKey] = Math.abs(Number(result.value));
+              }
+            } else if (mappedKey === 'format') {
+              // Handle format attribute - validate allowed values
+              const validFormats = ['ICU', 'STRING', 'I18NEXT'];
+              if (
+                typeof result.value === 'string' &&
+                validFormats.includes(result.value)
+              ) {
+                metadata[mappedKey] = result.value;
+              } else {
+                output.warnings.add(
+                  warnInvalidFormatSync(
+                    config.file,
+                    String(result.value),
+                    `${prop.loc?.start?.line}:${prop.loc?.start?.column}`
+                  )
+                );
               }
             } else {
               // Add the $context or $id or other attributes value to the metadata

--- a/packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/handleLiteralTranslationCall.ts
+++ b/packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/handleLiteralTranslationCall.ts
@@ -1,4 +1,5 @@
 import * as t from '@babel/types';
+import type { DataFormat } from 'generaltranslation/types';
 import { ParsingConfig } from '../types.js';
 import { ParsingOutput } from '../types.js';
 import { isValidIcu } from '../../../evaluateJsx.js';
@@ -47,7 +48,7 @@ export function handleLiteralTranslationCall({
   }
 
   output.updates.push({
-    dataFormat: 'ICU',
+    dataFormat: (metadata.format || 'ICU') as DataFormat,
     source,
     metadata: {
       ...metadata,

--- a/packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/handleLiteralTranslationCall.ts
+++ b/packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/handleLiteralTranslationCall.ts
@@ -31,8 +31,11 @@ export function handleLiteralTranslationCall({
   const source =
     arg.type === 'StringLiteral' ? arg.value : arg.quasis[0].value.raw;
 
-  // Validate is ICU
-  if (!config.ignoreInvalidIcu) {
+  // Validate is ICU — skip for non-ICU formats
+  if (
+    !config.ignoreInvalidIcu &&
+    (!metadata.format || metadata.format === 'ICU')
+  ) {
     const { isValid, error } = isValidIcu(source);
     if (!isValid) {
       output.warnings.add(

--- a/packages/compiler/src/processing/collection/processCallExpression.ts
+++ b/packages/compiler/src/processing/collection/processCallExpression.ts
@@ -148,6 +148,7 @@ function handleUseGTCallback(
     id: useGTCallbackParams.id,
     maxChars: useGTCallbackParams.maxChars,
     hash: useGTCallbackParams.hash,
+    format: useGTCallbackParams.format,
   });
 }
 

--- a/packages/compiler/src/transform/registration/callbacks/registerUseGTCallback.ts
+++ b/packages/compiler/src/transform/registration/callbacks/registerUseGTCallback.ts
@@ -1,5 +1,6 @@
 import { TransformState } from '../../../state/types';
 import hashSource from '../../../utils/calculateHash';
+import type { DataFormat } from 'generaltranslation/types';
 
 /**
  * Track gt() function invocations
@@ -13,6 +14,7 @@ export function registerUseGTCallback({
   id,
   maxChars,
   hash,
+  format,
 }: {
   identifier: number;
   state: TransformState;
@@ -21,6 +23,7 @@ export function registerUseGTCallback({
   id?: string;
   maxChars?: number;
   hash?: string;
+  format?: string;
 }): void {
   // Calculate hash for the call expression
   hash ||= hashSource({
@@ -28,7 +31,7 @@ export function registerUseGTCallback({
     id,
     context,
     maxChars,
-    dataFormat: 'ICU',
+    dataFormat: (format || 'ICU') as DataFormat,
   });
 
   // Add the translation content to the string collector (under identifier mapping to useGT call)

--- a/packages/compiler/src/transform/validation/__tests__/validateTranslationFunctionCallback.test.ts
+++ b/packages/compiler/src/transform/validation/__tests__/validateTranslationFunctionCallback.test.ts
@@ -772,10 +772,7 @@ describe('validateTranslationFunctionCallback', () => {
       const callExpr = t.callExpression(t.identifier('useGT_callback'), [
         t.stringLiteral('Hello world'),
         t.objectExpression([
-          t.objectProperty(
-            t.identifier('$format'),
-            t.stringLiteral('STRING')
-          ),
+          t.objectProperty(t.identifier('$format'), t.stringLiteral('STRING')),
         ]),
       ]);
       const result = validateUseGTCallback(callExpr, state);
@@ -808,10 +805,7 @@ describe('validateTranslationFunctionCallback', () => {
             t.identifier('$context'),
             t.stringLiteral('greeting')
           ),
-          t.objectProperty(
-            t.identifier('$format'),
-            t.stringLiteral('I18NEXT')
-          ),
+          t.objectProperty(t.identifier('$format'), t.stringLiteral('I18NEXT')),
         ]),
       ]);
       const result = validateUseGTCallback(callExpr, state);
@@ -825,10 +819,7 @@ describe('validateTranslationFunctionCallback', () => {
       const callExpr = t.callExpression(t.identifier('useGT_callback'), [
         t.stringLiteral('Hello'),
         t.objectExpression([
-          t.objectProperty(
-            t.identifier('$format'),
-            t.identifier('someVar')
-          ),
+          t.objectProperty(t.identifier('$format'), t.identifier('someVar')),
         ]),
       ]);
       const result = validateUseGTCallback(callExpr, state);

--- a/packages/compiler/src/transform/validation/__tests__/validateTranslationFunctionCallback.test.ts
+++ b/packages/compiler/src/transform/validation/__tests__/validateTranslationFunctionCallback.test.ts
@@ -766,4 +766,73 @@ describe('validateTranslationFunctionCallback', () => {
       expect(result.errors).toHaveLength(0);
     });
   });
+
+  describe('$format option', () => {
+    it('should extract $format from options object', () => {
+      const callExpr = t.callExpression(t.identifier('useGT_callback'), [
+        t.stringLiteral('Hello world'),
+        t.objectExpression([
+          t.objectProperty(
+            t.identifier('$format'),
+            t.stringLiteral('STRING')
+          ),
+        ]),
+      ]);
+      const result = validateUseGTCallback(callExpr, state);
+      expect(result.errors).toHaveLength(0);
+      expect(result.content).toBe('Hello world');
+      expect(result.format).toBe('STRING');
+    });
+
+    it('should return undefined format when $format not provided', () => {
+      const callExpr = t.callExpression(t.identifier('useGT_callback'), [
+        t.stringLiteral('Hello world'),
+        t.objectExpression([
+          t.objectProperty(
+            t.identifier('$context'),
+            t.stringLiteral('greeting')
+          ),
+        ]),
+      ]);
+      const result = validateUseGTCallback(callExpr, state);
+      expect(result.errors).toHaveLength(0);
+      expect(result.format).toBeUndefined();
+    });
+
+    it('should extract $format alongside other options', () => {
+      const callExpr = t.callExpression(t.identifier('useGT_callback'), [
+        t.stringLiteral('Hello'),
+        t.objectExpression([
+          t.objectProperty(t.identifier('$id'), t.stringLiteral('hello')),
+          t.objectProperty(
+            t.identifier('$context'),
+            t.stringLiteral('greeting')
+          ),
+          t.objectProperty(
+            t.identifier('$format'),
+            t.stringLiteral('I18NEXT')
+          ),
+        ]),
+      ]);
+      const result = validateUseGTCallback(callExpr, state);
+      expect(result.errors).toHaveLength(0);
+      expect(result.id).toBe('hello');
+      expect(result.context).toBe('greeting');
+      expect(result.format).toBe('I18NEXT');
+    });
+
+    it('should error when $format is not a string literal', () => {
+      const callExpr = t.callExpression(t.identifier('useGT_callback'), [
+        t.stringLiteral('Hello'),
+        t.objectExpression([
+          t.objectProperty(
+            t.identifier('$format'),
+            t.identifier('someVar')
+          ),
+        ]),
+      ]);
+      const result = validateUseGTCallback(callExpr, state);
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
+  });
 });

--- a/packages/compiler/src/transform/validation/validateTranslationFunctionCallback.ts
+++ b/packages/compiler/src/transform/validation/validateTranslationFunctionCallback.ts
@@ -23,6 +23,7 @@ export function validateUseGTCallback(
   hash?: string;
   id?: string;
   maxChars?: number;
+  format?: string;
 } {
   const errors: string[] = [];
 
@@ -64,6 +65,7 @@ export function validateUseGTCallback(
   let id: string | undefined;
   let hash: string | undefined;
   let maxChars: number | undefined;
+  let format: string | undefined;
   if (callExpr.arguments.length === 1) {
     return { errors, content };
   }
@@ -96,9 +98,16 @@ export function validateUseGTCallback(
     );
     errors.push(...hashProperty.errors);
     hash = hashProperty.value;
+    const formatProperty = validatePropertyFromObjectExpression(
+      callExpr.arguments[1],
+      USEGT_CALLBACK_OPTIONS.$format,
+      'string'
+    );
+    errors.push(...formatProperty.errors);
+    format = formatProperty.value;
   }
 
-  return { errors, content, context, id, hash, maxChars };
+  return { errors, content, context, id, hash, maxChars, format };
 }
 
 /**

--- a/packages/compiler/src/utils/constants/gt/constants.ts
+++ b/packages/compiler/src/utils/constants/gt/constants.ts
@@ -133,6 +133,7 @@ export enum USEGT_CALLBACK_OPTIONS {
   $context = '$context',
   $maxChars = '$maxChars',
   $_hash = '$_hash',
+  $format = '$format',
 }
 
 /**

--- a/packages/core/src/types-dir/api/enqueueFiles.ts
+++ b/packages/core/src/types-dir/api/enqueueFiles.ts
@@ -16,6 +16,10 @@ export type Updates = ({
       dataFormat: 'I18NEXT';
       source: string;
     }
+  | {
+      dataFormat: 'STRING';
+      source: string;
+    }
 ))[];
 
 /**

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -14,6 +14,7 @@ import {
   HTML_CONTENT_PROPS,
   DataFormat,
   Content,
+  StringFormat,
 } from './types-dir/jsx/content';
 import {
   ActionType,
@@ -41,6 +42,7 @@ export {
   EntryMetadata,
   TranslateManyEntry,
   Content,
+  StringFormat,
   HashMetadata,
 };
 

--- a/packages/i18n/src/translation-functions/internal/__tests__/resolveTranslationSync.test.ts
+++ b/packages/i18n/src/translation-functions/internal/__tests__/resolveTranslationSync.test.ts
@@ -15,6 +15,7 @@ describe('resolveTranslationSync', () => {
   it('should call interpolateMessage with the translation and $_fallback set to original message when translation found', () => {
     const mockManager = {
       resolveTranslationSync: vi.fn().mockReturnValue('Bonjour {name} !'),
+      getLocale: vi.fn().mockReturnValue('fr'),
     };
     vi.mocked(getI18nManager).mockReturnValue(mockManager as any);
 
@@ -24,6 +25,7 @@ describe('resolveTranslationSync', () => {
     resolveTranslationSync(message, options);
 
     expect(interpolateMessage).toHaveBeenCalledWith('Bonjour {name} !', {
+      $_locales: 'fr',
       name: 'Alice',
       $_fallback: 'Hello {name}!',
     });
@@ -47,6 +49,7 @@ describe('resolveTranslationSync', () => {
   it('should preserve user options alongside $_fallback when translation found', () => {
     const mockManager = {
       resolveTranslationSync: vi.fn().mockReturnValue('Translated'),
+      getLocale: vi.fn().mockReturnValue('es'),
     };
     vi.mocked(getI18nManager).mockReturnValue(mockManager as any);
 
@@ -56,9 +59,30 @@ describe('resolveTranslationSync', () => {
     resolveTranslationSync(message, options);
 
     expect(interpolateMessage).toHaveBeenCalledWith('Translated', {
+      $_locales: 'es',
       name: 'Bob',
       $context: 'greeting',
       $id: 'hello-msg',
+      $_fallback: 'Hello {name}!',
+    });
+  });
+
+  it('should preserve $format in options passed to interpolateMessage', () => {
+    const mockManager = {
+      resolveTranslationSync: vi.fn().mockReturnValue('Translated'),
+      getLocale: vi.fn().mockReturnValue('fr'),
+    };
+    vi.mocked(getI18nManager).mockReturnValue(mockManager as any);
+
+    const message = 'Hello {name}!';
+    const options = { name: 'Alice', $format: 'STRING' };
+
+    resolveTranslationSync(message, options);
+
+    expect(interpolateMessage).toHaveBeenCalledWith('Translated', {
+      $_locales: 'fr',
+      name: 'Alice',
+      $format: 'STRING',
       $_fallback: 'Hello {name}!',
     });
   });

--- a/packages/i18n/src/translation-functions/internal/getGT.ts
+++ b/packages/i18n/src/translation-functions/internal/getGT.ts
@@ -41,10 +41,15 @@ export async function getGT(): Promise<GTFunctionType> {
     if (translation) {
       return interpolateMessage(translation, {
         ...options,
+        $_locales: i18nManager.getLocale(),
         $_fallback: message,
       });
     }
-    return interpolateMessage(message, options);
+    return interpolateMessage(message, {
+      ...options,
+      $_locales: i18nManager.getDefaultLocale(),
+      $_fallback: message,
+    });
   };
 
   return gt;

--- a/packages/i18n/src/translation-functions/internal/sync-translation-resolution.ts
+++ b/packages/i18n/src/translation-functions/internal/sync-translation-resolution.ts
@@ -19,6 +19,7 @@ export const resolveTranslationSync: SyncResolutionFunction = (
   const translation = i18nManager.resolveTranslationSync(message, options);
   if (!translation) return undefined;
   return interpolateMessage(translation, {
+    $_locales: i18nManager.getLocale(),
     ...options,
     $_fallback: message,
   });
@@ -34,5 +35,10 @@ export const resolveTranslationSyncWithFallback: SyncResolutionFunctionWithFallb
   (message, options = {}) => {
     const translation = resolveTranslationSync(message, options);
     if (translation) return translation;
-    return interpolateMessage(message, options);
+    const i18nManager = getI18nManager();
+    return interpolateMessage(message, {
+      $_locales: i18nManager.getDefaultLocale(),
+      ...options,
+      $_fallback: message,
+    });
   };

--- a/packages/i18n/src/translation-functions/types/options.ts
+++ b/packages/i18n/src/translation-functions/types/options.ts
@@ -13,6 +13,7 @@ export type DictionaryTranslationOptions = BaseTranslationOptions;
 export type InlineTranslationOptions = BaseTranslationOptions & {
   $context?: string;
   $id?: string;
+  /** The data format for the message (e.g., 'ICU', 'STRING'). Defaults to 'ICU'. */
   $format?: StringFormat;
   $_locales?: string | string[];
   $_hash?: string;

--- a/packages/i18n/src/translation-functions/types/options.ts
+++ b/packages/i18n/src/translation-functions/types/options.ts
@@ -1,3 +1,5 @@
+import { StringFormat } from 'generaltranslation/types';
+
 // TODO: next major version, this should be Record<string, string>
 export type BaseTranslationOptions = Record<string, any>;
 
@@ -11,6 +13,8 @@ export type DictionaryTranslationOptions = BaseTranslationOptions;
 export type InlineTranslationOptions = BaseTranslationOptions & {
   $context?: string;
   $id?: string;
+  $format?: StringFormat;
+  $_locales?: string | string[];
   $_hash?: string;
   $maxChars?: number;
   /** @internal Used to carry the original source when rendering a translation */

--- a/packages/i18n/src/translation-functions/utils/formatMessage.ts
+++ b/packages/i18n/src/translation-functions/utils/formatMessage.ts
@@ -1,3 +1,4 @@
+import { StringFormat } from 'generaltranslation/types';
 import logger from '../../logs/logger';
 import { createInterpolationFailureMessage } from './messages';
 import { formatMessage as _formatMessage } from 'generaltranslation';
@@ -11,10 +12,12 @@ import { formatMessage as _formatMessage } from 'generaltranslation';
  */
 export function formatMessage(
   encodedMsg: string,
-  variables: Record<string, string>
+  variables: Record<string, string>,
+  locales?: string | string[],
+  dataFormat?: StringFormat
 ): string {
   try {
-    return _formatMessage(encodedMsg, { variables });
+    return _formatMessage(encodedMsg, { variables, locales, dataFormat });
   } catch {
     logger.warn(createInterpolationFailureMessage(encodedMsg));
     return encodedMsg;

--- a/packages/i18n/src/translation-functions/utils/interpolateMessage.ts
+++ b/packages/i18n/src/translation-functions/utils/interpolateMessage.ts
@@ -39,11 +39,16 @@ export function interpolateMessage<T extends string | null | undefined>(
       : encodedMsg;
 
     // Interpolate the message
-    const interpolatedMessage = formatMessage(message, {
-      ...variables,
-      ...declaredVars,
-      [VAR_IDENTIFIER]: 'other',
-    });
+    const interpolatedMessage = formatMessage(
+      message,
+      {
+        ...variables,
+        ...declaredVars,
+        [VAR_IDENTIFIER]: 'other',
+      },
+      options.$locales,
+      options.$format
+    );
     // Apply cutoff formatting
     const cutoffMessage = formatCutoff(interpolatedMessage, {
       maxChars: options.$maxChars,

--- a/packages/i18n/src/translation-functions/utils/interpolateMessage.ts
+++ b/packages/i18n/src/translation-functions/utils/interpolateMessage.ts
@@ -46,7 +46,7 @@ export function interpolateMessage<T extends string | null | undefined>(
         ...declaredVars,
         [VAR_IDENTIFIER]: 'other',
       },
-      options.$locales,
+      options.$_locales,
       options.$format
     );
     // Apply cutoff formatting

--- a/packages/i18n/src/utils/extractVariables.ts
+++ b/packages/i18n/src/utils/extractVariables.ts
@@ -17,7 +17,9 @@ export function extractVariables<T extends BaseTranslationOptions>(
         key !== '$hash' && // this is already being done in @gt/react-core
         key !== '$_hash' &&
         key !== '$_source' &&
-        key !== '$_fallback'
+        key !== '$_fallback' &&
+        key !== '$format' &&
+        key !== '$_locales'
     )
   );
 }

--- a/packages/i18n/src/utils/hashMessage.ts
+++ b/packages/i18n/src/utils/hashMessage.ts
@@ -16,6 +16,6 @@ export function hashMessage(
     ...(options?.$maxChars != null && {
       maxChars: Math.abs(options.$maxChars),
     }),
-    dataFormat: 'ICU',
+    dataFormat: options?.$format || 'ICU',
   });
 }

--- a/packages/next/src/index.types.ts
+++ b/packages/next/src/index.types.ts
@@ -24,6 +24,7 @@ import {
   InlineTranslationOptions,
   RuntimeTranslationOptions,
 } from 'gt-react';
+import type { StringFormat } from 'generaltranslation/types';
 import {
   msg,
   decodeMsg,
@@ -303,6 +304,11 @@ export const LocaleSelector: typeof _LocaleSelector = () => {
  * Returns the string translation function `t`.
  *
  * @returns {Function} A translation function that accepts an ICU format string and returns that ICU format string translated.
+ * @param {InlineTranslationOptions} [options] - Translation options including variables and special `$`-prefixed options.
+ * @param {string} [options.$context] - Additional context for the translation.
+ * @param {string} [options.$id] - Optional identifier for the translation string.
+ * @param {number} [options.$maxChars] - Maximum number of characters for the translated message.
+ * @param {StringFormat} [options.$format] - The data format for the message (e.g., 'ICU', 'STRING'). Defaults to 'ICU'.
  *
  * @example
  * const t = useGT();
@@ -327,6 +333,9 @@ export const useGT: (
  *
  * @param {string} [id] - Optional prefix to prepend to the translation keys.
  * @returns {Function} A translation function that accepts a key string and returns the translated value.
+ * The returned function accepts `DictionaryTranslationOptions` which includes:
+ * - `$format` - The data format for the message (e.g., 'ICU', 'STRING'). Defaults to 'ICU'.
+ * - `$maxChars` - Maximum number of characters for the translated message.
  *
  * @example
  * const t = useTranslations('user');
@@ -507,6 +516,8 @@ export {
   InlineTranslationOptions,
   RuntimeTranslationOptions,
 };
+
+export type { StringFormat };
 
 export {
   msg,

--- a/packages/next/src/server-dir/buildtime/getTranslationFunction.ts
+++ b/packages/next/src/server-dir/buildtime/getTranslationFunction.ts
@@ -184,7 +184,7 @@ async function createTranslator(_messages?: _Messages): Promise<Translator> {
         ...(context && { context }),
         ...(maxChars != null && { maxChars: Math.abs(maxChars) }),
         ...(id && { id }),
-        dataFormat: 'ICU',
+        dataFormat: format || 'ICU',
       });
 
     return {

--- a/packages/next/src/server-dir/buildtime/getTranslationFunction.ts
+++ b/packages/next/src/server-dir/buildtime/getTranslationFunction.ts
@@ -23,6 +23,7 @@ import {
   VAR_IDENTIFIER,
   indexVars,
 } from 'generaltranslation/internal';
+import { StringFormat } from 'generaltranslation/types';
 import use from '../../utils/use';
 
 type RenderFn = (msg: string, locales: string[], fallback?: string) => string;
@@ -34,6 +35,7 @@ type RenderMessageParams = {
   fallback?: string;
   id?: string;
   maxChars?: number;
+  format?: StringFormat;
 };
 
 type InitResult = {
@@ -90,6 +92,7 @@ async function createTranslator(_messages?: _Messages): Promise<Translator> {
     fallback,
     id,
     maxChars,
+    format,
   }: RenderMessageParams) {
     try {
       // (1) Try to format message
@@ -103,6 +106,7 @@ async function createTranslator(_messages?: _Messages): Promise<Translator> {
             ...declaredVars,
             [VAR_IDENTIFIER]: 'other',
           },
+          dataFormat: format,
         }
       );
       const cutoffMessage = gtClass.formatCutoff(formattedMessage, {
@@ -158,6 +162,7 @@ async function createTranslator(_messages?: _Messages): Promise<Translator> {
       $context: context,
       $maxChars: maxChars,
       $_hash: _hash,
+      $format: format,
       ...variables
     } = options;
 
@@ -169,6 +174,7 @@ async function createTranslator(_messages?: _Messages): Promise<Translator> {
         id,
         fallback,
         maxChars,
+        format,
       });
     };
 
@@ -364,8 +370,15 @@ async function createTranslator(_messages?: _Messages): Promise<Translator> {
       return gt(encodedMsg, options) as T extends string ? string : T;
     }
 
-    const { $_hash, $_source, $context, $id, $maxChars, ...decodedVariables } =
-      decodedOptions;
+    const {
+      $_hash,
+      $_source,
+      $context,
+      $id,
+      $maxChars,
+      $format,
+      ...decodedVariables
+    } = decodedOptions;
 
     const renderMessage: RenderFn = (msg, locales, fallback) => {
       return renderMessageHelper({
@@ -374,6 +387,7 @@ async function createTranslator(_messages?: _Messages): Promise<Translator> {
         variables: decodedVariables,
         fallback,
         maxChars: $maxChars,
+        format: $format,
       });
     };
 
@@ -447,7 +461,12 @@ async function createTranslator(_messages?: _Messages): Promise<Translator> {
 /**
  * getGT() returns a function that translates an ICU message string.
  *
- * @returns A promise of the t() function used for translating strings
+ * @returns A promise of the t() function used for translating strings.
+ * The returned function accepts `InlineTranslationOptions` which includes:
+ * - `$format` - The data format for the message (e.g., 'ICU', 'STRING'). Defaults to 'ICU'.
+ * - `$context` - Additional context for the translation.
+ * - `$id` - Optional identifier for the translation string.
+ * - `$maxChars` - Maximum number of characters for the translated message.
  *
  * @example
  * const t = await getGT();

--- a/packages/next/src/server-dir/buildtime/getTranslations.tsx
+++ b/packages/next/src/server-dir/buildtime/getTranslations.tsx
@@ -39,12 +39,16 @@ import {
   VAR_IDENTIFIER,
   indexVars,
 } from 'generaltranslation/internal';
+import { StringFormat } from 'generaltranslation/types';
 
 /**
  * Returns the dictionary access function t(), which is used to translate an item from the dictionary.
  *
  * @param {string} [id] - Optional prefix to prepend to the translation keys.
  * @returns {Function} A translation function that accepts a key string and returns the translated value.
+ * The returned function accepts `DictionaryTranslationOptions` which includes:
+ * - `$format` - The data format for the message (e.g., 'ICU', 'STRING'). Defaults to 'ICU'.
+ * - `$maxChars` - Maximum number of characters for the translated message.
  *
  * @example
  * const t = await getTranslations('user');
@@ -125,6 +129,12 @@ export async function getTranslations(id?: string): Promise<
     // Validate entry
     if (!entry || typeof entry !== 'string') return '';
 
+    // Extract format from options
+    const { $format: format, ...variableOptions } = options as Record<
+      string,
+      any
+    > & { $format?: StringFormat };
+
     // Render method
     const renderContent = (
       message: string,
@@ -139,10 +149,11 @@ export async function getTranslations(id?: string): Promise<
           {
             locales,
             variables: {
-              ...options,
+              ...variableOptions,
               ...declaredVars,
               [VAR_IDENTIFIER]: 'other',
             },
+            dataFormat: format,
           }
         );
         const cutoffMessage = gt.formatCutoff(formattedMessage, {

--- a/packages/next/src/server-dir/runtime/tx.ts
+++ b/packages/next/src/server-dir/runtime/tx.ts
@@ -25,6 +25,7 @@ import {
  * @param {number} [options.maxChars] - The maximum number of characters to translate.
  * @param {Object} [options.variables] - An optional map of variables to be injected into the translated content.
  * @param {Object} [options.variableOptions] - Options for formatting numbers and dates using `Intl.NumberFormat` or `Intl.DateTimeFormat`.
+ * @param {StringFormat} [options.$format] - The data format for the message (e.g., 'ICU', 'STRING'). Defaults to 'ICU'.
  *
  * @returns {Promise<string>} - A promise that resolves to the translated content string, or the original content if no translation is needed.
  *
@@ -53,6 +54,7 @@ export default async function tx(
     $locale,
     $context: context,
     $maxChars: maxChars,
+    $format: format,
     ...variables
   } = options;
 
@@ -77,6 +79,7 @@ export default async function tx(
           ...declaredVars,
           [VAR_IDENTIFIER]: 'other',
         },
+        dataFormat: format,
       }
     );
     const cutoffMessage = gt.formatCutoff(formattedMessage, {

--- a/packages/next/src/server-dir/runtime/tx.ts
+++ b/packages/next/src/server-dir/runtime/tx.ts
@@ -99,7 +99,7 @@ export default async function tx(
     source: indexVars(message),
     ...(context && { context }),
     ...(maxChars != null && { maxChars: Math.abs(maxChars) }),
-    dataFormat: 'ICU',
+    dataFormat: format || 'ICU',
   });
 
   // ----- CHECK LOCAL CACHE ----- //

--- a/packages/next/swc-plugin/src/visitor/expr_utils.rs
+++ b/packages/next/swc-plugin/src/visitor/expr_utils.rs
@@ -101,16 +101,17 @@ pub fn extract_number_from_expr(expr: &Expr) -> Option<i32> {
   }
 }
 
-// Helper function to extract id and context from options
+// Helper function to extract id, context, maxChars, and format from options
 pub fn extract_id_and_context_from_options(
   options: Option<&ExprOrSpread>,
-) -> (Option<String>, Option<String>, Option<i32>) {
-  let (id, context, max_chars) = match options {
+) -> (Option<String>, Option<String>, Option<i32>, Option<String>) {
+  let (id, context, max_chars, format) = match options {
     Some(options) => match options.expr.as_ref() {
       Expr::Object(obj) => {
         let mut id_value = None;
         let mut context_value = None;
         let mut max_chars_value = None;
+        let mut format_value = None;
 
         for prop in &obj.props {
           if let PropOrSpread::Prop(prop) = prop {
@@ -126,6 +127,9 @@ pub fn extract_id_and_context_from_options(
                   "$maxChars" => {
                     max_chars_value = extract_number_from_expr(&key_value.value);
                   }
+                  "$format" => {
+                    format_value = extract_string_from_expr(&key_value.value);
+                  }
                   _ => {}
                 }
               }
@@ -133,13 +137,13 @@ pub fn extract_id_and_context_from_options(
           }
         }
 
-        (id_value, context_value, max_chars_value)
+        (id_value, context_value, max_chars_value, format_value)
       }
-      _ => (None, None, None),
+      _ => (None, None, None, None),
     },
-    None => (None, None, None),
+    None => (None, None, None, None),
   };
-  (id, context, max_chars)
+  (id, context, max_chars, format)
 }
 
 pub fn create_string_prop(key: &str, value: &str, span: Span) -> PropOrSpread {

--- a/packages/next/swc-plugin/src/visitor/expr_utils_tests.rs
+++ b/packages/next/swc-plugin/src/visitor/expr_utils_tests.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use crate::visitor::expr_utils::{extract_number_from_expr, is_allowed_dynamic_content, validate_declare_static};
+    use crate::visitor::expr_utils::{extract_id_and_context_from_options, extract_number_from_expr, is_allowed_dynamic_content, validate_declare_static};
     use swc_core::common::{DUMMY_SP, SyntaxContext};
     use swc_core::ecma::atoms::Atom;
     use swc_core::ecma::ast::*;
@@ -522,5 +522,75 @@ mod tests {
             })),
         });
         assert_eq!(extract_number_from_expr(&plus_ident), None);
+    }
+
+    // Helper to build an options object expression with given properties
+    fn make_options_arg(props: Vec<(&str, Box<Expr>)>) -> ExprOrSpread {
+        ExprOrSpread {
+            spread: None,
+            expr: Box::new(Expr::Object(ObjectLit {
+                span: DUMMY_SP,
+                props: props
+                    .into_iter()
+                    .map(|(key, value)| {
+                        PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
+                            key: PropName::Ident(IdentName {
+                                span: DUMMY_SP,
+                                sym: Atom::new(key),
+                            }),
+                            value,
+                        })))
+                    })
+                    .collect(),
+            })),
+        }
+    }
+
+    fn str_expr(s: &str) -> Box<Expr> {
+        Box::new(Expr::Lit(Lit::Str(Str {
+            span: DUMMY_SP,
+            value: Atom::new(s).into(),
+            raw: None,
+        })))
+    }
+
+    #[test]
+    fn test_extract_format_from_options() {
+        let options = make_options_arg(vec![("$format", str_expr("STRING"))]);
+        let (id, context, max_chars, format) =
+            extract_id_and_context_from_options(Some(&options));
+        assert_eq!(format, Some("STRING".to_string()));
+        assert_eq!(id, None);
+        assert_eq!(context, None);
+        assert_eq!(max_chars, None);
+    }
+
+    #[test]
+    fn test_extract_format_none_when_absent() {
+        let options = make_options_arg(vec![("$context", str_expr("greeting"))]);
+        let (_id, _context, _max_chars, format) =
+            extract_id_and_context_from_options(Some(&options));
+        assert_eq!(format, None);
+    }
+
+    #[test]
+    fn test_extract_format_with_other_options() {
+        let options = make_options_arg(vec![
+            ("$id", str_expr("hello")),
+            ("$context", str_expr("greeting")),
+            ("$format", str_expr("I18NEXT")),
+        ]);
+        let (id, context, _max_chars, format) =
+            extract_id_and_context_from_options(Some(&options));
+        assert_eq!(id, Some("hello".to_string()));
+        assert_eq!(context, Some("greeting".to_string()));
+        assert_eq!(format, Some("I18NEXT".to_string()));
+    }
+
+    #[test]
+    fn test_extract_format_none_when_no_options() {
+        let (_id, _context, _max_chars, format) =
+            extract_id_and_context_from_options(None);
+        assert_eq!(format, None);
     }
 }

--- a/packages/next/swc-plugin/src/visitor/transform.rs
+++ b/packages/next/swc-plugin/src/visitor/transform.rs
@@ -171,7 +171,7 @@ impl TransformVisitor {
     let options = call_expr.args.get(1);
 
     // Get context and id
-    let (context, id, max_chars) = extract_id_and_context_from_options(options);
+    let (context, id, max_chars, _format) = extract_id_and_context_from_options(options);
 
     // Calculate hash for the call expression
     let (hash, _) = self.calculate_hash_for_call_expr(string, options);
@@ -432,7 +432,7 @@ pub fn validate_string_literal_or_declare_static(&self,expr: &Expr, errors: &mut
     }
 
     // Extract the options content
-    let (id, context, max_chars) = extract_id_and_context_from_options(options);
+    let (id, context, max_chars, format) = extract_id_and_context_from_options(options);
 
     // Construct the json object
     use crate::hash::{SanitizedChild, SanitizedChildren, SanitizedData};
@@ -443,7 +443,7 @@ pub fn validate_string_literal_or_declare_static(&self,expr: &Expr, errors: &mut
       id,
       context,
       max_chars,
-      data_format: Some("ICU".to_string()),
+      data_format: Some(format.unwrap_or_else(|| "ICU".to_string())),
     };
     // Calculate hash using stable stringify (like TypeScript fast-json-stable-stringify)
     use crate::hash::JsxHasher;

--- a/packages/react-core/src/provider/hooks/translation/__tests__/useCreateInternalUseGTFunction.test.ts
+++ b/packages/react-core/src/provider/hooks/translation/__tests__/useCreateInternalUseGTFunction.test.ts
@@ -834,4 +834,98 @@ describe('useCreateInternalUseGTFunction', () => {
       });
     });
   });
+
+  describe('$format option', () => {
+    describe('_gtFunction', () => {
+      it('should pass dataFormat to formatMessage when $format is provided', () => {
+        const { _gtFunction } = useCreateInternalUseGTFunction({
+          gt: mockGT,
+          registerIcuForTranslation: mockRegisterIcuForTranslation,
+          ...defaultProps,
+          translationRequired: false,
+        });
+
+        _gtFunction('Hello World', { $format: 'STRING' });
+        expect(mockGT.formatMessage).toHaveBeenCalledWith('Hello World', {
+          locales: ['en'],
+          variables: { [VAR_IDENTIFIER]: 'other' },
+          dataFormat: 'STRING',
+        });
+      });
+
+      it('should not include $format in variables', () => {
+        const { _gtFunction } = useCreateInternalUseGTFunction({
+          gt: mockGT,
+          registerIcuForTranslation: mockRegisterIcuForTranslation,
+          ...defaultProps,
+          translationRequired: false,
+        });
+
+        _gtFunction('Hello {name}', { name: 'John', $format: 'STRING' });
+        expect(mockGT.formatMessage).toHaveBeenCalledWith('Hello {name}', {
+          locales: ['en'],
+          variables: { name: 'John', [VAR_IDENTIFIER]: 'other' },
+          dataFormat: 'STRING',
+        });
+      });
+
+      it('should pass dataFormat through when translation is available', () => {
+        const translations: Translations = {
+          'hash-hello-world': 'Hola Mundo',
+        };
+
+        const { _gtFunction } = useCreateInternalUseGTFunction({
+          gt: mockGT,
+          registerIcuForTranslation: mockRegisterIcuForTranslation,
+          ...defaultProps,
+          translations,
+        });
+
+        _gtFunction('Hello World', { $format: 'STRING' });
+        expect(mockGT.formatMessage).toHaveBeenCalledWith('Hola Mundo', {
+          locales: ['es', 'en'],
+          variables: { [VAR_IDENTIFIER]: 'other' },
+          dataFormat: 'STRING',
+        });
+      });
+
+      it('should pass undefined dataFormat when $format is not provided', () => {
+        const { _gtFunction } = useCreateInternalUseGTFunction({
+          gt: mockGT,
+          registerIcuForTranslation: mockRegisterIcuForTranslation,
+          ...defaultProps,
+          translationRequired: false,
+        });
+
+        _gtFunction('Hello World');
+        expect(mockGT.formatMessage).toHaveBeenCalledWith('Hello World', {
+          locales: ['en'],
+          variables: { [VAR_IDENTIFIER]: 'other' },
+          dataFormat: undefined,
+        });
+      });
+    });
+
+    describe('_mFunction', () => {
+      it('should pass dataFormat from decoded $format option', () => {
+        const { _mFunction } = useCreateInternalUseGTFunction({
+          gt: mockGT,
+          registerIcuForTranslation: mockRegisterIcuForTranslation,
+          ...defaultProps,
+          translationRequired: false,
+        });
+
+        // The mock decodeOptions returns { $_hash, $_source, $context, $id, name: 'World' }
+        // for encoded messages. Since our mock doesn't include $format,
+        // we test via a non-encoded message path which delegates to _gtFunction
+        _mFunction('Hello World', { $format: 'STRING' });
+        expect(mockGT.formatMessage).toHaveBeenCalledWith(
+          'Hello World',
+          expect.objectContaining({
+            dataFormat: 'STRING',
+          })
+        );
+      });
+    });
+  });
 });

--- a/packages/react-core/src/provider/hooks/translation/useCreateInternalUseGTFunction.ts
+++ b/packages/react-core/src/provider/hooks/translation/useCreateInternalUseGTFunction.ts
@@ -176,7 +176,7 @@ export default function useCreateInternalUseGTFunction({
         ...(context && { context }),
         ...(maxChars != null && { maxChars: Math.abs(maxChars) }),
         ...(id && { id }),
-        dataFormat: 'ICU',
+        dataFormat: format || 'ICU',
       });
 
     return {

--- a/packages/react-core/src/provider/hooks/translation/useCreateInternalUseGTFunction.ts
+++ b/packages/react-core/src/provider/hooks/translation/useCreateInternalUseGTFunction.ts
@@ -5,6 +5,7 @@ import {
   _Messages,
   _Message,
 } from '../../../types-dir/types';
+import { StringFormat } from 'generaltranslation/types';
 import { TranslateIcuCallback } from '../../../types-dir/runtime';
 import { GT } from 'generaltranslation';
 import {
@@ -29,6 +30,7 @@ type RenderMessageParams = {
   fallback?: string;
   id?: string;
   maxChars?: number;
+  format?: StringFormat;
 };
 
 export default function useCreateInternalUseGTFunction({
@@ -80,6 +82,7 @@ export default function useCreateInternalUseGTFunction({
     fallback,
     id,
     maxChars,
+    format,
   }: RenderMessageParams) {
     try {
       // (1) Try to format message
@@ -93,6 +96,7 @@ export default function useCreateInternalUseGTFunction({
             ...declaredVars,
             [VAR_IDENTIFIER]: 'other',
           },
+          dataFormat: format,
         }
       );
       // Apply cutoff formatting
@@ -144,6 +148,7 @@ export default function useCreateInternalUseGTFunction({
       $context: context,
       $maxChars: maxChars,
       $_hash: _hash,
+      $format: format,
       ...variables
     } = options;
 
@@ -160,6 +165,7 @@ export default function useCreateInternalUseGTFunction({
         id,
         fallback,
         maxChars,
+        format,
       });
     };
 
@@ -355,6 +361,7 @@ export default function useCreateInternalUseGTFunction({
       // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
       $id,
       $maxChars: maxChars,
+      $format: format,
       ...decodedVariables
     } = decodedOptions;
 
@@ -369,6 +376,7 @@ export default function useCreateInternalUseGTFunction({
         variables: decodedVariables,
         fallback,
         maxChars,
+        format,
       });
     };
 

--- a/packages/react-core/src/provider/hooks/translation/useCreateInternalUseTranslationsFunction.ts
+++ b/packages/react-core/src/provider/hooks/translation/useCreateInternalUseTranslationsFunction.ts
@@ -24,6 +24,7 @@ import {
   VAR_IDENTIFIER,
   condenseVars,
 } from 'generaltranslation/internal';
+import { StringFormat } from 'generaltranslation/types';
 
 export default function useCreateInternalUseTranslationsFunction(
   gt: GT,
@@ -68,6 +69,10 @@ export default function useCreateInternalUseTranslationsFunction(
       // Check: reject invalid content
       if (!entry || typeof entry !== 'string') return '';
 
+      // Extract format from options
+      const { $format: format, ...variableOptions } =
+        options as DictionaryTranslationOptions & { $format?: StringFormat };
+
       // Render method
       const renderMessage = (
         message: string,
@@ -82,10 +87,11 @@ export default function useCreateInternalUseTranslationsFunction(
             {
               locales,
               variables: {
-                ...options,
+                ...variableOptions,
                 ...declaredVars,
                 [VAR_IDENTIFIER]: 'other',
               },
+              dataFormat: format,
             }
           );
           const cutoffMessage = gt.formatCutoff(formattedMessage, {

--- a/packages/react-core/src/translation/hooks/useGT.tsx
+++ b/packages/react-core/src/translation/hooks/useGT.tsx
@@ -62,6 +62,10 @@ export default function useGT(_messages?: _Messages) {
   /**
    * @param {string} message
    * @param {InlineTranslationOptions} options Interpolated variables and translation context.
+   * @param {string} [options.$context] - Additional context for the translation.
+   * @param {string} [options.$id] - Optional identifier for the translation string.
+   * @param {number} [options.$maxChars] - Maximum number of characters for the translated message.
+   * @param {StringFormat} [options.$format] - The data format for the message (e.g., 'ICU', 'STRING'). Defaults to 'ICU'.
    * @returns The translated version of content
    *
    * @example

--- a/packages/react-core/src/translation/hooks/useMessages.ts
+++ b/packages/react-core/src/translation/hooks/useMessages.ts
@@ -60,6 +60,7 @@ export default function useMessages(_messages?: _Messages): MFunctionType {
   /**
    * @param {string} encodedMsg - The encoded message string, typically created by the `msg()` utility.
    * @param {InlineTranslationOptions} options
+   * @param {StringFormat} [options.$format] - The data format for the message (e.g., 'ICU', 'STRING'). Defaults to 'ICU'.
    * @returns A translation
    *
    * @example

--- a/packages/react-core/src/translation/hooks/useTranslations.tsx
+++ b/packages/react-core/src/translation/hooks/useTranslations.tsx
@@ -33,6 +33,8 @@ export default function useTranslations(id?: string): ((
    * @description A function that translates a dictionary entry based on its `id` and options.
    * @param {string} id The identifier of the dictionary entry to translate.
    * @param {DictionaryTranslationOptions} options for translating strings.
+   * @param {StringFormat} [options.$format] - The data format for the message (e.g., 'ICU', 'STRING'). Defaults to 'ICU'.
+   * @param {number} [options.$maxChars] - Maximum number of characters for the translated message.
    * @returns The translated version of the dictionary entry.
    *
    * @example

--- a/tests/apps/next/general-cases/tsconfig.json
+++ b/tests/apps/next/general-cases/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -11,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {
@@ -19,9 +23,19 @@
       }
     ],
     "paths": {
-      "@/*": ["./*"]
+      "@/*": [
+        "./*"
+      ]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `$format` field to all translation function APIs (`t()`, `useGT`, `useTranslations`, `getGT`, `getTranslations`, `tx`) across the CLI, compiler, SWC plugin, `i18n`, `next`, and `react-core` packages. The field lets callers declare the data format of their source strings (`'ICU'` | `'STRING'` | `'I18NEXT'`), which is then threaded through to hash calculation (so the correct translation is looked up) and to `formatMessage` at render time (so the string is parsed with the right engine). A version bump to `2.13.1` accompanies the change.

The implementation is well-structured and consistent across the server-side (`getTranslationFunction.ts`, `getTranslations.tsx`, `tx.ts`), client-side (`useCreateInternalUseGTFunction.ts`, `useCreateInternalUseTranslationsFunction.ts`), and the `i18n` standalone package. Hash calculation in the TypeScript compiler, the Rust SWC plugin, and the CLI all correctly include `format` (defaulting to `'ICU'`). The `extractVariables` helper is updated to exclude `$format` and `$_locales` so they are never accidentally injected as template substitution variables.

Key points to note:

- The pre-existing `options.$locales` → `options.$_locales` property-name bug in `interpolateMessage.ts` (flagged previously) means locale-sensitive formatting still falls back to system default — this is orthogonal to the `$format` work but worth resolving together.
- `DictionaryTranslationOptions` is not updated to declare `$format`, leaving a documentation/autocomplete gap for dictionary function consumers.
- The compiler's `validateTranslationFunctionCallback.ts` validates `$format` only as a string type, not against the allowed set. An invalid value will be used verbatim in hash calculation, which would differ from the CLI's behaviour of falling back to `'ICU'` — silently breaking translation lookups for that string.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- Safe to merge with minor follow-up: two P2 items (missing type on DictionaryTranslationOptions, no format-value validation in compiler) do not break the happy path but leave a hash-mismatch trap for invalid format inputs.
- The `$format` feature is correctly wired end-to-end across every runtime path: CLI scanner, TypeScript compiler, Rust SWC plugin, server and client render helpers all include `format` in hash calculation and pass it to `formatMessage`. The pre-existing locale bug is orthogonal and already tracked. The two remaining gaps (type declaration on `DictionaryTranslationOptions`, compiler-side value validation) affect only edge-case misuse or developer ergonomics and do not break the primary translation path for valid inputs.
- packages/compiler/src/transform/validation/validateTranslationFunctionCallback.ts — format value not validated against the allowed set, which can silently produce hash mismatches when users provide an invalid $format string.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/i18n/src/translation-functions/utils/interpolateMessage.ts | Passes `$format` correctly to `formatMessage`, but reads `options.$locales` (wrong property) instead of `options.$_locales` — locale is always `undefined` at runtime (already flagged in thread). |
| packages/i18n/src/translation-functions/types/options.ts | Adds `$format` and `$_locales` to `InlineTranslationOptions`; `DictionaryTranslationOptions` is left as `Record<string, any>` so `$format` is usable but undiscoverable in IDE autocomplete for dictionary functions. |
| packages/i18n/src/translation-functions/internal/sync-translation-resolution.ts | Adds `$_locales` injection; note the spread order places `$_locales` before `...options`, unlike the same pattern in `getGT.ts` where it comes after — a minor inconsistency (benign given `$_locales` is internal). |
| packages/i18n/src/utils/extractVariables.ts | Correctly excludes `$format` and `$_locales` from the variables object so they are not leaked into ICU/STRING template substitution. |
| packages/compiler/src/transform/validation/validateTranslationFunctionCallback.ts | Extracts `$format` and validates it as a `'string'` type, but does not check that the value is one of the allowed formats ('ICU', 'STRING', 'I18NEXT') — unlike the CLI which warns on invalid values. |
| packages/next/swc-plugin/src/visitor/transform.rs | `_format` at line 171 is intentionally unused because `calculate_hash_for_call_expr` extracts format internally; the static validation path correctly includes format in the hash. Both code paths are consistent. |
| packages/next/src/server-dir/buildtime/getTranslationFunction.ts | Cleanly threads `$format` through the render pipeline: destructured from options, passed to `renderMessageHelper`, used as `dataFormat` in `formatMessage` and in hash calculation. |
| packages/core/src/types-dir/api/enqueueFiles.ts | Adds `STRING` as a new valid `dataFormat` discriminant in the `Updates` union type, required for the API to accept STRING-format string updates. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User as User Code<br/>t("Hello", { $format: "STRING" })
    participant CLI as CLI Scanner<br/>(extractStringEntryMetadata)
    participant Compiler as TS Compiler<br/>(validateTranslationFunctionCallback)
    participant SWC as SWC Rust Plugin<br/>(calculate_hash_for_call_expr)
    participant API as GT API
    participant RT as Runtime<br/>(interpolateMessage / formatMessage)

    User->>CLI: Scans source for t() calls
    CLI->>CLI: Validates $format ∈ ['ICU','STRING','I18NEXT']<br/>Falls back to 'ICU' if invalid
    CLI->>API: Update { source, dataFormat: format||'ICU' }

    User->>Compiler: Build transform pass
    Compiler->>Compiler: Extracts $format as string<br/>(no value validation)
    Compiler->>Compiler: hashSource({ source, dataFormat: format||'ICU' })
    Compiler->>User: Injects $_hash into call site

    User->>SWC: Next.js SWC transform
    SWC->>SWC: extract_id_and_context_from_options → format
    SWC->>SWC: SanitizedData { data_format: format||"ICU" }
    SWC->>User: Injects hash attribute

    User->>RT: t("Hello", { $format: "STRING" }) at runtime
    RT->>RT: Destructures $format from options
    RT->>RT: extractVariables (excludes $format, $_locales)
    RT->>RT: formatMessage(msg, vars, locales, dataFormat:"STRING")
    RT-->>User: Formatted / translated string
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/i18n/src/translation-functions/types/options.ts
Line: 13-14

Comment:
**`$format` missing from `DictionaryTranslationOptions`**

Both `getTranslations.tsx` and `useCreateInternalUseTranslationsFunction.ts` now read and act on `$format` when called through dictionary translation functions. However, `DictionaryTranslationOptions` is not updated to declare `$format`, leaving users relying on the typed interface without IDE autocomplete or documentation for this option.

Since `DictionaryTranslationOptions = BaseTranslationOptions = Record<string, any>` the feature works at runtime, but it is invisible at the type level for dictionary consumers. Consider adding the field here alongside the one already added to `InlineTranslationOptions`:

```suggestion
export type DictionaryTranslationOptions = BaseTranslationOptions & {
  /** The data format for the message (e.g., 'ICU', 'STRING'). Defaults to 'ICU'. */
  $format?: StringFormat;
};
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/compiler/src/transform/validation/validateTranslationFunctionCallback.ts
Line: 98-104

Comment:
**`$format` value not validated against allowed set**

`validatePropertyFromObjectExpression` with `'string'` only confirms the property is a string literal; it does not check that the value is one of `'ICU'`, `'STRING'`, or `'I18NEXT'`.

In contrast, the CLI's `extractStringEntryMetadata.ts` explicitly validates against `['ICU', 'STRING', 'I18NEXT']` and emits a warning when the value is invalid, and crucially **does not** set `metadata.format` for invalid values (so the hash falls back to `'ICU'`). The compiler, however, will accept any string and use it verbatim in `registerUseGTCallback` via `(format || 'ICU') as DataFormat`. This means a user who writes `t("Hello", { $format: "TYPO" })` gets:

- **CLI**: hash computed with `dataFormat: 'ICU'` (falls back silently)
- **Compiler**: hash computed with `dataFormat: 'TYPO'`

These hashes will not match, causing translation lookups to fail silently for that string. Consider adding a validation step after extracting `format`:

```typescript
const VALID_FORMATS = ['ICU', 'STRING', 'I18NEXT'];
if (format && !VALID_FORMATS.includes(format)) {
  errors.push(`Invalid $format value: "${format}". Must be one of: ${VALID_FORMATS.map(f => `'${f}'`).join(', ')}.`);
  format = undefined;
}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix issues"](https://github.com/generaltranslation/gt/commit/f0a4449802abead0f83e0b1f81316f3b08cfdccd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26245560)</sub>

<!-- /greptile_comment -->