### PR TITLE
chore(node): add locale extractor

### DIFF
--- a/.changeset/rotten-words-drop.md
+++ b/.changeset/rotten-words-drop.md
@@ -1,0 +1,5 @@
+---
+'gt-node': patch
+---
+
+fix: utility function for extracting a request locale

--- a/packages/node/src/helpers/__tests__/getLocale.test.ts
+++ b/packages/node/src/helpers/__tests__/getLocale.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { initializeGT } from '../setup/initializeGT';
-import { getRequestLocale } from './getRequestLocale';
+import { initializeGT } from '../../setup/initializeGT';
+import { getRequestLocale } from '../getRequestLocale';
 
 describe('getLocale', () => {
   beforeEach(() => {

--- a/packages/node/src/helpers/getLocale.test.ts
+++ b/packages/node/src/helpers/getLocale.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { initializeGT } from '../setup/initializeGT';
+import { getRequestLocale } from './getRequestLocale';
+
+describe('getLocale', () => {
+  beforeEach(() => {
+    initializeGT({
+      defaultLocale: 'en-US',
+      locales: ['en-US', 'es', 'fr', 'ja'],
+    });
+  });
+
+  it('returns the best matching locale from Accept-Language', () => {
+    const request = {
+      headers: { 'accept-language': 'fr-FR,fr;q=0.9,en;q=0.8' },
+    };
+    expect(getRequestLocale(request)).toBe('fr');
+  });
+
+  it('returns exact match when available', () => {
+    const request = { headers: { 'accept-language': 'en-US' } };
+    expect(getRequestLocale(request)).toBe('en-US');
+  });
+
+  it('respects quality values', () => {
+    const request = { headers: { 'accept-language': 'ja;q=0.5,es;q=0.9' } };
+    expect(getRequestLocale(request)).toBe('es');
+  });
+
+  it('returns default locale when no match found', () => {
+    const request = { headers: { 'accept-language': 'zh-CN,zh;q=0.9' } };
+    expect(getRequestLocale(request)).toBe('en-US');
+  });
+
+  it('returns default locale when header is missing', () => {
+    const request = {
+      headers: {} as Record<string, string | string[] | undefined>,
+    };
+    expect(getRequestLocale(request)).toBe('en-US');
+  });
+
+  it('handles array header values', () => {
+    const request = {
+      headers: { 'accept-language': ['es,en-US;q=0.9', 'fr'] },
+    };
+    expect(getRequestLocale(request)).toBe('es');
+  });
+
+  it('handles wildcard locale', () => {
+    const request = { headers: { 'accept-language': '*' } };
+    const result = getRequestLocale(request);
+    expect(['en-US', 'es', 'fr', 'ja']).toContain(result);
+  });
+});

--- a/packages/node/src/helpers/getRequestLocale.ts
+++ b/packages/node/src/helpers/getRequestLocale.ts
@@ -23,9 +23,10 @@ function parseAcceptLanguage(header: string): string[] {
     .split(',')
     .map((entry) => {
       const [locale, quality] = entry.trim().split(';');
+      const qPart = quality?.split('=')[1];
       return {
         locale: locale.trim(),
-        quality: quality ? parseFloat(quality.split('=')[1]) : 1,
+        quality: qPart !== undefined ? parseFloat(qPart) || 1 : 1,
       };
     })
     .sort((a, b) => b.quality - a.quality)

--- a/packages/node/src/helpers/getRequestLocale.ts
+++ b/packages/node/src/helpers/getRequestLocale.ts
@@ -1,0 +1,68 @@
+import { getI18nManager } from '../async-i18n-manager/singleton-operations';
+
+/**
+ * A request object like interface
+ * @interface RequestLike
+ * @property {Record<string, string | string[] | undefined>} headers - The request headers
+ */
+interface RequestLike {
+  headers: Record<string, string | string[] | undefined>;
+}
+
+/**
+ * Parse the Accept-Language header into an array of locales
+ * @param header - The Accept-Language header
+ * @returns An array of locales
+ *
+ * @example
+ * const locales = parseAcceptLanguage('fr-FR,fr;q=0.9,en;q=0.8');
+ * console.log(locales); // ['fr-FR', 'fr', 'en']
+ */
+function parseAcceptLanguage(header: string): string[] {
+  return header
+    .split(',')
+    .map((entry) => {
+      const [locale, quality] = entry.trim().split(';');
+      return {
+        locale: locale.trim(),
+        quality: quality ? parseFloat(quality.split('=')[1]) : 1,
+      };
+    })
+    .sort((a, b) => b.quality - a.quality)
+    .map((entry) => entry.locale);
+}
+
+/**
+ * Resolve the preferred locale from the request Accept-Language header, fallback to the default locale if no match is found
+ * @param request - The request object
+ * @returns The preferred locale
+ *
+ * @example
+ * const locale = getRequestLocale({ headers: { 'accept-language': 'fr-FR,fr;q=0.9,en;q=0.8' } });
+ * console.log(locale); // 'fr'
+ *
+ * @example
+ * app.get('/', (req, res) => {
+ *   const locale = getRequestLocale(req);
+ *   withGT(locale, () => {
+ *     res.send(`Locale: ${locale}`);
+ *   });
+ * });
+ */
+export function getRequestLocale(request: RequestLike): string {
+  // Setup
+  const i18nManager = getI18nManager();
+  const defaultLocale = i18nManager.getDefaultLocale();
+  const gtInstance = i18nManager.getGTClass();
+
+  // Get the accept-language header
+  const acceptLanguage = request.headers['accept-language'];
+  const headerValue = Array.isArray(acceptLanguage)
+    ? acceptLanguage[0]
+    : acceptLanguage;
+  if (!headerValue) return defaultLocale;
+
+  // Parse the accept-language header
+  const preferredLocales = parseAcceptLanguage(headerValue);
+  return gtInstance.determineLocale(preferredLocales) || defaultLocale;
+}

--- a/packages/node/src/helpers/getRequestLocale.ts
+++ b/packages/node/src/helpers/getRequestLocale.ts
@@ -24,9 +24,10 @@ function parseAcceptLanguage(header: string): string[] {
     .map((entry) => {
       const [locale, quality] = entry.trim().split(';');
       const qPart = quality?.split('=')[1];
+      const q = qPart !== undefined ? parseFloat(qPart) : 1;
       return {
         locale: locale.trim(),
-        quality: qPart !== undefined ? parseFloat(qPart) || 1 : 1,
+        quality: isNaN(q) ? 1 : q,
       };
     })
     .sort((a, b) => b.quality - a.quality)

--- a/packages/node/src/helpers/index.ts
+++ b/packages/node/src/helpers/index.ts
@@ -1,4 +1,5 @@
 // Locale Utilities
+export { getRequestLocale } from './getRequestLocale';
 export {
   getLocale,
   getLocales,


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `getRequestLocale`, a new utility that parses the `Accept-Language` header and resolves the best-matching locale against the configured locale list. The `q=0` and malformed-quality-value bugs flagged in the previous review are correctly addressed in this version.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — only one minor P2 finding about dropping array header elements beyond index 0.

All prior P1 concerns (q=0 treated as q=1, NaN sort instability) are resolved. The single remaining finding is a minor edge case (multi-element array headers) that doesn't affect real-world HTTP traffic where Accept-Language is almost always a single string.

packages/node/src/helpers/getRequestLocale.ts — array header joining on line 62–64.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/node/src/helpers/getRequestLocale.ts | New locale extractor — q=0 and NaN cases from prior review are now correctly handled; array header elements beyond index 0 are silently dropped (minor). |
| packages/node/src/helpers/__tests__/getLocale.test.ts | Good test coverage for the main scenarios; the array-header test only validates the first element, masking the dropped-tail bug. |
| packages/node/src/helpers/index.ts | Exports getRequestLocale from the helpers barrel — straightforward, no issues. |
| .changeset/rotten-words-drop.md | Patch changeset for gt-node — correct bump type for a new utility addition. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Incoming Request] --> B{accept-language header present?}
    B -- No --> C[Return defaultLocale]
    B -- Yes --> D{Header is array?}
    D -- Yes --> E[Take first element only]
    D -- No --> F[Use string directly]
    E --> G[parseAcceptLanguage]
    F --> G
    G --> H[Split by comma]
    H --> I[Parse each entry: locale + quality]
    I --> J{q part present?}
    J -- Yes --> K[parseFloat q]
    J -- No --> L[quality = 1]
    K --> M{isNaN?}
    M -- Yes --> L
    M -- No --> N[Use parsed quality]
    L --> O[Sort descending by quality]
    N --> O
    O --> P[gtInstance.determineLocale]
    P --> Q{Match found?}
    Q -- Yes --> R[Return matched locale]
    Q -- No --> C
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/node/src/helpers/getRequestLocale.ts
Line: 62-64

Comment:
**Array header values are partially dropped**

When `acceptLanguage` is an array, only `acceptLanguage[0]` is parsed — all subsequent elements are silently discarded. Per RFC 7230 §3.2.2, multiple header fields with the same name are equivalent to a single comma-joined value. If an array like `['ja;q=0.5', 'es;q=0.9']` is supplied, `es` is never considered even though it has the highest quality value.

```suggestion
  const headerValue = Array.isArray(acceptLanguage)
    ? acceptLanguage.join(',')
    : acceptLanguage;
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: header parsing"](https://github.com/generaltranslation/gt/commit/3da460324adb6ff15f4f3628403f494108b34d49) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29212667)</sub>

<!-- /greptile_comment -->