### PR TITLE
fix(react/browser): update lang tag

### DIFF
--- a/.changeset/fruity-years-dress.md
+++ b/.changeset/fruity-years-dress.md
@@ -1,0 +1,6 @@
+---
+'@generaltranslation/react-core': patch
+'gt-react': patch
+---
+
+fix: update html langtag for i18n-context

--- a/packages/react-core/src/rendering/renderVariable.tsx
+++ b/packages/react-core/src/rendering/renderVariable.tsx
@@ -3,7 +3,7 @@ import Var from '../variables/Var';
 import Currency from '../variables/Currency';
 import DateTime from '../variables/DateTime';
 import RelativeTime from '../variables/RelativeTime';
-import { RenderVariable } from '../types-dir/types';
+import { RelativeTimeFormatOptions, RenderVariable } from '../types-dir/types';
 
 const renderVariable: RenderVariable = ({
   variableType,
@@ -11,22 +11,32 @@ const renderVariable: RenderVariable = ({
   variableOptions,
 }) => {
   if (variableType === 'n') {
-    return <Num options={variableOptions}>{variableValue}</Num>;
+    const numOptions = variableOptions as Intl.NumberFormatOptions | undefined;
+    return <Num options={numOptions}>{variableValue}</Num>;
   } else if (variableType === 'd') {
-    return <DateTime options={variableOptions}>{variableValue}</DateTime>;
+    const dateTimeOptions = variableOptions as
+      | Intl.DateTimeFormatOptions
+      | undefined;
+    return <DateTime options={dateTimeOptions}>{variableValue}</DateTime>;
   } else if (variableType === 'c') {
-    return <Currency options={variableOptions}>{variableValue}</Currency>;
+    const currencyOptions = variableOptions as
+      | Intl.NumberFormatOptions
+      | undefined;
+    return <Currency options={currencyOptions}>{variableValue}</Currency>;
   } else if (variableType === 'rt') {
     // RelativeTime supports two modes:
     // 1. value + unit (e.g., value=-3, unit="hour") — explicit relative time
     // 2. date (Date object) — auto-select unit from date difference
-    if (typeof variableValue === 'number' && variableOptions?.unit) {
+    const relativeTimeOptions = variableOptions as
+      | RelativeTimeFormatOptions
+      | undefined;
+    if (typeof variableValue === 'number' && relativeTimeOptions?.unit) {
       return (
         <RelativeTime
           value={variableValue}
-          unit={variableOptions.unit}
-          baseDate={variableOptions?.baseDate}
-          options={variableOptions}
+          unit={relativeTimeOptions.unit}
+          baseDate={relativeTimeOptions?.baseDate}
+          options={relativeTimeOptions}
         />
       );
     }
@@ -39,8 +49,8 @@ const renderVariable: RenderVariable = ({
     return (
       <RelativeTime
         date={dateValue && !isNaN(dateValue.getTime()) ? dateValue : undefined}
-        baseDate={variableOptions?.baseDate}
-        options={variableOptions}
+        baseDate={relativeTimeOptions?.baseDate}
+        options={relativeTimeOptions}
       />
     );
   }

--- a/packages/react-core/src/types-dir/types.ts
+++ b/packages/react-core/src/types-dir/types.ts
@@ -98,6 +98,10 @@ export type CustomLoader = (locale: string) => Promise<any>;
 
 export type RenderMethod = 'skeleton' | 'replace' | 'default';
 
+export type RelativeTimeFormatOptions = Intl.RelativeTimeFormatOptions & {
+  unit?: Intl.RelativeTimeFormatUnit;
+  baseDate?: Date;
+};
 export type VariableProps = {
   /** Whether the variable was automatically injected by the compiler */
   variableType: VariableType;
@@ -105,10 +109,7 @@ export type VariableProps = {
   variableOptions:
     | Intl.NumberFormatOptions
     | Intl.DateTimeFormatOptions
-    | (Intl.RelativeTimeFormatOptions & {
-        unit?: Intl.RelativeTimeFormatUnit;
-        baseDate?: Date;
-      });
+    | RelativeTimeFormatOptions;
   variableName: string;
   injectionType: InjectionType;
 };

--- a/packages/react/src/i18n-context/browser-i18n-manager/BrowserI18nManager.ts
+++ b/packages/react/src/i18n-context/browser-i18n-manager/BrowserI18nManager.ts
@@ -95,7 +95,6 @@ export class BrowserI18nManager extends I18nManager<
 
     // Merge options
     const mergedHtmlTagOptions = {
-      ...DEFAULT_HTML_TAG_OPTIONS,
       ...this.htmlTagOptions,
       ...htmlTagOptions,
     };

--- a/packages/react/src/i18n-context/browser-i18n-manager/BrowserI18nManager.ts
+++ b/packages/react/src/i18n-context/browser-i18n-manager/BrowserI18nManager.ts
@@ -3,10 +3,7 @@ import type { I18nManagerConstructorParams } from 'gt-i18n/internal/types';
 import type { BrowserStorageAdapter } from './BrowserStorageAdapter';
 import type { HtmlTagOptions } from './utils/types';
 import { determineLocale as gtDetermineLocale } from 'generaltranslation';
-import {
-  createInvalidLocaleError,
-  createInvalidLocaleWarning,
-} from '../../shared/messages';
+import { createInvalidLocaleWarning } from '../../shared/messages';
 import { Translation } from 'gt-i18n/types';
 import { DEFAULT_HTML_TAG_OPTIONS } from './utils/constants';
 
@@ -90,7 +87,8 @@ export class BrowserI18nManager extends I18nManager<
 
     // Validate parameters
     if (!gtInstance.isValidLocale(canonicalLocale)) {
-      throw new Error(createInvalidLocaleError(locale));
+      console.warn(createInvalidLocaleWarning(locale));
+      return;
     }
 
     // Merge options

--- a/packages/react/src/i18n-context/browser-i18n-manager/BrowserI18nManager.ts
+++ b/packages/react/src/i18n-context/browser-i18n-manager/BrowserI18nManager.ts
@@ -85,7 +85,8 @@ export class BrowserI18nManager extends I18nManager<
     const locale = htmlTagOptions?.lang || this.getLocale();
     const gtInstance = this.getGTClass();
     const canonicalLocale = gtInstance.resolveCanonicalLocale(locale);
-    const localeDirection = gtInstance.getLocaleDirection(locale);
+    const localeDirection =
+      htmlTagOptions?.dir || gtInstance.getLocaleDirection(locale);
 
     // Validate parameters
     if (!gtInstance.isValidLocale(canonicalLocale)) {

--- a/packages/react/src/i18n-context/browser-i18n-manager/BrowserI18nManager.ts
+++ b/packages/react/src/i18n-context/browser-i18n-manager/BrowserI18nManager.ts
@@ -1,9 +1,22 @@
 import { I18nManager } from 'gt-i18n/internal';
 import type { I18nManagerConstructorParams } from 'gt-i18n/internal/types';
 import type { BrowserStorageAdapter } from './BrowserStorageAdapter';
+import type { HtmlTagOptions } from './utils/types';
 import { determineLocale as gtDetermineLocale } from 'generaltranslation';
-import { createInvalidLocaleWarning } from '../../shared/messages';
+import {
+  createInvalidLocaleError,
+  createInvalidLocaleWarning,
+} from '../../shared/messages';
 import { Translation } from 'gt-i18n/types';
+import { DEFAULT_HTML_TAG_OPTIONS } from './utils/constants';
+
+/**
+ * The configuration for the BrowserI18nManager
+ */
+type BrowserI18nManagerConstructorParams =
+  I18nManagerConstructorParams<BrowserStorageAdapter> & {
+    htmlTagOptions?: HtmlTagOptions;
+  };
 
 /**
  * I18nManager implementation for Browser.
@@ -12,13 +25,21 @@ export class BrowserI18nManager extends I18nManager<
   BrowserStorageAdapter,
   Translation
 > {
-  constructor(config: I18nManagerConstructorParams<BrowserStorageAdapter>) {
+  /** Customize browser-related behavior */
+  private htmlTagOptions?: HtmlTagOptions;
+
+  constructor(config: BrowserI18nManagerConstructorParams) {
     super(config);
     this.storeAdapter.setConfig({
       defaultLocale: this.getDefaultLocale(),
       locales: this.getLocales(),
       customMapping: config.customMapping,
     });
+
+    this.htmlTagOptions = {
+      ...DEFAULT_HTML_TAG_OPTIONS,
+      ...config.htmlTagOptions,
+    };
   }
 
   /**
@@ -52,5 +73,38 @@ export class BrowserI18nManager extends I18nManager<
     }
     this.storeAdapter.setItem('locale', locale);
     window.location.reload();
+  }
+
+  /**
+   * Update the html tag (lang, dir)
+   */
+  updateHtmlTag(
+    htmlTagOptions?: { lang?: string; dir?: 'ltr' | 'rtl' } & HtmlTagOptions
+  ): void {
+    // Get parameters
+    const locale = htmlTagOptions?.lang || this.getLocale();
+    const gtInstance = this.getGTClass();
+    const canonicalLocale = gtInstance.resolveCanonicalLocale(locale);
+    const localeDirection = gtInstance.getLocaleDirection(locale);
+
+    // Validate parameters
+    if (!gtInstance.isValidLocale(canonicalLocale)) {
+      throw new Error(createInvalidLocaleError(locale));
+    }
+
+    // Merge options
+    const mergedHtmlTagOptions = {
+      ...DEFAULT_HTML_TAG_OPTIONS,
+      ...this.htmlTagOptions,
+      ...htmlTagOptions,
+    };
+
+    // Update html tag
+    if (mergedHtmlTagOptions.updateHtmlLangTag) {
+      document.documentElement.lang = canonicalLocale;
+    }
+    if (mergedHtmlTagOptions.updateHtmlDirTag) {
+      document.documentElement.dir = localeDirection;
+    }
   }
 }

--- a/packages/react/src/i18n-context/browser-i18n-manager/utils/constants.ts
+++ b/packages/react/src/i18n-context/browser-i18n-manager/utils/constants.ts
@@ -1,0 +1,6 @@
+import type { HtmlTagOptions } from './types';
+
+export const DEFAULT_HTML_TAG_OPTIONS: HtmlTagOptions = {
+  updateHtmlLangTag: true,
+  updateHtmlDirTag: true,
+};

--- a/packages/react/src/i18n-context/browser-i18n-manager/utils/types.ts
+++ b/packages/react/src/i18n-context/browser-i18n-manager/utils/types.ts
@@ -2,3 +2,13 @@
  * Type for custom getLocale function
  */
 export type GetLocale = () => string;
+
+/**
+ * Html tag options
+ * @param {boolean} updateHtmlLangTag - Whether to update the html lang tag on locale change
+ * @param {boolean} updateHtmlDirTag - Whether to update the html dir tag on locale change
+ */
+export type HtmlTagOptions = {
+  updateHtmlLangTag?: boolean;
+  updateHtmlDirTag?: boolean;
+};

--- a/packages/react/src/i18n-context/functions/html-tag-operations.ts
+++ b/packages/react/src/i18n-context/functions/html-tag-operations.ts
@@ -10,7 +10,11 @@ import { getBrowserI18nManager } from '../browser-i18n-manager/singleton-operati
  */
 export function updateHtmlTagLang(locale: string): void {
   const i18nManager = getBrowserI18nManager();
-  i18nManager.updateHtmlTag({ lang: locale });
+  i18nManager.updateHtmlTag({
+    lang: locale,
+    updateHtmlLangTag: true,
+    updateHtmlDirTag: false,
+  });
 }
 
 /**
@@ -23,5 +27,9 @@ export function updateHtmlTagLang(locale: string): void {
  */
 export function updateHtmlTagDir(dir: 'ltr' | 'rtl'): void {
   const i18nManager = getBrowserI18nManager();
-  i18nManager.updateHtmlTag({ dir });
+  i18nManager.updateHtmlTag({
+    dir,
+    updateHtmlLangTag: false,
+    updateHtmlDirTag: true,
+  });
 }

--- a/packages/react/src/i18n-context/functions/html-tag-operations.ts
+++ b/packages/react/src/i18n-context/functions/html-tag-operations.ts
@@ -1,0 +1,27 @@
+import { getBrowserI18nManager } from '../browser-i18n-manager/singleton-operations';
+
+/**
+ * Update the html tag lang property
+ * @param {string} locale - The locale to update the html tag lang property to
+ * @returns {void}
+ *
+ * @example
+ * updateHtmlTagLang('en');
+ */
+export function updateHtmlTagLang(locale: string): void {
+  const i18nManager = getBrowserI18nManager();
+  i18nManager.updateHtmlTag({ lang: locale });
+}
+
+/**
+ * Update the html tag dir property
+ * @param {string} dir - The direction to update the html tag dir property to
+ * @returns {void}
+ *
+ * @example
+ * updateHtmlTagDir('ltr');
+ */
+export function updateHtmlTagDir(dir: 'ltr' | 'rtl'): void {
+  const i18nManager = getBrowserI18nManager();
+  i18nManager.updateHtmlTag({ dir });
+}

--- a/packages/react/src/i18n-context/functions/index.ts
+++ b/packages/react/src/i18n-context/functions/index.ts
@@ -4,3 +4,4 @@ export * from './translation';
 export * from './variables';
 export * from './locale-operations';
 export * from './versionId';
+export * from './html-tag-operations';

--- a/packages/react/src/i18n-context/setup/bootstrap.ts
+++ b/packages/react/src/i18n-context/setup/bootstrap.ts
@@ -24,5 +24,10 @@ import { InitializeGTParams } from './types';
 export async function bootstrap(params: InitializeGTParams): Promise<void> {
   initializeGT(params);
   const i18nManager = getBrowserI18nManager();
+
+  // Update the html tag
+  i18nManager.updateHtmlTag();
+
+  // Load translations
   await i18nManager.loadTranslations();
 }

--- a/packages/react/src/i18n-context/setup/types.ts
+++ b/packages/react/src/i18n-context/setup/types.ts
@@ -1,16 +1,19 @@
 import type { GTConfig, TranslationsLoader } from 'gt-i18n/internal/types';
-import { GetLocale } from '../browser-i18n-manager/utils/types';
+import { GetLocale, HtmlTagOptions } from '../browser-i18n-manager/utils/types';
 
 /**
  * Parameters for the initializing GT
  * @param {string} params.defaultLocale - The default locale to use
  * @param {string[]} params.locales - The locales to support
- * @param {GetLocale} params.getLocale - The function to get the locale
  * @param {TranslationsLoader} params.loadTranslations - The custom translation loader to use
+ * @param {GetLocale} [params.getLocale] - The function to get the locale
+ * @param {HtmlTagOptions} [params.htmlTagOptions.updateHtmlLangTag] - (true) Whether to update the html lang tag on locale change
+ * @param {HtmlTagOptions} [params.htmlTagOptions.updateHtmlDirTag] - (true) Whether to update the html dir tag on locale change
  */
 export type InitializeGTParams = GTConfig & {
   loadTranslations?: TranslationsLoader;
   getLocale?: GetLocale;
+  htmlTagOptions?: HtmlTagOptions;
 };
 
 // Other Reexports

--- a/packages/react/src/shared/messages.ts
+++ b/packages/react/src/shared/messages.ts
@@ -5,6 +5,8 @@ export const PACKAGE_NAME = 'gt-react';
 export const BROWSER_ENVIRONMENT_ERROR = `${PACKAGE_NAME}/browser Error: The ${PACKAGE_NAME}/browser module requires a browser environment`;
 export const GENERIC_BROWSER_ENVIRONMENT_ERROR = `${PACKAGE_NAME} Error: You are trying to import a browser-only module into a non-browser environment.`;
 export const BROWSER_I18N_MANAGER_NOT_INITIALIZED_ERROR = `${PACKAGE_NAME} Error: BrowserI18nManager not initialized. Invoke initializeGT() to initialize.`;
+export const createInvalidLocaleError = (locale: string) =>
+  `${PACKAGE_NAME} Error: "${locale}" is not a valid locale.`;
 
 // ---- Warnings ---- //
 

--- a/packages/react/src/shared/messages.ts
+++ b/packages/react/src/shared/messages.ts
@@ -5,8 +5,6 @@ export const PACKAGE_NAME = 'gt-react';
 export const BROWSER_ENVIRONMENT_ERROR = `${PACKAGE_NAME}/browser Error: The ${PACKAGE_NAME}/browser module requires a browser environment`;
 export const GENERIC_BROWSER_ENVIRONMENT_ERROR = `${PACKAGE_NAME} Error: You are trying to import a browser-only module into a non-browser environment.`;
 export const BROWSER_I18N_MANAGER_NOT_INITIALIZED_ERROR = `${PACKAGE_NAME} Error: BrowserI18nManager not initialized. Invoke initializeGT() to initialize.`;
-export const createInvalidLocaleError = (locale: string) =>
-  `${PACKAGE_NAME} Error: "${locale}" is not a valid locale.`;
 
 // ---- Warnings ---- //
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a `updateHtmlTag()` method on `BrowserI18nManager` that updates `document.documentElement.lang` and `document.documentElement.dir` based on the current locale, and calls it during `bootstrap()` before loading translations. It also adds two public helper functions (`updateHtmlTagLang`, `updateHtmlTagDir`) and a configurable `HtmlTagOptions` type to control which attributes get updated. A secondary change in `react-core` extracts an inline `RelativeTimeFormatOptions` type and adds explicit type casts in `renderVariable.tsx` to improve type safety across the variable rendering branches.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; prior P1 concerns (throwing on invalid locale) are resolved and the only remaining finding is a minor JSDoc annotation typo.

All previously raised P1 issues have been addressed — updateHtmlTag now uses console.warn + early return on invalid locale instead of throwing. The remaining finding is a P2 JSDoc type annotation nit that has no runtime impact.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react/src/i18n-context/browser-i18n-manager/BrowserI18nManager.ts | Adds updateHtmlTag() method with locale validation (warn+return on invalid locale), configurable via HtmlTagOptions; addresses prior review concerns about throwing on invalid locale. |
| packages/react/src/i18n-context/functions/html-tag-operations.ts | New file exporting updateHtmlTagLang and updateHtmlTagDir public helpers; correctly sets updateHtmlLangTag/updateHtmlDirTag flags to avoid touching the other attribute. |
| packages/react/src/i18n-context/setup/bootstrap.ts | Calls updateHtmlTag() synchronously before loadTranslations() to set lang/dir early in the page lifecycle. |
| packages/react/src/i18n-context/setup/types.ts | Adds htmlTagOptions to InitializeGTParams; JSDoc @param type annotations for sub-properties use {HtmlTagOptions} instead of {boolean}. |
| packages/react-core/src/rendering/renderVariable.tsx | Adds explicit type casts for each variable options branch to improve type safety; uses the newly extracted RelativeTimeFormatOptions type. |
| packages/react-core/src/types-dir/types.ts | Extracts RelativeTimeFormatOptions as a named exported type (previously inline in VariableProps); no behavioral change. |
| packages/react/src/i18n-context/browser-i18n-manager/utils/types.ts | Adds HtmlTagOptions type with optional updateHtmlLangTag and updateHtmlDirTag booleans. |
| packages/react/src/i18n-context/browser-i18n-manager/utils/constants.ts | New file with DEFAULT_HTML_TAG_OPTIONS (both flags true by default). |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant App
    participant bootstrap
    participant BrowserI18nManager
    participant document

    App->>bootstrap: bootstrap(params)
    bootstrap->>BrowserI18nManager: initializeGT(params)
    Note over BrowserI18nManager: Merges htmlTagOptions with defaults
    bootstrap->>BrowserI18nManager: updateHtmlTag()
    BrowserI18nManager->>BrowserI18nManager: getLocale()
    BrowserI18nManager->>BrowserI18nManager: resolveCanonicalLocale(locale)
    BrowserI18nManager->>BrowserI18nManager: isValidLocale(canonicalLocale)
    alt invalid locale
        BrowserI18nManager-->>bootstrap: console.warn + return
    else valid locale
        BrowserI18nManager->>document: documentElement.lang = canonicalLocale
        BrowserI18nManager->>document: documentElement.dir = localeDirection
    end
    bootstrap->>BrowserI18nManager: loadTranslations()
    BrowserI18nManager-->>bootstrap: resolved
    bootstrap-->>App: resolved

    Note over App: Public API usage
    App->>BrowserI18nManager: updateHtmlTagLang(locale)
    BrowserI18nManager->>document: documentElement.lang = canonicalLocale
    App->>BrowserI18nManager: updateHtmlTagDir('rtl')
    BrowserI18nManager->>document: documentElement.dir = 'rtl'
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/react/src/i18n-context/setup/types.ts
Line: 10-11

Comment:
**Incorrect JSDoc `@param` types for sub-properties**

The `@param` type annotation for `htmlTagOptions.updateHtmlLangTag` and `htmlTagOptions.updateHtmlDirTag` is `{HtmlTagOptions}` but it should be `{boolean}` since these are the boolean leaf values being documented.

```suggestion
 * @param {boolean} [params.htmlTagOptions.updateHtmlLangTag] - (true) Whether to update the html lang tag on locale change
 * @param {boolean} [params.htmlTagOptions.updateHtmlDirTag] - (true) Whether to update the html dir tag on locale change
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["remove unused function"](https://github.com/generaltranslation/gt/commit/ada6e0ac4eb41b9dd382feaa8b18a08db28590b1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27943552)</sub>

<!-- /greptile_comment -->