### PR TITLE
fix: recursive tracing for gt function

### DIFF
--- a/.changeset/dull-groups-buy.md
+++ b/.changeset/dull-groups-buy.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+fix: recursive string translation function resolution

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.14.3';
+export const PACKAGE_VERSION = '2.14.4';

--- a/packages/cli/src/react/jsx/utils/__tests__/parseStringFunction.test.ts
+++ b/packages/cli/src/react/jsx/utils/__tests__/parseStringFunction.test.ts
@@ -3298,4 +3298,176 @@ describe('parseStrings', () => {
       expect(params.errors.length).toBeGreaterThan(0);
     });
   });
+
+  describe('recursive callback function resolution', () => {
+    const runUseGTParseStrings = (
+      code: string,
+      params: ReturnType<typeof createMockParams>
+    ) => {
+      const ast = parseCode(code);
+      traverse(ast, {
+        ImportSpecifier(path) {
+          if (
+            t.isIdentifier(path.node.imported) &&
+            path.node.imported.name === 'useGT' &&
+            t.isIdentifier(path.node.local)
+          ) {
+            parseStrings(
+              path.node.local.name,
+              'useGT',
+              path,
+              {
+                parsingOptions: params.parsingOptions,
+                file: params.file,
+                ignoreInlineMetadata: false,
+                ignoreDynamicContent: false,
+                ignoreInvalidIcu: false,
+                ignoreInlineListContent: true,
+                ignoreTaggedTemplates: false,
+                ignoreGlobalTaggedTemplates: false,
+                autoDeriveMethod: 'DISABLED',
+              },
+              {
+                updates: params.updates,
+                errors: params.errors,
+                warnings: params.warnings,
+              }
+            );
+          }
+        },
+      });
+    };
+
+    it('should handle a directly recursive function that passes gt to itself', () => {
+      const code = `
+        import { useGT } from 'generaltranslation';
+
+        function renderTree(gt, nodes) {
+          gt('leaf node', { $id: 'leaf' });
+          gt('branch node', { $id: 'branch' });
+          for (const child of nodes) {
+            renderTree(gt, child.children);
+          }
+        }
+
+        const gt = useGT();
+        renderTree(gt, tree);
+      `;
+      const params = createMockParams();
+      runUseGTParseStrings(code, params);
+
+      expect(params.updates).toHaveLength(2);
+      const sources = params.updates.map((u) => u.source);
+      expect(sources).toContain('leaf node');
+      expect(sources).toContain('branch node');
+      expect(params.errors).toHaveLength(0);
+    });
+
+    it('should handle mutually recursive functions that pass gt', () => {
+      const code = `
+        import { useGT } from 'generaltranslation';
+
+        function processEven(gt, n) {
+          gt('even case', { $id: 'even' });
+          if (n > 0) processOdd(gt, n - 1);
+        }
+
+        function processOdd(gt, n) {
+          gt('odd case', { $id: 'odd' });
+          if (n > 0) processEven(gt, n - 1);
+        }
+
+        const gt = useGT();
+        processEven(gt, 10);
+      `;
+      const params = createMockParams();
+      runUseGTParseStrings(code, params);
+
+      expect(params.updates).toHaveLength(2);
+      const sources = params.updates.map((u) => u.source);
+      expect(sources).toContain('even case');
+      expect(sources).toContain('odd case');
+      expect(params.errors).toHaveLength(0);
+    });
+
+    it('should handle recursive arrow function that passes gt', () => {
+      const code = `
+        import { useGT } from 'generaltranslation';
+
+        const traverse = (gt, node) => {
+          gt('visiting node', { $id: 'visit' });
+          node.children.forEach(child => traverse(gt, child));
+        };
+
+        const gt = useGT();
+        traverse(gt, root);
+      `;
+      const params = createMockParams();
+      runUseGTParseStrings(code, params);
+
+      expect(params.updates).toHaveLength(1);
+      expect(params.updates[0]).toMatchObject({
+        source: 'visiting node',
+        metadata: { id: 'visit' },
+      });
+      expect(params.errors).toHaveLength(0);
+    });
+
+    it('should register all strings in a recursive function with multiple gt calls', () => {
+      const code = `
+        import { useGT } from 'generaltranslation';
+
+        function walkMenu(gt, items) {
+          gt('menu header', { $id: 'header' });
+          gt('menu item', { $id: 'item' });
+          gt('menu footer', { $id: 'footer' });
+          items.forEach(item => {
+            if (item.submenu) {
+              walkMenu(gt, item.submenu);
+            }
+          });
+        }
+
+        const gt = useGT();
+        walkMenu(gt, menuData);
+      `;
+      const params = createMockParams();
+      runUseGTParseStrings(code, params);
+
+      expect(params.updates).toHaveLength(3);
+      const sources = params.updates.map((u) => u.source);
+      expect(sources).toContain('menu header');
+      expect(sources).toContain('menu item');
+      expect(sources).toContain('menu footer');
+      expect(params.errors).toHaveLength(0);
+    });
+
+    it('should handle recursive function that also passes gt to a non-recursive helper', () => {
+      const code = `
+        import { useGT } from 'generaltranslation';
+
+        function formatLabel(gt) {
+          return gt('label text', { $id: 'label' });
+        }
+
+        function walkTree(gt, node) {
+          gt('tree node', { $id: 'node' });
+          formatLabel(gt);
+          if (node.left) walkTree(gt, node.left);
+          if (node.right) walkTree(gt, node.right);
+        }
+
+        const gt = useGT();
+        walkTree(gt, binaryTree);
+      `;
+      const params = createMockParams();
+      runUseGTParseStrings(code, params);
+
+      expect(params.updates).toHaveLength(2);
+      const sources = params.updates.map((u) => u.source);
+      expect(sources).toContain('tree node');
+      expect(sources).toContain('label text');
+      expect(params.errors).toHaveLength(0);
+    });
+  });
 });

--- a/packages/cli/src/react/jsx/utils/parseStringFunction.ts
+++ b/packages/cli/src/react/jsx/utils/parseStringFunction.ts
@@ -122,7 +122,8 @@ function handleFunctionCall(
   tPath: NodePath,
   config: ParsingConfig,
   state: ParsingState,
-  output: ParsingOutput
+  output: ParsingOutput,
+  visitedFunctions: Set<t.Node>
 ): void {
   if (
     tPath.parent.type === 'CallExpression' &&
@@ -157,7 +158,8 @@ function handleFunctionCall(
           functionPath.node,
           functionPath,
           config,
-          output
+          output,
+          visitedFunctions
         );
       }
       // Handle arrow functions assigned to variables: const getData = (t) => {...}
@@ -175,7 +177,8 @@ function handleFunctionCall(
           calleeBinding.path.node.init,
           initPath,
           config,
-          output
+          output,
+          visitedFunctions
         );
       }
       // If not found locally, check if it's an imported function
@@ -214,16 +217,28 @@ function processFunctionIfMatches(
   functionNode: t.Function,
   functionPath: NodePath,
   config: ParsingConfig,
-  output: ParsingOutput
+  output: ParsingOutput,
+  visitedFunctions: Set<t.Node>
 ): void {
+  if (visitedFunctions.has(functionNode)) return;
+  visitedFunctions.add(functionNode);
+
   if (functionNode.params.length > argIndex) {
     const param = functionNode.params[argIndex];
     const paramName = extractParameterName(param);
 
     if (paramName) {
-      findFunctionParameterUsage(functionPath, paramName, config, output);
+      findFunctionParameterUsage(
+        functionPath,
+        paramName,
+        config,
+        output,
+        visitedFunctions
+      );
     }
   }
+
+  visitedFunctions.delete(functionNode);
 }
 
 /**
@@ -238,7 +253,8 @@ function findFunctionParameterUsage(
   functionPath: NodePath,
   parameterName: string,
   config: ParsingConfig,
-  output: ParsingOutput
+  output: ParsingOutput,
+  visitedFunctions: Set<t.Node>
 ): void {
   // Look for the function body and find all usages of the parameter
   if (functionPath.isFunction()) {
@@ -264,7 +280,8 @@ function findFunctionParameterUsage(
             refPath,
             config,
             { visited: new Set(), importMap },
-            output
+            output,
+            visitedFunctions
           );
         });
       }
@@ -312,6 +329,9 @@ function processFunctionInFile(
 
     let found = false;
     const reExports: string[] = [];
+    // Fresh set per cross-file parse — node identity is only stable within a single parse.
+    // Cross-file cycles are already guarded by processFunctionCache above.
+    const visitedFunctions = new Set<t.Node>();
 
     traverse(ast, {
       // Handle function declarations: function getInfo(t) { ... }
@@ -324,7 +344,8 @@ function processFunctionInFile(
             path.node,
             path,
             config,
-            output
+            output,
+            visitedFunctions
           );
         }
       },
@@ -345,7 +366,8 @@ function processFunctionInFile(
             path.node.init,
             initPath,
             config,
-            output
+            output,
+            visitedFunctions
           );
         }
       },
@@ -598,6 +620,7 @@ export function parseStrings(
         );
 
         // Process references for all translation function names and their aliases
+        const visitedFunctions = new Set<t.Node>();
         allTranslationNames.forEach((name) => {
           const tReferencePaths =
             variableScope.bindings[name]?.referencePaths || [];
@@ -607,7 +630,8 @@ export function parseStrings(
               tPath,
               hookConfig,
               { visited: new Set(), importMap },
-              output
+              output,
+              visitedFunctions
             );
           }
         });


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a stack overflow bug where the CLI's translation string tracer would infinitely recurse when encountering recursive user-defined functions that receive and pass the `gt` callback (e.g., `renderTree(gt, children)` calling itself). The fix introduces a `visitedFunctions: Set<t.Node>` guard using DFS-with-backtracking semantics across `handleFunctionCall`, `processFunctionIfMatches`, and `findFunctionParameterUsage`.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the fix correctly prevents infinite recursion and is validated by comprehensive new tests.

The single finding is P2 (a minor edge-case style/correctness concern around backtracking delete semantics). All remaining changes are straightforward and well-tested. P2 findings do not reduce the score below 5.

parseStringFunction.ts line 241 — the delete-after-process backtracking semantics are worth revisiting for scenarios with multiple outer-scope call sites to the same recursive function.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/react/jsx/utils/parseStringFunction.ts | Adds DFS-with-backtracking visitedFunctions guard to prevent infinite recursion; delete-after-process semantics could allow duplicate string registration when the same recursive function is reached via multiple outer-scope call sites |
| packages/cli/src/react/jsx/utils/__tests__/parseStringFunction.test.ts | Adds 5 well-structured test cases covering direct recursion, mutual recursion, arrow functions, multiple gt calls, and mixed recursive+helper patterns |
| packages/cli/src/generated/version.ts | Routine auto-generated version bump from 2.14.3 to 2.14.4 |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[parseStrings\ncreate visitedFunctions Set] --> B[handleFunctionCall\nfor each gt reference]
    B --> C{Direct gt call?}
    C -- Yes --> D[processTranslationCall\nregister string]
    C -- No, gt passed as arg --> E[processFunctionIfMatches]
    E --> F{functionNode\nalready in visitedFunctions?}
    F -- Yes --> G[Return early\ncycle detected]
    F -- No --> H[Add functionNode\nto visitedFunctions]
    H --> I[findFunctionParameterUsage]
    I --> J[Resolve param aliases\nresolveVariableAliases]
    J --> K[handleFunctionCall\nfor each reference in body]
    K --> B
    I --> L[visitedFunctions.delete\nfunctionNode]
    L --> M[Processing complete]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/cli/src/react/jsx/utils/parseStringFunction.ts
Line: 241

Comment:
**Backtracking delete may cause duplicate string registrations**

The `visitedFunctions.delete(functionNode)` removes the function from the "in-stack" guard after it finishes processing. This is correct for cycle detection, but it means the same function can be fully re-entered if the `gt` callback is passed to it from *multiple* call sites in the outer scope (e.g., `walkTree(gt, left)` and `walkTree(gt, right)` as separate top-level invocations). Each call would process `walkTree`'s body independently, registering the same strings twice in `output.updates`.

For static string extraction, a function's strings are the same regardless of which call site triggered the traversal. Dropping the `delete` (permanent-marking instead of backtracking) would prevent duplicate registrations without affecting cycle detection:

```suggestion
  // Do not delete: permanent marking prevents re-processing the same node
  // from multiple call sites, which would produce duplicate output.updates entries.
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: changeset"](https://github.com/generaltranslation/gt/commit/928e7d09d3ab124b7aa7c0b98534b584a1aa4fa3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27531530)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->