### PR TITLE
fix(cli): don't prefix GT_API_KEY with framework env prefix

### DIFF
--- a/.changeset/fix-api-key-prefix.md
+++ b/.changeset/fix-api-key-prefix.md
@@ -1,0 +1,5 @@
+---
+"gtx-cli": patch
+---
+
+Fixed setup wizard to not prefix GT_API_KEY with framework-specific prefixes (VITE_, NEXT_PUBLIC_, etc.) since production API keys should never be exposed to the client bundle.

--- a/packages/cli/src/utils/credentials.ts
+++ b/packages/cli/src/utils/credentials.ts
@@ -157,7 +157,7 @@ export async function setCredentials(
     if (apiKey.type === 'development') {
       envContent += `${prefix || ''}GT_DEV_API_KEY=${apiKey.key}\n`;
     } else {
-      envContent += `${prefix || ''}GT_API_KEY=${apiKey.key}\n`;
+      envContent += `GT_API_KEY=${apiKey.key}\n`;
     }
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -953,9 +953,6 @@ importers:
       lodash.merge:
         specifier: ^4.6.2
         version: 4.6.2
-      sanity-plugin-internationalized-array:
-        specifier: '>=5.0.0'
-        version: 5.1.0(97a085cb45d4e610dda649a5d0001302)
     devDependencies:
       '@portabletext/types':
         specifier: ^2.0.15


### PR DESCRIPTION
## Problem

The setup wizard in `credentials.ts` prefixes all env vars with the framework-specific prefix (e.g. `VITE_`, `NEXT_PUBLIC_`, `GATSBY_`, `REDWOOD_ENV_`). This is correct for `GT_PROJECT_ID` and `GT_DEV_API_KEY` (safe for client exposure), but **`GT_API_KEY` is a production secret** — prefixing it causes it to be bundled into the client bundle, exposing it publicly.

## Fix

Removed the `${prefix || ''}` from the `GT_API_KEY` line so production API keys are never exposed to the client. Dev keys and project IDs retain their prefixes as intended.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a security issue in the CLI setup wizard where `GT_API_KEY` (a production secret) was incorrectly prefixed with framework-specific client-exposure prefixes (e.g. `NEXT_PUBLIC_`, `VITE_`, `GATSBY_`), which would bundle it into the client bundle. The one-line fix removes the prefix only for production keys, while dev keys and project IDs retain their prefixes as intended.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This PR is safe to merge — it correctly fixes a security issue with no side effects.

The fix is a single targeted line removal that prevents production API key exposure in client bundles. There are no P0 or P1 issues. The changeset description is accurate, and the surrounding logic for dev keys and project IDs is unchanged and correct.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .changeset/fix-api-key-prefix.md | New changeset accurately documenting the security fix for GT_API_KEY prefix removal. |
| packages/cli/src/utils/credentials.ts | Single-line fix removing framework prefix from GT_API_KEY to prevent production key exposure in client bundles; dev keys and project ID remain correctly prefixed. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant CLI as CLI Wizard
    participant Env as .env.local
    participant Client as Client Bundle

    CLI->>Env: NEXT_PUBLIC_GT_PROJECT_ID=... (prefixed)
    Note over Env,Client: Safe — project ID is intended to be public

    CLI->>Env: NEXT_PUBLIC_GT_DEV_API_KEY=... (prefixed)
    Note over Env,Client: Intentional — dev keys can be client-exposed

    CLI->>Env: GT_API_KEY=... (no prefix, after this fix)
    Note over Env,Client: Correct — production secret stays server-only
    Note over Client: GT_API_KEY never reaches the client bundle
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(cli): don&#39;t prefix GT\_API\_KEY with f..."](https://github.com/generaltranslation/gt/commit/ea6b64b2101b0a30d37f2ddc2b4e95de4fadcbbf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27619951)</sub>

<!-- /greptile_comment -->