### PR TITLE
fix(swc): extend autoderive gt msg

### DIFF
--- a/.changeset/extend-autoderive-swc.md
+++ b/.changeset/extend-autoderive-swc.md
@@ -1,0 +1,5 @@
+---
+'gt-next': patch
+---
+
+feat(swc): support autoDerive flag in SWC plugin to allow bare variables and function calls in gt() template literals and concatenations

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.14.6';
+export const PACKAGE_VERSION = '2.14.7';

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -93,8 +93,7 @@ export function withGTConfig(
   props: withGTConfigProps = {}
 ) {
   // ---------- LOAD GT CONFIG FILE ---------- //
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let rawConfig: any = {};
+
   let loadedConfig: Partial<withGTConfigProps> = {};
   try {
     let configPath: string | undefined;
@@ -111,8 +110,7 @@ export function withGTConfig(
     }
     if (typeof configPath === 'string' && fs.existsSync(configPath)) {
       const fileContent = fs.readFileSync(configPath, 'utf-8');
-      rawConfig = JSON.parse(fileContent);
-      loadedConfig = rawConfig;
+      loadedConfig = JSON.parse(fileContent);
     }
   } catch (error) {
     console.error('Error reading GT config file:', error);
@@ -531,7 +529,7 @@ export function withGTConfig(
     mergedConfig.experimentalCompilerOptions || {};
 
   // Read autoDerive from parsingFlags (single source of truth shared with CLI)
-  const autoDerive = rawConfig?.files?.gt?.parsingFlags?.autoDerive === true;
+  const autoDerive = loadedConfig?.files?.gt?.parsingFlags?.autoDerive === true;
 
   const swcPluginEntry =
     mergedConfig.experimentalCompilerOptions?.type === 'swc'

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -93,6 +93,8 @@ export function withGTConfig(
   props: withGTConfigProps = {}
 ) {
   // ---------- LOAD GT CONFIG FILE ---------- //
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let rawConfig: any = {};
   let loadedConfig: Partial<withGTConfigProps> = {};
   try {
     let configPath: string | undefined;
@@ -109,7 +111,8 @@ export function withGTConfig(
     }
     if (typeof configPath === 'string' && fs.existsSync(configPath)) {
       const fileContent = fs.readFileSync(configPath, 'utf-8');
-      loadedConfig = JSON.parse(fileContent);
+      rawConfig = JSON.parse(fileContent);
+      loadedConfig = rawConfig;
     }
   } catch (error) {
     console.error('Error reading GT config file:', error);
@@ -527,9 +530,12 @@ export function withGTConfig(
   const { type, ...compilerOptions } =
     mergedConfig.experimentalCompilerOptions || {};
 
+  // Read autoDerive from parsingFlags (single source of truth shared with CLI)
+  const autoDerive = rawConfig?.files?.gt?.parsingFlags?.autoDerive === true;
+
   const swcPluginEntry =
     mergedConfig.experimentalCompilerOptions?.type === 'swc'
-      ? [resolvedWasmFilePath, compilerOptions]
+      ? [resolvedWasmFilePath, { ...compilerOptions, autoDerive }]
       : null;
 
   const turboAliases = {

--- a/packages/next/swc-plugin/src/ast/traversal.rs
+++ b/packages/next/swc-plugin/src/ast/traversal.rs
@@ -755,7 +755,7 @@ mod tests {
       statistics: Statistics::default(),
       traversal_state: TraversalState::default(),
       import_tracker: ImportTracker::default(),
-      settings: PluginSettings::new(LogLevel::Silent, false, None, false),
+      settings: PluginSettings::new(LogLevel::Silent, false, None, false, false),
       logger: Logger::new(LogLevel::Silent),
       string_collector: crate::ast::StringCollector::new(),
     }

--- a/packages/next/swc-plugin/src/config.rs
+++ b/packages/next/swc-plugin/src/config.rs
@@ -12,15 +12,18 @@ pub struct PluginSettings {
   pub filename: Option<String>,
   /// Disable dynamic content check
   pub disable_build_checks: bool,
+  /// When true, bare variables/calls in template literals and concatenations are allowed
+  pub auto_derive: bool,
 }
 
 impl PluginSettings {
-  pub fn new(log_level: LogLevel, compile_time_hash: bool, filename: Option<String>, disable_build_checks: bool) -> Self {
+  pub fn new(log_level: LogLevel, compile_time_hash: bool, filename: Option<String>, disable_build_checks: bool, auto_derive: bool) -> Self {
     Self {
       log_level,
       compile_time_hash,
       filename,
       disable_build_checks,
+      auto_derive,
     }
   }
 }
@@ -37,6 +40,8 @@ pub struct PluginConfig {
   pub filename: Option<String>,
   #[serde(default)]
   pub disable_build_checks: bool,
+  #[serde(default)]
+  pub auto_derive: bool,
 }
 
 impl Default for PluginConfig {
@@ -46,6 +51,7 @@ impl Default for PluginConfig {
       compile_time_hash: false,
       filename: None,
       disable_build_checks: false,
+      auto_derive: false,
     }
   }
 }

--- a/packages/next/swc-plugin/src/lib.rs
+++ b/packages/next/swc-plugin/src/lib.rs
@@ -380,6 +380,7 @@ pub fn process_transform(program: Program, metadata: TransformPluginProgramMetad
     config.compile_time_hash,
     filename.clone(),
     config.disable_build_checks,
+    config.auto_derive,
     string_collector,
   );
   program.visit_mut_with(&mut visitor);
@@ -397,6 +398,7 @@ pub fn process_transform(program: Program, metadata: TransformPluginProgramMetad
     config.compile_time_hash,
     filename,
     config.disable_build_checks,
+    config.auto_derive,
     collected_data,
   );
   program.fold_with(&mut visitor)

--- a/packages/next/swc-plugin/src/visitor/transform.rs
+++ b/packages/next/swc-plugin/src/visitor/transform.rs
@@ -1766,6 +1766,304 @@ mod tests {
     }
   }
 
+  mod auto_derive_violations {
+    use super::*;
+
+    /// Creates a visitor with auto_derive enabled and standard imports tracked
+    fn create_visitor_with_auto_derive() -> TransformVisitor {
+      let mut visitor =
+        TransformVisitor::new(LogLevel::Silent, false, None, false, StringCollector::new());
+      visitor.settings.auto_derive = true;
+
+      // Track standard gt-next imports
+      visitor
+        .import_tracker
+        .scope_tracker
+        .track_translation_variable(Atom::new("T"), Atom::new("T"), 0);
+      visitor
+        .import_tracker
+        .scope_tracker
+        .track_translation_variable(Atom::new("useGT"), Atom::new("useGT"), 0);
+      visitor
+        .import_tracker
+        .scope_tracker
+        .track_translation_variable(Atom::new("gt"), Atom::new("gt"), 0);
+      visitor
+        .import_tracker
+        .scope_tracker
+        .track_translation_variable(Atom::new("t"), Atom::new("t"), 0);
+
+      visitor
+    }
+
+    fn create_call_expr(function_name: &str, arg: Expr) -> CallExpr {
+      CallExpr {
+        span: DUMMY_SP,
+        callee: Callee::Expr(Box::new(Expr::Ident(Ident {
+          span: DUMMY_SP,
+          sym: Atom::new(function_name),
+          optional: false,
+          ctxt: SyntaxContext::empty(),
+        }))),
+        args: vec![ExprOrSpread {
+          spread: None,
+          expr: Box::new(arg),
+        }],
+        type_args: None,
+        ctxt: SyntaxContext::empty(),
+      }
+    }
+
+    /// `Hello ${name}` — template literal with bare variable interpolation
+    fn create_template_literal_with_variable() -> Expr {
+      Expr::Tpl(Tpl {
+        span: DUMMY_SP,
+        exprs: vec![Box::new(Expr::Ident(Ident {
+          span: DUMMY_SP,
+          sym: Atom::new("name"),
+          optional: false,
+          ctxt: SyntaxContext::empty(),
+        }))],
+        quasis: vec![
+          TplElement {
+            span: DUMMY_SP,
+            tail: false,
+            cooked: Some(Atom::new("Hello ").into()),
+            raw: Atom::new("Hello "),
+          },
+          TplElement {
+            span: DUMMY_SP,
+            tail: true,
+            cooked: Some(Atom::new("!").into()),
+            raw: Atom::new("!"),
+          },
+        ],
+      })
+    }
+
+    /// "Hello " + name — string concatenation with bare variable
+    fn create_string_concat_with_variable() -> Expr {
+      Expr::Bin(BinExpr {
+        span: DUMMY_SP,
+        op: BinaryOp::Add,
+        left: Box::new(Expr::Lit(Lit::Str(Str {
+          span: DUMMY_SP,
+          value: Atom::new("Hello ").into(),
+          raw: None,
+        }))),
+        right: Box::new(Expr::Ident(Ident {
+          span: DUMMY_SP,
+          sym: Atom::new("name"),
+          optional: false,
+          ctxt: SyntaxContext::empty(),
+        })),
+      })
+    }
+
+    /// `Hello ${getName()}` — template literal with bare function call
+    fn create_template_literal_with_function_call() -> Expr {
+      Expr::Tpl(Tpl {
+        span: DUMMY_SP,
+        exprs: vec![Box::new(Expr::Call(CallExpr {
+          span: DUMMY_SP,
+          callee: Callee::Expr(Box::new(Expr::Ident(Ident {
+            span: DUMMY_SP,
+            sym: Atom::new("getName"),
+            optional: false,
+            ctxt: SyntaxContext::empty(),
+          }))),
+          args: vec![],
+          type_args: None,
+          ctxt: SyntaxContext::empty(),
+        }))],
+        quasis: vec![
+          TplElement {
+            span: DUMMY_SP,
+            tail: false,
+            cooked: Some(Atom::new("Hello ").into()),
+            raw: Atom::new("Hello "),
+          },
+          TplElement {
+            span: DUMMY_SP,
+            tail: true,
+            cooked: Some(Atom::new("!").into()),
+            raw: Atom::new("!"),
+          },
+        ],
+      })
+    }
+
+    // ── Auto-derive ON: should NOT produce violations ──
+
+    // gt(`Hello ${name}!`)  →  treated as gt(`Hello ${derive(name)}!`)
+    #[test]
+    fn auto_derive_on_allows_template_literal_with_bare_variable() {
+      let mut visitor = create_visitor_with_auto_derive();
+      let call_expr = create_call_expr("gt", create_template_literal_with_variable());
+
+      if let Some(first_arg) = call_expr.args.first() {
+        visitor.check_call_expr_for_violations(first_arg, "gt");
+      }
+
+      assert_eq!(visitor.statistics.dynamic_content_violations, 0);
+    }
+
+    // gt("Hello " + name)  →  treated as gt("Hello " + derive(name))
+    #[test]
+    fn auto_derive_on_allows_concatenation_with_bare_variable() {
+      let mut visitor = create_visitor_with_auto_derive();
+      let call_expr = create_call_expr("gt", create_string_concat_with_variable());
+
+      if let Some(first_arg) = call_expr.args.first() {
+        visitor.check_call_expr_for_violations(first_arg, "gt");
+      }
+
+      assert_eq!(visitor.statistics.dynamic_content_violations, 0);
+    }
+
+    // gt(`Hello ${getName()}!`)  →  treated as gt(`Hello ${derive(getName())}!`)
+    #[test]
+    fn auto_derive_on_allows_template_literal_with_bare_function_call() {
+      let mut visitor = create_visitor_with_auto_derive();
+      let call_expr = create_call_expr("gt", create_template_literal_with_function_call());
+
+      if let Some(first_arg) = call_expr.args.first() {
+        visitor.check_call_expr_for_violations(first_arg, "gt");
+      }
+
+      assert_eq!(visitor.statistics.dynamic_content_violations, 0);
+    }
+
+    // ── Auto-derive OFF: should produce violations (existing behavior) ──
+
+    // gt(`Hello ${name}!`)  →  ERROR: bare variable without derive()
+    #[test]
+    fn auto_derive_off_rejects_template_literal_with_bare_variable() {
+      let mut visitor = create_visitor_with_imports(); // auto_derive defaults to false
+      let call_expr = create_call_expr("gt", create_template_literal_with_variable());
+
+      if let Some(first_arg) = call_expr.args.first() {
+        visitor.check_call_expr_for_violations(first_arg, "gt");
+      }
+
+      assert_eq!(visitor.statistics.dynamic_content_violations, 1);
+    }
+
+    // gt("Hello " + name)  →  ERROR: bare variable without derive()
+    #[test]
+    fn auto_derive_off_rejects_concatenation_with_bare_variable() {
+      let mut visitor = create_visitor_with_imports(); // auto_derive defaults to false
+      let call_expr = create_call_expr("gt", create_string_concat_with_variable());
+
+      if let Some(first_arg) = call_expr.args.first() {
+        visitor.check_call_expr_for_violations(first_arg, "gt");
+      }
+
+      assert_eq!(visitor.statistics.dynamic_content_violations, 1);
+    }
+
+    // ── Existing behavior preserved regardless of auto-derive flag ──
+
+    // gt(`Hello ${derive(getName())}`)  →  explicit derive() always works
+    #[test]
+    fn explicit_derive_works_with_auto_derive_on() {
+      let mut visitor = create_visitor_with_auto_derive();
+      // Also track derive import
+      visitor
+        .import_tracker
+        .scope_tracker
+        .track_translation_variable(Atom::new("derive"), Atom::new("declareStatic"), 0);
+
+      let template_expr = Expr::Tpl(Tpl {
+        span: DUMMY_SP,
+        exprs: vec![Box::new(Expr::Call(CallExpr {
+          span: DUMMY_SP,
+          callee: Callee::Expr(Box::new(Expr::Ident(Ident {
+            span: DUMMY_SP,
+            sym: Atom::new("derive"),
+            optional: false,
+            ctxt: SyntaxContext::empty(),
+          }))),
+          args: vec![ExprOrSpread {
+            spread: None,
+            expr: Box::new(Expr::Call(CallExpr {
+              span: DUMMY_SP,
+              callee: Callee::Expr(Box::new(Expr::Ident(Ident {
+                span: DUMMY_SP,
+                sym: Atom::new("getName"),
+                optional: false,
+                ctxt: SyntaxContext::empty(),
+              }))),
+              args: vec![],
+              type_args: None,
+              ctxt: SyntaxContext::empty(),
+            })),
+          }],
+          type_args: None,
+          ctxt: SyntaxContext::empty(),
+        }))],
+        quasis: vec![
+          TplElement {
+            span: DUMMY_SP,
+            tail: false,
+            cooked: Some(Atom::new("Hello ").into()),
+            raw: Atom::new("Hello "),
+          },
+          TplElement {
+            span: DUMMY_SP,
+            tail: true,
+            cooked: Some(Atom::new("").into()),
+            raw: Atom::new(""),
+          },
+        ],
+      });
+
+      let call_expr = create_call_expr("gt", template_expr);
+
+      if let Some(first_arg) = call_expr.args.first() {
+        visitor.check_call_expr_for_violations(first_arg, "gt");
+      }
+
+      assert_eq!(visitor.statistics.dynamic_content_violations, 0);
+    }
+
+    // gt("Hello world")  →  plain string literal always passes
+    #[test]
+    fn plain_string_literal_works_with_auto_derive_on() {
+      let mut visitor = create_visitor_with_auto_derive();
+      let string_literal = Expr::Lit(Lit::Str(Str {
+        span: DUMMY_SP,
+        value: Atom::new("Hello world").into(),
+        raw: None,
+      }));
+      let call_expr = create_call_expr("gt", string_literal);
+
+      if let Some(first_arg) = call_expr.args.first() {
+        visitor.check_call_expr_for_violations(first_arg, "gt");
+      }
+
+      assert_eq!(visitor.statistics.dynamic_content_violations, 0);
+    }
+
+    // gt("Hello world")  →  plain string literal always passes
+    #[test]
+    fn plain_string_literal_works_with_auto_derive_off() {
+      let mut visitor = create_visitor_with_imports(); // auto_derive defaults to false
+      let string_literal = Expr::Lit(Lit::Str(Str {
+        span: DUMMY_SP,
+        value: Atom::new("Hello world").into(),
+        raw: None,
+      }));
+      let call_expr = create_call_expr("gt", string_literal);
+
+      if let Some(first_arg) = call_expr.args.first() {
+        visitor.check_call_expr_for_violations(first_arg, "gt");
+      }
+
+      assert_eq!(visitor.statistics.dynamic_content_violations, 0);
+    }
+  }
+
   mod variable_assignment_tracking {
     use super::*;
 

--- a/packages/next/swc-plugin/src/visitor/transform.rs
+++ b/packages/next/swc-plugin/src/visitor/transform.rs
@@ -34,7 +34,7 @@ pub struct TransformVisitor {
 
 impl Default for TransformVisitor {
   fn default() -> Self {
-    Self::new(LogLevel::Warn, false, None, false, StringCollector::new())
+    Self::new(LogLevel::Warn, false, None, false, false, StringCollector::new())
   }
 }
 
@@ -44,6 +44,7 @@ impl TransformVisitor {
     compile_time_hash: bool,
     filename: Option<String>,
     disable_build_checks: bool,
+    auto_derive: bool,
     mut string_collector: StringCollector,
   ) -> Self {
     // Reset the counter to 0
@@ -52,7 +53,7 @@ impl TransformVisitor {
       traversal_state: TraversalState::default(),
       statistics: Statistics::default(),
       import_tracker: ImportTracker::new(),
-      settings: PluginSettings::new(log_level.clone(), compile_time_hash, filename.clone(), disable_build_checks),
+      settings: PluginSettings::new(log_level.clone(), compile_time_hash, filename.clone(), disable_build_checks, auto_derive),
       logger: Logger::new(log_level),
       string_collector,
     }
@@ -319,7 +320,7 @@ impl TransformVisitor {
     self.validate_string_literal_or_declare_static(arg.expr.as_ref(), &mut errors);
 
     if !errors.is_empty() {
-      if !self.settings.disable_build_checks {
+      if !self.settings.disable_build_checks && !self.settings.auto_derive {
         self.statistics.dynamic_content_violations += 1;
         // Use the first error message for the violation type
         let default_error = &"invalid expression".to_string();
@@ -768,7 +769,7 @@ mod tests {
 
   // Helper to create a test visitor with specific imports
   fn create_visitor_with_imports() -> TransformVisitor {
-    let mut visitor = TransformVisitor::new(LogLevel::Silent, false, None, false, StringCollector::new());
+    let mut visitor = TransformVisitor::new(LogLevel::Silent, false, None, false, false, StringCollector::new());
 
     // Add some test imports using the scope tracker
     visitor
@@ -938,6 +939,7 @@ mod tests {
         true,
         Some("test.tsx".to_string()),
         false,
+        false,
         StringCollector::new(),
       );
 
@@ -1025,7 +1027,7 @@ mod tests {
 
     #[test]
     fn creates_dynamic_content_warning_without_filename() {
-      TransformVisitor::new(LogLevel::Warn, false, None, false, StringCollector::new());
+      TransformVisitor::new(LogLevel::Warn, false, None, false, false, StringCollector::new());
       let warning = create_dynamic_content_warning(None, "T");
 
       assert!(warning.contains("gt-next"));
@@ -1041,6 +1043,7 @@ mod tests {
         false,
         Some("components/Test.tsx".to_string()),
         false,
+        false,
         StringCollector::new(),
       );
       let warning = create_dynamic_content_warning(Some("components/Test.tsx"), "T");
@@ -1051,7 +1054,7 @@ mod tests {
 
     #[test]
     fn creates_dynamic_function_warning_without_filename() {
-      TransformVisitor::new(LogLevel::Warn, false, None, false, StringCollector::new());
+      TransformVisitor::new(LogLevel::Warn, false, None, false, false, StringCollector::new());
       let warning = create_dynamic_function_warning(None, "useGT", "template literals");
 
       assert!(warning.contains("gt-next"));
@@ -1066,6 +1069,7 @@ mod tests {
         LogLevel::Warn,
         false,
         Some("hooks/useTranslation.ts".to_string()),
+        false,
         false,
         StringCollector::new(),
       );
@@ -1086,7 +1090,7 @@ mod tests {
     #[test]
     fn processes_gt_next_named_imports() {
       let mut visitor =
-        TransformVisitor::new(LogLevel::Silent, false, None, false, StringCollector::new());
+        TransformVisitor::new(LogLevel::Silent, false, None, false, false, StringCollector::new());
       let import_decl = create_import_decl(
         "gt-next",
         vec![
@@ -1119,7 +1123,7 @@ mod tests {
     #[test]
     fn processes_namespace_imports() {
       let mut visitor =
-        TransformVisitor::new(LogLevel::Silent, false, None, false, StringCollector::new());
+        TransformVisitor::new(LogLevel::Silent, false, None, false, false, StringCollector::new());
       let import_decl = create_import_decl("gt-next", vec![create_namespace_import("GT")]);
 
       visitor.process_gt_import_declaration(&import_decl);
@@ -1133,7 +1137,7 @@ mod tests {
     #[test]
     fn processes_gt_next_client_imports() {
       let mut visitor =
-        TransformVisitor::new(LogLevel::Silent, false, None, false, StringCollector::new());
+        TransformVisitor::new(LogLevel::Silent, false, None, false, false, StringCollector::new());
       let import_decl = create_import_decl("gt-next/client", vec![create_named_import("T", None)]);
 
       visitor.process_gt_import_declaration(&import_decl);
@@ -1148,7 +1152,7 @@ mod tests {
     #[test]
     fn ignores_non_gt_imports() {
       let mut visitor =
-        TransformVisitor::new(LogLevel::Silent, false, None, false, StringCollector::new());
+        TransformVisitor::new(LogLevel::Silent, false, None, false, false, StringCollector::new());
       let import_decl = create_import_decl("react", vec![create_named_import("React", None)]);
 
       visitor.process_gt_import_declaration(&import_decl);
@@ -1772,7 +1776,7 @@ mod tests {
     /// Creates a visitor with auto_derive enabled and standard imports tracked
     fn create_visitor_with_auto_derive() -> TransformVisitor {
       let mut visitor =
-        TransformVisitor::new(LogLevel::Silent, false, None, false, StringCollector::new());
+        TransformVisitor::new(LogLevel::Silent, false, None, false, false, StringCollector::new());
       visitor.settings.auto_derive = true;
 
       // Track standard gt-next imports
@@ -2141,7 +2145,7 @@ mod tests {
     #[test]
     fn calculates_hash_for_empty_element() {
       let mut visitor =
-        TransformVisitor::new(LogLevel::Silent, false, None, false, StringCollector::new());
+        TransformVisitor::new(LogLevel::Silent, false, None, false, false, StringCollector::new());
       let element = create_jsx_element("T", vec![]);
 
       let mut traversal = crate::ast::JsxTraversal::new(&mut visitor);
@@ -2155,7 +2159,7 @@ mod tests {
     #[test]
     fn hash_changes_with_different_content() {
       let mut visitor =
-        TransformVisitor::new(LogLevel::Silent, false, None, false, StringCollector::new());
+        TransformVisitor::new(LogLevel::Silent, false, None, false, false, StringCollector::new());
 
       let element1 = create_jsx_element("T", vec![]);
       let mut element2 = create_jsx_element("T", vec![]);
@@ -2185,6 +2189,7 @@ mod tests {
         LogLevel::Silent,
         false,
         Some("test.tsx".to_string()),
+        false,
         false,
         StringCollector::new(),
       );


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an `autoDerive` flag to the SWC plugin, allowing bare variables and function calls inside `gt()` template literals and string concatenations to bypass the dynamic-content violation check at build time. The flag is threaded from `gt.config.json` (via `rawConfig?.files?.gt?.parsingFlags?.autoDerive`) through `withGTConfig` into the SWC plugin config, with corresponding Rust changes to `PluginSettings`, `PluginConfig`, and the violation-check logic in `check_call_expr_for_violations`.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; all remaining findings are P2 style suggestions that do not affect correctness.

The core logic is sound: `auto_derive` suppresses the violation counter and log without disrupting the caller's tracking flow, and the panic guard in lib.rs remains correct because the counter is never incremented when `auto_derive=true`. The two P2 comments (shallow-copy aliasing and hard-coded config path) are hygiene suggestions with no current impact on runtime behavior.

packages/next/src/config.ts — the rawConfig/loadedConfig aliasing and deep optional-chain path are worth a second read.
</details>

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified. The new `autoDerive` flag is a boolean read from a local config file and deserialized with `serde` defaults; there is no user-controlled input path or injection surface introduced.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/next/src/config.ts | Introduces `rawConfig` to preserve the raw parsed JSON for deep path access; reads `autoDerive` from `rawConfig?.files?.gt?.parsingFlags?.autoDerive` and forwards it to the SWC plugin. The alias `loadedConfig = rawConfig` is a reference assignment worth noting. |
| packages/next/swc-plugin/src/config.rs | Adds `auto_derive: bool` to both `PluginSettings` and `PluginConfig` with a `#[serde(default)]` annotation; constructor updated consistently. |
| packages/next/swc-plugin/src/visitor/transform.rs | Guards the violation counter and error log in `check_call_expr_for_violations` behind `!self.settings.auto_derive`; new tests validate the flag's behavior for template literals and string concatenations. |
| packages/next/swc-plugin/src/lib.rs | Threads `config.auto_derive` into both passes of `TransformVisitor::new`; the panic check at line 388 remains gated only on `disable_build_checks` which is correct because violations are never incremented when `auto_derive=true`. |
| packages/next/swc-plugin/src/ast/traversal.rs | Test helper updated to pass the new `false` `auto_derive` argument to `PluginSettings::new` — mechanical, no logic change. |
| .changeset/extend-autoderive-swc.md | Changeset notes a `patch` bump for `gt-next`; the PR title says "fix" but the changeset says "feat" — minor discrepancy. |
| packages/cli/src/generated/version.ts | Auto-generated version bump from 2.14.6 to 2.14.7. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["gt.config.json\nfiles.gt.parsingFlags.autoDerive"] -->|"read as rawConfig"| B["withGTConfig (config.ts)"]
    B -->|"autoDerive === true"| C["SWC plugin options\n{ ...compilerOptions, autoDerive }"]
    C -->|"serde deserialize"| D["PluginConfig.auto_derive"]
    D --> E["TransformVisitor::new(auto_derive)"]
    E --> F["PluginSettings.auto_derive"]
    F --> G{"check_call_expr_for_violations"}
    G -->|"errors AND auto_derive=true"| H["Skip violation counter\nSkip error log\nReturn early"]
    G -->|"errors AND auto_derive=false"| I["Increment violation counter\nLog error\nReturn early"]
    G -->|"no errors"| J["Pass — continue tracking"]
    H --> K["track_translation_callback\n(caller continues normally)"]
    I --> L["panic if violations > 0\n(lib.rs post-pass check)"]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/next/src/config.ts
Line: 534

Comment:
**Hard-coded deep config path may silently return `false`**

`rawConfig?.files?.gt?.parsingFlags?.autoDerive` is a five-level deep optional chain against an untyped `any` object. If the schema path changes (e.g. the CLI moves the flag elsewhere), `autoDerive` silently defaults to `false` with no warning, effectively disabling the feature without any build-time feedback. Consider extracting the path as a named constant or adding a fallback log when the flag is expected but not found.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/next/src/config.ts
Line: 114-115

Comment:
**`rawConfig` and `loadedConfig` are the same object reference**

`loadedConfig = rawConfig` makes both variables point to the same parsed JSON object. Any downstream code that mutates `loadedConfig` (e.g. property reassignment) would silently affect `rawConfig` too, potentially corrupting the `autoDerive` read that happens later at line 534. A shallow copy keeps the intent clear:

```suggestion
      rawConfig = JSON.parse(fileContent);
      loadedConfig = { ...rawConfig };
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["changeset"](https://github.com/generaltranslation/gt/commit/d074c4911114320859855be3b58c8d1ba98e8d55) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27773928)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->