### PR TITLE
fix(cli): multiplication for props

### DIFF
--- a/.changeset/curly-loops-leave.md
+++ b/.changeset/curly-loops-leave.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+fix: exploration of properties for Branch and Plural during multiplication step

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.14.4';
+export const PACKAGE_VERSION = '2.14.6';

--- a/packages/cli/src/react/jsx/utils/jsxParsing/__tests__/parseJsx.test.ts
+++ b/packages/cli/src/react/jsx/utils/jsxParsing/__tests__/parseJsx.test.ts
@@ -2213,4 +2213,379 @@ describe('parseTranslationComponent with cross-file resolution', () => {
       expect(updates[0].metadata.context).toBe('greeting');
     });
   });
+
+  describe('Derive inside Plural/Branch named props', () => {
+    it('should multiply when Derive is inside a single Plural prop', () => {
+      const pageFile = `
+        import { T, Derive, Plural } from "gt-next";
+
+        function getAnimal() {
+          if (Math.random() > 0.5) return "cat";
+          return "dog";
+        }
+
+        export default function Page() {
+          return (
+            <T>
+              <Plural
+                n={count}
+                one={<><Derive>{getAnimal()}</Derive> is here</>}
+                other="animals"
+              />
+            </T>
+          );
+        }
+      `;
+
+      const ast = parse(pageFile, {
+        sourceType: 'module',
+        plugins: ['jsx', 'typescript'],
+      });
+
+      let tLocalName = '';
+      const importAliases: Record<string, string> = {};
+
+      traverse(ast, {
+        ImportDeclaration(path) {
+          if (path.node.source.value === 'gt-next') {
+            path.node.specifiers.forEach((spec) => {
+              if (t.isImportSpecifier(spec) && t.isIdentifier(spec.imported)) {
+                importAliases[spec.local.name] = spec.imported.name;
+                if (spec.imported.name === 'T') tLocalName = spec.local.name;
+              }
+            });
+          }
+        },
+      });
+
+      traverse(ast, {
+        Program(programPath) {
+          const tBinding = programPath.scope.getBinding(tLocalName);
+          if (tBinding) {
+            parseTranslationComponent({
+              originalName: 'T',
+              localName: tLocalName,
+              path: tBinding.path,
+              updates,
+              config: {
+                importAliases,
+                parsingOptions,
+                pkgs: [Libraries.GT_NEXT],
+                file: '/test/derive-plural-single/page.tsx',
+              },
+              output: {
+                errors,
+                warnings,
+                unwrappedExpressions: [],
+              },
+            });
+          }
+        },
+      });
+
+      expect(errors).toHaveLength(0);
+      expect(updates).toHaveLength(2); // 2 branches from getAnimal()
+    });
+
+    it('should produce cross-product when Derive is in both Plural props', () => {
+      const pageFile = `
+        import { T, Derive, Plural } from "gt-next";
+
+        function getAnimal() {
+          if (Math.random() > 0.5) return "cat";
+          if (Math.random() > 0.5) return "dog";
+          return "bird";
+        }
+
+        export default function Page() {
+          return (
+            <T>
+              <Plural
+                n={count}
+                one={<><Derive>{getAnimal()}</Derive> is here</>}
+                other={<><Derive>{getAnimal()}</Derive> are here</>}
+              />
+            </T>
+          );
+        }
+      `;
+
+      const ast = parse(pageFile, {
+        sourceType: 'module',
+        plugins: ['jsx', 'typescript'],
+      });
+
+      let tLocalName = '';
+      const importAliases: Record<string, string> = {};
+
+      traverse(ast, {
+        ImportDeclaration(path) {
+          if (path.node.source.value === 'gt-next') {
+            path.node.specifiers.forEach((spec) => {
+              if (t.isImportSpecifier(spec) && t.isIdentifier(spec.imported)) {
+                importAliases[spec.local.name] = spec.imported.name;
+                if (spec.imported.name === 'T') tLocalName = spec.local.name;
+              }
+            });
+          }
+        },
+      });
+
+      traverse(ast, {
+        Program(programPath) {
+          const tBinding = programPath.scope.getBinding(tLocalName);
+          if (tBinding) {
+            parseTranslationComponent({
+              originalName: 'T',
+              localName: tLocalName,
+              path: tBinding.path,
+              updates,
+              config: {
+                importAliases,
+                parsingOptions,
+                pkgs: [Libraries.GT_NEXT],
+                file: '/test/derive-plural-cross/page.tsx',
+              },
+              output: {
+                errors,
+                warnings,
+                unwrappedExpressions: [],
+              },
+            });
+          }
+        },
+      });
+
+      expect(errors).toHaveLength(0);
+      expect(updates).toHaveLength(9); // 3 x 3 cross-product
+    });
+
+    it('should multiply when Derive is inside a Branch prop', () => {
+      const pageFile = `
+        import { T, Derive, Branch } from "gt-next";
+
+        function getGreeting() {
+          if (isFormal) return "Good day";
+          return "Hey";
+        }
+
+        export default function Page() {
+          return (
+            <T>
+              <Branch
+                branch={mode}
+                formal={<><Derive>{getGreeting()}</Derive>, welcome</>}
+                casual="What's up"
+              />
+            </T>
+          );
+        }
+      `;
+
+      const ast = parse(pageFile, {
+        sourceType: 'module',
+        plugins: ['jsx', 'typescript'],
+      });
+
+      let tLocalName = '';
+      const importAliases: Record<string, string> = {};
+
+      traverse(ast, {
+        ImportDeclaration(path) {
+          if (path.node.source.value === 'gt-next') {
+            path.node.specifiers.forEach((spec) => {
+              if (t.isImportSpecifier(spec) && t.isIdentifier(spec.imported)) {
+                importAliases[spec.local.name] = spec.imported.name;
+                if (spec.imported.name === 'T') tLocalName = spec.local.name;
+              }
+            });
+          }
+        },
+      });
+
+      traverse(ast, {
+        Program(programPath) {
+          const tBinding = programPath.scope.getBinding(tLocalName);
+          if (tBinding) {
+            parseTranslationComponent({
+              originalName: 'T',
+              localName: tLocalName,
+              path: tBinding.path,
+              updates,
+              config: {
+                importAliases,
+                parsingOptions,
+                pkgs: [Libraries.GT_NEXT],
+                file: '/test/derive-branch/page.tsx',
+              },
+              output: {
+                errors,
+                warnings,
+                unwrappedExpressions: [],
+              },
+            });
+          }
+        },
+      });
+
+      expect(errors).toHaveLength(0);
+      expect(updates).toHaveLength(2); // 2 branches from getGreeting()
+    });
+
+    it('should produce 9 entries for user scenario: getSubject() in both Plural props', () => {
+      const pageFile = `
+        import { T, Derive, Plural, Num } from "gt-next";
+
+        function getSubject() {
+          const subject = Math.random() > 0.5 ? 'man' : 'woman';
+          if (subject === 'man') return <Plural n={count} one='man' other='men' />;
+          if (subject === 'woman') return <Plural n={count} one='woman' other='women' />;
+          return <Plural n={count} one='child' other='children' />;
+        }
+
+        export default function Page() {
+          return (
+            <T>
+              <p>
+                <Plural
+                  n={count}
+                  one={<>Here is <Num>{count}</Num> <Derive>{getSubject()}</Derive> who is a racing driver</>}
+                  other={<>Here are <Num>{count}</Num> <Derive>{getSubject()}</Derive> who are racing drivers</>}
+                />
+                .
+              </p>
+            </T>
+          );
+        }
+      `;
+
+      const ast = parse(pageFile, {
+        sourceType: 'module',
+        plugins: ['jsx', 'typescript'],
+      });
+
+      let tLocalName = '';
+      const importAliases: Record<string, string> = {};
+
+      traverse(ast, {
+        ImportDeclaration(path) {
+          if (path.node.source.value === 'gt-next') {
+            path.node.specifiers.forEach((spec) => {
+              if (t.isImportSpecifier(spec) && t.isIdentifier(spec.imported)) {
+                importAliases[spec.local.name] = spec.imported.name;
+                if (spec.imported.name === 'T') tLocalName = spec.local.name;
+              }
+            });
+          }
+        },
+      });
+
+      traverse(ast, {
+        Program(programPath) {
+          const tBinding = programPath.scope.getBinding(tLocalName);
+          if (tBinding) {
+            parseTranslationComponent({
+              originalName: 'T',
+              localName: tLocalName,
+              path: tBinding.path,
+              updates,
+              config: {
+                importAliases,
+                parsingOptions,
+                pkgs: [Libraries.GT_NEXT],
+                file: '/test/derive-plural-user-scenario/page.tsx',
+              },
+              output: {
+                errors,
+                warnings,
+                unwrappedExpressions: [],
+              },
+            });
+          }
+        },
+      });
+
+      expect(errors).toHaveLength(0);
+      expect(updates).toHaveLength(9); // 3 x 3 cross-product
+    });
+
+    it('should cross-multiply Derive in Branch children (fallback) and named props', () => {
+      const pageFile = `
+        import { T, Derive, Branch } from "gt-next";
+
+        function getGreeting() {
+          if (isFormal) return "Good day";
+          return "Hey";
+        }
+
+        function getDefault() {
+          if (isNight) return "Good night";
+          if (isMorning) return "Good morning";
+          return "Hello";
+        }
+
+        export default function Page() {
+          return (
+            <T>
+              <Branch
+                branch={mode}
+                formal={<><Derive>{getGreeting()}</Derive>, welcome</>}
+              >
+                <Derive>{getDefault()}</Derive> there
+              </Branch>
+            </T>
+          );
+        }
+      `;
+
+      const ast = parse(pageFile, {
+        sourceType: 'module',
+        plugins: ['jsx', 'typescript'],
+      });
+
+      let tLocalName = '';
+      const importAliases: Record<string, string> = {};
+
+      traverse(ast, {
+        ImportDeclaration(path) {
+          if (path.node.source.value === 'gt-next') {
+            path.node.specifiers.forEach((spec) => {
+              if (t.isImportSpecifier(spec) && t.isIdentifier(spec.imported)) {
+                importAliases[spec.local.name] = spec.imported.name;
+                if (spec.imported.name === 'T') tLocalName = spec.local.name;
+              }
+            });
+          }
+        },
+      });
+
+      traverse(ast, {
+        Program(programPath) {
+          const tBinding = programPath.scope.getBinding(tLocalName);
+          if (tBinding) {
+            parseTranslationComponent({
+              originalName: 'T',
+              localName: tLocalName,
+              path: tBinding.path,
+              updates,
+              config: {
+                importAliases,
+                parsingOptions,
+                pkgs: [Libraries.GT_NEXT],
+                file: '/test/derive-branch-children-and-props/page.tsx',
+              },
+              output: {
+                errors,
+                warnings,
+                unwrappedExpressions: [],
+              },
+            });
+          }
+        },
+      });
+
+      expect(errors).toHaveLength(0);
+      expect(updates).toHaveLength(6); // 2 (formal) x 3 (children fallback)
+    });
+  });
 });

--- a/packages/cli/src/react/jsx/utils/jsxParsing/multiplication/findMultiplicationNode.ts
+++ b/packages/cli/src/react/jsx/utils/jsxParsing/multiplication/findMultiplicationNode.ts
@@ -4,6 +4,12 @@ import {
   isWhitespaceMultiplicationNode,
   isWhitespaceJsxTree,
 } from '../types.js';
+import { isAcceptedPluralForm } from 'generaltranslation/internal';
+import {
+  PLURAL_COMPONENT,
+  BRANCH_COMPONENT,
+  BRANCH_CONTROL_PROPS,
+} from '../../constants.js';
 
 export type MultiplicationNodeResult = {
   parent: any | undefined;
@@ -55,11 +61,36 @@ export function findMultiplicationNode(
     if (isWhitespaceMultiplicationNode(curr)) {
       return { parent, key, node: curr };
     } else if (isWhitespaceJsxTree(curr)) {
-      if (curr.props?.children) {
-        return handleChildren(curr.props.children, curr.props, 'children');
-      } else {
-        return undefined;
+      if (!curr.props) return undefined;
+
+      // Check children first
+      if (curr.props.children) {
+        const result = handleChildren(
+          curr.props.children,
+          curr.props,
+          'children'
+        );
+        if (result) return result;
       }
+
+      // For Plural/Branch, also search translatable content props
+      // Mirrors the prop filtering in handleChildrenWhitespace.ts and autoInsertion.ts
+      const elementIsPlural = curr.type === PLURAL_COMPONENT;
+      const elementIsBranch = curr.type === BRANCH_COMPONENT;
+      if (elementIsPlural || elementIsBranch) {
+        for (const [propKey, propValue] of Object.entries(curr.props)) {
+          if (propKey === 'children') continue;
+          if (typeof propValue === 'string') continue;
+          if (elementIsPlural && !isAcceptedPluralForm(propKey)) continue;
+          if (elementIsBranch && BRANCH_CONTROL_PROPS.has(propKey)) continue;
+          if (propValue && typeof propValue === 'object') {
+            const result = handleChildren(propValue, curr.props, propKey);
+            if (result) return result;
+          }
+        }
+      }
+
+      return undefined;
     } else {
       return undefined;
     }

--- a/packages/cli/src/react/jsx/utils/jsxParsing/multiplication/findMultiplicationNode.ts
+++ b/packages/cli/src/react/jsx/utils/jsxParsing/multiplication/findMultiplicationNode.ts
@@ -80,7 +80,6 @@ export function findMultiplicationNode(
       if (elementIsPlural || elementIsBranch) {
         for (const [propKey, propValue] of Object.entries(curr.props)) {
           if (propKey === 'children') continue;
-          if (typeof propValue === 'string') continue;
           if (elementIsPlural && !isAcceptedPluralForm(propKey)) continue;
           if (elementIsBranch && BRANCH_CONTROL_PROPS.has(propKey)) continue;
           if (propValue && typeof propValue === 'object') {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -953,9 +953,6 @@ importers:
       lodash.merge:
         specifier: ^4.6.2
         version: 4.6.2
-      sanity-plugin-internationalized-array:
-        specifier: '>=5.0.0'
-        version: 5.1.0(97a085cb45d4e610dda649a5d0001302)
     devDependencies:
       '@portabletext/types':
         specifier: ^2.0.15


### PR DESCRIPTION
For `Branch` and `Plural`, we need to explore properties during multiplication.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes `findMultiplicationNode` to search named props of `Plural` (e.g. `one`, `other`) and `Branch` (e.g. `formal`, `casual`) components for multiplication nodes created by `Derive`, in addition to `children`. The fix mirrors existing prop-filtering logic in `handleChildrenWhitespace.ts` — using `isAcceptedPluralForm` for Plural and `BRANCH_CONTROL_PROPS` exclusion for Branch — and is backed by five new test cases covering single-prop expansion, 3×3 cross-products, and children×named-prop cross-multiplication.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — no blocking issues found.

The only finding is a P2 style note about a redundant string-type guard (line 83 of findMultiplicationNode.ts). The fix logic is correct and consistent with the surrounding codebase, the parent mutation target is properly set to curr.props, prop filtering mirrors the canonical logic in handleChildrenWhitespace.ts, and five new tests cover all critical scenarios including cross-product multiplication.

No files require special attention.
</details>

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified. This is internal CLI tooling for AST parsing at build time; no user-facing inputs, network requests, or secrets handling are involved.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/react/jsx/utils/jsxParsing/multiplication/findMultiplicationNode.ts | Core bug fix: adds named-prop traversal for Plural/Branch after checking children, with correct parent mutation target and consistent prop filtering |
| packages/cli/src/react/jsx/utils/jsxParsing/__tests__/parseJsx.test.ts | New describe block with 5 test cases covering all major Derive-in-named-prop scenarios including cross-products and mixed children+named-prop multiplication |
| packages/cli/src/generated/version.ts | Auto-generated patch version bump from 2.14.5 to 2.14.6 |
| pnpm-lock.yaml | Routine lockfile sync accompanying the 2.14.6 version bump |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([findMultiplicationNode root]) --> B[handleChildren]
    B --> C{Array?}
    C -->|Yes| D[Iterate via Object.entries]
    D --> E[handleChild for each item]
    C -->|No| F[handleChild curr parent key]
    E --> G{isMultiplicationNode?}
    F --> G
    G -->|Yes| H([Return parent key node])
    G -->|No| I{isWhitespaceJsxTree?}
    I -->|No| J([Return undefined])
    I -->|Yes| K{has children?}
    K -->|Yes| L[handleChildren children]
    L --> M{Result?}
    M -->|Yes| N([Return result])
    M -->|No| O{Plural or Branch?}
    K -->|No| O
    O -->|No| P([Return undefined])
    O -->|Yes| Q["For each [propKey, propValue] in props"]
    Q --> R{propKey === children?}
    R -->|Yes| Q
    R -->|No| S{string value?}
    S -->|Yes| Q
    S -->|No| T{Plural and not acceptedPluralForm?}
    T -->|Yes| Q
    T -->|No| U{Branch and BRANCH_CONTROL_PROP?}
    U -->|Yes| Q
    U -->|No| V{propValue is object?}
    V -->|No| Q
    V -->|Yes| W[handleChildren propValue curr.props propKey]
    W --> X{Result?}
    X -->|Yes| Y([Return result])
    X -->|No| Q
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/cli/src/react/jsx/utils/jsxParsing/multiplication/findMultiplicationNode.ts
Line: 83

Comment:
**Redundant string guard**

The `typeof propValue === 'string'` check is redundant — the condition on line 86 (`propValue && typeof propValue === 'object'`) already excludes strings (and all other non-object primitives). Both lines are harmless together, but the early `continue` adds noise without benefit.

```suggestion
          if (propKey === 'children') continue;
```
(Remove line 83 and rely solely on the `typeof propValue === 'object'` guard two lines below.)

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["add changeset"](https://github.com/generaltranslation/gt/commit/7c9498d323c6033657fe2e65e7c4c67acfa55493) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27658732)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->