### PR TITLE
chore(compiler): more robust string extraction

### DIFF
--- a/.changeset/dark-paws-happen.md
+++ b/.changeset/dark-paws-happen.md
@@ -1,0 +1,5 @@
+---
+'@generaltranslation/compiler': patch
+---
+
+fix: more robust string extraction

--- a/packages/compiler/src/passes/__tests__/stringExtractionE2E.test.ts
+++ b/packages/compiler/src/passes/__tests__/stringExtractionE2E.test.ts
@@ -282,6 +282,107 @@ describe('t() string extraction E2E', () => {
 });
 
 // ─────────────────────────────────────────────────────
+// t`` — tagged template (collection pass extraction)
+//
+// Unlike gt()/msg()/t(), tagged templates convert dynamic
+// expressions into ICU {0} placeholders rather than rejecting them.
+// The collection pass extracts via processTaggedTemplateExpression
+// for unbound t or t imported from gt-react/browser.
+// ─────────────────────────────────────────────────────
+
+describe('t`` tagged template extraction E2E', () => {
+  it('extracts simple tagged template: t`Hello`', () => {
+    const state = collect('t`Hello`;');
+    const content = getRuntimeContent(state);
+    expect(content).toHaveLength(1);
+    expect(content[0].message).toBe('Hello');
+    expect(content[0].hash).toBeTruthy();
+  });
+
+  it('extracts tagged template with dynamic expression as ICU placeholder: t`Hello ${name}`', () => {
+    const state = collect('const name = "World";\nt`Hello ${name}`;');
+    const content = getRuntimeContent(state);
+    expect(content).toHaveLength(1);
+    expect(content[0].message).toBe('Hello {0}');
+  });
+
+  it('extracts tagged template with multiple dynamic expressions: t`${greeting} ${name}!`', () => {
+    const state = collect(
+      'const greeting = "Hi";\nconst name = "World";\nt`${greeting} ${name}!`;'
+    );
+    const content = getRuntimeContent(state);
+    expect(content).toHaveLength(1);
+    expect(content[0].message).toBe('{0} {1}!');
+  });
+
+  it('extracts tagged template with static string expression collapsed: t`Hello ${"World"}`', () => {
+    const state = collect('t`Hello ${"World"}`;');
+    const content = getRuntimeContent(state);
+    expect(content).toHaveLength(1);
+    expect(content[0].message).toBe('Hello World');
+  });
+
+  it('extracts tagged template with nested static template: t`A ${`B`}`', () => {
+    const state = collect('t`A ${`B`}`;');
+    const content = getRuntimeContent(state);
+    expect(content).toHaveLength(1);
+    expect(content[0].message).toBe('A B');
+  });
+
+  it('extracts tagged template with static concat in expression: t`Hello ${"Wo" + "rld"}`', () => {
+    const state = collect('t`Hello ${"Wo" + "rld"}`;');
+    const content = getRuntimeContent(state);
+    expect(content).toHaveLength(1);
+    expect(content[0].message).toBe('Hello World');
+  });
+
+  it('extracts tagged template with numeric literal collapsed: t`Count: ${5}`', () => {
+    const state = collect('t`Count: ${5}`;');
+    const content = getRuntimeContent(state);
+    expect(content).toHaveLength(1);
+    expect(content[0].message).toBe('Count: 5');
+  });
+
+  it('extracts tagged template with mixed static and dynamic: t`Hello ${"World"}, ${name}!`', () => {
+    const state = collect('const name = "X";\nt`Hello ${"World"}, ${name}!`;');
+    const content = getRuntimeContent(state);
+    expect(content).toHaveLength(1);
+    expect(content[0].message).toBe('Hello World, {0}!');
+  });
+
+  it('extracts tagged template imported from gt-react/browser', () => {
+    const state = collect(`import { t } from 'gt-react/browser';\nt\`Hello\`;`);
+    const content = getRuntimeContent(state);
+    expect(content).toHaveLength(1);
+    expect(content[0].message).toBe('Hello');
+  });
+
+  it('does not extract tagged template imported from non-GT source', () => {
+    const state = collect(`import { t } from 'i18next';\nt\`Hello\`;`);
+    const content = getRuntimeContent(state);
+    expect(content).toHaveLength(0);
+  });
+
+  it('skips tagged template containing derive() (returns TemplateLiteral)', () => {
+    const state = collect(
+      `import { derive } from 'gt-react/browser';\nt\`Hello \${derive(getName())}\`;`
+    );
+    const content = getRuntimeContent(state);
+    expect(content).toHaveLength(0);
+  });
+
+  it('produces same hash as gt() for purely static content', () => {
+    const gtCode = `import { useGT } from 'gt-next';\nconst gt = useGT();\ngt("Hello World");`;
+    const taggedCode = `t\`Hello World\`;`;
+    const gtState = collect(gtCode);
+    const taggedState = collect(taggedCode);
+    const gtHash = getCallbackContent(gtState)[0].hash;
+    const taggedHash = getRuntimeContent(taggedState)[0].hash;
+    expect(gtHash).toBe(taggedHash);
+  });
+});
+
+// ─────────────────────────────────────────────────────
 // Cross-function consistency
 // ─────────────────────────────────────────────────────
 

--- a/packages/compiler/src/passes/__tests__/stringExtractionE2E.test.ts
+++ b/packages/compiler/src/passes/__tests__/stringExtractionE2E.test.ts
@@ -1,0 +1,306 @@
+import { describe, it, expect } from 'vitest';
+import * as parser from '@babel/parser';
+import traverse from '@babel/traverse';
+import { collectionPass } from '../collectionPass';
+import { initializeState } from '../../state/utils/initializeState';
+import { TransformState } from '../../state/types';
+import { TranslationContent } from '../../state/StringCollector';
+
+/**
+ * E2E tests for string extraction through the collection pass.
+ *
+ * Exercises the full pipeline: source code → parse → collection pass → StringCollector
+ * for gt() (useGT callback), msg(), and t() with complex static expressions.
+ */
+
+function collect(
+  code: string,
+  overrides: Record<string, unknown> = {}
+): TransformState {
+  const state = initializeState(overrides, 'test.tsx');
+  const ast = parser.parse(code, {
+    sourceType: 'module',
+    plugins: ['jsx', 'typescript'],
+  });
+  traverse(ast, collectionPass(state));
+  return state;
+}
+
+function getCallbackContent(state: TransformState): TranslationContent[] {
+  return state.stringCollector.getAllTranslationContent();
+}
+
+function getRuntimeContent(state: TransformState): TranslationContent[] {
+  return state.stringCollector.getRuntimeOnlyContent();
+}
+
+// ─────────────────────────────────────────────────────
+// gt() — useGT callback
+// ─────────────────────────────────────────────────────
+
+describe('gt() string extraction E2E', () => {
+  const prefix = `import { useGT } from 'gt-next';\nconst gt = useGT();\n`;
+
+  it('extracts simple string literal', () => {
+    const state = collect(prefix + `gt("Hello");`);
+    const content = getCallbackContent(state);
+    expect(content).toHaveLength(1);
+    expect(content[0].message).toBe('Hello');
+    expect(content[0].hash).toBeTruthy();
+  });
+
+  it('extracts string concatenation: "Hello" + " World"', () => {
+    const state = collect(prefix + `gt("Hello" + " World");`);
+    const content = getCallbackContent(state);
+    expect(content).toHaveLength(1);
+    expect(content[0].message).toBe('Hello World');
+    expect(content[0].hash).toBeTruthy();
+  });
+
+  it('extracts template literal with static expression: `Hello ${"World"}`', () => {
+    const state = collect(prefix + 'gt(`Hello ${"World"}`);');
+    const content = getCallbackContent(state);
+    expect(content).toHaveLength(1);
+    expect(content[0].message).toBe('Hello World');
+  });
+
+  it('extracts nested template: `A ${`B ${"C"}`}`', () => {
+    const state = collect(prefix + 'gt(`A ${`B ${"C"}`}`);');
+    const content = getCallbackContent(state);
+    expect(content).toHaveLength(1);
+    expect(content[0].message).toBe('A B C');
+  });
+
+  it('extracts mixed concat + template: "A" + `B ${"C"}`', () => {
+    const state = collect(prefix + 'gt("A" + `B ${"C"}`);');
+    const content = getCallbackContent(state);
+    expect(content).toHaveLength(1);
+    expect(content[0].message).toBe('AB C');
+  });
+
+  it('extracts with numeric literal: `Count: ${5}`', () => {
+    const state = collect(prefix + 'gt(`Count: ${5}`);');
+    const content = getCallbackContent(state);
+    expect(content).toHaveLength(1);
+    expect(content[0].message).toBe('Count: 5');
+  });
+
+  it('extracts with options alongside complex expression', () => {
+    const state = collect(
+      prefix + 'gt("Hello" + " World", { $id: "hw", $context: "greeting" });'
+    );
+    const content = getCallbackContent(state);
+    expect(content).toHaveLength(1);
+    expect(content[0].message).toBe('Hello World');
+    expect(content[0].id).toBe('hw');
+    expect(content[0].context).toBe('greeting');
+  });
+
+  it('extracts multiple calls independently', () => {
+    const state = collect(
+      prefix + `gt("Hello" + " World");\ngt(\`Foo \${"Bar"}\`);`
+    );
+    const content = getCallbackContent(state);
+    expect(content).toHaveLength(2);
+    expect(content[0].message).toBe('Hello World');
+    expect(content[1].message).toBe('Foo Bar');
+  });
+
+  it('produces different hashes for different content', () => {
+    const state = collect(prefix + `gt("Hello");\ngt("World");`);
+    const content = getCallbackContent(state);
+    expect(content).toHaveLength(2);
+    expect(content[0].hash).not.toBe(content[1].hash);
+  });
+
+  it('produces same hash regardless of expression form', () => {
+    const state1 = collect(prefix + `gt("Hello World");`);
+    const state2 = collect(prefix + `gt("Hello" + " World");`);
+    const state3 = collect(prefix + 'gt(`Hello ${"World"}`);');
+    const c1 = getCallbackContent(state1);
+    const c2 = getCallbackContent(state2);
+    const c3 = getCallbackContent(state3);
+    expect(c1[0].hash).toBe(c2[0].hash);
+    expect(c2[0].hash).toBe(c3[0].hash);
+  });
+
+  it('rejects dynamic content with no extraction', () => {
+    const state = collect(prefix + `gt(name);`);
+    const content = getCallbackContent(state);
+    expect(content).toHaveLength(0);
+    expect(state.errorTracker.getErrors().length).toBeGreaterThan(0);
+  });
+
+  it('rejects template with dynamic expression', () => {
+    const state = collect(prefix + 'gt(`Hello ${name}`);');
+    const content = getCallbackContent(state);
+    expect(content).toHaveLength(0);
+    expect(state.errorTracker.getErrors().length).toBeGreaterThan(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────
+// msg() — standalone
+// ─────────────────────────────────────────────────────
+
+describe('msg() string extraction E2E', () => {
+  const prefix = `import { msg } from 'gt-next';\n`;
+
+  it('extracts simple string literal', () => {
+    const state = collect(prefix + `msg("Hello");`);
+    const content = getRuntimeContent(state);
+    expect(content).toHaveLength(1);
+    expect(content[0].message).toBe('Hello');
+    expect(content[0].hash).toBeTruthy();
+  });
+
+  it('extracts string concatenation: "Hello" + " World"', () => {
+    const state = collect(prefix + `msg("Hello" + " World");`);
+    const content = getRuntimeContent(state);
+    expect(content).toHaveLength(1);
+    expect(content[0].message).toBe('Hello World');
+  });
+
+  it('extracts template literal with static expression: `Hello ${"World"}`', () => {
+    const state = collect(prefix + 'msg(`Hello ${"World"}`);');
+    const content = getRuntimeContent(state);
+    expect(content).toHaveLength(1);
+    expect(content[0].message).toBe('Hello World');
+  });
+
+  it('extracts nested template: `A ${`B ${"C"}`}`', () => {
+    const state = collect(prefix + 'msg(`A ${`B ${"C"}`}`);');
+    const content = getRuntimeContent(state);
+    expect(content).toHaveLength(1);
+    expect(content[0].message).toBe('A B C');
+  });
+
+  it('extracts mixed concat + template', () => {
+    const state = collect(prefix + 'msg("A" + `B ${"C"}`);');
+    const content = getRuntimeContent(state);
+    expect(content).toHaveLength(1);
+    expect(content[0].message).toBe('AB C');
+  });
+
+  it('extracts with options', () => {
+    const state = collect(
+      prefix + 'msg("Hello" + " World", { $id: "hw", $context: "nav" });'
+    );
+    const content = getRuntimeContent(state);
+    expect(content).toHaveLength(1);
+    expect(content[0].message).toBe('Hello World');
+    expect(content[0].id).toBe('hw');
+    expect(content[0].context).toBe('nav');
+  });
+
+  it('produces same hash as gt() for identical content', () => {
+    const gtCode = `import { useGT } from 'gt-next';\nconst gt = useGT();\ngt("Hello World");`;
+    const msgCode = `import { msg } from 'gt-next';\nmsg("Hello" + " World");`;
+    const gtState = collect(gtCode);
+    const msgState = collect(msgCode);
+    const gtContent = getCallbackContent(gtState);
+    const msgContent = getRuntimeContent(msgState);
+    expect(gtContent[0].hash).toBe(msgContent[0].hash);
+  });
+
+  it('rejects dynamic content', () => {
+    const state = collect(prefix + 'msg(name);');
+    const content = getRuntimeContent(state);
+    expect(content).toHaveLength(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────
+// t() — standalone (not tagged template)
+// ─────────────────────────────────────────────────────
+
+describe('t() string extraction E2E', () => {
+  const prefix = `import { t } from 'gt-next';\n`;
+
+  it('extracts simple string literal', () => {
+    const state = collect(prefix + `t("Hello");`);
+    const content = getRuntimeContent(state);
+    expect(content).toHaveLength(1);
+    expect(content[0].message).toBe('Hello');
+    expect(content[0].hash).toBeTruthy();
+  });
+
+  it('extracts string concatenation: "Hello" + " World"', () => {
+    const state = collect(prefix + `t("Hello" + " World");`);
+    const content = getRuntimeContent(state);
+    expect(content).toHaveLength(1);
+    expect(content[0].message).toBe('Hello World');
+  });
+
+  it('extracts template literal with static expression: `Hello ${"World"}`', () => {
+    const state = collect(prefix + 't(`Hello ${"World"}`);');
+    const content = getRuntimeContent(state);
+    expect(content).toHaveLength(1);
+    expect(content[0].message).toBe('Hello World');
+  });
+
+  it('extracts nested template: `A ${`B ${"C"}`}`', () => {
+    const state = collect(prefix + 't(`A ${`B ${"C"}`}`);');
+    const content = getRuntimeContent(state);
+    expect(content).toHaveLength(1);
+    expect(content[0].message).toBe('A B C');
+  });
+
+  it('extracts mixed concat + template', () => {
+    const state = collect(prefix + 't("A" + `B ${"C"}`);');
+    const content = getRuntimeContent(state);
+    expect(content).toHaveLength(1);
+    expect(content[0].message).toBe('AB C');
+  });
+
+  it('extracts with options', () => {
+    const state = collect(
+      prefix + 't("Hello" + " World", { $id: "hw", $context: "nav" });'
+    );
+    const content = getRuntimeContent(state);
+    expect(content).toHaveLength(1);
+    expect(content[0].message).toBe('Hello World');
+    expect(content[0].id).toBe('hw');
+    expect(content[0].context).toBe('nav');
+  });
+
+  it('produces same hash as gt() for identical content', () => {
+    const gtCode = `import { useGT } from 'gt-next';\nconst gt = useGT();\ngt("Hello World");`;
+    const tCode = `import { t } from 'gt-next';\nt("Hello" + " World");`;
+    const gtState = collect(gtCode);
+    const tState = collect(tCode);
+    const gtContent = getCallbackContent(gtState);
+    const tContent = getRuntimeContent(tState);
+    expect(gtContent[0].hash).toBe(tContent[0].hash);
+  });
+
+  it('rejects dynamic content', () => {
+    const state = collect(prefix + 't(name);');
+    const content = getRuntimeContent(state);
+    expect(content).toHaveLength(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────
+// Cross-function consistency
+// ─────────────────────────────────────────────────────
+
+describe('cross-function hash consistency', () => {
+  it('gt(), msg(), and t() produce identical hashes for same complex expression result', () => {
+    const gtCode = `import { useGT } from 'gt-next';\nconst gt = useGT();\ngt("A" + \`B \${"C"}\`);`;
+    const msgCode = `import { msg } from 'gt-next';\nmsg("A" + \`B \${"C"}\`);`;
+    const tCode = `import { t } from 'gt-next';\nt("A" + \`B \${"C"}\`);`;
+
+    const gtState = collect(gtCode);
+    const msgState = collect(msgCode);
+    const tState = collect(tCode);
+
+    const gtHash = getCallbackContent(gtState)[0].hash;
+    const msgHash = getRuntimeContent(msgState)[0].hash;
+    const tHash = getRuntimeContent(tState)[0].hash;
+
+    expect(gtHash).toBeTruthy();
+    expect(gtHash).toBe(msgHash);
+    expect(msgHash).toBe(tHash);
+  });
+});

--- a/packages/compiler/src/transform/templates-and-concat/__tests__/flattenExpressionToParts.test.ts
+++ b/packages/compiler/src/transform/templates-and-concat/__tests__/flattenExpressionToParts.test.ts
@@ -5,7 +5,6 @@ import * as t from '@babel/types';
 import { flattenExpressionToParts } from '../flattenExpressionToParts';
 import { mergeAdjacentStaticParts } from '../mergeAdjacentStaticParts';
 import { buildTransformResult } from '../buildTransformationResult';
-
 /**
  * Parse code and extract the first expression's NodePath, then run the callback.
  */

--- a/packages/compiler/src/transform/templates-and-concat/resolveStaticExpression.ts
+++ b/packages/compiler/src/transform/templates-and-concat/resolveStaticExpression.ts
@@ -31,14 +31,19 @@ export function resolveStaticExpression(expr: t.Expression): {
   if (t.isTemplateLiteral(expr)) {
     let result = '';
     for (let i = 0; i < expr.quasis.length; i++) {
-      const { cooked, raw } = expr.quasis[i].value;
-      result += cooked ?? raw;
+      const cooked = expr.quasis[i].value.cooked;
+      if (cooked == null) {
+        return {
+          errors: ['Template literal contains an invalid escape sequence'],
+        };
+      }
+      result += cooked;
       if (i < expr.expressions.length) {
         const resolved = resolveStaticExpression(
           expr.expressions[i] as t.Expression
         );
         if (resolved.errors.length || resolved.value == null) return resolved;
-        result += resolved.value ?? '';
+        result += resolved.value;
       }
     }
     return { errors: [], value: result };
@@ -49,7 +54,7 @@ export function resolveStaticExpression(expr: t.Expression): {
     if (left.errors.length || left.value == null) return left;
     const right = resolveStaticExpression(expr.right as t.Expression);
     if (right.errors.length || right.value == null) return right;
-    return { errors: [], value: (left.value ?? '') + (right.value ?? '') };
+    return { errors: [], value: left.value + right.value };
   }
 
   return { errors: ['Expression is not a static string'] };

--- a/packages/compiler/src/transform/templates-and-concat/resolveStaticExpression.ts
+++ b/packages/compiler/src/transform/templates-and-concat/resolveStaticExpression.ts
@@ -1,0 +1,56 @@
+import * as t from '@babel/types';
+
+/**
+ * Attempt to resolve an expression to a static string at compile time.
+ * Handles string literals, template literals, binary '+' concatenation,
+ * nested combinations, and numeric/boolean/null literals coerced to string.
+ *
+ * Returns the resolved string, or undefined if the expression contains
+ * any dynamic content (variables, function calls, etc.).
+ */
+export function resolveStaticExpression(expr: t.Expression): {
+  errors: string[];
+  value?: string;
+} {
+  if (t.isStringLiteral(expr)) {
+    return { errors: [], value: expr.value };
+  }
+
+  if (t.isNumericLiteral(expr)) {
+    return { errors: [], value: String(expr.value) };
+  }
+
+  if (t.isBooleanLiteral(expr)) {
+    return { errors: [], value: String(expr.value) };
+  }
+
+  if (t.isNullLiteral(expr)) {
+    return { errors: [], value: 'null' };
+  }
+
+  if (t.isTemplateLiteral(expr)) {
+    let result = '';
+    for (let i = 0; i < expr.quasis.length; i++) {
+      const { cooked, raw } = expr.quasis[i].value;
+      result += cooked ?? raw;
+      if (i < expr.expressions.length) {
+        const resolved = resolveStaticExpression(
+          expr.expressions[i] as t.Expression
+        );
+        if (resolved.errors.length || resolved.value == null) return resolved;
+        result += resolved.value ?? '';
+      }
+    }
+    return { errors: [], value: result };
+  }
+
+  if (t.isBinaryExpression(expr) && expr.operator === '+') {
+    const left = resolveStaticExpression(expr.left as t.Expression);
+    if (left.errors.length || left.value == null) return left;
+    const right = resolveStaticExpression(expr.right as t.Expression);
+    if (right.errors.length || right.value == null) return right;
+    return { errors: [], value: (left.value ?? '') + (right.value ?? '') };
+  }
+
+  return { errors: ['Expression is not a static string'] };
+}

--- a/packages/compiler/src/transform/validation/__tests__/robustStringExtraction.test.ts
+++ b/packages/compiler/src/transform/validation/__tests__/robustStringExtraction.test.ts
@@ -1,0 +1,841 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import * as t from '@babel/types';
+import { validateUseGTCallback } from '../validateTranslationFunctionCallback';
+import { TransformState } from '../../../state/types';
+import { StringCollector } from '../../../state/StringCollector';
+import { Logger } from '../../../state/Logger';
+import { ErrorTracker } from '../../../state/ErrorTracker';
+import { ScopeTracker } from '../../../state/ScopeTracker';
+import { PluginSettings } from '../../../config';
+import { GT_OTHER_FUNCTIONS } from '../../../utils/constants/gt/constants';
+
+/**
+ * Golden standard tests for robust string extraction.
+ *
+ * The compiler should be able to extract the fully-resolved string content
+ * from any expression that is statically deterministic at compile time.
+ * This includes:
+ * - String concatenation: "Hello" + " World"
+ * - Template literals with static expressions: `Hello ${"World"}`
+ * - Nested template literals: `A ${`B ${`C`}`}`
+ * - Mixed: "Hello" + `World ${" Here"}`
+ * - Numeric/boolean literals coerced in concat
+ *
+ * These tests validate gt(), msg(), and t() extraction via validateUseGTCallback,
+ * which is the shared validation function for all three.
+ */
+
+function createState(overrides?: Partial<PluginSettings>): TransformState {
+  const stringCollector = new StringCollector();
+  const logger = new Logger('silent');
+  const errorTracker = new ErrorTracker();
+  const scopeTracker = new ScopeTracker();
+  const settings: PluginSettings = {
+    logLevel: 'silent',
+    compileTimeHash: false,
+    disableBuildChecks: false,
+    enableMacroTransform: true,
+    stringTranslationMacro: GT_OTHER_FUNCTIONS.t,
+    enableTaggedTemplate: true,
+    enableTemplateLiteralArg: true,
+    enableConcatenationArg: true,
+    enableMacroImportInjection: true,
+    enableAutoJsxInjection: false,
+    autoderive: { jsx: false, strings: false },
+    _debugHashManifest: false,
+    devHotReload: { strings: false, jsx: false },
+    ...overrides,
+  };
+
+  scopeTracker.trackTranslationVariable(
+    GT_OTHER_FUNCTIONS.derive,
+    GT_OTHER_FUNCTIONS.derive,
+    0
+  );
+
+  return {
+    settings,
+    stringCollector,
+    scopeTracker,
+    logger,
+    errorTracker,
+    statistics: {
+      jsxElementCount: 0,
+      dynamicContentViolations: 0,
+      macroExpansionsCount: 0,
+      jsxInsertionsCount: 0,
+      runtimeTranslateCount: 0,
+    },
+  };
+}
+
+function makeCall(firstArg: t.Expression): t.CallExpression {
+  return t.callExpression(t.identifier('gt'), [firstArg]);
+}
+
+function makeCallWithOptions(
+  firstArg: t.Expression,
+  options: t.ObjectExpression
+): t.CallExpression {
+  return t.callExpression(t.identifier('gt'), [firstArg, options]);
+}
+
+// Helper: "a" + "b"
+function concat(left: t.Expression, right: t.Expression): t.BinaryExpression {
+  return t.binaryExpression('+', left, right);
+}
+
+// Helper: `...${expr}...`
+function template(
+  strings: string[],
+  ...exprs: t.Expression[]
+): t.TemplateLiteral {
+  const quasis = strings.map((s, i) =>
+    t.templateElement({ raw: s, cooked: s }, i === strings.length - 1)
+  );
+  return t.templateLiteral(quasis, exprs);
+}
+
+describe('Robust string extraction — golden standard', () => {
+  let state: TransformState;
+
+  beforeEach(() => {
+    state = createState();
+  });
+
+  // ─────────────────────────────────────────────────
+  // 1. STRING CONCATENATION
+  // ─────────────────────────────────────────────────
+
+  describe('string concatenation', () => {
+    it('should extract from two string literals: "Hello" + " World"', () => {
+      const expr = concat(t.stringLiteral('Hello'), t.stringLiteral(' World'));
+      const result = validateUseGTCallback(makeCall(expr), state);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.content).toBe('Hello World');
+    });
+
+    it('should extract from three chained string literals: "A" + "B" + "C"', () => {
+      // "A" + "B" + "C" parses as ("A" + "B") + "C"
+      const expr = concat(
+        concat(t.stringLiteral('A'), t.stringLiteral('B')),
+        t.stringLiteral('C')
+      );
+      const result = validateUseGTCallback(makeCall(expr), state);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.content).toBe('ABC');
+    });
+
+    it('should extract from right-associative concatenation: "A" + ("B" + "C")', () => {
+      const expr = concat(
+        t.stringLiteral('A'),
+        concat(t.stringLiteral('B'), t.stringLiteral('C'))
+      );
+      const result = validateUseGTCallback(makeCall(expr), state);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.content).toBe('ABC');
+    });
+
+    it('should extract from deeply chained concatenation: "A" + "B" + "C" + "D" + "E"', () => {
+      // Left-associative: (((("A" + "B") + "C") + "D") + "E")
+      let expr: t.Expression = t.stringLiteral('A');
+      for (const s of ['B', 'C', 'D', 'E']) {
+        expr = concat(expr, t.stringLiteral(s));
+      }
+      const result = validateUseGTCallback(makeCall(expr), state);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.content).toBe('ABCDE');
+    });
+
+    it('should extract from concatenation with empty strings: "" + "Hello" + ""', () => {
+      const expr = concat(
+        concat(t.stringLiteral(''), t.stringLiteral('Hello')),
+        t.stringLiteral('')
+      );
+      const result = validateUseGTCallback(makeCall(expr), state);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.content).toBe('Hello');
+    });
+
+    it('should extract from string + template literal: "Hello" + ` World`', () => {
+      const expr = concat(t.stringLiteral('Hello'), template([' World']));
+      const result = validateUseGTCallback(makeCall(expr), state);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.content).toBe('Hello World');
+    });
+
+    it('should extract from template literal + string: `Hello` + " World"', () => {
+      const expr = concat(template(['Hello']), t.stringLiteral(' World'));
+      const result = validateUseGTCallback(makeCall(expr), state);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.content).toBe('Hello World');
+    });
+
+    it('should extract from template + template: `Hello` + ` World`', () => {
+      const expr = concat(template(['Hello']), template([' World']));
+      const result = validateUseGTCallback(makeCall(expr), state);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.content).toBe('Hello World');
+    });
+  });
+
+  // ─────────────────────────────────────────────────
+  // 2. TEMPLATE LITERALS WITH STATIC EXPRESSIONS
+  // ─────────────────────────────────────────────────
+
+  describe('template literals with static expressions', () => {
+    it('should extract from template with string expression: `Hello ${"World"}`', () => {
+      const expr = template(['Hello ', ''], t.stringLiteral('World'));
+      const result = validateUseGTCallback(makeCall(expr), state);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.content).toBe('Hello World');
+    });
+
+    it('should extract from template with multiple string expressions: `${"Hello"} ${"World"}`', () => {
+      const expr = template(
+        ['', ' ', ''],
+        t.stringLiteral('Hello'),
+        t.stringLiteral('World')
+      );
+      const result = validateUseGTCallback(makeCall(expr), state);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.content).toBe('Hello World');
+    });
+
+    it('should extract from template with template expression: `Hello ${`World`}`', () => {
+      const expr = template(['Hello ', ''], template(['World']));
+      const result = validateUseGTCallback(makeCall(expr), state);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.content).toBe('Hello World');
+    });
+
+    it('should extract from template with concatenation expression: `Hello ${"Wo" + "rld"}`', () => {
+      const expr = template(
+        ['Hello ', ''],
+        concat(t.stringLiteral('Wo'), t.stringLiteral('rld'))
+      );
+      const result = validateUseGTCallback(makeCall(expr), state);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.content).toBe('Hello World');
+    });
+
+    it('should extract from template expression at start: `${"Hello"} World`', () => {
+      const expr = template(['', ' World'], t.stringLiteral('Hello'));
+      const result = validateUseGTCallback(makeCall(expr), state);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.content).toBe('Hello World');
+    });
+
+    it('should extract from template expression at end: `Hello ${" World"}`', () => {
+      const expr = template(['Hello', ''], t.stringLiteral(' World'));
+      const result = validateUseGTCallback(makeCall(expr), state);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.content).toBe('Hello World');
+    });
+
+    it('should extract from template with only an expression: `${"Hello World"}`', () => {
+      const expr = template(['', ''], t.stringLiteral('Hello World'));
+      const result = validateUseGTCallback(makeCall(expr), state);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.content).toBe('Hello World');
+    });
+  });
+
+  // ─────────────────────────────────────────────────
+  // 3. NESTED TEMPLATE LITERALS
+  // ─────────────────────────────────────────────────
+
+  describe('nested template literals', () => {
+    it('should extract from two levels of nesting: `A ${`B ${"C"}`}`', () => {
+      const inner = template(['B ', ''], t.stringLiteral('C'));
+      const outer = template(['A ', ''], inner);
+      const result = validateUseGTCallback(makeCall(outer), state);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.content).toBe('A B C');
+    });
+
+    it('should extract from three levels of nesting: `A ${`B ${`C ${"D"}`}`}`', () => {
+      const innermost = template(['C ', ''], t.stringLiteral('D'));
+      const middle = template(['B ', ''], innermost);
+      const outer = template(['A ', ''], middle);
+      const result = validateUseGTCallback(makeCall(outer), state);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.content).toBe('A B C D');
+    });
+
+    it('should extract from nested template with multiple expressions: `${`${"A"}${`B`}`}`', () => {
+      const inner = template(
+        ['', '', ''],
+        t.stringLiteral('A'),
+        template(['B'])
+      );
+      const outer = template(['', ''], inner);
+      const result = validateUseGTCallback(makeCall(outer), state);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.content).toBe('AB');
+    });
+  });
+
+  // ─────────────────────────────────────────────────
+  // 4. MIXED CONCATENATION + TEMPLATE LITERALS
+  // ─────────────────────────────────────────────────
+
+  describe('mixed concatenation and template literals', () => {
+    it('should extract from: "Hello" + ` World ${"Here"}`', () => {
+      const expr = concat(
+        t.stringLiteral('Hello'),
+        template([' World ', ''], t.stringLiteral('Here'))
+      );
+      const result = validateUseGTCallback(makeCall(expr), state);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.content).toBe('Hello World Here');
+    });
+
+    it('should extract from: `Hello ${"World"}` + " End"', () => {
+      const expr = concat(
+        template(['Hello ', ''], t.stringLiteral('World')),
+        t.stringLiteral(' End')
+      );
+      const result = validateUseGTCallback(makeCall(expr), state);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.content).toBe('Hello World End');
+    });
+
+    it('should extract the user example: "Hello" + `World` + ` Here ${"is" + `a ${"nested"}`} string`', () => {
+      // `a ${"nested"}` → "a nested"
+      const innerTemplate = template(['a ', ''], t.stringLiteral('nested'));
+      // "is" + `a ${"nested"}` → "isa nested"
+      const concatInner = concat(t.stringLiteral('is'), innerTemplate);
+      // ` Here ${"is" + `a ${"nested"}`} string` → " Here isa nested string"
+      const outerTemplate = template([' Here ', ' string'], concatInner);
+      // "Hello" + `World` + ` Here ...`
+      const expr = concat(
+        concat(t.stringLiteral('Hello'), template(['World'])),
+        outerTemplate
+      );
+      const result = validateUseGTCallback(makeCall(expr), state);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.content).toBe('HelloWorld Here isa nested string');
+    });
+
+    it('should extract from concat inside template inside concat: "A" + `B ${"C" + "D"}` + "E"', () => {
+      const innerConcat = concat(t.stringLiteral('C'), t.stringLiteral('D'));
+      const middleTemplate = template(['B ', ''], innerConcat);
+      const expr = concat(
+        concat(t.stringLiteral('A'), middleTemplate),
+        t.stringLiteral('E')
+      );
+      const result = validateUseGTCallback(makeCall(expr), state);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.content).toBe('AB CDE');
+    });
+
+    it('should extract from template inside concat inside template: `A ${`B` + `C`} D`', () => {
+      const innerConcat = concat(template(['B']), template(['C']));
+      const expr = template(['A ', ' D'], innerConcat);
+      const result = validateUseGTCallback(makeCall(expr), state);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.content).toBe('A BC D');
+    });
+  });
+
+  // ─────────────────────────────────────────────────
+  // 5. NUMERIC LITERALS IN STATIC EXPRESSIONS
+  // ─────────────────────────────────────────────────
+
+  describe('numeric literals in static expressions', () => {
+    it('should extract from template with numeric expression: `Count: ${5}`', () => {
+      const expr = template(['Count: ', ''], t.numericLiteral(5));
+      const result = validateUseGTCallback(makeCall(expr), state);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.content).toBe('Count: 5');
+    });
+
+    it('should extract from concatenation with numeric: "Count: " + 42', () => {
+      const expr = concat(t.stringLiteral('Count: '), t.numericLiteral(42));
+      const result = validateUseGTCallback(makeCall(expr), state);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.content).toBe('Count: 42');
+    });
+
+    it('should extract from template with float: `Price: ${9.99}`', () => {
+      const expr = template(['Price: ', ''], t.numericLiteral(9.99));
+      const result = validateUseGTCallback(makeCall(expr), state);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.content).toBe('Price: 9.99');
+    });
+
+    it('should extract from template with zero: `${0} items`', () => {
+      const expr = template(['', ' items'], t.numericLiteral(0));
+      const result = validateUseGTCallback(makeCall(expr), state);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.content).toBe('0 items');
+    });
+  });
+
+  // ─────────────────────────────────────────────────
+  // 6. BOOLEAN LITERALS IN STATIC EXPRESSIONS
+  // ─────────────────────────────────────────────────
+
+  describe('boolean literals in static expressions', () => {
+    it('should extract from template with boolean: `Value: ${true}`', () => {
+      const expr = template(['Value: ', ''], t.booleanLiteral(true));
+      const result = validateUseGTCallback(makeCall(expr), state);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.content).toBe('Value: true');
+    });
+
+    it('should extract from concatenation with boolean: "Active: " + false', () => {
+      const expr = concat(t.stringLiteral('Active: '), t.booleanLiteral(false));
+      const result = validateUseGTCallback(makeCall(expr), state);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.content).toBe('Active: false');
+    });
+  });
+
+  // ─────────────────────────────────────────────────
+  // 7. NULL LITERAL IN STATIC EXPRESSIONS
+  // ─────────────────────────────────────────────────
+
+  describe('null literal in static expressions', () => {
+    it('should extract from template with null: `Value: ${null}`', () => {
+      const expr = template(['Value: ', ''], t.nullLiteral());
+      const result = validateUseGTCallback(makeCall(expr), state);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.content).toBe('Value: null');
+    });
+
+    it('should extract from concatenation with null: "Value: " + null', () => {
+      const expr = concat(t.stringLiteral('Value: '), t.nullLiteral());
+      const result = validateUseGTCallback(makeCall(expr), state);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.content).toBe('Value: null');
+    });
+  });
+
+  // ─────────────────────────────────────────────────
+  // 8. EDGE CASES
+  // ─────────────────────────────────────────────────
+
+  describe('edge cases', () => {
+    it('should extract from single empty string literal: ""', () => {
+      const result = validateUseGTCallback(
+        makeCall(t.stringLiteral('')),
+        state
+      );
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.content).toBe('');
+    });
+
+    it('should extract from concatenation of empty strings: "" + ""', () => {
+      const expr = concat(t.stringLiteral(''), t.stringLiteral(''));
+      const result = validateUseGTCallback(makeCall(expr), state);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.content).toBe('');
+    });
+
+    it('should extract from empty template literal: ``', () => {
+      const expr = template(['']);
+      const result = validateUseGTCallback(makeCall(expr), state);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.content).toBe('');
+    });
+
+    it('should extract from template with empty expression: `${""}`', () => {
+      const expr = template(['', ''], t.stringLiteral(''));
+      const result = validateUseGTCallback(makeCall(expr), state);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.content).toBe('');
+    });
+
+    it('should handle strings with special characters in concat: "Hello\\n" + "World"', () => {
+      const expr = concat(t.stringLiteral('Hello\n'), t.stringLiteral('World'));
+      const result = validateUseGTCallback(makeCall(expr), state);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.content).toBe('Hello\nWorld');
+    });
+
+    it('should handle strings with unicode in concat: "Hello " + "🌍"', () => {
+      const expr = concat(t.stringLiteral('Hello '), t.stringLiteral('🌍'));
+      const result = validateUseGTCallback(makeCall(expr), state);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.content).toBe('Hello 🌍');
+    });
+
+    it('should handle template with escaped backticks in quasis', () => {
+      // `Hello \`World\`` — raw must use \\` for backtick escaping
+      const quasis = [
+        t.templateElement(
+          { raw: 'Hello \\`World\\`', cooked: 'Hello `World`' },
+          true
+        ),
+      ];
+      const expr = t.templateLiteral(quasis, []);
+      const result = validateUseGTCallback(makeCall(expr), state);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.content).toBe('Hello `World`');
+    });
+
+    it('should handle very long concatenation chains (20 segments)', () => {
+      let expr: t.Expression = t.stringLiteral('0');
+      for (let i = 1; i < 20; i++) {
+        expr = concat(expr, t.stringLiteral(String(i)));
+      }
+      const result = validateUseGTCallback(makeCall(expr), state);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.content).toBe(
+        Array.from({ length: 20 }, (_, i) => String(i)).join('')
+      );
+    });
+
+    it('should handle deeply nested templates (5 levels)', () => {
+      // `A ${`B ${`C ${`D ${"E"}`}`}`}`
+      let expr: t.Expression = t.stringLiteral('E');
+      for (const prefix of ['D ', 'C ', 'B ', 'A ']) {
+        expr = template([prefix, ''], expr);
+      }
+      const result = validateUseGTCallback(makeCall(expr), state);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.content).toBe('A B C D E');
+    });
+  });
+
+  // ─────────────────────────────────────────────────
+  // 9. MUST STILL REJECT DYNAMIC CONTENT
+  // ─────────────────────────────────────────────────
+
+  describe('rejection of dynamic content', () => {
+    it('should reject identifier variable: gt(name)', () => {
+      const result = validateUseGTCallback(
+        makeCall(t.identifier('name')),
+        state
+      );
+      expect(result.errors.length).toBeGreaterThan(0);
+      expect(result.content).toBeUndefined();
+    });
+
+    it('should reject template with identifier expression: gt(`Hello ${name}`)', () => {
+      const expr = template(['Hello ', ''], t.identifier('name'));
+      const result = validateUseGTCallback(makeCall(expr), state);
+
+      expect(result.errors.length).toBeGreaterThan(0);
+      expect(result.content).toBeUndefined();
+    });
+
+    it('should reject concatenation with identifier: gt("Hello " + name)', () => {
+      const expr = concat(t.stringLiteral('Hello '), t.identifier('name'));
+      const result = validateUseGTCallback(makeCall(expr), state);
+
+      expect(result.errors.length).toBeGreaterThan(0);
+      expect(result.content).toBeUndefined();
+    });
+
+    it('should reject if any part of concatenation is dynamic: "A" + name + "B"', () => {
+      const expr = concat(
+        concat(t.stringLiteral('A'), t.identifier('name')),
+        t.stringLiteral('B')
+      );
+      const result = validateUseGTCallback(makeCall(expr), state);
+
+      expect(result.errors.length).toBeGreaterThan(0);
+      expect(result.content).toBeUndefined();
+    });
+
+    it('should reject function call in concatenation: "Hello " + getName()', () => {
+      const expr = concat(
+        t.stringLiteral('Hello '),
+        t.callExpression(t.identifier('getName'), [])
+      );
+      const result = validateUseGTCallback(makeCall(expr), state);
+
+      expect(result.errors.length).toBeGreaterThan(0);
+      expect(result.content).toBeUndefined();
+    });
+
+    it('should reject function call in template: `Hello ${getName()}`', () => {
+      const expr = template(
+        ['Hello ', ''],
+        t.callExpression(t.identifier('getName'), [])
+      );
+      const result = validateUseGTCallback(makeCall(expr), state);
+
+      expect(result.errors.length).toBeGreaterThan(0);
+      expect(result.content).toBeUndefined();
+    });
+
+    it('should reject mixed static + dynamic in deeply nested template', () => {
+      // `A ${`B ${name}`}` — name is dynamic even though the rest is static
+      const inner = template(['B ', ''], t.identifier('name'));
+      const outer = template(['A ', ''], inner);
+      const result = validateUseGTCallback(makeCall(outer), state);
+
+      expect(result.errors.length).toBeGreaterThan(0);
+      expect(result.content).toBeUndefined();
+    });
+
+    it('should reject member expression in concatenation: "Hello " + obj.name', () => {
+      const expr = concat(
+        t.stringLiteral('Hello '),
+        t.memberExpression(t.identifier('obj'), t.identifier('name'))
+      );
+      const result = validateUseGTCallback(makeCall(expr), state);
+
+      expect(result.errors.length).toBeGreaterThan(0);
+      expect(result.content).toBeUndefined();
+    });
+
+    it('should reject conditional expression: "Hello " + (flag ? "A" : "B")', () => {
+      const expr = concat(
+        t.stringLiteral('Hello '),
+        t.conditionalExpression(
+          t.identifier('flag'),
+          t.stringLiteral('A'),
+          t.stringLiteral('B')
+        )
+      );
+      const result = validateUseGTCallback(makeCall(expr), state);
+
+      expect(result.errors.length).toBeGreaterThan(0);
+      expect(result.content).toBeUndefined();
+    });
+
+    it('should reject non-+ binary operator: "Hello " - "World"', () => {
+      const expr = t.binaryExpression(
+        '-',
+        t.stringLiteral('Hello '),
+        t.stringLiteral('World')
+      );
+      const result = validateUseGTCallback(makeCall(expr), state);
+
+      expect(result.errors.length).toBeGreaterThan(0);
+      expect(result.content).toBeUndefined();
+    });
+  });
+
+  // ─────────────────────────────────────────────────
+  // 10. DERIVE STILL WORKS WITH COMPLEX EXPRESSIONS
+  // ─────────────────────────────────────────────────
+
+  describe('derive with complex static expressions', () => {
+    it('should accept derive alongside static concatenation', () => {
+      // gt("Hello " + "World " + derive(getName()))
+      const deriveCall = t.callExpression(
+        t.identifier(GT_OTHER_FUNCTIONS.derive),
+        [t.callExpression(t.identifier('getName'), [])]
+      );
+      const expr = concat(
+        concat(t.stringLiteral('Hello '), t.stringLiteral('World ')),
+        deriveCall
+      );
+      const result = validateUseGTCallback(makeCall(expr), state);
+
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should accept derive inside template with static concat: `${"A" + "B"} ${derive(fn())}`', () => {
+      const staticConcat = concat(t.stringLiteral('A'), t.stringLiteral('B'));
+      const deriveCall = t.callExpression(
+        t.identifier(GT_OTHER_FUNCTIONS.derive),
+        [t.callExpression(t.identifier('fn'), [])]
+      );
+      const expr = template(['', ' ', ''], staticConcat, deriveCall);
+      const result = validateUseGTCallback(makeCall(expr), state);
+
+      expect(result.errors).toHaveLength(0);
+    });
+  });
+
+  // ─────────────────────────────────────────────────
+  // 11. SECOND ARGUMENT (OPTIONS) UNAFFECTED
+  // ─────────────────────────────────────────────────
+
+  describe('options with complex first argument', () => {
+    it('should extract content and options from concat: gt("Hello" + " World", { $id: "hw" })', () => {
+      const expr = concat(t.stringLiteral('Hello'), t.stringLiteral(' World'));
+      const options = t.objectExpression([
+        t.objectProperty(t.identifier('$id'), t.stringLiteral('hw')),
+      ]);
+      const result = validateUseGTCallback(
+        makeCallWithOptions(expr, options),
+        state
+      );
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.content).toBe('Hello World');
+      expect(result.id).toBe('hw');
+    });
+
+    it('should extract content and context from nested template', () => {
+      // gt(`Hello ${"World"}`, { $context: "greeting" })
+      const expr = template(['Hello ', ''], t.stringLiteral('World'));
+      const options = t.objectExpression([
+        t.objectProperty(t.identifier('$context'), t.stringLiteral('greeting')),
+      ]);
+      const result = validateUseGTCallback(
+        makeCallWithOptions(expr, options),
+        state
+      );
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.content).toBe('Hello World');
+      expect(result.context).toBe('greeting');
+    });
+
+    it('should extract content and maxChars from concat', () => {
+      // gt("Hello" + " World", { $maxChars: 20 })
+      const expr = concat(t.stringLiteral('Hello'), t.stringLiteral(' World'));
+      const options = t.objectExpression([
+        t.objectProperty(t.identifier('$maxChars'), t.numericLiteral(20)),
+      ]);
+      const result = validateUseGTCallback(
+        makeCallWithOptions(expr, options),
+        state
+      );
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.content).toBe('Hello World');
+      expect(result.maxChars).toBe(20);
+    });
+
+    it('should extract all options alongside complex first argument', () => {
+      // gt("A" + `B ${"C"}`, { $id: "abc", $context: "test", $maxChars: 50, $format: "STRING" })
+      const expr = concat(
+        t.stringLiteral('A'),
+        template(['B ', ''], t.stringLiteral('C'))
+      );
+      const options = t.objectExpression([
+        t.objectProperty(t.identifier('$id'), t.stringLiteral('abc')),
+        t.objectProperty(t.identifier('$context'), t.stringLiteral('test')),
+        t.objectProperty(t.identifier('$maxChars'), t.numericLiteral(50)),
+        t.objectProperty(t.identifier('$format'), t.stringLiteral('STRING')),
+      ]);
+      const result = validateUseGTCallback(
+        makeCallWithOptions(expr, options),
+        state
+      );
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.content).toBe('AB C');
+      expect(result.id).toBe('abc');
+      expect(result.context).toBe('test');
+      expect(result.maxChars).toBe(50);
+      expect(result.format).toBe('STRING');
+    });
+  });
+
+  // ─────────────────────────────────────────────────
+  // 12. REGRESSION TESTS — existing behavior preserved
+  // ─────────────────────────────────────────────────
+
+  describe('regression — existing behavior preserved', () => {
+    it('plain string literal still works: gt("Hello")', () => {
+      const result = validateUseGTCallback(
+        makeCall(t.stringLiteral('Hello')),
+        state
+      );
+      expect(result.errors).toHaveLength(0);
+      expect(result.content).toBe('Hello');
+    });
+
+    it('plain template literal (no expressions) still works: gt(`Hello`)', () => {
+      const expr = template(['Hello']);
+      const result = validateUseGTCallback(makeCall(expr), state);
+      expect(result.errors).toHaveLength(0);
+      expect(result.content).toBe('Hello');
+    });
+
+    it('string with options still works', () => {
+      const options = t.objectExpression([
+        t.objectProperty(t.identifier('$context'), t.stringLiteral('greeting')),
+        t.objectProperty(t.identifier('$id'), t.stringLiteral('hello-id')),
+      ]);
+      const result = validateUseGTCallback(
+        makeCallWithOptions(t.stringLiteral('Hello'), options),
+        state
+      );
+      expect(result.errors).toHaveLength(0);
+      expect(result.content).toBe('Hello');
+      expect(result.context).toBe('greeting');
+      expect(result.id).toBe('hello-id');
+    });
+
+    it('derive as first argument still works', () => {
+      const deriveCall = t.callExpression(
+        t.identifier(GT_OTHER_FUNCTIONS.derive),
+        [t.callExpression(t.identifier('getName'), [])]
+      );
+      const result = validateUseGTCallback(makeCall(deriveCall), state);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('no arguments still errors', () => {
+      const result = validateUseGTCallback(
+        t.callExpression(t.identifier('gt'), []),
+        state
+      );
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
+
+    it('identifier as first argument still errors (without autoderive)', () => {
+      const result = validateUseGTCallback(
+        makeCall(t.identifier('myVar')),
+        state
+      );
+      expect(result.errors.length).toBeGreaterThan(0);
+      expect(result.content).toBeUndefined();
+    });
+
+    it('autoderive still skips validation for non-string content', () => {
+      const autoState = createState({
+        autoderive: { jsx: false, strings: true },
+      });
+      const result = validateUseGTCallback(
+        makeCall(t.identifier('myVar')),
+        autoState
+      );
+      expect(result.errors).toHaveLength(0);
+      expect(result.content).toBeUndefined();
+      expect(result.hasDeriveContext).toBe(true);
+    });
+  });
+});

--- a/packages/compiler/src/transform/validation/__tests__/validateTranslationFunctionCallback.test.ts
+++ b/packages/compiler/src/transform/validation/__tests__/validateTranslationFunctionCallback.test.ts
@@ -126,7 +126,7 @@ describe('validateTranslationFunctionCallback', () => {
         expect(result.errors).toHaveLength(3);
         expect(result.errors).toEqual([
           'Variables are not allowed',
-          'Expression is not a string literal',
+          'Expression is not a static string',
           'useGT_callback / getGT_callback must use a string literal or derive() call as the first argument. Variable content is not allowed.',
         ]);
         expect(result.content).toBeUndefined();
@@ -151,7 +151,7 @@ describe('validateTranslationFunctionCallback', () => {
         expect(result.errors).toEqual([
           'Variables are not allowed',
           'Expression does not use an allowed call expression',
-          'Expression is not a string literal',
+          'Expression is not a static string',
           'useGT_callback / getGT_callback must use a string literal or derive() call as the first argument. Variable content is not allowed.',
         ]);
         expect(result.content).toBeUndefined();

--- a/packages/compiler/src/transform/validation/validateTranslationFunctionCallback.ts
+++ b/packages/compiler/src/transform/validation/validateTranslationFunctionCallback.ts
@@ -6,6 +6,7 @@ import {
 import { TransformState } from '../../state/types';
 import { getCalleeNameFromExpression } from '../../utils/parsing/getCalleeNameFromExpression';
 import { getTrackedVariable } from '../getTrackedVariable';
+import { resolveStaticExpression } from '../templates-and-concat/resolveStaticExpression';
 
 /**
  * Validate useGT_callback / getGT_callback
@@ -44,17 +45,17 @@ export function validateUseGTCallback(
     return { errors };
   }
 
-  // Get content and validate that it is a string literal
-  const validatedContent = validateExpressionIsStringLiteral(
+  // Try to resolve the expression to a static string (handles concat, nested templates, etc.)
+  const resolvedStaticExpression = resolveStaticExpression(
     callExpr.arguments[0]
   );
-  const content = validatedContent.value;
+  const content = resolvedStaticExpression.value;
 
   if (content === undefined && !state.settings.autoderive.strings) {
-    // Check if it contains a derive() function invocation (no requirement for derive() invoc with autoderive)
+    // Not a static expression — check if it contains a derive() function invocation
     validateDerive(callExpr.arguments[0], state, errors);
     if (errors.length > 0) {
-      errors.push(...validatedContent.errors);
+      errors.push(...resolvedStaticExpression.errors);
       errors.push(
         'useGT_callback / getGT_callback must use a string literal or derive() call as the first argument. Variable content is not allowed.'
       );

--- a/packages/compiler/src/transform/validation/validateTranslationFunctionCallback.ts
+++ b/packages/compiler/src/transform/validation/validateTranslationFunctionCallback.ts
@@ -10,9 +10,9 @@ import { resolveStaticExpression } from '../templates-and-concat/resolveStaticEx
 
 /**
  * Validate useGT_callback / getGT_callback
- * - first argument must be a string literal
+ * - first argument must be a statically resolvable string expression
+ *   (string literal, template literal, binary '+' concatenation, or derive() call)
  * - second argument, if present, $id field + $context field must be a string literal
- * TODO: Add maxChars validation
  */
 export function validateUseGTCallback(
   callExpr: t.CallExpression,


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the narrow `validateExpressionIsStringLiteral` check with a new `resolveStaticExpression` utility that recursively resolves binary `+` concatenation, nested template literals, and primitive literals (string, numeric, boolean, null) to a compile-time string. The change broadens what `gt()`, `msg()`, and `t()` accept as their first argument while keeping `$id`/`$context` options strictly as string literals. Test coverage is thorough across unit, integration, and E2E layers.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the one finding is a minor edge-case gap (unary-negated numerics) that does not break existing behavior.

All remaining findings are P2. The core logic is correct, derive interaction is preserved, error messages are consistent, and the test suite is comprehensive. No regressions or data-integrity issues were found.

resolveStaticExpression.ts — minor: unary-negated numeric literals (e.g. -5) are not resolved statically.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/compiler/src/transform/templates-and-concat/resolveStaticExpression.ts | New utility for compile-time static expression resolution; handles string/template/binary-concat and primitive literals, but misses unary-negated numeric literals (e.g. -5) |
| packages/compiler/src/transform/validation/validateTranslationFunctionCallback.ts | Swapped validateExpressionIsStringLiteral for resolveStaticExpression for the first argument; options ($id, $context) still use the old strict string-literal validator as intended |
| packages/compiler/src/passes/__tests__/stringExtractionE2E.test.ts | New E2E tests covering gt(), msg(), t(), and tagged-template extraction across concatenation, nested templates, and dynamic/static mixing — comprehensive and well-organized |
| packages/compiler/src/transform/validation/__tests__/robustStringExtraction.test.ts | 841-line golden-standard test suite for validateUseGTCallback covering concatenation, nested templates, mixed forms, primitives, edge cases, rejection of dynamic content, and derive interactions |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[validateUseGTCallback] --> B{arg is Expression?}
    B -- No --> ERR1[return error]
    B -- Yes --> C[resolveStaticExpression]
    C --> D{StringLiteral}
    D -- Yes --> RET_STR[return value]
    C --> E{NumericLiteral}
    E -- Yes --> RET_NUM[return String of n]
    C --> F{BooleanLiteral}
    F -- Yes --> RET_BOOL[return true or false]
    C --> G{NullLiteral}
    G -- Yes --> RET_NULL[return null string]
    C --> H{TemplateLiteral}
    H -- Yes --> H1[iterate quasis + expressions]
    H1 --> H2{cooked is null?}
    H2 -- Yes --> ERR_TPL[return invalid escape error]
    H2 -- No --> H3[recurse on each expression]
    H3 --> H4{child error?}
    H4 -- Yes --> PROP[propagate error]
    H4 -- No --> H5[accumulate string]
    C --> I{BinaryExpression +}
    I -- Yes --> I1[resolve left]
    I1 --> I2{left error?}
    I2 -- Yes --> ERR_L[propagate error]
    I2 -- No --> I3[resolve right]
    I3 --> I4{right error?}
    I4 -- Yes --> ERR_R[propagate error]
    I4 -- No --> CONCAT[return left + right]
    C --> Z[return static string error]
    D -- No --> E
    E -- No --> F
    F -- No --> G
    G -- No --> H
    H -- No --> I
    I -- No --> Z
    RET_STR --> CONT[content defined]
    RET_NUM --> CONT
    RET_BOOL --> CONT
    RET_NULL --> CONT
    H5 --> CONT
    CONCAT --> CONT
    ERR_TPL --> CONT2{autoderive enabled?}
    PROP --> CONT2
    ERR_L --> CONT2
    ERR_R --> CONT2
    Z --> CONT2
    CONT2 -- Yes --> SKIP[skip validation]
    CONT2 -- No --> DRV[validateDerive]
    DRV --> DRV2{derive errors?}
    DRV2 -- Yes --> ERR2[return errors]
    DRV2 -- No --> SKIP
    CONT --> OPT[validate options]
    SKIP --> OPT
    OPT --> FINAL[return result]
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/compiler/src/transform/validation/validateTranslationFunctionCallback.ts`, line 12-14 ([link](https://github.com/generaltranslation/gt/blob/673babde100bd46915719c7b8e184c2a7f422cc3/packages/compiler/src/transform/validation/validateTranslationFunctionCallback.ts#L12-L14)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Stale JSDoc after refactor**

   The doc comment still says "first argument must be a string literal", but the implementation now accepts any statically-resolvable expression (concatenation, template literals, numeric/boolean/null literals, or `derive()` calls). Consider updating it to reflect the broadened contract.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/compiler/src/transform/validation/validateTranslationFunctionCallback.ts
   Line: 12-14

   Comment:
   **Stale JSDoc after refactor**

   The doc comment still says "first argument must be a string literal", but the implementation now accepts any statically-resolvable expression (concatenation, template literals, numeric/boolean/null literals, or `derive()` calls). Consider updating it to reflect the broadened contract.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/compiler/src/transform/templates-and-concat/resolveStaticExpression.ts
Line: 19-21

Comment:
**Negative numeric literals silently fail static resolution**

In Babel's AST, source code like `-5` or `-3.14` is represented as a `UnaryExpression(operator: '-', argument: NumericLiteral)`, not as a `NumericLiteral` directly. The current handler only matches `isNumericLiteral`, so `gt(\`Count: ${-5}\`)` falls through to the "Expression is not a static string" error even though the value is fully deterministic at compile time. Users writing translation strings with negative numbers in template interpolations will get a confusing rejection.

```suggestion
  if (t.isNumericLiteral(expr)) {
    return { errors: [], value: String(expr.value) };
  }

  if (
    t.isUnaryExpression(expr) &&
    expr.operator === '-' &&
    t.isNumericLiteral(expr.argument)
  ) {
    return { errors: [], value: String(-expr.argument.value) };
  }
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix minor feedback"](https://github.com/generaltranslation/gt/commit/e74dca8f6dcf344f4e466f2f80ff189b97cff056) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29358871)</sub>

<!-- /greptile_comment -->