### PR TITLE
fix(compiler): extend autoderive gt msg

### DIFF
--- a/.changeset/ninety-wings-cough.md
+++ b/.changeset/ninety-wings-cough.md
@@ -1,0 +1,5 @@
+---
+'@generaltranslation/compiler': patch
+---
+
+fix(compiler): extend autoderive gt msg

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.14.6';
+export const PACKAGE_VERSION = '2.14.7';

--- a/packages/compiler/src/config.ts
+++ b/packages/compiler/src/config.ts
@@ -35,6 +35,8 @@ export interface PluginConfig {
   stringTranslationMacro?: string;
   /** Enable Auto Jsx Injection (e.g. <div>Hello</div> -> <div><T>Hello</T></div>) */
   enableAutoJsxInjection?: boolean;
+  /** Automatically treat interpolated/concatenated values as derive() calls */
+  autoDerive?: boolean;
   /** Debug: write a hash → jsxChildren manifest file on build */
   _debugHashManifest?: boolean;
 }
@@ -55,6 +57,8 @@ export interface PluginSettings {
   enableMacroImportInjection: boolean;
   /** Enable Auto Jsx Injection (e.g. <div>Hello</div> -> <div><T>Hello</T></div>) */
   enableAutoJsxInjection: boolean;
+  /** Automatically treat interpolated/concatenated values as derive() calls */
+  autoDerive: boolean;
   /** Debug: write a hash → jsxChildren manifest file on build */
   _debugHashManifest: boolean;
 }

--- a/packages/compiler/src/state/utils/initializeState.ts
+++ b/packages/compiler/src/state/utils/initializeState.ts
@@ -18,6 +18,7 @@ const DEFAULT_SETTINGS: PluginSettings = {
   enableConcatenationArg: true,
   enableMacroImportInjection: true,
   enableAutoJsxInjection: false,
+  autoDerive: false,
   _debugHashManifest: false,
 };
 

--- a/packages/compiler/src/transform/validation/__tests__/validateTranslationFunctionCallback.test.ts
+++ b/packages/compiler/src/transform/validation/__tests__/validateTranslationFunctionCallback.test.ts
@@ -1069,6 +1069,23 @@ describe('validateTranslationFunctionCallback', () => {
       expect(result.errors).toHaveLength(0);
       expect(result.hasDeriveContext).toBe(true);
     });
+
+    it('should still reject bare variable in $context when autoDerive is enabled', () => {
+      // autoDerive only applies to content, not $context
+      const callExpr = t.callExpression(t.identifier('useGT_callback'), [
+        t.stringLiteral('Hello'),
+        t.objectExpression([
+          t.objectProperty(
+            t.identifier('$context'),
+            t.identifier('contextVar')
+          ),
+        ]),
+      ]);
+
+      const result = validateUseGTCallback(callExpr, autoDeriveState);
+
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
   });
 
   describe('$format option', () => {

--- a/packages/compiler/src/transform/validation/__tests__/validateTranslationFunctionCallback.test.ts
+++ b/packages/compiler/src/transform/validation/__tests__/validateTranslationFunctionCallback.test.ts
@@ -874,6 +874,201 @@ describe('validateTranslationFunctionCallback', () => {
 
       expect(result.errors).toHaveLength(0);
     });
+
+    it('should not error on template literal with bare variable when autoDerive is enabled', () => {
+      // msg(`Hello, ${name}`) — should pass regardless of autoDerive
+      const callExpr = t.callExpression(t.identifier('useMessages_callback'), [
+        t.templateLiteral(
+          [
+            t.templateElement({ raw: 'Hello, ', cooked: 'Hello, ' }),
+            t.templateElement({ raw: '', cooked: '' }),
+          ],
+          [t.identifier('name')]
+        ),
+      ]);
+
+      const result = validateUseMessagesCallback(callExpr);
+
+      expect(result.errors).toHaveLength(0);
+    });
+  });
+
+  describe('autoDerive', () => {
+    let autoDeriveState: TransformState;
+
+    beforeEach(() => {
+      const stringCollector = new StringCollector();
+      const logger = new Logger('silent');
+      const errorTracker = new ErrorTracker();
+      const scopeTracker = new ScopeTracker();
+      const settings: PluginSettings = {
+        logLevel: 'silent',
+        compileTimeHash: false,
+        disableBuildChecks: false,
+        autoDerive: true,
+      };
+
+      autoDeriveState = {
+        settings,
+        stringCollector,
+        scopeTracker,
+        logger,
+        errorTracker,
+        statistics: {
+          jsxElementCount: 0,
+          dynamicContentViolations: 0,
+          macroExpansionsCount: 0,
+        },
+      };
+
+      scopeTracker.trackTranslationVariable(
+        GT_OTHER_FUNCTIONS.derive,
+        GT_OTHER_FUNCTIONS.derive,
+        0
+      );
+    });
+
+    it('should accept template literal with bare variable when autoDerive is enabled', () => {
+      // gt(`Hello, ${name}`)
+      const callExpr = t.callExpression(t.identifier('useGT_callback'), [
+        t.templateLiteral(
+          [
+            t.templateElement({ raw: 'Hello, ', cooked: 'Hello, ' }),
+            t.templateElement({ raw: '', cooked: '' }),
+          ],
+          [t.identifier('name')]
+        ),
+      ]);
+
+      const result = validateUseGTCallback(callExpr, autoDeriveState);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.hasDeriveContext).toBe(true);
+    });
+
+    it('should accept concatenation with bare variable when autoDerive is enabled', () => {
+      // gt("Hello, " + name)
+      const callExpr = t.callExpression(t.identifier('useGT_callback'), [
+        t.binaryExpression(
+          '+',
+          t.stringLiteral('Hello, '),
+          t.identifier('name')
+        ),
+      ]);
+
+      const result = validateUseGTCallback(callExpr, autoDeriveState);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.hasDeriveContext).toBe(true);
+    });
+
+    it('should accept template literal with bare function call when autoDerive is enabled', () => {
+      // gt(`Hello, ${getName()}`)
+      const callExpr = t.callExpression(t.identifier('useGT_callback'), [
+        t.templateLiteral(
+          [
+            t.templateElement({ raw: 'Hello, ', cooked: 'Hello, ' }),
+            t.templateElement({ raw: '', cooked: '' }),
+          ],
+          [t.callExpression(t.identifier('getName'), [])]
+        ),
+      ]);
+
+      const result = validateUseGTCallback(callExpr, autoDeriveState);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.hasDeriveContext).toBe(true);
+    });
+
+    it('should accept concatenation with bare function call when autoDerive is enabled', () => {
+      // gt("Hello, " + getName())
+      const callExpr = t.callExpression(t.identifier('useGT_callback'), [
+        t.binaryExpression(
+          '+',
+          t.stringLiteral('Hello, '),
+          t.callExpression(t.identifier('getName'), [])
+        ),
+      ]);
+
+      const result = validateUseGTCallback(callExpr, autoDeriveState);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.hasDeriveContext).toBe(true);
+    });
+
+    it('should reject template literal with bare variable when autoDerive is disabled', () => {
+      // gt(`Hello, ${name}`) with autoDerive off (default state)
+      const callExpr = t.callExpression(t.identifier('useGT_callback'), [
+        t.templateLiteral(
+          [
+            t.templateElement({ raw: 'Hello, ', cooked: 'Hello, ' }),
+            t.templateElement({ raw: '', cooked: '' }),
+          ],
+          [t.identifier('name')]
+        ),
+      ]);
+
+      const result = validateUseGTCallback(callExpr, state);
+
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
+
+    it('should reject concatenation with bare variable when autoDerive is disabled', () => {
+      // gt("Hello, " + name) with autoDerive off (default state)
+      const callExpr = t.callExpression(t.identifier('useGT_callback'), [
+        t.binaryExpression(
+          '+',
+          t.stringLiteral('Hello, '),
+          t.identifier('name')
+        ),
+      ]);
+
+      const result = validateUseGTCallback(callExpr, state);
+
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
+
+    it('should accept mixed explicit derive and bare variable when autoDerive is enabled', () => {
+      // gt(`Hello, ${derive(getName())} and ${name}`)
+      const deriveCall = t.callExpression(
+        t.identifier(GT_OTHER_FUNCTIONS.derive),
+        [t.callExpression(t.identifier('getName'), [])]
+      );
+
+      const callExpr = t.callExpression(t.identifier('useGT_callback'), [
+        t.templateLiteral(
+          [
+            t.templateElement({ raw: 'Hello, ', cooked: 'Hello, ' }),
+            t.templateElement({ raw: ' and ', cooked: ' and ' }),
+            t.templateElement({ raw: '', cooked: '' }),
+          ],
+          [deriveCall, t.identifier('name')]
+        ),
+      ]);
+
+      const result = validateUseGTCallback(callExpr, autoDeriveState);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.hasDeriveContext).toBe(true);
+    });
+
+    it('should accept getGT_callback with template literal and bare variable when autoDerive is enabled', () => {
+      // const gt = getGT(); gt(`Hello, ${name}`)
+      const callExpr = t.callExpression(t.identifier('getGT_callback'), [
+        t.templateLiteral(
+          [
+            t.templateElement({ raw: 'Hello, ', cooked: 'Hello, ' }),
+            t.templateElement({ raw: '', cooked: '' }),
+          ],
+          [t.identifier('name')]
+        ),
+      ]);
+
+      const result = validateUseGTCallback(callExpr, autoDeriveState);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.hasDeriveContext).toBe(true);
+    });
   });
 
   describe('$format option', () => {

--- a/packages/compiler/src/transform/validation/__tests__/validateTranslationFunctionCallback.test.ts
+++ b/packages/compiler/src/transform/validation/__tests__/validateTranslationFunctionCallback.test.ts
@@ -26,6 +26,15 @@ describe('validateTranslationFunctionCallback', () => {
       logLevel: 'silent',
       compileTimeHash: false,
       disableBuildChecks: false,
+      enableMacroTransform: true,
+      stringTranslationMacro: GT_OTHER_FUNCTIONS.t,
+      enableTaggedTemplate: true,
+      enableTemplateLiteralArg: true,
+      enableConcatenationArg: true,
+      enableMacroImportInjection: true,
+      enableAutoJsxInjection: false,
+      autoDerive: false,
+      _debugHashManifest: false,
     };
 
     state = {
@@ -38,6 +47,7 @@ describe('validateTranslationFunctionCallback', () => {
         jsxElementCount: 0,
         dynamicContentViolations: 0,
         macroExpansionsCount: 0,
+        jsxInsertionsCount: 0,
       },
     };
 
@@ -905,7 +915,15 @@ describe('validateTranslationFunctionCallback', () => {
         logLevel: 'silent',
         compileTimeHash: false,
         disableBuildChecks: false,
+        enableMacroTransform: true,
+        stringTranslationMacro: GT_OTHER_FUNCTIONS.t,
+        enableTaggedTemplate: true,
+        enableTemplateLiteralArg: true,
+        enableConcatenationArg: true,
+        enableMacroImportInjection: true,
+        enableAutoJsxInjection: false,
         autoDerive: true,
+        _debugHashManifest: false,
       };
 
       autoDeriveState = {
@@ -918,6 +936,7 @@ describe('validateTranslationFunctionCallback', () => {
           jsxElementCount: 0,
           dynamicContentViolations: 0,
           macroExpansionsCount: 0,
+          jsxInsertionsCount: 0,
         },
       };
 

--- a/packages/compiler/src/transform/validation/validateTranslationFunctionCallback.ts
+++ b/packages/compiler/src/transform/validation/validateTranslationFunctionCallback.ts
@@ -50,8 +50,8 @@ export function validateUseGTCallback(
   );
   const content = validatedContent.value;
 
-  if (content === undefined) {
-    // expression is not a string literal. Check if it contains a derive() function invocation
+  if (content === undefined && !state.settings.autoDerive) {
+    // Check if it contains a derive() function invocation (no requirement for derive() invoc with autoDerive)
     validateDerive(callExpr.arguments[0], state, errors);
     if (errors.length > 0) {
       errors.push(...validatedContent.errors);
@@ -61,6 +61,14 @@ export function validateUseGTCallback(
       return { errors };
     }
   }
+
+  // TODO: hasDeriveContext should be refactored to enforce no hash generated HERE in this function
+  // instead of passing that information outside of this function.
+  // We skip hash gen with autoDerive, derive in content, and derive in $context. This flag is being
+  // reused for all 3 cases.
+  const contentHasAutoDerive =
+    state.settings.autoDerive && content === undefined;
+
   // Validate second argument
   let context: string | undefined;
   let id: string | undefined;
@@ -69,7 +77,11 @@ export function validateUseGTCallback(
   let format: string | undefined;
   let hasDeriveContext: boolean | undefined;
   if (callExpr.arguments.length === 1) {
-    return { errors, content };
+    return {
+      errors,
+      content,
+      hasDeriveContext: contentHasAutoDerive || undefined,
+    };
   }
   if (t.isObjectExpression(callExpr.arguments[1])) {
     const contextProperty = validatePropertyFromObjectExpression(
@@ -80,7 +92,8 @@ export function validateUseGTCallback(
     );
     errors.push(...contextProperty.errors);
     context = contextProperty.value as string | undefined;
-    hasDeriveContext = contextProperty.hasDeriveExpression;
+    hasDeriveContext =
+      contentHasAutoDerive || contextProperty.hasDeriveExpression;
     const idProperty = validatePropertyFromObjectExpression(
       callExpr.arguments[1],
       USEGT_CALLBACK_OPTIONS.$id,


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces an `autoDerive` option to the compiler plugin that, when enabled, suppresses validation errors for bare variables (identifiers, template literals with expressions, concatenations) in `gt()` / `getGT()` content — allowing dynamic values without requiring explicit `derive()` wrapping. The feature is wired through `PluginConfig`, `PluginSettings`, and `initializeState` with a safe `false` default, and is guarded correctly in the validator.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — changes are well-scoped, opt-in with a `false` default, and covered by comprehensive tests.

All remaining findings are P2 (misleading test description). The core logic is correct: `autoDerive` is opt-in, the validator correctly skips `validateDerive` when the flag is set, `contentHasAutoDerive` properly drives `hasDeriveContext`, and the caller's early-return guard on `content === undefined` ensures no partial registration occurs. No correctness or data-integrity issues were found.

No files require special attention.
</details>

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified. The `autoDerive` flag is a compile-time validation relaxation that does not affect runtime behavior or introduce any injection vectors.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/compiler/src/transform/validation/validateTranslationFunctionCallback.ts | Core logic change: skips `validateDerive` when `autoDerive=true` and content is not a string literal; introduces `contentHasAutoDerive` flag to propagate `hasDeriveContext=true` so callers skip hash generation. |
| packages/compiler/src/config.ts | Adds `autoDerive?: boolean` to `PluginConfig` and `autoDerive: boolean` to `PluginSettings` in consistent positions. |
| packages/compiler/src/state/utils/initializeState.ts | Adds `autoDerive: false` to `DEFAULT_SETTINGS`, keeping existing behaviour unchanged unless explicitly opted-in. |
| packages/compiler/src/transform/validation/__tests__/validateTranslationFunctionCallback.test.ts | Comprehensive autoDerive test suite added; one test inside the `useMessages_callback` block has a misleading description mentioning autoDerive but doesn't test that feature. |
| packages/cli/src/generated/version.ts | Auto-generated version bump from 2.14.6 to 2.14.7. |
| .changeset/ninety-wings-cough.md | Changeset entry marking a patch release for `@generaltranslation/compiler`. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["validateUseGTCallback(callExpr, state)"] --> B["validateExpressionIsStringLiteral(arg0)"]
    B --> C{content defined?}
    C -- Yes --> F["contentHasAutoDerive = false"]
    C -- No --> D{autoDerive enabled?}
    D -- No --> E["validateDerive(arg0) → push errors on failure"]
    E --> F
    D -- Yes --> G["contentHasAutoDerive = true\n(skip derive validation)"]
    G --> H{numArgs == 1?}
    F --> H
    H -- Yes --> I["return {errors, content,\nhasDeriveContext: contentHasAutoDerive || undefined}"]
    H -- No --> J["validatePropertyFromObjectExpression\n($context, $id, $maxChars, $_hash, $format)"]
    J --> K["hasDeriveContext =\ncontentHasAutoDerive || hasDeriveExpression"]
    K --> L["return {errors, content, context, id, hash,\nmaxChars, format, hasDeriveContext}"]

    subgraph Caller ["processCallExpression.ts (caller)"]
        M["errors.length > 0 OR content === undefined?"] -- Yes --> N["return early (no registration)"]
        M -- No --> O["hash = hasDeriveContext ? '' : hash\nregisterUseGTCallback(...)"]
    end
    L --> M
    I --> M
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/compiler/src/transform/validation/__tests__/validateTranslationFunctionCallback.test.ts
Line: 888-903

Comment:
**Misleading test description**

The test is named "should not error on template literal with bare variable when autoDerive is enabled", but it's placed in the `useMessages_callback` describe block and calls `validateUseMessagesCallback` without an `autoDerive` state — that validator is a no-op and always returns zero errors regardless of settings. The description implies autoDerive is being exercised here, but it isn't.

```suggestion
    it('should always accept any argument (useMessages_callback is unconditionally valid)', () => {
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["greptile feedback"](https://github.com/generaltranslation/gt/commit/5cb5763571a5ee3c879a206f97f89ddfa3639f92) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27773914)</sub>

<!-- /greptile_comment -->