### PR TITLE
F/source content hashing

### DIFF
--- a/.changeset/odd-lions-sing.md
+++ b/.changeset/odd-lions-sing.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+Hash postprocessed source content

--- a/packages/cli/src/formats/files/aggregateFiles.ts
+++ b/packages/cli/src/formats/files/aggregateFiles.ts
@@ -358,7 +358,7 @@ export async function aggregateFiles(
             fileName: relativePath,
             fileFormat: fileType.toUpperCase() as FileFormat,
             fileId: hashStringSync(relativePath),
-            versionId: hashStringSync(content),
+            versionId: hashStringSync(processed),
             locale: settings.defaultLocale,
           } satisfies FileToUpload;
         })

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.14.10';
+export const PACKAGE_VERSION = '2.14.11';


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This patch fixes the `versionId` computation for non-JSON/YAML file types in `aggregateFiles.ts`, changing the hash input from the raw file content (`content`) to the post-processed content (`processed`). This aligns with how JSON and YAML files already behave (using `parsedJson`/`parsedYaml` as the hash input), ensuring `versionId` only changes when the content that is actually sent for translation changes.

- Existing uploads of non-JSON/YAML file types (e.g. MDX, PO, etc.) will have a different `versionId` after this change, causing a one-time re-upload of all such files on the next CLI run. This is expected behavior for a correctness fix but may surprise users on upgrade.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — minimal, targeted fix with no logic risks.

Single-line correctness fix that aligns non-JSON/YAML file type hashing with the already-correct JSON/YAML branches. No new logic is introduced; `processed` is already validated as a string before the return. The only side effect (one-time re-upload of affected files) is intentional and captured in the summary.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/formats/files/aggregateFiles.ts | Single-line fix: `versionId` for non-JSON/YAML file types now hashes `processed` (post-processed content) instead of `content` (raw file bytes), making hashing consistent across all file type branches. |
| .changeset/odd-lions-sing.md | Changeset for a patch bump to `gt`, describing the source content hashing fix. |
| packages/cli/src/generated/version.ts | Auto-generated version bump from 2.14.10 → 2.14.11, consistent with the patch changeset. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[readFile → raw content] --> B{File Type?}
    B -->|JSON| C[parseJson → parsedJson]
    B -->|YAML| D[parseYaml → parsedYaml]
    B -->|TwilioContentJSON| E[parseJson → parsedJson]
    B -->|Other: MDX, PO, ...| F[preprocessContent → processed]
    C --> G[versionId = hashStringSync parsedJson]
    D --> H[versionId = hashStringSync parsedYaml]
    E --> I[versionId = hashStringSync parsedJson]
    F --> J["versionId = hashStringSync(processed) ✅ was: content"]
    style J fill:#d4edda,stroke:#28a745
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: changeset"](https://github.com/generaltranslation/gt/commit/4072efba39eefcfd7f1a019a413f923bb2838e67) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28067436)</sub>

<!-- /greptile_comment -->