### PR TITLE
fix: testing ci

### DIFF
--- a/tests/apps/compiler-cli-parity/scripts/check-parity.ts
+++ b/tests/apps/compiler-cli-parity/scripts/check-parity.ts
@@ -5,7 +5,7 @@
  *
  * 1. Cleans previous outputs
  * 2. Runs `pnpm vite build` (produces _gt_debug_hash_manifest.json)
- * 3. Runs `pnpm exec gt generate` (produces src/_gt/en.json)
+ * 3. Runs `gt generate` (produces src/_gt/en.json)
  * 4. Compares manifests with Derive filtering
  * 5. Reports results, exits 1 on mismatch
  */
@@ -94,7 +94,8 @@ function main() {
 
   // 3. Run CLI (gt generate)
   console.log('\n📝 Running gt generate...\n');
-  execSync('pnpm exec gt generate', { cwd: ROOT, stdio: 'inherit' });
+  const gtBin = path.join(ROOT, 'node_modules', '.bin', 'gt');
+  execSync(`${gtBin} generate`, { cwd: ROOT, stdio: 'inherit' });
 
   // 4. Load manifests
   if (!fs.existsSync(COMPILER_MANIFEST)) {

--- a/tests/apps/compiler-cli-parity/scripts/check-parity.ts
+++ b/tests/apps/compiler-cli-parity/scripts/check-parity.ts
@@ -94,8 +94,9 @@ function main() {
 
   // 3. Run CLI (gt generate)
   console.log('\n📝 Running gt generate...\n');
-  const gtBin = path.join(ROOT, 'node_modules', '.bin', 'gt');
-  execSync(`${gtBin} generate`, { cwd: ROOT, stdio: 'inherit' });
+  const MONOREPO_ROOT = path.resolve(ROOT, '..', '..', '..');
+  const gtMain = path.join(MONOREPO_ROOT, 'packages', 'cli', 'dist', 'main.js');
+  execSync(`node ${gtMain} generate`, { cwd: ROOT, stdio: 'inherit' });
 
   // 4. Load manifests
   if (!fs.existsSync(COMPILER_MANIFEST)) {

--- a/tests/apps/compiler-cli-parity/scripts/check-parity.ts
+++ b/tests/apps/compiler-cli-parity/scripts/check-parity.ts
@@ -9,7 +9,7 @@
  * 4. Compares manifests with Derive filtering
  * 5. Reports results, exits 1 on mismatch
  */
-import { execSync } from 'child_process';
+import { execFileSync, execSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
@@ -96,7 +96,7 @@ function main() {
   console.log('\n📝 Running gt generate...\n');
   const MONOREPO_ROOT = path.resolve(ROOT, '..', '..', '..');
   const gtMain = path.join(MONOREPO_ROOT, 'packages', 'cli', 'dist', 'main.js');
-  execSync(`node ${gtMain} generate`, { cwd: ROOT, stdio: 'inherit' });
+  execFileSync('node', [gtMain, 'generate'], { cwd: ROOT, stdio: 'inherit' });
 
   // 4. Load manifests
   if (!fs.existsSync(COMPILER_MANIFEST)) {


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new CI parity-check script (`check-parity.ts`) that runs both the Vite compiler and the `gt generate` CLI, then compares their JSON manifests entry-by-entry, skipping Derive/Static entries that are intentionally excluded from compiler extraction. The comparison logic, Derive detection, and exit-code handling all look correct.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; all findings are minor style suggestions that do not affect correctness in typical CI environments.

The core comparison logic, Derive filtering, and exit-code handling are all correct. The two flagged items (unquoted path and missing pre-flight guard) are P2 quality improvements — CI paths rarely contain spaces, and the existing manifest-existence checks already catch most misconfiguration scenarios.

No files require special attention.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| tests/apps/compiler-cli-parity/scripts/check-parity.ts | New CI parity-check script that runs vite build and gt generate, then compares their JSON manifests key-by-key with Derive-entry filtering; minor path-quoting and missing pre-flight guard issues noted. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Start: check-parity.ts] --> B[Clean previous outputs]
    B --> C[pnpm vite build]
    C --> D{COMPILER_MANIFEST exists?}
    D -- No --> E[console.error + exit 1]
    D -- Yes --> F[node cli/dist/main.js generate]
    F --> G{CLI_MANIFEST exists?}
    G -- No --> E
    G -- Yes --> H[Load both JSON manifests]
    H --> I[Build allHashes union set]
    I --> J{For each hash}
    J -- both present --> K{containsDerive?}
    K -- Yes --> L[skippedDerive++]
    K -- No --> M{deepEqual?}
    M -- Yes --> N[matched++]
    M -- No --> O[mismatched++ / push mismatch]
    J -- compiler only --> P{containsDerive?}
    P -- Yes --> L
    P -- No --> Q[compilerOnly++ / push mismatch]
    J -- CLI only --> R{containsDerive?}
    R -- Yes --> L
    R -- No --> S[cliOnly++ / push mismatch]
    L & N & O & Q & S --> T{more hashes?}
    T -- Yes --> J
    T -- No --> U{mismatches.length > 0?}
    U -- Yes --> V[Print mismatches + exit 1]
    U -- No --> W{matched === 0?}
    W -- Yes --> X[Print warning + exit 1]
    W -- No --> Y[Print success + exit 0]
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `tests/apps/compiler-cli-parity/scripts/check-parity.ts`, line 68-78 ([link](https://github.com/generaltranslation/gt/blob/24a511b995d207c0ab2062161ad8ab6b6636802e/tests/apps/compiler-cli-parity/scripts/check-parity.ts#L68-L78)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Array vs plain-object conflation in `deepEqual`**

   When one operand is an `Array` and the other is a plain object, both pass the `typeof value === 'object'` guard, so the function falls through to the object-key comparison branch instead of returning `false`. This means `deepEqual([1, 2], { 0: 1, 1: 2 })` returns `true`, which is wrong. A guard is needed before the object branch.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: tests/apps/compiler-cli-parity/scripts/check-parity.ts
   Line: 68-78

   Comment:
   **Array vs plain-object conflation in `deepEqual`**

   When one operand is an `Array` and the other is a plain object, both pass the `typeof value === 'object'` guard, so the function falls through to the object-key comparison branch instead of returning `false`. This means `deepEqual([1, 2], { 0: 1, 1: 2 })` returns `true`, which is wrong. A guard is needed before the object branch.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: tests/apps/compiler-cli-parity/scripts/check-parity.ts
Line: 99

Comment:
**Unquoted path in shell command**

`gtMain` is interpolated directly into the shell command string without quoting. If `MONOREPO_ROOT` (resolved via three `..` hops from `__dirname`) ever contains spaces, `node` will receive a split path and fail with a confusing "module not found" error.

```suggestion
  execSync(`node "${gtMain}" generate`, { cwd: ROOT, stdio: 'inherit' });
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: tests/apps/compiler-cli-parity/scripts/check-parity.ts
Line: 99

Comment:
**Missing pre-flight check for CLI binary**

`gtMain` is used directly without checking whether the file exists. If the `cli` package hasn't been built yet (i.e. `dist/main.js` is absent), the error from Node will say "Cannot find module …" rather than something actionable. A short guard here would save debugging time in CI.

```suggestion
  if (!fs.existsSync(gtMain)) {
    console.error('ERROR: CLI dist not found at', gtMain, '— run `pnpm build` in the cli package first.');
    process.exit(1);
  }
  execSync(`node "${gtMain}" generate`, { cwd: ROOT, stdio: 'inherit' });
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["address github sec issue"](https://github.com/generaltranslation/gt/commit/6c1a63f7869628b68bc06710f9bcaec614424f60) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27334546)</sub>

<!-- /greptile_comment -->