### PR TITLE
fix(gt-next): narrow DataFormat to StringFormat in tx() formatMessage call

### DIFF
--- a/.changeset/fix-tx-dataformat-narrowing.md
+++ b/.changeset/fix-tx-dataformat-narrowing.md
@@ -1,0 +1,5 @@
+---
+"gt-next": patch
+---
+
+Fix type error in `tx()`: narrow `DataFormat` to `StringFormat` before passing to `formatMessage()`, filtering out `'JSX'` which is not a valid string format.

--- a/packages/next/src/server-dir/runtime/tx.ts
+++ b/packages/next/src/server-dir/runtime/tx.ts
@@ -79,7 +79,7 @@ export default async function tx(
           ...declaredVars,
           [VAR_IDENTIFIER]: 'other',
         },
-        dataFormat: format,
+        dataFormat: format === 'JSX' ? undefined : format,
       }
     );
     const cutoffMessage = gt.formatCutoff(formattedMessage, {


### PR DESCRIPTION
## Problem

`RuntimeTranslationOptions.$format` was changed from `StringFormat` to `DataFormat` (which includes `'JSX'`), but `formatMessage()` only accepts `StringFormat | undefined`. This causes a TS2322 build error in `packages/next/src/server-dir/runtime/tx.ts` line 82:

```
Type 'DataFormat | undefined' is not assignable to type 'StringFormat | undefined'.
  Type '"JSX"' is not assignable to type 'StringFormat | undefined'.
```

This was the sole build failure blocking CI on `e/i18n/add-runtime-translation` — all other package failures cascaded from `gt-next#build`.

## Fix

Since `tx()` is a string-only translation function, exclude `'JSX'` before passing `format` to `formatMessage`:

```ts
dataFormat: format === 'JSX' ? undefined : format,
```

One-line change. Full turbo build passes (25/25 tasks).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes the TypeScript `TS2322` build error in `tx.ts` by guarding `format === 'JSX'` before passing to `gt.formatMessage()`, which only accepts `StringFormat`. The change is correct and minimal.

One small follow-up worth considering: the `hashSource` call on line 102 (`dataFormat: format || 'ICU'`) still passes `'JSX'` unchanged, so if a caller ever supplies `$format: 'JSX'`, the cached translation would be keyed under a `'JSX'` hash while rendering uses ICU — applying the same guard there keeps both paths consistent.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the fix is type-correct and eliminates the sole CI blocker; the one remaining note is a P2 style suggestion.

All findings are P2 (the hash/render format inconsistency only matters if a caller deliberately passes $format: 'JSX' to a string-only function, which is out-of-spec). The fix resolves the TypeScript error without introducing any new runtime issues.

No files require special attention.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/next/src/server-dir/runtime/tx.ts | One-line fix narrows DataFormat to StringFormat for the formatMessage call; minor inconsistency remains in the hashSource call where 'JSX' still flows through as-is. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["tx(message, options)"] --> B["Extract $format from options"]
    B --> C{{"translationRequired?"}}
    C -- No --> D["renderContent(message, defaultLocale)"]
    C -- Yes --> E["hashSource({ dataFormat: format || 'ICU' })"]
    E --> F{{"cache hit?"}}
    F -- Yes --> G["renderContent(cached, locale)"]
    F -- No --> H["translateIcu(source, targetLocale)"]
    H --> I["renderContent(target, locale)"]
    D & G & I --> J["gt.formatMessage(content, { dataFormat: format === 'JSX' ? undefined : format })"]
    J --> K["Return formatted string"]

    style J fill:#d4edda,stroke:#28a745
    style E fill:#fff3cd,stroke:#ffc107
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/next/src/server-dir/runtime/tx.ts`, line 102 ([link](https://github.com/generaltranslation/gt/blob/797a8e44fa599e29c1f9e7b53e312ae82461fb9c/packages/next/src/server-dir/runtime/tx.ts#L102)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Hash/render format inconsistency when `$format: 'JSX'`**

   The `hashSource` call on line 102 still passes `format` directly (`format || 'ICU'`), so when `format === 'JSX'` the hash is computed with `'JSX'` as the `dataFormat`, while `renderContent` now effectively uses `undefined` (ICU). The two code paths would disagree on the format key for any cached translation. Extracting the narrowed value into a shared variable keeps them in sync:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/next/src/server-dir/runtime/tx.ts
   Line: 102

   Comment:
   **Hash/render format inconsistency when `$format: 'JSX'`**

   The `hashSource` call on line 102 still passes `format` directly (`format || 'ICU'`), so when `format === 'JSX'` the hash is computed with `'JSX'` as the `dataFormat`, while `renderContent` now effectively uses `undefined` (ICU). The two code paths would disagree on the format key for any cached translation. Extracting the narrowed value into a shared variable keeps them in sync:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/next/src/server-dir/runtime/tx.ts
Line: 102

Comment:
**Hash/render format inconsistency when `$format: 'JSX'`**

The `hashSource` call on line 102 still passes `format` directly (`format || 'ICU'`), so when `format === 'JSX'` the hash is computed with `'JSX'` as the `dataFormat`, while `renderContent` now effectively uses `undefined` (ICU). The two code paths would disagree on the format key for any cached translation. Extracting the narrowed value into a shared variable keeps them in sync:

```suggestion
    dataFormat: (format === 'JSX' ? undefined : format) || 'ICU',
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(gt-next): narrow DataFormat to Strin..."](https://github.com/generaltranslation/gt/commit/797a8e44fa599e29c1f9e7b53e312ae82461fb9c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28287013)</sub>

<!-- /greptile_comment -->