### PR TITLE
fix(compiler): string extaction concat with non-strings

### DIFF
--- a/.changeset/tangy-bushes-crash.md
+++ b/.changeset/tangy-bushes-crash.md
@@ -1,0 +1,5 @@
+---
+'@generaltranslation/compiler': patch
+---
+
+fix: string extraction for concat with non-strings

--- a/packages/compiler/src/passes/__tests__/stringExtractionE2E.test.ts
+++ b/packages/compiler/src/passes/__tests__/stringExtractionE2E.test.ts
@@ -96,6 +96,38 @@ describe('gt() string extraction E2E', () => {
     expect(content[0].context).toBe('greeting');
   });
 
+  it('extracts $context from string concatenation: "section" + ".title"', () => {
+    const state = collect(
+      prefix + 'gt("Hello", { $context: "section" + ".title" });'
+    );
+    const content = getCallbackContent(state);
+    expect(content).toHaveLength(1);
+    expect(content[0].context).toBe('section.title');
+  });
+
+  it('extracts $context from string + numeric: "section" + 1', () => {
+    const state = collect(prefix + 'gt("Hello", { $context: "section" + 1 });');
+    const content = getCallbackContent(state);
+    expect(content).toHaveLength(1);
+    expect(content[0].context).toBe('section1');
+  });
+
+  it('extracts $context from template literal: `section.title`', () => {
+    const state = collect(
+      prefix + 'gt("Hello", { $context: `section.title` });'
+    );
+    const content = getCallbackContent(state);
+    expect(content).toHaveLength(1);
+    expect(content[0].context).toBe('section.title');
+  });
+
+  it('rejects $context with dynamic variable', () => {
+    const state = collect(prefix + 'gt("Hello", { $context: contextVar });');
+    const content = getCallbackContent(state);
+    expect(content).toHaveLength(0);
+    expect(state.errorTracker.getErrors().length).toBeGreaterThan(0);
+  });
+
   it('extracts multiple calls independently', () => {
     const state = collect(
       prefix + `gt("Hello" + " World");\ngt(\`Foo \${"Bar"}\`);`

--- a/packages/compiler/src/passes/__tests__/stringExtractionE2E.test.ts
+++ b/packages/compiler/src/passes/__tests__/stringExtractionE2E.test.ts
@@ -124,6 +124,55 @@ describe('gt() string extraction E2E', () => {
     expect(c2[0].hash).toBe(c3[0].hash);
   });
 
+  it('extracts string + numeric literal: "Hello, " + 1', () => {
+    const state = collect(prefix + `gt("Hello, " + 1);`);
+    const content = getCallbackContent(state);
+    expect(content).toHaveLength(1);
+    expect(content[0].message).toBe('Hello, 1');
+  });
+
+  it('extracts string + string via concat: "page" + ".title"', () => {
+    const state = collect(prefix + `gt("page" + ".title");`);
+    const content = getCallbackContent(state);
+    expect(content).toHaveLength(1);
+    expect(content[0].message).toBe('page.title');
+  });
+
+  it('extracts string + numeric: "section" + 1', () => {
+    const state = collect(prefix + `gt("section" + 1);`);
+    const content = getCallbackContent(state);
+    expect(content).toHaveLength(1);
+    expect(content[0].message).toBe('section1');
+  });
+
+  it('extracts chained concat: "a" + "b" + "c"', () => {
+    const state = collect(prefix + `gt("a" + "b" + "c");`);
+    const content = getCallbackContent(state);
+    expect(content).toHaveLength(1);
+    expect(content[0].message).toBe('abc');
+  });
+
+  it('extracts string + boolean: "value: " + true', () => {
+    const state = collect(prefix + `gt("value: " + true);`);
+    const content = getCallbackContent(state);
+    expect(content).toHaveLength(1);
+    expect(content[0].message).toBe('value: true');
+  });
+
+  it('extracts string + null: "value: " + null', () => {
+    const state = collect(prefix + `gt("value: " + null);`);
+    const content = getCallbackContent(state);
+    expect(content).toHaveLength(1);
+    expect(content[0].message).toBe('value: null');
+  });
+
+  it('rejects variable + string: variable + ".title"', () => {
+    const state = collect(prefix + `gt(variable + ".title");`);
+    const content = getCallbackContent(state);
+    expect(content).toHaveLength(0);
+    expect(state.errorTracker.getErrors().length).toBeGreaterThan(0);
+  });
+
   it('rejects dynamic content with no extraction', () => {
     const state = collect(prefix + `gt(name);`);
     const content = getCallbackContent(state);

--- a/packages/compiler/src/transform/validation/__tests__/validateTranslationFunctionCallback.test.ts
+++ b/packages/compiler/src/transform/validation/__tests__/validateTranslationFunctionCallback.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import * as t from '@babel/types';
-import generate from '@babel/generator';
 import {
   validateUseGTCallback,
   validateUseTranslationsCallback,
@@ -35,6 +34,7 @@ describe('validateTranslationFunctionCallback', () => {
       enableAutoJsxInjection: false,
       autoderive: { jsx: false, strings: false },
       _debugHashManifest: false,
+      devHotReload: { strings: false, jsx: false },
     };
 
     state = {
@@ -46,6 +46,7 @@ describe('validateTranslationFunctionCallback', () => {
       statistics: {
         jsxElementCount: 0,
         dynamicContentViolations: 0,
+        runtimeTranslateCount: 0,
         macroExpansionsCount: 0,
         jsxInsertionsCount: 0,
       },
@@ -585,7 +586,7 @@ describe('validateTranslationFunctionCallback', () => {
         expect(result.context).toBe('greeting');
       });
 
-      it('should return error when $context is not a string literal', () => {
+      it('should return error when $context is not a static expression', () => {
         const callExpr = t.callExpression(t.identifier('useGT_callback'), [
           t.stringLiteral('Hello'),
           t.objectExpression([
@@ -599,9 +600,6 @@ describe('validateTranslationFunctionCallback', () => {
         const result = validateUseGTCallback(callExpr, state);
 
         expect(result.errors.length).toBeGreaterThan(0);
-        expect(result.errors.some((e) => e.includes('string literal'))).toBe(
-          true
-        );
       });
 
       it('should return error when $id is not a string literal', () => {
@@ -924,6 +922,7 @@ describe('validateTranslationFunctionCallback', () => {
         enableAutoJsxInjection: false,
         autoderive: { jsx: true, strings: true },
         _debugHashManifest: false,
+        devHotReload: { strings: false, jsx: false },
       };
 
       autoderiveState = {
@@ -937,6 +936,7 @@ describe('validateTranslationFunctionCallback', () => {
           dynamicContentViolations: 0,
           macroExpansionsCount: 0,
           jsxInsertionsCount: 0,
+          runtimeTranslateCount: 0,
         },
       };
 
@@ -1188,6 +1188,7 @@ describe('validateTranslationFunctionCallback', () => {
         enableAutoJsxInjection: false,
         autoderive: { jsx: true, strings: false },
         _debugHashManifest: false,
+        devHotReload: { strings: false, jsx: false },
       };
 
       jsxOnlyState = {
@@ -1201,6 +1202,7 @@ describe('validateTranslationFunctionCallback', () => {
           dynamicContentViolations: 0,
           macroExpansionsCount: 0,
           jsxInsertionsCount: 0,
+          runtimeTranslateCount: 0,
         },
       };
 
@@ -1261,6 +1263,7 @@ describe('validateTranslationFunctionCallback', () => {
         enableAutoJsxInjection: false,
         autoderive: { jsx: false, strings: true },
         _debugHashManifest: false,
+        devHotReload: { strings: false, jsx: false },
       };
 
       stringsOnlyState = {
@@ -1274,6 +1277,7 @@ describe('validateTranslationFunctionCallback', () => {
           dynamicContentViolations: 0,
           macroExpansionsCount: 0,
           jsxInsertionsCount: 0,
+          runtimeTranslateCount: 0,
         },
       };
 

--- a/packages/compiler/src/transform/validation/validateTranslationFunctionCallback.ts
+++ b/packages/compiler/src/transform/validation/validateTranslationFunctionCallback.ts
@@ -232,20 +232,20 @@ function validatePropertyFromObjectExpression(
 
   // extract value
   if (type === 'string-or-derive') {
-    const stringValidation = validateExpressionIsStringLiteral(value.value);
-    if (stringValidation.value !== undefined) {
-      result.value = stringValidation.value;
+    const resolved = resolveStaticExpression(value.value);
+    if (resolved.value !== undefined) {
+      result.value = resolved.value;
     } else if (state) {
-      // String validation failed — check if it's a valid derive() expression
+      // Static resolution failed — check if it's a valid derive() expression
       const deriveErrors: string[] = [];
       validateDerive(value.value, state, deriveErrors);
       if (deriveErrors.length === 0) {
         result.hasDeriveExpression = true;
       } else {
-        result.errors.push(...stringValidation.errors);
+        result.errors.push(...resolved.errors);
       }
     } else {
-      result.errors.push(...stringValidation.errors);
+      result.errors.push(...resolved.errors);
     }
   } else {
     const validatedValue =
@@ -327,8 +327,11 @@ export function validateDerive(
     return { errors };
   }
 
-  // 3. Template literal: `Hello there ${derive(getName())}`
+  // 3. Template literal: `Hello there ${derive(getName())}` or `static text`
   if (t.isTemplateLiteral(expr)) {
+    if (expr.expressions.length === 0) {
+      return { errors };
+    }
     if (
       !expr.expressions.some(
         (expression) =>
@@ -343,8 +346,20 @@ export function validateDerive(
     };
   }
 
-  // 4. String literal / number literal
+  // 4. Static literals (string, number, boolean, null)
   if (t.isStringLiteral(expr)) {
+    return { errors };
+  }
+
+  if (t.isNumericLiteral(expr)) {
+    return { errors };
+  }
+
+  if (t.isBooleanLiteral(expr)) {
+    return { errors };
+  }
+
+  if (t.isNullLiteral(expr)) {
     return { errors };
   }
 


### PR DESCRIPTION
## Summary

- `validateDerive()` now accepts `NumericLiteral`, `BooleanLiteral`, `NullLiteral`, and expression-less `TemplateLiteral` as valid terminals, matching the CLI's `isStaticExpression()` behavior. Previously, `gt(1 + derive(getName()))` would error.
- `$context` property validation now uses `resolveStaticExpression()` instead of `validateExpressionIsStringLiteral()`, so `{ $context: "section" + 1 }` correctly resolves to `"section1"`.

Example — previously errored, now works:
```ts
gt("count: " + 1)
// validates successfully; "count: " and 1 are accepted as static terminals alongside derive()
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This patch fixes two related validation gaps in the compiler's string extraction pass. `validateDerive()` now accepts numeric, boolean, null literals and expression-less template literals as valid static terminals, and `$context` property validation is upgraded from `validateExpressionIsStringLiteral()` to `resolveStaticExpression()` so that concatenated contexts like `"section" + 1` are handled. The change is well-covered by new E2E tests.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — targeted bug fix with comprehensive test coverage and no regressions.

All findings are P2 or lower. The logic change is minimal and correct: `resolveStaticExpression` is a superset of the old `validateExpressionIsStringLiteral`, and the new literal terminals in `validateDerive` mirror exactly what `resolveStaticExpression` already accepted. New E2E tests cover every added case as well as rejection of dynamic inputs.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/compiler/src/transform/validation/validateTranslationFunctionCallback.ts | Core fix: swaps `validateExpressionIsStringLiteral` for `resolveStaticExpression` in the `string-or-derive` branch, and adds numeric/boolean/null/empty-template-literal terminals to `validateDerive`. Logic is correct and symmetric with `resolveStaticExpression`. |
| packages/compiler/src/passes/__tests__/stringExtractionE2E.test.ts | Adds 10 new E2E cases covering string+number, string+boolean, string+null, chained concat, template literal context, and rejection of dynamic identifiers — comprehensive coverage of the new behavior. |
| packages/compiler/src/transform/validation/__tests__/validateTranslationFunctionCallback.test.ts | Updates test fixtures to include `devHotReload` and `runtimeTranslateCount` fields; relaxes the `$context` error-message assertion from checking for the string literal "string literal" to just checking that errors exist — intentional since the error text changed. |
| .changeset/tangy-bushes-crash.md | Patch-level changeset entry for `@generaltranslation/compiler`; correctly scoped. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["validatePropertyFromObjectExpression\n(type = 'string-or-derive')"] --> B["resolveStaticExpression(value)"]
    B -- "value defined\n(string/number/bool/null/concat/template)" --> C["result.value = resolved string\n✅ static context"]
    B -- "value undefined\n(dynamic or derive call)" --> D{state provided?}
    D -- yes --> E["validateDerive(value, state, deriveErrors)"]
    E -- "0 derive errors" --> F["result.hasDeriveExpression = true\n✅ derive context"]
    E -- "errors" --> G["result.errors ← resolved.errors\n❌ invalid"]
    D -- no --> G

    subgraph "validateDerive terminals (NEW)"
        H["StringLiteral ✅"]
        I["NumericLiteral ✅ NEW"]
        J["BooleanLiteral ✅ NEW"]
        K["NullLiteral ✅ NEW"]
        L["TemplateLiteral (no exprs) ✅ NEW"]
    end

    E --> H & I & J & K & L
```
</details>

<sub>Reviews (1): Last reviewed commit: ["test: context param"](https://github.com/generaltranslation/gt/commit/4b2305fc7ba0ad64e2067b3d3d7587861fb393ae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29485891)</sub>

<!-- /greptile_comment -->