### PR TITLE
feat(cli): add --skip-on-payment-error flag for translate/stage/enqueue

### DIFF
--- a/.changeset/skip-enqueue-payment-error.md
+++ b/.changeset/skip-enqueue-payment-error.md
@@ -1,0 +1,6 @@
+---
+'gt': patch
+'gtx-cli': patch
+---
+
+Add `--skip-on-payment-error` flag to the `translate`, `stage`, and `enqueue` CLI commands. When enabled, if the enqueue step fails due to insufficient account credits (HTTP 402), the command treats those files as skipped instead of exiting with an error. This prevents CI pipelines from breaking when the account runs out of credits. All other behavior (upload, download, post-processing) continues normally.

--- a/packages/cli/src/cli/flags.ts
+++ b/packages/cli/src/cli/flags.ts
@@ -84,6 +84,11 @@ export function attachTranslateFlags(command: Command) {
       false
     )
     .option(
+      '--skip-on-payment-error',
+      'Skip enqueue gracefully when the account has insufficient credits, instead of failing the command.',
+      false
+    )
+    .option(
       '--force-download',
       'Force download and overwrite local files, bypassing gt-lock.json checks.',
       false

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -72,6 +72,7 @@ export type TranslateFlags = SharedFlags & {
   publish?: boolean;
   force?: boolean;
   forceDownload?: boolean;
+  skipOnPaymentError?: boolean;
   tag?: string;
   message?: string;
   experimentalLocalizeStaticUrls?: boolean;

--- a/packages/cli/src/workflows/enqueue.ts
+++ b/packages/cli/src/workflows/enqueue.ts
@@ -34,7 +34,12 @@ export async function runEnqueueWorkflow({
     // Create workflow with steps
     const branchStep = new BranchStep(gt, settings);
     // const queryFileDataStep = new QueryFileDataStep(gt);
-    const enqueueStep = new EnqueueStep(gt, settings, options.force, options.skipOnPaymentError);
+    const enqueueStep = new EnqueueStep(
+      gt,
+      settings,
+      options.force,
+      options.skipOnPaymentError
+    );
 
     // (1) run the branch step
     const branchData = await branchStep.run();

--- a/packages/cli/src/workflows/enqueue.ts
+++ b/packages/cli/src/workflows/enqueue.ts
@@ -34,7 +34,7 @@ export async function runEnqueueWorkflow({
     // Create workflow with steps
     const branchStep = new BranchStep(gt, settings);
     // const queryFileDataStep = new QueryFileDataStep(gt);
-    const enqueueStep = new EnqueueStep(gt, settings, options.force);
+    const enqueueStep = new EnqueueStep(gt, settings, options.force, options.skipOnPaymentError);
 
     // (1) run the branch step
     const branchData = await branchStep.run();

--- a/packages/cli/src/workflows/stage.ts
+++ b/packages/cli/src/workflows/stage.ts
@@ -43,7 +43,7 @@ export async function runStageFilesWorkflow({
     const uploadStep = new UploadSourcesStep(gt, settings);
     const userEditDiffsStep = new UserEditDiffsStep(settings);
     const setupStep = new SetupStep(gt, settings, timeoutMs);
-    const enqueueStep = new EnqueueStep(gt, settings, options.force);
+    const enqueueStep = new EnqueueStep(gt, settings, options.force, options.skipOnPaymentError);
 
     // first run the branch step
     const branchData = await branchStep.run();

--- a/packages/cli/src/workflows/stage.ts
+++ b/packages/cli/src/workflows/stage.ts
@@ -43,7 +43,12 @@ export async function runStageFilesWorkflow({
     const uploadStep = new UploadSourcesStep(gt, settings);
     const userEditDiffsStep = new UserEditDiffsStep(settings);
     const setupStep = new SetupStep(gt, settings, timeoutMs);
-    const enqueueStep = new EnqueueStep(gt, settings, options.force, options.skipOnPaymentError);
+    const enqueueStep = new EnqueueStep(
+      gt,
+      settings,
+      options.force,
+      options.skipOnPaymentError
+    );
 
     // first run the branch step
     const branchData = await branchStep.run();

--- a/packages/cli/src/workflows/steps/EnqueueStep.ts
+++ b/packages/cli/src/workflows/steps/EnqueueStep.ts
@@ -7,11 +7,11 @@ import type { FileReference } from 'generaltranslation/types';
 import { ApiError } from 'generaltranslation/errors';
 import chalk from 'chalk';
 
-const EMPTY_ENQUEUE_RESULT: EnqueueFilesResult = {
+const EMPTY_ENQUEUE_RESULT = (): EnqueueFilesResult => ({
   jobData: {},
   locales: [],
   message: 'Enqueue skipped due to insufficient credits.',
-};
+});
 
 export class EnqueueStep extends WorkflowStep<
   FileReference[],
@@ -48,7 +48,7 @@ export class EnqueueStep extends WorkflowStep<
         error.code === 402
       ) {
         this.skippedDueToPayment = true;
-        this.result = EMPTY_ENQUEUE_RESULT;
+        this.result = EMPTY_ENQUEUE_RESULT();
         return this.result;
       }
       throw error;

--- a/packages/cli/src/workflows/steps/EnqueueStep.ts
+++ b/packages/cli/src/workflows/steps/EnqueueStep.ts
@@ -4,7 +4,14 @@ import { logger } from '../../console/logger.js';
 import { GT } from 'generaltranslation';
 import { Settings } from '../../types/index.js';
 import type { FileReference } from 'generaltranslation/types';
+import { ApiError } from 'generaltranslation/errors';
 import chalk from 'chalk';
+
+const EMPTY_ENQUEUE_RESULT: EnqueueFilesResult = {
+  jobData: {},
+  locales: [],
+  message: 'Enqueue skipped due to insufficient credits.',
+};
 
 export class EnqueueStep extends WorkflowStep<
   FileReference[],
@@ -12,11 +19,13 @@ export class EnqueueStep extends WorkflowStep<
 > {
   private spinner = logger.createSpinner('dots');
   private result: EnqueueFilesResult | null = null;
+  private skippedDueToPayment = false;
 
   constructor(
     private gt: GT,
     private settings: Settings,
-    private force?: boolean
+    private force?: boolean,
+    private skipOnPaymentError?: boolean
   ) {
     super();
   }
@@ -24,19 +33,38 @@ export class EnqueueStep extends WorkflowStep<
   async run(files: FileReference[]): Promise<EnqueueFilesResult> {
     this.spinner.start('Enqueuing translations...');
 
-    this.result = await this.gt.enqueueFiles(files, {
-      sourceLocale: this.settings.defaultLocale,
-      targetLocales: this.settings.locales,
-      requireApproval: this.settings.stageTranslations,
-      modelProvider: this.settings.modelProvider,
-      force: this.force,
-    });
+    try {
+      this.result = await this.gt.enqueueFiles(files, {
+        sourceLocale: this.settings.defaultLocale,
+        targetLocales: this.settings.locales,
+        requireApproval: this.settings.stageTranslations,
+        modelProvider: this.settings.modelProvider,
+        force: this.force,
+      });
+    } catch (error) {
+      if (
+        this.skipOnPaymentError &&
+        error instanceof ApiError &&
+        error.code === 402
+      ) {
+        this.skippedDueToPayment = true;
+        this.result = EMPTY_ENQUEUE_RESULT;
+        return this.result;
+      }
+      throw error;
+    }
 
     return this.result;
   }
 
   async wait(): Promise<void> {
-    if (this.result) {
+    if (this.skippedDueToPayment) {
+      this.spinner.stop(
+        chalk.yellow(
+          'Enqueue skipped: insufficient credits. Files that were not enqueued have been treated as skipped.'
+        )
+      );
+    } else if (this.result) {
       this.spinner.stop(chalk.green('Translations enqueued successfully'));
     }
   }


### PR DESCRIPTION
## Summary

Adds a `--skip-on-payment-error` flag to the `translate`, `stage`, and `enqueue` CLI commands.

## Problem

When a user's account has insufficient credits, the enqueue step throws:

```
Failed to send files for translation. ApiError: Your account's credit balance is insufficient to complete this request.
```

This breaks CI pipelines — there's no way to gracefully continue.

## Solution

When `--skip-on-payment-error` is enabled:
- If the enqueue step receives an HTTP 402 (insufficient credits), it treats the files as **skipped** instead of failing
- A yellow warning is printed: *"Enqueue skipped: insufficient credits. Files that were not enqueued have been treated as skipped."*
- All other workflow steps (upload, download, post-processing) continue normally
- Without the flag, behavior is unchanged (error exits the process)

## Changes

- `packages/cli/src/cli/flags.ts` — add `--skip-on-payment-error` flag
- `packages/cli/src/types/index.ts` — add `skipOnPaymentError` to `TranslateFlags`
- `packages/cli/src/workflows/steps/EnqueueStep.ts` — catch `ApiError` with code 402 when flag is set, return empty enqueue result
- `packages/cli/src/workflows/stage.ts` / `enqueue.ts` — pass flag through to `EnqueueStep`

## Changeset

Patch bump for `gt` and `gtx-cli`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `--skip-on-payment-error` flag to the `translate`, `stage`, and `enqueue` CLI commands so that a HTTP 402 from the enqueue step is treated as a skip rather than a hard failure, preventing CI pipeline breaks when account credits run out.

- **P1 (enqueue workflow):** `logEnqueueResult` in `runEnqueueWorkflow` unconditionally checks `jobData === {}` and prints `\"All N files already translated. 0 files enqueued.\"` — this fires immediately after the yellow skip warning, giving users a contradictory and incorrect success message.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge after fixing the misleading success message in the enqueue workflow's logEnqueueResult call.

One P1 finding: the enqueue command path prints a contradictory 'All files already translated' success message right after the skip warning. The stage/translate paths are unaffected. Everything else (flag wiring, type extension, error handling logic, changeset) looks correct.

packages/cli/src/workflows/enqueue.ts — logEnqueueResult produces misleading output when the payment-skip path returns an empty jobData.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/cli/src/workflows/steps/EnqueueStep.ts | Core change: catches ApiError with code 402 when skipOnPaymentError is set, returning a shared empty result and deferring the skip warning to wait(). Module-level mutable constant is returned by reference. |
| packages/cli/src/workflows/enqueue.ts | Passes skipOnPaymentError to EnqueueStep, but logEnqueueResult incorrectly prints "All files already translated. 0 files enqueued." after the skip warning when jobData is empty — misleading output in the payment-skip path. |
| packages/cli/src/workflows/stage.ts | Passes skipOnPaymentError to EnqueueStep; no logEnqueueResult call here so the misleading message issue does not affect the stage workflow path. |
| packages/cli/src/cli/flags.ts | Adds --skip-on-payment-error flag with correct description and default false. |
| packages/cli/src/types/index.ts | Adds optional skipOnPaymentError boolean to TranslateFlags — straightforward type extension. |
| .changeset/skip-enqueue-payment-error.md | Patch-level changeset for gt and gtx-cli with accurate description of the new flag behavior. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CLI: enqueue / stage / translate
with --skip-on-payment-error] --> B[EnqueueStep.run]
    B --> C{gt.enqueueFiles}
    C -->|Success| D[return EnqueueFilesResult]
    C -->|ApiError 402 AND skipOnPaymentError| E[skippedDueToPayment = true
result = EMPTY_ENQUEUE_RESULT]
    C -->|Other error| F[throw → outer catch → logErrorAndExit]
    E --> G[EnqueueStep.wait
spinner.stop — yellow warning]
    D --> H[EnqueueStep.wait
spinner.stop — green success]
    G --> I{runEnqueueWorkflow
calls logEnqueueResult}
    H --> I
    I -->|jobData is empty — P1 bug| J[Prints misleading
'All files already translated']
    I -->|jobData non-empty| K[Prints correct success message]
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/cli/src/workflows/enqueue.ts`, line 76-82 ([link](https://github.com/generaltranslation/gt/blob/03744e41e6587332e4c306c97b8d40043365c874/packages/cli/src/workflows/enqueue.ts#L76-L82)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Misleading success message after payment-error skip**

   When `--skip-on-payment-error` triggers, `EMPTY_ENQUEUE_RESULT` returns `jobData: {}`. `logEnqueueResult` checks `Object.keys(enqueueResult.jobData).length === 0` and enters the first branch, printing: `"All N files already translated. 0 files enqueued."` — directly after the spinner has already shown the yellow warning about insufficient credits. The two messages contradict each other and leave users with an incorrect conclusion about translation state.

   A simple guard fixes this — skip the log call when the result is the empty payment-skip sentinel, or add an `isSkipped` field to `EnqueueFilesResult` and check it here.

   ```
   function logEnqueueResult(
     enqueueResult: EnqueueFilesResult,
     files: FileToUpload[]
   ): void {
     if (enqueueResult.message === 'Enqueue skipped due to insufficient credits.') {
       // Warning already printed by EnqueueStep.wait(); do not log a misleading success.
       return;
     }
     if (Object.keys(enqueueResult.jobData).length === 0) {
       logger.success(
         `All ${files.length} files already translated. 0 files enqueued.`
       );
     } else {
       logger.success(enqueueResult.message);
     }
   }
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/cli/src/workflows/enqueue.ts
   Line: 76-82

   Comment:
   **Misleading success message after payment-error skip**

   When `--skip-on-payment-error` triggers, `EMPTY_ENQUEUE_RESULT` returns `jobData: {}`. `logEnqueueResult` checks `Object.keys(enqueueResult.jobData).length === 0` and enters the first branch, printing: `"All N files already translated. 0 files enqueued."` — directly after the spinner has already shown the yellow warning about insufficient credits. The two messages contradict each other and leave users with an incorrect conclusion about translation state.

   A simple guard fixes this — skip the log call when the result is the empty payment-skip sentinel, or add an `isSkipped` field to `EnqueueFilesResult` and check it here.

   ```
   function logEnqueueResult(
     enqueueResult: EnqueueFilesResult,
     files: FileToUpload[]
   ): void {
     if (enqueueResult.message === 'Enqueue skipped due to insufficient credits.') {
       // Warning already printed by EnqueueStep.wait(); do not log a misleading success.
       return;
     }
     if (Object.keys(enqueueResult.jobData).length === 0) {
       logger.success(
         `All ${files.length} files already translated. 0 files enqueued.`
       );
     } else {
       logger.success(enqueueResult.message);
     }
   }
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/cli/src/workflows/enqueue.ts
Line: 76-82

Comment:
**Misleading success message after payment-error skip**

When `--skip-on-payment-error` triggers, `EMPTY_ENQUEUE_RESULT` returns `jobData: {}`. `logEnqueueResult` checks `Object.keys(enqueueResult.jobData).length === 0` and enters the first branch, printing: `"All N files already translated. 0 files enqueued."` — directly after the spinner has already shown the yellow warning about insufficient credits. The two messages contradict each other and leave users with an incorrect conclusion about translation state.

A simple guard fixes this — skip the log call when the result is the empty payment-skip sentinel, or add an `isSkipped` field to `EnqueueFilesResult` and check it here.

```
function logEnqueueResult(
  enqueueResult: EnqueueFilesResult,
  files: FileToUpload[]
): void {
  if (enqueueResult.message === 'Enqueue skipped due to insufficient credits.') {
    // Warning already printed by EnqueueStep.wait(); do not log a misleading success.
    return;
  }
  if (Object.keys(enqueueResult.jobData).length === 0) {
    logger.success(
      `All ${files.length} files already translated. 0 files enqueued.`
    );
  } else {
    logger.success(enqueueResult.message);
  }
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/cli/src/workflows/steps/EnqueueStep.ts
Line: 10-14

Comment:
**Shared mutable constant as a return value**

`EMPTY_ENQUEUE_RESULT` is a module-level object returned directly from `run()`. Any downstream code that mutates `jobData` or `locales` on the returned object (e.g., `result.jobData[id] = ...`) would silently corrupt the shared constant for any subsequent `EnqueueStep` usage in the same process. Return a fresh object instead:

```suggestion
const EMPTY_ENQUEUE_RESULT = (): EnqueueFilesResult => ({
  jobData: {},
  locales: [],
  message: 'Enqueue skipped due to insufficient credits.',
});
```

And at the call site: `this.result = EMPTY_ENQUEUE_RESULT();`

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(cli): add --skip-on-payment-error f..."](https://github.com/generaltranslation/gt/commit/03744e41e6587332e4c306c97b8d40043365c874) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29051301)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->