### PR TITLE
chore(cli): customize autoderive behavior

### DIFF
--- a/.changeset/smart-sites-learn.md
+++ b/.changeset/smart-sites-learn.md
@@ -1,0 +1,7 @@
+---
+'@generaltranslation/compiler': patch
+'gt-next': patch
+'gt': patch
+---
+
+chore: customize autoderive

--- a/packages/cli/src/config/defaults.ts
+++ b/packages/cli/src/config/defaults.ts
@@ -2,7 +2,7 @@ import { BaseParsingFlags, GTParsingFlags } from '../types/parsing.js';
 
 /**
  * Default parsing flags for GT files
- * @property {boolean} autoderive - Whether to enable autoderive for the t() function. (true -> 'AUTO', false -> 'DISABLED' {@link ParsingConfig['autoderiveMethod']})
+ * @property {boolean | { jsx?: boolean; strings?: boolean }} autoderive - Whether to enable autoderive. A plain boolean enables/disables both; an object enables selectively.
  * @property {boolean} includeSourceCodeContext - Include surrounding source code lines as context for translations.
  */
 export const GT_PARSING_FLAGS_DEFAULT: GTParsingFlags = {

--- a/packages/cli/src/react/jsx/utils/jsxParsing/__tests__/autoderiveJsx.test.ts
+++ b/packages/cli/src/react/jsx/utils/jsxParsing/__tests__/autoderiveJsx.test.ts
@@ -3,7 +3,10 @@ import * as t from '@babel/types';
 import { parse } from '@babel/parser';
 import traverse from '@babel/traverse';
 import { parseTranslationComponent } from '../parseJsx.js';
-import { ParsingConfigOptions } from '../../../../../types/parsing.js';
+import {
+  ParsingConfigOptions,
+  resolveAutoderive,
+} from '../../../../../types/parsing.js';
 import { Updates } from '../../../../../types/index.js';
 import { Libraries } from '../../../../../types/libraries.js';
 
@@ -462,5 +465,47 @@ describe('Autoderive JSX: edge cases', () => {
         )
     );
     expect(hasDerive).toBe(true);
+  });
+});
+
+describe('resolveAutoderive', () => {
+  it('true enables both jsx and strings', () => {
+    expect(resolveAutoderive(true)).toEqual({ jsx: true, strings: true });
+  });
+
+  it('false disables both jsx and strings', () => {
+    expect(resolveAutoderive(false)).toEqual({ jsx: false, strings: false });
+  });
+
+  it('{ jsx: true, strings: false } enables only jsx', () => {
+    expect(resolveAutoderive({ jsx: true, strings: false })).toEqual({
+      jsx: true,
+      strings: false,
+    });
+  });
+
+  it('{ jsx: false, strings: true } enables only strings', () => {
+    expect(resolveAutoderive({ jsx: false, strings: true })).toEqual({
+      jsx: false,
+      strings: true,
+    });
+  });
+
+  it('{ jsx: true } defaults strings to false', () => {
+    expect(resolveAutoderive({ jsx: true })).toEqual({
+      jsx: true,
+      strings: false,
+    });
+  });
+
+  it('{ strings: true } defaults jsx to false', () => {
+    expect(resolveAutoderive({ strings: true })).toEqual({
+      jsx: false,
+      strings: true,
+    });
+  });
+
+  it('{} defaults both to false', () => {
+    expect(resolveAutoderive({})).toEqual({ jsx: false, strings: false });
   });
 });

--- a/packages/cli/src/react/parse/createInlineUpdates.ts
+++ b/packages/cli/src/react/parse/createInlineUpdates.ts
@@ -11,6 +11,7 @@ import type {
   ParsingConfigOptions,
   GTParsingFlags,
 } from '../../types/parsing.js';
+import { resolveAutoderive } from '../../types/parsing.js';
 import { getPathsAndAliases } from '../jsx/utils/getPathsAndAliases.js';
 import {
   GTLibrary,
@@ -44,6 +45,8 @@ export async function createInlineUpdates(
   const warnings: Set<string> = new Set();
 
   const pkgs = getUpstreamPackages(pkg);
+
+  const autoderive = resolveAutoderive(parsingFlags.autoderive);
 
   // Use the provided app directory or default to the current directory
   const files = matchFiles(process.cwd(), filePatterns || DEFAULT_SRC_PATTERNS);
@@ -86,7 +89,7 @@ export async function createInlineUpdates(
           ignoreTaggedTemplates: false,
           ignoreGlobalTaggedTemplates: false,
           // User configurable, otherwise default to AUTO
-          autoderiveMethod: parsingFlags.autoderive ? 'AUTO' : 'DISABLED',
+          autoderiveMethod: autoderive.strings ? 'AUTO' : 'DISABLED',
         },
         { updates, errors, warnings }
       );
@@ -106,7 +109,7 @@ export async function createInlineUpdates(
             pkgs,
             file,
             includeSourceCodeContext: parsingFlags.includeSourceCodeContext,
-            autoderive: parsingFlags.autoderive,
+            autoderive: autoderive.jsx,
           },
           output: {
             errors,
@@ -168,7 +171,7 @@ export async function createInlineUpdates(
               file,
               includeSourceCodeContext: parsingFlags.includeSourceCodeContext,
               enableAutoJsxInjection: true,
-              autoderive: parsingFlags.autoderive,
+              autoderive: autoderive.jsx,
             },
             output: {
               errors,

--- a/packages/cli/src/types/parsing.ts
+++ b/packages/cli/src/types/parsing.ts
@@ -35,15 +35,30 @@ export type BaseParsingFlags = Record<string, unknown>;
  * parsing features depending on the function being parsed. Parsing flags is for users to override
  * some of these defaults or enable/disable other features.
  *
- * @property {boolean} autoderive - Whether to enable autoderive for the t() function. (true -> 'AUTO', false -> 'DISABLED' {@link ParsingConfig['autoderiveMethod']})
+ * @property {boolean | { jsx?: boolean; strings?: boolean }} autoderive - Whether to enable autoderive. A plain boolean enables/disables both JSX and strings. An object enables selectively.
  * @property {boolean} includeSourceCodeContext - Include surrounding source code lines as context for translations.
  * @property {boolean} enableAutoJsxInjection - Whether to enable auto-jsx injection for the internal <_T> and <_Var> components.
  */
 export type GTParsingFlags = BaseParsingFlags & {
-  autoderive: boolean;
+  autoderive: boolean | { jsx?: boolean; strings?: boolean };
   includeSourceCodeContext: boolean;
   enableAutoJsxInjection: boolean;
 };
+
+/**
+ * Resolves the autoderive config value into separate jsx and strings flags.
+ * - `true` enables both (backward compatible)
+ * - `false` disables both (backward compatible)
+ * - `{ jsx?: boolean; strings?: boolean }` enables selectively (missing keys default to false)
+ */
+export function resolveAutoderive(
+  value: boolean | { jsx?: boolean; strings?: boolean } | undefined
+): { jsx: boolean; strings: boolean } {
+  if (value === undefined || typeof value === 'boolean') {
+    return { jsx: !!value, strings: !!value };
+  }
+  return { jsx: value.jsx ?? false, strings: value.strings ?? false };
+}
 
 /**
  * Flags for parsing content with each filetype having its own flags

--- a/packages/compiler/src/config.ts
+++ b/packages/compiler/src/config.ts
@@ -75,10 +75,10 @@ export interface PluginSettings {
  * - `{ jsx?: boolean; strings?: boolean }` enables selectively (missing keys default to false)
  */
 export function resolveAutoderive(
-  value: boolean | { jsx?: boolean; strings?: boolean }
+  value: boolean | { jsx?: boolean; strings?: boolean } | undefined
 ): { jsx: boolean; strings: boolean } {
-  if (typeof value === 'boolean') {
-    return { jsx: value, strings: value };
+  if (value === undefined || typeof value === 'boolean') {
+    return { jsx: !!value, strings: !!value };
   }
   return { jsx: value.jsx ?? false, strings: value.strings ?? false };
 }

--- a/packages/compiler/src/config.ts
+++ b/packages/compiler/src/config.ts
@@ -12,7 +12,7 @@ type GTConfig = {
     gt?: {
       parsingFlags?: {
         enableAutoJsxInjection?: boolean;
-        autoderive?: boolean;
+        autoderive?: boolean | { jsx?: boolean; strings?: boolean };
         /** @deprecated Use `autoderive` instead */
         autoDerive?: boolean;
       };
@@ -39,7 +39,7 @@ export interface PluginConfig {
   /** Enable Auto Jsx Injection (e.g. <div>Hello</div> -> <div><T>Hello</T></div>) */
   enableAutoJsxInjection?: boolean;
   /** Automatically treat interpolated/concatenated values as derive() calls */
-  autoderive?: boolean;
+  autoderive?: boolean | { jsx?: boolean; strings?: boolean };
   /** @deprecated Use `autoderive` instead */
   autoDerive?: boolean;
   /** Debug: write a hash → jsxChildren manifest file on build */
@@ -63,7 +63,22 @@ export interface PluginSettings {
   /** Enable Auto Jsx Injection (e.g. <div>Hello</div> -> <div><T>Hello</T></div>) */
   enableAutoJsxInjection: boolean;
   /** Automatically treat interpolated/concatenated values as derive() calls */
-  autoderive: boolean;
+  autoderive: { jsx: boolean; strings: boolean };
   /** Debug: write a hash → jsxChildren manifest file on build */
   _debugHashManifest: boolean;
+}
+
+/**
+ * Resolves the autoderive config value into separate jsx and strings flags.
+ * - `true` enables both (backward compatible)
+ * - `false` disables both (backward compatible)
+ * - `{ jsx?: boolean; strings?: boolean }` enables selectively (missing keys default to false)
+ */
+export function resolveAutoderive(
+  value: boolean | { jsx?: boolean; strings?: boolean }
+): { jsx: boolean; strings: boolean } {
+  if (typeof value === 'boolean') {
+    return { jsx: value, strings: value };
+  }
+  return { jsx: value.jsx ?? false, strings: value.strings ?? false };
 }

--- a/packages/compiler/src/passes/__tests__/autoderiveJsxE2E.test.ts
+++ b/packages/compiler/src/passes/__tests__/autoderiveJsxE2E.test.ts
@@ -321,3 +321,156 @@ describe('Autoderive JSX E2E — edge cases', () => {
     expect(result.errors.length).toBeGreaterThan(0);
   });
 });
+
+// --- Selective autoderive tests ---
+
+/**
+ * Runs the pipeline with autoderive: { jsx: true, strings: false }.
+ * JSX dynamic content should be allowed, but string function violations
+ * are not tested here (no string functions in this E2E file).
+ */
+function fullPipelineAutoderiveJsxOnly(code: string): {
+  code: string | null;
+  errors: string[];
+  hasCollectionContent: boolean;
+  manifest: Record<string, unknown>;
+} {
+  const state = initializeState(
+    { autoderive: { jsx: true, strings: false } },
+    'test.tsx'
+  );
+  state.debugManifest = new Map<string, unknown>();
+
+  const ast = parser.parse(code, {
+    sourceType: 'module',
+    plugins: ['typescript'],
+  });
+
+  traverse(ast, jsxInsertionPass(state));
+  traverse(ast, collectionPass(state));
+
+  const errors = state.errorTracker.getErrors();
+  const hasCollectionContent = state.stringCollector.hasContent();
+  const manifest = Object.fromEntries(state.debugManifest!);
+
+  if (errors.length > 0) {
+    return { code: null, errors, hasCollectionContent, manifest };
+  }
+
+  if (hasCollectionContent) {
+    traverse(ast, injectionPass(state));
+  }
+
+  if (!hasCollectionContent && state.statistics.jsxInsertionsCount === 0) {
+    return { code: null, errors, hasCollectionContent, manifest };
+  }
+
+  const output = generate(ast, { retainLines: true, compact: false });
+  return { code: output.code, errors, hasCollectionContent, manifest };
+}
+
+/**
+ * Runs the pipeline with autoderive: { jsx: false, strings: true }.
+ * JSX dynamic content should still error.
+ */
+function fullPipelineAutoderiveStringsOnly(code: string): {
+  code: string | null;
+  errors: string[];
+  hasCollectionContent: boolean;
+  manifest: Record<string, unknown>;
+} {
+  const state = initializeState(
+    { autoderive: { jsx: false, strings: true } },
+    'test.tsx'
+  );
+  state.debugManifest = new Map<string, unknown>();
+
+  const ast = parser.parse(code, {
+    sourceType: 'module',
+    plugins: ['typescript'],
+  });
+
+  traverse(ast, jsxInsertionPass(state));
+  traverse(ast, collectionPass(state));
+
+  const errors = state.errorTracker.getErrors();
+  const hasCollectionContent = state.stringCollector.hasContent();
+  const manifest = Object.fromEntries(state.debugManifest!);
+
+  if (errors.length > 0) {
+    return { code: null, errors, hasCollectionContent, manifest };
+  }
+
+  if (hasCollectionContent) {
+    traverse(ast, injectionPass(state));
+  }
+
+  if (!hasCollectionContent && state.statistics.jsxInsertionsCount === 0) {
+    return { code: null, errors, hasCollectionContent, manifest };
+  }
+
+  const output = generate(ast, { retainLines: true, compact: false });
+  return { code: output.code, errors, hasCollectionContent, manifest };
+}
+
+describe('Selective autoderive — { jsx: true, strings: false }', () => {
+  it('dynamic content in <T> — no errors (jsx enabled)', () => {
+    const code = `
+      import { jsx, jsxs } from 'react/jsx-runtime';
+      import { T } from 'gt-react';
+      jsxs(T, { children: ["Hello ", name] });
+    `;
+    const result = fullPipelineAutoderiveJsxOnly(code);
+    expect(result.errors).toHaveLength(0);
+    expect(result.hasCollectionContent).toBe(true);
+    expect(result.manifest).toHaveProperty('');
+  });
+
+  it('static content still hashes normally', () => {
+    const code = `
+      import { jsx } from 'react/jsx-runtime';
+      import { T } from 'gt-react';
+      jsx(T, { children: "Hello world" });
+    `;
+    const result = fullPipelineAutoderiveJsxOnly(code);
+    expect(result.errors).toHaveLength(0);
+    expect(result.hasCollectionContent).toBe(true);
+    const hashes = Object.keys(result.manifest);
+    expect(hashes.every((h) => h.length > 0)).toBe(true);
+  });
+});
+
+describe('Selective autoderive — { jsx: false, strings: true }', () => {
+  it('dynamic content in <T> — errors (jsx disabled)', () => {
+    const code = `
+      import { jsx, jsxs } from 'react/jsx-runtime';
+      import { T } from 'gt-react';
+      jsxs(T, { children: ["Hello ", name] });
+    `;
+    const result = fullPipelineAutoderiveStringsOnly(code);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+});
+
+describe('Selective autoderive — backward compatibility', () => {
+  it('autoderive: true still allows dynamic JSX content', () => {
+    const code = `
+      import { jsx, jsxs } from 'react/jsx-runtime';
+      import { T } from 'gt-react';
+      jsxs(T, { children: ["Hello ", name] });
+    `;
+    const result = fullPipelineAutoderive(code);
+    expect(result.errors).toHaveLength(0);
+    expect(result.hasCollectionContent).toBe(true);
+  });
+
+  it('autoderive: false still rejects dynamic JSX content', () => {
+    const code = `
+      import { jsx, jsxs } from 'react/jsx-runtime';
+      import { T } from 'gt-react';
+      jsxs(T, { children: ["Hello ", name] });
+    `;
+    const result = fullPipelineDefault(code);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/compiler/src/state/utils/initializeState.ts
+++ b/packages/compiler/src/state/utils/initializeState.ts
@@ -1,6 +1,6 @@
 import { GTUnpluginOptions } from '../..';
 import { TransformState } from '../types';
-import { PluginSettings } from '../../config';
+import { PluginSettings, resolveAutoderive } from '../../config';
 import { StringCollector } from '../StringCollector';
 import { ScopeTracker } from '../ScopeTracker';
 import { Logger } from '../Logger';
@@ -18,7 +18,7 @@ const DEFAULT_SETTINGS: PluginSettings = {
   enableConcatenationArg: true,
   enableMacroImportInjection: true,
   enableAutoJsxInjection: false,
-  autoderive: false,
+  autoderive: { jsx: false, strings: false },
   _debugHashManifest: false,
 };
 
@@ -33,23 +33,28 @@ export function initializeState(
   const gtConfig = options.gtConfig;
   const enableAutoJsxInjection =
     gtConfig?.files?.gt?.parsingFlags?.enableAutoJsxInjection ?? false;
-  const autoderive =
+  const rawAutoderive =
     gtConfig?.files?.gt?.parsingFlags?.autoderive ??
     gtConfig?.files?.gt?.parsingFlags?.autoDerive ??
     false;
+
+  // Backwards compat: normalize deprecated autoDerive → autoderive from options
+  const rawOptionsAutoderive =
+    options.autoderive ?? options.autoDerive ?? undefined;
+
+  const autoderive = resolveAutoderive(rawOptionsAutoderive ?? rawAutoderive);
+
+  // Spread options but exclude autoderive/autoDerive (already resolved above)
+  // eslint-disable-next-line no-unused-vars
+  const { autoderive: _a, autoDerive: _b, ...restOptions } = options;
 
   const settings: PluginSettings = {
     ...DEFAULT_SETTINGS,
     enableAutoJsxInjection, // can be overridden by options.enableAutoJsxInjection
     autoderive,
-    ...options,
+    ...restOptions,
     filename,
   };
-
-  // Backwards compat: normalize deprecated autoDerive → autoderive
-  if (options.autoDerive !== undefined && options.autoderive === undefined) {
-    settings.autoderive = options.autoDerive;
-  }
 
   return {
     settings,

--- a/packages/compiler/src/transform/validation/__tests__/validateTranslationFunctionCallback.test.ts
+++ b/packages/compiler/src/transform/validation/__tests__/validateTranslationFunctionCallback.test.ts
@@ -33,7 +33,7 @@ describe('validateTranslationFunctionCallback', () => {
       enableConcatenationArg: true,
       enableMacroImportInjection: true,
       enableAutoJsxInjection: false,
-      autoderive: false,
+      autoderive: { jsx: false, strings: false },
       _debugHashManifest: false,
     };
 
@@ -922,7 +922,7 @@ describe('validateTranslationFunctionCallback', () => {
         enableConcatenationArg: true,
         enableMacroImportInjection: true,
         enableAutoJsxInjection: false,
-        autoderive: true,
+        autoderive: { jsx: true, strings: true },
         _debugHashManifest: false,
       };
 
@@ -1164,6 +1164,154 @@ describe('validateTranslationFunctionCallback', () => {
       ]);
       const result = validateUseGTCallback(callExpr, state);
       expect(result.errors.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('selective autoderive — { jsx: true, strings: false }', () => {
+    let jsxOnlyState: TransformState;
+
+    beforeEach(() => {
+      const stringCollector = new StringCollector();
+      const logger = new Logger('silent');
+      const errorTracker = new ErrorTracker();
+      const scopeTracker = new ScopeTracker();
+      const settings: PluginSettings = {
+        logLevel: 'silent',
+        compileTimeHash: false,
+        disableBuildChecks: false,
+        enableMacroTransform: true,
+        stringTranslationMacro: GT_OTHER_FUNCTIONS.t,
+        enableTaggedTemplate: true,
+        enableTemplateLiteralArg: true,
+        enableConcatenationArg: true,
+        enableMacroImportInjection: true,
+        enableAutoJsxInjection: false,
+        autoderive: { jsx: true, strings: false },
+        _debugHashManifest: false,
+      };
+
+      jsxOnlyState = {
+        settings,
+        stringCollector,
+        scopeTracker,
+        logger,
+        errorTracker,
+        statistics: {
+          jsxElementCount: 0,
+          dynamicContentViolations: 0,
+          macroExpansionsCount: 0,
+          jsxInsertionsCount: 0,
+        },
+      };
+
+      scopeTracker.trackTranslationVariable(
+        GT_OTHER_FUNCTIONS.derive,
+        GT_OTHER_FUNCTIONS.derive,
+        0
+      );
+    });
+
+    it('should reject template literal with bare variable (strings disabled)', () => {
+      const callExpr = t.callExpression(t.identifier('useGT_callback'), [
+        t.templateLiteral(
+          [
+            t.templateElement({ raw: 'Hello, ', cooked: 'Hello, ' }),
+            t.templateElement({ raw: '', cooked: '' }),
+          ],
+          [t.identifier('name')]
+        ),
+      ]);
+
+      const result = validateUseGTCallback(callExpr, jsxOnlyState);
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
+
+    it('should reject concatenation with bare variable (strings disabled)', () => {
+      const callExpr = t.callExpression(t.identifier('useGT_callback'), [
+        t.binaryExpression(
+          '+',
+          t.stringLiteral('Hello, '),
+          t.identifier('name')
+        ),
+      ]);
+
+      const result = validateUseGTCallback(callExpr, jsxOnlyState);
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('selective autoderive — { jsx: false, strings: true }', () => {
+    let stringsOnlyState: TransformState;
+
+    beforeEach(() => {
+      const stringCollector = new StringCollector();
+      const logger = new Logger('silent');
+      const errorTracker = new ErrorTracker();
+      const scopeTracker = new ScopeTracker();
+      const settings: PluginSettings = {
+        logLevel: 'silent',
+        compileTimeHash: false,
+        disableBuildChecks: false,
+        enableMacroTransform: true,
+        stringTranslationMacro: GT_OTHER_FUNCTIONS.t,
+        enableTaggedTemplate: true,
+        enableTemplateLiteralArg: true,
+        enableConcatenationArg: true,
+        enableMacroImportInjection: true,
+        enableAutoJsxInjection: false,
+        autoderive: { jsx: false, strings: true },
+        _debugHashManifest: false,
+      };
+
+      stringsOnlyState = {
+        settings,
+        stringCollector,
+        scopeTracker,
+        logger,
+        errorTracker,
+        statistics: {
+          jsxElementCount: 0,
+          dynamicContentViolations: 0,
+          macroExpansionsCount: 0,
+          jsxInsertionsCount: 0,
+        },
+      };
+
+      scopeTracker.trackTranslationVariable(
+        GT_OTHER_FUNCTIONS.derive,
+        GT_OTHER_FUNCTIONS.derive,
+        0
+      );
+    });
+
+    it('should accept template literal with bare variable (strings enabled)', () => {
+      const callExpr = t.callExpression(t.identifier('useGT_callback'), [
+        t.templateLiteral(
+          [
+            t.templateElement({ raw: 'Hello, ', cooked: 'Hello, ' }),
+            t.templateElement({ raw: '', cooked: '' }),
+          ],
+          [t.identifier('name')]
+        ),
+      ]);
+
+      const result = validateUseGTCallback(callExpr, stringsOnlyState);
+      expect(result.errors).toHaveLength(0);
+      expect(result.hasDeriveContext).toBe(true);
+    });
+
+    it('should accept concatenation with bare variable (strings enabled)', () => {
+      const callExpr = t.callExpression(t.identifier('useGT_callback'), [
+        t.binaryExpression(
+          '+',
+          t.stringLiteral('Hello, '),
+          t.identifier('name')
+        ),
+      ]);
+
+      const result = validateUseGTCallback(callExpr, stringsOnlyState);
+      expect(result.errors).toHaveLength(0);
+      expect(result.hasDeriveContext).toBe(true);
     });
   });
 });

--- a/packages/compiler/src/transform/validation/validateTranslationComponentArgs.ts
+++ b/packages/compiler/src/transform/validation/validateTranslationComponentArgs.ts
@@ -134,7 +134,7 @@ export function validateChildrenProperty(
   // Autoderive: filter out dynamic-content errors
   let hasAutoderive = false;
   let filteredErrors: JsxValidationError[] = validation.errors;
-  if (state.settings.autoderive) {
+  if (state.settings.autoderive.jsx) {
     filteredErrors = validation.errors.filter(
       (e) => e.type !== 'dynamic-content'
     );

--- a/packages/compiler/src/transform/validation/validateTranslationFunctionCallback.ts
+++ b/packages/compiler/src/transform/validation/validateTranslationFunctionCallback.ts
@@ -50,7 +50,7 @@ export function validateUseGTCallback(
   );
   const content = validatedContent.value;
 
-  if (content === undefined && !state.settings.autoderive) {
+  if (content === undefined && !state.settings.autoderive.strings) {
     // Check if it contains a derive() function invocation (no requirement for derive() invoc with autoderive)
     validateDerive(callExpr.arguments[0], state, errors);
     if (errors.length > 0) {
@@ -67,7 +67,7 @@ export function validateUseGTCallback(
   // We skip hash gen with autoderive, derive in content, and derive in $context. This flag is being
   // reused for all 3 cases.
   const contentHasAutoderive =
-    state.settings.autoderive && content === undefined;
+    state.settings.autoderive.strings && content === undefined;
 
   // Validate second argument
   let context: string | undefined;

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -529,13 +529,25 @@ export function withGTConfig(
     mergedConfig.experimentalCompilerOptions || {};
 
   // Read autoderive from parsingFlags (single source of truth shared with CLI)
-  const autoderive =
-    loadedConfig?.files?.gt?.parsingFlags?.autoderive === true ||
-    loadedConfig?.files?.gt?.parsingFlags?.autoDerive === true;
+  const rawAutoderive: boolean | { jsx?: boolean; strings?: boolean } =
+    loadedConfig?.files?.gt?.parsingFlags?.autoderive ??
+    loadedConfig?.files?.gt?.parsingFlags?.autoDerive ??
+    false;
+  const autoderiveJsx =
+    typeof rawAutoderive === 'boolean'
+      ? rawAutoderive
+      : (rawAutoderive.jsx ?? false);
+  const autoderiveStrings =
+    typeof rawAutoderive === 'boolean'
+      ? rawAutoderive
+      : (rawAutoderive.strings ?? false);
 
   const swcPluginEntry =
     mergedConfig.experimentalCompilerOptions?.type === 'swc'
-      ? [resolvedWasmFilePath, { ...compilerOptions, autoderive }]
+      ? [
+          resolvedWasmFilePath,
+          { ...compilerOptions, autoderiveJsx, autoderiveStrings },
+        ]
       : null;
 
   const turboAliases = {

--- a/packages/next/swc-plugin/src/ast/traversal.rs
+++ b/packages/next/swc-plugin/src/ast/traversal.rs
@@ -41,7 +41,7 @@ impl<'a> JsxTraversal<'a> {
     use crate::hash::JsxHasher;
 
     // Autoderive: if element or any descendant has dynamic expressions, produce empty hash
-    if self.visitor.settings.autoderive && has_dynamic_content_recursive(&element.children) {
+    if self.visitor.settings.autoderive_jsx && has_dynamic_content_recursive(&element.children) {
       return (String::new(), String::new());
     }
 
@@ -778,7 +778,7 @@ mod tests {
       statistics: Statistics::default(),
       traversal_state: TraversalState::default(),
       import_tracker: ImportTracker::default(),
-      settings: PluginSettings::new(LogLevel::Silent, false, None, false, false),
+      settings: PluginSettings::new(LogLevel::Silent, false, None, false, false, false),
       logger: Logger::new(LogLevel::Silent),
       string_collector: crate::ast::StringCollector::new(),
     }

--- a/packages/next/swc-plugin/src/ast/traversal.rs
+++ b/packages/next/swc-plugin/src/ast/traversal.rs
@@ -1564,7 +1564,7 @@ mod tests {
         statistics: Statistics::default(),
         traversal_state: TraversalState::default(),
         import_tracker: ImportTracker::default(),
-        settings: PluginSettings::new(LogLevel::Silent, false, None, false, true),
+        settings: PluginSettings::new(LogLevel::Silent, false, None, false, true, false),
         logger: Logger::new(LogLevel::Silent),
         string_collector: crate::ast::StringCollector::new(),
       }

--- a/packages/next/swc-plugin/src/config.rs
+++ b/packages/next/swc-plugin/src/config.rs
@@ -12,18 +12,21 @@ pub struct PluginSettings {
   pub filename: Option<String>,
   /// Disable dynamic content check
   pub disable_build_checks: bool,
+  /// When true, bare variables/calls in JSX expression containers are allowed
+  pub autoderive_jsx: bool,
   /// When true, bare variables/calls in template literals and concatenations are allowed
-  pub autoderive: bool,
+  pub autoderive_strings: bool,
 }
 
 impl PluginSettings {
-  pub fn new(log_level: LogLevel, compile_time_hash: bool, filename: Option<String>, disable_build_checks: bool, autoderive: bool) -> Self {
+  pub fn new(log_level: LogLevel, compile_time_hash: bool, filename: Option<String>, disable_build_checks: bool, autoderive_jsx: bool, autoderive_strings: bool) -> Self {
     Self {
       log_level,
       compile_time_hash,
       filename,
       disable_build_checks,
-      autoderive,
+      autoderive_jsx,
+      autoderive_strings,
     }
   }
 }
@@ -41,7 +44,9 @@ pub struct PluginConfig {
   #[serde(default)]
   pub disable_build_checks: bool,
   #[serde(default)]
-  pub autoderive: bool,
+  pub autoderive_jsx: bool,
+  #[serde(default)]
+  pub autoderive_strings: bool,
 }
 
 impl Default for PluginConfig {
@@ -51,7 +56,8 @@ impl Default for PluginConfig {
       compile_time_hash: false,
       filename: None,
       disable_build_checks: false,
-      autoderive: false,
+      autoderive_jsx: false,
+      autoderive_strings: false,
     }
   }
 }

--- a/packages/next/swc-plugin/src/lib.rs
+++ b/packages/next/swc-plugin/src/lib.rs
@@ -146,7 +146,7 @@ impl VisitMut for TransformVisitor {
     // Only check for violations if we're in a translation component and NOT in a JSX attribute
     if self.traversal_state.in_translation_component && !self.traversal_state.in_jsx_attribute {
       // Check if the expression is allowed dynamic content
-      if !self.settings.disable_build_checks && !self.settings.autoderive && !is_allowed_dynamic_content(&expr_container.expr) {
+      if !self.settings.disable_build_checks && !self.settings.autoderive_jsx && !is_allowed_dynamic_content(&expr_container.expr) {
         self.statistics.dynamic_content_violations += 1;
         let warning = create_dynamic_content_warning(self.settings.filename.as_deref(), "T");
         self.logger.log_error(&warning);
@@ -380,7 +380,8 @@ pub fn process_transform(program: Program, metadata: TransformPluginProgramMetad
     config.compile_time_hash,
     filename.clone(),
     config.disable_build_checks,
-    config.autoderive,
+    config.autoderive_jsx,
+    config.autoderive_strings,
     string_collector,
   );
   program.visit_mut_with(&mut visitor);
@@ -398,7 +399,8 @@ pub fn process_transform(program: Program, metadata: TransformPluginProgramMetad
     config.compile_time_hash,
     filename,
     config.disable_build_checks,
-    config.autoderive,
+    config.autoderive_jsx,
+    config.autoderive_strings,
     collected_data,
   );
   program.fold_with(&mut visitor)

--- a/packages/next/swc-plugin/src/visitor/transform.rs
+++ b/packages/next/swc-plugin/src/visitor/transform.rs
@@ -34,7 +34,7 @@ pub struct TransformVisitor {
 
 impl Default for TransformVisitor {
   fn default() -> Self {
-    Self::new(LogLevel::Warn, false, None, false, false, StringCollector::new())
+    Self::new(LogLevel::Warn, false, None, false, false, false, StringCollector::new())
   }
 }
 
@@ -44,7 +44,8 @@ impl TransformVisitor {
     compile_time_hash: bool,
     filename: Option<String>,
     disable_build_checks: bool,
-    autoderive: bool,
+    autoderive_jsx: bool,
+    autoderive_strings: bool,
     mut string_collector: StringCollector,
   ) -> Self {
     // Reset the counter to 0
@@ -53,7 +54,7 @@ impl TransformVisitor {
       traversal_state: TraversalState::default(),
       statistics: Statistics::default(),
       import_tracker: ImportTracker::new(),
-      settings: PluginSettings::new(log_level.clone(), compile_time_hash, filename.clone(), disable_build_checks, autoderive),
+      settings: PluginSettings::new(log_level.clone(), compile_time_hash, filename.clone(), disable_build_checks, autoderive_jsx, autoderive_strings),
       logger: Logger::new(log_level),
       string_collector,
     }
@@ -320,7 +321,7 @@ impl TransformVisitor {
     self.validate_string_literal_or_declare_static(arg.expr.as_ref(), &mut errors);
 
     if !errors.is_empty() {
-      if !self.settings.disable_build_checks && !self.settings.autoderive {
+      if !self.settings.disable_build_checks && !self.settings.autoderive_strings {
         self.statistics.dynamic_content_violations += 1;
         // Use the first error message for the violation type
         let default_error = &"invalid expression".to_string();
@@ -769,7 +770,7 @@ mod tests {
 
   // Helper to create a test visitor with specific imports
   fn create_visitor_with_imports() -> TransformVisitor {
-    let mut visitor = TransformVisitor::new(LogLevel::Silent, false, None, false, false, StringCollector::new());
+    let mut visitor = TransformVisitor::new(LogLevel::Silent, false, None, false, false, false, StringCollector::new());
 
     // Add some test imports using the scope tracker
     visitor
@@ -940,6 +941,7 @@ mod tests {
         Some("test.tsx".to_string()),
         false,
         false,
+        false,
         StringCollector::new(),
       );
 
@@ -1027,7 +1029,7 @@ mod tests {
 
     #[test]
     fn creates_dynamic_content_warning_without_filename() {
-      TransformVisitor::new(LogLevel::Warn, false, None, false, false, StringCollector::new());
+      TransformVisitor::new(LogLevel::Warn, false, None, false, false, false, StringCollector::new());
       let warning = create_dynamic_content_warning(None, "T");
 
       assert!(warning.contains("gt-next"));
@@ -1044,6 +1046,7 @@ mod tests {
         Some("components/Test.tsx".to_string()),
         false,
         false,
+        false,
         StringCollector::new(),
       );
       let warning = create_dynamic_content_warning(Some("components/Test.tsx"), "T");
@@ -1054,7 +1057,7 @@ mod tests {
 
     #[test]
     fn creates_dynamic_function_warning_without_filename() {
-      TransformVisitor::new(LogLevel::Warn, false, None, false, false, StringCollector::new());
+      TransformVisitor::new(LogLevel::Warn, false, None, false, false, false, StringCollector::new());
       let warning = create_dynamic_function_warning(None, "useGT", "template literals");
 
       assert!(warning.contains("gt-next"));
@@ -1069,6 +1072,7 @@ mod tests {
         LogLevel::Warn,
         false,
         Some("hooks/useTranslation.ts".to_string()),
+        false,
         false,
         false,
         StringCollector::new(),
@@ -1090,7 +1094,7 @@ mod tests {
     #[test]
     fn processes_gt_next_named_imports() {
       let mut visitor =
-        TransformVisitor::new(LogLevel::Silent, false, None, false, false, StringCollector::new());
+        TransformVisitor::new(LogLevel::Silent, false, None, false, false, false, StringCollector::new());
       let import_decl = create_import_decl(
         "gt-next",
         vec![
@@ -1123,7 +1127,7 @@ mod tests {
     #[test]
     fn processes_namespace_imports() {
       let mut visitor =
-        TransformVisitor::new(LogLevel::Silent, false, None, false, false, StringCollector::new());
+        TransformVisitor::new(LogLevel::Silent, false, None, false, false, false, StringCollector::new());
       let import_decl = create_import_decl("gt-next", vec![create_namespace_import("GT")]);
 
       visitor.process_gt_import_declaration(&import_decl);
@@ -1137,7 +1141,7 @@ mod tests {
     #[test]
     fn processes_gt_next_client_imports() {
       let mut visitor =
-        TransformVisitor::new(LogLevel::Silent, false, None, false, false, StringCollector::new());
+        TransformVisitor::new(LogLevel::Silent, false, None, false, false, false, StringCollector::new());
       let import_decl = create_import_decl("gt-next/client", vec![create_named_import("T", None)]);
 
       visitor.process_gt_import_declaration(&import_decl);
@@ -1152,7 +1156,7 @@ mod tests {
     #[test]
     fn ignores_non_gt_imports() {
       let mut visitor =
-        TransformVisitor::new(LogLevel::Silent, false, None, false, false, StringCollector::new());
+        TransformVisitor::new(LogLevel::Silent, false, None, false, false, false, StringCollector::new());
       let import_decl = create_import_decl("react", vec![create_named_import("React", None)]);
 
       visitor.process_gt_import_declaration(&import_decl);
@@ -1773,11 +1777,11 @@ mod tests {
   mod autoderive_violations {
     use super::*;
 
-    /// Creates a visitor with autoderive enabled and standard imports tracked
+    /// Creates a visitor with autoderive strings enabled and standard imports tracked
     fn create_visitor_with_autoderive() -> TransformVisitor {
       let mut visitor =
-        TransformVisitor::new(LogLevel::Silent, false, None, false, false, StringCollector::new());
-      visitor.settings.autoderive = true;
+        TransformVisitor::new(LogLevel::Silent, false, None, false, false, false, StringCollector::new());
+      visitor.settings.autoderive_strings = true;
 
       // Track standard gt-next imports
       visitor
@@ -2072,11 +2076,11 @@ mod tests {
     use super::*;
     use swc_core::ecma::visit::VisitMut;
 
-    /// Creates a visitor with autoderive enabled and standard imports tracked
+    /// Creates a visitor with autoderive jsx enabled and standard imports tracked
     fn create_visitor_with_autoderive() -> TransformVisitor {
       let mut visitor =
-        TransformVisitor::new(LogLevel::Silent, false, None, false, false, StringCollector::new());
-      visitor.settings.autoderive = true;
+        TransformVisitor::new(LogLevel::Silent, false, None, false, false, false, StringCollector::new());
+      visitor.settings.autoderive_jsx = true;
 
       // Track standard gt-next imports
       visitor
@@ -2176,7 +2180,8 @@ mod tests {
         true,  // compile_time_hash = true
         None,
         false, // disable_build_checks
-        true,  // autoderive = true
+        true,  // autoderive_jsx = true
+        false, // autoderive_strings = false
         StringCollector::new(),
       );
       // Track T import
@@ -2234,7 +2239,8 @@ mod tests {
         true,  // compile_time_hash = true
         None,
         false, // disable_build_checks
-        true,  // autoderive = true
+        true,  // autoderive_jsx = true
+        false, // autoderive_strings = false
         StringCollector::new(),
       );
       // Track T import
@@ -2317,7 +2323,8 @@ mod tests {
         true,  // compile_time_hash = true
         None,
         false, // disable_build_checks
-        true,  // autoderive = true
+        true,  // autoderive_jsx = true
+        false, // autoderive_strings = false
         StringCollector::new(),
       );
       // Track T import
@@ -2525,7 +2532,7 @@ mod tests {
     #[test]
     fn autoderive_on_mixed_static_and_dynamic_produces_empty_hash() {
       let mut visitor = TransformVisitor::new(
-        LogLevel::Silent, true, None, false, true, StringCollector::new(),
+        LogLevel::Silent, true, None, false, true, false, StringCollector::new(),
       );
       visitor.import_tracker.scope_tracker
         .track_translation_variable(Atom::new("T"), Atom::new("T"), 0);
@@ -2560,7 +2567,7 @@ mod tests {
     #[test]
     fn autoderive_on_number_literal_child_produces_nonempty_hash() {
       let mut visitor = TransformVisitor::new(
-        LogLevel::Silent, true, None, false, true, StringCollector::new(),
+        LogLevel::Silent, true, None, false, true, false, StringCollector::new(),
       );
       visitor.import_tracker.scope_tracker
         .track_translation_variable(Atom::new("T"), Atom::new("T"), 0);
@@ -2596,7 +2603,7 @@ mod tests {
     #[test]
     fn autoderive_on_3_level_deep_nesting_produces_empty_hash() {
       let mut visitor = TransformVisitor::new(
-        LogLevel::Silent, true, None, false, true, StringCollector::new(),
+        LogLevel::Silent, true, None, false, true, false, StringCollector::new(),
       );
       visitor.import_tracker.scope_tracker
         .track_translation_variable(Atom::new("T"), Atom::new("T"), 0);
@@ -2727,7 +2734,7 @@ mod tests {
     #[test]
     fn calculates_hash_for_empty_element() {
       let mut visitor =
-        TransformVisitor::new(LogLevel::Silent, false, None, false, false, StringCollector::new());
+        TransformVisitor::new(LogLevel::Silent, false, None, false, false, false, StringCollector::new());
       let element = create_jsx_element("T", vec![]);
 
       let mut traversal = crate::ast::JsxTraversal::new(&mut visitor);
@@ -2741,7 +2748,7 @@ mod tests {
     #[test]
     fn hash_changes_with_different_content() {
       let mut visitor =
-        TransformVisitor::new(LogLevel::Silent, false, None, false, false, StringCollector::new());
+        TransformVisitor::new(LogLevel::Silent, false, None, false, false, false, StringCollector::new());
 
       let element1 = create_jsx_element("T", vec![]);
       let mut element2 = create_jsx_element("T", vec![]);
@@ -2771,6 +2778,7 @@ mod tests {
         LogLevel::Silent,
         false,
         Some("test.tsx".to_string()),
+        false,
         false,
         false,
         StringCollector::new(),


### PR DESCRIPTION
allow for applying auto derive to just jsx or just strings

```
// BEFORE
{
  "files": {
    "gt": {
      "parsingFlags": {
        "autoderive": boolean
      }
    }
  }
// AFTER
{
  "files": {
    "gt": {
      "parsingFlags": {
        "autoderive": boolean | { "jsx": boolean, "strings": boolean }
      }
    }
  }
```