### PR TITLE
fix(lint): add var import for auto fix

### DIFF
--- a/.changeset/bright-places-cry.md
+++ b/.changeset/bright-places-cry.md
@@ -1,0 +1,5 @@
+---
+'@generaltranslation/react-core-linter': patch
+---
+
+fix: auto var wrapping

--- a/packages/react-core-linter/src/rules/static-jsx/__tests__/static-jsx-auto-import.test.ts
+++ b/packages/react-core-linter/src/rules/static-jsx/__tests__/static-jsx-auto-import.test.ts
@@ -1,0 +1,163 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { describe } from 'vitest';
+import { staticJsx } from '../index.js';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2020,
+    sourceType: 'module',
+    parserOptions: {
+      ecmaFeatures: {
+        jsx: true,
+      },
+    },
+  },
+});
+
+/**
+ * Tests for auto-import of Var when the static-jsx auto-fix wraps
+ * dynamic content in <Var>. The fix must also add `Var` to the
+ * existing GT import declaration so the fixed code actually compiles.
+ *
+ * NOTE: ruleTester.run() is called directly inside describe(), NOT
+ * wrapped in it(). Wrapping in it() causes output assertions to be
+ * silently swallowed by the test framework.
+ */
+
+describe('static-jsx auto-fix should add Var import', () => {
+  ruleTester.run('auto-import Var from gt-react', staticJsx, {
+    valid: [],
+    invalid: [
+      {
+        code: `
+          import { T } from 'gt-react';
+          function Component({ name }) {
+            return <T>{name}</T>;
+          }
+        `,
+        options: [{ libs: ['gt-react'] }],
+        errors: [{ messageId: 'dynamicContent' }],
+        output: `
+          import { T, Var } from 'gt-react';
+          function Component({ name }) {
+            return <T><Var>{name}</Var></T>;
+          }
+        `,
+      },
+    ],
+  });
+
+  ruleTester.run('auto-import Var from react-core', staticJsx, {
+    valid: [],
+    invalid: [
+      {
+        code: `
+          import { T } from '@generaltranslation/react-core';
+          function Component({ name }) {
+            return <T>{name}</T>;
+          }
+        `,
+        options: [{ libs: ['@generaltranslation/react-core'] }],
+        errors: [{ messageId: 'dynamicContent' }],
+        output: `
+          import { T, Var } from '@generaltranslation/react-core';
+          function Component({ name }) {
+            return <T><Var>{name}</Var></T>;
+          }
+        `,
+      },
+    ],
+  });
+
+  ruleTester.run('auto-import Var from gt-next', staticJsx, {
+    valid: [],
+    invalid: [
+      {
+        code: `
+          import { T } from 'gt-next';
+          function Component() {
+            return <T>{getLabel()}</T>;
+          }
+        `,
+        options: [{ libs: ['gt-next'] }],
+        errors: [{ messageId: 'dynamicContent' }],
+        output: `
+          import { T, Var } from 'gt-next';
+          function Component() {
+            return <T><Var>{getLabel()}</Var></T>;
+          }
+        `,
+      },
+    ],
+  });
+
+  ruleTester.run('auto-import Var alongside existing specifiers', staticJsx, {
+    valid: [],
+    invalid: [
+      {
+        code: `
+          import { T, Num } from 'gt-react';
+          function Component({ name }) {
+            return <T>{name}</T>;
+          }
+        `,
+        options: [{ libs: ['gt-react'] }],
+        errors: [{ messageId: 'dynamicContent' }],
+        output: `
+          import { T, Num, Var } from 'gt-react';
+          function Component({ name }) {
+            return <T><Var>{name}</Var></T>;
+          }
+        `,
+      },
+    ],
+  });
+});
+
+describe('static-jsx auto-fix should not duplicate existing Var import', () => {
+  ruleTester.run('Var already imported', staticJsx, {
+    valid: [],
+    invalid: [
+      {
+        code: `
+          import { T, Var } from 'gt-react';
+          function Component({ name }) {
+            return <T>{name}</T>;
+          }
+        `,
+        options: [{ libs: ['gt-react'] }],
+        errors: [{ messageId: 'dynamicContent' }],
+        output: `
+          import { T, Var } from 'gt-react';
+          function Component({ name }) {
+            return <T><Var>{name}</Var></T>;
+          }
+        `,
+      },
+    ],
+  });
+});
+
+describe('static-jsx auto-fix should respect aliased Var import', () => {
+  ruleTester.run('Var imported as alias', staticJsx, {
+    valid: [],
+    invalid: [
+      {
+        code: `
+          import { T, Var as V } from 'gt-react';
+          function Component({ name }) {
+            return <T>{name}</T>;
+          }
+        `,
+        options: [{ libs: ['gt-react'] }],
+        errors: [{ messageId: 'dynamicContent' }],
+        output: `
+          import { T, Var as V } from 'gt-react';
+          function Component({ name }) {
+            return <T><V>{name}</V></T>;
+          }
+        `,
+      },
+    ],
+  });
+});

--- a/packages/react-core-linter/src/rules/static-jsx/index.ts
+++ b/packages/react-core-linter/src/rules/static-jsx/index.ts
@@ -66,30 +66,39 @@ export const staticJsx = createRule({
     ) {
       const fixes: ReturnType<RuleFixer['replaceText']>[] = [];
 
-      // Find the GT import declaration
-      const gtImportDecl = context.sourceCode.ast.body.find(
+      // Find all GT import declarations
+      const gtImportDecls = context.sourceCode.ast.body.filter(
         (stmt): stmt is TSESTree.ImportDeclaration =>
           stmt.type === TSESTree.AST_NODE_TYPES.ImportDeclaration &&
           libs.includes(stmt.source.value as string)
       );
 
-      // Check if Var is already imported and resolve its local name
+      // Check across all GT imports if Var is already imported
       let tagName = VAR_COMPONENT_NAME;
-      if (gtImportDecl) {
-        const varSpecifier = gtImportDecl.specifiers.find(
+      let varSpecifier: TSESTree.ImportSpecifier | undefined;
+      for (const decl of gtImportDecls) {
+        varSpecifier = decl.specifiers.find(
           (spec): spec is TSESTree.ImportSpecifier =>
             spec.type === TSESTree.AST_NODE_TYPES.ImportSpecifier &&
             spec.imported.type === TSESTree.AST_NODE_TYPES.Identifier &&
             spec.imported.name === VAR_COMPONENT_NAME
         );
+        if (varSpecifier) break;
+      }
 
-        if (varSpecifier) {
-          // Var is already imported — use its local name (handles aliases)
-          tagName = varSpecifier.local.name;
-        } else if (gtImportDecl.specifiers.length > 0) {
-          // Var is not imported — add it to the existing import
+      if (varSpecifier) {
+        // Var is already imported — use its local name (handles aliases)
+        tagName = varSpecifier.local.name;
+      } else if (gtImportDecls.length > 0) {
+        // Var is not imported — add it to the first GT import
+        const targetDecl = gtImportDecls[0];
+        const namedSpecifiers = targetDecl.specifiers.filter(
+          (s): s is TSESTree.ImportSpecifier =>
+            s.type === TSESTree.AST_NODE_TYPES.ImportSpecifier
+        );
+        if (namedSpecifiers.length > 0) {
           const lastSpecifier =
-            gtImportDecl.specifiers[gtImportDecl.specifiers.length - 1];
+            namedSpecifiers[namedSpecifiers.length - 1];
           fixes.push(
             fixer.insertTextAfter(lastSpecifier, `, ${VAR_COMPONENT_NAME}`)
           );

--- a/packages/react-core-linter/src/rules/static-jsx/index.ts
+++ b/packages/react-core-linter/src/rules/static-jsx/index.ts
@@ -97,8 +97,7 @@ export const staticJsx = createRule({
             s.type === TSESTree.AST_NODE_TYPES.ImportSpecifier
         );
         if (namedSpecifiers.length > 0) {
-          const lastSpecifier =
-            namedSpecifiers[namedSpecifiers.length - 1];
+          const lastSpecifier = namedSpecifiers[namedSpecifiers.length - 1];
           fixes.push(
             fixer.insertTextAfter(lastSpecifier, `, ${VAR_COMPONENT_NAME}`)
           );

--- a/packages/react-core-linter/src/rules/static-jsx/index.ts
+++ b/packages/react-core-linter/src/rules/static-jsx/index.ts
@@ -1,13 +1,11 @@
 import { ESLintUtils, TSESTree } from '@typescript-eslint/utils';
-import type {
-  RuleFixer,
-  RuleContext,
-} from '@typescript-eslint/utils/ts-eslint';
+import type { RuleFixer } from '@typescript-eslint/utils/ts-eslint';
 import {
   ALLOWED_BRANCH_ATTRIBUTE_JSX_EXPRESSIONS,
   ALLOWED_JSX_EXPRESSIONS,
   GT_LIBRARIES,
   RULE_URL,
+  VAR_COMPONENT_NAME,
 } from '../../utils/constants.js';
 import {
   isBranchComponent,
@@ -18,21 +16,6 @@ import {
 } from '../../utils/isGTFunction.js';
 import { isContentBranch } from '../../utils/branching-utils.js';
 import { ScopeStack } from './ScopeStack.js';
-
-/**
- * Creates a fixer that wraps a JSX expression container in a <Var> component
- */
-function createVarWrapperFix(
-  context: RuleContext<any, any>,
-  fixer: RuleFixer,
-  node: TSESTree.JSXExpressionContainer
-) {
-  // Get the source code of the expression container
-  const sourceCode = context.sourceCode.getText(node);
-  // Wrap in <Var> component
-  const fixedCode = `<Var>${sourceCode}</Var>`;
-  return fixer.replaceText(node, fixedCode);
-}
 
 /**
  * Static JSX applies to children of the <T> component
@@ -73,6 +56,54 @@ export const staticJsx = createRule({
   create(context, [options]) {
     const { libs = GT_LIBRARIES } = options;
 
+    /**
+     * Creates a fixer that wraps a JSX expression container in a <Var> component
+     * and adds the Var import to the existing GT import declaration if needed.
+     */
+    function createVarWrapperFix(
+      fixer: RuleFixer,
+      node: TSESTree.JSXExpressionContainer
+    ) {
+      const fixes: ReturnType<RuleFixer['replaceText']>[] = [];
+
+      // Find the GT import declaration
+      const gtImportDecl = context.sourceCode.ast.body.find(
+        (stmt): stmt is TSESTree.ImportDeclaration =>
+          stmt.type === TSESTree.AST_NODE_TYPES.ImportDeclaration &&
+          libs.includes(stmt.source.value as string)
+      );
+
+      // Check if Var is already imported and resolve its local name
+      let tagName = VAR_COMPONENT_NAME;
+      if (gtImportDecl) {
+        const varSpecifier = gtImportDecl.specifiers.find(
+          (spec): spec is TSESTree.ImportSpecifier =>
+            spec.type === TSESTree.AST_NODE_TYPES.ImportSpecifier &&
+            spec.imported.type === TSESTree.AST_NODE_TYPES.Identifier &&
+            spec.imported.name === VAR_COMPONENT_NAME
+        );
+
+        if (varSpecifier) {
+          // Var is already imported — use its local name (handles aliases)
+          tagName = varSpecifier.local.name;
+        } else if (gtImportDecl.specifiers.length > 0) {
+          // Var is not imported — add it to the existing import
+          const lastSpecifier =
+            gtImportDecl.specifiers[gtImportDecl.specifiers.length - 1];
+          fixes.push(
+            fixer.insertTextAfter(lastSpecifier, `, ${VAR_COMPONENT_NAME}`)
+          );
+        }
+      }
+
+      // Wrap the expression in <Var> (or its alias)
+      const sourceCode = context.sourceCode.getText(node);
+      const fixedCode = `<${tagName}>${sourceCode}</${tagName}>`;
+      fixes.push(fixer.replaceText(node, fixedCode));
+
+      return fixes;
+    }
+
     // Track the T component stack
     const scopeStack = new ScopeStack();
     return {
@@ -89,7 +120,7 @@ export const staticJsx = createRule({
               node,
               messageId: 'dynamicContent',
               fix(fixer) {
-                return createVarWrapperFix(context, fixer, node);
+                return createVarWrapperFix(fixer, node);
               },
             });
           }
@@ -106,7 +137,7 @@ export const staticJsx = createRule({
               node,
               messageId: 'dynamicContent',
               fix(fixer) {
-                return createVarWrapperFix(context, fixer, node);
+                return createVarWrapperFix(fixer, node);
               },
             });
           }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the auto-fix for the `static-jsx` rule so that when a dynamic expression is wrapped in `<Var>`, the `Var` named import is also inserted into the existing GT import declaration. The fix moves `createVarWrapperFix` inside `create()` so it can close over `context` and `libs`, searches all GT import declarations for an existing `Var` specifier (respecting aliases), and adds it to the first GT import's named-specifier list when absent. A new test file covers adding the import for multiple GT libraries, deduplication when `Var` is already present, and alias handling.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the core fix is correct, well-tested, and the only remaining gap is a missing multi-expression test case (P2).

All previously flagged P1 issues are addressed (zero-specifier guard, alias handling). The one new observation (no test for multiple dynamic expressions in one <T>) is P2 and does not affect correctness since ESLint's conflict-resolution handles it correctly at runtime.

No files require special attention.
</details>

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified. The changes are limited to an ESLint rule fixer that operates on AST nodes at lint time; no user input is executed or evaluated.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react-core-linter/src/rules/static-jsx/index.ts | createVarWrapperFix moved inside create() to access libs/context via closure; now searches all GT imports for an existing Var specifier (including aliases), then inserts it into the first GT import's named-specifier list when absent. The namedSpecifiers guard addresses the zero-specifier edge case flagged in the previous review. |
| packages/react-core-linter/src/rules/static-jsx/__tests__/static-jsx-auto-import.test.ts | New test file covering: adding Var import for gt-react, @generaltranslation/react-core, and gt-next; no duplication when Var is already imported; alias (Var as V) handled correctly; multiple existing specifiers (T, Num → T, Num, Var). |
| .changeset/bright-places-cry.md | Patch-level changeset entry for the auto Var-wrapping fix in @generaltranslation/react-core-linter. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["JSXExpressionContainer\nreported as dynamic content"] --> B["createVarWrapperFix(fixer, node)"]
    B --> C["Find all GT import decls\n(libs filter)"]
    C --> D{"Any GT imports?"}
    D -- No --> E["Wrap only: &lt;Var&gt;{expr}&lt;/Var&gt;\n(no import added)"]
    D -- Yes --> F{"Var already\nimported?"}
    F -- "Yes (exact or alias)" --> G["tagName = local alias name"]
    F -- No --> H["Filter named specifiers\n(ImportSpecifier only)"]
    H --> I{"namedSpecifiers\n.length > 0?"}
    I -- Yes --> J["insertTextAfter(lastSpecifier, ', Var')"]
    I -- No --> K["Skip import fix\n(namespace import edge case)"]
    G --> L["replaceText: &lt;tagName&gt;{expr}&lt;/tagName&gt;"]
    J --> L
    K --> L
    L --> M["Return Fix[]"]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/react-core-linter/src/rules/static-jsx/__tests__/static-jsx-auto-import.test.ts
Line: 27-163

Comment:
**Missing test: multiple dynamic expressions in one `<T>`**

The suite doesn't cover a `<T>` with two dynamic children (e.g. `{name}` and `{age}`). Each violation emits its own `fix`, both of which try to `insertTextAfter` the same last specifier. ESLint's conflict-resolution skips the second insertion in the same pass and only applies it in the next pass — but this behaviour is subtle and worth pinning with a test case to ensure the import never ends up with `Var` appended twice.

```ts
{
  code: `
    import { T } from 'gt-react';
    function Component({ name, age }) {
      return <T>{name} and {age}</T>;
    }
  `,
  options: [{ libs: ['gt-react'] }],
  errors: [{ messageId: 'dynamicContent' }, { messageId: 'dynamicContent' }],
  // After ESLint's two-pass fix: single Var in import, both expressions wrapped
  output: `
    import { T, Var } from 'gt-react';
    function Component({ name, age }) {
      return <T><Var>{name}</Var> and <Var>{age}</Var></T>;
    }
  `,
},
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix greptile feedback"](https://github.com/generaltranslation/gt/commit/829eb3b2f1f22fa3a2836e591368bf656651cbc0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27813924)</sub>

<!-- /greptile_comment -->