### PR TITLE
chore: improve claude ergonomics

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,77 @@
+# General Translation Monorepo
+
+Open source i18n libraries for React, Next.js, and more. Repo: `generaltranslation/gt`.
+
+## Monorepo Structure
+
+- **Package manager:** pnpm (v10.20.0)
+- **Build system:** Turbo (`turbo.json` defines task graph)
+- **Releases:** Changesets (`pnpm changeset` to add, `changeset publish` to release)
+- **Testing:** Vitest across all packages
+- **Linting:** ESLint + Prettier (enforced via lefthook pre-commit)
+- **License:** FSL-1.1-ALv2
+
+## Commands
+
+```sh
+pnpm build          # Build all packages (turbo, cached)
+pnpm test           # Test all packages
+pnpm lint           # Lint all packages
+pnpm lint:fix       # Lint + auto-fix
+pnpm format         # Prettier format everything
+pnpm changeset      # Create a changeset for a new release
+pnpm version-packages  # Apply changesets to bump versions
+pnpm release        # Publish packages (changeset publish)
+```
+
+Per-package commands: `pnpm --filter <pkg> <script>` (e.g., `pnpm --filter gt test`).
+
+Turbo tasks: `build`, `test`, `lint`, `lint:fix`, `transpile`, `build:clean`, `build:release`, `bench`.
+
+## Key Packages
+
+| Package                                 | Path                         | Description                                                       |
+| --------------------------------------- | ---------------------------- | ----------------------------------------------------------------- |
+| `generaltranslation`                    | `packages/core`              | Pure JS, i18n helpers and API client                              |
+| `gt-i18n`                               | `packages/i18n`              | Pure JS i18n runtime                                              |
+| `gt-react`                              | `packages/react`             | React i18n with `<T>` component, hooks, providers                 |
+| `@generaltranslation/react-core`        | `packages/react-core`        | Pure React i18n primitives (no framework deps)                    |
+| `gt-next`                               | `packages/next`              | Next.js integration (server/client split, SWC plugin, middleware) |
+| `gt-node`                               | `packages/node`              | Node.js backend translation utilities                             |
+| `gt-tanstack-start`                     | `packages/tanstack-start`    | TanStack Start integration                                        |
+| `gt-sanity`                             | `packages/sanity`            | Sanity CMS plugin                                                 |
+| `@generaltranslation/compiler`          | `packages/compiler`          | Build plugin (webpack, Vite, Rollup, esbuild) via unplugin        |
+| `gt`                                    | `packages/cli`               | Main CLI tool (`npx gt`)                                          |
+| `gtx-cli`                               | `packages/gtx-cli`           | Wrapper CLI for gt (backward compatibility)                       |
+| `locadex`                               | `packages/locadex`           | AI agent for i18n with MCP support                                |
+| `@generaltranslation/mcp`               | `packages/mcp`               | MCP server for AI tool integration                                |
+| `@generaltranslation/react-core-linter` | `packages/react-core-linter` | ESLint plugin for react-core                                      |
+| `@generaltranslation/gt-next-lint`      | `packages/next-lint`         | ESLint plugin for gt-next                                         |
+| `gt-remark`                             | `packages/remark`            | Remark plugin for MDX escaping                                    |
+| `@generaltranslation/python-extractor`  | `packages/python-extractor`  | Python source extraction (tree-sitter)                            |
+
+## Code Conventions
+
+- TypeScript everywhere. Strict mode.
+- Prettier: single quotes, 2-space indent, trailing commas (es5), semicolons, LF line endings.
+- ESLint: `@typescript-eslint` rules, unused vars prefixed with `_`, no explicit `any` (warn).
+- Prefer `const` over `let`. Never `var`.
+- Test files: `*.test.ts` / `*.spec.ts` using Vitest.
+- Build outputs go to `dist/`. Never edit `dist/` directly.
+
+## Important Patterns
+
+- **Exports:** Most packages use conditional exports (`package.json` `exports` field) with separate paths for different entry points (e.g., `gt-next` has `/client`, `/server`, `/middleware`, `/config`).
+- **Internal subpaths:** Packages expose `/internal` subpaths for cross-package use. These are not part of the public API.
+- **React i18n-context:** `packages/react/src/i18n-context/` has restricted imports from `gt-i18n` (only `/types`, `/internal`, `/internal/types`). This is enforced by ESLint.
+- **CLI version generation:** `packages/cli` has a pre-commit hook that runs `node scripts/generate-version.js` to keep `src/generated/version.ts` in sync.
+
+## MCP Server
+
+The repo includes its own MCP server (`@generaltranslation/mcp`) that provides documentation and tools for AI assistants. It's configured in `.mcp.json` at the repo root.
+
+## CI/CD
+
+- GitHub Actions with a `claude.yml` workflow for `@claude` mentions in issues/PRs.
+- Turbo caching for builds. `build` depends on `^build` (dependencies build first).
+- Changesets for automated release management.

--- a/.claude/rules/cli.md
+++ b/.claude/rules/cli.md
@@ -1,0 +1,14 @@
+---
+paths:
+  - "packages/cli/**"
+  - "packages/gtx-cli/**"
+---
+
+# CLI Package Rules
+
+- The `gt` CLI (`packages/cli`) is the primary command-line tool. `gtx-cli` is a thin wrapper.
+- CLI entry point is `src/main.ts`. Library entry point is `src/index.ts`.
+- Uses `commander` for argument parsing and `chalk` for terminal output.
+- The CLI has a pre-commit hook that generates `src/generated/version.ts` — never edit this file manually.
+- Test with `pnpm --filter gt test`. Type-check with `pnpm --filter gt typecheck`.
+- When adding new CLI commands, follow the existing pattern in `src/cli/`.

--- a/.claude/rules/compiler.md
+++ b/.claude/rules/compiler.md
@@ -1,0 +1,12 @@
+---
+paths:
+  - "packages/compiler/**"
+  - "packages/next/src/plugin/**"
+---
+
+# Compiler & Build Plugin Rules
+
+- `@generaltranslation/compiler` is an `unplugin`-based build plugin supporting webpack, Vite, Rollup, and esbuild.
+- It uses Babel for AST transformations at compile time.
+- `gt-next` includes an SWC plugin (Rust-based) in addition to the JS compiler plugin.
+- Test compiler changes against the test apps in `tests/apps/` and examples in `examples/`.

--- a/.claude/rules/core.md
+++ b/.claude/rules/core.md
@@ -1,0 +1,16 @@
+---
+paths:
+  - 'packages/core/**'
+  - 'packages/i18n/**'
+  - 'packages/supported-locales/**'
+---
+
+# Core Library Rules
+
+- `generaltranslation` (packages/core) is the foundation package. Almost everything depends on it — changes here have wide blast radius.
+- `gt-i18n` (packages/i18n) builds on core and provides the runtime i18n layer.
+- `@generaltranslation/supported-locales` provides locale metadata.
+- These packages must remain framework-agnostic — no React, Next.js, or Node.js-specific imports. Engine agnostic as well.
+- Run `pnpm build` from root after making changes here to verify downstream packages still compile.
+- Exports use subpath exports (e.g., `/internal`, `/types`). Internal subpaths are not public API but are used across packages.
+- Be careful with breaking changes to `/internal` subpaths — other packages in the monorepo depend on them.

--- a/.claude/rules/linter-plugins.md
+++ b/.claude/rules/linter-plugins.md
@@ -1,0 +1,14 @@
+---
+paths:
+  - 'packages/react-core-linter/**'
+  - 'packages/next-lint/**'
+---
+
+# ESLint Plugin Rules
+
+- These packages provide ESLint rules for enforcing GT best practices.
+- `react-core-linter`: rules for `@generaltranslation/react-core` usage.
+- `gt-next-lint`: rules for `gt-next` usage. This is being deprecated in favor of `react-core-linter`.
+- Both use `@typescript-eslint/utils` for rule implementation.
+- Follow the AST visitor pattern used in existing rules when adding new ones.
+- Peer dependencies: eslint and @typescript-eslint packages.

--- a/.claude/rules/react-packages.md
+++ b/.claude/rules/react-packages.md
@@ -1,0 +1,17 @@
+---
+paths:
+  - 'packages/react/**'
+  - 'packages/react-core/**'
+  - 'packages/next/**'
+  - 'packages/tanstack-start/**'
+---
+
+# React Package Rules
+
+- These packages provide i18n components and hooks for React-based frameworks.
+- `react-core` is the foundation. `react` and `react-native` extends it. `next` and `tanstack-start` extend `react`.
+- Exports are split by entry point (e.g., `/client`, `/server`, `/internal`). Check `package.json` `exports` field before adding new public API.
+- `packages/react/src/i18n-context/` has restricted imports: only `gt-i18n/types`, `gt-i18n/internal`, or `gt-i18n/internal/types`. This is enforced by ESLint. This is an alternative approach to i18n react that does NOT use react context.
+- Never import from framework-specific packages (like `next`) in `react-core` or `react` — they must stay framework-agnostic.
+- Use React Server Components patterns in `gt-next`: separate `index.server.ts` and `index.client.ts` entry points.
+- Run tests with `pnpm --filter <package-name> test`.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,17 @@
+---
+paths:
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.spec.ts"
+  - "**/*.spec.tsx"
+  - "**/__tests__/**"
+---
+
+# Testing Rules
+
+- Use Vitest for all tests. Import from `vitest` (describe, it, expect, vi, beforeEach, etc.).
+- Test files live next to source or in `__tests__/` directories.
+- Run a single package's tests: `pnpm --filter <package-name> test`.
+- Run all tests: `pnpm test`.
+- Environment variables for CI tests: `VITE_CI_TEST_GT_PROJECT_ID`, `VITE_CI_TEST_GT_API_KEY`.
+- Prefer testing behavior over implementation details.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,47 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(pnpm run:*)",
+      "Bash(pnpm test:*)",
+      "Bash(pnpm build:*)",
+      "Bash(pnpm lint:*)",
+      "Bash(pnpm --filter:*)",
+      "Bash(pnpm install:*)",
+      "Bash(pnpm exec:*)",
+      "Bash(pnpm add:*)",
+      "Bash(pnpm typecheck:*)",
+      "Bash(pnpm changeset:*)",
+      "Bash(pnpm format:*)",
+      "Bash(npm test)",
+      "Bash(npx tsc:*)",
+      "Bash(npx vitest:*)",
+      "Bash(npx prettier:*)",
+      "Bash(npx eslint:*)",
+      "Bash(node:*)",
+      "Bash(turbo:*)",
+      "Bash(git:*)",
+      "Bash(gh:*)",
+      "Bash(ls:*)",
+      "Bash(mkdir:*)",
+      "Bash(wc:*)",
+      "Bash(find:*)"
+    ],
+    "deny": ["Bash(rm -rf *)", "Edit(.env*)"]
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path // empty' | xargs -I {} sh -c 'echo \"{}\" | grep -qE \"\\.(js|jsx|ts|tsx|json|md|yml|yaml)$\" && npx prettier --write \"{}\" 2>/dev/null || true'",
+            "timeout": 15
+          }
+        ]
+      }
+    ]
+  },
+  "enableAllProjectMcpServers": true,
+  "enabledMcpjsonServers": ["generaltranslation"]
+}

--- a/.claude/skills/build.md
+++ b/.claude/skills/build.md
@@ -1,0 +1,22 @@
+---
+name: build
+description: Build packages in the monorepo
+user-invocable: true
+allowed-tools: Bash(pnpm *), Bash(turbo *)
+argument-hint: "[package-name or 'all']"
+---
+
+Build packages in the General Translation monorepo.
+
+## Usage
+
+- If `$ARGUMENTS` specifies a package name, run: `pnpm --filter <package-name> build`
+- If `$ARGUMENTS` is "all" or empty, run: `pnpm build`
+- For a clean build: `pnpm build:clean`
+
+## After running
+
+- Report the results concisely
+- If the build fails, read the error output carefully and diagnose the issue
+- TypeScript errors are the most common build failures — check the relevant source files
+- Remember that `build` tasks depend on `^build` (dependencies build first), so a failure may be in an upstream package

--- a/.claude/skills/changeset.md
+++ b/.claude/skills/changeset.md
@@ -1,0 +1,36 @@
+---
+name: changeset
+description: Create a changeset for releasing package changes
+user-invocable: true
+allowed-tools: Bash(pnpm changeset *), Write, Read, Bash(git *)
+argument-hint: "[description of changes]"
+---
+
+Create a changeset for releasing changes to General Translation packages.
+
+## Steps
+
+1. Run `git diff main --name-only` to see which packages have changed
+2. Determine which packages need version bumps based on the changes
+3. Determine the bump type:
+   - `patch`: bug fixes, internal changes
+   - `minor`: new features, non-breaking additions
+   - `major`: breaking changes to public API
+4. Create the changeset file manually at `.changeset/<descriptive-name>.md`:
+
+```markdown
+---
+"<package-name>": <patch|minor|major>
+---
+
+<Description of the changes>
+```
+
+5. If `$ARGUMENTS` is provided, use it as the description. Otherwise, summarize the changes from the diff.
+
+## Important
+
+- Only include packages whose public API or behavior has changed
+- Internal-only changes (refactors, test updates) may not need a changeset
+- If multiple packages changed, you can include multiple packages in one changeset file
+- Package names must match the `name` field in each package's `package.json`

--- a/.claude/skills/check-package.md
+++ b/.claude/skills/check-package.md
@@ -1,0 +1,24 @@
+---
+name: check-package
+description: Run full validation (build + lint + test + typecheck) on a package
+user-invocable: true
+allowed-tools: Bash(pnpm *), Bash(npx *)
+argument-hint: "<package-name>"
+---
+
+Run full validation on a specific package in the monorepo.
+
+## Steps
+
+Run these checks sequentially for the specified package (`$ARGUMENTS`):
+
+1. **Build:** `pnpm --filter $ARGUMENTS build`
+2. **Type check:** `cd packages/<dir> && npx tsc --noEmit`
+3. **Lint:** `pnpm --filter $ARGUMENTS lint`
+4. **Test:** `pnpm --filter $ARGUMENTS test`
+
+## After running
+
+- Report a summary: which checks passed and which failed
+- For failures, diagnose the issue and suggest fixes
+- If all checks pass, confirm the package is ready

--- a/.claude/skills/check-package.md
+++ b/.claude/skills/check-package.md
@@ -3,7 +3,7 @@ name: check-package
 description: Run full validation (build + lint + test + typecheck) on a package
 user-invocable: true
 allowed-tools: Bash(pnpm *), Bash(npx *)
-argument-hint: "<package-name>"
+argument-hint: '<package-name>'
 ---
 
 Run full validation on a specific package in the monorepo.
@@ -13,7 +13,7 @@ Run full validation on a specific package in the monorepo.
 Run these checks sequentially for the specified package (`$ARGUMENTS`):
 
 1. **Build:** `pnpm --filter $ARGUMENTS build`
-2. **Type check:** `cd packages/<dir> && npx tsc --noEmit`
+2. **Type check:** Resolve the package directory from the Key Packages table in `CLAUDE.md` (the directory name often differs from the npm package name, e.g. `gt` → `packages/cli`). Then run `cd packages/<dir> && npx tsc --noEmit`.
 3. **Lint:** `pnpm --filter $ARGUMENTS lint`
 4. **Test:** `pnpm --filter $ARGUMENTS test`
 

--- a/.claude/skills/lint-fix.md
+++ b/.claude/skills/lint-fix.md
@@ -1,0 +1,21 @@
+---
+name: lint-fix
+description: Run ESLint with auto-fix on changed files
+user-invocable: true
+allowed-tools: Bash(npx eslint *), Bash(pnpm lint *), Bash(git *)
+argument-hint: "[package-name, file path, or 'all']"
+---
+
+Run ESLint with auto-fix on the General Translation monorepo.
+
+## Usage
+
+- If `$ARGUMENTS` specifies a package name: `pnpm --filter <package-name> lint:fix`
+- If `$ARGUMENTS` specifies a file: `npx eslint --fix <file>`
+- If `$ARGUMENTS` is "all" or empty: `pnpm lint:fix`
+- To lint only staged files: `npx eslint --fix $(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(js|ts|tsx|jsx)$')`
+
+## After running
+
+- Report remaining warnings/errors that couldn't be auto-fixed
+- For unfixable issues, read the source and suggest manual fixes

--- a/.claude/skills/test.md
+++ b/.claude/skills/test.md
@@ -1,0 +1,21 @@
+---
+name: test
+description: Run tests for specific packages or the entire monorepo
+user-invocable: true
+allowed-tools: Bash(pnpm *), Bash(npx vitest *)
+argument-hint: "[package-name or 'all']"
+---
+
+Run tests for the General Translation monorepo.
+
+## Usage
+
+- If `$ARGUMENTS` specifies a package name, run: `pnpm --filter <package-name> test`
+- If `$ARGUMENTS` is "all" or empty, run: `pnpm test`
+- If `$ARGUMENTS` specifies a file path, run: `npx vitest run <path>`
+
+## After running
+
+- Report the results concisely: how many tests passed/failed
+- If tests fail, read the failing test files and the source they test to diagnose the issue
+- Suggest fixes if the failures are straightforward

--- a/.claude/skills/typecheck.md
+++ b/.claude/skills/typecheck.md
@@ -1,0 +1,20 @@
+---
+name: typecheck
+description: Run TypeScript type checking across the monorepo
+user-invocable: true
+allowed-tools: Bash(npx tsc *), Bash(pnpm *)
+argument-hint: "[package-name or 'all']"
+---
+
+Run TypeScript type checking for the General Translation monorepo.
+
+## Usage
+
+- If `$ARGUMENTS` specifies a package name: `cd packages/<package-dir> && npx tsc --noEmit`
+- If `$ARGUMENTS` is "all" or empty: `pnpm typecheck` or run `npx tsc --noEmit` in each package
+
+## After running
+
+- Report errors concisely, grouped by file
+- For each error, suggest the fix if straightforward
+- Common issues: missing types, incorrect imports from internal subpaths, generic type mismatches

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,9 @@ _test_cli
 _testing
 dist/
 .turbo
-.claude/
+.claude/settings.local.json
+.claude/mcp.json
+CLAUDE.local.md
 tsconfig.tsbuildinfo
 target/
 .rollup.cache

--- a/packages/compiler/.claude/CLAUDE.md
+++ b/packages/compiler/.claude/CLAUDE.md
@@ -1,0 +1,79 @@
+# GT Compiler Plugin
+
+`@generaltranslation/compiler` — an unplugin-based build plugin for compile-time i18n optimization. Works with webpack, Vite, Rollup, and esbuild.
+
+## Architecture
+
+The compiler uses a **4-pass Babel pipeline** on `.tsx/.jsx/.ts/.js` files:
+
+1. **JSX Insertion Pass** — Auto-wraps translatable JSX in `_T` / `_Var` components (when `enableAutoJsxInjection` is enabled)
+2. **Macro Expansion Pass** — Transforms `t`\`...\``tagged templates and`t("...")` calls
+3. **Collection Pass** — Collects translation data, computes hashes, validates usage
+4. **Injection Pass** — Injects hashes and metadata into the AST
+
+Entry point: `src/index.ts` (creates the unplugin).
+
+## Code Organization
+
+```
+src/
+├── index.ts              # Unplugin entry point
+├── config.ts             # PluginConfig / PluginSettings types
+├── passes/               # Babel visitor passes (one per pipeline stage)
+│   ├── jsxInsertionPass.ts
+│   ├── macroExpansionPass.ts
+│   ├── collectionPass.ts
+│   ├── injectionPass.ts
+│   └── __tests__/
+├── processing/           # Core logic invoked by passes
+│   ├── jsx-insertion/    # JSX auto-insertion logic + rules doc
+│   ├── collection/
+│   └── injection/
+├── state/                # State management classes
+└── utils/                # Stateless helpers
+```
+
+## JSX Insertion Rules
+
+The full 15-rule spec lives in `.claude/rules/jsx-insertion-rules.md` and loads automatically when editing JSX insertion code. The original source copy is at `src/processing/jsx-insertion/JSX_INSERTION_RULES.md`.
+
+Both the compiler plugin and the CLI registration tool must implement these rules identically, or translation hashes will disagree and runtime resolution will fail.
+
+Key concepts:
+
+- `_T` (`GtInternalTranslateJsx`) wraps the highest ancestor with translatable text
+- `_Var` (`GtInternalVar`) wraps dynamic expressions, only inside `_T` regions
+- User-written `<T>`, `<Var>`, `<Num>`, `<Currency>`, `<DateTime>` are never modified
+- `Branch`, `Plural`, `Derive`, `Static` trigger `_T` at the parent level
+- Nested `_T` inside `Derive` is expected — removed at runtime by `removeInjectedT()`
+
+## Configuration
+
+Key flags in `PluginConfig` (`src/config.ts`):
+
+- `enableAutoJsxInjection` — enables JSX insertion pass
+- `enableMacroTransform` — enables t\`\` macro expansion
+- `compileTimeHash` — enables hash generation
+- `disableBuildChecks` — skips validation checks
+- `autoDerive` — treats interpolated values as `derive()` calls
+
+Can be set via `gt.config.json` under `files.gt.parsingFlags.enableAutoJsxInjection`.
+
+## Testing
+
+```sh
+pnpm --filter @generaltranslation/compiler test
+```
+
+Test suites in `src/passes/__tests__/`:
+
+- `jsxInsertionPass.test.ts` — core JSX insertion behavior
+- `jsxInsertionE2E.test.ts` — end-to-end pipeline tests
+- `jsxInsertionEdgeCases.test.ts` — edge cases and regressions
+
+## Important Invariants
+
+- The JSX insertion pass operates on **compiled JSX** (after Vite/SWC transforms `<div>` into `jsx("div", ...)`), not raw JSX syntax.
+- Each `{expression}` maps to exactly one `_Var` — never grouped or combined.
+- The CLI extraction tool must simulate the same insertion to compute matching hashes.
+- Processing functions have a 1-to-1 relationship with their Babel visitor counterparts.

--- a/packages/compiler/.claude/rules/jsx-insertion-rules.md
+++ b/packages/compiler/.claude/rules/jsx-insertion-rules.md
@@ -1,0 +1,561 @@
+---
+paths:
+  - 'packages/compiler/src/processing/jsx-insertion/**'
+  - 'packages/compiler/src/passes/jsxInsertionPass.ts'
+  - 'packages/compiler/src/passes/__tests__/jsxInsertion*'
+  - 'packages/cli/src/react/jsx/utils/jsxParsing/**'
+---
+
+# JSX Auto-Insertion Rules
+
+The JSX insertion pass automatically wraps translatable JSX content in `GtInternalTranslateJsx` (\_T) and dynamic expressions in `GtInternalVar` (\_Var) at build time. It operates on compiled JSX — after Vite/SWC transforms JSX syntax into `jsx()`/`jsxs()`/`jsxDEV()` calls.
+
+## Why this document exists
+
+These rules must be followed by **two independent systems** that need to agree on the same output:
+
+1. **The compiler plugin** (this pass) — runs at build time and physically inserts \_T and \_Var components into the JSX tree.
+2. **The CLI registration tool** — runs before the build to extract translatable content, compute hashes, and register translations with the GT API. When `enableAutoJsxInjection` is enabled, the CLI must **simulate** where \_T and \_Var would be inserted so it can compute hashes that match what the compiler will produce. If these two systems disagree — if the CLI thinks \_T wraps at one level but the compiler wraps at another — the hashes will be different and translation resolution will fail at runtime.
+
+This document is the single source of truth for the insertion rules. Both the compiler pass and the CLI registration logic must implement these rules identically. Any change to these rules requires updating both systems.
+
+---
+
+## Rule 1: Insert \_T at the highest level that directly contains translatable text
+
+\_T wraps the children of the **first ancestor element that has translatable string content as a direct child**. "Translatable text" means `StringLiteral` or static `TemplateLiteral` (no interpolation) with non-whitespace content. Numeric literals (`{42}`), booleans, `null`, `undefined`, etc. are NOT translatable text — they are data, not content a translator would touch. They do not trigger \_T insertion on their own.
+
+```jsx
+// Text is a direct child of <div>
+<div>Hello</div>
+<div><_T>Hello</_T></div>
+
+// Text is inside <span>, not <div> — _T goes inside <span>
+<div><span>Click me</span></div>
+<div><span><_T>Click me</_T></span></div>
+
+// Text is deeply nested — _T goes at the level with text
+<main><section><p>Deep text</p></section></main>
+<main><section><p><_T>Deep text</_T></p></section></main>
+```
+
+## Rule 2: When a parent has direct text, it claims the entire subtree
+
+If a parent element has text as a direct child, _T wraps at that level. Nested child elements become part of the same translation unit — they do NOT get their own _T.
+
+```jsx
+// <div> has "Hello " as direct text — _T at div, <b> is part of the unit
+<div>Hello <b>World</b></div>
+<div><_T>Hello <b>World</b></_T></div>
+
+// <div> has "Hello " and " today" — _T at div
+<div>Hello <b>World</b> today</div>
+<div><_T>Hello <b>World</b> today</_T></div>
+
+// <div> has "Welcome, " — _T at div, <span> inside is part of the unit
+<div>Welcome, <span><em>friend</em></span>!</div>
+<div><_T>Welcome, <span><em>friend</em></span>!</_T></div>
+```
+
+## Rule 3: Sibling elements without a common text parent get independent _T
+
+When a parent has no direct text, each child subtree is processed independently.
+
+```jsx
+// <div> has no direct text — each child gets its own _T
+<div><span>First</span><p><em>Second</em></p></div>
+<div><span><_T>First</_T></span><p><em><_T>Second</_T></em></p></div>
+
+// <ul> has no text, each <li> gets _T independently
+<ul><li>Item A</li><li>Item B</li></ul>
+<ul><li><_T>Item A</_T></li><li><_T>Item B</_T></li></ul>
+```
+
+## Rule 4: Dynamic expressions get wrapped in _Var
+
+Any expression that is not statically parseable gets wrapped in `GtInternalVar` (_Var). _Var is ONLY inserted inside a _T region.
+
+### Expressions that need _Var (dynamic):
+
+```jsx
+// Identifier (variable reference)
+<div>Hello {name}</div>
+<div><_T>Hello <_Var>{name}</_Var></_T></div>
+
+// Member expression
+<div>Price: {obj.price}</div>
+<div><_T>Price: <_Var>{obj.price}</_Var></_T></div>
+
+// Conditional expression
+<div>Status: {isActive ? "on" : "off"}</div>
+<div><_T>Status: <_Var>{isActive ? "on" : "off"}</_Var></_T></div>
+
+// Binary expression (even if part is static)
+<div>Total: {"$" + amount}</div>
+<div><_T>Total: <_Var>{"$" + amount}</_Var></_T></div>
+
+// Logical expression
+<div>Name: {name && name.toUpperCase()}</div>
+<div><_T>Name: <_Var>{name && name.toUpperCase()}</_Var></_T></div>
+
+// Function call (non-jsx)
+<div>Result: {getValue()}</div>
+<div><_T>Result: <_Var>{getValue()}</_Var></_T></div>
+
+// Template literal with interpolation
+<div>Hello {`${name}!`}</div>
+<div><_T>Hello <_Var>{`${name}!`}</_Var></_T></div>
+
+// Multiple dynamic expressions → each gets its own _Var
+<div>Hello {firstName}, welcome to {city}!</div>
+<div><_T>Hello <_Var>{firstName}</_Var>, welcome to <_Var>{city}</_Var>!</_T></div>
+```
+
+**Important: each dynamic child expression gets its own individual \_Var.** Dynamic expressions are never combined or grouped. This is a 1-to-1 mapping: each `{expression}` in the JSX source becomes exactly one \_Var wrapper. This matters for hash agreement between the compiler plugin and the CLI extraction tool — both must produce the same structure.
+
+The React JSX transform (Babel/SWC) preserves expressions exactly as written. It does not precompute, constant-fold, or reorder them. Adjacent bare text (not in `{}`) is merged into a single string literal, but expressions inside `{}` are always kept as-is. This means the children array our pass receives is deterministic and maps directly to the source JSX.
+
+```jsx
+// Each {expr} → one _Var, bare text → string literals
+<div>{a + "hello"}sometext{b}{c} and {d + e}</div>
+<div><_T><_Var>{a + "hello"}</_Var>sometext<_Var>{b}</_Var><_Var>{c}</_Var> and <_Var>{d + e}</_Var></_T></div>
+// 4 _Vars: (a + "hello"), b, c, (d + e)
+// 2 strings: "sometext", " and "
+// Note: a + "hello" is NOT precomputed — the BinaryExpression is preserved as-is
+```
+
+### Expressions that do NOT need \_Var (static/parseable):
+
+These are valid children inside a \_T region and do not get wrapped in \_Var. However, they do NOT trigger \_T insertion on their own — only string content does (see Rule 5).
+
+```jsx
+// String literals — trigger _T AND are valid children
+<div>Hello World</div>
+<div><_T>Hello World</_T></div>
+
+// Static template literals (no interpolation) — trigger _T AND are valid children
+<div>{`Hello`}</div>
+<div><_T>{`Hello`}</_T></div>
+
+// Numeric literals — valid children but do NOT trigger _T on their own
+<div>Price: {42}</div>          // "Price: " triggers _T, 42 is valid inside it
+<div><_T>Price: {42}</_T></div>
+<div>{42}</div>                 // No text → no _T → unchanged
+<div>{42}</div>
+
+// Boolean literals, null — valid children, do NOT trigger _T
+<div>Text {true} {null}</div>
+<div><_T>Text {true} {null}</_T></div>
+
+// Negative numbers — valid children, do NOT trigger _T on their own
+<div>Temperature: {-5}</div>
+<div><_T>Temperature: {-5}</_T></div>
+
+// Special identifiers: undefined, NaN, Infinity — valid children, do NOT trigger _T
+<div>Value: {undefined}</div>   // no _T — "Value: " wait, that IS text
+<div><_T>Value: {undefined}</_T></div>
+
+// Nested JSX elements — valid translation children, not variables
+<div>Hello <b>World</b></div>
+<div><_T>Hello <b>World</b></_T></div>
+```
+
+## Rule 5: No \_T when there is no translatable string content
+
+If an element's children contain no non-whitespace string content (`StringLiteral` or static `TemplateLiteral`) and no opaque GT components, no \_T is inserted. Numeric literals, booleans, null, and other non-string values do NOT count as translatable content.
+
+```jsx
+// No children
+<div />
+<div />  // unchanged
+
+// Only dynamic content, no text
+<div>{userName}</div>
+<div>{userName}</div>  // unchanged — nothing to translate
+
+// Only whitespace between dynamic expressions
+<div>{firstName} {lastName}</div>
+<div>{firstName} {lastName}</div>  // unchanged — whitespace alone is not translatable
+
+// Only numeric content — not translatable
+<div>{42}</div>
+<div>{42}</div>  // unchanged — numbers are data, not text
+
+// Only nested elements, no direct text
+<div><span><img /></span></div>
+<div><span><img /></span></div>  // unchanged
+
+// Only boolean/null — not translatable
+<div>{true} {null}</div>
+<div>{true} {null}</div>  // unchanged
+```
+
+## Rule 6: User-written T — completely hands off
+
+If the user has manually written a `<T>` component (imported from a GT library), the pass does **nothing** to it or any of its descendants. No _T, no _Var, nothing.
+
+```jsx
+// User T with text
+<T>Hello World</T>
+<T>Hello World</T>  // unchanged
+
+// User T with user Var
+<T>Hello <Var>{name}</Var></T>
+<T>Hello <Var>{name}</Var></T>  // unchanged
+
+// User T with deeply nested content — all descendants untouched
+<T>Hello <span>{name} <b>World</b></span></T>
+<T>Hello <span>{name} <b>World</b></span></T>  // unchanged
+
+// User T next to other content — T is hands-off, other content still processed
+<div><T>Translated</T><span>Auto translate me</span></div>
+<div><T>Translated</T><span><_T>Auto translate me</_T></span></div>
+```
+
+## Rule 7: User-written Var, Num, Currency, DateTime — completely hands off
+
+User-imported variable components are left untouched. They are valid children of \_T but their internals are **never modified** — no \_T or \_Var insertion happens anywhere inside them, regardless of what content they contain.
+
+**Implementation detail:** When the compiler/CLI traversal enters a user Var/Num/Currency/DateTime, it sets an internal flag to suppress ALL transformations. The flag is cleared on exit of that component. This is more robust than trying to mark individual descendant nodes — it correctly handles JSX nested inside arbitrary expressions (ternaries, logical operators, function calls, etc.) within the user component.
+
+This does NOT apply to auto-inserted \_Var. When the pass itself inserts a \_Var, JSX inside it is still fair game for \_T insertion (since the \_Var was our insertion, not the user's).
+
+```jsx
+// User Var inside auto-translated content — simple case
+<div>Hello <Var>{name}</Var></div>
+<div><_T>Hello <Var>{name}</Var></_T></div>
+// Note: no _Var wrapping — user Var handles it
+
+// User Var with JSX inside a ternary — everything inside is opaque
+<T>Status: <Var>{isActive ? <span>Active</span> : <span>Inactive</span>}</Var></T>
+<T>Status: <Var>{isActive ? <span>Active</span> : <span>Inactive</span>}</Var></T>
+// "Active" and "Inactive" do NOT get _T — they are inside user Var
+
+// Contrast with auto-inserted Var — JSX inside IS translated
+// SOURCE:  <div>Status: {isActive ? <span>Active</span> : <span>Inactive</span>}</div>
+// RESULT:  <div><_T>Status: <_Var>{isActive ? <span><_T>Active</_T></span> : <span><_T>Inactive</_T></span>}</_Var></_T></div>
+// "Active" and "Inactive" DO get _T because the _Var was auto-inserted
+
+// User Num
+<div>Price: <Num>{price}</Num></div>
+<div><_T>Price: <Num>{price}</Num></_T></div>
+
+// User Currency
+<div>Cost: <Currency>{amount}</Currency></div>
+<div><_T>Cost: <Currency>{amount}</Currency></_T></div>
+
+// User DateTime
+<div>Date: <DateTime>{date}</DateTime></div>
+<div><_T>Date: <DateTime>{date}</DateTime></_T></div>
+```
+
+## Rule 8: Branch and Plural — \_T wraps from parent, control props untouched, content props processed
+
+Branch and Plural components trigger \_T insertion at the **parent** level. The `<T>` component already knows how to translate their branches, so static content inside Branch/Plural props and children is left alone.
+
+**Control props are never modified.** These are selector/configuration props, not translatable content:
+- Branch: `branch` (selector key), `data-*` (HTML attributes, ignored at runtime)
+- Plural: `n` (count), `locales` (locale hint)
+
+**Content props** (branch value keys like `Ernest`, `summary`, plural forms like `one`, `other`, and `children` as fallback) are processed:
+
+- **Static content prop values** (direct JSX like `summary={<p>Text</p>}`) are left untouched — no \_T inside.
+- **Dynamic non-JSX content prop values** (variables, function calls, etc.) get \_Var wrapped.
+- **JSX content prop values with dynamic children** (e.g., `Ernest={<>Text {name}</>}`) — the JSX itself is not \_T-wrapped, but dynamic expressions inside its children get \_Var wrapped.
+- **Dynamic content prop values containing JSX** (ternaries, logical expressions) get \_Var wrapped. JSX inside those \_Var wrappers still gets \_T.
+
+```jsx
+// Branch as only child — _T wraps at parent, `branch` selector untouched
+<div><Branch branch="mode" summary={<p>Summary</p>}>Fallback</Branch></div>
+<div><_T><Branch branch="mode" summary={<p>Summary</p>}>Fallback</Branch></_T></div>
+// `branch` is a control prop → never Var-wrapped, even if dynamic
+
+// Plural as only child — _T wraps at parent, `n` and `locales` untouched
+<div><Plural n={count} one="item" other="items" /></div>
+<div><_T><Plural n={count} one="item" other="items" /></_T></div>
+// `n` is a control prop → never Var-wrapped, even though `count` is dynamic
+
+// Branch with static JSX in prop arguments — NO _T inside the props
+<div><Branch branch="mode" summary={<p>Summary text</p>} details={<p>Details text</p>}>Fallback</Branch></div>
+<div><_T><Branch branch="mode" summary={<p>Summary text</p>} details={<p>Details text</p>}>Fallback</Branch></_T></div>
+// Only 1 _T at div — "Summary text" and "Details text" are static, left alone
+
+// Plural with static JSX in prop arguments — NO _T inside the props
+<div><Plural n={count} one={<span>One item</span>} other={<span>Many items</span>} /></div>
+<div><_T><Plural n={count} one={<span>One item</span>} other={<span>Many items</span>} /></_T></div>
+// Only 1 _T at div — "One item" and "Many items" are static, left alone
+
+// Branch with nested JSX children — NO _T inside children either
+<div><Branch branch="test"><p>Fallback text</p></Branch></div>
+<div><_T><Branch branch="test"><p>Fallback text</p></Branch></_T></div>
+// Only 1 _T at div — "Fallback text" is static, left alone
+
+// Branch alongside text — _T wraps everything at parent
+<div>Results: <Branch branch="view" list={<ul>...</ul>}>Default</Branch></div>
+<div><_T>Results: <Branch branch="view" list={<ul>...</ul>}>Default</Branch></_T></div>
+
+// Branch with dynamic expression in content prop — dynamic value gets _Var
+<div><Branch branch="hello" hello={count} /></div>
+<div><_T><Branch branch="hello" hello={<_Var>{count}</_Var>} /></_T></div>
+// count is dynamic → _Var wraps it (Branch is inside _T region)
+// Note: `branch` selector stays as-is — it's a control prop
+
+// Branch with JSX content prop containing dynamic children — _Var inside JSX
+<div><Branch branch="mode" Ernest={<>Hello {userName}</>} /></div>
+<div><_T><Branch branch="mode" Ernest={<>Hello <_Var>{userName}</_Var></>} /></_T></div>
+// The Fragment itself is static JSX (no _T inside), but {userName} is dynamic → _Var
+
+// Branch with ternary containing JSX in prop — ternary gets _Var, JSX inside gets _T
+<div><Branch branch="mode" summary={condition ? <p>Option A</p> : <p>Option B</p>}>Fallback</Branch></div>
+<div><_T><Branch branch="mode" summary={<_Var>{condition ? <p><_T>Option A</_T></p> : <p><_T>Option B</_T></p>}</_Var>}>Fallback</Branch></_T></div>
+// The ternary is dynamic → _Var. The <p> elements inside are JSX with text → each gets _T.
+// This works because _Var is auto-inserted, so JSX inside it is still fair game.
+```
+
+## Rule 9: Derive and Static — same treatment as Branch/Plural
+
+Same as Branch/Plural. \_T wraps from the parent level. Static JSX props are left alone; dynamic props get \_Var wrapped. JSX inside auto-inserted \_Var is still eligible for \_T.
+
+```jsx
+// Derive as only child
+<div><Derive>{getName()}</Derive></div>
+<div><_T><Derive>{getName()}</Derive></_T></div>
+
+// Static as only child
+<div><Static>{getLabel()}</Static></div>
+<div><_T><Static>{getLabel()}</Static></_T></div>
+
+// Derive with dynamic prop — gets _Var
+<div><Derive context={someVar}>{getName()}</Derive></div>
+<div><_T><Derive context={<_Var>{someVar}</_Var>}>{getName()}</Derive></_T></div>
+```
+
+## Rule 10: Non-children props are independent (except Branch/Plural/Derive/Static)
+
+For **regular components**, JSX in non-`children` props (e.g. `header`, `icon`, `footer`) is an independent subtree. The pass processes it separately — the parent's \_T state does not carry over. This is the default behavior for any component that is not a GT opaque component.
+
+**Exception:** Branch, Plural, Derive, and Static (see Rules 8-9). Their props are not processed independently as separate subtrees. Instead, static JSX props are left alone and dynamic props get \_Var wrapped within the parent's \_T context.
+
+```jsx
+// header prop has its own JSX — processed independently
+<Card header={<h1>Title</h1>}>Body text</Card>
+<Card header={<h1><_T>Title</_T></h1>}><_T>Body text</_T></Card>
+// Two independent _T insertions
+
+// icon prop is independent from children
+<Button icon={<span>X</span>}>Click me</Button>
+<Button icon={<span><_T>X</_T></span>}><_T>Click me</_T></Button>
+```
+
+## Rule 11: _Var is only inserted inside _T
+
+Dynamic expressions are only wrapped in _Var when they are inside a _T region (auto-inserted). If there is no _T (e.g., no text to translate), dynamic expressions are left as-is.
+
+```jsx
+// Has text → _T inserted → dynamic expressions get _Var
+<div>Hello {name}</div>
+<div><_T>Hello <_Var>{name}</_Var></_T></div>
+
+// No text → no _T → no _Var either
+<div>{name}</div>
+<div>{name}</div>  // unchanged
+
+// Whitespace only → no _T → no _Var
+<div>{firstName} {lastName}</div>
+<div>{firstName} {lastName}</div>  // unchanged
+```
+
+## Rule 12: Nested dynamic content inside _T gets _Var at the expression level
+
+When _T claims a subtree and a nested element contains dynamic content, the _Var wraps the expression inside that nested element.
+
+```jsx
+// Parent has text → claims _T. Child <span> has dynamic content → _Var inside span
+<div>Hello <span>{userName}</span></div>
+<div><_T>Hello <span><_Var>{userName}</_Var></span></_T></div>
+
+// Parent has text, child has mix of text and dynamic
+<div>Welcome <span>to {city}</span>!</div>
+<div><_T>Welcome <span>to <_Var>{city}</_Var></span>!</_T></div>
+```
+
+## Rule 13: Fragments are treated like regular elements
+
+React fragments (`<>...</>`) compile to `jsx(Fragment, { children: ... })`. The pass treats them the same as any other element — if their children contain translatable text, \_T is inserted inside the fragment.
+
+```jsx
+// Fragment with text — _T inside fragment
+<>Hello World</>
+<><_T>Hello World</_T></>
+
+// Fragment with no text — unchanged
+<><div /><span /></>
+<><div /><span /></>  // unchanged
+
+// Fragment with mixed content
+<>Welcome {name}!</>
+<><_T>Welcome <_Var>{name}</_Var>!</_T></>
+```
+
+## Rule 14: Conditional rendering and iterators are dynamic expressions
+
+Ternaries (`? :`), logical expressions (`&&`, `||`), and function calls like `.map()` are dynamic expressions. They get \_Var wrapped if inside a \_T region. JSX inside them (e.g., inside the branches of a ternary or the callback of a map) is still eligible for independent \_T insertion by the Babel visitor since those JSX calls are not marked as processed.
+
+```jsx
+// Ternary — the whole expression is dynamic → _Var
+// JSX inside each branch gets its own _T independently
+<div>Status: {isActive ? <span>Active</span> : <span>Inactive</span>}</div>
+<div><_T>Status: <_Var>{isActive ? <span><_T>Active</_T></span> : <span><_T>Inactive</_T></span>}</_Var></_T></div>
+
+// Logical AND — dynamic expression → _Var
+<div>Hello {showName && <b>{name}</b>}</div>
+<div><_T>Hello <_Var>{showName && <b><_Var>{name}</_Var></b>}</_Var></_T></div>
+
+// .map() — the map call is a single dynamic expression → _Var
+<ul>Items: {items.map(i => <li>{i.name}</li>)}</ul>
+<ul><_T>Items: <_Var>{items.map(i => <li><_Var>{i.name}</_Var></li>)}</_Var></_T></ul>
+
+// Ternary with no surrounding text — no _T at this level
+<div>{show ? <p>Yes</p> : <p>No</p>}</div>
+<div>{show ? <p><_T>Yes</_T></p> : <p><_T>No</_T></p>}</div>
+// No _T at div (no text), but each branch's <p> gets _T independently
+```
+
+## Rule 15: String-only attributes are not touched
+
+The pass only operates on JSX children, not on string-valued props/attributes. Props like `placeholder`, `alt`, `title`, `aria-label`, etc. are left as-is even if they contain translatable text.
+
+```jsx
+// String attributes — unchanged
+<input placeholder="Search here" />
+<input placeholder="Search here" />  // unchanged
+
+<img alt="Company logo" />
+<img alt="Company logo" />  // unchanged
+```
+
+---
+
+## Import injection
+
+When the pass inserts at least one _T, it automatically adds:
+
+```javascript
+import { GtInternalTranslateJsx, GtInternalVar } from 'gt-react/browser';
+```
+
+If `GtInternalTranslateJsx` is already imported from a GT source, no duplicate import is added.
+
+---
+
+## Runtime removal of injected components
+
+The compiler cannot always avoid inserting \_T inside another \_T. The primary case is `<Derive>`: the compiler inserts \_T into any element with text, but it cannot know at compile time whether that element will later appear as a child of `<Derive>`. This would require whole-program analysis of every call site — not practical.
+
+### The Derive problem
+
+```jsx
+// Before injection:
+function getName() {
+  return <div>John</div>;
+}
+
+<div>
+  <Derive>{getName()}</Derive>
+</div>
+
+// After injection:
+function getName() {
+  return <div><_T>John</_T></div>;  // _T injected here — compiler doesn't know this is derived
+}
+
+<div>
+  <_T>
+    <Derive>{getName()}</Derive>
+  </_T>
+</div>
+
+// Result: nested _T inside Derive — the inner _T needs to be removed at runtime
+```
+
+The compiler would have to trace every call site of `getName()` and prove it is never used under `<Derive>` to avoid this. That is not practical.
+
+### Runtime solution: `removeInjectedT()`
+
+Instead of relying on the compiler to never emit nested \_T, the **runtime removes them**. The `_T` component (`GtInternalTranslateJsx`) calls `removeInjectedT()` on its children before processing. This function traverses the React element tree and unwraps any auto-injected \_T components that appear inside a `<Derive>` or `<Static>` context.
+
+**Key invariant that makes this safe:** \_T is always inserted by wrapping the children of an existing element. This means removing \_T is always a simple child replacement — unwrap \_T's children back into the parent. No merging or restructuring needed.
+
+The function uses a `derivationDepth` counter:
+- Entering `<Derive>` or `<Static>` increments the depth
+- When depth > 0 and an auto-injected \_T is encountered, it is unwrapped (replaced by its children)
+- User-written `<T>` components are never removed (distinguished by the `_gtt` transformation tag: `'translate-client'` vs `'translate-client-automatic'`)
+
+### Runtime solution: `renderVariable()` removes \_Var
+
+A similar issue exists with \_Var. Auto-injected \_Var wrappers could break user logic if left in the tree (e.g., a component expecting a plain string child gets a \_Var element instead). The `renderVariable()` function handles this by unwrapping auto-injected \_Var components during the render phase, reinserting the original value back to its original place.
+
+### Opaque GT components inside Derive produce independent entries
+
+When Branch, Plural, or other opaque GT components appear inside Derive's children, they get their own independent \_T and produce standalone hash entries. This is correct and intentional — the same JSX could appear inside a function definition that is invoked by Derive, where the compiler cannot know it's in a Derive context.
+
+```jsx
+// Direct child of Derive:
+<div>Hello <Derive><Branch branch="x">fallback</Branch></Derive></div>
+
+// After injection:
+<div>
+  <_T>Hello <Derive><_T><Branch branch="x">fallback</Branch></_T></Derive></_T>
+</div>
+
+// Produces 2 hash entries:
+//   1. ["Hello ", { t: "Derive", i: 1 }]  (outer _T — contains Derive)
+//   2. { t: "Branch", i: 1, c: "fallback" }  (inner _T — standalone Branch)
+//
+// At runtime, removeInjectedT strips the inner _T, but the standalone hash
+// entry is still needed for translation resolution.
+```
+
+This is consistent with the function-definition case:
+
+```jsx
+// Function that returns Branch:
+function getNav() {
+  return <Branch branch="x">fallback</Branch>;
+}
+// The compiler inserts _T inside getNav(), producing the same standalone Branch entry.
+// If this function is called inside <Derive>{getNav()}</Derive>, the inner _T is
+// removed at runtime — but the hash entry must exist for both cases to work.
+```
+
+**Both the compiler and CLI must produce these standalone entries** for opaque GT components inside Derive, to ensure hash agreement.
+
+### Why this matters for CLI extraction
+
+The CLI extraction tool must be aware that:
+1. The compiler **will** produce nested \_T in Derive cases — this is expected, not a bug
+2. The runtime removes these nested \_T before hash computation, so the **effective** structure (after removal) is what the hash is computed against
+3. The CLI must simulate the same removal when computing hashes from source to maintain agreement
+4. Opaque GT components (Branch, Plural) inside Derive must produce their own standalone hash entries, matching what the compiler produces
+
+---
+
+## Summary table
+
+| Scenario | \_T inserted? | \_Var inserted? | Where? |
+|----------|-------------|----------------|--------|
+| `<div>Hello</div>` | Yes | No | Inside div |
+| `<div>{name}</div>` | No | No | — (no text) |
+| `<div>{42}</div>` | No | No | — (number is not text) |
+| `<div>Hello {name}</div>` | Yes | Yes (name) | Inside div |
+| `<div><span>Hi</span></div>` | Yes | No | Inside span |
+| `<div>Hi <b>W</b></div>` | Yes | No | Inside div |
+| `<div>{a} {b}</div>` | No | No | — (whitespace only) |
+| `<>Hello</>` | Yes | No | Inside fragment |
+| `<T>Hello</T>` | No | No | — (user T, hands off) |
+| `<div><Var>{x}</Var></div>` | No | No | — (no text) |
+| `<div>Hi <Var>{x}</Var></div>` | Yes | No | Inside div (user Var untouched) |
+| `<div><Branch ...>F</Branch></div>` | Yes | No | Inside div (wraps Branch) |
+| `<div><Derive>{x}</Derive></div>` | Yes | No | Inside div (wraps Derive) |
+| `<div>Hi {x ? <a/> : <b/>}</div>` | Yes | Yes (ternary) | Inside div |
+| `<input placeholder="Hi" />` | No | No | — (attributes untouched) |


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a comprehensive set of Claude Code configuration files (`.claude/CLAUDE.md`, scoped rules, skills, and a package-level context for the compiler) to improve AI assistant ergonomics across the monorepo. No production source files are changed.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — no production code changed, only Claude configuration and documentation files.

All findings are P2 style/documentation suggestions with no runtime impact. The two minor issues (stale react-native reference and missing package→directory mapping hint) affect AI ergonomics only and do not block merge.

.claude/rules/react-packages.md (stale react-native reference) and .claude/skills/check-package.md (missing package→directory mapping note).
</details>

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified. All changes are documentation and AI-assistant configuration files with no executable code paths.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .claude/CLAUDE.md | New root-level Claude context file covering monorepo structure, commands, packages, and conventions — content accurate and well-organized. |
| .claude/rules/react-packages.md | New rule file for React packages; references a react-native package that does not appear in the monorepo's package table. |
| .claude/skills/check-package.md | New full-validation skill; the type-check step uses `cd packages/<dir>` without explaining the package-name→directory mapping. |
| .gitignore | Adds .claude/settings.local.json and .claude/mcp.json to gitignore to prevent committing user-local Claude settings. |
| packages/compiler/.claude/CLAUDE.md | Detailed package-level Claude context for the compiler; architecture, passes, config flags, and invariants are accurately documented. |
| packages/compiler/.claude/rules/jsx-insertion-rules.md | Comprehensive 15-rule JSX auto-insertion spec; mirrors src/processing/jsx-insertion/JSX_INSERTION_RULES.md and loads automatically for the relevant source paths. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[".claude/CLAUDE.md\n(root context)"] --> B[".claude/rules/\n(path-scoped rules)"]
    A --> C[".claude/skills/\n(user-invocable skills)"]
    B --> B1["cli.md"]
    B --> B2["compiler.md"]
    B --> B3["core.md"]
    B --> B4["react-packages.md"]
    B --> B5["linter-plugins.md"]
    B --> B6["testing.md"]
    C --> C1["build.md"]
    C --> C2["test.md"]
    C --> C3["typecheck.md"]
    C --> C4["lint-fix.md"]
    C --> C5["changeset.md"]
    C --> C6["check-package.md"]
    D["packages/compiler/.claude/CLAUDE.md\n(package context)"] --> E[".claude/rules/jsx-insertion-rules.md\n(auto-loaded for JSX insertion paths)"]
    E -.mirrors.-> F["src/processing/jsx-insertion/\nJSX_INSERTION_RULES.md"]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .claude/rules/react-packages.md
Line: 12

Comment:
**Undocumented `react-native` package reference**

`react-native` is mentioned here as extending `react-core`, but it does not appear in the key packages table in `.claude/CLAUDE.md` and there is no `packages/react-native/` directory in the monorepo. This stale reference could mislead Claude into inventing paths or commands for a package that doesn't exist.

```suggestion
- `react-core` is the foundation. `react` extends it. `next` and `tanstack-start` extend `react`.
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .claude/skills/check-package.md
Line: 15-16

Comment:
**Package name → directory mapping not documented**

The type-check step uses `cd packages/<dir>` but several packages have a directory name that does not match their npm package name (e.g. `gt` → `packages/cli`, `@generaltranslation/compiler` → `packages/compiler`). Without an explicit note or lookup hint, Claude may generate the wrong path and the `tsc` invocation will fail silently or on the wrong package.

Consider adding a note like:

```markdown
   Note: the directory name often differs from the package name — check the Key Packages table in CLAUDE.md for the correct path (e.g. package `gt` lives in `packages/cli`).
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["improve claude ergonomics"](https://github.com/generaltranslation/gt/commit/ddf6363c464d743a5ee63dd6215b2a33396e26ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27898748)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->