### PR TITLE
chore: update anchor ids to handle new mint support

### DIFF
--- a/.changeset/famous-plums-shop.md
+++ b/.changeset/famous-plums-shop.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+Ignore Mintlify headers with existing custom anchors

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.13.1';
+export const PACKAGE_VERSION = '2.13.2';

--- a/packages/cli/src/utils/__tests__/addExplicitAnchorIds.test.ts
+++ b/packages/cli/src/utils/__tests__/addExplicitAnchorIds.test.ts
@@ -786,6 +786,76 @@ This is just an example
     });
   });
 
+  describe('Mintlify mode skips headings with existing anchor IDs', () => {
+    const mintlifyOnlySettings = {
+      options: { experimentalAddHeaderAnchorIds: 'mintlify' as const },
+    };
+
+    it('should not div-wrap a heading that already has {#id} syntax', () => {
+      const source = `## Getting Started {#getting-started}`;
+      const translated = `## Empezando {#getting-started}`;
+
+      const sourceHeadingMap = extractHeadingInfo(source);
+      const result = addExplicitAnchorIds(
+        translated,
+        sourceHeadingMap,
+        mintlifyOnlySettings as any
+      );
+
+      expect(result.hasChanges).toBe(false);
+      expect(result.content).toBe(translated);
+      expect(result.content).not.toContain('<div id=');
+    });
+
+    it('should not div-wrap a heading that has escaped \\{#id\\} syntax', () => {
+      const source = `## Getting Started {#getting-started}`;
+      const translated = `## Empezando \\{#getting-started\\}`;
+
+      const sourceHeadingMap = extractHeadingInfo(source);
+      const result = addExplicitAnchorIds(
+        translated,
+        sourceHeadingMap,
+        mintlifyOnlySettings as any
+      );
+
+      expect(result.hasChanges).toBe(false);
+      expect(result.content).toBe(translated);
+      expect(result.content).not.toContain('<div id=');
+    });
+
+    it('should div-wrap headings without {#id} but skip ones that have it', () => {
+      const source = `## First Heading {#first-heading}
+
+## Second Heading
+
+## Third Heading {#custom-id}
+`;
+
+      const translated = `## Primer Encabezado {#first-heading}
+
+## Segundo Encabezado
+
+## Tercer Encabezado {#custom-id}
+`;
+
+      const sourceHeadingMap = extractHeadingInfo(source);
+      const result = addExplicitAnchorIds(
+        translated,
+        sourceHeadingMap,
+        mintlifyOnlySettings as any
+      );
+
+      expect(result.hasChanges).toBe(true);
+      // Only the second heading (without {#id}) should be div-wrapped
+      expect(result.content).toContain(
+        '<div id="second-heading">\n  ## Segundo Encabezado\n</div>'
+      );
+      // The others should NOT be div-wrapped
+      expect(result.content).not.toContain('<div id="first-heading">');
+      expect(result.content).not.toContain('<div id="custom-id">');
+    });
+  });
+
   describe('Header Count Validation', () => {
     it('should work when source and translated files have same header count', () => {
       const sourceContent = `## Header 1

--- a/packages/cli/src/utils/addExplicitAnchorIds.ts
+++ b/packages/cli/src/utils/addExplicitAnchorIds.ts
@@ -508,6 +508,12 @@ function applyDivWrappedIds(
       });
 
       if (matchingLine) {
+        // Skip if heading already has explicit {#id} syntax —
+        // the translation will have naturally adopted it
+        const lineText = matchingLine.line.replace(/^#{1,6}\s+/, '');
+        if (/(\{#[^}]+\}|\\\{#[^}]+\\\})\s*$/.test(lineText)) {
+          return;
+        }
         headingsToWrap.push({
           originalLine: matchingLine.line,
           id,


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds logic to the `applyDivWrappedIds` function (Mintlify mode) to skip div-wrapping for translated headings that already carry `{#id}` or `\{#id\}` anchor syntax, preventing double-anchoring. Three test cases are added to validate this behavior.

**Key changes:**
- `addExplicitAnchorIds.ts`: New guard (lines 511–516) in `applyDivWrappedIds` checks the matched translated line for existing `{#id}` syntax and skips it if present.
- `addExplicitAnchorIds.test.ts`: Three new tests cover `{#id}` preserved in translation, escaped `\{#id\}` preserved, and a mixed document where only the anchor-less heading is wrapped.
- Version bumped `2.13.1 → 2.13.2` with a corresponding changeset entry.

**One observation worth reviewing:** The new guard at lines 511–516 appears to be dead code. Because `extractHeadingInfo` strips `{#id}` from `heading.text`, any translated line containing `{#id}` will have `normalizedLineText ≠ normalizedHeadingText`, so `matchingLine` will always be `undefined` for such lines — the guard is never reached. The tests pass because the correct behavior is already guaranteed by the existing mismatch logic, not the new check. This is harmless but worth clarifying.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- PR is safe to merge; behavior is correct and tests pass, but the new guard appears to be dead code worth a follow-up review.
- The intended behavior (don't double-wrap headings that already have custom anchors) is achieved correctly through the existing matching logic, and the new tests validate it. The only concern is that the new guard code at lines 511–516 is unreachable and its tests don't actually exercise that code path — this warrants a targeted fix or clarifying comment before merge.
- packages/cli/src/utils/addExplicitAnchorIds.ts — the new guard at lines 511–516
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/utils/addExplicitAnchorIds.ts | Adds a guard in `applyDivWrappedIds` to skip div-wrapping when a translated heading already has `{#id}` syntax; the guard is logically sound but appears unreachable with the current matching logic, making it dead code. |
| packages/cli/src/utils/__tests__/addExplicitAnchorIds.test.ts | Adds three new test cases for mintlify mode covering `{#id}` and `\{#id\}` syntax and mixed headings; tests validate correct behavior but do not exercise the new guard code directly. |
| packages/cli/src/generated/version.ts | Auto-generated version bump from 2.13.1 to 2.13.2 — no logic changes. |
| .changeset/famous-plums-shop.md | Changeset entry describing the patch: ignoring Mintlify headers with existing custom anchors. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["addExplicitAnchorIds(translatedContent, sourceHeadingMap)"] --> B["extractHeadingInfo(translatedContent)\n→ translatedHeadings (text stripped of {#id})"]
    A --> C["Build idMappings\n(position → source slug)"]
    B --> D{"useDivWrapping?"}
    C --> D
    D -- "mintlify mode" --> E["applyDivWrappedIds(translatedContent, translatedHeadings, idMappings)"]
    D -- "standard mode" --> F["applyInlineIds(translatedContent, idMappings, escapeAnchors)"]
    E --> G["Extract headingLines from raw translatedContent\n(includes {#id} in line text)"]
    G --> H["For each translatedHeading, find matchingLine\nnormalizedLineText === normalizedHeadingText"]
    H --> I{"Match found?\nnote: lines with {#id} WON'T match\nbecause heading.text has {#id} stripped"}
    I -- "No match" --> J["Skip — heading not added to headingsToWrap"]
    I -- "Match found" --> K["NEW CHECK (lines 511–516):\nDoes matchingLine.line contain {#id}?"]
    K -- "Yes (unreachable in practice)" --> J
    K -- "No" --> L["Add to headingsToWrap\n→ wrap with div id"]
    L --> M["Replace heading with\n&lt;div id='slug'&gt;\n  ## Heading\n&lt;/div&gt;"]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/cli/src/utils/addExplicitAnchorIds.ts
Line: 511-516

Comment:
**Guard appears unreachable with current matching logic**

The new check at lines 511–516 is designed to skip div-wrapping when a translated heading already contains `{#id}` syntax. However, this guard is effectively dead code because the upstream matching logic already prevents such headings from producing a `matchingLine`.

Here's why: `translatedHeadings` is built by `extractHeadingInfo`, which calls `parseHeadingContent` to strip `{#id}` from `heading.text`. Meanwhile, `headingLines` holds the raw translated lines — so `normalizedLineText` still contains `{#id}`. The comparison:

```ts
return (
  normalizedLineText === normalizedHeadingText &&
  hl.level === heading.level
);
```

will always fail for a translated line containing `{#id}` (e.g. `Empezando {#getting-started}` ≠ `Empezando`), so `matchingLine` is `undefined` and lines 511–516 are never reached.

The three new tests all pass — but they pass because of the existing mismatch logic, not the new guard. As a result, no test actually exercises lines 511–516.

If the intent is truly to provide a defensive guard, that's reasonable — but consider either:
1. Adding a comment that makes the "belt-and-suspenders" intent explicit, or
2. Adding a test case that actually reaches this code path (if one exists).

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: update anchor ids to handle new m..."](https://github.com/generaltranslation/gt/commit/66c7123d8371ff18b27110418fec8f091662d13d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26365189)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->