### PR TITLE
chore: update logo blocks in READMEs

### DIFF
--- a/.changeset/update-readme-logos.md
+++ b/.changeset/update-readme-logos.md
@@ -1,0 +1,22 @@
+---
+"gt": patch
+"gtx-cli": patch
+"gt-next": patch
+"gt-react": patch
+"gt-i18n": patch
+"gt-node": patch
+"gt-remark": patch
+"gt-sanity": patch
+"gt-tanstack-start": patch
+"generaltranslation": patch
+"locadex": patch
+"@generaltranslation/compiler": patch
+"@generaltranslation/mcp": patch
+"@generaltranslation/next-internal": patch
+"@generaltranslation/gt-next-lint": patch
+"@generaltranslation/react-core": patch
+"@generaltranslation/react-core-linter": patch
+"@generaltranslation/supported-locales": patch
+---
+
+Update logo blocks in READMEs

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <div align="center">
   <a href="https://generaltranslation.com">
     <picture>
-      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/brand/gt-logo-light.svg">
-      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-dark.svg" height="64">
+      <source media="(prefers-color-scheme: dark)" srcset="https://generaltranslation.com/brand/gt-logo-dark.svg">
+      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-light.svg" height="64">
     </picture>
   </a>
   <h1>General Translation</h1>

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,9 @@
 <p align="center">
   <a href="https://generaltranslation.com" target="_blank">
-    <img src="https://generaltranslation.com/brand/gt-logo-light.svg" alt="General Translation" width="100" height="100">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://generaltranslation.com/brand/gt-logo-dark.svg">
+      <img src="https://generaltranslation.com/brand/gt-logo-light.svg" alt="General Translation" width="100" height="100">
+    </picture>
   </a>
 </p>
 
@@ -15,7 +18,10 @@ Use this template for each example app's README:
 ```markdown
 <p align="center">
   <a href="https://generaltranslation.com" target="_blank">
-    <img src="https://generaltranslation.com/brand/gt-logo-light.svg" alt="General Translation" width="100" height="100">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://generaltranslation.com/brand/gt-logo-dark.svg">
+      <img src="https://generaltranslation.com/brand/gt-logo-light.svg" alt="General Translation" width="100" height="100">
+    </picture>
   </a>
 </p>
 

--- a/examples/create-react-app/README.md
+++ b/examples/create-react-app/README.md
@@ -1,6 +1,9 @@
 <p align="center">
   <a href="https://generaltranslation.com" target="_blank">
-    <img src="https://generaltranslation.com/brand/gt-logo-light.svg" alt="General Translation" width="100" height="100">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://generaltranslation.com/brand/gt-logo-dark.svg">
+      <img src="https://generaltranslation.com/brand/gt-logo-light.svg" alt="General Translation" width="100" height="100">
+    </picture>
   </a>
 </p>
 

--- a/examples/next-chatbot/README.md
+++ b/examples/next-chatbot/README.md
@@ -1,6 +1,9 @@
 <p align="center">
   <a href="https://generaltranslation.com" target="_blank">
-    <img src="https://generaltranslation.com/brand/gt-logo-light.svg" alt="General Translation" width="100" height="100">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://generaltranslation.com/brand/gt-logo-dark.svg">
+      <img src="https://generaltranslation.com/brand/gt-logo-light.svg" alt="General Translation" width="100" height="100">
+    </picture>
   </a>
 </p>
 

--- a/examples/next-create-app/README.md
+++ b/examples/next-create-app/README.md
@@ -1,6 +1,9 @@
 <p align="center">
   <a href="https://generaltranslation.com" target="_blank">
-    <img src="https://generaltranslation.com/brand/gt-logo-light.svg" alt="General Translation" width="100" height="100">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://generaltranslation.com/brand/gt-logo-dark.svg">
+      <img src="https://generaltranslation.com/brand/gt-logo-light.svg" alt="General Translation" width="100" height="100">
+    </picture>
   </a>
 </p>
 

--- a/examples/next-gt-starter/README.md
+++ b/examples/next-gt-starter/README.md
@@ -1,6 +1,9 @@
 <p align="center">
   <a href="https://generaltranslation.com" target="_blank">
-    <img src="https://generaltranslation.com/brand/gt-logo-light.svg" alt="General Translation" width="100" height="100">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://generaltranslation.com/brand/gt-logo-dark.svg">
+      <img src="https://generaltranslation.com/brand/gt-logo-light.svg" alt="General Translation" width="100" height="100">
+    </picture>
   </a>
 </p>
 

--- a/examples/next-pages-router/README.md
+++ b/examples/next-pages-router/README.md
@@ -1,6 +1,9 @@
 <p align="center">
   <a href="https://generaltranslation.com" target="_blank">
-    <img src="https://generaltranslation.com/brand/gt-logo-light.svg" alt="General Translation" width="100" height="100">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://generaltranslation.com/brand/gt-logo-dark.svg">
+      <img src="https://generaltranslation.com/brand/gt-logo-light.svg" alt="General Translation" width="100" height="100">
+    </picture>
   </a>
 </p>
 

--- a/examples/next-ssg/README.md
+++ b/examples/next-ssg/README.md
@@ -1,6 +1,9 @@
 <p align="center">
   <a href="https://generaltranslation.com" target="_blank">
-    <img src="https://generaltranslation.com/brand/gt-logo-light.svg" alt="General Translation" width="100" height="100">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://generaltranslation.com/brand/gt-logo-dark.svg">
+      <img src="https://generaltranslation.com/brand/gt-logo-light.svg" alt="General Translation" width="100" height="100">
+    </picture>
   </a>
 </p>
 

--- a/examples/vite-create-app/README.md
+++ b/examples/vite-create-app/README.md
@@ -1,6 +1,9 @@
 <p align="center">
   <a href="https://generaltranslation.com" target="_blank">
-    <img src="https://generaltranslation.com/brand/gt-logo-light.svg" alt="General Translation" width="100" height="100">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://generaltranslation.com/brand/gt-logo-dark.svg">
+      <img src="https://generaltranslation.com/brand/gt-logo-light.svg" alt="General Translation" width="100" height="100">
+    </picture>
   </a>
 </p>
 

--- a/packages/README.md
+++ b/packages/README.md
@@ -12,8 +12,8 @@ When creating a new package, use this README template:
 <p align="center">
   <a href="https://generaltranslation.com/docs/PACKAGE_NAME">
     <picture>
-      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/brand/gt-logo-light.svg">
-      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-dark.svg" width="100" height="100">
+      <source media="(prefers-color-scheme: dark)" srcset="https://generaltranslation.com/brand/gt-logo-dark.svg">
+      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-light.svg" width="100" height="100">
     </picture>
   </a>
 </p>

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,8 +1,8 @@
 <p align="center">
   <a href="https://generaltranslation.com/docs/cli">
     <picture>
-      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/brand/gt-logo-light.svg">
-      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-dark.svg" width="100" height="100">
+      <source media="(prefers-color-scheme: dark)" srcset="https://generaltranslation.com/brand/gt-logo-dark.svg">
+      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-light.svg" width="100" height="100">
     </picture>
   </a>
 </p>

--- a/packages/compiler/README.md
+++ b/packages/compiler/README.md
@@ -1,8 +1,8 @@
 <p align="center">
   <a href="https://generaltranslation.com/docs">
     <picture>
-      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/brand/gt-logo-light.svg">
-      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-dark.svg" width="100" height="100">
+      <source media="(prefers-color-scheme: dark)" srcset="https://generaltranslation.com/brand/gt-logo-dark.svg">
+      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-light.svg" width="100" height="100">
     </picture>
   </a>
 </p>

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,8 +1,8 @@
 <p align="center">
   <a href="https://generaltranslation.com/docs">
     <picture>
-      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/brand/gt-logo-light.svg">
-      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-dark.svg" width="100" height="100">
+      <source media="(prefers-color-scheme: dark)" srcset="https://generaltranslation.com/brand/gt-logo-dark.svg">
+      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-light.svg" width="100" height="100">
     </picture>
   </a>
 </p>

--- a/packages/gtx-cli/README.md
+++ b/packages/gtx-cli/README.md
@@ -1,8 +1,8 @@
 <p align="center">
   <a href="https://generaltranslation.com/docs/cli">
     <picture>
-      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/brand/gt-logo-light.svg">
-      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-dark.svg" width="100" height="100">
+      <source media="(prefers-color-scheme: dark)" srcset="https://generaltranslation.com/brand/gt-logo-dark.svg">
+      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-light.svg" width="100" height="100">
     </picture>
   </a>
 </p>

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -1,8 +1,8 @@
 <p align="center">
   <a href="https://generaltranslation.com/docs/i18n">
     <picture>
-      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/brand/gt-logo-light.svg">
-      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-dark.svg" width="100" height="100">
+      <source media="(prefers-color-scheme: dark)" srcset="https://generaltranslation.com/brand/gt-logo-dark.svg">
+      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-light.svg" width="100" height="100">
     </picture>
   </a>
 </p>

--- a/packages/locadex/README.md
+++ b/packages/locadex/README.md
@@ -1,8 +1,8 @@
 <p align="center">
   <a href="https://generaltranslation.com/docs/locadex">
     <picture>
-      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/brand/gt-logo-light.svg">
-      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-dark.svg" width="100" height="100">
+      <source media="(prefers-color-scheme: dark)" srcset="https://generaltranslation.com/brand/gt-logo-dark.svg">
+      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-light.svg" width="100" height="100">
     </picture>
   </a>
 </p>

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,8 +1,8 @@
 <p align="center">
   <a href="https://generaltranslation.com/docs">
     <picture>
-      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/brand/gt-logo-light.svg">
-      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-dark.svg" width="100" height="100">
+      <source media="(prefers-color-scheme: dark)" srcset="https://generaltranslation.com/brand/gt-logo-dark.svg">
+      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-light.svg" width="100" height="100">
     </picture>
   </a>
 </p>

--- a/packages/next-internal/README.md
+++ b/packages/next-internal/README.md
@@ -1,8 +1,8 @@
 <p align="center">
   <a href="https://generaltranslation.com/docs/next">
     <picture>
-      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/brand/gt-logo-light.svg">
-      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-dark.svg" width="100" height="100">
+      <source media="(prefers-color-scheme: dark)" srcset="https://generaltranslation.com/brand/gt-logo-dark.svg">
+      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-light.svg" width="100" height="100">
     </picture>
   </a>
 </p>

--- a/packages/next-lint/README.md
+++ b/packages/next-lint/README.md
@@ -1,8 +1,8 @@
 <p align="center">
   <a href="https://generaltranslation.com/docs/next">
     <picture>
-      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/brand/gt-logo-light.svg">
-      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-dark.svg" width="100" height="100">
+      <source media="(prefers-color-scheme: dark)" srcset="https://generaltranslation.com/brand/gt-logo-dark.svg">
+      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-light.svg" width="100" height="100">
     </picture>
   </a>
 </p>

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -1,8 +1,8 @@
 <p align="center">
   <a href="https://generaltranslation.com/docs/next">
     <picture>
-      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/brand/gt-logo-light.svg">
-      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-dark.svg" width="100" height="100">
+      <source media="(prefers-color-scheme: dark)" srcset="https://generaltranslation.com/brand/gt-logo-dark.svg">
+      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-light.svg" width="100" height="100">
     </picture>
   </a>
 </p>

--- a/packages/react-core-linter/README.md
+++ b/packages/react-core-linter/README.md
@@ -1,8 +1,8 @@
 <p align="center">
   <a href="https://generaltranslation.com/docs/react-core-linter">
     <picture>
-      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/brand/gt-logo-light.svg">
-      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-dark.svg" width="100" height="100">
+      <source media="(prefers-color-scheme: dark)" srcset="https://generaltranslation.com/brand/gt-logo-dark.svg">
+      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-light.svg" width="100" height="100">
     </picture>
   </a>
 </p>

--- a/packages/react-core/README.md
+++ b/packages/react-core/README.md
@@ -1,8 +1,8 @@
 <p align="center">
   <a href="https://generaltranslation.com/docs/react">
     <picture>
-      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/brand/gt-logo-light.svg">
-      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-dark.svg" width="100" height="100">
+      <source media="(prefers-color-scheme: dark)" srcset="https://generaltranslation.com/brand/gt-logo-dark.svg">
+      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-light.svg" width="100" height="100">
     </picture>
   </a>
 </p>

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,8 +1,8 @@
 <p align="center">
   <a href="https://generaltranslation.com/docs/react">
     <picture>
-      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/brand/gt-logo-light.svg">
-      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-dark.svg" width="100" height="100">
+      <source media="(prefers-color-scheme: dark)" srcset="https://generaltranslation.com/brand/gt-logo-dark.svg">
+      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-light.svg" width="100" height="100">
     </picture>
   </a>
 </p>

--- a/packages/remark/README.md
+++ b/packages/remark/README.md
@@ -1,8 +1,8 @@
 <p align="center">
   <a href="https://generaltranslation.com/docs">
     <picture>
-      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/brand/gt-logo-light.svg">
-      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-dark.svg" width="100" height="100">
+      <source media="(prefers-color-scheme: dark)" srcset="https://generaltranslation.com/brand/gt-logo-dark.svg">
+      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-light.svg" width="100" height="100">
     </picture>
   </a>
 </p>

--- a/packages/sanity/README.md
+++ b/packages/sanity/README.md
@@ -1,8 +1,8 @@
 <p align="center">
   <a href="https://generaltranslation.com/docs/sanity">
     <picture>
-      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/brand/gt-logo-light.svg">
-      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-dark.svg" width="100" height="100">
+      <source media="(prefers-color-scheme: dark)" srcset="https://generaltranslation.com/brand/gt-logo-dark.svg">
+      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-light.svg" width="100" height="100">
     </picture>
   </a>
 </p>

--- a/packages/supported-locales/README.md
+++ b/packages/supported-locales/README.md
@@ -1,8 +1,8 @@
 <p align="center">
   <a href="https://generaltranslation.com/docs">
     <picture>
-      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/brand/gt-logo-light.svg">
-      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-dark.svg" width="100" height="100">
+      <source media="(prefers-color-scheme: dark)" srcset="https://generaltranslation.com/brand/gt-logo-dark.svg">
+      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-light.svg" width="100" height="100">
     </picture>
   </a>
 </p>

--- a/packages/tanstack-start/README.md
+++ b/packages/tanstack-start/README.md
@@ -1,8 +1,8 @@
 <p align="center">
   <a href="https://generaltranslation.com/docs/tanstack-start">
     <picture>
-      <source media="(prefers-color-scheme: light)" srcset="https://generaltranslation.com/brand/gt-logo-light.svg">
-      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-dark.svg" width="100" height="100">
+      <source media="(prefers-color-scheme: dark)" srcset="https://generaltranslation.com/brand/gt-logo-dark.svg">
+      <img alt="General Translation" src="https://generaltranslation.com/brand/gt-logo-light.svg" width="100" height="100">
     </picture>
   </a>
 </p>


### PR DESCRIPTION
Swap light/dark mode logo sources across all 27 README files so that:
- Dark theme shows the dark logo (`gt-logo-dark.svg`)
- Light theme shows the light logo (`gt-logo-light.svg`)

Also adds `<picture>` elements to example READMEs that previously only had plain `<img>` tags, giving them proper dark mode support.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the dark/light logo selection logic across all 27 README files in the repository. The old `<picture>` pattern used `<source media="(prefers-color-scheme: light)">` with the dark logo as the `<img>` fallback — meaning any environment where the media query wasn't evaluated (older browsers, certain Markdown renderers, RSS readers) would silently show the dark logo regardless of theme. The new pattern correctly uses `<source media="(prefers-color-scheme: dark)">` for the dark logo and places the light logo in the `<img>` fallback, which is both the idiomatic HTML5 recommendation and the safer default.

Key changes:
- **18 package READMEs**: Existing `<picture>` elements had their `<source>` media query and `<img>` fallback swapped to the correct orientation.
- **7 example READMEs**: Plain `<img>` tags were upgraded to full `<picture>` elements with proper dark-mode support.
- **`examples/README.md` template block**: The embedded copy-paste template in the body of the file was also updated, keeping it in sync with actual usage.
- All 27 files now follow a single, consistent pattern.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- Safe to merge — all changes are documentation-only and correctly implement the idiomatic HTML5 picture/source pattern for theme-aware logos.
- No logic, runtime, or data-integrity issues. The change is a straightforward, mechanical swap of the `<source>` media query and `<img>` fallback across 27 README files, and every file follows the same correct pattern consistently. The new approach (dark source + light fallback) is both technically correct and the industry-standard recommendation. No P0 or P1 findings.
- No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Corrects picture element: dark-mode source now points to dark logo, light logo used as img fallback |
| examples/README.md | Wraps plain img in picture element for dark mode support; also updates the embedded README template in the body of the file |
| packages/README.md | Template README for new packages updated to use correct dark-mode source/light-fallback pattern |
| packages/next/README.md | Swaps source/img logo to correct dark-mode pattern; representative of all 18 package READMEs |
| examples/next-chatbot/README.md | Plain img upgraded to picture element with proper dark/light source; representative of all 7 example READMEs |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Browser renders README logo] --> B{Evaluates picture sources in order}
    B --> C{"prefers-color-scheme: dark matches?"}
    C -- Yes --> D["Use gt-logo-dark.svg\n(dark logo for dark mode)"]
    C -- No / Not supported --> E["Fall through to img fallback\ngt-logo-light.svg\n(light logo — safe default)"]

    subgraph OLD ["❌ Old (broken) logic"]
        F{"prefers-color-scheme: light matches?"}
        F -- Yes --> G["gt-logo-light.svg ✓"]
        F -- No / Not supported --> H["Fallback img: gt-logo-dark.svg ✗\n(dark logo shown on light bg by default)"]
    end

    subgraph NEW ["✅ New (correct) logic"]
        D
        E
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: update logo blocks in READMEs"](https://github.com/generaltranslation/gt/commit/94f325f2a7ff6374e53e2c504b9a0e34b30fc8e1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27069171)</sub>

<!-- /greptile_comment -->