### PR TITLE
fix(cli): detect gt-tanstack-start for inline content extraction

### DIFF
--- a/.changeset/fix-cli-tanstack-start-detection.md
+++ b/.changeset/fix-cli-tanstack-start-detection.md
@@ -1,0 +1,5 @@
+---
+'gtx-cli': patch
+---
+
+Fix inline content extraction for gt-tanstack-start projects. The CLI now correctly detects gt-tanstack-start in package.json, routes it to ReactCLI, and scans imports from gt-tanstack-start for translatable content like `<T>` components.

--- a/.changeset/fix-cli-tanstack-start-detection.md
+++ b/.changeset/fix-cli-tanstack-start-detection.md
@@ -1,5 +1,5 @@
 ---
-'gtx-cli': patch
+'gt': patch
 ---
 
 Fix inline content extraction for gt-tanstack-start projects. The CLI now correctly detects gt-tanstack-start in package.json, routes it to ReactCLI, and scans imports from gt-tanstack-start for translatable content like `<T>` components.

--- a/packages/cli/src/cli/inline.ts
+++ b/packages/cli/src/cli/inline.ts
@@ -195,6 +195,7 @@ function fallbackToGtReact(library: SupportedLibraries): InlineLibrary {
     Libraries.GT_NEXT,
     Libraries.GT_NODE,
     Libraries.GT_REACT_NATIVE,
+    Libraries.GT_TANSTACK_START,
     Libraries.GT_FLASK,
     Libraries.GT_FASTAPI,
   ].includes(library as Libraries)
@@ -202,6 +203,7 @@ function fallbackToGtReact(library: SupportedLibraries): InlineLibrary {
         | typeof Libraries.GT_NEXT
         | typeof Libraries.GT_NODE
         | typeof Libraries.GT_REACT_NATIVE
+        | typeof Libraries.GT_TANSTACK_START
         | typeof Libraries.GT_FLASK
         | typeof Libraries.GT_FASTAPI)
     : Libraries.GT_REACT;

--- a/packages/cli/src/fs/determineFramework/index.ts
+++ b/packages/cli/src/fs/determineFramework/index.ts
@@ -29,6 +29,8 @@ export function determineLibrary(): {
       // Check for gt-next or gt-react in dependencies
       if (dependencies[Libraries.GT_NEXT]) {
         library = Libraries.GT_NEXT;
+      } else if (dependencies[Libraries.GT_TANSTACK_START]) {
+        library = Libraries.GT_TANSTACK_START;
       } else if (dependencies[Libraries.GT_REACT]) {
         library = Libraries.GT_REACT;
       } else if (dependencies[Libraries.GT_REACT_NATIVE]) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -16,7 +16,8 @@ export function main(program: Command) {
     cli = new NextCLI(program, library, additionalModules);
   } else if (
     library === Libraries.GT_REACT ||
-    library === Libraries.GT_REACT_NATIVE
+    library === Libraries.GT_REACT_NATIVE ||
+    library === Libraries.GT_TANSTACK_START
   ) {
     cli = new ReactCLI(program, library, additionalModules);
   } else if (library === Libraries.GT_NODE) {

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -116,7 +116,8 @@ export type GenerateSourceOptions = {
 export type Framework =
   | typeof Libraries.GT_NEXT
   | typeof Libraries.GT_REACT
-  | typeof Libraries.GT_REACT_NATIVE;
+  | typeof Libraries.GT_REACT_NATIVE
+  | typeof Libraries.GT_TANSTACK_START;
 
 export type FrameworkObject =
   | {


### PR DESCRIPTION
## Problem

`gtx-cli` doesn't extract inline content (e.g. `<T>` components) from projects using `gt-tanstack-start`.

Three issues:

1. **`determineLibrary()`** (`packages/cli/src/fs/determineFramework/index.ts`) doesn't check for `gt-tanstack-start` in `package.json` dependencies — falls back to `'base'`
2. **`main()`** (`packages/cli/src/index.ts`) doesn't route `GT_TANSTACK_START` to `ReactCLI` — falls through to `BaseCLI` (no inline extraction, no `validate` command)
3. **`fallbackToGtReact()`** (`packages/cli/src/cli/inline.ts`) doesn't include `GT_TANSTACK_START` in its whitelist — falls back to `gt-react`, which doesn't scan imports from `gt-tanstack-start`

## Fix

- Add `gt-tanstack-start` detection in `determineLibrary()` (before `gt-react`, since it's more specific)
- Route `GT_TANSTACK_START` to `ReactCLI` in `main()`
- Add `GT_TANSTACK_START` to `Framework` type
- Add `GT_TANSTACK_START` to `fallbackToGtReact()` whitelist

## Testing

Created a minimal TanStack Start project with `gt-tanstack-start` as the only GT dependency and two `<T>` components.

**Before (main):** `gt validate` → `error: unknown command 'validate'` (BaseCLI, no inline extraction at all)

**After (this branch):** `gt validate` → `Success! Found 2 translatable entries for gt-tanstack-start.`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes three detection gaps that caused `gt-tanstack-start` projects to fall through to `BaseCLI`: missing detection in `determineLibrary()`, missing routing to `ReactCLI` in `main()`, and missing inclusion in the `fallbackToGtReact()` whitelist. The logic changes across the four source files are correct and consistent with how other React-based libraries are handled.

- The changeset lists `gtx-cli: patch` but all changed files live in `packages/cli/` (the `gt` npm package). Without a `gt: patch` entry the `gt` package won't get a new version on npm, so users installing `gt` directly will not receive this fix.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge after correcting the changeset to bump the `gt` package instead of (or in addition to) `gtx-cli`.

The four source-file changes are correct and complete. The only blocking issue is the changeset targeting the wrong package, which would prevent the fix from reaching `gt` users on npm.

`.changeset/fix-cli-tanstack-start-detection.md` — must reference `gt` instead of (or alongside) `gtx-cli`.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .changeset/fix-cli-tanstack-start-detection.md | Changeset bumps `gtx-cli` but all code changes are in the `gt` package — will not trigger a `gt` npm release |
| packages/cli/src/fs/determineFramework/index.ts | Correctly adds `GT_TANSTACK_START` detection between `GT_NEXT` and `GT_REACT` so the more-specific library takes priority |
| packages/cli/src/index.ts | Routes `GT_TANSTACK_START` to `ReactCLI`, consistent with how `GT_REACT` and `GT_REACT_NATIVE` are handled |
| packages/cli/src/cli/inline.ts | Adds `GT_TANSTACK_START` to the `fallbackToGtReact` whitelist so validate/translate use the correct library rather than falling back to `gt-react` |
| packages/cli/src/types/index.ts | Adds `GT_TANSTACK_START` to the `Framework` union type used by `ContentScanner`, completing the type-level support |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .changeset/fix-cli-tanstack-start-detection.md
Line: 2

Comment:
**Changeset targets wrong package**

All code changes in this PR are in `packages/cli/src/` which belongs to the `gt` npm package, but the changeset only bumps `gtx-cli`. Without a `gt: patch` entry, the `gt` package won't get a new version published to npm, so users who install `gt` directly will not receive this fix.

`gtx-cli` is a thin wrapper with `"gt": "workspace:*"` as a runtime dependency — bumping `gtx-cli` without bumping `gt` means the fix ships in the monorepo but the `gt` package stays at its current published version.

```suggestion
'gt': patch
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["add changeset"](https://github.com/generaltranslation/gt/commit/7848d8ace78bc09bb6a0f838da3f9fe55f0e0e5f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28381030)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->