### PR TITLE
fix(cli): extend autoderive gt msg

### DIFF
--- a/.changeset/breezy-walls-hunt.md
+++ b/.changeset/breezy-walls-hunt.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+fix(cli): extend autoderive gt msg

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.14.6';
+export const PACKAGE_VERSION = '2.14.7';

--- a/packages/cli/src/react/jsx/utils/__tests__/parseStringFunction.test.ts
+++ b/packages/cli/src/react/jsx/utils/__tests__/parseStringFunction.test.ts
@@ -3299,6 +3299,123 @@ describe('parseStrings', () => {
     });
   });
 
+  describe('auto-derive for msg() and hook functions', () => {
+    const runParseStringsAutoDeriveForFunc = (
+      code: string,
+      functionName: string,
+      params: ReturnType<typeof createMockParams>
+    ) => {
+      const ast = parseCode(code);
+      traverse(ast, {
+        ImportSpecifier(path) {
+          if (
+            t.isIdentifier(path.node.imported) &&
+            path.node.imported.name === functionName &&
+            t.isIdentifier(path.node.local)
+          ) {
+            parseStrings(
+              path.node.local.name,
+              functionName,
+              path,
+              {
+                parsingOptions: params.parsingOptions,
+                file: params.file,
+                ignoreInlineMetadata: false,
+                ignoreDynamicContent: false,
+                ignoreInvalidIcu: false,
+                ignoreInlineListContent: true,
+                ignoreTaggedTemplates: false,
+                ignoreGlobalTaggedTemplates: false,
+                autoDeriveMethod: 'AUTO',
+              },
+              {
+                updates: params.updates,
+                errors: params.errors,
+                warnings: params.warnings,
+              }
+            );
+          }
+        },
+      });
+    };
+
+    it('should auto-derive msg() with template literal interpolation', () => {
+      const code = `
+        import { msg } from 'gt-react';
+        const name = "John";
+        msg(\`Hello, \${name}\`);
+      `;
+      const params = createMockParams();
+      runParseStringsAutoDeriveForFunc(code, 'msg', params);
+
+      expect(params.updates).toHaveLength(1);
+      expect(params.updates[0].source).toBe('Hello, John');
+      expect(params.errors).toHaveLength(0);
+    });
+
+    it('should auto-derive msg() with concatenation', () => {
+      const code = `
+        import { msg } from 'gt-react';
+        const name = "John";
+        msg("Hello, " + name);
+      `;
+      const params = createMockParams();
+      runParseStringsAutoDeriveForFunc(code, 'msg', params);
+
+      expect(params.updates).toHaveLength(1);
+      expect(params.updates[0].source).toBe('Hello, John');
+      expect(params.errors).toHaveLength(0);
+    });
+
+    it('should auto-derive gt() from useGT() with template literal interpolation', () => {
+      const code = `
+        import { useGT } from 'gt-react';
+        const name = "John";
+        const gt = useGT();
+        gt(\`Hello, \${name}\`);
+      `;
+      const params = createMockParams();
+      runParseStringsAutoDeriveForFunc(code, 'useGT', params);
+
+      expect(params.updates).toHaveLength(1);
+      expect(params.updates[0].source).toBe('Hello, John');
+      expect(params.errors).toHaveLength(0);
+    });
+
+    it('should auto-derive gt() from useGT() with concatenation', () => {
+      const code = `
+        import { useGT } from 'gt-react';
+        const name = "John";
+        const gt = useGT();
+        gt("Hello, " + name);
+      `;
+      const params = createMockParams();
+      runParseStringsAutoDeriveForFunc(code, 'useGT', params);
+
+      expect(params.updates).toHaveLength(1);
+      expect(params.updates[0].source).toBe('Hello, John');
+      expect(params.errors).toHaveLength(0);
+    });
+
+    it('should auto-derive gt() from getGT() with template literal interpolation', () => {
+      const code = `
+        import { getGT } from 'gt-react';
+        const name = "John";
+        async function test() {
+          const gt = await getGT();
+          gt(\`Hello, \${name}\`);
+        }
+      `;
+      const params = createMockParams();
+      runParseStringsAutoDeriveForFunc(code, 'getGT', params);
+
+      expect(params.updates).toHaveLength(1);
+      expect(params.updates[0].source).toBe('Hello, John');
+      expect(params.errors).toHaveLength(0);
+    });
+
+  });
+
   describe('recursive callback function resolution', () => {
     const runUseGTParseStrings = (
       code: string,

--- a/packages/cli/src/react/jsx/utils/__tests__/parseStringFunction.test.ts
+++ b/packages/cli/src/react/jsx/utils/__tests__/parseStringFunction.test.ts
@@ -3204,7 +3204,7 @@ describe('parseStrings', () => {
     });
   });
 
-  describe('auto-derive for t() function', () => {
+  describe('auto-derive for string registration and hook functions', () => {
     const runParseStrings = (
       code: string,
       functionName: string,
@@ -3299,75 +3299,6 @@ describe('parseStrings', () => {
       expect(params.updates[0].source).toBe('Hello, John');
       expect(params.errors).toHaveLength(0);
     });
-  });
-
-  describe('auto-derive for msg() and hook functions', () => {
-    const runParseStringsAutoDeriveForFunc = (
-      code: string,
-      functionName: string,
-      params: ReturnType<typeof createMockParams>
-    ) => {
-      const ast = parseCode(code);
-      traverse(ast, {
-        ImportSpecifier(path) {
-          if (
-            t.isIdentifier(path.node.imported) &&
-            path.node.imported.name === functionName &&
-            t.isIdentifier(path.node.local)
-          ) {
-            parseStrings(
-              path.node.local.name,
-              functionName,
-              path,
-              {
-                parsingOptions: params.parsingOptions,
-                file: params.file,
-                ignoreInlineMetadata: false,
-                ignoreDynamicContent: false,
-                ignoreInvalidIcu: false,
-                ignoreInlineListContent: true,
-                ignoreTaggedTemplates: false,
-                ignoreGlobalTaggedTemplates: false,
-                autoDeriveMethod: 'AUTO',
-              },
-              {
-                updates: params.updates,
-                errors: params.errors,
-                warnings: params.warnings,
-              }
-            );
-          }
-        },
-      });
-    };
-
-    it('should auto-derive msg() with template literal interpolation', () => {
-      const code = `
-        import { msg } from 'gt-react';
-        const name = "John";
-        msg(\`Hello, \${name}\`);
-      `;
-      const params = createMockParams();
-      runParseStringsAutoDeriveForFunc(code, 'msg', params);
-
-      expect(params.updates).toHaveLength(1);
-      expect(params.updates[0].source).toBe('Hello, John');
-      expect(params.errors).toHaveLength(0);
-    });
-
-    it('should auto-derive msg() with concatenation', () => {
-      const code = `
-        import { msg } from 'gt-react';
-        const name = "John";
-        msg("Hello, " + name);
-      `;
-      const params = createMockParams();
-      runParseStringsAutoDeriveForFunc(code, 'msg', params);
-
-      expect(params.updates).toHaveLength(1);
-      expect(params.updates[0].source).toBe('Hello, John');
-      expect(params.errors).toHaveLength(0);
-    });
 
     it('should auto-derive gt() from useGT() with template literal interpolation', () => {
       const code = `
@@ -3377,7 +3308,7 @@ describe('parseStrings', () => {
         gt(\`Hello, \${name}\`);
       `;
       const params = createMockParams();
-      runParseStringsAutoDeriveForFunc(code, 'useGT', params);
+      runParseStrings(code, 'useGT', params);
 
       expect(params.updates).toHaveLength(1);
       expect(params.updates[0].source).toBe('Hello, John');
@@ -3392,7 +3323,7 @@ describe('parseStrings', () => {
         gt("Hello, " + name);
       `;
       const params = createMockParams();
-      runParseStringsAutoDeriveForFunc(code, 'useGT', params);
+      runParseStrings(code, 'useGT', params);
 
       expect(params.updates).toHaveLength(1);
       expect(params.updates[0].source).toBe('Hello, John');
@@ -3409,7 +3340,7 @@ describe('parseStrings', () => {
         }
       `;
       const params = createMockParams();
-      runParseStringsAutoDeriveForFunc(code, 'getGT', params);
+      runParseStrings(code, 'getGT', params);
 
       expect(params.updates).toHaveLength(1);
       expect(params.updates[0].source).toBe('Hello, John');

--- a/packages/cli/src/react/jsx/utils/__tests__/parseStringFunction.test.ts
+++ b/packages/cli/src/react/jsx/utils/__tests__/parseStringFunction.test.ts
@@ -3272,7 +3272,7 @@ describe('parseStrings', () => {
       expect(params.errors).toHaveLength(0);
     });
 
-    it('should error for msg() with template literal interpolation', () => {
+    it('should auto-derive msg() with template literal interpolation', () => {
       const code = `
         import { msg } from 'gt-react';
         const name = "John";
@@ -3281,11 +3281,12 @@ describe('parseStrings', () => {
       const params = createMockParams();
       runParseStrings(code, 'msg', params);
 
-      expect(params.updates).toHaveLength(0);
-      expect(params.errors.length).toBeGreaterThan(0);
+      expect(params.updates).toHaveLength(1);
+      expect(params.updates[0].source).toBe('Hello, John');
+      expect(params.errors).toHaveLength(0);
     });
 
-    it('should error for msg() with concatenation', () => {
+    it('should auto-derive msg() with concatenation', () => {
       const code = `
         import { msg } from 'gt-react';
         const name = "John";
@@ -3294,8 +3295,9 @@ describe('parseStrings', () => {
       const params = createMockParams();
       runParseStrings(code, 'msg', params);
 
-      expect(params.updates).toHaveLength(0);
-      expect(params.errors.length).toBeGreaterThan(0);
+      expect(params.updates).toHaveLength(1);
+      expect(params.updates[0].source).toBe('Hello, John');
+      expect(params.errors).toHaveLength(0);
     });
   });
 
@@ -3413,7 +3415,6 @@ describe('parseStrings', () => {
       expect(params.updates[0].source).toBe('Hello, John');
       expect(params.errors).toHaveLength(0);
     });
-
   });
 
   describe('recursive callback function resolution', () => {

--- a/packages/cli/src/react/jsx/utils/parseStringFunction.ts
+++ b/packages/cli/src/react/jsx/utils/parseStringFunction.ts
@@ -7,7 +7,6 @@ import {
   INLINE_MESSAGE_HOOK_ASYNC,
   STRING_REGISTRATION_FUNCS,
   T_GLOBAL_REGISTRATION_FUNCTION_MARKER,
-  T_REGISTRATION_FUNCTION,
 } from './constants.js';
 import { warnAsyncUseGT, warnSyncGetGT } from '../../../console/index.js';
 

--- a/packages/cli/src/react/jsx/utils/parseStringFunction.ts
+++ b/packages/cli/src/react/jsx/utils/parseStringFunction.ts
@@ -503,7 +503,7 @@ export function parseStrings(
         refPath.parent.callee === refPath.node
       ) {
         /**
-         * SPECIAL CASE: Auto-derive t() function
+         * CASE: Auto-derive t() and msg() function
          * The t() function, will treat variable content as if it was marked for derivation
          * without explicit calls to derive().
          *
@@ -516,20 +516,16 @@ export function parseStrings(
          * );
          * // "Hello, John! My name is {interpolatedValue}"
          */
-        if (originalName === T_REGISTRATION_FUNCTION) {
-          processTranslationCall(
-            refPath,
-            config.autoDeriveMethod === 'AUTO'
-              ? {
-                  ...stringRegistrationConfig,
-                  autoDeriveMethod: 'ENABLED',
-                }
-              : stringRegistrationConfig,
-            output
-          );
-        } else {
-          processTranslationCall(refPath, stringRegistrationConfig, output);
-        }
+        processTranslationCall(
+          refPath,
+          config.autoDeriveMethod === 'AUTO'
+            ? {
+                ...stringRegistrationConfig,
+                autoDeriveMethod: 'ENABLED',
+              }
+            : stringRegistrationConfig,
+          output
+        );
       } else if (
         !stringRegistrationConfig.ignoreTaggedTemplates &&
         refPath.parent.type === 'TaggedTemplateExpression' &&
@@ -595,7 +591,9 @@ export function parseStrings(
         // User configurable, otherwise default to DISABLED
         autoDeriveMethod:
           config.autoDeriveMethod === 'AUTO'
-            ? 'DISABLED'
+            ? isInlineGT
+              ? 'ENABLED'
+              : 'DISABLED'
             : config.autoDeriveMethod,
       };
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends auto-derivation of string content to `msg()` calls and to the `useGT()`/`getGT()` hook-returned functions, which previously only applied to `t()`. The change removes the `T_REGISTRATION_FUNCTION`-specific guard in `parseStrings`, applying `autoDeriveMethod: 'ENABLED'` uniformly to all `STRING_REGISTRATION_FUNCS` in AUTO mode, and adds the same for `isInlineGT` in the hook config.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the logic change is correct and well-tested; only a leftover unused import remains.

All findings are P2. The sole issue (unused T_REGISTRATION_FUNCTION import) is a trivial cleanup that does not affect runtime behavior. The core logic change is straightforward, tests have been updated to match, and no security or data-integrity concerns exist.

packages/cli/src/react/jsx/utils/parseStringFunction.ts — minor unused import cleanup.
</details>

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/react/jsx/utils/parseStringFunction.ts | Extends auto-derive to all STRING_REGISTRATION_FUNCS (msg + t) and to useGT/getGT hooks in AUTO mode; T_REGISTRATION_FUNCTION import is now unused. |
| packages/cli/src/react/jsx/utils/__tests__/parseStringFunction.test.ts | Test expectations updated for msg() auto-derive; new tests added for useGT/getGT hook auto-derive; describe block renamed to reflect broader scope. |
| .changeset/breezy-walls-hunt.md | Changeset entry for a patch bump of the 'gt' package describing the fix. |
| packages/cli/src/generated/version.ts | Auto-generated version bump from 2.14.6 to 2.14.7. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[parseStrings called] --> B{originalName in STRING_REGISTRATION_FUNCS?}
    B -- Yes msg or t --> C{config.autoDeriveMethod === AUTO?}
    C -- Yes --> D[autoDeriveMethod = ENABLED\nprocessTranslationCall]
    C -- No --> E[use config value\nprocessTranslationCall]
    B -- No --> F{useGT / getGT / useMessages / getMessages?}
    F --> G{isInlineGT? useGT or getGT}
    G -- Yes --> H{config.autoDeriveMethod === AUTO?}
    H -- Yes --> I[autoDeriveMethod = ENABLED\nhookConfig]
    H -- No --> J[use config value\nhookConfig]
    G -- No isMessageHook --> K[autoDeriveMethod = DISABLED\nhookConfig]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/cli/src/react/jsx/utils/parseStringFunction.ts
Line: 10

Comment:
**Unused import after refactor**

`T_REGISTRATION_FUNCTION` was previously used in the `if (originalName === T_REGISTRATION_FUNCTION)` conditional that was removed in this PR. It is now an unused import and can be removed.

```suggestion
  STRING_REGISTRATION_FUNCS,
  T_GLOBAL_REGISTRATION_FUNCTION_MARKER,
} from './constants.js';
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix greptile"](https://github.com/generaltranslation/gt/commit/cde94771432f795113c4d73acd45ad86abdc438d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27773901)</sub>

<!-- /greptile_comment -->