### PR TITLE
fix(gt-next): spread derivation

### DIFF
--- a/.changeset/slick-ideas-sell.md
+++ b/.changeset/slick-ideas-sell.md
@@ -1,0 +1,5 @@
+---
+'gt-next': patch
+---
+
+fix: spread derivation

--- a/packages/next/swc-plugin/src/ast/traversal.rs
+++ b/packages/next/swc-plugin/src/ast/traversal.rs
@@ -746,6 +746,7 @@ fn has_dynamic_content_recursive(children: &[JSXElementChild]) -> bool {
     JSXElementChild::JSXFragment(fragment) => {
       has_dynamic_content_recursive(&fragment.children)
     }
+    JSXElementChild::JSXSpreadChild(_) => true,
     _ => false,
   })
 }
@@ -1409,6 +1410,290 @@ mod tests {
       assert_eq!(branches.len(), 2);
       assert!(branches.contains_key("database"));
       assert!(branches.contains_key("dataSource"));
+    }
+  }
+
+  mod has_dynamic_content_recursive_tests {
+    use super::*;
+
+    fn create_jsx_expr_container(expr: JSXExpr) -> JSXElementChild {
+      JSXElementChild::JSXExprContainer(JSXExprContainer {
+        span: DUMMY_SP,
+        expr,
+      })
+    }
+
+    fn create_ident_expr(name: &str) -> JSXExpr {
+      JSXExpr::Expr(Box::new(Expr::Ident(Ident {
+        span: DUMMY_SP,
+        sym: Atom::new(name),
+        optional: false,
+        ctxt: SyntaxContext::empty(),
+      })))
+    }
+
+    fn create_spread_child(name: &str) -> JSXElementChild {
+      JSXElementChild::JSXSpreadChild(JSXSpreadChild {
+        span: DUMMY_SP,
+        expr: Box::new(Expr::Ident(Ident {
+          span: DUMMY_SP,
+          sym: Atom::new(name),
+          optional: false,
+          ctxt: SyntaxContext::empty(),
+        })),
+      })
+    }
+
+    fn create_fragment_child(children: Vec<JSXElementChild>) -> JSXElementChild {
+      JSXElementChild::JSXFragment(JSXFragment {
+        span: DUMMY_SP,
+        opening: JSXOpeningFragment { span: DUMMY_SP },
+        closing: JSXClosingFragment { span: DUMMY_SP },
+        children,
+      })
+    }
+
+    fn create_element_child(tag: &str, children: Vec<JSXElementChild>) -> JSXElementChild {
+      JSXElementChild::JSXElement(Box::new(JSXElement {
+        span: DUMMY_SP,
+        opening: JSXOpeningElement {
+          span: DUMMY_SP,
+          name: JSXElementName::Ident(Ident {
+            span: DUMMY_SP,
+            sym: Atom::new(tag),
+            optional: false,
+            ctxt: SyntaxContext::empty(),
+          }),
+          attrs: vec![],
+          self_closing: false,
+          type_args: None,
+        },
+        children,
+        closing: Some(JSXClosingElement {
+          span: DUMMY_SP,
+          name: JSXElementName::Ident(Ident {
+            span: DUMMY_SP,
+            sym: Atom::new(tag),
+            optional: false,
+            ctxt: SyntaxContext::empty(),
+          }),
+        }),
+      }))
+    }
+
+    #[test]
+    fn empty_children_not_dynamic() {
+      assert!(!has_dynamic_content_recursive(&[]));
+    }
+
+    #[test]
+    fn text_only_not_dynamic() {
+      let children = vec![create_jsx_text_child("Hello world")];
+      assert!(!has_dynamic_content_recursive(&children));
+    }
+
+    #[test]
+    fn allowed_expr_not_dynamic() {
+      // String literal in expression container is allowed (not dynamic)
+      let expr = JSXExpr::Expr(Box::new(Expr::Lit(Lit::Str(Str {
+        span: DUMMY_SP,
+        value: Atom::new("static").into(),
+        raw: None,
+      }))));
+      let children = vec![create_jsx_expr_container(expr)];
+      assert!(!has_dynamic_content_recursive(&children));
+    }
+
+    #[test]
+    fn identifier_expr_is_dynamic() {
+      // A bare identifier like {someVar} is dynamic
+      let children = vec![create_jsx_expr_container(create_ident_expr("someVar"))];
+      assert!(has_dynamic_content_recursive(&children));
+    }
+
+    #[test]
+    fn spread_child_is_dynamic() {
+      // {...items} should be treated as dynamic
+      let children = vec![create_spread_child("items")];
+      assert!(has_dynamic_content_recursive(&children));
+    }
+
+    #[test]
+    fn spread_child_among_text_is_dynamic() {
+      let children = vec![
+        create_jsx_text_child("Hello "),
+        create_spread_child("items"),
+        create_jsx_text_child(" world"),
+      ];
+      assert!(has_dynamic_content_recursive(&children));
+    }
+
+    #[test]
+    fn spread_child_nested_in_element_is_dynamic() {
+      // <div>{...items}</div> nested inside parent
+      let children = vec![
+        create_element_child("div", vec![create_spread_child("items")]),
+      ];
+      assert!(has_dynamic_content_recursive(&children));
+    }
+
+    #[test]
+    fn spread_child_nested_in_fragment_is_dynamic() {
+      // <>{...items}</> nested inside parent
+      let children = vec![
+        create_fragment_child(vec![create_spread_child("items")]),
+      ];
+      assert!(has_dynamic_content_recursive(&children));
+    }
+
+    #[test]
+    fn nested_static_elements_not_dynamic() {
+      let children = vec![
+        create_element_child("div", vec![create_jsx_text_child("text")]),
+        create_fragment_child(vec![create_jsx_text_child("more text")]),
+      ];
+      assert!(!has_dynamic_content_recursive(&children));
+    }
+  }
+
+  mod autoderive_spread_child_hash_tests {
+    use super::*;
+
+    fn create_autoderive_visitor() -> TransformVisitor {
+      TransformVisitor {
+        statistics: Statistics::default(),
+        traversal_state: TraversalState::default(),
+        import_tracker: ImportTracker::default(),
+        settings: PluginSettings::new(LogLevel::Silent, false, None, false, true),
+        logger: Logger::new(LogLevel::Silent),
+        string_collector: crate::ast::StringCollector::new(),
+      }
+    }
+
+    fn create_jsx_element_with_children(tag_name: &str, children: Vec<JSXElementChild>) -> JSXElement {
+      JSXElement {
+        span: DUMMY_SP,
+        opening: JSXOpeningElement {
+          span: DUMMY_SP,
+          name: JSXElementName::Ident(Ident {
+            span: DUMMY_SP,
+            sym: Atom::new(tag_name),
+            optional: false,
+            ctxt: SyntaxContext::empty(),
+          }),
+          attrs: vec![],
+          self_closing: false,
+          type_args: None,
+        },
+        children,
+        closing: Some(JSXClosingElement {
+          span: DUMMY_SP,
+          name: JSXElementName::Ident(Ident {
+            span: DUMMY_SP,
+            sym: Atom::new(tag_name),
+            optional: false,
+            ctxt: SyntaxContext::empty(),
+          }),
+        }),
+      }
+    }
+
+    #[test]
+    fn autoderive_spread_child_produces_empty_hash() {
+      let visitor = create_autoderive_visitor();
+      let mut traversal = JsxTraversal::new(&visitor);
+
+      let element = create_jsx_element_with_children("T", vec![
+        create_jsx_text_child("Hello "),
+        JSXElementChild::JSXSpreadChild(JSXSpreadChild {
+          span: DUMMY_SP,
+          expr: Box::new(Expr::Ident(Ident {
+            span: DUMMY_SP,
+            sym: Atom::new("items"),
+            optional: false,
+            ctxt: SyntaxContext::empty(),
+          })),
+        }),
+      ]);
+
+      let (hash, json_string) = traversal.calculate_element_hash(&element);
+      assert!(hash.is_empty(), "Spread child with autoderive should produce empty hash");
+      assert!(json_string.is_empty(), "Spread child with autoderive should produce empty json");
+    }
+
+    #[test]
+    fn autoderive_text_only_produces_nonempty_hash() {
+      let visitor = create_autoderive_visitor();
+      let mut traversal = JsxTraversal::new(&visitor);
+
+      let element = create_jsx_element_with_children("T", vec![
+        create_jsx_text_child("Hello world"),
+      ]);
+
+      let (hash, _) = traversal.calculate_element_hash(&element);
+      assert!(!hash.is_empty(), "Text-only content with autoderive should still produce a hash");
+    }
+
+    #[test]
+    fn no_autoderive_spread_child_produces_nonempty_hash() {
+      // Without autoderive, spread children don't trigger the empty-hash path
+      let visitor = create_test_visitor(); // autoderive=false
+      let mut traversal = JsxTraversal::new(&visitor);
+
+      let element = create_jsx_element_with_children("T", vec![
+        create_jsx_text_child("Hello "),
+        JSXElementChild::JSXSpreadChild(JSXSpreadChild {
+          span: DUMMY_SP,
+          expr: Box::new(Expr::Ident(Ident {
+            span: DUMMY_SP,
+            sym: Atom::new("items"),
+            optional: false,
+            ctxt: SyntaxContext::empty(),
+          })),
+        }),
+      ]);
+
+      let (hash, _) = traversal.calculate_element_hash(&element);
+      assert!(!hash.is_empty(), "Without autoderive, spread child should not trigger empty hash");
+    }
+
+    #[test]
+    fn autoderive_expr_container_and_spread_child_both_produce_empty_hash() {
+      let visitor = create_autoderive_visitor();
+
+      // Expression container with dynamic ident
+      let mut traversal1 = JsxTraversal::new(&visitor);
+      let expr_element = create_jsx_element_with_children("T", vec![
+        JSXElementChild::JSXExprContainer(JSXExprContainer {
+          span: DUMMY_SP,
+          expr: JSXExpr::Expr(Box::new(Expr::Ident(Ident {
+            span: DUMMY_SP,
+            sym: Atom::new("count"),
+            optional: false,
+            ctxt: SyntaxContext::empty(),
+          }))),
+        }),
+      ]);
+
+      // Spread child
+      let mut traversal2 = JsxTraversal::new(&visitor);
+      let spread_element = create_jsx_element_with_children("T", vec![
+        JSXElementChild::JSXSpreadChild(JSXSpreadChild {
+          span: DUMMY_SP,
+          expr: Box::new(Expr::Ident(Ident {
+            span: DUMMY_SP,
+            sym: Atom::new("items"),
+            optional: false,
+            ctxt: SyntaxContext::empty(),
+          })),
+        }),
+      ]);
+
+      let (expr_hash, _) = traversal1.calculate_element_hash(&expr_element);
+      let (spread_hash, _) = traversal2.calculate_element_hash(&spread_element);
+
+      assert!(expr_hash.is_empty(), "Dynamic expr container should produce empty hash");
+      assert!(spread_hash.is_empty(), "Spread child should produce empty hash");
     }
   }
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This patch fixes a bug in the SWC plugin's `has_dynamic_content_recursive` function where `JSXSpreadChild` nodes were not recognized as dynamic content. Before the fix, `{...items}` inside a `<T>` element with `autoderive=true` would fall through to the `_ => false` arm, causing the compiler to generate a static hash from only the surrounding text (e.g. `"Hello "`) while silently dropping the spread — instead of returning an empty hash to trigger runtime derivation. The fix adds the explicit `JSXSpreadChild(_) => true` arm and backs it with a comprehensive suite of tests covering nested, fragment, and mixed scenarios in both autoderive and non-autoderive modes.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the fix is minimal, correct, and well-covered by new tests.

A single targeted arm added to a match statement in the SWC plugin, directly fixing a real bug where spread children were silently treated as static in autoderive mode. No P0/P1 findings; all new tests clearly verify the expected behavior for both autoderive and non-autoderive paths.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/next/swc-plugin/src/ast/traversal.rs | Adds `JSXSpreadChild(_) => true` arm to `has_dynamic_content_recursive`, preventing spread children from being silently treated as static in autoderive mode; backed by ~100 lines of new tests covering nested, fragment, and autoderive/non-autoderive paths. |
| .changeset/slick-ideas-sell.md | Correct patch-level changeset for a bug fix in gt-next. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["calculate_element_hash(element)"] --> B{autoderive enabled?}
    B -- Yes --> C["has_dynamic_content_recursive(children)"]
    C --> D{child type?}
    D -- JSXExprContainer --> E{is_allowed_dynamic_content?}
    E -- No --> F["return true (dynamic)"]
    E -- Yes --> G["continue"]
    D -- JSXElement --> H["recurse into children"]
    D -- JSXFragment --> I["recurse into children"]
    D -- JSXSpreadChild --> J["return true (dynamic) ✅ NEW FIX"]
    D -- other --> K["return false"]
    F --> L["return empty hash ('')"]
    J --> L
    H -- dynamic found --> L
    I -- dynamic found --> L
    B -- No --> M["build_sanitized_children()"]
    C -- no dynamic --> M
    M --> N["JSXSpreadChild → None (skipped)"]
    N --> O["hash computed from remaining children"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(gt-next): spread derivation"](https://github.com/generaltranslation/gt/commit/24481bd69b5802f3780788f76d40b13aa17b0704) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27931174)</sub>

<!-- /greptile_comment -->