### PR TITLE
fix: relative import resolution failures

### DIFF
--- a/.changeset/sweet-mammals-lick.md
+++ b/.changeset/sweet-mammals-lick.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+fix: cross file resolution failure on relative imports

--- a/packages/cli/src/console/index.ts
+++ b/packages/cli/src/console/index.ts
@@ -385,6 +385,18 @@ export const warnDeriveOptionalChainingSync = (
     location
   );
 
+export const warnUnresolvedImportSync = (
+  file: string,
+  functionName: string,
+  importPath: string,
+  location?: string
+): string =>
+  withLocation(
+    file,
+    `Could not resolve import ${colorizeFunctionName(importPath)} for function ${colorizeFunctionName(functionName)}. Translation strings inside this function will not be extracted.`,
+    location
+  );
+
 // Re-export error messages
 export const noLocalesError = `No locales found! Provide a list of locales for translation, or specify them in your gt.config.json file.`;
 export const noDefaultLocaleError = `No default locale found! Provide a default locale, or specify it in your gt.config.json file.`;

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.14.15';
+export const PACKAGE_VERSION = '2.14.16';

--- a/packages/cli/src/react/jsx/utils/__tests__/parseStringFunctionCrossFile.test.ts
+++ b/packages/cli/src/react/jsx/utils/__tests__/parseStringFunctionCrossFile.test.ts
@@ -278,4 +278,115 @@ describe('parseStrings — cross-file gt parameter tracing', () => {
     expect(ids).toContain('direct');
     expect(ids).toContain('formatted');
   });
+
+  describe('warnUnresolvedImportSync', () => {
+    it('should warn when an imported function receiving gt cannot be resolved', () => {
+      const file1 = `
+        import { useGT } from 'gt-react';
+        import { getData } from '@app/data';
+
+        function Component() {
+          const gt = useGT();
+          getData(gt);
+        }
+      `;
+
+      // Resolve returns null for @app/data
+      mockResolveImportPath.mockReturnValue(null);
+
+      extractStrings(file1, '/app/page.tsx');
+
+      expect(errors).toHaveLength(0);
+      expect(updates).toHaveLength(0);
+      expect(warnings.size).toBe(1);
+      const warning = [...warnings][0];
+      expect(warning).toContain('getData');
+      expect(warning).toContain('@app/data');
+    });
+
+    it('should warn when a nested cross-file import cannot be resolved', () => {
+      const file1 = `
+        import { useGT } from 'gt-react';
+        import { outer } from '@pkg/outer';
+
+        function Component() {
+          const gt = useGT();
+          outer(gt);
+        }
+      `;
+
+      const file2 = `
+        import { inner } from './missing-file';
+
+        export function outer(gt) {
+          gt('found', { $id: 'found' });
+          inner(gt);
+        }
+      `;
+
+      mockFs.readFileSync.mockImplementation(
+        (path: fs.PathOrFileDescriptor) => {
+          if (path === '/pkg/src/outer.ts') return file2;
+          throw new Error(`File not found: ${path}`);
+        }
+      );
+      mockResolveImportPath.mockImplementation(
+        (_currentFile: string, importPath: string) => {
+          if (importPath === '@pkg/outer') return '/pkg/src/outer.ts';
+          // ./missing-file cannot be resolved
+          if (importPath === './missing-file') return null;
+          return null;
+        }
+      );
+
+      extractStrings(file1, '/app/page.tsx');
+
+      expect(errors).toHaveLength(0);
+      // Should still extract the string from file2
+      expect(updates).toHaveLength(1);
+      expect(updates[0].metadata.id).toBe('found');
+      // Should warn about the unresolved inner import
+      expect(warnings.size).toBe(1);
+      const warning = [...warnings][0];
+      expect(warning).toContain('inner');
+      expect(warning).toContain('./missing-file');
+    });
+
+    it('should not warn when all imports resolve successfully', () => {
+      const file1 = `
+        import { useGT } from 'gt-react';
+        import { helper } from '@app/helper';
+
+        function Component() {
+          const gt = useGT();
+          helper(gt);
+        }
+      `;
+
+      const file2 = `
+        export function helper(gt) {
+          gt('works', { $id: 'works' });
+        }
+      `;
+
+      mockFs.readFileSync.mockImplementation(
+        (path: fs.PathOrFileDescriptor) => {
+          if (path === '/app/src/helper.ts') return file2;
+          throw new Error(`File not found: ${path}`);
+        }
+      );
+      mockResolveImportPath.mockImplementation(
+        (_currentFile: string, importPath: string) => {
+          if (importPath === '@app/helper') return '/app/src/helper.ts';
+          return null;
+        }
+      );
+
+      extractStrings(file1, '/app/page.tsx');
+
+      expect(errors).toHaveLength(0);
+      expect(updates).toHaveLength(1);
+      expect(warnings.size).toBe(0);
+    });
+  });
 });

--- a/packages/cli/src/react/jsx/utils/__tests__/parseStringFunctionCrossFile.test.ts
+++ b/packages/cli/src/react/jsx/utils/__tests__/parseStringFunctionCrossFile.test.ts
@@ -129,7 +129,7 @@ describe('parseStrings — cross-file gt parameter tracing', () => {
     expect(ids).toContain('label');
   });
 
-  it('should fail to trace 3-file chain when config.file is not updated (regression guard)', () => {
+  it('should correctly trace a 3-file chain by updating config.file at each file boundary (regression guard)', () => {
     // This test verifies that resolveImportPath is called with the correct
     // currentFile for nested cross-file resolution.
     const file1 = `

--- a/packages/cli/src/react/jsx/utils/__tests__/parseStringFunctionCrossFile.test.ts
+++ b/packages/cli/src/react/jsx/utils/__tests__/parseStringFunctionCrossFile.test.ts
@@ -1,0 +1,281 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as t from '@babel/types';
+import fs from 'node:fs';
+import { parse } from '@babel/parser';
+import traverseModule from '@babel/traverse';
+import { parseStrings, clearParsingCaches } from '../parseStringFunction.js';
+import { resolveImportPath } from '../resolveImportPath.js';
+import { Updates } from '../../../../types/index.js';
+
+const traverse = (traverseModule as any).default || traverseModule;
+
+vi.mock('node:fs');
+vi.mock('../resolveImportPath.js');
+
+const mockFs = vi.mocked(fs);
+const mockResolveImportPath = vi.mocked(resolveImportPath);
+
+describe('parseStrings — cross-file gt parameter tracing', () => {
+  let updates: Updates;
+  let errors: string[];
+  let warnings: Set<string>;
+
+  beforeEach(() => {
+    updates = [];
+    errors = [];
+    warnings = new Set();
+    vi.clearAllMocks();
+    clearParsingCaches();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function extractStrings(sourceCode: string, filePath: string) {
+    const ast = parse(sourceCode, {
+      sourceType: 'module',
+      plugins: ['jsx', 'typescript'],
+    });
+
+    traverse(ast, {
+      ImportSpecifier(path) {
+        if (
+          t.isIdentifier(path.node.imported) &&
+          path.node.imported.name === 'useGT' &&
+          t.isIdentifier(path.node.local)
+        ) {
+          parseStrings(
+            path.node.local.name,
+            'useGT',
+            path,
+            {
+              parsingOptions: { conditionNames: [] },
+              file: filePath,
+              ignoreInlineMetadata: false,
+              ignoreDynamicContent: false,
+              ignoreInvalidIcu: false,
+              ignoreInlineListContent: true,
+              includeSourceCodeContext: false,
+              ignoreTaggedTemplates: false,
+              ignoreGlobalTaggedTemplates: false,
+              autoderiveMethod: 'DISABLED',
+            },
+            {
+              updates,
+              errors,
+              warnings,
+            }
+          );
+        }
+      },
+    });
+  }
+
+  it('should trace gt parameter through a 3-file chain with relative imports', () => {
+    // file1.tsx imports getDetails from file2, which imports getLabel from file3
+    // gt is passed: file1 → file2 → file3
+    const file1 = `
+      import { useGT } from 'gt-react';
+      import { getDetails } from '@app/utils';
+
+      function Component() {
+        const gt = useGT();
+        getDetails(gt);
+      }
+    `;
+
+    const file2 = `
+      import { getLabel } from './helpers';
+
+      export function getDetails(gt) {
+        gt('detail string', { $id: 'detail' });
+        getLabel(gt);
+      }
+    `;
+
+    const file3 = `
+      export function getLabel(gt) {
+        gt('label string', { $id: 'label' });
+      }
+    `;
+
+    mockFs.readFileSync.mockImplementation((path: fs.PathOrFileDescriptor) => {
+      if (path === '/project/src/utils.ts') return file2;
+      if (path === '/project/src/helpers.ts') return file3;
+      throw new Error(`File not found: ${path}`);
+    });
+    mockResolveImportPath.mockImplementation(
+      (currentFile: string, importPath: string) => {
+        if (importPath === '@app/utils') return '/project/src/utils.ts';
+        // This is the key: ./helpers must be resolved relative to utils.ts, not file1.tsx
+        if (
+          currentFile === '/project/src/utils.ts' &&
+          importPath === './helpers'
+        )
+          return '/project/src/helpers.ts';
+        return null;
+      }
+    );
+
+    extractStrings(file1, '/project/app/page.tsx');
+
+    expect(errors).toHaveLength(0);
+    // Should find strings in both file2 and file3
+    expect(updates).toHaveLength(2);
+
+    const ids = updates.map((u) => u.metadata.id);
+    expect(ids).toContain('detail');
+    expect(ids).toContain('label');
+  });
+
+  it('should fail to trace 3-file chain when config.file is not updated (regression guard)', () => {
+    // This test verifies that resolveImportPath is called with the correct
+    // currentFile for nested cross-file resolution.
+    const file1 = `
+      import { useGT } from 'gt-react';
+      import { outer } from '@pkg/outer';
+
+      function Component() {
+        const gt = useGT();
+        outer(gt);
+      }
+    `;
+
+    const file2 = `
+      import { inner } from './inner';
+
+      export function outer(gt) {
+        inner(gt);
+      }
+    `;
+
+    const file3 = `
+      export function inner(gt) {
+        gt('inner string', { $id: 'inner' });
+      }
+    `;
+
+    mockFs.readFileSync.mockImplementation((path: fs.PathOrFileDescriptor) => {
+      if (path === '/pkg/src/outer.ts') return file2;
+      if (path === '/pkg/src/inner.ts') return file3;
+      throw new Error(`File not found: ${path}`);
+    });
+    mockResolveImportPath.mockImplementation(
+      (currentFile: string, importPath: string) => {
+        if (importPath === '@pkg/outer') return '/pkg/src/outer.ts';
+        // Only resolve ./inner when called with the correct currentFile (outer.ts)
+        if (currentFile === '/pkg/src/outer.ts' && importPath === './inner')
+          return '/pkg/src/inner.ts';
+        return null;
+      }
+    );
+
+    extractStrings(file1, '/app/page.tsx');
+
+    expect(errors).toHaveLength(0);
+    expect(updates).toHaveLength(1);
+    expect(updates[0].metadata.id).toBe('inner');
+
+    // Verify resolveImportPath was called with the correct file for nested resolution
+    const resolveImportPathCalls = mockResolveImportPath.mock.calls;
+    const innerResolutionCall = resolveImportPathCalls.find(
+      (call) => call[1] === './inner'
+    );
+    expect(innerResolutionCall).toBeDefined();
+    expect(innerResolutionCall![0]).toBe('/pkg/src/outer.ts');
+  });
+
+  it('should trace gt through re-exports in a 3-file chain', () => {
+    const file1 = `
+      import { useGT } from 'gt-react';
+      import { process } from '@lib/index';
+
+      function Component() {
+        const gt = useGT();
+        process(gt);
+      }
+    `;
+
+    const indexFile = `
+      export { process } from './processor';
+    `;
+
+    const processorFile = `
+      export function process(gt) {
+        gt('processed', { $id: 'processed' });
+      }
+    `;
+
+    mockFs.readFileSync.mockImplementation((path: fs.PathOrFileDescriptor) => {
+      if (path === '/lib/src/index.ts') return indexFile;
+      if (path === '/lib/src/processor.ts') return processorFile;
+      throw new Error(`File not found: ${path}`);
+    });
+    mockResolveImportPath.mockImplementation(
+      (currentFile: string, importPath: string) => {
+        if (importPath === '@lib/index') return '/lib/src/index.ts';
+        if (currentFile === '/lib/src/index.ts' && importPath === './processor')
+          return '/lib/src/processor.ts';
+        return null;
+      }
+    );
+
+    extractStrings(file1, '/app/page.tsx');
+
+    expect(errors).toHaveLength(0);
+    expect(updates).toHaveLength(1);
+    expect(updates[0].metadata.id).toBe('processed');
+  });
+
+  it('should handle gt with default value parameter across files', () => {
+    // Mirrors the real-world case: gt = gtFallback default parameter
+    const file1 = `
+      import { useGT } from 'gt-react';
+      import { getCopy } from '@app/copy';
+
+      function Component() {
+        const gt = useGT();
+        getCopy(gt);
+      }
+    `;
+
+    const file2 = `
+      import { formatCopy } from './format';
+
+      export function getCopy(gt = fallback) {
+        gt('direct copy', { $id: 'direct' });
+        formatCopy(gt);
+      }
+    `;
+
+    const file3 = `
+      export function formatCopy(gt = fallback) {
+        gt('formatted copy', { $id: 'formatted' });
+      }
+    `;
+
+    mockFs.readFileSync.mockImplementation((path: fs.PathOrFileDescriptor) => {
+      if (path === '/app/src/copy.ts') return file2;
+      if (path === '/app/src/format.ts') return file3;
+      throw new Error(`File not found: ${path}`);
+    });
+    mockResolveImportPath.mockImplementation(
+      (currentFile: string, importPath: string) => {
+        if (importPath === '@app/copy') return '/app/src/copy.ts';
+        if (currentFile === '/app/src/copy.ts' && importPath === './format')
+          return '/app/src/format.ts';
+        return null;
+      }
+    );
+
+    extractStrings(file1, '/app/pages/page.tsx');
+
+    expect(errors).toHaveLength(0);
+    expect(updates).toHaveLength(2);
+
+    const ids = updates.map((u) => u.metadata.id);
+    expect(ids).toContain('direct');
+    expect(ids).toContain('formatted');
+  });
+});

--- a/packages/cli/src/react/jsx/utils/parseStringFunction.ts
+++ b/packages/cli/src/react/jsx/utils/parseStringFunction.ts
@@ -8,7 +8,11 @@ import {
   STRING_REGISTRATION_FUNCS,
   T_GLOBAL_REGISTRATION_FUNCTION_MARKER,
 } from './constants.js';
-import { warnAsyncUseGT, warnSyncGetGT } from '../../../console/index.js';
+import {
+  warnAsyncUseGT,
+  warnSyncGetGT,
+  warnUnresolvedImportSync,
+} from '../../../console/index.js';
 
 import traverseModule from '@babel/traverse';
 // Handle CommonJS/ESM interop
@@ -199,6 +203,17 @@ function handleFunctionCall(
             state,
             output
           );
+        } else {
+          output.warnings.add(
+            warnUnresolvedImportSync(
+              config.file,
+              callee.name,
+              importPath,
+              tPath.node.loc
+                ? `${tPath.node.loc.start.line}:${tPath.node.loc.start.column}`
+                : undefined
+            )
+          );
         }
       }
     }
@@ -331,6 +346,8 @@ function processFunctionInFile(
     // Fresh set per cross-file parse — node identity is only stable within a single parse.
     // Cross-file cycles are already guarded by processFunctionCache above.
     const visitedFunctions = new Set<t.Node>();
+    // Update config.file so relative imports in the target file resolve correctly
+    const crossFileConfig: ParsingConfig = { ...config, file: filePath };
 
     traverse(ast, {
       // Handle function declarations: function getInfo(t) { ... }
@@ -342,7 +359,7 @@ function processFunctionInFile(
             argIndex,
             path.node,
             path,
-            config,
+            crossFileConfig,
             output,
             visitedFunctions
           );
@@ -364,7 +381,7 @@ function processFunctionInFile(
             argIndex,
             path.node.init,
             initPath,
-            config,
+            crossFileConfig,
             output,
             visitedFunctions
           );


### PR DESCRIPTION
When tracing `gt` parameter across files (e.g., file1 → file2 → file3), relative imports in file2 were resolved against file1's directory instead of file2's, silently breaking the chain. Fixed by updating `config.file` to the current file when crossing file boundaries, matching what the JSX/Derive tracer already does. Also added a warning when import resolution fails so this kind of issue surfaces immediately.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug in the CLI's cross-file `gt` parameter tracer where relative imports in an intermediate file (e.g. `file2`) were resolved against the originating file's (`file1`) directory instead of `file2`'s own directory. The fix introduces `crossFileConfig = { ...config, file: filePath }` inside `processFunctionInFile` — matching the pattern the JSX/Derive tracer already uses — and adds a `warnUnresolvedImportSync` warning so resolution failures are no longer silent.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the fix is correct, well-scoped, and covered by targeted tests.

The only finding is a P2 test-name clarity issue with no impact on correctness or behavior. The core logic change (propagating the current file path through `crossFileConfig`) is sound and consistent with the existing JSX/Derive tracer pattern. Tests exercise the 3-file chain, re-exports, and default-value parameters.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/react/jsx/utils/parseStringFunction.ts | Core bug fix: `crossFileConfig = { ...config, file: filePath }` ensures relative imports inside a cross-file function are resolved from that file's directory; also adds a warning when import resolution fails. |
| packages/cli/src/react/jsx/utils/__tests__/parseStringFunctionCrossFile.test.ts | New tests covering 3-file chains (direct, re-export, default parameters) with mocked fs/resolveImportPath; second test name is misleading ("should fail") but asserts the fixed/correct behavior. |
| packages/cli/src/console/index.ts | Adds `warnUnresolvedImportSync` — surfaces previously-silent import resolution failures so users know translation strings inside unresolvable imported functions won't be extracted. |
| .changeset/sweet-mammals-lick.md | Standard patch-level changeset for the `gt` CLI package. |
| packages/cli/src/generated/version.ts | Auto-generated version bump to 2.14.16 by the pre-commit hook; no manual changes. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["parseStrings (file1.tsx)\nconfig.file = /app/page.tsx"] --> B[handleFunctionCall]
    B --> C{Callee in importMap?}
    C -->|Yes| D["resolveImportPath(config.file, importPath)"]
    D --> E{Resolved?}
    E -->|No| F["⚠️ warnUnresolvedImportSync\n(NEW: surface silent failure)"]
    E -->|Yes| G["processFunctionInFile(resolvedPath, ...)"]
    G --> H["crossFileConfig = { ...config, file: filePath }\n(BUG FIX: update file to current file)"]
    H --> I["traverse AST of resolvedPath\nfind target function"]
    I --> J["processFunctionIfMatches(crossFileConfig)"]
    J --> K["findFunctionParameterUsage(crossFileConfig)"]
    K --> L["handleFunctionCall(crossFileConfig)\nconfig.file = resolvedPath ✓"]
    L --> C
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/cli/src/react/jsx/utils/__tests__/parseStringFunctionCrossFile.test.ts
Line: 132

Comment:
**Misleading test description**

The test is named "should fail to trace 3-file chain when config.file is not updated" but its assertions verify the opposite — that the chain *succeeds* (1 update found, `./inner` resolved from the correct `currentFile`). This is a proper regression guard for the fix, but the "should fail" phrasing implies it tests the broken behavior rather than the corrected one.

```suggestion
  it('should correctly trace a 3-file chain by updating config.file at each file boundary (regression guard)', () => {
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["add tests for warning"](https://github.com/generaltranslation/gt/commit/7c31cc82baf661411113e2a8aeb88350311cfb52) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28703719)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->