### PR TITLE
fix: restore GTFunctionType to return string instead of string | undefined

### DIFF
--- a/packages/i18n/src/translation-functions/types/functions.ts
+++ b/packages/i18n/src/translation-functions/types/functions.ts
@@ -41,7 +41,7 @@ export type SyncResolutionFunctionWithFallback = (
  * @returns {string} The translated message
  * TODO: next major version, remove the "...type" suffix, it's redundant
  */
-export type GTFunctionType = SyncResolutionFunction;
+export type GTFunctionType = SyncResolutionFunctionWithFallback;
 
 /**
  * Type for the m() function


### PR DESCRIPTION
## Problem

`GTFunctionType` was accidentally changed to alias `SyncResolutionFunction` (returns `string | undefined`) in PR #1113. This broke the expected return type.

## Fix

Alias `GTFunctionType` to `SyncResolutionFunctionWithFallback` (returns `string`) to restore the original behavior.

One-line change in `packages/i18n/src/translation-functions/types/functions.ts`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a one-line type fix that restores `GTFunctionType` to alias `SyncResolutionFunctionWithFallback` (returns `string`) after it was accidentally changed to alias `SyncResolutionFunction` (returns `string | undefined`) in PR #1113.

**Key observations:**
- The fix is correct and well-targeted: `getGT.ts` always returns a `string` — when no translation is found it falls back to `interpolateMessage(message, ...)` on the original input, so `undefined` is never returned.
- Downstream consumers in `packages/react`, `packages/react-core`, and `packages/node` all re-export or consume `GTFunctionType`, so restoring it to `=> string` prevents unnecessary null-checks being forced on callers.
- No logic changes, no new behavior — purely a type alias correction.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — single-line type alias fix with no runtime behavior change.

The fix matches the actual implementation in getGT.ts (which always returns string, never undefined), is narrow in scope, and is consistent with the JSDoc and the intent of GTFunctionType. No logic is touched and the change is a clear revert of an accidental regression.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/i18n/src/translation-functions/types/functions.ts | One-line fix restoring GTFunctionType alias from SyncResolutionFunction (returns string | undefined) to SyncResolutionFunctionWithFallback (returns string), consistent with the implementation in getGT.ts which always returns a string via fallback logic |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["GTFunctionType (alias)"] -->|"Before PR #1113 (correct)"| B["SyncResolutionFunctionWithFallback\n(message: string) => string"]
    A -->|"After PR #1113 (broken)"| C["SyncResolutionFunction\n(message: string) => string | undefined"]
    A -->|"After this PR (restored)"| B

    subgraph getGT.ts
        D["resolveTranslation(message, options)"]
        D -->|"translation found"| E["interpolateMessage(translation, ...) → string"]
        D -->|"no translation"| F["interpolateMessage(message, ...) → string (fallback)"]
    end

    B --> G["Callers never need to handle undefined"]
    C --> H["Callers forced to null-check unnecessarily"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: restore GTFunctionType to return st..."](https://github.com/generaltranslation/gt/commit/e8c3daeb472f5e40b298455cf9c75e050037e68a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26482823)</sub>

<!-- /greptile_comment -->