### PR TITLE
feat: add translation tagging

### DIFF
--- a/.changeset/ninety-needles-begin.md
+++ b/.changeset/ninety-needles-begin.md
@@ -1,0 +1,6 @@
+---
+'generaltranslation': patch
+'gt': patch
+---
+
+Adding translation tagging

--- a/packages/cli/src/cli/flags.ts
+++ b/packages/cli/src/cli/flags.ts
@@ -107,6 +107,14 @@ export function attachTranslateFlags(command: Command) {
       '--remote-name <name>',
       'Specify a custom remote name to use for branch detection',
       DEFAULT_GIT_REMOTE_NAME
+    )
+    .option(
+      '--tag <value>',
+      'Tag ID for this translation run (use "git" to auto-resolve from current commit)'
+    )
+    .option(
+      '-m, --message <message>',
+      'Message to attach to the translation tag'
     );
   return command;
 }

--- a/packages/cli/src/config/generateSettings.ts
+++ b/packages/cli/src/config/generateSettings.ts
@@ -317,18 +317,19 @@ export async function generateSettings(
         }).trim();
       }
     } catch {
-      // Not in a git repo or git unavailable — leave tag as-is
+      // Not in a git repo or git unavailable — fall back to auto-generation
+      mergedOptions.tag = undefined;
     }
-  }
-
-  // Auto-generate tag if none provided
-  if (!mergedOptions.tag) {
-    mergedOptions.tag = crypto.randomUUID().slice(0, 12);
   }
 
   // Map -m/--message flag to tagMessage
   if (flags.message) {
     mergedOptions.tagMessage = flags.message;
+  }
+
+  // Auto-generate a tag ID only when the user provided a message but no explicit tag
+  if (!mergedOptions.tag && mergedOptions.tagMessage) {
+    mergedOptions.tag = crypto.randomBytes(4).toString('hex');
   }
 
   // if there's no existing config file, creates one

--- a/packages/cli/src/config/generateSettings.ts
+++ b/packages/cli/src/config/generateSettings.ts
@@ -20,6 +20,8 @@ import {
   GT_DASHBOARD_URL,
 } from '../utils/constants.js';
 import { resolveProjectId } from '../fs/utils.js';
+import crypto from 'node:crypto';
+import { execSync } from 'node:child_process';
 import path from 'node:path';
 import chalk from 'chalk';
 import { resolveConfig } from './resolveConfig.js';
@@ -301,6 +303,33 @@ export async function generateSettings(
     gtConfig.branchOptions?.remoteName ??
     DEFAULT_GIT_REMOTE_NAME;
   mergedOptions.branchOptions = branchOptions;
+
+  // Resolve tag
+  if (flags.tag === 'git') {
+    try {
+      mergedOptions.tag = execSync('git rev-parse --short HEAD', {
+        encoding: 'utf-8',
+      }).trim();
+      // If no message provided, use git commit message
+      if (!flags.message) {
+        mergedOptions.tagMessage = execSync('git log -1 --format=%s', {
+          encoding: 'utf-8',
+        }).trim();
+      }
+    } catch {
+      // Not in a git repo or git unavailable — leave tag as-is
+    }
+  }
+
+  // Auto-generate tag if none provided
+  if (!mergedOptions.tag) {
+    mergedOptions.tag = crypto.randomUUID().slice(0, 12);
+  }
+
+  // Map -m/--message flag to tagMessage
+  if (flags.message) {
+    mergedOptions.tagMessage = flags.message;
+  }
 
   // if there's no existing config file, creates one
   // does not include the API key to avoid exposing it

--- a/packages/cli/src/config/generateSettings.ts
+++ b/packages/cli/src/config/generateSettings.ts
@@ -304,32 +304,30 @@ export async function generateSettings(
     DEFAULT_GIT_REMOTE_NAME;
   mergedOptions.branchOptions = branchOptions;
 
-  // Resolve tag
-  if (flags.tag === 'git') {
-    try {
-      mergedOptions.tag = execSync('git rev-parse --short HEAD', {
-        encoding: 'utf-8',
-      }).trim();
-      // If no message provided, use git commit message
-      if (!flags.message) {
-        mergedOptions.tagMessage = execSync('git log -1 --format=%s', {
-          encoding: 'utf-8',
-        }).trim();
-      }
-    } catch {
-      // Not in a git repo or git unavailable — fall back to auto-generation
-      mergedOptions.tag = undefined;
-    }
-  }
-
   // Map -m/--message flag to tagMessage
   if (flags.message) {
     mergedOptions.tagMessage = flags.message;
   }
 
-  // Auto-generate a tag ID only when the user provided a message but no explicit tag
-  if (!mergedOptions.tag && mergedOptions.tagMessage) {
-    mergedOptions.tag = crypto.randomBytes(4).toString('hex');
+  // Resolve tag:
+  // --tag git (explicit) or -m without --tag: try git SHA, fall back to random hex
+  // --tag <value>: use as-is
+  // No flags: no tag
+  if (flags.tag === 'git' || (!flags.tag && mergedOptions.tagMessage)) {
+    try {
+      mergedOptions.tag = execSync('git rev-parse --short HEAD', {
+        encoding: 'utf-8',
+      }).trim();
+      // If no message provided, use git commit message
+      if (!mergedOptions.tagMessage) {
+        mergedOptions.tagMessage = execSync('git log -1 --format=%s', {
+          encoding: 'utf-8',
+        }).trim();
+      }
+    } catch {
+      // Not in a git repo or git unavailable — fall back to random hex
+      mergedOptions.tag = crypto.randomBytes(4).toString('hex');
+    }
   }
 
   // if there's no existing config file, creates one

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.13.2';
+export const PACKAGE_VERSION = '2.13.3';

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -72,6 +72,8 @@ export type TranslateFlags = SharedFlags & {
   publish?: boolean;
   force?: boolean;
   forceDownload?: boolean;
+  tag?: string;
+  message?: string;
   experimentalLocalizeStaticUrls?: boolean;
   experimentalHideDefaultLocale?: boolean;
   experimentalFlattenJsonFiles?: boolean;
@@ -241,6 +243,8 @@ export type Settings = {
   framework?: SupportedFrameworks;
   options?: AdditionalOptions;
   modelProvider?: string;
+  tag?: string;
+  tagMessage?: string;
   parsingOptions: ParsingConfigOptions;
   branchOptions: BranchOptions;
   // Optional shared static assets config

--- a/packages/cli/src/workflows/stage.ts
+++ b/packages/cli/src/workflows/stage.ts
@@ -1,4 +1,5 @@
 import { logCollectedFiles, logErrorAndExit } from '../console/logging.js';
+import { logger } from '../console/logger.js';
 import { Settings, TranslateFlags } from '../types/index.js';
 import { gt } from '../utils/gt.js';
 import { EnqueueFilesResult, FileToUpload } from 'generaltranslation/types';
@@ -61,12 +62,16 @@ export async function runStageFilesWorkflow({
       await userEditDiffsStep.wait();
     }
 
-    // then run the tag step
+    // then run the tag step (non-fatal — tagging failure should not block translations)
     if (settings.tag) {
-      const userProvidedTag = !!options.tag;
-      const tagStep = new TagStep(gt, settings, userProvidedTag);
-      await tagStep.run(uploadedFiles);
-      await tagStep.wait();
+      try {
+        const userProvidedTag = !!options.tag;
+        const tagStep = new TagStep(gt, settings, userProvidedTag);
+        await tagStep.run(uploadedFiles);
+        await tagStep.wait();
+      } catch {
+        logger.warn('Failed to create translation tag. Continuing...');
+      }
     }
 
     // then run the setup step

--- a/packages/cli/src/workflows/stage.ts
+++ b/packages/cli/src/workflows/stage.ts
@@ -6,6 +6,7 @@ import { UploadSourcesStep } from './steps/UploadSourcesStep.js';
 import { SetupStep } from './steps/SetupStep.js';
 import { EnqueueStep } from './steps/EnqueueStep.js';
 import { BranchStep } from './steps/BranchStep.js';
+import { TagStep } from './steps/TagStep.js';
 import { UserEditDiffsStep } from './steps/UserEditDiffsStep.js';
 import { BranchData } from '../types/branch.js';
 import { calculateTimeoutMs } from '../utils/calculateTimeoutMs.js';
@@ -58,6 +59,14 @@ export async function runStageFilesWorkflow({
     if (options?.saveLocal) {
       await userEditDiffsStep.run(uploadedFiles);
       await userEditDiffsStep.wait();
+    }
+
+    // then run the tag step
+    if (settings.tag) {
+      const userProvidedTag = !!options.tag;
+      const tagStep = new TagStep(gt, settings, userProvidedTag);
+      await tagStep.run(uploadedFiles);
+      await tagStep.wait();
     }
 
     // then run the setup step

--- a/packages/cli/src/workflows/steps/TagStep.ts
+++ b/packages/cli/src/workflows/steps/TagStep.ts
@@ -23,15 +23,22 @@ export class TagStep extends WorkflowStep<FileReference[], CreateTagResult> {
       this.spinner.start('Creating translation tag...');
     }
 
-    this.result = await this.gt.createTag({
-      tagId: this.settings.tag!,
-      files: files.map((f) => ({
-        fileId: f.fileId,
-        versionId: f.versionId,
-        branchId: f.branchId,
-      })),
-      message: this.settings.tagMessage,
-    });
+    try {
+      this.result = await this.gt.createTag({
+        tagId: this.settings.tag!,
+        files: files.map((f) => ({
+          fileId: f.fileId,
+          versionId: f.versionId,
+          branchId: f.branchId,
+        })),
+        message: this.settings.tagMessage,
+      });
+    } catch (error) {
+      if (this.userProvided) {
+        this.spinner.stop(chalk.yellow('Failed to create translation tag'));
+      }
+      throw error;
+    }
 
     return this.result;
   }

--- a/packages/cli/src/workflows/steps/TagStep.ts
+++ b/packages/cli/src/workflows/steps/TagStep.ts
@@ -1,0 +1,46 @@
+import type { CreateTagResult } from 'generaltranslation/types';
+import { WorkflowStep } from './WorkflowStep.js';
+import { logger } from '../../console/logger.js';
+import { GT } from 'generaltranslation';
+import { Settings } from '../../types/index.js';
+import type { FileReference } from 'generaltranslation/types';
+import chalk from 'chalk';
+
+export class TagStep extends WorkflowStep<FileReference[], CreateTagResult> {
+  private spinner = logger.createSpinner('dots');
+  private result: CreateTagResult | null = null;
+
+  constructor(
+    private gt: GT,
+    private settings: Settings,
+    private userProvided: boolean
+  ) {
+    super();
+  }
+
+  async run(files: FileReference[]): Promise<CreateTagResult> {
+    if (this.userProvided) {
+      this.spinner.start('Creating translation tag...');
+    }
+
+    this.result = await this.gt.createTag({
+      tagId: this.settings.tag!,
+      files: files.map((f) => ({
+        fileId: f.fileId,
+        versionId: f.versionId,
+        branchId: f.branchId,
+      })),
+      message: this.settings.tagMessage,
+    });
+
+    return this.result;
+  }
+
+  async wait(): Promise<void> {
+    if (this.result && this.userProvided) {
+      this.spinner.stop(
+        chalk.green(`Tagged as ${chalk.bold(this.result.tag.tagId)}`)
+      );
+    }
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -56,6 +56,10 @@ import _setupProject, {
   SetupProjectOptions,
 } from './translate/setupProject';
 import _enqueueFiles, { EnqueueOptions } from './translate/enqueueFiles';
+import _createTag, {
+  CreateTagOptions,
+  CreateTagResult,
+} from './translate/createTag';
 import _downloadFileBatch from './translate/downloadFileBatch';
 import {
   FileQuery,
@@ -522,6 +526,18 @@ export class GT {
       mergedOptions,
       this._getTranslationConfig()
     );
+  }
+
+  /**
+   * Creates or upserts a file tag, associating a set of source files
+   * with a user-defined tag ID and optional message.
+   *
+   * @param {CreateTagOptions} options - Tag creation options including tagId, sourceFileIds, and optional message
+   * @returns {Promise<CreateTagResult>} The created or updated tag
+   */
+  async createTag(options: CreateTagOptions): Promise<CreateTagResult> {
+    this._validateAuth('createTag');
+    return await _createTag(options, this._getTranslationConfig());
   }
 
   /**

--- a/packages/core/src/translate/__tests__/createTag.test.ts
+++ b/packages/core/src/translate/__tests__/createTag.test.ts
@@ -57,8 +57,16 @@ describe('_createTag', () => {
         body: {
           tagId: 'v1.0.0',
           files: [
-            { fileId: 'file-123', versionId: 'version-456', branchId: 'branch-123' },
-            { fileId: 'file-456', versionId: 'version-456', branchId: 'branch-123' },
+            {
+              fileId: 'file-123',
+              versionId: 'version-456',
+              branchId: 'branch-123',
+            },
+            {
+              fileId: 'file-456',
+              versionId: 'version-456',
+              branchId: 'branch-123',
+            },
           ],
           message: 'initial release',
         },
@@ -86,7 +94,11 @@ describe('_createTag', () => {
         body: {
           tagId: 'v2.0.0',
           files: [
-            { fileId: 'file-123', versionId: 'version-456', branchId: 'branch-123' },
+            {
+              fileId: 'file-123',
+              versionId: 'version-456',
+              branchId: 'branch-123',
+            },
           ],
         },
       }
@@ -108,10 +120,7 @@ describe('_createTag', () => {
   it('should call the correct endpoint', async () => {
     vi.mocked(apiRequest).mockResolvedValue(mockTagResult);
 
-    await _createTag(
-      { tagId: 'test', files: [createMockFile()] },
-      mockConfig
-    );
+    await _createTag({ tagId: 'test', files: [createMockFile()] }, mockConfig);
 
     expect(apiRequest).toHaveBeenCalledWith(
       mockConfig,

--- a/packages/core/src/translate/__tests__/createTag.test.ts
+++ b/packages/core/src/translate/__tests__/createTag.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import _createTag, {
+  CreateTagOptions,
+  CreateTagResult,
+  CreateTagFileReference,
+} from '../createTag';
+import { TranslationRequestConfig } from '../../types';
+import apiRequest from '../utils/apiRequest';
+
+vi.mock('../utils/apiRequest');
+
+describe('_createTag', () => {
+  const mockConfig: TranslationRequestConfig = {
+    baseUrl: 'https://api.test.com',
+    projectId: 'test-project',
+    apiKey: 'test-api-key',
+  };
+
+  const createMockFile = (
+    overrides: Partial<CreateTagFileReference> = {}
+  ): CreateTagFileReference => ({
+    fileId: 'file-123',
+    versionId: 'version-456',
+    branchId: 'branch-123',
+    ...overrides,
+  });
+
+  const mockTagResult: CreateTagResult = {
+    tag: {
+      id: 'tag-internal-id',
+      tagId: 'v1.0.0',
+      message: 'initial release',
+      createdAt: '2026-04-01T00:00:00.000Z',
+      updatedAt: '2026-04-01T00:00:00.000Z',
+    },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should create a tag with tagId, files, and message', async () => {
+    vi.mocked(apiRequest).mockResolvedValue(mockTagResult);
+
+    const options: CreateTagOptions = {
+      tagId: 'v1.0.0',
+      files: [createMockFile(), createMockFile({ fileId: 'file-456' })],
+      message: 'initial release',
+    };
+
+    const result = await _createTag(options, mockConfig);
+
+    expect(apiRequest).toHaveBeenCalledWith(
+      mockConfig,
+      '/v2/project/tags/create',
+      {
+        body: {
+          tagId: 'v1.0.0',
+          files: [
+            { fileId: 'file-123', versionId: 'version-456', branchId: 'branch-123' },
+            { fileId: 'file-456', versionId: 'version-456', branchId: 'branch-123' },
+          ],
+          message: 'initial release',
+        },
+      }
+    );
+    expect(result).toEqual(mockTagResult);
+  });
+
+  it('should omit message from body when not provided', async () => {
+    vi.mocked(apiRequest).mockResolvedValue({
+      tag: { ...mockTagResult.tag, message: null },
+    });
+
+    const options: CreateTagOptions = {
+      tagId: 'v2.0.0',
+      files: [createMockFile()],
+    };
+
+    await _createTag(options, mockConfig);
+
+    expect(apiRequest).toHaveBeenCalledWith(
+      mockConfig,
+      '/v2/project/tags/create',
+      {
+        body: {
+          tagId: 'v2.0.0',
+          files: [
+            { fileId: 'file-123', versionId: 'version-456', branchId: 'branch-123' },
+          ],
+        },
+      }
+    );
+  });
+
+  it('should propagate API errors', async () => {
+    vi.mocked(apiRequest).mockRejectedValue(new Error('API error'));
+
+    const options: CreateTagOptions = {
+      tagId: 'v1.0.0',
+      files: [createMockFile()],
+      message: 'test',
+    };
+
+    await expect(_createTag(options, mockConfig)).rejects.toThrow('API error');
+  });
+
+  it('should call the correct endpoint', async () => {
+    vi.mocked(apiRequest).mockResolvedValue(mockTagResult);
+
+    await _createTag(
+      { tagId: 'test', files: [createMockFile()] },
+      mockConfig
+    );
+
+    expect(apiRequest).toHaveBeenCalledWith(
+      mockConfig,
+      '/v2/project/tags/create',
+      expect.any(Object)
+    );
+  });
+});

--- a/packages/core/src/translate/createTag.ts
+++ b/packages/core/src/translate/createTag.ts
@@ -1,0 +1,44 @@
+import { TranslationRequestConfig } from '../types';
+import apiRequest from './utils/apiRequest';
+
+export type CreateTagFileReference = {
+  fileId: string;
+  versionId: string;
+  branchId: string;
+};
+
+export type CreateTagOptions = {
+  tagId: string;
+  files: CreateTagFileReference[];
+  message?: string;
+};
+
+export type CreateTagResult = {
+  tag: {
+    id: string;
+    tagId: string;
+    message: string | null;
+    createdAt: string;
+    updatedAt: string;
+  };
+};
+
+/**
+ * @internal
+ * Creates or upserts a file tag in the General Translation API.
+ * @param options - The tag creation options
+ * @param config - The configuration for the API call
+ * @returns The created or updated tag
+ */
+export default async function _createTag(
+  options: CreateTagOptions,
+  config: TranslationRequestConfig
+): Promise<CreateTagResult> {
+  return await apiRequest<CreateTagResult>(config, '/v2/project/tags/create', {
+    body: {
+      tagId: options.tagId,
+      files: options.files,
+      ...(options.message && { message: options.message }),
+    },
+  });
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -64,6 +64,7 @@ export type {
   EnqueueFilesResult,
   Updates,
 } from './types-dir/api/enqueueFiles';
+export type { CreateTagOptions, CreateTagResult } from './translate/createTag';
 export type { FileToUpload } from './types-dir/api/file';
 export type { FileUpload } from './types-dir/api/uploadFiles';
 export type {


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a translation tagging feature to the CLI, allowing users to annotate translation runs with a `--tag <id>` and optionally a `-m/--message` flag. When `--tag git` is passed, the tag ID is auto-resolved from the current git commit hash and the commit subject line is used as the default message. If only `-m` is provided without a `--tag`, a random 4-byte hex tag ID is auto-generated. The tagging step is deliberately non-fatal — failures warn and continue rather than blocking translation.

Key changes:
- New `--tag` and `-m/--message` CLI flags added to `attachTranslateFlags`
- `generateSettings.ts` resolves the tag ID (git hash, explicit string, or auto-generated UUID) and tag message before the rest of the settings flow
- New `TagStep` workflow step calls `GT.createTag()` after source upload and before setup/enqueue
- New `createTag` API method on the `GT` class posts to `/v2/project/tags/create`
- `CreateTagOptions` / `CreateTagResult` types exported from `generaltranslation/types`
- Minor UX gaps: when the tag step fails and the user explicitly provided a `--tag`, both the spinner stop and the outer `logger.warn` emit near-identical error messages; also, when only `-m` is passed (no `--tag`), the auto-generated tag is created silently with no user feedback

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- Safe to merge — the two remaining findings are P2 UX polish items that do not affect correctness or data integrity
- All previously flagged issues (literal "git" sentinel as tag ID, dead guard on settings.tag) have been addressed in this revision. The only open findings are P2: a duplicate failure message in the explicit-tag failure path, and silent tag creation when only -m is provided. Neither affects translation correctness or API behaviour.
- packages/cli/src/workflows/stage.ts — userProvidedTag detection and duplicate failure message
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/config/generateSettings.ts | Added tag resolution logic: resolves git commit hash for --tag git, maps --message to tagMessage, and auto-generates a random hex tag when a message is provided without an explicit tag. Previous issues with the sentinel "git" string and the dead guard have been addressed. |
| packages/cli/src/workflows/steps/TagStep.ts | New workflow step that calls gt.createTag(); correctly non-fatal, but the spinner/warn double-message on failure and silent creation when auto-tagged (message-only path) are minor UX gaps. |
| packages/cli/src/workflows/stage.ts | TagStep integrated into the workflow; correctly positioned before setup/enqueue and wrapped in a non-fatal try/catch. The userProvidedTag flag needs adjustment to account for -m without --tag. |
| packages/core/src/translate/createTag.ts | New internal API call to /v2/project/tags/create; clean type definitions, correct conditional spread for message, no issues found. |
| packages/core/src/index.ts | Added createTag public method to the GT class with proper auth validation and delegation to internal _createTag; well-documented. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant CLI
    participant generateSettings
    participant stage as runStageFilesWorkflow
    participant UploadStep
    participant TagStep
    participant SetupStep
    participant EnqueueStep
    participant API as GT API

    User->>CLI: gt translate --tag git -m "release"
    CLI->>generateSettings: flags { tag: "git", message: "release" }
    generateSettings->>generateSettings: execSync git rev-parse --short HEAD → "abc1234"
    generateSettings->>generateSettings: mergedOptions.tag = "abc1234", tagMessage = "release"
    generateSettings-->>CLI: settings { tag: "abc1234", tagMessage: "release" }

    CLI->>stage: runStageFilesWorkflow(files, options, settings)
    stage->>UploadStep: run(files, branchData)
    UploadStep->>API: uploadSourceFiles(...)
    API-->>UploadStep: FileReference[]
    UploadStep-->>stage: uploadedFiles: FileReference[]

    stage->>TagStep: run(uploadedFiles)
    TagStep->>API: POST /v2/project/tags/create { tagId, files, message }
    API-->>TagStep: CreateTagResult
    TagStep-->>stage: result (spinner: "Tagged as abc1234")

    stage->>SetupStep: run(uploadedFiles)
    stage->>EnqueueStep: run(uploadedFiles)
    EnqueueStep->>API: enqueueFiles(...)
    API-->>EnqueueStep: EnqueueFilesResult
    stage-->>CLI: { branchData, enqueueResult }
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/cli/src/workflows/stage.ts
Line: 72-74

Comment:
**Duplicate failure message when user provided a tag**

When `userProvided` is `true` and the tag step fails, the user sees two nearly-identical error messages in quick succession:

1. `TagStep.run()`'s catch stops the spinner with: `chalk.yellow('Failed to create translation tag')`
2. The outer catch here emits: `logger.warn('Failed to create translation tag. Continuing...')`

Consider removing the redundant `logger.warn` for the `userProvided` case (since the spinner already surfaced the failure), or unconditionally rely on this outer `warn` and drop the spinner-stop inside `TagStep`.

```suggestion
      } catch {
        if (!options.tag) {
          // Only warn here when the tag was auto-generated (no spinner was shown)
          logger.warn('Failed to create translation tag. Continuing...');
        }
      }
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/cli/src/workflows/stage.ts
Line: 68

Comment:
**Silent tag creation when `-m` is used without `--tag`**

`userProvidedTag` is `false` whenever the user passes only `-m/--message` (no `--tag`). In that case `generateSettings` auto-generates a random hex tag ID, `settings.tag` is set, the `TagStep` runs and creates a tag — but the user receives no feedback (no spinner start, no success confirmation) because all output is gated on `this.userProvided`.

A user who passes `-m "release notes"` to annotate a run expects some indication that a tag was created. Consider treating an explicit `--message` flag as an "opt-in" that also warrants user feedback:

```suggestion
        const userProvidedTag = !!options.tag || !!options.message;
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: only tag explicitly"](https://github.com/generaltranslation/gt/commit/ae2e083ceabe8d7b4b5f2f362eec1ea60cfc53a1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26980030)</sub>

<!-- /greptile_comment -->