### PR TITLE
feat: Slack notification to #moss-pager on package release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
         id: find-release-pr
         if: steps.changesets.outputs.published == 'true'
         run: |
-          pr_url=$(gh pr list --state merged --search "[ci] release" --limit 1 --json url --jq '.[0].url')
+          pr_url=$(gh pr list --state merged --search "[ci] release" --limit 1 --json url --jq '.[0].url // ""')
           echo "pr_url=$pr_url" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -91,7 +91,11 @@ jobs:
           packages=$(echo "$published" | jq -r '.[] | "• `\(.name)` → `\(.version)`"')
 
           # Compose the message
-          message="📦 *New packages published!*\n\n${packages}\n\n🔗 <${pr_url}|Release PR>"
+          if [ -n "$pr_url" ]; then
+            message=$(printf '📦 *New packages published!*\n\n%s\n\n🔗 <%s|Release PR>' "$packages" "$pr_url")
+          else
+            message=$(printf '📦 *New packages published!*\n\n%s' "$packages")
+          fi
           
           # Escape for JSON
           message_escaped=$(echo "$message" | jq -Rs .)
@@ -99,6 +103,7 @@ jobs:
 
       - name: Notify Slack of release
         if: steps.changesets.outputs.published == 'true'
+        continue-on-error: true
         uses: slackapi/slack-github-action@v2.1.1
         with:
           webhook: ${{ secrets.MOSS_PAGER_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,9 +92,9 @@ jobs:
 
           # Compose the message
           if [ -n "$pr_url" ]; then
-            message=$(printf '📦 *New packages published!*\n\n%s\n\n🔗 <%s|Release PR>' "$packages" "$pr_url")
+            message=$(printf '📦 *New packages published!*\n\n%s\n\n🔗 <%s|Release PR>\n\n<@U0AF0LK9ZDY>' "$packages" "$pr_url")
           else
-            message=$(printf '📦 *New packages published!*\n\n%s' "$packages")
+            message=$(printf '📦 *New packages published!*\n\n%s\n\n<@U0AF0LK9ZDY>' "$packages")
           fi
           
           # Escape for JSON

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,52 @@ jobs:
           event-type: release-published
           client-payload: '{"publishedPackages": ${{ steps.changesets.outputs.publishedPackages }}}'
 
+      - name: Find release PR
+        id: find-release-pr
+        if: steps.changesets.outputs.published == 'true'
+        run: |
+          pr_url=$(gh pr list --state merged --search "[ci] release" --limit 1 --json url --jq '.[0].url')
+          echo "pr_url=$pr_url" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Format Slack release message
+        id: format-slack
+        if: steps.changesets.outputs.published == 'true'
+        run: |
+          published='${{ steps.changesets.outputs.publishedPackages }}'
+          pr_url='${{ steps.find-release-pr.outputs.pr_url }}'
+
+          # Build a bullet list of published packages
+          packages=$(echo "$published" | jq -r '.[] | "• `\(.name)` → `\(.version)`"')
+
+          # Compose the message
+          message="📦 *New packages published!*\n\n${packages}\n\n🔗 <${pr_url}|Release PR>"
+          
+          # Escape for JSON
+          message_escaped=$(echo "$message" | jq -Rs .)
+          echo "message=$message_escaped" >> $GITHUB_OUTPUT
+
+      - name: Notify Slack of release
+        if: steps.changesets.outputs.published == 'true'
+        uses: slackapi/slack-github-action@v2.1.1
+        with:
+          webhook: ${{ secrets.MOSS_PAGER_SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "New packages published",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ${{ steps.format-slack.outputs.message }}
+                  }
+                }
+              ]
+            }
+
       # gt (primary CLI package, lives in packages/cli/)
       - name: Check if gt was published
         id: check-gt


### PR DESCRIPTION
Adds a Slack notification step to the release workflow. When changesets publishes packages, it:

1. Finds the most recently merged `[ci] release` PR via `gh pr list`
2. Formats a message with published package names + versions
3. Posts to #moss-pager via incoming webhook

**Example message:**
> 📦 **New packages published!**
>
> • `gt-next` → `1.5.0`
> • `gt-react` → `1.3.2`
>
> 🔗 [Release PR](https://github.com/generaltranslation/gt/pull/123)

**Required:** Add a `MOSS_PAGER_SLACK_WEBHOOK_URL` secret to the repo (or the `release` environment) pointing to the #moss-pager Slack channel incoming webhook.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds three new steps to the release workflow that post a Slack notification to `#moss-pager` whenever changesets publishes packages. The implementation finds the most recently merged `[ci] release` PR via `gh pr list`, formats a mrkdwn bullet list of published packages using `printf` (correctly injecting real newlines), JSON-encodes the message with `jq -Rs .`, and POSTs it to Slack via `slackapi/slack-github-action@v2.1.1`.

The three issues flagged in the previous review round have all been addressed:
- `\n` in the message is now handled correctly via `printf` (not raw bash string literals).
- `continue-on-error: true` is present on the Slack step, preventing a missing webhook secret from aborting the release.
- The jq `// ""` fallback ensures `pr_url` is an empty string rather than `null` when no PR is found, and the message formatting step omits the link entirely when `pr_url` is empty.

One remaining minor issue: `echo "$message"` appends an extra `\n` before piping to `jq -Rs .`, producing a spurious trailing blank line in every Slack notification. Replacing it with `printf '%s' "$message"` would fix this.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all previously flagged P1 issues are resolved; only a cosmetic trailing-newline P2 remains.

The three substantive issues from prior rounds (broken 
 escaping, missing continue-on-error, silent null PR URL) are all fixed. The only remaining finding is a minor cosmetic extra blank line in Slack messages from using echo instead of printf '%s'. This does not affect correctness, pipeline reliability, or security.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Adds three new steps for Slack release notifications: finding the release PR, formatting the message with printf (correctly handling newlines), and posting via slackapi/slack-github-action with continue-on-error. The `echo` pipe into `jq -Rs .` appends an unintended trailing newline to the encoded message. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant CS as changesets/action
    participant GH as GitHub API (gh pr list)
    participant Runner as GitHub Actions Runner
    participant Slack as Slack Incoming Webhook

    CS->>Runner: publishedPackages JSON + published=true
    Runner->>GH: gh pr list --state merged --search "[ci] release" --limit 1
    GH-->>Runner: pr_url (or empty string)
    Runner->>Runner: printf + jq -Rs . → JSON-encoded message
    Runner->>Slack: POST payload with mrkdwn text block
    Slack-->>Runner: 200 OK (or error, continue-on-error: true)
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/release.yml
Line: 101

Comment:
**Trailing newline added by `echo` pollutes the Slack message**

`echo "$message"` appends a `\n` to `$message` before piping to `jq -Rs .`. The result is that the JSON-encoded string ends with `\n`, which Slack renders as an extra blank line at the bottom of every notification. Use `printf '%s'` instead to pass the message without appending a newline:

```suggestion
          message_escaped=$(printf '%s' "$message" | jq -Rs .)
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: address Greptile review feedback"](https://github.com/generaltranslation/gt/commit/c0af28c5e9c0dabd5b355f3c09eea249b6f24da9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27193319)</sub>

<!-- /greptile_comment -->