### PR TITLE
fix(cli): use ./src/_gt as default translations dir for Vite projects

### DIFF
--- a/.changeset/fix-vite-translations-dir.md
+++ b/.changeset/fix-vite-translations-dir.md
@@ -1,0 +1,5 @@
+---
+"gtx-cli": patch
+---
+
+Changed default translation output directory for Vite projects from `./public/_gt` to `./src/_gt` in the setup wizard.

--- a/packages/cli/src/cli/base.ts
+++ b/packages/cli/src/cli/base.ts
@@ -413,7 +413,8 @@ export class BaseCLI {
               : null;
 
           // Build defaults description based on detected framework
-          const defaultTranslationsDir = framework.name === 'vite' ? './src/_gt' : './public/_gt';
+          const defaultTranslationsDir =
+            framework.name === 'vite' ? './src/_gt' : './public/_gt';
 
           const defaultsDescription =
             framework.type === 'react'
@@ -454,7 +455,11 @@ export class BaseCLI {
             logger.startCommand('Setting up project config...');
           }
           // Configure gt.config.json
-          await this.handleInitCommand(ranReactSetup, useDefaults, framework.name === 'vite');
+          await this.handleInitCommand(
+            ranReactSetup,
+            useDefaults,
+            framework.name === 'vite'
+          );
 
           logger.endCommand(
             'Done! Check out our docs for more information on how to use General Translation: https://generaltranslation.com/docs'
@@ -567,7 +572,8 @@ export class BaseCLI {
         : null;
 
     // Determine final translations directory with fallback
-    const finalTranslationsDir = translationsDir?.trim() || defaultTranslationsDir;
+    const finalTranslationsDir =
+      translationsDir?.trim() || defaultTranslationsDir;
 
     if (isUsingGT && !usingCDN) {
       // Create loadTranslations.js file for local translations

--- a/packages/cli/src/cli/base.ts
+++ b/packages/cli/src/cli/base.ts
@@ -1,4 +1,8 @@
 import { Command } from 'commander';
+import {
+  DEFAULT_TRANSLATIONS_DIR,
+  DEFAULT_VITE_TRANSLATIONS_DIR,
+} from '../utils/constants.js';
 import { createOrUpdateConfig } from '../fs/config/setupConfig.js';
 import findFilepath from '../fs/findFilepath.js';
 import {
@@ -414,7 +418,9 @@ export class BaseCLI {
 
           // Build defaults description based on detected framework
           const defaultTranslationsDir =
-            framework.name === 'vite' ? './src/_gt' : './public/_gt';
+            framework.name === 'vite'
+              ? DEFAULT_VITE_TRANSLATIONS_DIR
+              : DEFAULT_TRANSLATIONS_DIR;
 
           const defaultsDescription =
             framework.type === 'react'
@@ -557,7 +563,9 @@ export class BaseCLI {
       return selectedValue === 'cdn';
     })();
 
-    const defaultTranslationsDir = isVite ? './src/_gt' : './public/_gt';
+    const defaultTranslationsDir = isVite
+      ? DEFAULT_VITE_TRANSLATIONS_DIR
+      : DEFAULT_TRANSLATIONS_DIR;
 
     // Ask where the translations are stored
     const translationsDir =

--- a/packages/cli/src/cli/base.ts
+++ b/packages/cli/src/cli/base.ts
@@ -552,20 +552,22 @@ export class BaseCLI {
       return selectedValue === 'cdn';
     })();
 
+    const defaultTranslationsDir = isVite ? './src/_gt' : './public/_gt';
+
     // Ask where the translations are stored
     const translationsDir =
       isUsingGT && !usingCDN
         ? useDefaults
-          ? (isVite ? './src/_gt' : './public/_gt')
+          ? defaultTranslationsDir
           : await promptText({
               message:
                 'What is the path to the directory where you would like to store your translation files?',
-              defaultValue: isVite ? './src/_gt' : './public/_gt',
+              defaultValue: defaultTranslationsDir,
             })
         : null;
 
     // Determine final translations directory with fallback
-    const finalTranslationsDir = translationsDir?.trim() || (isVite ? './src/_gt' : './public/_gt');
+    const finalTranslationsDir = translationsDir?.trim() || defaultTranslationsDir;
 
     if (isUsingGT && !usingCDN) {
       // Create loadTranslations.js file for local translations

--- a/packages/cli/src/cli/base.ts
+++ b/packages/cli/src/cli/base.ts
@@ -488,7 +488,8 @@ export class BaseCLI {
         );
 
         // Configure gt.config.json
-        await this.handleInitCommand(false);
+        const framework = await detectFramework();
+        await this.handleInitCommand(false, false, framework.name === 'vite');
 
         logger.endCommand(
           'Done! Make sure you have an API key and project ID to use General Translation. Get them on the dashboard: https://generaltranslation.com/dashboard'

--- a/packages/cli/src/cli/base.ts
+++ b/packages/cli/src/cli/base.ts
@@ -413,10 +413,12 @@ export class BaseCLI {
               : null;
 
           // Build defaults description based on detected framework
+          const defaultTranslationsDir = framework.name === 'vite' ? './src/_gt' : './public/_gt';
+
           const defaultsDescription =
             framework.type === 'react'
-              ? `${library} & GTProvider, ${frameworkDisplayName}, Files saved locally in ./public/_gt`
-              : 'Files saved locally in ./public/_gt';
+              ? `${library} & GTProvider, ${frameworkDisplayName}, Files saved locally in ${defaultTranslationsDir}`
+              : `Files saved locally in ${defaultTranslationsDir}`;
 
           // Ask if user wants to use defaults
           const useDefaults = await promptConfirm({
@@ -452,7 +454,7 @@ export class BaseCLI {
             logger.startCommand('Setting up project config...');
           }
           // Configure gt.config.json
-          await this.handleInitCommand(ranReactSetup, useDefaults);
+          await this.handleInitCommand(ranReactSetup, useDefaults, framework.name === 'vite');
 
           logger.endCommand(
             'Done! Check out our docs for more information on how to use General Translation: https://generaltranslation.com/docs'
@@ -522,7 +524,8 @@ export class BaseCLI {
   // Wizard for configuring gt.config.json
   protected async handleInitCommand(
     ranReactSetup: boolean,
-    useDefaults: boolean = false
+    useDefaults: boolean = false,
+    isVite: boolean = false
   ): Promise<void> {
     const { defaultLocale, locales } = await getDesiredLocales(); // Locales should still be asked for even if using defaults
 
@@ -553,16 +556,16 @@ export class BaseCLI {
     const translationsDir =
       isUsingGT && !usingCDN
         ? useDefaults
-          ? './public/_gt'
+          ? (isVite ? './src/_gt' : './public/_gt')
           : await promptText({
               message:
                 'What is the path to the directory where you would like to store your translation files?',
-              defaultValue: './public/_gt',
+              defaultValue: isVite ? './src/_gt' : './public/_gt',
             })
         : null;
 
     // Determine final translations directory with fallback
-    const finalTranslationsDir = translationsDir?.trim() || './public/_gt';
+    const finalTranslationsDir = translationsDir?.trim() || (isVite ? './src/_gt' : './public/_gt');
 
     if (isUsingGT && !usingCDN) {
       // Create loadTranslations.js file for local translations

--- a/packages/cli/src/fs/__tests__/createLoadTranslationsFile.test.ts
+++ b/packages/cli/src/fs/__tests__/createLoadTranslationsFile.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { createLoadTranslationsFile } from '../createLoadTranslationsFile.js';
+import {
+  DEFAULT_TRANSLATIONS_DIR,
+  DEFAULT_VITE_TRANSLATIONS_DIR,
+} from '../../utils/constants.js';
+
+describe('createLoadTranslationsFile', () => {
+  const tmpDir = path.join(__dirname, '__tmp_test_create_load_translations__');
+  let originalCwd: string;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    fs.mkdirSync(tmpDir, { recursive: true });
+    // The function uses cwd-relative paths for mkdir, so we chdir
+    process.chdir(tmpDir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('creates loadTranslations.js in src/ when src directory exists', async () => {
+    fs.mkdirSync(path.join(tmpDir, 'src'), { recursive: true });
+
+    await createLoadTranslationsFile(tmpDir, DEFAULT_TRANSLATIONS_DIR, [
+      'es',
+      'fr',
+    ]);
+
+    const filePath = path.join(tmpDir, 'src', 'loadTranslations.js');
+    expect(fs.existsSync(filePath)).toBe(true);
+
+    const content = fs.readFileSync(filePath, 'utf-8');
+    expect(content).toContain('export default async function loadTranslations');
+    expect(content).toContain('../public/_gt/');
+  });
+
+  it('creates loadTranslations.js at root when no src directory exists', async () => {
+    await createLoadTranslationsFile(tmpDir, DEFAULT_TRANSLATIONS_DIR, ['es']);
+
+    const filePath = path.join(tmpDir, 'loadTranslations.js');
+    expect(fs.existsSync(filePath)).toBe(true);
+
+    const content = fs.readFileSync(filePath, 'utf-8');
+    expect(content).toContain('export default async function loadTranslations');
+    expect(content).toContain('public/_gt/');
+  });
+
+  it('uses correct relative path for Vite translations dir (./src/_gt)', async () => {
+    fs.mkdirSync(path.join(tmpDir, 'src'), { recursive: true });
+
+    await createLoadTranslationsFile(tmpDir, DEFAULT_VITE_TRANSLATIONS_DIR, [
+      'es',
+    ]);
+
+    const filePath = path.join(tmpDir, 'src', 'loadTranslations.js');
+    expect(fs.existsSync(filePath)).toBe(true);
+
+    const content = fs.readFileSync(filePath, 'utf-8');
+    // From src/loadTranslations.js to src/_gt/ the relative path is just _gt/
+    expect(content).toContain('_gt/');
+    expect(content).not.toContain('public/_gt');
+  });
+
+  it('creates locale JSON files in the translations directory', async () => {
+    await createLoadTranslationsFile(tmpDir, DEFAULT_TRANSLATIONS_DIR, [
+      'es',
+      'fr',
+    ]);
+
+    const translationsPath = path.resolve(tmpDir, DEFAULT_TRANSLATIONS_DIR);
+    expect(fs.existsSync(path.join(translationsPath, 'es.json'))).toBe(true);
+    expect(fs.existsSync(path.join(translationsPath, 'fr.json'))).toBe(true);
+
+    const content = JSON.parse(
+      fs.readFileSync(path.join(translationsPath, 'es.json'), 'utf-8')
+    );
+    expect(content).toEqual({});
+  });
+
+  it('creates locale JSON files in Vite translations directory', async () => {
+    fs.mkdirSync(path.join(tmpDir, 'src'), { recursive: true });
+
+    await createLoadTranslationsFile(tmpDir, DEFAULT_VITE_TRANSLATIONS_DIR, [
+      'es',
+    ]);
+
+    const translationsPath = path.resolve(
+      tmpDir,
+      DEFAULT_VITE_TRANSLATIONS_DIR
+    );
+    expect(fs.existsSync(path.join(translationsPath, 'es.json'))).toBe(true);
+  });
+
+  it('does not overwrite existing loadTranslations.js', async () => {
+    fs.mkdirSync(path.join(tmpDir, 'src'), { recursive: true });
+    const filePath = path.join(tmpDir, 'src', 'loadTranslations.js');
+    fs.writeFileSync(filePath, '// custom content');
+
+    await createLoadTranslationsFile(tmpDir, DEFAULT_TRANSLATIONS_DIR, ['es']);
+
+    const content = fs.readFileSync(filePath, 'utf-8');
+    expect(content).toBe('// custom content');
+  });
+
+  it('does not overwrite existing locale JSON files', async () => {
+    const translationsPath = path.resolve(tmpDir, DEFAULT_TRANSLATIONS_DIR);
+    fs.mkdirSync(translationsPath, { recursive: true });
+    fs.writeFileSync(
+      path.join(translationsPath, 'es.json'),
+      '{"hello":"hola"}'
+    );
+
+    await createLoadTranslationsFile(tmpDir, DEFAULT_TRANSLATIONS_DIR, ['es']);
+
+    const content = JSON.parse(
+      fs.readFileSync(path.join(translationsPath, 'es.json'), 'utf-8')
+    );
+    expect(content).toEqual({ hello: 'hola' });
+  });
+
+  it('defaults to ./public/_gt when no translationsDir is provided', async () => {
+    await createLoadTranslationsFile(tmpDir, undefined as any, ['es']);
+
+    const filePath = path.join(tmpDir, 'loadTranslations.js');
+    expect(fs.existsSync(filePath)).toBe(true);
+
+    const content = fs.readFileSync(filePath, 'utf-8');
+    expect(content).toContain('public/_gt/');
+  });
+});

--- a/packages/cli/src/fs/createLoadTranslationsFile.ts
+++ b/packages/cli/src/fs/createLoadTranslationsFile.ts
@@ -2,10 +2,11 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { logger } from '../console/logger.js';
 import chalk from 'chalk';
+import { DEFAULT_TRANSLATIONS_DIR } from '../utils/constants.js';
 
 export async function createLoadTranslationsFile(
   appDirectory: string,
-  translationsDir: string = './public/_gt',
+  translationsDir: string = DEFAULT_TRANSLATIONS_DIR,
   locales: string[]
 ) {
   const usingSrcDirectory = fs.existsSync(path.join(appDirectory, 'src'));

--- a/packages/cli/src/utils/constants.ts
+++ b/packages/cli/src/utils/constants.ts
@@ -13,3 +13,7 @@ export const DEFAULT_TIMEOUT_SECONDS = 900;
 
 // Number of source code lines to capture above and below a translation site
 export const SURROUNDING_LINE_COUNT = 5;
+
+// Default translations directory paths
+export const DEFAULT_TRANSLATIONS_DIR = './public/_gt';
+export const DEFAULT_VITE_TRANSLATIONS_DIR = './src/_gt';


### PR DESCRIPTION
Vite projects should store GT output files at `./src/_gt` rather than `./public/_gt`, because Vite imports these as modules and they shouldn't be in the public directory.

## Changes

- Pass framework info (`isVite`) through to `handleInitCommand`
- Default translations directory is now `./src/_gt` for Vite projects, `./public/_gt` for everything else
- Updated the defaults description shown to the user during setup
- Added changeset

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the CLI setup wizard so that Vite projects are shown `./src/_gt` (instead of `./public/_gt`) as the default translations directory — correct, since Vite imports these as modules rather than serving them as static assets. Two named constants are extracted to `constants.ts` and an `isVite` flag is threaded through `handleInitCommand`.

- The `configure` command (`setupConfigureCommand`, line 491) never calls `detectFramework()` and still passes only two arguments to `handleInitCommand`, so Vite users running `gtx-cli configure` will still see `./public/_gt` as the prompt default.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for the setup wizard path; configure command will still show the wrong default for Vite users

The core fix is correct and well-structured, but one command path (configure) was not updated and will exhibit the same wrong-default behaviour this PR intends to fix — a straightforward one-liner addition would close the gap

packages/cli/src/cli/base.ts — setupConfigureCommand at line 491
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .changeset/fix-vite-translations-dir.md | Patch changeset correctly documenting the Vite translations directory default change |
| packages/cli/src/cli/base.ts | isVite flag correctly threaded through setup wizard; configure command at line 491 still omits framework detection |
| packages/cli/src/fs/createLoadTranslationsFile.ts | Default parameter updated to named constant; no behaviour change since all callers pass an explicit value |
| packages/cli/src/utils/constants.ts | Two new named constants for the default and Vite translations directory paths — clean extraction |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[gtx-cli setup] --> B[detectFramework]
    B --> C{framework.name === 'vite'?}
    C -- Yes --> D[DEFAULT_VITE_TRANSLATIONS_DIR
'./src/_gt']
    C -- No --> E[DEFAULT_TRANSLATIONS_DIR
'./public/_gt']
    D --> F[handleInitCommand isVite=true]
    E --> G[handleInitCommand isVite=false]
    F --> OK1[✅ Correct default for Vite]
    G --> OK2[✅ Correct default for others]

    H[gtx-cli configure] --> I[No detectFramework call]
    I --> J[handleInitCommand isVite=false]
    J --> BAD[❌ Always './public/_gt'
Wrong for Vite projects]
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/cli/src/cli/base.ts`, line 480 ([link](https://github.com/generaltranslation/gt/blob/b7c120fadb0d58cb986b637749594a7c92be02b8/packages/cli/src/cli/base.ts#L480)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`configure` command does not pass `isVite`**

   The `configure` command calls `handleInitCommand(false)` without an `isVite` argument, so Vite users who run `gt configure` instead of `gt init` will still receive `./public/_gt` as the default. This is a pre-existing gap (the `configure` path never did framework detection), but it means the fix is incomplete for that entry point. Consider detecting the framework here too, or at least noting it as a known limitation.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/cli/src/cli/base.ts
   Line: 480

   Comment:
   **`configure` command does not pass `isVite`**

   The `configure` command calls `handleInitCommand(false)` without an `isVite` argument, so Vite users who run `gt configure` instead of `gt init` will still receive `./public/_gt` as the default. This is a pre-existing gap (the `configure` path never did framework detection), but it means the fix is incomplete for that entry point. Consider detecting the framework here too, or at least noting it as a known limitation.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/cli/src/cli/base.ts
Line: 491

Comment:
**`configure` command missing Vite detection**

`setupConfigureCommand` calls `handleInitCommand(false)` without ever calling `detectFramework()`, so `isVite` permanently defaults to `false`. A Vite user running `gtx-cli configure` will be prompted with `./public/_gt` as the default instead of the correct `./src/_gt` — the same wrong-default behaviour this PR fixes for the `setup` wizard.

```suggestion
        const framework = await detectFramework();
        await this.handleInitCommand(false, false, framework.name === 'vite');
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>**[Greploops](https://www.greptile.com/docs/mcp-v2/skills#greploop)** — Automatically fix all review issues by running `/greploops` in [Claude Code](https://claude.ai/download). It iterates: fix, push, re-review, repeat until 5/5 confidence.<br>Use the **[Greptile plugin for Claude Code](https://www.greptile.com/docs/integrations/claude-code#claude-code-plugin)** to query reviews, search comments, and manage custom context directly from your terminal.</sub>

<sub>Reviews (2): Last reviewed commit: ["refactor: use constants for default tran..."](https://github.com/generaltranslation/gt/commit/21c19ebdb4c77a2297a54742dd708e303a6312c9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27620442)</sub>

<!-- /greptile_comment -->