### PR TITLE
refactor: standardize name for autoderive

### DIFF
--- a/.changeset/cool-laws-invent.md
+++ b/.changeset/cool-laws-invent.md
@@ -1,0 +1,7 @@
+---
+'@generaltranslation/compiler': patch
+'gt-next': patch
+'gt': patch
+---
+
+refactor: standardize naming convention for "autoderive"

--- a/packages/cli/src/config/defaults.ts
+++ b/packages/cli/src/config/defaults.ts
@@ -2,11 +2,11 @@ import { BaseParsingFlags, GTParsingFlags } from '../types/parsing.js';
 
 /**
  * Default parsing flags for GT files
- * @property {boolean} autoDerive - Whether to enable auto-derive for the t() function. (true -> 'AUTO', false -> 'DISABLED' {@link ParsingConfig['autoDeriveMethod']})
+ * @property {boolean} autoderive - Whether to enable autoderive for the t() function. (true -> 'AUTO', false -> 'DISABLED' {@link ParsingConfig['autoderiveMethod']})
  * @property {boolean} includeSourceCodeContext - Include surrounding source code lines as context for translations.
  */
 export const GT_PARSING_FLAGS_DEFAULT: GTParsingFlags = {
-  autoDerive: false,
+  autoderive: false,
   includeSourceCodeContext: false,
   enableAutoJsxInjection: false,
 };

--- a/packages/cli/src/console/index.ts
+++ b/packages/cli/src/console/index.ts
@@ -322,14 +322,14 @@ export const warnDeriveFunctionNoResultsSync = (
     location
   );
 
-export const warnAutoDeriveNoResultsSync = (
+export const warnAutoderiveNoResultsSync = (
   file: string,
   expression: string,
   location?: string
 ): string =>
   withLocation(
     file,
-    `Auto-derive could not resolve ${colorizeFunctionName(formatCodeClamp(expression))}. Only function calls with statically determinable return values can be used directly in t(). Consider wrapping with derive() for explicit derivation, or use an interpolation variable instead.`,
+    `Autoderive could not resolve ${colorizeFunctionName(formatCodeClamp(expression))}. Only function calls with statically determinable return values can be used directly in t(). Consider wrapping with derive() for explicit derivation, or use an interpolation variable instead.`,
     location
   );
 

--- a/packages/cli/src/fs/config/parseFilesConfig.ts
+++ b/packages/cli/src/fs/config/parseFilesConfig.ts
@@ -155,13 +155,23 @@ export function resolveFiles(
     publishPaths,
     unpublishPaths,
     parsingFlags,
-    gtJson: {
-      publish: files.gt?.publish,
-      parsingFlags: {
-        ...GT_PARSING_FLAGS_DEFAULT,
-        ...(files.gt?.parsingFlags || {}),
-      },
-    },
+    gtJson: (() => {
+      const rawGtFlags = (files.gt?.parsingFlags || {}) as Record<
+        string,
+        unknown
+      >;
+      if ('autoDerive' in rawGtFlags && !('autoderive' in rawGtFlags)) {
+        rawGtFlags.autoderive = rawGtFlags.autoDerive;
+        delete rawGtFlags.autoDerive;
+      }
+      return {
+        publish: files.gt?.publish,
+        parsingFlags: {
+          ...GT_PARSING_FLAGS_DEFAULT,
+          ...rawGtFlags,
+        },
+      };
+    })(),
   };
 }
 

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.14.7';
+export const PACKAGE_VERSION = '2.14.8';

--- a/packages/cli/src/react/jsx/utils/__tests__/parseStringFunction.test.ts
+++ b/packages/cli/src/react/jsx/utils/__tests__/parseStringFunction.test.ts
@@ -51,7 +51,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: true,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -104,7 +104,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: true,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -150,7 +150,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: true,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -206,7 +206,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: true,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -258,7 +258,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: true,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -309,7 +309,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: true,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -355,7 +355,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: true,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -402,7 +402,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: true,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -449,7 +449,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: true,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -499,7 +499,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: true,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -556,7 +556,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: true,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -614,7 +614,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: true,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -666,7 +666,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: true,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -719,7 +719,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: true,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -771,7 +771,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: true,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -825,7 +825,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: true,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -876,7 +876,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: true,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -927,7 +927,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: true,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -979,7 +979,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: true,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -1033,7 +1033,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: true,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -1089,7 +1089,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: true,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -1142,7 +1142,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: true,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -1187,7 +1187,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: true,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -1244,7 +1244,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: true,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -1307,7 +1307,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: true,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -1387,7 +1387,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: true,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -1479,7 +1479,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: true,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -1548,7 +1548,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: true,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -1606,7 +1606,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: true,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -1666,7 +1666,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: true,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -1750,7 +1750,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: true,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -1803,7 +1803,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: true,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -1858,7 +1858,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: true,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -1905,7 +1905,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: false,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -1957,7 +1957,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: false,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -2007,7 +2007,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: false,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -2052,7 +2052,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: false,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -2098,7 +2098,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: false,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -2147,7 +2147,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: false,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -2197,7 +2197,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: false,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -2262,7 +2262,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: false,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -2313,7 +2313,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: false,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -2363,7 +2363,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: true,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -2415,7 +2415,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: true,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -2465,7 +2465,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: true,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -2516,7 +2516,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: true,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -2562,7 +2562,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: true,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -2610,7 +2610,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: true,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -2658,7 +2658,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: true,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -2705,7 +2705,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: true,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -2752,7 +2752,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: true,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -2802,7 +2802,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: true,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -2859,7 +2859,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: true,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -2909,7 +2909,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: true,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -2961,7 +2961,7 @@ describe('parseStrings', () => {
               ignoreInlineListContent: true,
               ignoreTaggedTemplates: false,
               ignoreGlobalTaggedTemplates: false,
-              autoDeriveMethod: 'DISABLED',
+              autoderiveMethod: 'DISABLED',
             },
             {
               updates: params.updates,
@@ -3012,7 +3012,7 @@ describe('parseStrings', () => {
                 ignoreInlineListContent: false,
                 ignoreTaggedTemplates: false,
                 ignoreGlobalTaggedTemplates: false,
-                autoDeriveMethod: 'DISABLED',
+                autoderiveMethod: 'DISABLED',
               },
               {
                 updates: params.updates,
@@ -3204,7 +3204,7 @@ describe('parseStrings', () => {
     });
   });
 
-  describe('auto-derive for string registration and hook functions', () => {
+  describe('autoderive for string registration and hook functions', () => {
     const runParseStrings = (
       code: string,
       functionName: string,
@@ -3231,7 +3231,7 @@ describe('parseStrings', () => {
                 ignoreInlineListContent: true,
                 ignoreTaggedTemplates: false,
                 ignoreGlobalTaggedTemplates: false,
-                autoDeriveMethod: 'AUTO',
+                autoderiveMethod: 'AUTO',
               },
               {
                 updates: params.updates,
@@ -3244,7 +3244,7 @@ describe('parseStrings', () => {
       });
     };
 
-    it('should auto-derive t() with template literal interpolation', () => {
+    it('should autoderive t() with template literal interpolation', () => {
       const code = `
         import { t } from 'gt-react/browser';
         const name = "John";
@@ -3258,7 +3258,7 @@ describe('parseStrings', () => {
       expect(params.errors).toHaveLength(0);
     });
 
-    it('should auto-derive t() with concatenation', () => {
+    it('should autoderive t() with concatenation', () => {
       const code = `
         import { t } from 'gt-react/browser';
         const name = "John";
@@ -3272,7 +3272,7 @@ describe('parseStrings', () => {
       expect(params.errors).toHaveLength(0);
     });
 
-    it('should auto-derive msg() with template literal interpolation', () => {
+    it('should autoderive msg() with template literal interpolation', () => {
       const code = `
         import { msg } from 'gt-react';
         const name = "John";
@@ -3286,7 +3286,7 @@ describe('parseStrings', () => {
       expect(params.errors).toHaveLength(0);
     });
 
-    it('should auto-derive msg() with concatenation', () => {
+    it('should autoderive msg() with concatenation', () => {
       const code = `
         import { msg } from 'gt-react';
         const name = "John";
@@ -3300,7 +3300,7 @@ describe('parseStrings', () => {
       expect(params.errors).toHaveLength(0);
     });
 
-    it('should auto-derive gt() from useGT() with template literal interpolation', () => {
+    it('should autoderive gt() from useGT() with template literal interpolation', () => {
       const code = `
         import { useGT } from 'gt-react';
         const name = "John";
@@ -3315,7 +3315,7 @@ describe('parseStrings', () => {
       expect(params.errors).toHaveLength(0);
     });
 
-    it('should auto-derive gt() from useGT() with concatenation', () => {
+    it('should autoderive gt() from useGT() with concatenation', () => {
       const code = `
         import { useGT } from 'gt-react';
         const name = "John";
@@ -3330,7 +3330,7 @@ describe('parseStrings', () => {
       expect(params.errors).toHaveLength(0);
     });
 
-    it('should auto-derive gt() from getGT() with template literal interpolation', () => {
+    it('should autoderive gt() from getGT() with template literal interpolation', () => {
       const code = `
         import { getGT } from 'gt-react';
         const name = "John";
@@ -3374,7 +3374,7 @@ describe('parseStrings', () => {
                 ignoreInlineListContent: true,
                 ignoreTaggedTemplates: false,
                 ignoreGlobalTaggedTemplates: false,
-                autoDeriveMethod: 'DISABLED',
+                autoderiveMethod: 'DISABLED',
               },
               {
                 updates: params.updates,

--- a/packages/cli/src/react/jsx/utils/parseStringFunction.ts
+++ b/packages/cli/src/react/jsx/utils/parseStringFunction.ts
@@ -456,10 +456,10 @@ export function parseStrings(
         path,
         {
           ...config,
-          autoDeriveMethod:
-            config.autoDeriveMethod === 'AUTO'
+          autoderiveMethod:
+            config.autoderiveMethod === 'AUTO'
               ? 'DISABLED'
-              : config.autoDeriveMethod,
+              : config.autoderiveMethod,
         },
         output
       );
@@ -490,10 +490,10 @@ export function parseStrings(
         ignoreTaggedTemplates: false,
         ignoreGlobalTaggedTemplates: false,
         // User configurable, otherwise default to AUTO
-        autoDeriveMethod:
-          config.autoDeriveMethod === 'AUTO'
+        autoderiveMethod:
+          config.autoderiveMethod === 'AUTO'
             ? 'DISABLED'
-            : config.autoDeriveMethod,
+            : config.autoderiveMethod,
       };
 
       // Check if this is a direct call to msg('string') or t('string')
@@ -502,7 +502,7 @@ export function parseStrings(
         refPath.parent.callee === refPath.node
       ) {
         /**
-         * CASE: Auto-derive t() and msg() function
+         * CASE: Autoderive t() and msg() function
          * The t() function, will treat variable content as if it was marked for derivation
          * without explicit calls to derive().
          *
@@ -517,10 +517,10 @@ export function parseStrings(
          */
         processTranslationCall(
           refPath,
-          config.autoDeriveMethod === 'AUTO'
+          config.autoderiveMethod === 'AUTO'
             ? {
                 ...stringRegistrationConfig,
-                autoDeriveMethod: 'ENABLED',
+                autoderiveMethod: 'ENABLED',
               }
             : stringRegistrationConfig,
           output
@@ -588,12 +588,12 @@ export function parseStrings(
         ignoreTaggedTemplates: false,
         ignoreGlobalTaggedTemplates: false,
         // User configurable, otherwise default to DISABLED
-        autoDeriveMethod:
-          config.autoDeriveMethod === 'AUTO'
+        autoderiveMethod:
+          config.autoderiveMethod === 'AUTO'
             ? isInlineGT
               ? 'ENABLED'
               : 'DISABLED'
-            : config.autoDeriveMethod,
+            : config.autoderiveMethod,
       };
 
       const effectiveParent =

--- a/packages/cli/src/react/jsx/utils/stringParsing/derivation/__tests__/handleDerivation.test.ts
+++ b/packages/cli/src/react/jsx/utils/stringParsing/derivation/__tests__/handleDerivation.test.ts
@@ -246,7 +246,7 @@ describe('handleDerivation', () => {
     });
   });
 
-  describe('auto-derive (skipDeriveInvocation: true)', () => {
+  describe('autoderive (skipDeriveInvocation: true)', () => {
     /**
      * Runs handleDerivation with skipDeriveInvocation: true.
      */

--- a/packages/cli/src/react/jsx/utils/stringParsing/derivation/handleDerivation.ts
+++ b/packages/cli/src/react/jsx/utils/stringParsing/derivation/handleDerivation.ts
@@ -11,7 +11,7 @@ import {
   warnFunctionNotFoundSync,
   warnDeriveFunctionNoResultsSync,
   warnDeriveFunctionNotWrappedSync,
-  warnAutoDeriveNoResultsSync,
+  warnAutoderiveNoResultsSync,
 } from '../../../../../console/index.js';
 
 import traverseModule from '@babel/traverse';
@@ -281,10 +281,10 @@ export function handleDerivation({
         nodes: variants.map((v) => ({ type: 'text', text: v })),
       };
     }
-    // Auto-derive had no resolvable results
+    // Autoderive had no resolvable results
     const code = generate(expr).code;
     errors.push(
-      warnAutoDeriveNoResultsSync(
+      warnAutoderiveNoResultsSync(
         file,
         code,
         `${expr.loc?.start?.line}:${expr.loc?.start?.column}`

--- a/packages/cli/src/react/jsx/utils/stringParsing/derivation/index.ts
+++ b/packages/cli/src/react/jsx/utils/stringParsing/derivation/index.ts
@@ -57,7 +57,7 @@ export function deriveExpression({
     runtimeInterpolationState: enableRuntimeInterpolation
       ? { index: 0 }
       : undefined,
-    skipDeriveInvocation: config.autoDeriveMethod === 'ENABLED',
+    skipDeriveInvocation: config.autoderiveMethod === 'ENABLED',
   });
 
   // Nothing returned, push error

--- a/packages/cli/src/react/jsx/utils/stringParsing/types.ts
+++ b/packages/cli/src/react/jsx/utils/stringParsing/types.ts
@@ -38,11 +38,11 @@ export type ParsingConfig = {
   ignoreGlobalTaggedTemplates: boolean;
   /**
    * Skip requirement for a derive() invocation to trigger derivation
-   * - ENABLED: Always auto-derive
-   * - DISABLED: Never auto-derive
-   * - AUTO: Only auto-derive for the t() function
+   * - ENABLED: Always autoderive
+   * - DISABLED: Never autoderive
+   * - AUTO: Only autoderive for the t() function
    */
-  autoDeriveMethod: 'ENABLED' | 'DISABLED' | 'AUTO';
+  autoderiveMethod: 'ENABLED' | 'DISABLED' | 'AUTO';
 };
 
 /**

--- a/packages/cli/src/react/parse/createInlineUpdates.ts
+++ b/packages/cli/src/react/parse/createInlineUpdates.ts
@@ -86,7 +86,7 @@ export async function createInlineUpdates(
           ignoreTaggedTemplates: false,
           ignoreGlobalTaggedTemplates: false,
           // User configurable, otherwise default to AUTO
-          autoDeriveMethod: parsingFlags.autoDerive ? 'AUTO' : 'DISABLED',
+          autoderiveMethod: parsingFlags.autoderive ? 'AUTO' : 'DISABLED',
         },
         { updates, errors, warnings }
       );

--- a/packages/cli/src/types/parsing.ts
+++ b/packages/cli/src/types/parsing.ts
@@ -35,12 +35,12 @@ export type BaseParsingFlags = Record<string, unknown>;
  * parsing features depending on the function being parsed. Parsing flags is for users to override
  * some of these defaults or enable/disable other features.
  *
- * @property {boolean} autoDerive - Whether to enable auto-derive for the t() function. (true -> 'AUTO', false -> 'DISABLED' {@link ParsingConfig['autoDeriveMethod']})
+ * @property {boolean} autoderive - Whether to enable autoderive for the t() function. (true -> 'AUTO', false -> 'DISABLED' {@link ParsingConfig['autoderiveMethod']})
  * @property {boolean} includeSourceCodeContext - Include surrounding source code lines as context for translations.
  * @property {boolean} enableAutoJsxInjection - Whether to enable auto-jsx injection for the internal <_T> and <_Var> components.
  */
 export type GTParsingFlags = BaseParsingFlags & {
-  autoDerive: boolean;
+  autoderive: boolean;
   includeSourceCodeContext: boolean;
   enableAutoJsxInjection: boolean;
 };

--- a/packages/compiler/src/config.ts
+++ b/packages/compiler/src/config.ts
@@ -12,6 +12,9 @@ type GTConfig = {
     gt?: {
       parsingFlags?: {
         enableAutoJsxInjection?: boolean;
+        autoderive?: boolean;
+        /** @deprecated Use `autoderive` instead */
+        autoDerive?: boolean;
       };
     };
   };
@@ -36,6 +39,8 @@ export interface PluginConfig {
   /** Enable Auto Jsx Injection (e.g. <div>Hello</div> -> <div><T>Hello</T></div>) */
   enableAutoJsxInjection?: boolean;
   /** Automatically treat interpolated/concatenated values as derive() calls */
+  autoderive?: boolean;
+  /** @deprecated Use `autoderive` instead */
   autoDerive?: boolean;
   /** Debug: write a hash → jsxChildren manifest file on build */
   _debugHashManifest?: boolean;
@@ -58,7 +63,7 @@ export interface PluginSettings {
   /** Enable Auto Jsx Injection (e.g. <div>Hello</div> -> <div><T>Hello</T></div>) */
   enableAutoJsxInjection: boolean;
   /** Automatically treat interpolated/concatenated values as derive() calls */
-  autoDerive: boolean;
+  autoderive: boolean;
   /** Debug: write a hash → jsxChildren manifest file on build */
   _debugHashManifest: boolean;
 }

--- a/packages/compiler/src/state/utils/initializeState.ts
+++ b/packages/compiler/src/state/utils/initializeState.ts
@@ -18,7 +18,7 @@ const DEFAULT_SETTINGS: PluginSettings = {
   enableConcatenationArg: true,
   enableMacroImportInjection: true,
   enableAutoJsxInjection: false,
-  autoDerive: false,
+  autoderive: false,
   _debugHashManifest: false,
 };
 
@@ -33,13 +33,23 @@ export function initializeState(
   const gtConfig = options.gtConfig;
   const enableAutoJsxInjection =
     gtConfig?.files?.gt?.parsingFlags?.enableAutoJsxInjection ?? false;
+  const autoderive =
+    gtConfig?.files?.gt?.parsingFlags?.autoderive ??
+    gtConfig?.files?.gt?.parsingFlags?.autoDerive ??
+    false;
 
   const settings: PluginSettings = {
     ...DEFAULT_SETTINGS,
     enableAutoJsxInjection, // can be overridden by options.enableAutoJsxInjection
+    autoderive,
     ...options,
     filename,
   };
+
+  // Backwards compat: normalize deprecated autoDerive → autoderive
+  if (options.autoDerive !== undefined && options.autoderive === undefined) {
+    settings.autoderive = options.autoDerive;
+  }
 
   return {
     settings,

--- a/packages/compiler/src/transform/validation/__tests__/validateTranslationFunctionCallback.test.ts
+++ b/packages/compiler/src/transform/validation/__tests__/validateTranslationFunctionCallback.test.ts
@@ -33,7 +33,7 @@ describe('validateTranslationFunctionCallback', () => {
       enableConcatenationArg: true,
       enableMacroImportInjection: true,
       enableAutoJsxInjection: false,
-      autoDerive: false,
+      autoderive: false,
       _debugHashManifest: false,
     };
 
@@ -885,8 +885,8 @@ describe('validateTranslationFunctionCallback', () => {
       expect(result.errors).toHaveLength(0);
     });
 
-    it('should not error on template literal with bare variable when autoDerive is enabled', () => {
-      // msg(`Hello, ${name}`) — should pass regardless of autoDerive
+    it('should not error on template literal with bare variable when autoderive is enabled', () => {
+      // msg(`Hello, ${name}`) — should pass regardless of autoderive
       const callExpr = t.callExpression(t.identifier('useMessages_callback'), [
         t.templateLiteral(
           [
@@ -903,8 +903,8 @@ describe('validateTranslationFunctionCallback', () => {
     });
   });
 
-  describe('autoDerive', () => {
-    let autoDeriveState: TransformState;
+  describe('autoderive', () => {
+    let autoderiveState: TransformState;
 
     beforeEach(() => {
       const stringCollector = new StringCollector();
@@ -922,11 +922,11 @@ describe('validateTranslationFunctionCallback', () => {
         enableConcatenationArg: true,
         enableMacroImportInjection: true,
         enableAutoJsxInjection: false,
-        autoDerive: true,
+        autoderive: true,
         _debugHashManifest: false,
       };
 
-      autoDeriveState = {
+      autoderiveState = {
         settings,
         stringCollector,
         scopeTracker,
@@ -947,7 +947,7 @@ describe('validateTranslationFunctionCallback', () => {
       );
     });
 
-    it('should accept template literal with bare variable when autoDerive is enabled', () => {
+    it('should accept template literal with bare variable when autoderive is enabled', () => {
       // gt(`Hello, ${name}`)
       const callExpr = t.callExpression(t.identifier('useGT_callback'), [
         t.templateLiteral(
@@ -959,13 +959,13 @@ describe('validateTranslationFunctionCallback', () => {
         ),
       ]);
 
-      const result = validateUseGTCallback(callExpr, autoDeriveState);
+      const result = validateUseGTCallback(callExpr, autoderiveState);
 
       expect(result.errors).toHaveLength(0);
       expect(result.hasDeriveContext).toBe(true);
     });
 
-    it('should accept concatenation with bare variable when autoDerive is enabled', () => {
+    it('should accept concatenation with bare variable when autoderive is enabled', () => {
       // gt("Hello, " + name)
       const callExpr = t.callExpression(t.identifier('useGT_callback'), [
         t.binaryExpression(
@@ -975,13 +975,13 @@ describe('validateTranslationFunctionCallback', () => {
         ),
       ]);
 
-      const result = validateUseGTCallback(callExpr, autoDeriveState);
+      const result = validateUseGTCallback(callExpr, autoderiveState);
 
       expect(result.errors).toHaveLength(0);
       expect(result.hasDeriveContext).toBe(true);
     });
 
-    it('should accept template literal with bare function call when autoDerive is enabled', () => {
+    it('should accept template literal with bare function call when autoderive is enabled', () => {
       // gt(`Hello, ${getName()}`)
       const callExpr = t.callExpression(t.identifier('useGT_callback'), [
         t.templateLiteral(
@@ -993,13 +993,13 @@ describe('validateTranslationFunctionCallback', () => {
         ),
       ]);
 
-      const result = validateUseGTCallback(callExpr, autoDeriveState);
+      const result = validateUseGTCallback(callExpr, autoderiveState);
 
       expect(result.errors).toHaveLength(0);
       expect(result.hasDeriveContext).toBe(true);
     });
 
-    it('should accept concatenation with bare function call when autoDerive is enabled', () => {
+    it('should accept concatenation with bare function call when autoderive is enabled', () => {
       // gt("Hello, " + getName())
       const callExpr = t.callExpression(t.identifier('useGT_callback'), [
         t.binaryExpression(
@@ -1009,14 +1009,14 @@ describe('validateTranslationFunctionCallback', () => {
         ),
       ]);
 
-      const result = validateUseGTCallback(callExpr, autoDeriveState);
+      const result = validateUseGTCallback(callExpr, autoderiveState);
 
       expect(result.errors).toHaveLength(0);
       expect(result.hasDeriveContext).toBe(true);
     });
 
-    it('should reject template literal with bare variable when autoDerive is disabled', () => {
-      // gt(`Hello, ${name}`) with autoDerive off (default state)
+    it('should reject template literal with bare variable when autoderive is disabled', () => {
+      // gt(`Hello, ${name}`) with autoderive off (default state)
       const callExpr = t.callExpression(t.identifier('useGT_callback'), [
         t.templateLiteral(
           [
@@ -1032,8 +1032,8 @@ describe('validateTranslationFunctionCallback', () => {
       expect(result.errors.length).toBeGreaterThan(0);
     });
 
-    it('should reject concatenation with bare variable when autoDerive is disabled', () => {
-      // gt("Hello, " + name) with autoDerive off (default state)
+    it('should reject concatenation with bare variable when autoderive is disabled', () => {
+      // gt("Hello, " + name) with autoderive off (default state)
       const callExpr = t.callExpression(t.identifier('useGT_callback'), [
         t.binaryExpression(
           '+',
@@ -1047,7 +1047,7 @@ describe('validateTranslationFunctionCallback', () => {
       expect(result.errors.length).toBeGreaterThan(0);
     });
 
-    it('should accept mixed explicit derive and bare variable when autoDerive is enabled', () => {
+    it('should accept mixed explicit derive and bare variable when autoderive is enabled', () => {
       // gt(`Hello, ${derive(getName())} and ${name}`)
       const deriveCall = t.callExpression(
         t.identifier(GT_OTHER_FUNCTIONS.derive),
@@ -1065,13 +1065,13 @@ describe('validateTranslationFunctionCallback', () => {
         ),
       ]);
 
-      const result = validateUseGTCallback(callExpr, autoDeriveState);
+      const result = validateUseGTCallback(callExpr, autoderiveState);
 
       expect(result.errors).toHaveLength(0);
       expect(result.hasDeriveContext).toBe(true);
     });
 
-    it('should accept getGT_callback with template literal and bare variable when autoDerive is enabled', () => {
+    it('should accept getGT_callback with template literal and bare variable when autoderive is enabled', () => {
       // const gt = getGT(); gt(`Hello, ${name}`)
       const callExpr = t.callExpression(t.identifier('getGT_callback'), [
         t.templateLiteral(
@@ -1083,14 +1083,14 @@ describe('validateTranslationFunctionCallback', () => {
         ),
       ]);
 
-      const result = validateUseGTCallback(callExpr, autoDeriveState);
+      const result = validateUseGTCallback(callExpr, autoderiveState);
 
       expect(result.errors).toHaveLength(0);
       expect(result.hasDeriveContext).toBe(true);
     });
 
-    it('should still reject bare variable in $context when autoDerive is enabled', () => {
-      // autoDerive only applies to content, not $context
+    it('should still reject bare variable in $context when autoderive is enabled', () => {
+      // autoderive only applies to content, not $context
       const callExpr = t.callExpression(t.identifier('useGT_callback'), [
         t.stringLiteral('Hello'),
         t.objectExpression([
@@ -1101,7 +1101,7 @@ describe('validateTranslationFunctionCallback', () => {
         ]),
       ]);
 
-      const result = validateUseGTCallback(callExpr, autoDeriveState);
+      const result = validateUseGTCallback(callExpr, autoderiveState);
 
       expect(result.errors.length).toBeGreaterThan(0);
     });

--- a/packages/compiler/src/transform/validation/validateTranslationFunctionCallback.ts
+++ b/packages/compiler/src/transform/validation/validateTranslationFunctionCallback.ts
@@ -50,8 +50,8 @@ export function validateUseGTCallback(
   );
   const content = validatedContent.value;
 
-  if (content === undefined && !state.settings.autoDerive) {
-    // Check if it contains a derive() function invocation (no requirement for derive() invoc with autoDerive)
+  if (content === undefined && !state.settings.autoderive) {
+    // Check if it contains a derive() function invocation (no requirement for derive() invoc with autoderive)
     validateDerive(callExpr.arguments[0], state, errors);
     if (errors.length > 0) {
       errors.push(...validatedContent.errors);
@@ -64,10 +64,10 @@ export function validateUseGTCallback(
 
   // TODO: hasDeriveContext should be refactored to enforce no hash generated HERE in this function
   // instead of passing that information outside of this function.
-  // We skip hash gen with autoDerive, derive in content, and derive in $context. This flag is being
+  // We skip hash gen with autoderive, derive in content, and derive in $context. This flag is being
   // reused for all 3 cases.
-  const contentHasAutoDerive =
-    state.settings.autoDerive && content === undefined;
+  const contentHasAutoderive =
+    state.settings.autoderive && content === undefined;
 
   // Validate second argument
   let context: string | undefined;
@@ -80,7 +80,7 @@ export function validateUseGTCallback(
     return {
       errors,
       content,
-      hasDeriveContext: contentHasAutoDerive || undefined,
+      hasDeriveContext: contentHasAutoderive || undefined,
     };
   }
   if (t.isObjectExpression(callExpr.arguments[1])) {
@@ -93,7 +93,7 @@ export function validateUseGTCallback(
     errors.push(...contextProperty.errors);
     context = contextProperty.value as string | undefined;
     hasDeriveContext =
-      contentHasAutoDerive || contextProperty.hasDeriveExpression;
+      contentHasAutoderive || contextProperty.hasDeriveExpression;
     const idProperty = validatePropertyFromObjectExpression(
       callExpr.arguments[1],
       USEGT_CALLBACK_OPTIONS.$id,

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -528,12 +528,14 @@ export function withGTConfig(
   const { type, ...compilerOptions } =
     mergedConfig.experimentalCompilerOptions || {};
 
-  // Read autoDerive from parsingFlags (single source of truth shared with CLI)
-  const autoDerive = loadedConfig?.files?.gt?.parsingFlags?.autoDerive === true;
+  // Read autoderive from parsingFlags (single source of truth shared with CLI)
+  const autoderive =
+    loadedConfig?.files?.gt?.parsingFlags?.autoderive === true ||
+    loadedConfig?.files?.gt?.parsingFlags?.autoDerive === true;
 
   const swcPluginEntry =
     mergedConfig.experimentalCompilerOptions?.type === 'swc'
-      ? [resolvedWasmFilePath, { ...compilerOptions, autoDerive }]
+      ? [resolvedWasmFilePath, { ...compilerOptions, autoderive }]
       : null;
 
   const turboAliases = {

--- a/packages/next/swc-plugin/src/config.rs
+++ b/packages/next/swc-plugin/src/config.rs
@@ -13,17 +13,17 @@ pub struct PluginSettings {
   /// Disable dynamic content check
   pub disable_build_checks: bool,
   /// When true, bare variables/calls in template literals and concatenations are allowed
-  pub auto_derive: bool,
+  pub autoderive: bool,
 }
 
 impl PluginSettings {
-  pub fn new(log_level: LogLevel, compile_time_hash: bool, filename: Option<String>, disable_build_checks: bool, auto_derive: bool) -> Self {
+  pub fn new(log_level: LogLevel, compile_time_hash: bool, filename: Option<String>, disable_build_checks: bool, autoderive: bool) -> Self {
     Self {
       log_level,
       compile_time_hash,
       filename,
       disable_build_checks,
-      auto_derive,
+      autoderive,
     }
   }
 }
@@ -41,7 +41,7 @@ pub struct PluginConfig {
   #[serde(default)]
   pub disable_build_checks: bool,
   #[serde(default)]
-  pub auto_derive: bool,
+  pub autoderive: bool,
 }
 
 impl Default for PluginConfig {
@@ -51,7 +51,7 @@ impl Default for PluginConfig {
       compile_time_hash: false,
       filename: None,
       disable_build_checks: false,
-      auto_derive: false,
+      autoderive: false,
     }
   }
 }

--- a/packages/next/swc-plugin/src/lib.rs
+++ b/packages/next/swc-plugin/src/lib.rs
@@ -380,7 +380,7 @@ pub fn process_transform(program: Program, metadata: TransformPluginProgramMetad
     config.compile_time_hash,
     filename.clone(),
     config.disable_build_checks,
-    config.auto_derive,
+    config.autoderive,
     string_collector,
   );
   program.visit_mut_with(&mut visitor);
@@ -398,7 +398,7 @@ pub fn process_transform(program: Program, metadata: TransformPluginProgramMetad
     config.compile_time_hash,
     filename,
     config.disable_build_checks,
-    config.auto_derive,
+    config.autoderive,
     collected_data,
   );
   program.fold_with(&mut visitor)

--- a/packages/next/swc-plugin/src/visitor/transform.rs
+++ b/packages/next/swc-plugin/src/visitor/transform.rs
@@ -44,7 +44,7 @@ impl TransformVisitor {
     compile_time_hash: bool,
     filename: Option<String>,
     disable_build_checks: bool,
-    auto_derive: bool,
+    autoderive: bool,
     mut string_collector: StringCollector,
   ) -> Self {
     // Reset the counter to 0
@@ -53,7 +53,7 @@ impl TransformVisitor {
       traversal_state: TraversalState::default(),
       statistics: Statistics::default(),
       import_tracker: ImportTracker::new(),
-      settings: PluginSettings::new(log_level.clone(), compile_time_hash, filename.clone(), disable_build_checks, auto_derive),
+      settings: PluginSettings::new(log_level.clone(), compile_time_hash, filename.clone(), disable_build_checks, autoderive),
       logger: Logger::new(log_level),
       string_collector,
     }
@@ -320,7 +320,7 @@ impl TransformVisitor {
     self.validate_string_literal_or_declare_static(arg.expr.as_ref(), &mut errors);
 
     if !errors.is_empty() {
-      if !self.settings.disable_build_checks && !self.settings.auto_derive {
+      if !self.settings.disable_build_checks && !self.settings.autoderive {
         self.statistics.dynamic_content_violations += 1;
         // Use the first error message for the violation type
         let default_error = &"invalid expression".to_string();
@@ -1770,14 +1770,14 @@ mod tests {
     }
   }
 
-  mod auto_derive_violations {
+  mod autoderive_violations {
     use super::*;
 
-    /// Creates a visitor with auto_derive enabled and standard imports tracked
-    fn create_visitor_with_auto_derive() -> TransformVisitor {
+    /// Creates a visitor with autoderive enabled and standard imports tracked
+    fn create_visitor_with_autoderive() -> TransformVisitor {
       let mut visitor =
         TransformVisitor::new(LogLevel::Silent, false, None, false, false, StringCollector::new());
-      visitor.settings.auto_derive = true;
+      visitor.settings.autoderive = true;
 
       // Track standard gt-next imports
       visitor
@@ -1897,12 +1897,12 @@ mod tests {
       })
     }
 
-    // ── Auto-derive ON: should NOT produce violations ──
+    // ── Autoderive ON: should NOT produce violations ──
 
     // gt(`Hello ${name}!`)  →  treated as gt(`Hello ${derive(name)}!`)
     #[test]
-    fn auto_derive_on_allows_template_literal_with_bare_variable() {
-      let mut visitor = create_visitor_with_auto_derive();
+    fn autoderive_on_allows_template_literal_with_bare_variable() {
+      let mut visitor = create_visitor_with_autoderive();
       let call_expr = create_call_expr("gt", create_template_literal_with_variable());
 
       if let Some(first_arg) = call_expr.args.first() {
@@ -1914,8 +1914,8 @@ mod tests {
 
     // gt("Hello " + name)  →  treated as gt("Hello " + derive(name))
     #[test]
-    fn auto_derive_on_allows_concatenation_with_bare_variable() {
-      let mut visitor = create_visitor_with_auto_derive();
+    fn autoderive_on_allows_concatenation_with_bare_variable() {
+      let mut visitor = create_visitor_with_autoderive();
       let call_expr = create_call_expr("gt", create_string_concat_with_variable());
 
       if let Some(first_arg) = call_expr.args.first() {
@@ -1927,8 +1927,8 @@ mod tests {
 
     // gt(`Hello ${getName()}!`)  →  treated as gt(`Hello ${derive(getName())}!`)
     #[test]
-    fn auto_derive_on_allows_template_literal_with_bare_function_call() {
-      let mut visitor = create_visitor_with_auto_derive();
+    fn autoderive_on_allows_template_literal_with_bare_function_call() {
+      let mut visitor = create_visitor_with_autoderive();
       let call_expr = create_call_expr("gt", create_template_literal_with_function_call());
 
       if let Some(first_arg) = call_expr.args.first() {
@@ -1938,12 +1938,12 @@ mod tests {
       assert_eq!(visitor.statistics.dynamic_content_violations, 0);
     }
 
-    // ── Auto-derive OFF: should produce violations (existing behavior) ──
+    // ── Autoderive OFF: should produce violations (existing behavior) ──
 
     // gt(`Hello ${name}!`)  →  ERROR: bare variable without derive()
     #[test]
-    fn auto_derive_off_rejects_template_literal_with_bare_variable() {
-      let mut visitor = create_visitor_with_imports(); // auto_derive defaults to false
+    fn autoderive_off_rejects_template_literal_with_bare_variable() {
+      let mut visitor = create_visitor_with_imports(); // autoderive defaults to false
       let call_expr = create_call_expr("gt", create_template_literal_with_variable());
 
       if let Some(first_arg) = call_expr.args.first() {
@@ -1955,8 +1955,8 @@ mod tests {
 
     // gt("Hello " + name)  →  ERROR: bare variable without derive()
     #[test]
-    fn auto_derive_off_rejects_concatenation_with_bare_variable() {
-      let mut visitor = create_visitor_with_imports(); // auto_derive defaults to false
+    fn autoderive_off_rejects_concatenation_with_bare_variable() {
+      let mut visitor = create_visitor_with_imports(); // autoderive defaults to false
       let call_expr = create_call_expr("gt", create_string_concat_with_variable());
 
       if let Some(first_arg) = call_expr.args.first() {
@@ -1966,12 +1966,12 @@ mod tests {
       assert_eq!(visitor.statistics.dynamic_content_violations, 1);
     }
 
-    // ── Existing behavior preserved regardless of auto-derive flag ──
+    // ── Existing behavior preserved regardless of autoderive flag ──
 
     // gt(`Hello ${derive(getName())}`)  →  explicit derive() always works
     #[test]
-    fn explicit_derive_works_with_auto_derive_on() {
-      let mut visitor = create_visitor_with_auto_derive();
+    fn explicit_derive_works_with_autoderive_on() {
+      let mut visitor = create_visitor_with_autoderive();
       // Also track derive import
       visitor
         .import_tracker
@@ -2033,8 +2033,8 @@ mod tests {
 
     // gt("Hello world")  →  plain string literal always passes
     #[test]
-    fn plain_string_literal_works_with_auto_derive_on() {
-      let mut visitor = create_visitor_with_auto_derive();
+    fn plain_string_literal_works_with_autoderive_on() {
+      let mut visitor = create_visitor_with_autoderive();
       let string_literal = Expr::Lit(Lit::Str(Str {
         span: DUMMY_SP,
         value: Atom::new("Hello world").into(),
@@ -2051,8 +2051,8 @@ mod tests {
 
     // gt("Hello world")  →  plain string literal always passes
     #[test]
-    fn plain_string_literal_works_with_auto_derive_off() {
-      let mut visitor = create_visitor_with_imports(); // auto_derive defaults to false
+    fn plain_string_literal_works_with_autoderive_off() {
+      let mut visitor = create_visitor_with_imports(); // autoderive defaults to false
       let string_literal = Expr::Lit(Lit::Str(Str {
         span: DUMMY_SP,
         value: Atom::new("Hello world").into(),


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR renames the `autoDerive` / `autoDeriveMethod` identifiers to `autoderive` / `autoderiveMethod` (all lowercase) across the CLI, compiler, and `gt-next` packages. Backward compatibility is maintained via deprecated aliases in `PluginConfig`, runtime key migration in `parseFilesConfig.ts`, and fallback reads in `initializeState.ts` and `next/src/config.ts`. The Rust SWC plugin config already used the lowercase form, so no changes were needed there beyond using the existing field.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — rename is consistent across all packages with proper backward compat; only finding is a minor P2 mutation of the caller's input object.

All P0/P1 findings are absent. The single comment (mutation of input in parseFilesConfig.ts) is P2 and does not affect correctness in typical single-invocation CLI use.

packages/cli/src/fs/config/parseFilesConfig.ts — the IIFE should spread-copy rawGtFlags before mutating.
</details>

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/fs/config/parseFilesConfig.ts | Added IIFE-based backward-compat migration for autoDerive→autoderive; mutates the caller's input object rather than a copy. |
| packages/cli/src/types/parsing.ts | GTParsingFlags.autoDerive renamed to autoderive; all call sites updated. |
| packages/compiler/src/config.ts | PluginConfig gains autoderive with @deprecated autoDerive alias; PluginSettings updated to use autoderive. |
| packages/compiler/src/state/utils/initializeState.ts | Backward compat: reads autoderive ?? autoDerive from gtConfig, and normalizes deprecated options.autoDerive at runtime. |
| packages/next/src/config.ts | Reads autoderive with autoDerive fallback from loadedConfig; correctly maintains backward compat. |
| packages/next/swc-plugin/src/config.rs | Rust PluginConfig already used autoderive (all-lowercase); serde camelCase rename_all is a no-op for single-word all-lowercase field names. |
| packages/cli/src/react/jsx/utils/stringParsing/types.ts | ParsingConfig.autoDeriveMethod renamed to autoderiveMethod; consistent rename throughout. |
| packages/cli/src/react/jsx/utils/parseStringFunction.ts | All autoDeriveMethod references updated to autoderiveMethod; logic unchanged. |
| packages/cli/src/console/index.ts | warnAutoDeriveNoResultsSync renamed to warnAutoderiveNoResultsSync; message text updated to 'Autoderive'. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User config: gt.config.json] --> B{Contains autoDerive?}
    B -- "yes (legacy)" --> C["parseFilesConfig.ts IIFE:\ncopy autoDerive → autoderive\ndelete autoDerive"]
    B -- "no / autoderive" --> D[Use as-is]
    C --> E[Merge with GT_PARSING_FLAGS_DEFAULT]
    D --> E
    E --> F[GTParsingFlags.autoderive: boolean]
    F --> G{autoderive === true?}
    G -- yes --> H[autoderiveMethod: 'AUTO']
    G -- no --> I[autoderiveMethod: 'DISABLED']
    H --> J[parseStrings / deriveExpression]
    I --> J
    A2[Babel plugin options] --> K{options.autoDerive set and options.autoderive unset?}
    K -- yes --> L["initializeState.ts:\nsettings.autoderive = options.autoDerive"]
    K -- no --> M[Use autoderive directly]
    L --> N[PluginSettings.autoderive: boolean]
    M --> N
    N --> O[validateTranslationFunctionCallback]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/cli/src/fs/config/parseFilesConfig.ts
Line: 158-174

Comment:
**Mutation of caller's input object**

`rawGtFlags` is a direct reference to `files.gt.parsingFlags` (not a copy), so `delete rawGtFlags.autoDerive` mutates the object the caller passed in. If `resolveFiles` is called more than once with the same `files` argument, or if the caller inspects `files.gt.parsingFlags` after this call, the `autoDerive` key will be silently gone. Add a spread to clone the flags first:

```suggestion
    gtJson: (() => {
      const rawGtFlags = { ...(files.gt?.parsingFlags || {}) } as Record<
        string,
        unknown
      >;
      if ('autoDerive' in rawGtFlags && !('autoderive' in rawGtFlags)) {
        rawGtFlags.autoderive = rawGtFlags.autoDerive;
        delete rawGtFlags.autoDerive;
      }
      return {
        publish: files.gt?.publish,
        parsingFlags: {
          ...GT_PARSING_FLAGS_DEFAULT,
          ...rawGtFlags,
        },
      };
    })(),
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: standardize name for autoderiv..."](https://github.com/generaltranslation/gt/commit/328865a241e9bc90f9a049f649d9f84a81c4dd10) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27902275)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->