### PR TITLE
fix(compiler): member expression errors

### DIFF
--- a/.changeset/icy-cities-fail.md
+++ b/.changeset/icy-cities-fail.md
@@ -1,0 +1,5 @@
+---
+'@generaltranslation/compiler': patch
+---
+
+fix: handle member expressions without throwing errors

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.14.4';
+export const PACKAGE_VERSION = '2.14.6';

--- a/packages/compiler/src/transform/jsx-children/utils/getCalleeNameFromJsxExpressionParam.ts
+++ b/packages/compiler/src/transform/jsx-children/utils/getCalleeNameFromJsxExpressionParam.ts
@@ -1,5 +1,8 @@
 import * as t from '@babel/types';
 
+const UNKNOWN_NAMESPACE = '_gt_unknown_namespace';
+const UNKNOWN_FUNCTION = '_gt_unknown_function';
+
 /**
  * Get the callee name from an expression: ... = useGT();
  * Rule of thumb, only call on expressions with parentheses
@@ -24,6 +27,11 @@ export function getCalleeNameFromJsxExpressionParam(expr: t.Expression): {
       return {
         namespaceName: expr.object.name,
         functionName: expr.property.name,
+      };
+    } else {
+      return {
+        namespaceName: UNKNOWN_NAMESPACE,
+        functionName: UNKNOWN_FUNCTION,
       };
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -953,9 +953,6 @@ importers:
       lodash.merge:
         specifier: ^4.6.2
         version: 4.6.2
-      sanity-plugin-internationalized-array:
-        specifier: '>=5.0.0'
-        version: 5.1.0(97a085cb45d4e610dda649a5d0001302)
     devDependencies:
       '@portabletext/types':
         specifier: ^2.0.15


### PR DESCRIPTION
Fixes issue where fails on member expressions with three or more levels of chaining. For example, it would fail on the following:

```jsx
<One.two.three/>
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a hash mismatch in the compiler's injection pipeline by handling complex (chained) member expressions in `getCalleeNameFromJsxExpressionParam`. Previously, expressions like `a.b.c` (where the object or property is not a plain identifier) fell through to `return { namespaceName: null, functionName: null }`, triggering `!functionName` error guards in callers and causing the collection and injection phases to diverge on hash computation. The fix adds sentinel constants (`_gt_unknown_namespace`, `_gt_unknown_function`) returned in place of `null`, so both phases process unresolvable member expressions identically and produce consistent hashes. The remaining changes are a version bump and lockfile update.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — targeted, minimal fix with consistent behavior across both compiler phases

All changes are minimal and correct. Sentinel values use _gt_ prefix to avoid identifier collisions; getTrackedVariable returns null for them preventing false GT component matches; no logic errors or security issues found. All other findings are P2 or lower.

No files require special attention
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/compiler/src/transform/jsx-children/utils/getCalleeNameFromJsxExpressionParam.ts | Core fix: sentinel constants replace null for unresolvable member expressions, making collection and injection phases consistent |
| .changeset/icy-cities-fail.md | Changeset entry for @generaltranslation/compiler patch bump |
| packages/cli/src/generated/version.ts | Auto-generated version bump to 2.14.6 |
| pnpm-lock.yaml | Lockfile updated for version bump |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["MemberExpression node\nexpr.object / expr.property"] --> B{Both are\nIdentifiers?}
    B -- Yes --> C["return {\n  namespaceName: object.name,\n  functionName: property.name\n}"]
    B -- "No (OLD)" --> D["return { null, null }"]
    B -- "No (NEW)" --> E["return {\n  namespaceName: UNKNOWN_NAMESPACE,\n  functionName: UNKNOWN_FUNCTION\n}"]
    D --> F["!functionName guard fires\nin all callers"]
    F --> G["Error logged / operation aborted\n(collection or injection phase)"]
    G --> H["Hash mismatch between phases ✗"]
    E --> I["!functionName bypassed\n(sentinel is truthy)"]
    I --> J["getTrackedVariable returns null\n(sentinel not in scope tracker)"]
    J --> K["Early return, no error\nBoth phases handle consistently"]
    K --> L["Matching hashes in both phases ✓"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: changeset"](https://github.com/generaltranslation/gt/commit/ca78a0f3925077445c12158d7f653074d397dac5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27642199)</sub>

<!-- /greptile_comment -->