### PR TITLE
fix: update bootstrap comment to use loadTranslations

### DIFF
--- a/packages/react/src/i18n-context/setup/bootstrap.ts
+++ b/packages/react/src/i18n-context/setup/bootstrap.ts
@@ -10,13 +10,13 @@ import { InitializeGTParams } from './types';
  * @example
  * import gtConfig from '../gt.config.json';
  *
- * function getTranslations(locale: string) {
- *   return import(`./_gt/${locale}.json`);
+ * async function loadTranslations(locale: string) {
+ *   return (await import(`./_gt/${locale}.json`)).default;
  * }
  *
  * await bootstrap({
  *   ...gtConfig,
- *   getTranslations,
+ *   loadTranslations,
  * });
  *
  * await import('./main.tsx')


### PR DESCRIPTION
The JSDoc example in the `bootstrap` function referenced `getTranslations`, but the actual parameter name is `loadTranslations`. This updates the comment to match.

Companion to https://github.com/generaltranslation/content/pull/224

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR corrects a JSDoc comment in `bootstrap.ts` where the example used `getTranslations` but the actual `InitializeGTParams` type and function signature use `loadTranslations`. The fix aligns the documentation with the real API — verified against `types.ts` line 12.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — documentation-only fix with no runtime impact.

Single JSDoc correction matching the verified `InitializeGTParams` type. No logic changes, no risk.

No files require special attention.
</details>

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react/src/i18n-context/setup/bootstrap.ts | JSDoc example updated to use `loadTranslations` instead of `getTranslations`, matching the actual `InitializeGTParams` type definition. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[bootstrap called] --> B[initializeGT params]
    B --> C[getBrowserI18nManager]
    C --> D[i18nManager.loadTranslations]
    D --> E[Promise resolved]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: update bootstrap comment to use loa..."](https://github.com/generaltranslation/gt/commit/9a00689dbb3cca138e170d0293e34f226b19c175) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27651040)</sub>

<!-- /greptile_comment -->