### PR TITLE
feat(sanity): Add plugin dep

### DIFF
--- a/.changeset/hungry-dots-join.md
+++ b/.changeset/hungry-dots-join.md
@@ -1,0 +1,5 @@
+---
+'gt-sanity': patch
+---
+
+Add @sanity/document-internationalization as a dep

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -65,6 +65,7 @@
     "generaltranslation": "workspace:*",
     "jsonpath-plus": "^10.3.0",
     "jsonpointer": "^5.0.1",
+    "@sanity/document-internationalization": "^6.0.6",
     "lodash.merge": "^4.6.2"
   },
   "devDependencies": {

--- a/packages/sanity/src/documentInternationalization.ts
+++ b/packages/sanity/src/documentInternationalization.ts
@@ -1,0 +1,14 @@
+export {
+  documentInternationalization,
+  useDocumentInternationalizationContext,
+  DocumentInternationalizationMenu,
+  useDeleteTranslationAction,
+  useDuplicateWithTranslationsAction,
+} from '@sanity/document-internationalization';
+
+export type {
+  PluginConfig as DocumentInternationalizationConfig,
+  Language,
+  Metadata,
+  TranslationReference,
+} from '@sanity/document-internationalization';

--- a/packages/sanity/src/index.ts
+++ b/packages/sanity/src/index.ts
@@ -1,3 +1,17 @@
+export {
+  documentInternationalization,
+  useDocumentInternationalizationContext,
+  DocumentInternationalizationMenu,
+  useDeleteTranslationAction,
+  useDuplicateWithTranslationsAction,
+} from './documentInternationalization';
+export type {
+  DocumentInternationalizationConfig,
+  Language,
+  Metadata,
+  TranslationReference,
+} from './documentInternationalization';
+
 import TranslationsTab from './components/tab/TranslationsTab';
 import {
   Secrets,
@@ -45,6 +59,7 @@ import { definePlugin } from 'sanity';
 import { route } from 'sanity/router';
 import { gt, pluginConfig } from './adapter/core';
 import { libraryDefaultLocale } from 'generaltranslation/internal';
+import { getLocaleProperties } from 'generaltranslation';
 import type {
   IgnoreFields,
   SkipFields,
@@ -54,6 +69,7 @@ import TranslationsTool from './components/page/TranslationsTool';
 import { SECRETS_NAMESPACE } from './utils/shared';
 import type { PortableTextHtmlComponents } from '@portabletext/to-html';
 import { attachGTData, detachGTData } from './serialization/data';
+import { documentInternationalization } from './documentInternationalization';
 
 export type GTPluginConfig = Omit<
   Parameters<typeof gt.setConfig>[0],
@@ -69,12 +85,16 @@ export type GTPluginConfig = Omit<
   ignoreFields?: IgnoreFields[];
   skipFields?: SkipFields[];
   languageField?: string;
-  translateDocuments?: TranslateDocumentFilter[];
+  translateDocuments?: TranslateDocumentFilter[] | string[];
   secretsNamespace?: string;
   additionalStopTypes?: string[];
   additionalSerializers?: Partial<PortableTextHtmlComponents>;
   additionalDeserializers?: Record<string, any>;
   additionalBlockDeserializers?: any[];
+  // When true (default), automatically adds the @sanity/document-internationalization plugin
+  // with language badges, translation menu, and per-language templates.
+  // Requires translateDocuments to specify which document types to enable translations for.
+  showDocumentInternationalization?: boolean;
 };
 
 /**
@@ -109,18 +129,19 @@ export const gtPlugin = definePlugin<GTPluginConfig>(
     additionalSerializers = {},
     additionalDeserializers = {},
     additionalBlockDeserializers = [],
+    showDocumentInternationalization = true,
   }) => {
     // Resolve sourceLocale: explicit sourceLocale > defaultLocale (from gt.config.json) > library default
     const resolvedSourceLocale =
       sourceLocale ?? defaultLocale ?? libraryDefaultLocale;
 
-    // Validate the translateDocuments
-    translateDocuments = translateDocuments?.filter((filter) => {
-      if (filter.documentId || filter.type) {
-        return true;
-      }
-      return false;
-    });
+    // Normalize translateDocuments: string[] → TranslateDocumentFilter[]
+    let normalizedTranslateDocuments: TranslateDocumentFilter[] | undefined;
+    if (translateDocuments) {
+      normalizedTranslateDocuments = translateDocuments
+        .map((entry) => (typeof entry === 'string' ? { type: entry } : entry))
+        .filter((filter) => filter.documentId || filter.type);
+    }
 
     pluginConfig.init(
       secretsNamespace,
@@ -133,7 +154,7 @@ export const gtPlugin = definePlugin<GTPluginConfig>(
         ((sourceDocumentId, locale) => `${sourceDocumentId}-${locale}`),
       ignoreFields || [],
       skipFields || [],
-      translateDocuments || [],
+      normalizedTranslateDocuments || [],
       additionalStopTypes,
       additionalSerializers,
       additionalDeserializers,
@@ -145,8 +166,33 @@ export const gtPlugin = definePlugin<GTPluginConfig>(
       apiKey: apiKey,
       projectId: projectId,
     });
+
+    // Auto-add document internationalization plugin
+    const plugins = [];
+    if (showDocumentInternationalization) {
+      const schemaTypes =
+        normalizedTranslateDocuments
+          ?.map((filter) => filter.type)
+          .filter((type): type is string => !!type) ?? [];
+      if (schemaTypes.length > 0) {
+        const allLocales = [resolvedSourceLocale, ...locales];
+        const supportedLanguages = allLocales.map((locale) => {
+          const props = getLocaleProperties(locale, resolvedSourceLocale);
+          return { id: locale, title: props.name };
+        });
+        plugins.push(
+          documentInternationalization({
+            supportedLanguages,
+            schemaTypes,
+            languageField,
+          })
+        );
+      }
+    }
+
     return {
       name: 'gt-sanity',
+      plugins,
       tools: [
         {
           name: 'translations',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -920,6 +920,9 @@ importers:
       '@portabletext/to-html':
         specifier: ^2.0.14
         version: 2.0.17
+      '@sanity/document-internationalization':
+        specifier: ^6.0.6
+        version: 6.0.6(@emotion/is-prop-valid@1.2.2)(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react-is@19.2.4)(react@19.2.3)(sanity-plugin-internationalized-array@5.1.0(97a085cb45d4e610dda649a5d0001302))(sanity@5.19.0(@emotion/is-prop-valid@1.2.2)(@noble/hashes@2.0.1)(@oclif/core@4.10.3)(@sanity/cli-core@1.3.0(@noble/hashes@2.0.1)(@sanity/telemetry@0.9.0(react@19.2.4))(@types/node@24.8.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3))(@types/node@24.8.0)(@types/react@19.2.7)(bufferutil@4.0.9)(immer@10.1.3)(jiti@2.6.1)(lightningcss@1.32.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(terser@5.44.0)(ts-toolbelt@9.6.0)(typescript@5.9.3))(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       '@sanity/icons':
         specifier: ^3.7.4
         version: 3.7.4(react@19.2.3)
@@ -950,6 +953,9 @@ importers:
       lodash.merge:
         specifier: ^4.6.2
         version: 4.6.2
+      sanity-plugin-internationalized-array:
+        specifier: '>=5.0.0'
+        version: 5.1.0(97a085cb45d4e610dda649a5d0001302)
     devDependencies:
       '@portabletext/types':
         specifier: ^2.0.15
@@ -992,7 +998,7 @@ importers:
         version: 19.2.3(react@19.2.3)
       sanity:
         specifier: ^5.18.0
-        version: 5.19.0(@emotion/is-prop-valid@1.2.2)(@noble/hashes@2.0.1)(@oclif/core@4.10.3)(@sanity/cli-core@1.3.0(@noble/hashes@2.0.1)(@sanity/telemetry@0.9.0(react@19.2.3))(@types/node@24.8.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3))(@types/node@24.8.0)(@types/react@19.2.7)(bufferutil@4.0.9)(immer@10.1.3)(jiti@2.6.1)(lightningcss@1.32.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(terser@5.44.0)(ts-toolbelt@9.6.0)(typescript@5.9.3)
+        version: 5.19.0(@emotion/is-prop-valid@1.2.2)(@noble/hashes@2.0.1)(@oclif/core@4.10.3)(@sanity/cli-core@1.3.0(@noble/hashes@2.0.1)(@sanity/telemetry@0.9.0(react@19.2.4))(@types/node@24.8.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3))(@types/node@24.8.0)(@types/react@19.2.7)(bufferutil@4.0.9)(immer@10.1.3)(jiti@2.6.1)(lightningcss@1.32.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(terser@5.44.0)(ts-toolbelt@9.6.0)(typescript@5.9.3)
       styled-components:
         specifier: ^6.1.19
         version: 6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -5488,6 +5494,15 @@ packages:
     resolution: {integrity: sha512-QA4t6Y+AdT/hEuRmOeT4/vflsxAwb85OCTpASiuKVEyoTTfKFoUewQZhjQ40K5ZWn9LVXe4Suvhp+Ns8Wvqgrg==}
     engines: {node: '>=20.19 <22 || >=22.12'}
 
+  '@sanity/document-internationalization@6.0.6':
+    resolution: {integrity: sha512-n2z0bwXOrPoWMVtJPMQtP/q5PetdDkM7YROxebCN4VExBeFfXRyyofIQ89oZ9ItAuIz7VE9GE6ShhDfdiTGWOw==}
+    engines: {node: '>=20.19 <22 || >=22.12'}
+    peerDependencies:
+      react: ^19.2
+      react-dom: ^19.2
+      sanity: ^5
+      sanity-plugin-internationalized-array: ^5.0.0
+
   '@sanity/eventsource@5.0.2':
     resolution: {integrity: sha512-/B9PMkUvAlUrpRq0y+NzXgRv5lYCLxZNsBJD2WXVnqZYOfByL9oQBV7KiTaARuObp5hcQYuPfOAVjgXe3hrixA==}
 
@@ -5535,6 +5550,14 @@ packages:
   '@sanity/json-match@1.0.5':
     resolution: {integrity: sha512-skhIX8gT/hLritEBkjfc7+TBlJNu/NLisyA8noKceCk28OatFK0wX7dIuFawkt3pfhTYVomVPykAYFcIm2OqJg==}
     engines: {node: '>=18.2'}
+
+  '@sanity/language-filter@5.0.1':
+    resolution: {integrity: sha512-mMeApPoJYiNrHxJhcdkz8AW8KblBIWW2hrqKwIKMzi2E7SiGMdcYh97g6quhUO4cWhWvSy13j80OIu400Nl1SQ==}
+    engines: {node: '>=20.19 <22 || >=22.12'}
+    peerDependencies:
+      react: ^19.2
+      react-dom: ^19.2
+      sanity: ^5
 
   '@sanity/logos@2.2.2':
     resolution: {integrity: sha512-KIWFL7nYEOINXIzaTF9aVhd481hFF/ak+SRnpgksYuJXlo2hbY/UoEJBz6KhsEP5dfO/NwqG82QrkwzLvd6izA==}
@@ -11462,6 +11485,28 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  sanity-plugin-internationalized-array@5.1.0:
+    resolution: {integrity: sha512-y38PjoOtZUcxoKppzzehMbYdIVNLYgR6nrd1GwgWHgOuW1PLEQl+xg1SdjVIwjzrphSBQHjhs/GgByjQacmkJg==}
+    engines: {node: '>=20.19 <22 || >=22.12'}
+    peerDependencies:
+      '@sanity/assist': ^6.0.2
+      '@sanity/language-filter': ^5.0.0
+      react: ^19.2
+      react-dom: ^19.2
+      sanity: ^5
+    peerDependenciesMeta:
+      '@sanity/assist':
+        optional: true
+
+  sanity-plugin-utils@1.8.0:
+    resolution: {integrity: sha512-fzRThaEO/UIK3PRf7W8UXAaxTOsaB53xl6CJGoAVtBRBHANEMOv9bAcgZyBoMyIVuj17N2SGpKCZSIcAgsQmYQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^18 || ^19
+      rxjs: ^7.8.1
+      sanity: ^3.67.1 || ^4.0.0 || ^5.0.0
+      styled-components: ^6.1
+
   sanity@5.19.0:
     resolution: {integrity: sha512-PitRWXgGCxTm+/sCMQw4x5klkWoKiIp993aUSLpjhzioWfo1bunD1+lgPNKfJTGzuUtLHEbQgBvUhhnSEdTaJQ==}
     engines: {node: '>=20.19 <22 || >=22.12'}
@@ -17223,13 +17268,13 @@ snapshots:
 
   '@sanity/browserslist-config@1.0.5': {}
 
-  '@sanity/cli-core@1.3.0(@noble/hashes@2.0.1)(@sanity/telemetry@0.9.0(react@19.2.3))(@types/node@24.8.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3)':
+  '@sanity/cli-core@1.3.0(@noble/hashes@2.0.1)(@sanity/telemetry@0.9.0(react@19.2.4))(@types/node@24.8.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3)':
     dependencies:
       '@inquirer/prompts': 8.3.2(@types/node@24.8.0)
       '@oclif/core': 4.10.3
       '@rexxars/jiti': 2.6.2
       '@sanity/client': 7.20.0(debug@4.4.3)
-      '@sanity/telemetry': 0.9.0(react@19.2.4)
+      '@sanity/telemetry': 0.9.0(react@19.2.3)
       babel-plugin-react-compiler: 1.0.0
       boxen: 8.0.1
       debug: 4.4.3(supports-color@5.5.0)
@@ -17266,18 +17311,18 @@ snapshots:
       '@oclif/core': 4.10.3
       '@oclif/plugin-help': 6.2.41
       '@oclif/plugin-not-found': 3.2.78(@types/node@24.8.0)
-      '@sanity/cli-core': 1.3.0(@noble/hashes@2.0.1)(@sanity/telemetry@0.9.0(react@19.2.3))(@types/node@24.8.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3)
+      '@sanity/cli-core': 1.3.0(@noble/hashes@2.0.1)(@sanity/telemetry@0.9.0(react@19.2.4))(@types/node@24.8.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3)
       '@sanity/client': 7.20.0(debug@4.4.3)
-      '@sanity/codegen': 6.0.2(@oclif/core@4.10.3)(@sanity/cli-core@1.3.0(@noble/hashes@2.0.1)(@sanity/telemetry@0.9.0(react@19.2.3))(@types/node@24.8.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3))(@sanity/telemetry@0.9.0(react@19.2.3))
+      '@sanity/codegen': 6.0.2(@oclif/core@4.10.3)(@sanity/cli-core@1.3.0(@noble/hashes@2.0.1)(@sanity/telemetry@0.9.0(react@19.2.4))(@types/node@24.8.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3))(@sanity/telemetry@0.9.0(react@19.2.4))
       '@sanity/descriptors': 1.3.0
       '@sanity/export': 6.1.0
       '@sanity/generate-help-url': 4.0.0
       '@sanity/id-utils': 1.0.0
       '@sanity/import': 6.0.1(@sanity/client@7.20.0(debug@4.4.3))(@types/react@19.2.7)
-      '@sanity/migrate': 6.1.1(@oclif/core@4.10.3)(@sanity/cli-core@1.3.0(@noble/hashes@2.0.1)(@sanity/telemetry@0.9.0(react@19.2.3))(@types/node@24.8.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3))(@types/react@19.2.7)(xstate@5.30.0)
+      '@sanity/migrate': 6.1.1(@oclif/core@4.10.3)(@sanity/cli-core@1.3.0(@noble/hashes@2.0.1)(@sanity/telemetry@0.9.0(react@19.2.4))(@types/node@24.8.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3))(@types/react@19.2.7)(xstate@5.30.0)
       '@sanity/runtime-cli': 14.8.1(@types/node@24.8.0)(bufferutil@4.0.9)(debug@4.4.3)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       '@sanity/schema': 5.19.0(@types/react@19.2.7)(debug@4.4.3)
-      '@sanity/telemetry': 0.9.0(react@19.2.4)
+      '@sanity/telemetry': 0.9.0(react@19.2.3)
       '@sanity/template-validator': 3.1.0
       '@sanity/types': 5.19.0(@types/react@19.2.7)(debug@4.4.3)
       '@sanity/ui': 3.1.14(@emotion/is-prop-valid@1.2.2)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
@@ -17364,7 +17409,7 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@sanity/codegen@6.0.2(@oclif/core@4.10.3)(@sanity/cli-core@1.3.0(@noble/hashes@2.0.1)(@sanity/telemetry@0.9.0(react@19.2.3))(@types/node@24.8.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3))(@sanity/telemetry@0.9.0(react@19.2.3))':
+  '@sanity/codegen@6.0.2(@oclif/core@4.10.3)(@sanity/cli-core@1.3.0(@noble/hashes@2.0.1)(@sanity/telemetry@0.9.0(react@19.2.4))(@types/node@24.8.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3))(@sanity/telemetry@0.9.0(react@19.2.4))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
@@ -17375,8 +17420,8 @@ snapshots:
       '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
       '@oclif/core': 4.10.3
-      '@sanity/cli-core': 1.3.0(@noble/hashes@2.0.1)(@sanity/telemetry@0.9.0(react@19.2.3))(@types/node@24.8.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3)
-      '@sanity/telemetry': 0.9.0(react@19.2.4)
+      '@sanity/cli-core': 1.3.0(@noble/hashes@2.0.1)(@sanity/telemetry@0.9.0(react@19.2.4))(@types/node@24.8.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3)
+      '@sanity/telemetry': 0.9.0(react@19.2.3)
       '@sanity/worker-channels': 2.0.0
       chokidar: 3.6.0
       debug: 4.4.3(supports-color@5.5.0)
@@ -17429,6 +17474,27 @@ snapshots:
   '@sanity/diff@5.19.0':
     dependencies:
       '@sanity/diff-match-patch': 3.2.0
+
+  '@sanity/document-internationalization@6.0.6(@emotion/is-prop-valid@1.2.2)(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react-is@19.2.4)(react@19.2.3)(sanity-plugin-internationalized-array@5.1.0(97a085cb45d4e610dda649a5d0001302))(sanity@5.19.0(@emotion/is-prop-valid@1.2.2)(@noble/hashes@2.0.1)(@oclif/core@4.10.3)(@sanity/cli-core@1.3.0(@noble/hashes@2.0.1)(@sanity/telemetry@0.9.0(react@19.2.4))(@types/node@24.8.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3))(@types/node@24.8.0)(@types/react@19.2.7)(bufferutil@4.0.9)(immer@10.1.3)(jiti@2.6.1)(lightningcss@1.32.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(terser@5.44.0)(ts-toolbelt@9.6.0)(typescript@5.9.3))(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))':
+    dependencies:
+      '@sanity/icons': 3.7.4(react@19.2.3)
+      '@sanity/mutator': 5.19.0(@types/react@19.2.7)
+      '@sanity/ui': 3.1.14(@emotion/is-prop-valid@1.2.2)(react-dom@19.2.3(react@19.2.3))(react-is@19.2.4)(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+      '@sanity/util': 5.19.0(@types/react@19.2.7)(debug@4.4.3)
+      '@sanity/uuid': 3.0.2
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      rxjs: 7.8.2
+      sanity: 5.19.0(@emotion/is-prop-valid@1.2.2)(@noble/hashes@2.0.1)(@oclif/core@4.10.3)(@sanity/cli-core@1.3.0(@noble/hashes@2.0.1)(@sanity/telemetry@0.9.0(react@19.2.4))(@types/node@24.8.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3))(@types/node@24.8.0)(@types/react@19.2.7)(bufferutil@4.0.9)(immer@10.1.3)(jiti@2.6.1)(lightningcss@1.32.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(terser@5.44.0)(ts-toolbelt@9.6.0)(typescript@5.9.3)
+      sanity-plugin-internationalized-array: 5.1.0(97a085cb45d4e610dda649a5d0001302)
+      sanity-plugin-utils: 1.8.0(@emotion/is-prop-valid@1.2.2)(react-dom@19.2.3(react@19.2.3))(react-is@19.2.4)(react@19.2.3)(rxjs@7.8.2)(sanity@5.19.0(@emotion/is-prop-valid@1.2.2)(@noble/hashes@2.0.1)(@oclif/core@4.10.3)(@sanity/cli-core@1.3.0(@noble/hashes@2.0.1)(@sanity/telemetry@0.9.0(react@19.2.4))(@types/node@24.8.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3))(@types/node@24.8.0)(@types/react@19.2.7)(bufferutil@4.0.9)(immer@10.1.3)(jiti@2.6.1)(lightningcss@1.32.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(terser@5.44.0)(ts-toolbelt@9.6.0)(typescript@5.9.3))(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - '@types/react'
+      - debug
+      - react-is
+      - styled-components
+      - supports-color
 
   '@sanity/eventsource@5.0.2':
     dependencies:
@@ -17510,6 +17576,20 @@ snapshots:
 
   '@sanity/json-match@1.0.5': {}
 
+  '@sanity/language-filter@5.0.1(@emotion/is-prop-valid@1.2.2)(react-dom@19.2.3(react@19.2.3))(react-is@19.2.4)(react@19.2.3)(sanity@5.19.0(@emotion/is-prop-valid@1.2.2)(@noble/hashes@2.0.1)(@oclif/core@4.10.3)(@sanity/cli-core@1.3.0(@noble/hashes@2.0.1)(@sanity/telemetry@0.9.0(react@19.2.4))(@types/node@24.8.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3))(@types/node@24.8.0)(@types/react@19.2.7)(bufferutil@4.0.9)(immer@10.1.3)(jiti@2.6.1)(lightningcss@1.32.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(terser@5.44.0)(ts-toolbelt@9.6.0)(typescript@5.9.3))(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))':
+    dependencies:
+      '@sanity/icons': 3.7.4(react@19.2.3)
+      '@sanity/ui': 3.1.14(@emotion/is-prop-valid@1.2.2)(react-dom@19.2.3(react@19.2.3))(react-is@19.2.4)(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      react-rx: 4.2.2(react@19.2.3)(rxjs@7.8.2)
+      rxjs: 7.8.2
+      sanity: 5.19.0(@emotion/is-prop-valid@1.2.2)(@noble/hashes@2.0.1)(@oclif/core@4.10.3)(@sanity/cli-core@1.3.0(@noble/hashes@2.0.1)(@sanity/telemetry@0.9.0(react@19.2.4))(@types/node@24.8.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3))(@types/node@24.8.0)(@types/react@19.2.7)(bufferutil@4.0.9)(immer@10.1.3)(jiti@2.6.1)(lightningcss@1.32.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(terser@5.44.0)(ts-toolbelt@9.6.0)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - react-is
+      - styled-components
+
   '@sanity/logos@2.2.2(react@19.2.3)':
     dependencies:
       '@sanity/color': 3.0.6
@@ -17525,10 +17605,10 @@ snapshots:
     dependencies:
       '@sanity/comlink': 4.0.1
 
-  '@sanity/migrate@6.1.1(@oclif/core@4.10.3)(@sanity/cli-core@1.3.0(@noble/hashes@2.0.1)(@sanity/telemetry@0.9.0(react@19.2.3))(@types/node@24.8.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3))(@types/react@19.2.7)(xstate@5.30.0)':
+  '@sanity/migrate@6.1.1(@oclif/core@4.10.3)(@sanity/cli-core@1.3.0(@noble/hashes@2.0.1)(@sanity/telemetry@0.9.0(react@19.2.4))(@types/node@24.8.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3))(@types/react@19.2.7)(xstate@5.30.0)':
     dependencies:
       '@oclif/core': 4.10.3
-      '@sanity/cli-core': 1.3.0(@noble/hashes@2.0.1)(@sanity/telemetry@0.9.0(react@19.2.3))(@types/node@24.8.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3)
+      '@sanity/cli-core': 1.3.0(@noble/hashes@2.0.1)(@sanity/telemetry@0.9.0(react@19.2.4))(@types/node@24.8.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3)
       '@sanity/client': 7.20.0(debug@4.4.3)
       '@sanity/mutate': 0.16.1(debug@4.4.3)(xstate@5.30.0)
       '@sanity/types': 5.19.0(@types/react@19.2.7)(debug@4.4.3)
@@ -17853,12 +17933,6 @@ snapshots:
   '@sanity/telemetry@0.9.0(react@19.2.3)':
     dependencies:
       react: 19.2.3
-      rxjs: 7.8.2
-      typeid-js: 0.3.0
-
-  '@sanity/telemetry@0.9.0(react@19.2.4)':
-    dependencies:
-      react: 19.2.4
       rxjs: 7.8.2
       typeid-js: 0.3.0
 
@@ -19423,7 +19497,7 @@ snapshots:
 
   babel-plugin-macros@3.1.0:
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.2
       cosmiconfig: 7.1.0
       resolve: 1.22.11
     optional: true
@@ -25047,7 +25121,39 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sanity@5.19.0(@emotion/is-prop-valid@1.2.2)(@noble/hashes@2.0.1)(@oclif/core@4.10.3)(@sanity/cli-core@1.3.0(@noble/hashes@2.0.1)(@sanity/telemetry@0.9.0(react@19.2.3))(@types/node@24.8.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3))(@types/node@24.8.0)(@types/react@19.2.7)(bufferutil@4.0.9)(immer@10.1.3)(jiti@2.6.1)(lightningcss@1.32.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(terser@5.44.0)(ts-toolbelt@9.6.0)(typescript@5.9.3):
+  sanity-plugin-internationalized-array@5.1.0(97a085cb45d4e610dda649a5d0001302):
+    dependencies:
+      '@sanity/icons': 3.7.4(react@19.2.3)
+      '@sanity/language-filter': 5.0.1(@emotion/is-prop-valid@1.2.2)(react-dom@19.2.3(react@19.2.3))(react-is@19.2.4)(react@19.2.3)(sanity@5.19.0(@emotion/is-prop-valid@1.2.2)(@noble/hashes@2.0.1)(@oclif/core@4.10.3)(@sanity/cli-core@1.3.0(@noble/hashes@2.0.1)(@sanity/telemetry@0.9.0(react@19.2.4))(@types/node@24.8.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3))(@types/node@24.8.0)(@types/react@19.2.7)(bufferutil@4.0.9)(immer@10.1.3)(jiti@2.6.1)(lightningcss@1.32.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(terser@5.44.0)(ts-toolbelt@9.6.0)(typescript@5.9.3))(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+      '@sanity/ui': 3.1.14(@emotion/is-prop-valid@1.2.2)(react-dom@19.2.3(react@19.2.3))(react-is@19.2.4)(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+      '@sanity/util': 5.19.0(@types/react@19.2.7)(debug@4.4.3)
+      lodash-es: 4.18.1
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      sanity: 5.19.0(@emotion/is-prop-valid@1.2.2)(@noble/hashes@2.0.1)(@oclif/core@4.10.3)(@sanity/cli-core@1.3.0(@noble/hashes@2.0.1)(@sanity/telemetry@0.9.0(react@19.2.4))(@types/node@24.8.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3))(@types/node@24.8.0)(@types/react@19.2.7)(bufferutil@4.0.9)(immer@10.1.3)(jiti@2.6.1)(lightningcss@1.32.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(terser@5.44.0)(ts-toolbelt@9.6.0)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - '@types/react'
+      - debug
+      - react-is
+      - styled-components
+
+  sanity-plugin-utils@1.8.0(@emotion/is-prop-valid@1.2.2)(react-dom@19.2.3(react@19.2.3))(react-is@19.2.4)(react@19.2.3)(rxjs@7.8.2)(sanity@5.19.0(@emotion/is-prop-valid@1.2.2)(@noble/hashes@2.0.1)(@oclif/core@4.10.3)(@sanity/cli-core@1.3.0(@noble/hashes@2.0.1)(@sanity/telemetry@0.9.0(react@19.2.4))(@types/node@24.8.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3))(@types/node@24.8.0)(@types/react@19.2.7)(bufferutil@4.0.9)(immer@10.1.3)(jiti@2.6.1)(lightningcss@1.32.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(terser@5.44.0)(ts-toolbelt@9.6.0)(typescript@5.9.3))(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3)):
+    dependencies:
+      '@sanity/icons': 3.7.4(react@19.2.3)
+      '@sanity/incompatible-plugin': 1.0.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@sanity/ui': 3.1.14(@emotion/is-prop-valid@1.2.2)(react-dom@19.2.3(react@19.2.3))(react-is@19.2.4)(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+      react: 19.2.3
+      react-fast-compare: 3.2.2
+      rxjs: 7.8.2
+      sanity: 5.19.0(@emotion/is-prop-valid@1.2.2)(@noble/hashes@2.0.1)(@oclif/core@4.10.3)(@sanity/cli-core@1.3.0(@noble/hashes@2.0.1)(@sanity/telemetry@0.9.0(react@19.2.4))(@types/node@24.8.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3))(@types/node@24.8.0)(@types/react@19.2.7)(bufferutil@4.0.9)(immer@10.1.3)(jiti@2.6.1)(lightningcss@1.32.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(terser@5.44.0)(ts-toolbelt@9.6.0)(typescript@5.9.3)
+      styled-components: 6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - react-dom
+      - react-is
+
+  sanity@5.19.0(@emotion/is-prop-valid@1.2.2)(@noble/hashes@2.0.1)(@oclif/core@4.10.3)(@sanity/cli-core@1.3.0(@noble/hashes@2.0.1)(@sanity/telemetry@0.9.0(react@19.2.4))(@types/node@24.8.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3))(@types/node@24.8.0)(@types/react@19.2.7)(bufferutil@4.0.9)(immer@10.1.3)(jiti@2.6.1)(lightningcss@1.32.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(terser@5.44.0)(ts-toolbelt@9.6.0)(typescript@5.9.3):
     dependencies:
       '@algorithm.ts/lcs': 4.0.6
       '@date-fns/tz': 1.4.1
@@ -25087,7 +25193,7 @@ snapshots:
       '@sanity/logos': 2.2.2(react@19.2.3)
       '@sanity/media-library-types': 1.2.0
       '@sanity/message-protocol': 0.19.0
-      '@sanity/migrate': 6.1.1(@oclif/core@4.10.3)(@sanity/cli-core@1.3.0(@noble/hashes@2.0.1)(@sanity/telemetry@0.9.0(react@19.2.3))(@types/node@24.8.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3))(@types/react@19.2.7)(xstate@5.30.0)
+      '@sanity/migrate': 6.1.1(@oclif/core@4.10.3)(@sanity/cli-core@1.3.0(@noble/hashes@2.0.1)(@sanity/telemetry@0.9.0(react@19.2.4))(@types/node@24.8.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.3))(@types/react@19.2.7)(xstate@5.30.0)
       '@sanity/mutate': 0.16.1(debug@4.4.3)(xstate@5.30.0)
       '@sanity/mutator': 5.19.0(@types/react@19.2.7)
       '@sanity/presentation-comlink': 2.0.1(@sanity/client@7.20.0(debug@4.4.3))(@sanity/types@5.19.0(@types/react@19.2.7)(debug@4.4.3))


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `@sanity/document-internationalization` as a direct dependency to `gt-sanity` and auto-configures it inside `gtPlugin` when `showDocumentInternationalization` is `true` (the new default). It also re-exports the plugin's public API through a new shim file and widens `translateDocuments` to accept `string[]` as a shorthand for `TranslateDocumentFilter[]`.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; all findings are minor P2 style and hardening suggestions.

The core logic — normalizing translateDocuments, building supportedLanguages, and conditionally registering the plugin — is correct for the typical usage documented in the README (sourceLocale separate from locales). The two findings are defensive improvements (dedup guard and a missing developer warning) that don't affect correct usage.

packages/sanity/src/index.ts — review the allLocales construction and the silent-skip behavior when translateDocuments is absent.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .changeset/hungry-dots-join.md | Patch changeset entry documenting the new @sanity/document-internationalization dependency |
| packages/sanity/package.json | Adds @sanity/document-internationalization ^6.0.6 as a direct runtime dependency |
| packages/sanity/src/documentInternationalization.ts | New re-export shim exposing the plugin's functions and types under the gt-sanity namespace |
| packages/sanity/src/index.ts | Auto-integrates documentInternationalization plugin; minor hardening opportunities around locale dedup and silent no-op |
| pnpm-lock.yaml | Lock file updated with transitive dependencies for @sanity/document-internationalization |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[gtPlugin config] --> B{translateDocuments?}
    B -- undefined --> C[normalizedTranslateDocuments = undefined]
    B -- string[] or TranslateDocumentFilter[] --> D[Normalize: string → TranslateDocumentFilter]
    D --> E[Filter: keep entries with type or documentId]
    C --> F{showDocumentInternationalization?}
    E --> F
    F -- false --> G[plugins = empty array]
    F -- true --> H{schemaTypes.length > 0?}
    H -- no --> G
    H -- yes --> I[Build allLocales = resolvedSourceLocale + ...locales]
    I --> J[Map to supportedLanguages via getLocaleProperties]
    J --> K[Push documentInternationalization plugin]
    K --> L[Return gtPlugin with nested plugins]
    G --> L
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fsanity%2Fsrc%2Findex.ts%3A178%0A**Possible%20duplicate%20source%20locale%20in%20%60supportedLanguages%60**%0A%0AIf%20a%20caller%20inadvertently%20includes%20%60resolvedSourceLocale%60%20inside%20%60locales%60%20%28e.g.%20spreading%20a%20%60gt.config.json%60%20that%20lists%20all%20locales%29%2C%20%60allLocales%60%20will%20contain%20the%20source%20twice.%20%60%40sanity%2Fdocument-internationalization%60%20would%20then%20receive%20duplicate%20language%20entries.%20A%20%60Set%60%20dedup%20is%20a%20cheap%20defensive%20guard%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20const%20allLocales%20%3D%20%5B...new%20Set%28%5BresolvedSourceLocale%2C%20...locales%5D%29%5D%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fsanity%2Fsrc%2Findex.ts%3A172-191%0A**Silent%20no-op%20when%20%60translateDocuments%60%20is%20absent**%0A%0AWhen%20%60showDocumentInternationalization%60%20is%20%60true%60%20%28the%20default%29%20but%20%60translateDocuments%60%20is%20missing%20or%20contains%20no%20entries%20with%20a%20%60type%60%2C%20%60schemaTypes%60%20is%20empty%20and%20the%20plugin%20is%20silently%20skipped%20with%20no%20feedback.%20Users%20who%20rely%20on%20the%20auto-configuration%20but%20forget%20to%20pass%20%60translateDocuments%60%20will%20see%20no%20effect%20and%20no%20explanation.%20A%20%60console.warn%60%20at%20this%20branch%20would%20make%20the%20failure%20mode%20obvious.%0A%0A&repo=generaltranslation%2Fgt"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/sanity/src/index.ts
Line: 178

Comment:
**Possible duplicate source locale in `supportedLanguages`**

If a caller inadvertently includes `resolvedSourceLocale` inside `locales` (e.g. spreading a `gt.config.json` that lists all locales), `allLocales` will contain the source twice. `@sanity/document-internationalization` would then receive duplicate language entries. A `Set` dedup is a cheap defensive guard:

```suggestion
        const allLocales = [...new Set([resolvedSourceLocale, ...locales])];
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/sanity/src/index.ts
Line: 172-191

Comment:
**Silent no-op when `translateDocuments` is absent**

When `showDocumentInternationalization` is `true` (the default) but `translateDocuments` is missing or contains no entries with a `type`, `schemaTypes` is empty and the plugin is silently skipped with no feedback. Users who rely on the auto-configuration but forget to pass `translateDocuments` will see no effect and no explanation. A `console.warn` at this branch would make the failure mode obvious.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["changeset"](https://github.com/generaltranslation/gt/commit/250afb4988d1d6a9de2025b88b5a843e13afeaab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27542457)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->