### PR TITLE
fix(core): fix awaitJobs tests failing due to concurrent execution

### DIFF
--- a/packages/core/src/translate/__tests__/awaitJobs.test.ts
+++ b/packages/core/src/translate/__tests__/awaitJobs.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import _awaitJobs from '../awaitJobs';
 import { _checkJobStatus } from '../checkJobStatus';
 import { TranslationRequestConfig } from '../../types';
@@ -28,10 +28,13 @@ function makeEnqueueResult(jobIds: string[]): EnqueueFilesResult {
   return { jobData, locales: ['es'], message: 'ok' };
 }
 
-describe('_awaitJobs', () => {
+describe.sequential('_awaitJobs', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('should return immediately for empty jobData', async () => {
@@ -50,9 +53,10 @@ describe('_awaitJobs', () => {
       { jobId: 'job-2', status: 'completed' },
     ]);
 
+    // Use real timers — first poll resolves immediately with 'completed'
     const result = await _awaitJobs(
       makeEnqueueResult(['job-1', 'job-2']),
-      { pollingIntervalSeconds: 1 },
+      { pollingIntervalSeconds: 0.01 },
       mockConfig
     );
 
@@ -67,16 +71,11 @@ describe('_awaitJobs', () => {
       .mockResolvedValueOnce([{ jobId: 'job-1', status: 'processing' }])
       .mockResolvedValueOnce([{ jobId: 'job-1', status: 'completed' }]);
 
-    const promise = _awaitJobs(
+    const result = await _awaitJobs(
       makeEnqueueResult(['job-1']),
-      { pollingIntervalSeconds: 1 },
+      { pollingIntervalSeconds: 0.01 },
       mockConfig
     );
-
-    // First poll returns processing, then we need to advance the timer
-    await vi.advanceTimersByTimeAsync(1000);
-
-    const result = await promise;
 
     expect(result.complete).toBe(true);
     expect(result.jobs).toEqual([{ jobId: 'job-1', status: 'completed' }]);
@@ -94,7 +93,7 @@ describe('_awaitJobs', () => {
 
     const result = await _awaitJobs(
       makeEnqueueResult(['job-1']),
-      undefined,
+      { pollingIntervalSeconds: 0.01 },
       mockConfig
     );
 
@@ -115,7 +114,7 @@ describe('_awaitJobs', () => {
 
     const result = await _awaitJobs(
       makeEnqueueResult(['job-1']),
-      undefined,
+      { pollingIntervalSeconds: 0.01 },
       mockConfig
     );
 
@@ -131,15 +130,11 @@ describe('_awaitJobs', () => {
       ])
       .mockResolvedValueOnce([{ jobId: 'job-2', status: 'completed' }]);
 
-    const promise = _awaitJobs(
+    const result = await _awaitJobs(
       makeEnqueueResult(['job-1', 'job-2']),
-      { pollingIntervalSeconds: 1 },
+      { pollingIntervalSeconds: 0.01 },
       mockConfig
     );
-
-    await vi.advanceTimersByTimeAsync(1000);
-
-    const result = await promise;
 
     expect(result.complete).toBe(true);
     expect(result.jobs).toHaveLength(2);
@@ -148,41 +143,44 @@ describe('_awaitJobs', () => {
   });
 
   it('should respect timeout and return incomplete', async () => {
+    // Always return 'processing' so the timeout fires
     vi.mocked(_checkJobStatus).mockResolvedValue([
       { jobId: 'job-1', status: 'processing' },
     ]);
 
-    const promise = _awaitJobs(
+    const result = await _awaitJobs(
       makeEnqueueResult(['job-1']),
-      { pollingIntervalSeconds: 1, timeoutSeconds: 3 },
+      { pollingIntervalSeconds: 0.01, timeoutSeconds: 0.05 },
       mockConfig
     );
-
-    // Advance past the timeout
-    await vi.advanceTimersByTimeAsync(5000);
-
-    const result = await promise;
 
     expect(result.complete).toBe(false);
     expect(result.jobs).toEqual([{ jobId: 'job-1', status: 'processing' }]);
   });
 
-  it('should use default 5s polling interval', async () => {
+  it('should use default polling interval of 5 seconds', async () => {
+    // Verify via fake timers that polling waits 5s between polls
+    vi.useFakeTimers();
+
     vi.mocked(_checkJobStatus)
       .mockResolvedValueOnce([{ jobId: 'job-1', status: 'processing' }])
       .mockResolvedValueOnce([{ jobId: 'job-1', status: 'completed' }]);
 
     const promise = _awaitJobs(
       makeEnqueueResult(['job-1']),
-      undefined,
+      undefined, // uses default 5s interval
       mockConfig
     );
 
-    // Advance less than 5s — should not trigger second poll
+    // Flush first poll
+    await vi.advanceTimersByTimeAsync(0);
+    expect(_checkJobStatus).toHaveBeenCalledTimes(1);
+
+    // 4s: still waiting
     await vi.advanceTimersByTimeAsync(4000);
     expect(_checkJobStatus).toHaveBeenCalledTimes(1);
 
-    // Advance to 5s — should trigger second poll
+    // 5s: second poll
     await vi.advanceTimersByTimeAsync(1000);
 
     const result = await promise;
@@ -196,8 +194,15 @@ describe('_awaitJobs', () => {
       new Error('Network error')
     );
 
-    await expect(
-      _awaitJobs(makeEnqueueResult(['job-1']), undefined, mockConfig)
-    ).rejects.toThrow('Network error');
+    // Attach .catch immediately to prevent unhandled rejection
+    const promise = _awaitJobs(
+      makeEnqueueResult(['job-1']),
+      { pollingIntervalSeconds: 0.01 },
+      mockConfig
+    ).catch((err: Error) => err);
+
+    const result = await promise;
+    expect(result).toBeInstanceOf(Error);
+    expect((result as Error).message).toBe('Network error');
   });
 });

--- a/packages/core/src/translate/__tests__/awaitJobs.test.ts
+++ b/packages/core/src/translate/__tests__/awaitJobs.test.ts
@@ -143,19 +143,26 @@ describe.sequential('_awaitJobs', () => {
   });
 
   it('should respect timeout and return incomplete', async () => {
+    vi.useFakeTimers();
+
     // Always return 'processing' so the timeout fires
     vi.mocked(_checkJobStatus).mockResolvedValue([
       { jobId: 'job-1', status: 'processing' },
     ]);
 
-    const result = await _awaitJobs(
+    const promise = _awaitJobs(
       makeEnqueueResult(['job-1']),
-      { pollingIntervalSeconds: 0.01, timeoutSeconds: 0.05 },
+      { pollingIntervalSeconds: 1, timeoutSeconds: 3 },
       mockConfig
     );
 
+    await vi.advanceTimersByTimeAsync(3001);
+    const result = await promise;
+
     expect(result.complete).toBe(false);
     expect(result.jobs).toEqual([{ jobId: 'job-1', status: 'processing' }]);
+
+    vi.useRealTimers();
   });
 
   it('should use default polling interval of 5 seconds', async () => {


### PR DESCRIPTION
## Problem

All 9 tests in `packages/core/src/translate/__tests__/awaitJobs.test.ts` fail on CI (and locally).

## Root Cause

The vitest config for `packages/core` enables concurrent test execution within files (`sequence.concurrent: true`). The `awaitJobs` tests share a mocked `_checkJobStatus` module, so when tests run simultaneously, mock call counts from one test leak into another.

For example, the "should return immediately for empty jobData" test expects `_checkJobStatus` to never be called, but sees calls from other concurrently-running tests.

Additionally:
- Missing `afterEach(vi.useRealTimers)` caused fake timer state to leak between tests
- The "propagate API errors" test created an unhandled rejection that poisoned the entire test suite

## Fix

- Use `describe.sequential` so these tests run one at a time (they share mocked state)
- Add `afterEach(vi.useRealTimers)` to clean up fake timer state
- Move `vi.useFakeTimers()` into individual tests that need it
- Use real timers with short intervals (`pollingIntervalSeconds: 0.01`) for most tests
- Fix error propagation test to catch rejection immediately via `.catch()`

All 9 tests pass. No changes to source code — test-only fix.

**Note:** 2 pre-existing failures in `src/__tests__/index.test.ts` ("should throw error when no project ID is provided") are unrelated.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This is a test-only fix that correctly resolves all 9 failing tests in `awaitJobs.test.ts` by addressing three independent root causes introduced by the file-level `sequence.concurrent: true` setting in `vitest.config.ts`.

**Key changes:**
- `describe` → `describe.sequential` prevents shared-mock state from leaking across concurrently running tests
- `vi.useFakeTimers()` removed from `beforeEach` and scoped only to the "default 5s interval" test that actually needs it; `afterEach(vi.useRealTimers)` added to guarantee cleanup
- Most tests switched to real timers with a `pollingIntervalSeconds: 0.01` fast-loop, eliminating the need to manually advance fake time in simple pass/fail scenarios
- The error-propagation test now attaches `.catch()` synchronously to `_awaitJobs(...)`, preventing the unhandled rejection from poisoning the suite; the test still verifies that the rejection is of the right type and message
- No changes to production source code

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- Safe to merge — test-only fix with no production code changes and clear, correct reasoning for each change.
- All changes are confined to a single test file. The three root causes (shared-mock bleed from concurrency, fake-timer state leaking between tests, unhandled rejection poisoning the suite) are each addressed directly and correctly. The one open P2 note (real-timer timeout test) is a hypothetical future flakiness concern, not a current bug.
- No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/translate/__tests__/awaitJobs.test.ts | Migrates from concurrent to sequential execution, scoped fake timers, and real-timer fast intervals — correctly addresses the root cause of all 9 CI failures. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[describe.sequential block starts] --> B[beforeEach: vi.clearAllMocks]
    B --> C{Test type?}

    C -->|Real-timer tests| D[Set pollingIntervalSeconds: 0.01\nor timeoutSeconds: 0.05]
    D --> E[await _awaitJobs directly]
    E --> F[Resolves in ~10-50ms wall time]
    F --> G[Assertions pass]
    G --> H[afterEach: vi.useRealTimers]

    C -->|Default interval test| I[vi.useFakeTimers]
    I --> J[Start _awaitJobs promise\nno interval option]
    J --> K[advanceTimersByTimeAsync 0\nflush first poll]
    K --> L{checkJobStatus called once?}
    L -->|yes| M[advanceTimersByTimeAsync 4000\nstill 1 call]
    M --> N[advanceTimersByTimeAsync 1000\n5s elapsed → second poll]
    N --> O[await promise → complete]
    O --> H

    C -->|Error propagation test| P[mockRejectedValueOnce\npollingIntervalSeconds: 0.01]
    P --> Q[_awaitJobs.catch err => err\nattached synchronously]
    Q --> R[await promise → Error instance]
    R --> H

    H --> S[Next test begins]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/core/src/translate/__tests__/awaitJobs.test.ts
Line: 145-158

Comment:
**Real-time timeout test could be slightly flaky under heavy load**

This test now relies on real wall-clock time (`timeoutSeconds: 0.05` = 50ms, `pollingIntervalSeconds: 0.01` = 10ms). On a heavily loaded CI runner, the 50ms budget could in theory be consumed before the loop has a chance to produce a `result.jobs` entry to assert against — though in practice, because `_checkJobStatus` is a synchronous mock, this risk is minimal.

If you ever see this test become flaky, consider bumping `timeoutSeconds` to something like `0.1` to give the loop more headroom, or using fake timers (like the "default interval" test does) to make it fully deterministic:

```ts
vi.useFakeTimers();
vi.mocked(_checkJobStatus).mockResolvedValue([
  { jobId: 'job-1', status: 'processing' },
]);

const promise = _awaitJobs(
  makeEnqueueResult(['job-1']),
  { pollingIntervalSeconds: 1, timeoutSeconds: 3 },
  mockConfig
);

await vi.advanceTimersByTimeAsync(3001);
const result = await promise;
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(core): fix awaitJobs tests failing d..."](https://github.com/generaltranslation/gt/commit/45ec93b77e6b76bc5fb42fadce966ffbf08a9338) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26255692)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->