### PR TITLE
feat(react): add context derivation

### DIFF
--- a/.changeset/hot-seas-lick.md
+++ b/.changeset/hot-seas-lick.md
@@ -1,0 +1,13 @@
+---
+'gt-next': minor
+'gt-i18n': minor
+'gt-node': minor
+'gt-react': minor
+'@generaltranslation/react-core': minor
+'gt-tanstack-start': minor
+'@generaltranslation/python-extractor': patch
+'@generaltranslation/compiler': patch
+'gt': patch
+---
+
+add context derivation

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.14.3';
+export const PACKAGE_VERSION = '2.14.4';

--- a/packages/cli/src/react/jsx/utils/jsxParsing/__tests__/parseJsx.test.ts
+++ b/packages/cli/src/react/jsx/utils/jsxParsing/__tests__/parseJsx.test.ts
@@ -1987,4 +1987,242 @@ describe('parseTranslationComponent with cross-file resolution', () => {
       expect.any(Map)
     );
   });
+
+  describe('derive in context', () => {
+    it('should produce 2 updates when context uses derive with a function', () => {
+      const pageFile = `
+        import { T, derive } from "gt-next";
+
+        function getFormality() {
+          if (isFormal) {
+            return "formal";
+          } else {
+            return "casual";
+          }
+        }
+
+        export default function Page() {
+          return <T context={derive(getFormality())}>Hello</T>;
+        }
+      `;
+
+      const ast = parse(pageFile, {
+        sourceType: 'module',
+        plugins: ['jsx', 'typescript'],
+      });
+
+      let tLocalName = '';
+      const importAliases: Record<string, string> = {};
+
+      traverse(ast, {
+        ImportDeclaration(path) {
+          if (path.node.source.value === 'gt-next') {
+            path.node.specifiers.forEach((spec) => {
+              if (
+                t.isImportSpecifier(spec) &&
+                t.isIdentifier(spec.imported)
+              ) {
+                if (spec.imported.name === 'T') {
+                  tLocalName = spec.local.name;
+                  importAliases[tLocalName] = 'T';
+                }
+              }
+            });
+          }
+        },
+      });
+
+      traverse(ast, {
+        Program(programPath) {
+          const tBinding = programPath.scope.getBinding(tLocalName);
+          if (tBinding) {
+            parseTranslationComponent({
+              originalName: 'T',
+              localName: tLocalName,
+              path: tBinding.path,
+              updates,
+              config: {
+                importAliases,
+                parsingOptions,
+                pkgs: [Libraries.GT_NEXT],
+                file: '/test/derive-context/page.tsx',
+              },
+              output: {
+                errors,
+                warnings,
+                unwrappedExpressions: [],
+              },
+            });
+          }
+        },
+      });
+
+      expect(errors).toHaveLength(0);
+      expect(updates).toHaveLength(2);
+
+      const contexts = updates
+        .map((u) => u.metadata.context)
+        .sort();
+      expect(contexts).toEqual(['casual', 'formal']);
+
+      // Both should have same staticId
+      expect(updates[0].metadata.staticId).toBeDefined();
+      expect(updates[0].metadata.staticId).toBe(
+        updates[1].metadata.staticId
+      );
+    });
+
+    it('should produce cross-product when both content and context use derive', () => {
+      const pageFile = `
+        import { T, Derive, derive } from "gt-next";
+
+        function getFormality() {
+          if (isFormal) {
+            return "formal";
+          } else {
+            return "casual";
+          }
+        }
+
+        function getGreeting() {
+          if (isMorning) {
+            return "Good morning";
+          } else {
+            return "Good evening";
+          }
+        }
+
+        export default function Page() {
+          return <T context={derive(getFormality())}><Derive>{getGreeting()}</Derive></T>;
+        }
+      `;
+
+      const ast = parse(pageFile, {
+        sourceType: 'module',
+        plugins: ['jsx', 'typescript'],
+      });
+
+      let tLocalName = '';
+      const importAliases: Record<string, string> = {};
+
+      traverse(ast, {
+        ImportDeclaration(path) {
+          if (path.node.source.value === 'gt-next') {
+            path.node.specifiers.forEach((spec) => {
+              if (
+                t.isImportSpecifier(spec) &&
+                t.isIdentifier(spec.imported)
+              ) {
+                if (spec.imported.name === 'T') {
+                  tLocalName = spec.local.name;
+                  importAliases[tLocalName] = 'T';
+                } else if (spec.imported.name === 'Derive') {
+                  importAliases[spec.local.name] = 'Derive';
+                }
+              }
+            });
+          }
+        },
+      });
+
+      traverse(ast, {
+        Program(programPath) {
+          const tBinding = programPath.scope.getBinding(tLocalName);
+          if (tBinding) {
+            parseTranslationComponent({
+              originalName: 'T',
+              localName: tLocalName,
+              path: tBinding.path,
+              updates,
+              config: {
+                importAliases,
+                parsingOptions,
+                pkgs: [Libraries.GT_NEXT],
+                file: '/test/derive-context-cross/page.tsx',
+              },
+              output: {
+                errors,
+                warnings,
+                unwrappedExpressions: [],
+              },
+            });
+          }
+        },
+      });
+
+      expect(errors).toHaveLength(0);
+      expect(updates).toHaveLength(4); // 2 content × 2 context
+
+      // All 4 should share same staticId
+      const staticId = updates[0].metadata.staticId;
+      expect(staticId).toBeDefined();
+      expect(updates.every((u) => u.metadata.staticId === staticId)).toBe(
+        true
+      );
+    });
+
+    it('should still work with static string context (regression)', () => {
+      const pageFile = `
+        import { T } from "gt-next";
+
+        export default function Page() {
+          return <T context="greeting">Hello</T>;
+        }
+      `;
+
+      const ast = parse(pageFile, {
+        sourceType: 'module',
+        plugins: ['jsx', 'typescript'],
+      });
+
+      let tLocalName = '';
+      const importAliases: Record<string, string> = {};
+
+      traverse(ast, {
+        ImportDeclaration(path) {
+          if (path.node.source.value === 'gt-next') {
+            path.node.specifiers.forEach((spec) => {
+              if (
+                t.isImportSpecifier(spec) &&
+                t.isIdentifier(spec.imported) &&
+                spec.imported.name === 'T'
+              ) {
+                tLocalName = spec.local.name;
+                importAliases[tLocalName] = 'T';
+              }
+            });
+          }
+        },
+      });
+
+      traverse(ast, {
+        Program(programPath) {
+          const tBinding = programPath.scope.getBinding(tLocalName);
+          if (tBinding) {
+            parseTranslationComponent({
+              originalName: 'T',
+              localName: tLocalName,
+              path: tBinding.path,
+              updates,
+              config: {
+                importAliases,
+                parsingOptions,
+                pkgs: [Libraries.GT_NEXT],
+                file: '/test/derive-context-regression/page.tsx',
+              },
+              output: {
+                errors,
+                warnings,
+                unwrappedExpressions: [],
+              },
+            });
+          }
+        },
+      });
+
+      expect(errors).toHaveLength(0);
+      expect(updates).toHaveLength(1);
+      expect(updates[0].metadata.context).toBe('greeting');
+    });
+  });
 });

--- a/packages/cli/src/react/jsx/utils/jsxParsing/__tests__/parseJsx.test.ts
+++ b/packages/cli/src/react/jsx/utils/jsxParsing/__tests__/parseJsx.test.ts
@@ -2018,10 +2018,7 @@ describe('parseTranslationComponent with cross-file resolution', () => {
         ImportDeclaration(path) {
           if (path.node.source.value === 'gt-next') {
             path.node.specifiers.forEach((spec) => {
-              if (
-                t.isImportSpecifier(spec) &&
-                t.isIdentifier(spec.imported)
-              ) {
+              if (t.isImportSpecifier(spec) && t.isIdentifier(spec.imported)) {
                 if (spec.imported.name === 'T') {
                   tLocalName = spec.local.name;
                   importAliases[tLocalName] = 'T';
@@ -2060,16 +2057,12 @@ describe('parseTranslationComponent with cross-file resolution', () => {
       expect(errors).toHaveLength(0);
       expect(updates).toHaveLength(2);
 
-      const contexts = updates
-        .map((u) => u.metadata.context)
-        .sort();
+      const contexts = updates.map((u) => u.metadata.context).sort();
       expect(contexts).toEqual(['casual', 'formal']);
 
       // Both should have same staticId
       expect(updates[0].metadata.staticId).toBeDefined();
-      expect(updates[0].metadata.staticId).toBe(
-        updates[1].metadata.staticId
-      );
+      expect(updates[0].metadata.staticId).toBe(updates[1].metadata.staticId);
     });
 
     it('should produce cross-product when both content and context use derive', () => {
@@ -2109,10 +2102,7 @@ describe('parseTranslationComponent with cross-file resolution', () => {
         ImportDeclaration(path) {
           if (path.node.source.value === 'gt-next') {
             path.node.specifiers.forEach((spec) => {
-              if (
-                t.isImportSpecifier(spec) &&
-                t.isIdentifier(spec.imported)
-              ) {
+              if (t.isImportSpecifier(spec) && t.isIdentifier(spec.imported)) {
                 if (spec.imported.name === 'T') {
                   tLocalName = spec.local.name;
                   importAliases[tLocalName] = 'T';
@@ -2156,9 +2146,7 @@ describe('parseTranslationComponent with cross-file resolution', () => {
       // All 4 should share same staticId
       const staticId = updates[0].metadata.staticId;
       expect(staticId).toBeDefined();
-      expect(updates.every((u) => u.metadata.staticId === staticId)).toBe(
-        true
-      );
+      expect(updates.every((u) => u.metadata.staticId === staticId)).toBe(true);
     });
 
     it('should still work with static string context (regression)', () => {

--- a/packages/cli/src/react/jsx/utils/jsxParsing/parseJsx.ts
+++ b/packages/cli/src/react/jsx/utils/jsxParsing/parseJsx.ts
@@ -50,6 +50,8 @@ import { GTLibrary } from '../../../../types/libraries.js';
 import path from 'node:path';
 import { extractSourceCode } from '../extractSourceCode.js';
 import { SURROUNDING_LINE_COUNT } from '../../../../utils/constants.js';
+import { handleDerivation } from '../stringParsing/derivation/handleDerivation.js';
+import { nodeToStrings } from '../parseString.js';
 
 // Handle CommonJS/ESM interop
 const traverse = traverseModule.default || traverseModule;
@@ -811,20 +813,54 @@ function parseJSXElement({
   // Create a temporary unique flag for derivable content
   const temporaryDeriveId = `derive-temp-id-${randomUUID()}`;
 
+  // Resolve derive context variants if present
+  let contextVariants: string[] | undefined;
+  if (metadata._contextDeriveExpr) {
+    const contextExpr = metadata._contextDeriveExpr as t.Expression;
+    delete metadata._contextDeriveExpr;
+
+    const contextNode = handleDerivation({
+      expr: contextExpr,
+      tPath: scopeNode,
+      file: config.file,
+      parsingOptions: config.parsingOptions,
+      errors: componentErrors,
+      warnings: componentWarnings,
+    });
+    if (contextNode) {
+      contextVariants = nodeToStrings(contextNode);
+    }
+  }
+
   // <T> is valid here
   for (const minifiedTree of minifiedTress) {
     // Clean the tree by removing null 'c' fields from JsxElements
     const cleanedTree = removeNullChildrenFields(minifiedTree);
 
-    updates.push({
-      dataFormat: 'JSX',
-      source: cleanedTree,
-      metadata: {
-        // eslint-disable-next-line no-undef
-        ...structuredClone(metadata),
-        ...(derivableTracker.isDerivable && { staticId: temporaryDeriveId }),
-      },
-    });
+    if (contextVariants) {
+      for (const context of contextVariants) {
+        updates.push({
+          dataFormat: 'JSX',
+          source: cleanedTree,
+          metadata: {
+            // eslint-disable-next-line no-undef
+            ...structuredClone(metadata),
+            context,
+            staticId: temporaryDeriveId,
+          },
+        });
+      }
+    } else {
+      updates.push({
+        dataFormat: 'JSX',
+        source: cleanedTree,
+        metadata: {
+          // eslint-disable-next-line no-undef
+          ...structuredClone(metadata),
+          ...(derivableTracker.isDerivable && { staticId: temporaryDeriveId }),
+        },
+      });
+    }
   }
 }
 

--- a/packages/cli/src/react/jsx/utils/jsxParsing/parseTProps.ts
+++ b/packages/cli/src/react/jsx/utils/jsxParsing/parseTProps.ts
@@ -12,6 +12,7 @@ import {
   warnVariablePropSync,
 } from '../../../../console/index.js';
 import { isNumberLiteral } from '../isNumberLiteral.js';
+import { containsDeriveCall } from '../stringParsing/derivation/containsDeriveCall.js';
 
 // Parse the props of a <T> component
 export function parseTProps({
@@ -46,14 +47,22 @@ export function parseTProps({
         ) {
           const staticAnalysis = isStaticExpression(expr);
           if (!staticAnalysis.isStatic) {
-            componentErrors.push(
-              warnVariablePropSync(
-                file,
-                attrName,
-                code,
-                `${expr.loc?.start?.line}:${expr.loc?.start?.column}`
-              )
-            );
+            if (
+              mapAttributeName(attrName) === 'context' &&
+              t.isExpression(expr) &&
+              containsDeriveCall(expr)
+            ) {
+              metadata._contextDeriveExpr = expr;
+            } else {
+              componentErrors.push(
+                warnVariablePropSync(
+                  file,
+                  attrName,
+                  code,
+                  `${expr.loc?.start?.line}:${expr.loc?.start?.column}`
+                )
+              );
+            }
           }
           // Use the derived value if available
           if (staticAnalysis.isStatic && staticAnalysis.value !== undefined) {

--- a/packages/cli/src/react/jsx/utils/stringParsing/derivation/containsDeriveCall.ts
+++ b/packages/cli/src/react/jsx/utils/stringParsing/derivation/containsDeriveCall.ts
@@ -1,0 +1,35 @@
+import * as t from '@babel/types';
+import { GT_DERIVE_STRING_FUNCTIONS } from '../../constants.js';
+
+/**
+ * Lightweight name-based check for whether an expression tree contains
+ * a derive()/declareStatic() call. Does NOT validate imports or scope —
+ * used as a fast gate before full resolution via handleDerivation().
+ */
+export function containsDeriveCall(expr: t.Expression): boolean {
+  if (t.isCallExpression(expr) && t.isIdentifier(expr.callee)) {
+    return GT_DERIVE_STRING_FUNCTIONS.includes(
+      expr.callee.name as (typeof GT_DERIVE_STRING_FUNCTIONS)[number]
+    );
+  }
+  if (t.isBinaryExpression(expr)) {
+    return (
+      (t.isExpression(expr.left) && containsDeriveCall(expr.left)) ||
+      (t.isExpression(expr.right) && containsDeriveCall(expr.right))
+    );
+  }
+  if (t.isTemplateLiteral(expr)) {
+    return expr.expressions.some(
+      (e) => t.isExpression(e) && containsDeriveCall(e)
+    );
+  }
+  if (t.isConditionalExpression(expr)) {
+    return (
+      containsDeriveCall(expr.consequent) || containsDeriveCall(expr.alternate)
+    );
+  }
+  if (t.isParenthesizedExpression(expr)) {
+    return containsDeriveCall(expr.expression);
+  }
+  return false;
+}

--- a/packages/cli/src/react/jsx/utils/stringParsing/derivation/handleDerivation.ts
+++ b/packages/cli/src/react/jsx/utils/stringParsing/derivation/handleDerivation.ts
@@ -361,15 +361,31 @@ function getDeriveVariants<T extends t.CallExpression = t.CallExpression>({
       warnings
     );
   }
-  // Resolve the inner call's possible string outcomes
-  return resolveCallStringVariants(
-    arg,
+  // Handle call expression: derive(time())
+  if (t.isCallExpression(arg)) {
+    return resolveCallStringVariants(
+      arg,
+      tPath,
+      file,
+      parsingOptions,
+      errors,
+      warnings
+    );
+  }
+  // Handle other expressions (ternary, string literal, etc.) by recursing into handleDerivation
+  const node = handleDerivation({
+    expr: arg,
     tPath,
     file,
     parsingOptions,
     errors,
-    warnings
-  );
+    warnings,
+    skipDeriveInvocation: true,
+  });
+  if (node) {
+    return nodeToStrings(node);
+  }
+  return null;
 }
 
 function resolveCallStringVariants(

--- a/packages/cli/src/react/jsx/utils/stringParsing/derivation/index.ts
+++ b/packages/cli/src/react/jsx/utils/stringParsing/derivation/index.ts
@@ -35,6 +35,7 @@ export function deriveExpression({
   output,
   index,
   enableRuntimeInterpolation = false,
+  contextVariants,
 }: {
   tPath: NodePath;
   expr: t.Expression;
@@ -43,6 +44,7 @@ export function deriveExpression({
   output: ParsingOutput;
   index?: number;
   enableRuntimeInterpolation?: boolean;
+  contextVariants?: string[];
 }) {
   // parse derivable expression
   const stringNode = handleDerivation({
@@ -90,16 +92,21 @@ export function deriveExpression({
   }
 
   const temporaryDeriveId = `derive-temp-id-${randomUUID()}`;
+  const contexts = contextVariants ?? [metadata.context];
   for (const string of strings) {
-    output.updates.push({
-      dataFormat: (metadata.format || 'ICU') as DataFormat,
-      source: string,
-      metadata: {
-        ...metadata,
-        // Add the index if an id and index is provided (for handling when registering an array of strings)
-        ...(metadata.id && index != null && { id: `${metadata.id}.${index}` }),
-        staticId: temporaryDeriveId,
-      },
-    });
+    for (const context of contexts) {
+      output.updates.push({
+        dataFormat: (metadata.format || 'ICU') as DataFormat,
+        source: string,
+        metadata: {
+          ...metadata,
+          ...(context != null && { context }),
+          // Add the index if an id and index is provided (for handling when registering an array of strings)
+          ...(metadata.id &&
+            index != null && { id: `${metadata.id}.${index}` }),
+          staticId: temporaryDeriveId,
+        },
+      });
+    }
   }
 }

--- a/packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/__tests__/processTranslationCall.test.ts
+++ b/packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/__tests__/processTranslationCall.test.ts
@@ -294,3 +294,127 @@ describe('$format option support', () => {
     expect(output.warnings.size).toBeGreaterThan(0);
   });
 });
+
+describe('derive in context', () => {
+  it('should produce 2 updates when $context uses derive with ternary', () => {
+    const code = `
+      import { derive } from 'generaltranslation';
+      t("Hello", { $context: derive(x ? "formal" : "casual") })
+    `;
+    const output = runProcessTranslationCall(code);
+
+    expect(output.errors).toHaveLength(0);
+    expect(output.updates).toHaveLength(2);
+
+    const contexts = output.updates.map((u) => u.metadata.context).sort();
+    expect(contexts).toEqual(['casual', 'formal']);
+
+    // Both should have the same source
+    expect(output.updates[0].source).toBe('Hello');
+    expect(output.updates[1].source).toBe('Hello');
+
+    // Both should share the same staticId
+    expect(output.updates[0].metadata.staticId).toBeDefined();
+    expect(output.updates[0].metadata.staticId).toBe(
+      output.updates[1].metadata.staticId
+    );
+  });
+
+  it('should produce cross-product when both content and context use derive', () => {
+    const code = `
+      import { derive } from 'generaltranslation';
+      t(derive(x ? "Hello" : "Hi"), { $context: derive(y ? "formal" : "casual") })
+    `;
+    const output = runProcessTranslationCall(code);
+
+    expect(output.errors).toHaveLength(0);
+    expect(output.updates).toHaveLength(4);
+
+    const pairs = output.updates
+      .map((u) => `${u.source}|${u.metadata.context}`)
+      .sort();
+    expect(pairs).toEqual([
+      'Hello|casual',
+      'Hello|formal',
+      'Hi|casual',
+      'Hi|formal',
+    ]);
+
+    // All 4 should share the same staticId
+    const staticId = output.updates[0].metadata.staticId;
+    expect(staticId).toBeDefined();
+    expect(output.updates.every((u) => u.metadata.staticId === staticId)).toBe(
+      true
+    );
+  });
+
+  it('should still work with static string $context (regression)', () => {
+    const output = runProcessTranslationCall(
+      `t("Hello", { $context: "greeting" })`
+    );
+
+    expect(output.errors).toHaveLength(0);
+    expect(output.updates).toHaveLength(1);
+    expect(output.updates[0]).toMatchObject({
+      source: 'Hello',
+      metadata: { context: 'greeting' },
+    });
+  });
+
+  it('should produce N updates when context derives a function with N return variants', () => {
+    const code = `
+      import { derive } from 'generaltranslation';
+      function getFormality() {
+        if (isFormal) {
+          return "formal";
+        } else {
+          return "casual";
+        }
+      }
+      t("Hello", { $context: derive(getFormality()) })
+    `;
+    const output = runProcessTranslationCall(code);
+
+    expect(output.errors).toHaveLength(0);
+    expect(output.updates).toHaveLength(2);
+
+    const contexts = output.updates.map((u) => u.metadata.context).sort();
+    expect(contexts).toEqual(['casual', 'formal']);
+
+    expect(output.updates[0].source).toBe('Hello');
+    expect(output.updates[1].source).toBe('Hello');
+
+    expect(output.updates[0].metadata.staticId).toBeDefined();
+    expect(output.updates[0].metadata.staticId).toBe(
+      output.updates[1].metadata.staticId
+    );
+  });
+
+  it('should handle derive in context via string concatenation', () => {
+    const code = `
+      import { derive } from 'generaltranslation';
+      t("Hello", { $context: "prefix-" + derive(x ? "formal" : "casual") })
+    `;
+    const output = runProcessTranslationCall(code);
+
+    expect(output.errors).toHaveLength(0);
+    expect(output.updates).toHaveLength(2);
+
+    const contexts = output.updates.map((u) => u.metadata.context).sort();
+    expect(contexts).toEqual(['prefix-casual', 'prefix-formal']);
+  });
+
+  it('should handle derive in context via template literal', () => {
+    const code = `
+      import { derive } from 'generaltranslation';
+      t("Hello", { $context: \`prefix-\${derive(x ? "formal" : "casual")}\` })
+    `;
+    const output = runProcessTranslationCall(code);
+
+    expect(output.errors).toHaveLength(0);
+    expect(output.updates).toHaveLength(2);
+
+    const contexts = output.updates.map((u) => u.metadata.context).sort();
+    expect(contexts).toEqual(['prefix-casual', 'prefix-formal']);
+  });
+});

--- a/packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/__tests__/processTranslationCall.test.ts
+++ b/packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/__tests__/processTranslationCall.test.ts
@@ -298,7 +298,7 @@ describe('$format option support', () => {
 describe('derive in context', () => {
   it('should produce 2 updates when $context uses derive with ternary', () => {
     const code = `
-      import { derive } from 'generaltranslation';
+      import { derive } from 'gt-react';
       t("Hello", { $context: derive(x ? "formal" : "casual") })
     `;
     const output = runProcessTranslationCall(code);
@@ -322,7 +322,7 @@ describe('derive in context', () => {
 
   it('should produce cross-product when both content and context use derive', () => {
     const code = `
-      import { derive } from 'generaltranslation';
+      import { derive } from 'gt-react';
       t(derive(x ? "Hello" : "Hi"), { $context: derive(y ? "formal" : "casual") })
     `;
     const output = runProcessTranslationCall(code);
@@ -363,7 +363,7 @@ describe('derive in context', () => {
 
   it('should produce N updates when context derives a function with N return variants', () => {
     const code = `
-      import { derive } from 'generaltranslation';
+      import { derive } from 'gt-react';
       function getFormality() {
         if (isFormal) {
           return "formal";
@@ -392,7 +392,7 @@ describe('derive in context', () => {
 
   it('should handle derive in context via string concatenation', () => {
     const code = `
-      import { derive } from 'generaltranslation';
+      import { derive } from 'gt-react';
       t("Hello", { $context: "prefix-" + derive(x ? "formal" : "casual") })
     `;
     const output = runProcessTranslationCall(code);
@@ -406,7 +406,7 @@ describe('derive in context', () => {
 
   it('should handle derive in context via template literal', () => {
     const code = `
-      import { derive } from 'generaltranslation';
+      import { derive } from 'gt-react';
       t("Hello", { $context: \`prefix-\${derive(x ? "formal" : "casual")}\` })
     `;
     const output = runProcessTranslationCall(code);

--- a/packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/extractStringEntryMetadata.ts
+++ b/packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/extractStringEntryMetadata.ts
@@ -6,6 +6,7 @@ import { warnInvalidMaxCharsSync } from '../../../../../console/index.js';
 import { warnInvalidFormatSync } from '../../../../../console/index.js';
 import { warnNonStaticExpressionSync } from '../../../../../console/index.js';
 import { GT_ATTRIBUTES_WITH_SUGAR } from '../../constants.js';
+import { containsDeriveCall } from '../derivation/containsDeriveCall.js';
 import generateModule from '@babel/generator';
 import { mapAttributeName } from '../../mapAttributeName.js';
 import pathModule from 'node:path';
@@ -28,6 +29,7 @@ export type InlineMetadata = {
   format?: string;
   filePaths?: string[];
   sourceCode?: Record<string, SourceCode[]>;
+  contextDeriveExpr?: t.Expression;
 };
 
 /**
@@ -112,6 +114,7 @@ function extractInlineMetadata({
   config: ParsingConfig;
 }): InlineMetadata {
   const metadata: Record<string, string | number | string[]> = {};
+  let contextDeriveExpr: t.Expression | undefined;
   if (options && options.type === 'ObjectExpression') {
     options.properties.forEach((prop) => {
       if (prop.type === 'ObjectProperty' && prop.key.type === 'Identifier') {
@@ -124,14 +127,19 @@ function extractInlineMetadata({
         ) {
           const result = isStaticExpression(prop.value);
           if (!result.isStatic) {
-            output.errors.push(
-              warnNonStaticExpressionSync(
-                config.file,
-                attribute,
-                generate(prop.value).code,
-                `${prop.loc?.start?.line}:${prop.loc?.start?.column}`
-              )
-            );
+            const mappedKey = mapAttributeName(attribute);
+            if (mappedKey === 'context' && containsDeriveCall(prop.value)) {
+              contextDeriveExpr = prop.value;
+            } else {
+              output.errors.push(
+                warnNonStaticExpressionSync(
+                  config.file,
+                  attribute,
+                  generate(prop.value).code,
+                  `${prop.loc?.start?.line}:${prop.loc?.start?.column}`
+                )
+              );
+            }
           }
           if (
             result.isStatic &&
@@ -186,5 +194,8 @@ function extractInlineMetadata({
     });
   }
 
-  return metadata;
+  return {
+    ...metadata,
+    ...(contextDeriveExpr && { contextDeriveExpr }),
+  };
 }

--- a/packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/handleDeriveTranslationCall.ts
+++ b/packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/handleDeriveTranslationCall.ts
@@ -21,6 +21,7 @@ export function handleDeriveTranslationCall({
   config,
   output,
   index,
+  contextVariants,
 }: {
   arg: t.Expression;
   metadata: InlineMetadata;
@@ -28,6 +29,7 @@ export function handleDeriveTranslationCall({
   config: ParsingConfig;
   output: ParsingOutput;
   index?: number;
+  contextVariants?: string[];
 }): void {
   deriveExpression({
     tPath,
@@ -36,5 +38,6 @@ export function handleDeriveTranslationCall({
     config,
     output,
     index,
+    contextVariants,
   });
 }

--- a/packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/handleLiteralTranslationCall.ts
+++ b/packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/handleLiteralTranslationCall.ts
@@ -5,6 +5,7 @@ import { ParsingOutput } from '../types.js';
 import { isValidIcu } from '../../../evaluateJsx.js';
 import { warnInvalidIcuSync } from '../../../../../console/index.js';
 import { InlineMetadata } from './extractStringEntryMetadata.js';
+import { randomUUID } from 'node:crypto';
 
 /**
  * For the processTranslationCall function, this function handles the case where a string literal or template literal is used.
@@ -13,6 +14,7 @@ import { InlineMetadata } from './extractStringEntryMetadata.js';
  * @param config - The configuration to use
  * @param output - The output to use
  * @param index - The index of the argument
+ * @param contextVariants - Optional derive context variants for cross-product
  */
 export function handleLiteralTranslationCall({
   arg,
@@ -20,12 +22,14 @@ export function handleLiteralTranslationCall({
   config,
   output,
   index,
+  contextVariants,
 }: {
   arg: t.StringLiteral | t.TemplateLiteral;
   metadata: InlineMetadata;
   config: ParsingConfig;
   output: ParsingOutput;
   index?: number;
+  contextVariants?: string[];
 }): void {
   // ignore dynamic content flag is triggered, check strings are valid ICU
   const source =
@@ -50,13 +54,30 @@ export function handleLiteralTranslationCall({
     }
   }
 
-  output.updates.push({
-    dataFormat: (metadata.format || 'ICU') as DataFormat,
-    source,
-    metadata: {
-      ...metadata,
-      // Add the index if an id and index is provided (for handling when registering an array of strings)
-      ...(metadata.id && index != null && { id: `${metadata.id}.${index}` }),
-    },
-  });
+  if (contextVariants) {
+    const staticId = `derive-temp-id-${randomUUID()}`;
+    for (const context of contextVariants) {
+      output.updates.push({
+        dataFormat: (metadata.format || 'ICU') as DataFormat,
+        source,
+        metadata: {
+          ...metadata,
+          context,
+          ...(metadata.id &&
+            index != null && { id: `${metadata.id}.${index}` }),
+          staticId,
+        },
+      });
+    }
+  } else {
+    output.updates.push({
+      dataFormat: (metadata.format || 'ICU') as DataFormat,
+      source,
+      metadata: {
+        ...metadata,
+        // Add the index if an id and index is provided (for handling when registering an array of strings)
+        ...(metadata.id && index != null && { id: `${metadata.id}.${index}` }),
+      },
+    });
+  }
 }

--- a/packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/index.ts
+++ b/packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/index.ts
@@ -4,6 +4,8 @@ import { ParsingOutput } from '../types.js';
 import { routeTranslationCall } from './routeTranslationCall.js';
 import { extractStringEntryMetadata } from './extractStringEntryMetadata.js';
 import { SURROUNDING_LINE_COUNT } from '../../../../../utils/constants.js';
+import { handleDerivation } from '../derivation/handleDerivation.js';
+import { nodeToStrings } from '../../parseString.js';
 
 /**
  * Processes a single translation function call (e.g., t('hello world', { id: 'greeting' })).
@@ -44,6 +46,23 @@ export function processTranslationCall(
     surroundingLineCount: SURROUNDING_LINE_COUNT,
   });
 
+  // Resolve derive context variants if present
+  let contextVariants: string[] | undefined;
+  if (metadata.contextDeriveExpr) {
+    const contextNode = handleDerivation({
+      expr: metadata.contextDeriveExpr,
+      tPath,
+      file: config.file,
+      parsingOptions: config.parsingOptions,
+      errors: output.errors,
+      warnings: output.warnings,
+    });
+    if (contextNode) {
+      contextVariants = nodeToStrings(contextNode);
+    }
+    delete metadata.contextDeriveExpr;
+  }
+
   // Route tx call to appropriate handler
   routeTranslationCall({
     tPath,
@@ -51,5 +70,6 @@ export function processTranslationCall(
     output,
     arg,
     metadata,
+    contextVariants,
   });
 }

--- a/packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/routeTranslationCall.ts
+++ b/packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/routeTranslationCall.ts
@@ -26,6 +26,7 @@ export function routeTranslationCall({
   arg,
   metadata,
   index,
+  contextVariants,
 }: {
   tPath: NodePath;
   config: ParsingConfig;
@@ -33,6 +34,7 @@ export function routeTranslationCall({
   arg: t.CallExpression['arguments'][number];
   metadata: InlineMetadata;
   index?: number;
+  contextVariants?: string[];
 }): void {
   if (
     t.isArrayExpression(arg) &&
@@ -50,6 +52,7 @@ export function routeTranslationCall({
         arg: element,
         index: i,
         metadata,
+        contextVariants,
       });
     }
   } else if (
@@ -65,6 +68,7 @@ export function routeTranslationCall({
       config,
       output,
       index,
+      contextVariants,
     });
   } else if (
     arg.type === 'StringLiteral' ||
@@ -77,6 +81,7 @@ export function routeTranslationCall({
       config,
       output,
       index,
+      contextVariants,
     });
   } else {
     // error on invalid translation call

--- a/packages/compiler/src/processing/collection/processCallExpression.ts
+++ b/packages/compiler/src/processing/collection/processCallExpression.ts
@@ -140,6 +140,11 @@ function handleUseGTCallback(
   }
 
   // Track the function call
+  // When context contains derive(), skip hash calculation (CLI handles resolution)
+  const hash = useGTCallbackParams.hasDeriveContext
+    ? ''
+    : useGTCallbackParams.hash;
+
   registerUseGTCallback({
     identifier,
     state,
@@ -147,7 +152,7 @@ function handleUseGTCallback(
     context: useGTCallbackParams.context,
     id: useGTCallbackParams.id,
     maxChars: useGTCallbackParams.maxChars,
-    hash: useGTCallbackParams.hash,
+    hash,
     format: useGTCallbackParams.format,
   });
 }
@@ -252,7 +257,7 @@ function handleReactInvocation(
   }
 
   // Validate the arguments
-  const { errors, _hash, id, context, children, maxChars } =
+  const { errors, _hash, id, context, children, maxChars, hasDeriveContext } =
     validateTranslationComponentArgs(callExpr, canonicalName, state);
 
   if (errors.length > 0) {
@@ -260,16 +265,17 @@ function handleReactInvocation(
     return;
   }
 
-  // Calculate hash
-  const hash =
-    _hash ||
-    hashSource({
-      source: children!,
-      ...(context && { context }),
-      ...(id && { id }),
-      ...(maxChars != null && { maxChars }),
-      dataFormat: 'JSX',
-    });
+  // Calculate hash (skip when context contains derive — CLI handles resolution)
+  const hash = hasDeriveContext
+    ? ''
+    : _hash ||
+      hashSource({
+        source: children!,
+        ...(context && { context }),
+        ...(id && { id }),
+        ...(maxChars != null && { maxChars }),
+        dataFormat: 'JSX',
+      });
 
   // Debug: record hash → children mapping
   if (state.debugManifest) {

--- a/packages/compiler/src/transform/registration/callbacks/registerUseGTCallback.ts
+++ b/packages/compiler/src/transform/registration/callbacks/registerUseGTCallback.ts
@@ -25,8 +25,8 @@ export function registerUseGTCallback({
   hash?: string;
   format?: string;
 }): void {
-  // Calculate hash for the call expression
-  hash ||= hashSource({
+  // Calculate hash for the call expression (skip if already set, including empty string for derive context)
+  hash ??= hashSource({
     source: content,
     id,
     context,

--- a/packages/compiler/src/transform/validation/__tests__/validateTranslationFunctionCallback.test.ts
+++ b/packages/compiler/src/transform/validation/__tests__/validateTranslationFunctionCallback.test.ts
@@ -694,6 +694,121 @@ describe('validateTranslationFunctionCallback', () => {
         expect(result.context).toBe('greeting');
       });
     });
+
+    describe('derive in context', () => {
+      it('should not error when $context contains a derive() call', () => {
+        const deriveCall = t.callExpression(
+          t.identifier(GT_OTHER_FUNCTIONS.derive),
+          [t.callExpression(t.identifier('getFormality'), [])]
+        );
+
+        const callExpr = t.callExpression(t.identifier('useGT_callback'), [
+          t.stringLiteral('Hello'),
+          t.objectExpression([
+            t.objectProperty(t.identifier('$context'), deriveCall),
+          ]),
+        ]);
+
+        const result = validateUseGTCallback(callExpr, state);
+
+        expect(result.errors).toHaveLength(0);
+        expect(result.content).toBe('Hello');
+      });
+
+      it('should not error when $context contains derive() wrapping a ternary', () => {
+        const deriveCall = t.callExpression(
+          t.identifier(GT_OTHER_FUNCTIONS.derive),
+          [
+            t.conditionalExpression(
+              t.identifier('isFormal'),
+              t.stringLiteral('formal'),
+              t.stringLiteral('casual')
+            ),
+          ]
+        );
+
+        const callExpr = t.callExpression(t.identifier('useGT_callback'), [
+          t.stringLiteral('Hello'),
+          t.objectExpression([
+            t.objectProperty(t.identifier('$context'), deriveCall),
+          ]),
+        ]);
+
+        const result = validateUseGTCallback(callExpr, state);
+
+        expect(result.errors).toHaveLength(0);
+        expect(result.content).toBe('Hello');
+      });
+
+      it('should not error when $context contains derive() in string concatenation', () => {
+        const deriveCall = t.callExpression(
+          t.identifier(GT_OTHER_FUNCTIONS.derive),
+          [t.callExpression(t.identifier('getFormality'), [])]
+        );
+
+        const concatExpr = t.binaryExpression(
+          '+',
+          t.stringLiteral('prefix-'),
+          deriveCall
+        );
+
+        const callExpr = t.callExpression(t.identifier('useGT_callback'), [
+          t.stringLiteral('Hello'),
+          t.objectExpression([
+            t.objectProperty(t.identifier('$context'), concatExpr),
+          ]),
+        ]);
+
+        const result = validateUseGTCallback(callExpr, state);
+
+        expect(result.errors).toHaveLength(0);
+        expect(result.content).toBe('Hello');
+      });
+
+      it('should not error when $context contains derive() in template literal', () => {
+        const deriveCall = t.callExpression(
+          t.identifier(GT_OTHER_FUNCTIONS.derive),
+          [t.callExpression(t.identifier('getFormality'), [])]
+        );
+
+        const templateLiteral = t.templateLiteral(
+          [
+            t.templateElement({ raw: 'prefix-', cooked: 'prefix-' }),
+            t.templateElement({ raw: '', cooked: '' }),
+          ],
+          [deriveCall]
+        );
+
+        const callExpr = t.callExpression(t.identifier('useGT_callback'), [
+          t.stringLiteral('Hello'),
+          t.objectExpression([
+            t.objectProperty(t.identifier('$context'), templateLiteral),
+          ]),
+        ]);
+
+        const result = validateUseGTCallback(callExpr, state);
+
+        expect(result.errors).toHaveLength(0);
+        expect(result.content).toBe('Hello');
+      });
+
+      it('should still accept static string $context (regression)', () => {
+        const callExpr = t.callExpression(t.identifier('useGT_callback'), [
+          t.stringLiteral('Hello'),
+          t.objectExpression([
+            t.objectProperty(
+              t.identifier('$context'),
+              t.stringLiteral('greeting')
+            ),
+          ]),
+        ]);
+
+        const result = validateUseGTCallback(callExpr, state);
+
+        expect(result.errors).toHaveLength(0);
+        expect(result.context).toBe('greeting');
+      });
+    });
   });
 
   describe('validateUseTranslationsCallback', () => {

--- a/packages/compiler/src/transform/validation/__tests__/validateTranslationFunctionCallback.test.ts
+++ b/packages/compiler/src/transform/validation/__tests__/validateTranslationFunctionCallback.test.ts
@@ -715,16 +715,10 @@ describe('validateTranslationFunctionCallback', () => {
         expect(result.content).toBe('Hello');
       });
 
-      it('should not error when $context contains derive() wrapping a ternary', () => {
+      it('should not error when $context contains derive() wrapping a function call', () => {
         const deriveCall = t.callExpression(
           t.identifier(GT_OTHER_FUNCTIONS.derive),
-          [
-            t.conditionalExpression(
-              t.identifier('isFormal'),
-              t.stringLiteral('formal'),
-              t.stringLiteral('casual')
-            ),
-          ]
+          [t.callExpression(t.identifier('getTone'), [])]
         );
 
         const callExpr = t.callExpression(t.identifier('useGT_callback'), [

--- a/packages/compiler/src/transform/validation/validateTranslationComponentArgs.ts
+++ b/packages/compiler/src/transform/validation/validateTranslationComponentArgs.ts
@@ -7,6 +7,7 @@ import { JsxChildren } from 'generaltranslation/types';
 import { constructJsxChildren } from '../jsx-children';
 import { validateChildrenPropertyFromObjectExpression } from '../../utils/validation/validateChildrenFromObjectExpression';
 import { validateExpressionIsNumericLiteral } from '../../utils/validation/validateExpressionIsNumericLiteral';
+import { validateDerive } from './validateTranslationFunctionCallback';
 /**
  * Given a translation component, validate the arguments
  */
@@ -21,6 +22,7 @@ export function validateTranslationComponentArgs(
   context?: string;
   maxChars?: number;
   children?: JsxChildren;
+  hasDeriveContext?: boolean;
 } {
   // Check that there are at least 2 arguments (identifier, args)
   if (callExpr.arguments.length < 2) {
@@ -66,6 +68,7 @@ function validateTComponentArgs(
   context?: string;
   maxChars?: number;
   children?: JsxChildren;
+  hasDeriveContext?: boolean;
 } {
   const errors: string[] = [];
 
@@ -74,10 +77,11 @@ function validateTComponentArgs(
   errors.push(...idValidation.errors);
   const id = idValidation.value;
 
-  // Validate context
-  const contextValidation = validateStringProperty(args, 'context');
+  // Validate context (with derive fallback)
+  const contextValidation = validateStringProperty(args, 'context', state);
   errors.push(...contextValidation.errors);
   const context = contextValidation.value;
+  const hasDeriveContext = contextValidation.hasDeriveExpression;
 
   // Validate maxChars
   const maxCharsValidation = validateNumberProperty(args, 'maxChars');
@@ -94,7 +98,7 @@ function validateTComponentArgs(
   errors.push(...childrenValidation.errors);
   const children = childrenValidation.value;
 
-  return { errors, id, context, _hash, maxChars, children };
+  return { errors, id, context, _hash, maxChars, children, hasDeriveContext };
 }
 
 /**
@@ -137,10 +141,12 @@ export function validateChildrenProperty(
  */
 function validateStringProperty(
   args: t.ObjectExpression,
-  name: string
+  name: string,
+  state?: TransformState
 ): {
   errors: string[];
   value?: string;
+  hasDeriveExpression?: boolean;
 } {
   const errors: string[] = [];
 
@@ -154,10 +160,22 @@ function validateStringProperty(
 
   // Validate property
   const validation = validateObjectPropertyIsStringLiteral(property, name);
-  errors.push(...validation.errors);
-  const value = validation.value;
+  if (validation.errors.length === 0) {
+    return { errors, value: validation.value };
+  }
 
-  return { errors, value };
+  // String validation failed — check if it's a valid derive() expression
+  if (state && t.isObjectProperty(property) && t.isExpression(property.value)) {
+    const deriveErrors: string[] = [];
+    validateDerive(property.value, state, deriveErrors);
+    if (deriveErrors.length === 0) {
+      return { errors, hasDeriveExpression: true };
+    }
+  }
+
+  // Neither string nor derive — return original errors
+  errors.push(...validation.errors);
+  return { errors };
 }
 
 /**

--- a/packages/compiler/src/transform/validation/validateTranslationFunctionCallback.ts
+++ b/packages/compiler/src/transform/validation/validateTranslationFunctionCallback.ts
@@ -24,6 +24,7 @@ export function validateUseGTCallback(
   id?: string;
   maxChars?: number;
   format?: string;
+  hasDeriveContext?: boolean;
 } {
   const errors: string[] = [];
 
@@ -51,7 +52,7 @@ export function validateUseGTCallback(
 
   if (content === undefined) {
     // expression is not a string literal. Check if it contains a derive() function invocation
-    validateDeclareStatic(callExpr.arguments[0], state, errors);
+    validateDerive(callExpr.arguments[0], state, errors);
     if (errors.length > 0) {
       errors.push(...validatedContent.errors);
       errors.push(
@@ -66,6 +67,7 @@ export function validateUseGTCallback(
   let hash: string | undefined;
   let maxChars: number | undefined;
   let format: string | undefined;
+  let hasDeriveContext: boolean | undefined;
   if (callExpr.arguments.length === 1) {
     return { errors, content };
   }
@@ -73,10 +75,12 @@ export function validateUseGTCallback(
     const contextProperty = validatePropertyFromObjectExpression(
       callExpr.arguments[1],
       USEGT_CALLBACK_OPTIONS.$context,
-      'string'
+      'string-or-derive',
+      state
     );
     errors.push(...contextProperty.errors);
-    context = contextProperty.value;
+    context = contextProperty.value as string | undefined;
+    hasDeriveContext = contextProperty.hasDeriveExpression;
     const idProperty = validatePropertyFromObjectExpression(
       callExpr.arguments[1],
       USEGT_CALLBACK_OPTIONS.$id,
@@ -107,7 +111,16 @@ export function validateUseGTCallback(
     format = formatProperty.value;
   }
 
-  return { errors, content, context, id, hash, maxChars, format };
+  return {
+    errors,
+    content,
+    context,
+    id,
+    hash,
+    maxChars,
+    format,
+    hasDeriveContext,
+  };
 }
 
 /**
@@ -157,9 +170,24 @@ function validatePropertyFromObjectExpression(
 function validatePropertyFromObjectExpression(
   objExpr: t.ObjectExpression,
   name: string,
-  type: 'string' | 'number'
-): { errors: string[]; value?: string | number } {
-  const result: { errors: string[]; value?: string | number } = { errors: [] };
+  type: 'string-or-derive',
+  state: TransformState
+): { errors: string[]; value?: string; hasDeriveExpression?: boolean };
+function validatePropertyFromObjectExpression(
+  objExpr: t.ObjectExpression,
+  name: string,
+  type: 'string' | 'number' | 'string-or-derive',
+  state?: TransformState
+): {
+  errors: string[];
+  value?: string | number;
+  hasDeriveExpression?: boolean;
+} {
+  const result: {
+    errors: string[];
+    value?: string | number;
+    hasDeriveExpression?: boolean;
+  } = { errors: [] };
   let value: t.ObjectProperty | undefined;
   for (const property of objExpr.properties) {
     if (!t.isObjectProperty(property)) {
@@ -189,12 +217,30 @@ function validatePropertyFromObjectExpression(
   }
 
   // extract value
-  const validatedValue =
-    type === 'string'
-      ? validateExpressionIsStringLiteral(value.value)
-      : validateExpressionIsNumericLiteral(value.value);
-  result.errors.push(...validatedValue.errors);
-  result.value = validatedValue.value;
+  if (type === 'string-or-derive') {
+    const stringValidation = validateExpressionIsStringLiteral(value.value);
+    if (stringValidation.value !== undefined) {
+      result.value = stringValidation.value;
+    } else if (state) {
+      // String validation failed — check if it's a valid derive() expression
+      const deriveErrors: string[] = [];
+      validateDerive(value.value, state, deriveErrors);
+      if (deriveErrors.length === 0) {
+        result.hasDeriveExpression = true;
+      } else {
+        result.errors.push(...stringValidation.errors);
+      }
+    } else {
+      result.errors.push(...stringValidation.errors);
+    }
+  } else {
+    const validatedValue =
+      type === 'string'
+        ? validateExpressionIsStringLiteral(value.value)
+        : validateExpressionIsNumericLiteral(value.value);
+    result.errors.push(...validatedValue.errors);
+    result.value = validatedValue.value;
+  }
 
   return result;
 }
@@ -218,7 +264,7 @@ function validateExpressionIsStringLiteral(expr: t.Expression): {
 /**
  * Validates if an expression uses the derive() function correctly
  */
-function validateDeclareStatic(
+export function validateDerive(
   expr: t.Expression,
   state: TransformState,
   errors: string[]
@@ -262,8 +308,8 @@ function validateDeclareStatic(
       errors.push('Operands must be expressions');
       return { errors };
     }
-    validateDeclareStatic(expr.right, state, errors);
-    validateDeclareStatic(expr.left, state, errors);
+    validateDerive(expr.right, state, errors);
+    validateDerive(expr.left, state, errors);
     return { errors };
   }
 
@@ -273,7 +319,7 @@ function validateDeclareStatic(
       !expr.expressions.some(
         (expression) =>
           t.isExpression(expression) &&
-          validateDeclareStatic(expression, state, errors).errors.length === 0
+          validateDerive(expression, state, errors).errors.length === 0
       )
     ) {
       errors.push('Expression does not use an allowed call expression');

--- a/packages/next/swc-plugin/src/ast/traversal.rs
+++ b/packages/next/swc-plugin/src/ast/traversal.rs
@@ -7,7 +7,7 @@ use crate::hash::{
   HtmlContentProps, SanitizedChild, SanitizedChildren, SanitizedElement, SanitizedGtProp,
   SanitizedVariable, VariableType,
 };
-use crate::visitor::jsx_utils::{extract_attribute_from_jsx_attr, extract_max_chars_from_jsx_attr};
+use crate::visitor::jsx_utils::{extract_attribute_from_jsx_attr, extract_max_chars_from_jsx_attr, jsx_attr_contains_derive_call};
 use crate::TransformVisitor;
 use std::collections::BTreeMap;
 use swc_core::ecma::{ast::*, atoms::Atom};
@@ -54,9 +54,10 @@ impl<'a> JsxTraversal<'a> {
       let max_chars = extract_max_chars_from_jsx_attr(element, "maxChars")
         .or_else(|| extract_max_chars_from_jsx_attr(element, "$maxChars"));
 
-      // Get the id from the element
-      // Check if sanitized children contain static components - if so, return empty hash
-      let has_static = JsxHasher::contains_static(&sanitized_children);
+      // Check if sanitized children contain static components or context contains derive - if so, return empty hash
+      let has_derive_in_context = jsx_attr_contains_derive_call(element, "context")
+        || jsx_attr_contains_derive_call(element, "$context");
+      let has_static = JsxHasher::contains_static(&sanitized_children) || has_derive_in_context;
       
       // Create the full SanitizedData structure to match TypeScript implementation
       use crate::hash::SanitizedData;

--- a/packages/next/swc-plugin/src/visitor/expr_utils.rs
+++ b/packages/next/swc-plugin/src/visitor/expr_utils.rs
@@ -123,6 +123,9 @@ pub fn contains_derive_call(expr: &Expr) -> bool {
     }
     Expr::Tpl(tpl) => tpl.exprs.iter().any(|e| contains_derive_call(e)),
     Expr::Paren(paren) => contains_derive_call(&paren.expr),
+    Expr::Cond(cond) => {
+      contains_derive_call(&cond.cons) || contains_derive_call(&cond.alt)
+    }
     _ => false,
   }
 }

--- a/packages/next/swc-plugin/src/visitor/expr_utils.rs
+++ b/packages/next/swc-plugin/src/visitor/expr_utils.rs
@@ -101,17 +101,45 @@ pub fn extract_number_from_expr(expr: &Expr) -> Option<i32> {
   }
 }
 
+/// Checks if an expression is a derive()/declareStatic() call by name
+fn is_derive_call_expr(expr: &Expr) -> bool {
+  if let Expr::Call(call_expr) = expr {
+    if let Callee::Expr(callee_expr) = &call_expr.callee {
+      if let Expr::Ident(ident) = callee_expr.as_ref() {
+        return matches!(ident.sym.as_str(), "derive" | "declareStatic");
+      }
+    }
+  }
+  false
+}
+
+/// Recursively checks if an expression contains a derive()/declareStatic() call.
+/// Handles: bare call, binary concat ("a" + derive(fn())), template literal (`a${derive(fn())}`)
+pub fn contains_derive_call(expr: &Expr) -> bool {
+  match expr {
+    Expr::Call(_) => is_derive_call_expr(expr),
+    Expr::Bin(bin_expr) => {
+      contains_derive_call(&bin_expr.left) || contains_derive_call(&bin_expr.right)
+    }
+    Expr::Tpl(tpl) => tpl.exprs.iter().any(|e| contains_derive_call(e)),
+    Expr::Paren(paren) => contains_derive_call(&paren.expr),
+    _ => false,
+  }
+}
+
 // Helper function to extract id, context, maxChars, and format from options
+// Returns (id, context, maxChars, format, has_derive_context)
 pub fn extract_id_and_context_from_options(
   options: Option<&ExprOrSpread>,
-) -> (Option<String>, Option<String>, Option<i32>, Option<String>) {
-  let (id, context, max_chars, format) = match options {
+) -> (Option<String>, Option<String>, Option<i32>, Option<String>, bool) {
+  let (id, context, max_chars, format, has_derive_context) = match options {
     Some(options) => match options.expr.as_ref() {
       Expr::Object(obj) => {
         let mut id_value = None;
         let mut context_value = None;
         let mut max_chars_value = None;
         let mut format_value = None;
+        let mut has_derive_context = false;
 
         for prop in &obj.props {
           if let PropOrSpread::Prop(prop) = prop {
@@ -123,6 +151,9 @@ pub fn extract_id_and_context_from_options(
                   }
                   "$context" => {
                     context_value = extract_string_from_expr(&key_value.value);
+                    if context_value.is_none() && contains_derive_call(&key_value.value) {
+                      has_derive_context = true;
+                    }
                   }
                   "$maxChars" => {
                     max_chars_value = extract_number_from_expr(&key_value.value);
@@ -137,13 +168,13 @@ pub fn extract_id_and_context_from_options(
           }
         }
 
-        (id_value, context_value, max_chars_value, format_value)
+        (id_value, context_value, max_chars_value, format_value, has_derive_context)
       }
-      _ => (None, None, None, None),
+      _ => (None, None, None, None, false),
     },
-    None => (None, None, None, None),
+    None => (None, None, None, None, false),
   };
-  (id, context, max_chars, format)
+  (id, context, max_chars, format, has_derive_context)
 }
 
 pub fn create_string_prop(key: &str, value: &str, span: Span) -> PropOrSpread {

--- a/packages/next/swc-plugin/src/visitor/expr_utils_tests.rs
+++ b/packages/next/swc-plugin/src/visitor/expr_utils_tests.rs
@@ -593,4 +593,161 @@ mod tests {
             extract_id_and_context_from_options(None);
         assert_eq!(format, None);
     }
+
+    // --- derive in context tests ---
+
+    fn make_derive_call() -> Box<Expr> {
+        Box::new(Expr::Call(CallExpr {
+            span: DUMMY_SP,
+            ctxt: SyntaxContext::empty(),
+            callee: Callee::Expr(Box::new(Expr::Ident(Ident {
+                span: DUMMY_SP,
+                sym: Atom::new("derive"),
+                optional: false,
+                ctxt: SyntaxContext::empty(),
+            }))),
+            args: vec![ExprOrSpread {
+                spread: None,
+                expr: Box::new(Expr::Call(CallExpr {
+                    span: DUMMY_SP,
+                    ctxt: SyntaxContext::empty(),
+                    callee: Callee::Expr(Box::new(Expr::Ident(Ident {
+                        span: DUMMY_SP,
+                        sym: Atom::new("getFormality"),
+                        optional: false,
+                        ctxt: SyntaxContext::empty(),
+                    }))),
+                    args: vec![],
+                    type_args: None,
+                })),
+            }],
+            type_args: None,
+        }))
+    }
+
+    #[test]
+    fn test_derive_call_in_context_is_recognized() {
+        // { $context: derive(getFormality()) }
+        let options = make_options_arg(vec![("$context", make_derive_call())]);
+        let (_id, _context, _max_chars, _format, has_derive_context) =
+            extract_id_and_context_from_options(Some(&options));
+
+        assert!(
+            has_derive_context,
+            "derive() in $context should set has_derive_context to true"
+        );
+    }
+
+    #[test]
+    fn test_static_string_context_still_works() {
+        // { $context: "greeting" } — regression check
+        let options = make_options_arg(vec![("$context", str_expr("greeting"))]);
+        let (_id, context, _max_chars, _format, has_derive_context) =
+            extract_id_and_context_from_options(Some(&options));
+        assert_eq!(context, Some("greeting".to_string()));
+        assert!(!has_derive_context, "static string context should not set has_derive_context");
+    }
+
+    #[test]
+    fn test_derive_ternary_in_context() {
+        // { $context: derive(x ? "formal" : "casual") }
+        let derive_call = Box::new(Expr::Call(CallExpr {
+            span: DUMMY_SP,
+            ctxt: SyntaxContext::empty(),
+            callee: Callee::Expr(Box::new(Expr::Ident(Ident {
+                span: DUMMY_SP,
+                sym: Atom::new("derive"),
+                optional: false,
+                ctxt: SyntaxContext::empty(),
+            }))),
+            args: vec![ExprOrSpread {
+                spread: None,
+                expr: Box::new(Expr::Cond(CondExpr {
+                    span: DUMMY_SP,
+                    test: Box::new(Expr::Ident(Ident {
+                        span: DUMMY_SP,
+                        sym: Atom::new("x"),
+                        optional: false,
+                        ctxt: SyntaxContext::empty(),
+                    })),
+                    cons: Box::new(Expr::Lit(Lit::Str(Str {
+                        span: DUMMY_SP,
+                        value: Atom::new("formal").into(),
+                        raw: None,
+                    }))),
+                    alt: Box::new(Expr::Lit(Lit::Str(Str {
+                        span: DUMMY_SP,
+                        value: Atom::new("casual").into(),
+                        raw: None,
+                    }))),
+                })),
+            }],
+            type_args: None,
+        }));
+
+        let options = make_options_arg(vec![("$context", derive_call)]);
+        let (_id, _context, _max_chars, _format, has_derive_context) =
+            extract_id_and_context_from_options(Some(&options));
+
+        assert!(
+            has_derive_context,
+            "derive(ternary) in $context should set has_derive_context to true"
+        );
+    }
+
+    #[test]
+    fn test_derive_in_context_concat() {
+        // { $context: "prefix-" + derive(getFormality()) }
+        let concat_expr = Box::new(Expr::Bin(BinExpr {
+            span: DUMMY_SP,
+            op: BinaryOp::Add,
+            left: Box::new(Expr::Lit(Lit::Str(Str {
+                span: DUMMY_SP,
+                value: Atom::new("prefix-").into(),
+                raw: None,
+            }))),
+            right: make_derive_call(),
+        }));
+
+        let options = make_options_arg(vec![("$context", concat_expr)]);
+        let (_id, _context, _max_chars, _format, has_derive_context) =
+            extract_id_and_context_from_options(Some(&options));
+
+        assert!(
+            has_derive_context,
+            "string concat with derive() in $context should set has_derive_context to true"
+        );
+    }
+
+    #[test]
+    fn test_derive_in_context_template_literal() {
+        // { $context: `prefix-${derive(getFormality())}` }
+        let template_expr = Box::new(Expr::Tpl(Tpl {
+            span: DUMMY_SP,
+            exprs: vec![make_derive_call()],
+            quasis: vec![
+                TplElement {
+                    span: DUMMY_SP,
+                    tail: false,
+                    cooked: Some(Atom::new("prefix-").into()),
+                    raw: Atom::new("prefix-").into(),
+                },
+                TplElement {
+                    span: DUMMY_SP,
+                    tail: true,
+                    cooked: Some(Atom::new("").into()),
+                    raw: Atom::new("").into(),
+                },
+            ],
+        }));
+
+        let options = make_options_arg(vec![("$context", template_expr)]);
+        let (_id, _context, _max_chars, _format, has_derive_context) =
+            extract_id_and_context_from_options(Some(&options));
+
+        assert!(
+            has_derive_context,
+            "template literal with derive() in $context should set has_derive_context to true"
+        );
+    }
 }

--- a/packages/next/swc-plugin/src/visitor/expr_utils_tests.rs
+++ b/packages/next/swc-plugin/src/visitor/expr_utils_tests.rs
@@ -750,4 +750,33 @@ mod tests {
             "template literal with derive() in $context should set has_derive_context to true"
         );
     }
+
+    #[test]
+    fn test_derive_in_context_ternary_outer() {
+        // { $context: cond ? derive(getFormality()) : "fallback" }
+        let cond_expr = Box::new(Expr::Cond(CondExpr {
+            span: DUMMY_SP,
+            test: Box::new(Expr::Ident(Ident {
+                span: DUMMY_SP,
+                sym: Atom::new("cond"),
+                optional: false,
+                ctxt: SyntaxContext::empty(),
+            })),
+            cons: make_derive_call(),
+            alt: Box::new(Expr::Lit(Lit::Str(Str {
+                span: DUMMY_SP,
+                value: Atom::new("fallback").into(),
+                raw: None,
+            }))),
+        }));
+
+        let options = make_options_arg(vec![("$context", cond_expr)]);
+        let (_id, _context, _max_chars, _format, has_derive_context) =
+            extract_id_and_context_from_options(Some(&options));
+
+        assert!(
+            has_derive_context,
+            "ternary with derive() in one branch of $context should set has_derive_context to true"
+        );
+    }
 }

--- a/packages/next/swc-plugin/src/visitor/expr_utils_tests.rs
+++ b/packages/next/swc-plugin/src/visitor/expr_utils_tests.rs
@@ -557,7 +557,7 @@ mod tests {
     #[test]
     fn test_extract_format_from_options() {
         let options = make_options_arg(vec![("$format", str_expr("STRING"))]);
-        let (id, context, max_chars, format) =
+        let (id, context, max_chars, format, _has_derive_context) =
             extract_id_and_context_from_options(Some(&options));
         assert_eq!(format, Some("STRING".to_string()));
         assert_eq!(id, None);
@@ -568,7 +568,7 @@ mod tests {
     #[test]
     fn test_extract_format_none_when_absent() {
         let options = make_options_arg(vec![("$context", str_expr("greeting"))]);
-        let (_id, _context, _max_chars, format) =
+        let (_id, _context, _max_chars, format, _has_derive_context) =
             extract_id_and_context_from_options(Some(&options));
         assert_eq!(format, None);
     }
@@ -580,7 +580,7 @@ mod tests {
             ("$context", str_expr("greeting")),
             ("$format", str_expr("I18NEXT")),
         ]);
-        let (id, context, _max_chars, format) =
+        let (id, context, _max_chars, format, _has_derive_context) =
             extract_id_and_context_from_options(Some(&options));
         assert_eq!(id, Some("hello".to_string()));
         assert_eq!(context, Some("greeting".to_string()));
@@ -589,7 +589,7 @@ mod tests {
 
     #[test]
     fn test_extract_format_none_when_no_options() {
-        let (_id, _context, _max_chars, format) =
+        let (_id, _context, _max_chars, format, _has_derive_context) =
             extract_id_and_context_from_options(None);
         assert_eq!(format, None);
     }

--- a/packages/next/swc-plugin/src/visitor/jsx_utils.rs
+++ b/packages/next/swc-plugin/src/visitor/jsx_utils.rs
@@ -1,3 +1,4 @@
+use crate::visitor::expr_utils::contains_derive_call;
 use swc_core::ecma::ast::*;
 
 pub fn extract_template_string(tpl: &Tpl) -> Option<String> {
@@ -103,6 +104,24 @@ pub fn extract_max_chars_from_jsx_attr(
     } else {
       None
     }
+  })
+}
+
+/// Checks if a JSX attribute's expression value contains a derive()/declareStatic() call
+pub fn jsx_attr_contains_derive_call(element: &JSXElement, attr_name: &str) -> bool {
+  element.opening.attrs.iter().any(|attr| {
+    if let JSXAttrOrSpread::JSXAttr(jsx_attr) = attr {
+      if let JSXAttrName::Ident(ident) = &jsx_attr.name {
+        if ident.sym.as_ref() == attr_name {
+          if let Some(JSXAttrValue::JSXExprContainer(expr_container)) = &jsx_attr.value {
+            if let JSXExpr::Expr(expr) = &expr_container.expr {
+              return contains_derive_call(expr);
+            }
+          }
+        }
+      }
+    }
+    false
   })
 }
 

--- a/packages/next/swc-plugin/src/visitor/transform.rs
+++ b/packages/next/swc-plugin/src/visitor/transform.rs
@@ -171,7 +171,7 @@ impl TransformVisitor {
     let options = call_expr.args.get(1);
 
     // Get context and id
-    let (context, id, max_chars, _format, has_derive_context) = extract_id_and_context_from_options(options);
+    let (id, context, max_chars, _format, has_derive_context) = extract_id_and_context_from_options(options);
 
     // Calculate hash for the call expression
     let (hash, _) = self.calculate_hash_for_call_expr(string, options);

--- a/packages/next/swc-plugin/src/visitor/transform.rs
+++ b/packages/next/swc-plugin/src/visitor/transform.rs
@@ -171,12 +171,14 @@ impl TransformVisitor {
     let options = call_expr.args.get(1);
 
     // Get context and id
-    let (context, id, max_chars, _format) = extract_id_and_context_from_options(options);
+    let (context, id, max_chars, _format, has_derive_context) = extract_id_and_context_from_options(options);
 
     // Calculate hash for the call expression
     let (hash, _) = self.calculate_hash_for_call_expr(string, options);
 
     if let Some(message) = extract_string_from_expr(string.expr.as_ref()) {
+      // If context contains derive(), skip hashing (empty hash) — CLI handles resolution
+      let hash = if has_derive_context { Some(String::new()) } else { hash };
       if let Some(hash) = hash {
         // Construct the translation content object
         let translation_content =
@@ -432,7 +434,12 @@ pub fn validate_string_literal_or_declare_static(&self,expr: &Expr, errors: &mut
     }
 
     // Extract the options content
-    let (id, context, max_chars, format) = extract_id_and_context_from_options(options);
+    let (id, context, max_chars, format, has_derive_context) = extract_id_and_context_from_options(options);
+
+    // If context contains derive(), skip hashing — CLI handles resolution
+    if has_derive_context {
+      return (Some(String::new()), None);
+    }
 
     // Construct the json object
     use crate::hash::{SanitizedChild, SanitizedChildren, SanitizedData};

--- a/packages/python-extractor/src/__tests__/fixtures/derive_context_cross_product.py
+++ b/packages/python-extractor/src/__tests__/fixtures/derive_context_cross_product.py
@@ -1,0 +1,9 @@
+from gt_flask import t, derive
+
+def get_formality():
+    if formal:
+        return "formal"
+    else:
+        return "casual"
+
+a = t(f"It is {derive('day' if is_day else 'night')}!", _context=derive(get_formality()))

--- a/packages/python-extractor/src/__tests__/fixtures/derive_context_ternary.py
+++ b/packages/python-extractor/src/__tests__/fixtures/derive_context_ternary.py
@@ -1,0 +1,3 @@
+from gt_flask import t, derive
+
+a = t("Hello", _context=derive("formal" if x else "casual"))

--- a/packages/python-extractor/src/__tests__/index.test.ts
+++ b/packages/python-extractor/src/__tests__/index.test.ts
@@ -391,9 +391,7 @@ t(f"The {derive(get_gender(variant))}")`;
 
       // Both should share the same staticId
       expect(results[0].metadata.staticId).toBeDefined();
-      expect(results[0].metadata.staticId).toBe(
-        results[1].metadata.staticId
-      );
+      expect(results[0].metadata.staticId).toBe(results[1].metadata.staticId);
     });
 
     it('should produce cross-product when both content and context use derive', async () => {
@@ -417,9 +415,7 @@ t(f"The {derive(get_gender(variant))}")`;
       // All 4 should share the same staticId
       const staticId = results[0].metadata.staticId;
       expect(staticId).toBeDefined();
-      expect(results.every((r) => r.metadata.staticId === staticId)).toBe(
-        true
-      );
+      expect(results.every((r) => r.metadata.staticId === staticId)).toBe(true);
     });
 
     it('should produce 2 results with inline ternary context', async () => {

--- a/packages/python-extractor/src/__tests__/index.test.ts
+++ b/packages/python-extractor/src/__tests__/index.test.ts
@@ -370,6 +370,113 @@ t(f"The {derive(get_gender(variant))}")`;
     });
   });
 
+  // ===== derive in context tests ===== //
+
+  describe('derive in context', () => {
+    it('should produce 2 results when _context uses derive with ternary', async () => {
+      const { results, errors } = await extractFromPythonSource(
+        fixture('derive_context_ternary.py'),
+        'derive_context_ternary.py'
+      );
+      expect(errors).toEqual([]);
+      expect(results).toHaveLength(2);
+
+      // Both results should have the same source
+      expect(results[0].source).toBe('Hello');
+      expect(results[1].source).toBe('Hello');
+
+      // Contexts should be the two ternary branches
+      const contexts = results.map((r) => r.metadata.context).sort();
+      expect(contexts).toEqual(['casual', 'formal']);
+
+      // Both should share the same staticId
+      expect(results[0].metadata.staticId).toBeDefined();
+      expect(results[0].metadata.staticId).toBe(
+        results[1].metadata.staticId
+      );
+    });
+
+    it('should produce cross-product when both content and context use derive', async () => {
+      const { results, errors } = await extractFromPythonSource(
+        fixture('derive_context_cross_product.py'),
+        path.join(__dirname, 'fixtures', 'derive_context_cross_product.py')
+      );
+      expect(errors).toEqual([]);
+      expect(results).toHaveLength(4);
+
+      const pairs = results
+        .map((r) => `${r.source}|${r.metadata.context}`)
+        .sort();
+      expect(pairs).toEqual([
+        'It is day!|casual',
+        'It is day!|formal',
+        'It is night!|casual',
+        'It is night!|formal',
+      ]);
+
+      // All 4 should share the same staticId
+      const staticId = results[0].metadata.staticId;
+      expect(staticId).toBeDefined();
+      expect(results.every((r) => r.metadata.staticId === staticId)).toBe(
+        true
+      );
+    });
+
+    it('should produce 2 results with inline ternary context', async () => {
+      const code = `from gt_flask import t, derive\nt("Hello", _context=derive("formal" if x else "casual"))`;
+      const { results, errors } = await extractFromPythonSource(
+        code,
+        'test.py'
+      );
+      expect(errors).toEqual([]);
+      expect(results).toHaveLength(2);
+
+      const contexts = results.map((r) => r.metadata.context).sort();
+      expect(contexts).toEqual(['casual', 'formal']);
+
+      expect(results[0].source).toBe('Hello');
+      expect(results[1].source).toBe('Hello');
+    });
+
+    it('should handle derive in context via string concatenation', async () => {
+      const code = `from gt_flask import t, derive\nt("Hello", _context="prefix-" + derive("formal" if x else "casual"))`;
+      const { results, errors } = await extractFromPythonSource(
+        code,
+        'test.py'
+      );
+      expect(errors).toEqual([]);
+      expect(results).toHaveLength(2);
+
+      const contexts = results.map((r) => r.metadata.context).sort();
+      expect(contexts).toEqual(['prefix-casual', 'prefix-formal']);
+    });
+
+    it('should handle derive in context via f-string', async () => {
+      const code = `from gt_flask import t, derive\nt("Hello", _context=f"prefix-{derive('formal' if x else 'casual')}")`;
+      const { results, errors } = await extractFromPythonSource(
+        code,
+        'test.py'
+      );
+      expect(errors).toEqual([]);
+      expect(results).toHaveLength(2);
+
+      const contexts = results.map((r) => r.metadata.context).sort();
+      expect(contexts).toEqual(['prefix-casual', 'prefix-formal']);
+    });
+
+    it('should still work with static _context (regression)', async () => {
+      const code = `from gt_flask import t\nt("Hello", _context="greeting")`;
+      const { results, errors } = await extractFromPythonSource(
+        code,
+        'test.py'
+      );
+      expect(errors).toEqual([]);
+      expect(results).toHaveLength(1);
+      expect(results[0].source).toBe('Hello');
+      expect(results[0].metadata.context).toBe('greeting');
+    });
+  });
+
   // ===== declare_static tests (backwards compatibility) ===== //
 
   describe('declare_static (backwards compatibility)', () => {

--- a/packages/python-extractor/src/__tests__/index.test.ts
+++ b/packages/python-extractor/src/__tests__/index.test.ts
@@ -460,6 +460,19 @@ t(f"The {derive(get_gender(variant))}")`;
       expect(contexts).toEqual(['prefix-casual', 'prefix-formal']);
     });
 
+    it('should preserve unrelated kwarg errors when derive context resolves', async () => {
+      const code = `from gt_flask import t, derive\nt("Hello", _context=derive("formal" if x else "casual"), _max_chars=some_var)`;
+      const { results, errors } = await extractFromPythonSource(
+        code,
+        'test.py'
+      );
+      // Context should resolve to 2 variants
+      expect(results).toHaveLength(2);
+      // But _max_chars error should NOT be silently discarded
+      expect(errors.length).toBeGreaterThan(0);
+      expect(errors.some((e) => e.includes('_max_chars'))).toBe(true);
+    });
+
     it('should still work with static _context (regression)', async () => {
       const code = `from gt_flask import t\nt("Hello", _context="greeting")`;
       const { results, errors } = await extractFromPythonSource(

--- a/packages/python-extractor/src/extractCalls.ts
+++ b/packages/python-extractor/src/extractCalls.ts
@@ -174,8 +174,7 @@ async function processCall(
     }
 
     // Extract static metadata and check for derive in _context
-    const preErrors = errors.length;
-    const metadata = extractKwargs(argsNode, errors, callNode);
+    const metadata = extractKwargs(argsNode, errors, callNode, imports);
     const contextVariants = await extractDeriveContext(
       argsNode,
       imports,
@@ -183,11 +182,6 @@ async function processCall(
       rootNode,
       errors
     );
-
-    // If context has derive variants, remove the static context error that extractKwargs added
-    if (contextVariants) {
-      errors.length = preErrors;
-    }
 
     const staticId = `static-temp-id-${randomUUID()}`;
 
@@ -252,8 +246,7 @@ async function processCall(
   }
 
   // Extract keyword arguments and check for derive in _context
-  const preErrors = errors.length;
-  const metadata = extractKwargs(argsNode, errors, callNode);
+  const metadata = extractKwargs(argsNode, errors, callNode, imports);
 
   const rootNode = callNode.tree?.rootNode;
   const contextVariants = rootNode
@@ -261,8 +254,6 @@ async function processCall(
     : null;
 
   if (contextVariants) {
-    // Remove the static context error that extractKwargs added
-    errors.length = preErrors;
     const staticId = `static-temp-id-${randomUUID()}`;
     for (const context of contextVariants) {
       calls.push({
@@ -287,7 +278,8 @@ async function processCall(
 function extractKwargs(
   argsNode: SyntaxNode,
   errors: string[],
-  callNode: SyntaxNode
+  callNode: SyntaxNode,
+  imports?: ImportAlias[]
 ): { id?: string; context?: string; maxChars?: number } {
   const result: { id?: string; context?: string; maxChars?: number } = {};
 
@@ -320,6 +312,12 @@ function extractKwargs(
           if (metadataKey === 'id') result.id = value;
           else if (metadataKey === 'context') result.context = value;
         }
+      } else if (
+        metadataKey === 'context' &&
+        imports &&
+        containsStaticCalls(valueNode, imports)
+      ) {
+        // _context contains derive() — skip error, caller handles derivation
       } else {
         errors.push(
           `${locationStr(callNode)}: _${metadataKey} must be a string literal`

--- a/packages/python-extractor/src/extractCalls.ts
+++ b/packages/python-extractor/src/extractCalls.ts
@@ -173,17 +173,48 @@ async function processCall(
       return;
     }
 
+    // Extract static metadata and check for derive in _context
+    const preErrors = errors.length;
     const metadata = extractKwargs(argsNode, errors, callNode);
+    const contextVariants = await extractDeriveContext(
+      argsNode,
+      imports,
+      filePath,
+      rootNode,
+      errors
+    );
+
+    // If context has derive variants, remove the static context error that extractKwargs added
+    if (contextVariants) {
+      errors.length = preErrors;
+    }
+
     const staticId = `static-temp-id-${randomUUID()}`;
 
-    for (const source of strings) {
-      calls.push({
-        source,
-        ...metadata,
-        staticId,
-        line: callNode.startPosition.row + 1,
-        column: callNode.startPosition.column,
-      });
+    if (contextVariants) {
+      // Cross-product: content variants × context variants
+      for (const source of strings) {
+        for (const context of contextVariants) {
+          calls.push({
+            source,
+            ...metadata,
+            context,
+            staticId,
+            line: callNode.startPosition.row + 1,
+            column: callNode.startPosition.column,
+          });
+        }
+      }
+    } else {
+      for (const source of strings) {
+        calls.push({
+          source,
+          ...metadata,
+          staticId,
+          line: callNode.startPosition.row + 1,
+          column: callNode.startPosition.column,
+        });
+      }
     }
     return;
   }
@@ -220,15 +251,37 @@ async function processCall(
     return;
   }
 
-  // Extract keyword arguments
+  // Extract keyword arguments and check for derive in _context
+  const preErrors = errors.length;
   const metadata = extractKwargs(argsNode, errors, callNode);
 
-  calls.push({
-    source,
-    ...metadata,
-    line: callNode.startPosition.row + 1,
-    column: callNode.startPosition.column,
-  });
+  const rootNode = callNode.tree?.rootNode;
+  const contextVariants = rootNode
+    ? await extractDeriveContext(argsNode, imports, filePath, rootNode, errors)
+    : null;
+
+  if (contextVariants) {
+    // Remove the static context error that extractKwargs added
+    errors.length = preErrors;
+    const staticId = `static-temp-id-${randomUUID()}`;
+    for (const context of contextVariants) {
+      calls.push({
+        source,
+        ...metadata,
+        context,
+        staticId,
+        line: callNode.startPosition.row + 1,
+        column: callNode.startPosition.column,
+      });
+    }
+  } else {
+    calls.push({
+      source,
+      ...metadata,
+      line: callNode.startPosition.row + 1,
+      column: callNode.startPosition.column,
+    });
+  }
 }
 
 function extractKwargs(
@@ -276,6 +329,43 @@ function extractKwargs(
   }
 
   return result;
+}
+
+/**
+ * Finds the _context keyword argument node and, if it contains a derive() call,
+ * parses it into context variants. Returns null if _context is static or absent.
+ */
+async function extractDeriveContext(
+  argsNode: SyntaxNode,
+  imports: ImportAlias[],
+  filePath: string,
+  rootNode: SyntaxNode,
+  errors: string[]
+): Promise<string[] | null> {
+  // Find _context kwarg
+  for (let i = 0; i < argsNode.childCount; i++) {
+    const child = argsNode.child(i);
+    if (!child || child.type !== 'keyword_argument') continue;
+
+    const nameNode = child.childForFieldName('name');
+    const valueNode = child.childForFieldName('value');
+    if (!nameNode || !valueNode) continue;
+    if (nameNode.text !== '_context') continue;
+
+    // Check if value contains derive()
+    if (!containsStaticCalls(valueNode, imports)) return null;
+
+    const contextNode = await parseStringExpression(valueNode, {
+      rootNode,
+      imports,
+      filePath,
+      errors,
+    });
+    if (!contextNode) return null;
+
+    return nodeToStrings(contextNode);
+  }
+  return null;
 }
 
 function isFString(stringNode: SyntaxNode): boolean {


### PR DESCRIPTION
add the ability to derive context

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds context derivation support across the React/Next.js CLI extractor, the SWC Rust compiler plugin, and the Python extractor. When a translation call uses `derive()` in its `$context` attribute (e.g. `<T context={derive(getFormality())}>…</T>` or `t("Hello", { $context: derive(getFormality()) })`), the toolchain now statically resolves all possible context variants and emits one translation entry per variant, sharing a `staticId` to group them together.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; all remaining findings are P2 style/defensive improvements that do not affect the happy path.

The feature works correctly for the normal case. Both P2 findings are edge-case defensive improvements (stale metadata key and empty-array guard) that would only manifest in unusual error conditions or with dollar-prefixed $context syntax. No P0/P1 logic errors were found.

parseTProps.ts (stale $context key) and handleLiteralTranslationCall.ts / derivation/index.ts (empty contextVariants truthy check)
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/react/jsx/utils/jsxParsing/parseTProps.ts | Detects derive() in JSX context prop and stores as _contextDeriveExpr; else-branch also sets metadata[attrName]=code, leaving a stale $context key in metadata when derivation succeeds |
| packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/handleLiteralTranslationCall.ts | Adds contextVariants cross-product for string literals; truthy-check on empty array could silently swallow entries without error |
| packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/index.ts | Correctly resolves contextDeriveExpr → contextVariants before routing; cleans up the temporary AST expression field before structuredClone |
| packages/cli/src/react/jsx/utils/stringParsing/derivation/index.ts | Cross-product of content strings × context variants; same empty-array truthy-check concern when contextVariants is [] |
| packages/cli/src/react/jsx/utils/stringParsing/derivation/containsDeriveCall.ts | Added ConditionalExpression arm so ternaries containing derive() in context are correctly detected as derive expressions |
| packages/next/swc-plugin/src/visitor/expr_utils.rs | Added Cond arm to contains_derive_call and has_derive_context flag to emit empty hash when $context contains derive() |
| packages/next/swc-plugin/src/ast/traversal.rs | Uses jsx_attr_contains_derive_call to produce empty hash when JSX context attribute contains derive(), matching TS compiler behavior |
| packages/python-extractor/src/extractCalls.ts | Adds extractDeriveContext to parse _context=derive() kwargs and emit cross-product entries with shared staticId on both simple and hasStaticHelpers paths |
| packages/compiler/src/processing/collection/processCallExpression.ts | Sets hash to empty string when hasDeriveContext is true on JSX component and translation function paths, delegating hash resolution to the CLI |
| packages/cli/src/react/jsx/utils/jsxParsing/parseJsx.ts | Resolves _contextDeriveExpr to contextVariants and generates cross-product JSX updates; correctly deletes _contextDeriveExpr before structuredClone to prevent AST serialization errors |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Source: context={derive(fn())} or $context=derive(fn())] --> B{CLI/Babel parse}
    B --> C[containsDeriveCall detects derive]
    C --> D[Store _contextDeriveExpr on metadata]
    D --> E[handleDerivation resolves fn return variants]
    E --> F{Resolved?}
    F -- Yes: variants=[formal,casual] --> G[contextVariants array]
    F -- No --> H[Push error, contextVariants=undefined]
    G --> I{Content type?}
    I -- JSX Tree --> J[parseJsx: emit N updates, one per context variant]
    I -- String Literal --> K[handleLiteralTranslationCall: emit N updates]
    I -- Derive content --> L[deriveExpression: cross-product content×context]
    J --> M[Each update: source + context + shared staticId]
    K --> M
    L --> M
    M --> N[Compiler: hash='' when hasDeriveContext, CLI resolves real hashes]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/cli/src/react/jsx/utils/jsxParsing/parseTProps.ts
Line: 93-97

Comment:
**Stale `$context` key persists in metadata after derivation**

When `attrName` is `'$context'` (the dollar-sign sugar form) and the expression contains `derive()`, both `metadata._contextDeriveExpr = expr` and `metadata['$context'] = code` are set. `parseJsx.ts` overrides `metadata.context` with the resolved value, but `metadata['$context']` (with the dollar prefix) is never cleaned up and ends up in every emitted update payload. If the translation API treats `$context` as an alias for `context`, it would see the raw code string instead of the resolved context.

The `else` branch should be skipped when the derive expression was already captured:
```suggestion
        } else if (!(mapAttributeName(attrName) === 'context' && t.isExpression(expr) && containsDeriveCall(expr))) {
          // Only store the code if we couldn't extract a derivable value
          metadata[attrName] = code;
        }
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/handleLiteralTranslationCall.ts
Line: 57

Comment:
**Empty `contextVariants` array silently drops the translation entry**

`if (contextVariants)` is truthy for `[]`. If `nodeToStrings` ever returns an empty array (e.g. a `derive()` call that resolves to zero variants), the `for` loop runs zero times and nothing is pushed to `output.updates` — the string silently disappears with no error. A length guard is safer:
```suggestion
  if (contextVariants && contextVariants.length > 0) {
```
The same pattern applies in `derivation/index.ts` where `contexts = contextVariants ?? [metadata.context]` — an empty `contextVariants` causes the entire outer content loop to produce no updates.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (5): Last reviewed commit: ["fix greptile feedback"](https://github.com/generaltranslation/gt/commit/8f02bf554ab147db192279152861c1e67fccabbd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27525481)</sub>

<!-- /greptile_comment -->