### PR TITLE
F/remerged tracking

### DIFF
--- a/.changeset/solid-webs-work.md
+++ b/.changeset/solid-webs-work.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+Record re-merged files for postprocessing

--- a/packages/cli/src/api/downloadFileBatch.ts
+++ b/packages/cli/src/api/downloadFileBatch.ts
@@ -14,10 +14,7 @@ import {
   writeLockfile,
   findOrCreateEntry,
 } from '../fs/config/downloadedVersions.js';
-import {
-  recordDownloaded,
-  recordRemerged,
-} from '../state/recentDownloads.js';
+import { recordDownloaded, recordRemerged } from '../state/recentDownloads.js';
 import { recordWarning } from '../state/translateWarnings.js';
 import stringify from 'fast-json-stable-stringify';
 import type { FileStatusTracker } from '../workflows/steps/PollJobsStep.js';

--- a/packages/cli/src/api/downloadFileBatch.ts
+++ b/packages/cli/src/api/downloadFileBatch.ts
@@ -14,7 +14,10 @@ import {
   writeLockfile,
   findOrCreateEntry,
 } from '../fs/config/downloadedVersions.js';
-import { recordDownloaded } from '../state/recentDownloads.js';
+import {
+  recordDownloaded,
+  recordRemerged,
+} from '../state/recentDownloads.js';
 import { recordWarning } from '../state/translateWarnings.js';
 import stringify from 'fast-json-stable-stringify';
 import type { FileStatusTracker } from '../workflows/steps/PollJobsStep.js';
@@ -203,6 +206,9 @@ export async function downloadFileBatch(
               if (remerged !== existingContent) {
                 await fs.promises.writeFile(outputPath, remerged);
               }
+              // Track for postprocessing (e.g. openapi path localization)
+              // even when the API download was skipped
+              recordRemerged(outputPath);
             }
           } catch {
             // If re-merge fails, still count as skipped — not worth failing the download

--- a/packages/cli/src/cli/base.ts
+++ b/packages/cli/src/cli/base.ts
@@ -43,7 +43,10 @@ import {
   handleTranslate,
   postProcessTranslations,
 } from './commands/translate.js';
-import { getDownloaded, clearDownloaded } from '../state/recentDownloads.js';
+import {
+  getNeedsPostprocessing,
+  clearDownloaded,
+} from '../state/recentDownloads.js';
 import { clearWarnings } from '../state/translateWarnings.js';
 import { displayTranslateSummary } from '../console/displayTranslateSummary.js';
 import updateConfig from '../fs/config/updateConfig.js';
@@ -281,7 +284,7 @@ export class BaseCLI {
       await handleDownload(initOptions, settings, this.library);
     }
     // Only postprocess files downloaded in this run
-    const include = getDownloaded();
+    const include = getNeedsPostprocessing();
     if (include.size > 0) {
       await postProcessTranslations(settings, include);
     }

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.14.0';
+export const PACKAGE_VERSION = '2.14.1';

--- a/packages/cli/src/state/recentDownloads.ts
+++ b/packages/cli/src/state/recentDownloads.ts
@@ -8,6 +8,7 @@ type DownloadMeta = {
 
 const recent = new Set<string>();
 const recentMeta = new Map<string, DownloadMeta>();
+const remerged = new Set<string>();
 
 export function recordDownloaded(filePath: string, meta?: DownloadMeta) {
   recent.add(filePath);
@@ -16,8 +17,21 @@ export function recordDownloaded(filePath: string, meta?: DownloadMeta) {
   }
 }
 
+/**
+ * Track a file that was re-merged with the source
+ * so that postprocessing still runs on it.
+ */
+export function recordRemerged(filePath: string) {
+  remerged.add(filePath);
+}
+
 export function getDownloaded(): Set<string> {
   return recent;
+}
+
+/** Files that need postprocessing: downloaded OR re-merged */
+export function getNeedsPostprocessing(): Set<string> {
+  return new Set([...recent, ...remerged]);
 }
 
 export function getDownloadedMeta(): Map<string, DownloadMeta> {
@@ -27,4 +41,5 @@ export function getDownloadedMeta(): Map<string, DownloadMeta> {
 export function clearDownloaded() {
   recent.clear();
   recentMeta.clear();
+  remerged.clear();
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR ensures that schema-based files (JSON/YAML) that are re-merged with the source during a skipped download are still included in the postprocessing step (e.g. OpenAPI path localization). It introduces `recordRemerged` / `getNeedsPostprocessing` in `recentDownloads.ts` and wires them into `downloadFileBatch.ts` and `base.ts`.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the only finding is a minor P2 about unconditionally enqueuing postprocessing even for unchanged files.

All logic is additive and non-breaking: new state (remerged set) is properly initialised, populated, included in postprocessing, and cleared alongside the existing sets. The single remaining comment is a style/efficiency suggestion with no correctness impact.

packages/cli/src/api/downloadFileBatch.ts — minor placement of recordRemerged relative to the file-changed guard.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/state/recentDownloads.ts | Adds a new `remerged` Set to track re-merged files, a `recordRemerged` function, and `getNeedsPostprocessing` that unions `recent` and `remerged`; `clearDownloaded` correctly clears the new set. |
| packages/cli/src/api/downloadFileBatch.ts | Calls `recordRemerged(outputPath)` after re-merge logic; the call is placed outside the `if (remerged !== existingContent)` guard, so postprocessing is enqueued even when the file content is unchanged after re-merge. |
| packages/cli/src/cli/base.ts | Replaces `getDownloaded()` with `getNeedsPostprocessing()` as the include set for `postProcessTranslations`, correctly broadening the scope to re-merged files. |
| packages/cli/src/generated/version.ts | Auto-generated version bump from 2.14.0 to 2.14.1. |
| .changeset/solid-webs-work.md | Changeset entry marking a patch-level change for the `gt` package. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[downloadFileBatch called] --> B{File already at correct version?}
    B -- No --> C[Download from API]
    C --> D[mergeWithSource]
    D --> E[writeFile]
    E --> F[recordDownloaded]
    F --> G[result.successful]

    B -- Yes --> H{Schema-based file?\njsonSchema / yamlSchema}
    H -- No --> I[result.skipped]
    H -- Yes --> J[extractJson / extractYaml]
    J --> K[mergeWithSource re-merge]
    K --> L{Content changed?}
    L -- Yes --> M[writeFile]
    L -- No --> N[skip write]
    M --> O[recordRemerged - NEW]
    N --> O
    O --> I

    subgraph base.ts postprocessing
        P[getNeedsPostprocessing - NEW\nrecent union remerged] --> Q{size > 0?}
        Q -- Yes --> R[postProcessTranslations]
        Q -- No --> S[skip]
    end

    F --> P
    O --> P
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/cli/src/api/downloadFileBatch.ts
Line: 206-208

Comment:
**Postprocessing enqueued even when file is unchanged**

`recordRemerged(outputPath)` is called unconditionally inside the `if (extracted)` block, so postprocessing runs even when `remerged === existingContent` and the file was not actually written to disk. If the intent is only to postprocess files whose content changed (or was freshly written), moving the call inside the `if (remerged !== existingContent)` guard would avoid unnecessary work. If postprocessing must run regardless (e.g. to handle OpenAPI path localization idempotently), the current placement is correct and the comment could clarify this.

```suggestion
              if (remerged !== existingContent) {
                await fs.promises.writeFile(outputPath, remerged);
                // Track for postprocessing (e.g. openapi path localization)
                // even when the API download was skipped
                recordRemerged(outputPath);
              }
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: changeset"](https://github.com/generaltranslation/gt/commit/6d23d49c494b8d009592e5856f18276a0bd5aac3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27215316)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->