### PR TITLE
F/tag git fix

### DIFF
--- a/.changeset/four-ends-relax.md
+++ b/.changeset/four-ends-relax.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+Make `git` tagging command default behavior

--- a/packages/cli/src/cli/flags.ts
+++ b/packages/cli/src/cli/flags.ts
@@ -109,8 +109,8 @@ export function attachTranslateFlags(command: Command) {
       DEFAULT_GIT_REMOTE_NAME
     )
     .option(
-      '--tag <value>',
-      'Tag ID for this translation run (use "git" to auto-resolve from current commit)'
+      '--tag [value]',
+      'Tag this translation run (auto-resolves from git if no value provided)'
     )
     .option(
       '-m, --message <message>',

--- a/packages/cli/src/config/generateSettings.ts
+++ b/packages/cli/src/config/generateSettings.ts
@@ -310,10 +310,10 @@ export async function generateSettings(
   }
 
   // Resolve tag:
-  // --tag git (explicit) or -m without --tag: try git SHA, fall back to random hex
+  // --tag (bare) or -m without --tag: try git SHA, fall back to random hex
   // --tag <value>: use as-is
   // No flags: no tag
-  if (flags.tag === 'git' || (!flags.tag && mergedOptions.tagMessage)) {
+  if (flags.tag === true || (!flags.tag && mergedOptions.tagMessage)) {
     try {
       mergedOptions.tag = execSync('git rev-parse --short HEAD', {
         encoding: 'utf-8',

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.13.3';
+export const PACKAGE_VERSION = '2.14.0';


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves the UX of the `--tag` CLI flag by making its value optional — users can now run `--tag` bare to auto-resolve the git SHA, instead of the previous `--tag git` syntax. The version is bumped from `2.13.3` to `2.14.0`.

**Key changes:**
- `flags.ts`: `--tag <value>` (required argument) → `--tag [value]` (optional argument), causing Commander.js to set `flags.tag = true` when the flag is passed without a value.
- `generateSettings.ts`: Tag-resolution condition updated from `flags.tag === 'git'` to `flags.tag === true` to match the new Commander behavior.
- `version.ts`: Version bumped `2.13.3` → `2.14.0`.
- `.changeset/four-ends-relax.md`: Changeset added for the release.

**Issues found:**
- The documented `--tag git` API is silently broken: passing `--tag git` will now set the tag to the literal string `"git"` instead of resolving the git SHA. Users with this pattern in their CI pipelines have no warning or migration path.
- The changeset declares a `patch` release while `version.ts` reflects a `minor` bump (`2.14.0`); these are inconsistent and one of them should be corrected.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- Safe to merge after addressing the backward-compatibility regression for --tag git users and aligning the changeset type with the version bump.
- Two P1 findings remain: a silent behavioral regression for existing --tag git users (documented API now silently misbehaves), and a mismatch between the patch-level changeset and the minor version bump in version.ts. Neither is catastrophic, but both should be resolved before publishing.
- `.changeset/four-ends-relax.md` (patch vs minor inconsistency) and `packages/cli/src/config/generateSettings.ts` (missing backward-compat guard for --tag git).
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .changeset/four-ends-relax.md | New changeset file marking this as a patch release, but the version.ts is bumped to 2.14.0 (minor), creating a semver inconsistency. |
| packages/cli/src/cli/flags.ts | Changed --tag option from required-value (&lt;value&gt;) to optional-value ([value]) so the flag can be used bare; description updated accordingly. |
| packages/cli/src/config/generateSettings.ts | Updated tag-resolution guard from flags.tag === 'git' to flags.tag === true, matching Commander's boolean for bare --tag; breaks existing --tag git usage without a deprecation path. |
| packages/cli/src/generated/version.ts | Auto-generated version bump from 2.13.3 to 2.14.0; inconsistent with the patch-level changeset. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User runs CLI with --tag flag] --> B{How was --tag passed?}
    B -->|"--tag (bare)"| C["flags.tag === true (Commander [value] syntax)"]
    B -->|"--tag somevalue"| D["flags.tag = 'somevalue' (string)"]
    B -->|"Not passed"| E["flags.tag = undefined"]

    C --> F{Resolve git SHA}
    F -->|Success| G["mergedOptions.tag = git rev-parse --short HEAD"]
    F -->|Failure / not in git repo| H["mergedOptions.tag = random hex (crypto)"]

    D --> I["mergedOptions.tag = 'somevalue' (used as-is)"]

    E --> J{tagMessage set via -m flag?}
    J -->|Yes| F
    J -->|No| K["No tag set"]

    style C fill:#90EE90
    style D fill:#FFD700
    style I fill:#FFD700

    subgraph "⚠️ Broken Path (pre-existing users)"
        L["--tag git (old documented API)"] --> M["flags.tag = 'git' (string)"]
        M --> N["Condition flags.tag === true → FALSE"]
        N --> O["mergedOptions.tag = 'git' (literal string — WRONG)"]
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/cli/src/config/generateSettings.ts
Line: 316

Comment:
**Silent regression for existing `--tag git` users**

The previous implementation explicitly documented that users should pass `--tag git` to trigger git SHA auto-resolution. The old flag description even read: *"use `'git'` to auto-resolve from current commit"*.

With this change, a user who already has `--tag git` in their CI pipeline or scripts will no longer get a git SHA — instead, their tag will silently be set to the literal string `"git"`, which is almost certainly not the intended value. There is no warning, error, or deprecation path for this behavior change.

This is a breaking change for any existing consumer relying on the documented `--tag git` API. At minimum, a deprecation warning should be emitted when `flags.tag === 'git'` is detected, or the old string path should be handled alongside the new boolean path:

```
if (flags.tag === true || flags.tag === 'git' || (!flags.tag && mergedOptions.tagMessage)) {
```

This would maintain backward compatibility while also supporting the new bare-flag UX.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .changeset/four-ends-relax.md
Line: 2

Comment:
**Changeset type inconsistent with version bump**

The changeset marks this as a `patch` release, but `packages/cli/src/generated/version.ts` jumps from `2.13.3` → `2.14.0`, which is a **minor** version bump in semver. A `patch` bump would produce `2.13.4`. Additionally, changing the behavior of `--tag git` (a documented CLI API) is technically a breaking change, which in strict semver would warrant a **major** bump.

Either the changeset should be updated to `minor` (to match the version file), or the version file should be corrected to `2.13.4` to match the changeset. These two should always agree.

```suggestion
'gt': minor
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: changeset"](https://github.com/generaltranslation/gt/commit/53b7f641c6b4efb38a6f5074cc47517f39e6a8a4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27071228)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->