### PR TITLE
fix: branch id

### DIFF
--- a/.changeset/bitter-meals-make.md
+++ b/.changeset/bitter-meals-make.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+Add branch ID to lockfile during staging

--- a/packages/cli/src/cli/commands/stage.ts
+++ b/packages/cli/src/cli/commands/stage.ts
@@ -65,7 +65,7 @@ export async function handleStage(
           fileName: data.fileName,
         })
       );
-      writeStagedEntries(settings, stagedFiles);
+      writeStagedEntries(settings, stagedFiles, branchData.currentBranch.id);
     }
     const templateData = allFiles.find(
       (file) => file.fileId === TEMPLATE_FILE_ID

--- a/packages/cli/src/fs/config/__tests__/downloadedVersions.test.ts
+++ b/packages/cli/src/fs/config/__tests__/downloadedVersions.test.ts
@@ -431,6 +431,28 @@ describe('readLockfile / writeLockfile', () => {
       expect(written.entries[0].translations).toEqual({});
     });
 
+    it('uses branchId parameter over settings._branchId', () => {
+      writeStagedEntries(
+        settings(), // no branchId in settings
+        [{ fileId: 'f1', versionId: 'v1', fileName: 'en.json' }],
+        'brc_from_workflow'
+      );
+
+      const written = readLockFile();
+      expect(written.version).toBe(2);
+      expect(written.branchId).toBe('brc_from_workflow');
+      expect(written.entries[0].staged).toBe(true);
+    });
+
+    it('falls back to settings branchId when parameter is not provided', () => {
+      writeStagedEntries(settings('brc_from_settings'), [
+        { fileId: 'f1', versionId: 'v1', fileName: 'en.json' },
+      ]);
+
+      const written = readLockFile();
+      expect(written.branchId).toBe('brc_from_settings');
+    });
+
     it('does not clobber non-staged entries', () => {
       writeLockFile({
         version: 2,

--- a/packages/cli/src/fs/config/downloadedVersions.ts
+++ b/packages/cli/src/fs/config/downloadedVersions.ts
@@ -254,9 +254,14 @@ export function findOrCreateEntry(
  */
 export function writeStagedEntries(
   settings: Settings,
-  stagedFiles: { fileId: string; versionId: string; fileName: string }[]
+  stagedFiles: { fileId: string; versionId: string; fileName: string }[],
+  branchId?: string
 ): void {
   const { data, entryMap, originalV1 } = readLockfile(settings);
+
+  if (branchId) {
+    data.branchId = branchId;
+  }
 
   for (const file of stagedFiles) {
     const entry = findOrCreateEntry(

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.13.1';
+export const PACKAGE_VERSION = '2.13.2';


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where the branch ID was not being written to the lockfile (`gt-lock.json`) during the staging workflow. The fix passes `branchData.currentBranch.id` into `writeStagedEntries`, which now accepts an optional `branchId` parameter and persists it to the lockfile before writing staged entries.

**Key changes:**
- `writeStagedEntries` gains an optional `branchId` parameter; when provided, it overwrites `data.branchId` on the in-memory lockfile data before writing to disk.
- `handleStage` now supplies `branchData.currentBranch.id` when calling `writeStagedEntries`.
- Patch version bump to `2.13.2` and a corresponding changeset entry.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- Safe to merge after addressing the potential undefined access on `branchData.currentBranch.id`.
- One P1 issue: `branchData` is typed as `BranchData | undefined` and `.currentBranch.id` is accessed without a null-guard on the new line 68. If `runStageFilesWorkflow` returns undefined for `branchData`, this throws a `TypeError` at runtime. Since `branchId` is already optional in `writeStagedEntries`, using `branchData?.currentBranch?.id` is the trivial one-character fix. All other changes (the lockfile write logic, version bump, changeset) are correct and low-risk.
- `packages/cli/src/cli/commands/stage.ts` — undefined access on `branchData.currentBranch.id` at line 68.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/cli/commands/stage.ts | Passes `branchData.currentBranch.id` to `writeStagedEntries`, but `branchData` is typed as `BranchData | undefined` — accessing `.currentBranch.id` without a null-guard could throw at runtime. |
| packages/cli/src/fs/config/downloadedVersions.ts | Adds optional `branchId` parameter to `writeStagedEntries`; sets `data.branchId` before writing the lockfile when provided. Logic is sound and safe. |
| packages/cli/src/generated/version.ts | Auto-generated patch version bump from 2.13.1 to 2.13.2. |
| .changeset/bitter-meals-make.md | Changeset entry for a patch release describing the branch ID lockfile fix. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C as handleStage
    participant W as runStageFilesWorkflow
    participant S as writeStagedEntries
    participant L as writeLockfile

    C->>W: runStageFilesWorkflow(files, options, settings)
    W-->>C: { branchData, enqueueResult }
    C->>S: writeStagedEntries(settings, stagedFiles, branchData.currentBranch.id)
    S->>S: readLockfile(settings)
    S->>S: data.branchId = branchId (new)
    S->>S: findOrCreateEntry(...)  per staged file
    S->>L: writeLockfile(data, originalV1)
    L-->>S: gt-lock.json written with branchId
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/cli/src/cli/commands/stage.ts
Line: 68

Comment:
**Potential undefined access on `branchData`**

`branchData` is typed as `BranchData | undefined` (declared on line 50). Even though we're inside the `if (allFiles.length > 0)` block, `runStageFilesWorkflow` could return `branchData` as `undefined` (e.g., on a network error or unexpected response). Accessing `.currentBranch.id` directly would then throw a `TypeError` at runtime.

Since `branchId` is already declared optional in `writeStagedEntries`, using optional chaining here is the safe pattern — and consistent with how `branchData` should be treated throughout this function:

```suggestion
      writeStagedEntries(settings, stagedFiles, branchData?.currentBranch?.id);
```

Note: the existing call on line 77 (`branchData.currentBranch.id` inside `updateConfig`) has the same latent issue, but it was pre-existing. The new line 68 is the net-new change introduced by this PR.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: branch id"](https://github.com/generaltranslation/gt/commit/0adbef4255ffdc572be14cf5b9c6ca5f635cace9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26808589)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->