### PR TITLE
chore: feature parity

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -66,6 +66,7 @@ Turbo tasks: `build`, `test`, `lint`, `lint:fix`, `transpile`, `build:clean`, `b
 - **Internal subpaths:** Packages expose `/internal` subpaths for cross-package use. These are not part of the public API.
 - **React i18n-context:** `packages/react/src/i18n-context/` has restricted imports from `gt-i18n` (only `/types`, `/internal`, `/internal/types`). This is enforced by ESLint.
 - **CLI version generation:** `packages/cli` has a pre-commit hook that runs `node scripts/generate-version.js` to keep `src/generated/version.ts` in sync.
+- **gt-react / gt-react-native parity:** These two packages are fixed-version siblings (released together via changesets). When a feature is added to one, the equivalent should be added to the other unless it's platform-specific (e.g., DOM-only UI components). Compare their `index.ts`/`index.tsx` exports to verify parity.
 
 ## MCP Server
 

--- a/.claude/rules/react-packages.md
+++ b/.claude/rules/react-packages.md
@@ -16,3 +16,14 @@ paths:
 - Never import from framework-specific packages (like `next`) in `react-core` or `react` — they must stay framework-agnostic.
 - Use React Server Components patterns in `gt-next`: separate `index.server.ts` and `index.client.ts` entry points.
 - Run tests with `pnpm --filter <package-name> test`.
+
+## Feature Parity: gt-react ↔ gt-react-native
+
+`gt-react` and `gt-react-native` are fixed-version siblings (see `.changeset/config.json`). Both re-export most of their API from `@generaltranslation/react-core`, with platform-specific wrappers (e.g., GTProvider, locale detection, storage).
+
+**When reviewing or implementing changes:**
+
+- If a new component, hook, or function is added to `gt-react`, check whether an equivalent should be added to `gt-react-native` (and vice versa). Most exports from `react-core` should be re-exported from both packages.
+- Platform-specific features (e.g., `LocaleSelector`/`RegionSelector` are DOM-only) are exempt from parity.
+- Compare `packages/react/src/index.ts` and `packages/react-native/src/index.tsx` exports to spot gaps.
+- If a change intentionally breaks parity, the PR description should explain why.


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds documentation guidance for maintaining feature parity between `gt-react` and `gt-react-native`, adding a brief bullet to `CLAUDE.md` and a detailed section to `.claude/rules/react-packages.md`. The two additions are consistent with each other and clearly describe the parity expectation, exemptions for platform-specific features, and how to verify gaps.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only change with no code modifications — safe to merge.

Both additions are internally consistent, clearly written, and introduce no code risk. The CLAUDE.md bullet and the react-packages.md section convey the same policy without contradiction.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .claude/CLAUDE.md | Adds one bullet point under "Important Patterns" documenting the gt-react/gt-react-native fixed-version sibling and parity expectation — clear and consistent with the react-packages.md addition. |
| .claude/rules/react-packages.md | Adds a "Feature Parity" section with actionable guidance: check both packages when adding exports, exempt platform-specific features, compare index files, and require PR description justification for intentional parity breaks. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Feature added to gt-react or gt-react-native] --> B{Is it platform-specific?}
    B -- Yes\ne.g. LocaleSelector DOM-only --> C[Exempt from parity\nDocument in PR description]
    B -- No --> D[Add equivalent to sibling package]
    D --> E[Compare index.ts vs index.tsx exports]
    E --> F{Parity gap found?}
    F -- Yes --> G[Add missing export to sibling]
    F -- No --> H[Parity confirmed ✓]
    G --> H
    C --> I[Intentional parity break\nPR description must explain why]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["add info about feature parity for gt-rea..."](https://github.com/generaltranslation/gt/commit/10e621072c3006724d507a53d9f217522619829f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29338533)</sub>

<!-- /greptile_comment -->