### PR TITLE
chore(core): inline stable-stringify, drop fast-json-stable-stringify dep

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -59,7 +59,6 @@
   "dependencies": {
     "@formatjs/icu-messageformat-parser": "^2.11.4",
     "@noble/hashes": "^2.2.0",
-    "fast-json-stable-stringify": "^2.1.0",
     "intl-messageformat": "^10.7.16"
   },
   "exports": {

--- a/packages/core/src/backwards-compatability/oldHashJsxChildren.ts
+++ b/packages/core/src/backwards-compatability/oldHashJsxChildren.ts
@@ -1,7 +1,7 @@
 // Functions provided to other GT libraries
 
 import { OldJsxChild, OldJsxChildren, OldVariableObject } from './oldTypes';
-import stringify from 'fast-json-stable-stringify';
+import { stableStringify as stringify } from '../utils/stableStringify';
 import { sha256 } from '@noble/hashes/sha2.js';
 import { bytesToHex, utf8ToBytes } from '@noble/hashes/utils.js';
 

--- a/packages/core/src/id/hashSource.ts
+++ b/packages/core/src/id/hashSource.ts
@@ -1,7 +1,7 @@
 // Functions provided to other GT libraries
 
 import { JsxChild, JsxChildren, Variable } from '../types';
-import stringify from 'fast-json-stable-stringify';
+import { stableStringify as stringify } from '../utils/stableStringify';
 import { sha256 } from '@noble/hashes/sha2.js';
 import { bytesToHex, utf8ToBytes } from '@noble/hashes/utils.js';
 import isVariable from '../utils/isVariable';

--- a/packages/core/src/id/hashTemplate.ts
+++ b/packages/core/src/id/hashTemplate.ts
@@ -1,5 +1,5 @@
 import { hashString } from './hashSource';
-import stringify from 'fast-json-stable-stringify';
+import { stableStringify as stringify } from '../utils/stableStringify';
 
 export default function hashTemplate(
   template: {

--- a/packages/core/src/utils/stableStringify.ts
+++ b/packages/core/src/utils/stableStringify.ts
@@ -1,0 +1,34 @@
+/**
+ * Deterministic JSON stringification with sorted object keys.
+ * Drop-in replacement for `fast-json-stable-stringify` for plain
+ * JSON-compatible data (no toJSON, no circular references).
+ */
+function _stringify(node: unknown): string | undefined {
+  if (node === undefined) return undefined;
+  if (node === null) return 'null';
+  if (typeof node === 'number') return isFinite(node) ? '' + node : 'null';
+  if (typeof node !== 'object') return JSON.stringify(node);
+
+  if (Array.isArray(node)) {
+    let out = '[';
+    for (let i = 0; i < node.length; i++) {
+      if (i) out += ',';
+      out += _stringify(node[i]) || 'null';
+    }
+    return out + ']';
+  }
+
+  const keys = Object.keys(node as Record<string, unknown>).sort();
+  let out = '';
+  for (const key of keys) {
+    const value = _stringify((node as Record<string, unknown>)[key]);
+    if (!value) continue;
+    if (out) out += ',';
+    out += JSON.stringify(key) + ':' + value;
+  }
+  return '{' + out + '}';
+}
+
+export function stableStringify(data: unknown): string {
+  return _stringify(data) ?? '';
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -415,9 +415,6 @@ importers:
       '@noble/hashes':
         specifier: ^2.2.0
         version: 2.2.0
-      fast-json-stable-stringify:
-        specifier: ^2.1.0
-        version: 2.1.0
       intl-messageformat:
         specifier: ^10.7.16
         version: 10.7.16


### PR DESCRIPTION
## Summary

- Replace `fast-json-stable-stringify` dependency with a ~35 line inline implementation
- Produces identical output for all inputs used by `hashSource`, `hashTemplate`, and `oldHashJsxChildren`
- No hash changes, no migration needed

## Changes

- New `packages/core/src/utils/stableStringify.ts`
- Update imports in `hashSource.ts`, `hashTemplate.ts`, `oldHashJsxChildren.ts`
- Remove `fast-json-stable-stringify` from `package.json`

## Test plan

- [x] `pnpm --filter generaltranslation build` — zero TS warnings
- [x] `pnpm --filter generaltranslation test` — 605 tests pass
- [x] `pnpm --filter gt test` — 1831 tests pass (includes hardcoded hash assertions)
- [x] Inline implementation tested against library output on 24 edge cases (undefined, NaN, Infinity, nested objects, falsy values, simulated hashSource data)

Stacked on #1241.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces the `fast-json-stable-stringify` npm dependency with a ~35-line inline implementation that is a faithful drop-in for the plain-object use cases in `hashSource`, `hashTemplate`, and `oldHashJsxChildren`. The inline implementation correctly sorts object keys, maps non-finite numbers and explicit `undefined` values to `null`/skip (matching library and `JSON.stringify` semantics), and delegates primitive serialization to `JSON.stringify`.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the only finding is a minor style suggestion on the falsy guard in the new utility.

All three call sites pass plain JSON-compatible objects; the inline implementation is behaviourally equivalent to the removed library for those inputs. 605 + 1831 tests pass including hardcoded hash assertions, so there is no hash drift. The single P2 comment is a readability nit.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/utils/stableStringify.ts | New inline stable-stringify implementation; correctly sorts keys, handles undefined/null/NaN/Infinity, and delegates primitives to JSON.stringify. One minor style note: `!value` guard should be `=== undefined`. |
| packages/core/src/id/hashSource.ts | Import swapped from `fast-json-stable-stringify` to the new inline utility; no other changes. |
| packages/core/src/id/hashTemplate.ts | Import swapped from `fast-json-stable-stringify` to the new inline utility; no other changes. |
| packages/core/src/backwards-compatability/oldHashJsxChildren.ts | Import swapped from `fast-json-stable-stringify` to the new inline utility; no other changes. |
| packages/core/package.json | `fast-json-stable-stringify` removed from dependencies; clean dep reduction. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[hashSource / hashTemplate / oldHashJsxChildren] -->|stringify call| B[stableStringify]
    B --> C{node type?}
    C -->|undefined| D[return undefined]
    C -->|null| E[return 'null']
    C -->|non-finite number| F[return 'null']
    C -->|finite number| G[return '' + node]
    C -->|other primitive| H[return JSON.stringify node]
    C -->|Array| I[recurse each element\nundefined → 'null']
    C -->|Object| J[sort keys\nskip undefined values\nrecurse each value]
    B -->|result ?? ''| K[string passed to sha256 hash]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/core/src/utils/stableStringify.ts
Line: 25

Comment:
The guard `if (!value)` is technically correct here — `_stringify` only ever returns `undefined` or a non-empty string — but it's subtly misleading. A reader might wonder whether the empty-string `''` case is intentionally dropped, or whether falsy numbers/booleans could sneak through. Using the explicit `=== undefined` form makes the intent unambiguous and future-proof if the return type ever widens.

```suggestion
    if (value === undefined) continue;
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(core): inline stable-stringify, dr..."](https://github.com/generaltranslation/gt/commit/3569a110ec7494bdd333f838e8f3b4e875a751d4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29560260)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->