### PR TITLE
ci: separate lint into its own non-blocking job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ permissions:
   contents: read
 
 jobs:
-  tests:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -44,6 +44,34 @@ jobs:
 
       - name: Run lint
         run: pnpm exec turbo lint --filter='...[origin/${{ github.base_ref }}]'
+
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: 'pnpm'
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-wasip1
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Rebuild packages
+        run: pnpm rebuild --filter='...[origin/${{ github.base_ref }}]'
 
       - name: Build packages
         run: pnpm exec turbo build --filter='...[origin/${{ github.base_ref }}]' --filter='!gt-next-middleware-e2e'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,7 +282,7 @@ jobs:
         run: cd tests/apps/cli-test-app && pnpm install && pnpm gtx-cli --help
 
   run-tests:
-    needs: [tests, test-builds, test-cli-binaries, test-gtx-cli-binaries]
+    needs: [lint, tests, test-builds, test-cli-binaries, test-gtx-cli-binaries]
     runs-on: ubuntu-latest
     steps:
       - run: echo "All tests passed"


### PR DESCRIPTION
Addresses the issue where lint failures block test execution in CI.

## Problem
The lint step runs sequentially inside the `tests` job, before build and test. If linting fails, you have to fix it before you can even see whether tests pass.

## Fix
Moves linting into its own dedicated `lint` job that runs **in parallel** with the `tests` job. The `run-tests` status gate only depends on test jobs — lint is independent and non-blocking.

Both jobs still run on every PR, so lint failures are visible but don't prevent test results from appearing.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR separates lint from the `tests` job into its own parallel `lint` job, so lint failures no longer block test results from appearing. The `run-tests` gate intentionally excludes `lint` from its `needs` list, keeping it purely informational.

The restructuring faithfully preserves the original step order: the lint job retains checkout → pnpm → Node → Rust → install → rebuild → lint, while the new `tests` job gets the same setup plus build → test. The duplication is expected for parallel GitHub Actions jobs.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the restructuring is correct, the run-tests gate is unchanged, and the only finding is a minor optimization suggestion.

All findings are P2. The parallel job split is implemented correctly: lint runs independently, the run-tests gate still requires all four test jobs, and the step ordering within each job matches the original. No logic errors or regressions introduced.

No files require special attention.
</details>


<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Lint extracted into its own parallel job; `run-tests` gate unchanged at [tests, test-builds, test-cli-binaries, test-gtx-cli-binaries]. Rust toolchain + pnpm rebuild steps retained in the lint job — necessary only if native addons are required for linting, otherwise minor overhead. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    PR[Pull Request] --> lint
    PR --> tests
    PR --> test-builds
    PR --> test-cli-binaries
    PR --> test-gtx-cli-binaries

    lint["lint\n(checkout → pnpm → node → rust → install → rebuild → lint)"]
    tests["tests\n(checkout → pnpm → node → rust → install → rebuild → build → test)"]
    test-builds["test-builds\n(matrix: os × node)"]
    test-cli-binaries["test-cli-binaries\n(matrix: os × arch)"]
    test-gtx-cli-binaries["test-gtx-cli-binaries\n(matrix: os × arch)"]

    tests --> run-tests
    test-builds --> run-tests
    test-cli-binaries --> run-tests
    test-gtx-cli-binaries --> run-tests

    run-tests["✅ run-tests gate\n(status check)"]

    lint -. "non-blocking\n(visible but does not gate merge)" .-> run-tests

    style lint fill:#f9f,stroke:#333
    style run-tests fill:#9f9,stroke:#333
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/ci.yml`, line 34-43 ([link](https://github.com/generaltranslation/gt/blob/ea6cd547a327cb24228365d13aa029802b2bca38/.github/workflows/ci.yml#L34-L43)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Rust toolchain + rebuild may be unnecessary for linting**

   The `lint` job sets up the Rust toolchain and runs `pnpm rebuild` before linting. These steps were inherited from the old combined job where Rust/WASM was needed for the `build` and `test` steps that followed. Since lint now runs in isolation, these steps are only needed if a native addon (or WASM compilation) is actually required at lint time. If not, they add ~1–2 minutes of unnecessary CI time per PR.

   Consider whether `pnpm rebuild` and `dtolnay/rust-toolchain` are actually exercised during `turbo lint`. If linting works without them, you can trim the lint job to just checkout → pnpm → node → install → lint.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: .github/workflows/ci.yml
   Line: 34-43

   Comment:
   **Rust toolchain + rebuild may be unnecessary for linting**

   The `lint` job sets up the Rust toolchain and runs `pnpm rebuild` before linting. These steps were inherited from the old combined job where Rust/WASM was needed for the `build` and `test` steps that followed. Since lint now runs in isolation, these steps are only needed if a native addon (or WASM compilation) is actually required at lint time. If not, they add ~1–2 minutes of unnecessary CI time per PR.

   Consider whether `pnpm rebuild` and `dtolnay/rust-toolchain` are actually exercised during `turbo lint`. If linting works without them, you can trim the lint job to just checkout → pnpm → node → install → lint.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/ci.yml
Line: 34-43

Comment:
**Rust toolchain + rebuild may be unnecessary for linting**

The `lint` job sets up the Rust toolchain and runs `pnpm rebuild` before linting. These steps were inherited from the old combined job where Rust/WASM was needed for the `build` and `test` steps that followed. Since lint now runs in isolation, these steps are only needed if a native addon (or WASM compilation) is actually required at lint time. If not, they add ~1–2 minutes of unnecessary CI time per PR.

Consider whether `pnpm rebuild` and `dtolnay/rust-toolchain` are actually exercised during `turbo lint`. If linting works without them, you can trim the lint job to just checkout → pnpm → node → install → lint.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: separate lint into its own non-block..."](https://github.com/generaltranslation/gt/commit/ea6cd547a327cb24228365d13aa029802b2bca38) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27914979)</sub>

<!-- /greptile_comment -->