### PR TITLE
F/mintlify ref

### DIFF
--- a/.changeset/rich-falcons-mate.md
+++ b/.changeset/rich-falcons-mate.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+Handling Mintlify $ref

--- a/packages/cli/src/api/downloadFileBatch.ts
+++ b/packages/cli/src/api/downloadFileBatch.ts
@@ -9,6 +9,7 @@ import { mergeJson } from '../formats/json/mergeJson.js';
 import { extractJson } from '../formats/json/extractJson.js';
 import mergeYaml from '../formats/yaml/mergeYaml.js';
 import { extractYaml } from '../formats/yaml/extractYaml.js';
+import { resolveMintlifyRefs, shouldResolveRefs } from '../utils/resolveMintlifyRefs.js';
 import {
   readLockfile,
   writeLockfile,
@@ -44,8 +45,19 @@ function mergeWithSource(
   if (!sourceContent) return translatedContent;
 
   if (jsonSchema) {
+    // Resolve $ref before merging if configured
+    let resolvedSourceContent = sourceContent;
+    if (shouldResolveRefs(inputPath, options.options)) {
+      try {
+        const json = JSON.parse(sourceContent);
+        const { resolved } = resolveMintlifyRefs(json, inputPath);
+        resolvedSourceContent = JSON.stringify(resolved, null, 2);
+      } catch {
+        // Fall through with original content
+      }
+    }
     return mergeJson(
-      sourceContent,
+      resolvedSourceContent,
       inputPath,
       options.options,
       [{ translatedContent, targetLocale: locale }],
@@ -178,7 +190,17 @@ export async function downloadFileBatch(
           // For schema-based files, re-merge with current source in case
           // non-translatable fields changed (skip the API download, not the merge)
           try {
-            const existingContent = fs.readFileSync(outputPath, 'utf8');
+            let existingContent = fs.readFileSync(outputPath, 'utf8');
+            // Resolve $ref before extraction if configured
+            if (shouldResolveRefs(outputPath, options.options)) {
+              try {
+                const json = JSON.parse(existingContent);
+                const { resolved } = resolveMintlifyRefs(json, outputPath);
+                existingContent = JSON.stringify(resolved, null, 2);
+              } catch {
+                // Fall through with original content
+              }
+            }
             const jsonExtracted = options.options?.jsonSchema
               ? extractJson(
                   existingContent,
@@ -297,3 +319,4 @@ export async function downloadFileBatch(
   }
   return result;
 }
+

--- a/packages/cli/src/api/downloadFileBatch.ts
+++ b/packages/cli/src/api/downloadFileBatch.ts
@@ -9,7 +9,10 @@ import { mergeJson } from '../formats/json/mergeJson.js';
 import { extractJson } from '../formats/json/extractJson.js';
 import mergeYaml from '../formats/yaml/mergeYaml.js';
 import { extractYaml } from '../formats/yaml/extractYaml.js';
-import { resolveMintlifyRefs, shouldResolveRefs } from '../utils/resolveMintlifyRefs.js';
+import {
+  resolveMintlifyRefs,
+  shouldResolveRefs,
+} from '../utils/resolveMintlifyRefs.js';
 import {
   readLockfile,
   writeLockfile,
@@ -319,4 +322,3 @@ export async function downloadFileBatch(
   }
   return result;
 }
-

--- a/packages/cli/src/cli/base.ts
+++ b/packages/cli/src/cli/base.ts
@@ -67,6 +67,7 @@ import {
 } from '../setup/frameworkUtils.js';
 import { INLINE_LIBRARIES } from '../types/libraries.js';
 import { handleEnqueue } from './commands/enqueue.js';
+import { splitMintlifyLanguageRefs } from '../utils/splitMintlifyLanguageRefs.js';
 
 export type UploadOptions = {
   config?: string;
@@ -304,6 +305,8 @@ export class BaseCLI {
     if (include.size > 0) {
       await postProcessTranslations(settings, include);
     }
+    // Split Mintlify language entries into $ref files to keep docs.json small
+    await splitMintlifyLanguageRefs(settings);
     // Mirror assets after translations are downloaded and locale dirs are populated
     await mirrorAssetsToLocales(settings);
     clearDownloaded();

--- a/packages/cli/src/cli/commands/upload.ts
+++ b/packages/cli/src/cli/commands/upload.ts
@@ -13,10 +13,8 @@ import { UploadOptions } from '../base.js';
 import sanitizeFileContent from '../../utils/sanitizeFileContent.js';
 import { parseJson } from '../../formats/json/parseJson.js';
 import { extractJson } from '../../formats/json/extractJson.js';
-import {
-  validateJsonSchema,
-  detectMintlifyUnsupportedFields,
-} from '../../formats/json/utils.js';
+import { validateJsonSchema } from '../../formats/json/utils.js';
+import { resolveMintlifyRefs, shouldResolveRefs } from '../../utils/resolveMintlifyRefs.js';
 import { runUploadFilesWorkflow } from '../../workflows/upload.js';
 import { existsSync, readFileSync } from 'node:fs';
 import { createFileMapping } from '../../formats/files/fileMapping.js';
@@ -62,20 +60,20 @@ export async function upload(
     const jsonFiles = filePaths.json.map((filePath) => {
       const content = readFile(filePath);
 
-      // Detect unsupported fields in Mintlify docs.json
-      if (
-        settings.framework === 'mintlify' &&
-        path.basename(filePath) === 'docs.json'
-      ) {
+      // Resolve $ref before parsing if configured
+      let contentForParsing = content;
+      if (shouldResolveRefs(filePath, additionalOptions)) {
         try {
-          detectMintlifyUnsupportedFields(JSON.parse(content), filePath);
+          const json = JSON.parse(content);
+          const { resolved } = resolveMintlifyRefs(json, filePath);
+          contentForParsing = JSON.stringify(resolved, null, 2);
         } catch {
           // JSON parse errors are handled below by parseJson
         }
       }
 
       const parsedJson = parseJson(
-        content,
+        contentForParsing,
         filePath,
         additionalOptions,
         settings.defaultLocale

--- a/packages/cli/src/cli/commands/upload.ts
+++ b/packages/cli/src/cli/commands/upload.ts
@@ -14,7 +14,10 @@ import sanitizeFileContent from '../../utils/sanitizeFileContent.js';
 import { parseJson } from '../../formats/json/parseJson.js';
 import { extractJson } from '../../formats/json/extractJson.js';
 import { validateJsonSchema } from '../../formats/json/utils.js';
-import { resolveMintlifyRefs, shouldResolveRefs } from '../../utils/resolveMintlifyRefs.js';
+import {
+  resolveMintlifyRefs,
+  shouldResolveRefs,
+} from '../../utils/resolveMintlifyRefs.js';
 import { runUploadFilesWorkflow } from '../../workflows/upload.js';
 import { existsSync, readFileSync } from 'node:fs';
 import { createFileMapping } from '../../formats/files/fileMapping.js';

--- a/packages/cli/src/formats/files/aggregateFiles.ts
+++ b/packages/cli/src/formats/files/aggregateFiles.ts
@@ -5,7 +5,8 @@ import { Settings } from '../../types/index.js';
 import type { FileFormat, DataFormat, FileToUpload } from '../../types/data.js';
 import { SUPPORTED_FILE_EXTENSIONS } from './supportedFiles.js';
 import { parseJson } from '../json/parseJson.js';
-import { detectMintlifyUnsupportedFields } from '../json/utils.js';
+import { resolveMintlifyRefs, shouldResolveRefs } from '../../utils/resolveMintlifyRefs.js';
+import { storeRefMap } from '../../state/mintlifyRefMap.js';
 import path from 'node:path';
 import parseYaml from '../yaml/parseYaml.js';
 import { validateYamlSchema } from '../yaml/utils.js';
@@ -100,20 +101,21 @@ export async function aggregateFiles(
           }
         }
 
-        // Detect unsupported fields in Mintlify docs.json
-        if (
-          settings.framework === 'mintlify' &&
-          path.basename(filePath) === 'docs.json'
-        ) {
+        // Resolve $ref before parsing if configured
+        let contentForParsing = content;
+        if (shouldResolveRefs(filePath, settings.options)) {
           try {
-            detectMintlifyUnsupportedFields(JSON.parse(content), filePath);
+            const json = JSON.parse(content);
+            const { resolved, refMap } = resolveMintlifyRefs(json, filePath);
+            storeRefMap(refMap);
+            contentForParsing = JSON.stringify(resolved, null, 2);
           } catch {
             // JSON parse errors are handled below by parseJson
           }
         }
 
         const parsedJson = parseJson(
-          content,
+          contentForParsing,
           filePath,
           settings.options || {},
           settings.defaultLocale

--- a/packages/cli/src/formats/files/aggregateFiles.ts
+++ b/packages/cli/src/formats/files/aggregateFiles.ts
@@ -5,7 +5,10 @@ import { Settings } from '../../types/index.js';
 import type { FileFormat, DataFormat, FileToUpload } from '../../types/data.js';
 import { SUPPORTED_FILE_EXTENSIONS } from './supportedFiles.js';
 import { parseJson } from '../json/parseJson.js';
-import { resolveMintlifyRefs, shouldResolveRefs } from '../../utils/resolveMintlifyRefs.js';
+import {
+  resolveMintlifyRefs,
+  shouldResolveRefs,
+} from '../../utils/resolveMintlifyRefs.js';
 import { storeRefMap } from '../../state/mintlifyRefMap.js';
 import path from 'node:path';
 import parseYaml from '../yaml/parseYaml.js';

--- a/packages/cli/src/state/mintlifyRefMap.ts
+++ b/packages/cli/src/state/mintlifyRefMap.ts
@@ -1,15 +1,17 @@
 import type { RefMap } from '../utils/resolveMintlifyRefs.js';
 
-let storedRefMap: RefMap | null = null;
+let storedRefMap: RefMap = new Map();
 
 export function storeRefMap(refMap: RefMap): void {
-  storedRefMap = refMap;
+  for (const [key, value] of refMap.entries()) {
+    storedRefMap.set(key, value);
+  }
 }
 
 export function getStoredRefMap(): RefMap | null {
-  return storedRefMap;
+  return storedRefMap.size > 0 ? storedRefMap : null;
 }
 
 export function clearStoredRefMap(): void {
-  storedRefMap = null;
+  storedRefMap = new Map();
 }

--- a/packages/cli/src/state/mintlifyRefMap.ts
+++ b/packages/cli/src/state/mintlifyRefMap.ts
@@ -1,0 +1,15 @@
+import type { RefMap } from '../utils/resolveMintlifyRefs.js';
+
+let storedRefMap: RefMap | null = null;
+
+export function storeRefMap(refMap: RefMap): void {
+  storedRefMap = refMap;
+}
+
+export function getStoredRefMap(): RefMap | null {
+  return storedRefMap;
+}
+
+export function clearStoredRefMap(): void {
+  storedRefMap = null;
+}

--- a/packages/cli/src/utils/__tests__/resolveMintlifyRefs.test.ts
+++ b/packages/cli/src/utils/__tests__/resolveMintlifyRefs.test.ts
@@ -389,4 +389,92 @@ describe('resolveMintlifyRefs', () => {
     expect(navEntry).toBeDefined();
     expect(navEntry!.originalContent).toEqual(navContent);
   });
+
+  it('records refPath and containingDir in refMap entries', () => {
+    setupFiles({
+      '/project/config/nav.json': {
+        groups: [{ $ref: './groups/api.json' }],
+      },
+      '/project/config/groups/api.json': {
+        group: 'API',
+        pages: ['api/users'],
+      },
+    });
+
+    const json = { navigation: { $ref: './config/nav.json' } };
+    const { refMap } = resolveMintlifyRefs(json, '/project/docs.json');
+
+    const navEntry = refMap.get('/navigation');
+    expect(navEntry!.refPath).toBe('./config/nav.json');
+    expect(navEntry!.containingDir).toBe(path.resolve('/project'));
+
+    const apiEntry = refMap.get('/navigation/groups/0');
+    expect(apiEntry!.refPath).toBe('./groups/api.json');
+    expect(apiEntry!.containingDir).toBe(
+      path.resolve('/project/config')
+    );
+  });
+
+  it('handles $ref resolving to a non-object (string)', () => {
+    setupFiles({
+      '/project/config/description.json': 'A simple string value',
+    });
+
+    // $ref resolves to a string — Mintlify drops sibling keys
+    const json = {
+      description: { $ref: './config/description.json', extra: 'dropped' },
+    };
+    const { resolved } = resolveMintlifyRefs(json, '/project/docs.json');
+
+    // Non-object: sibling keys are dropped, value replaces the object
+    expect((resolved as any).description).toBe('A simple string value');
+  });
+
+  it('handles multiple $ref at the same level', () => {
+    setupFiles({
+      '/project/config/nav.json': { groups: [] },
+      '/project/config/navbar.json': {
+        links: [{ label: 'Support' }],
+      },
+      '/project/config/footer.json': {
+        socials: { github: 'https://github.com/acme' },
+      },
+    });
+
+    const json = {
+      navigation: { $ref: './config/nav.json' },
+      navbar: { $ref: './config/navbar.json' },
+      footer: { $ref: './config/footer.json' },
+    };
+
+    const { resolved, refMap } = resolveMintlifyRefs(
+      json,
+      '/project/docs.json'
+    );
+
+    expect(resolved).toEqual({
+      navigation: { groups: [] },
+      navbar: { links: [{ label: 'Support' }] },
+      footer: { socials: { github: 'https://github.com/acme' } },
+    });
+    expect(refMap.size).toBe(3);
+  });
+
+  it('handles shouldResolveRefs correctly', async () => {
+    const { shouldResolveRefs } = await import('../resolveMintlifyRefs');
+
+    expect(shouldResolveRefs('/project/docs.json', undefined)).toBe(false);
+    expect(shouldResolveRefs('/project/docs.json', {})).toBe(false);
+    expect(
+      shouldResolveRefs('/project/docs.json', {
+        mintlify: { inferTitleFromFilename: true },
+      })
+    ).toBe(false);
+    expect(
+      shouldResolveRefs('/project/docs.json', {
+        mintlify: { inferTitleFromFilename: true },
+        jsonSchema: { './other.json': { composite: {} } },
+      })
+    ).toBe(false);
+  });
 });

--- a/packages/cli/src/utils/__tests__/resolveMintlifyRefs.test.ts
+++ b/packages/cli/src/utils/__tests__/resolveMintlifyRefs.test.ts
@@ -51,7 +51,10 @@ describe('resolveMintlifyRefs', () => {
       name: 'My Docs',
       navigation: { groups: [{ group: 'Home', pages: ['index'] }] },
     };
-    const { resolved, refMap } = resolveMintlifyRefs(json, '/project/docs.json');
+    const { resolved, refMap } = resolveMintlifyRefs(
+      json,
+      '/project/docs.json'
+    );
     expect(resolved).toEqual(json);
     expect(refMap.size).toBe(0);
   });
@@ -68,7 +71,10 @@ describe('resolveMintlifyRefs', () => {
       navigation: { $ref: './config/nav.json' },
     };
 
-    const { resolved, refMap } = resolveMintlifyRefs(json, '/project/docs.json');
+    const { resolved, refMap } = resolveMintlifyRefs(
+      json,
+      '/project/docs.json'
+    );
 
     expect(resolved).toEqual({
       name: 'My Docs',
@@ -136,9 +142,7 @@ describe('resolveMintlifyRefs', () => {
 
   it('drops sibling keys when $ref resolves to a non-object', () => {
     setupFiles({
-      '/project/config/groups.json': [
-        { group: 'Home', pages: ['index'] },
-      ],
+      '/project/config/groups.json': [{ group: 'Home', pages: ['index'] }],
     });
 
     const json = {
@@ -171,7 +175,10 @@ describe('resolveMintlifyRefs', () => {
       navigation: { $ref: './config/nav.json' },
     };
 
-    const { resolved, refMap } = resolveMintlifyRefs(json, '/project/docs.json');
+    const { resolved, refMap } = resolveMintlifyRefs(
+      json,
+      '/project/docs.json'
+    );
 
     expect(resolved).toEqual({
       navigation: {
@@ -282,14 +289,14 @@ describe('resolveMintlifyRefs', () => {
 
     const json = {
       navigation: {
-        groups: [
-          { $ref: './groups/home.json' },
-          { $ref: './groups/api.json' },
-        ],
+        groups: [{ $ref: './groups/home.json' }, { $ref: './groups/api.json' }],
       },
     };
 
-    const { resolved, refMap } = resolveMintlifyRefs(json, '/project/docs.json');
+    const { resolved, refMap } = resolveMintlifyRefs(
+      json,
+      '/project/docs.json'
+    );
 
     expect(resolved).toEqual({
       navigation: {

--- a/packages/cli/src/utils/__tests__/resolveMintlifyRefs.test.ts
+++ b/packages/cli/src/utils/__tests__/resolveMintlifyRefs.test.ts
@@ -410,9 +410,7 @@ describe('resolveMintlifyRefs', () => {
 
     const apiEntry = refMap.get('/navigation/groups/0');
     expect(apiEntry!.refPath).toBe('./groups/api.json');
-    expect(apiEntry!.containingDir).toBe(
-      path.resolve('/project/config')
-    );
+    expect(apiEntry!.containingDir).toBe(path.resolve('/project/config'));
   });
 
   it('handles $ref resolving to a non-object (string)', () => {

--- a/packages/cli/src/utils/__tests__/resolveMintlifyRefs.test.ts
+++ b/packages/cli/src/utils/__tests__/resolveMintlifyRefs.test.ts
@@ -1,0 +1,385 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import path from 'node:path';
+import { resolveMintlifyRefs } from '../resolveMintlifyRefs';
+
+// Mock fs and logger
+vi.mock('node:fs', () => ({
+  default: {
+    existsSync: vi.fn(),
+    readFileSync: vi.fn(),
+  },
+}));
+
+vi.mock('../../console/logger.js', () => ({
+  logger: {
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+import fs from 'node:fs';
+import { logger } from '../../console/logger.js';
+
+const mockExists = vi.mocked(fs.existsSync);
+const mockRead = vi.mocked(fs.readFileSync);
+
+function setupFiles(files: Record<string, unknown>) {
+  const resolvedFiles: Record<string, string> = {};
+  for (const [filePath, content] of Object.entries(files)) {
+    resolvedFiles[path.resolve(filePath)] = JSON.stringify(content);
+  }
+
+  mockExists.mockImplementation((p) => {
+    return path.resolve(p as string) in resolvedFiles;
+  });
+
+  mockRead.mockImplementation((p) => {
+    const resolved = path.resolve(p as string);
+    if (resolved in resolvedFiles) return resolvedFiles[resolved];
+    throw new Error(`ENOENT: ${resolved}`);
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('resolveMintlifyRefs', () => {
+  it('returns json unchanged when no $ref present', () => {
+    const json = {
+      name: 'My Docs',
+      navigation: { groups: [{ group: 'Home', pages: ['index'] }] },
+    };
+    const { resolved, refMap } = resolveMintlifyRefs(json, '/project/docs.json');
+    expect(resolved).toEqual(json);
+    expect(refMap.size).toBe(0);
+  });
+
+  it('resolves a top-level $ref to an object', () => {
+    setupFiles({
+      '/project/config/nav.json': {
+        groups: [{ group: 'Home', pages: ['index'] }],
+      },
+    });
+
+    const json = {
+      name: 'My Docs',
+      navigation: { $ref: './config/nav.json' },
+    };
+
+    const { resolved, refMap } = resolveMintlifyRefs(json, '/project/docs.json');
+
+    expect(resolved).toEqual({
+      name: 'My Docs',
+      navigation: {
+        groups: [{ group: 'Home', pages: ['index'] }],
+      },
+    });
+    expect(refMap.size).toBe(1);
+    expect(refMap.has('/navigation')).toBe(true);
+    expect(refMap.get('/navigation')!.sourceFile).toBe(
+      path.resolve('/project/config/nav.json')
+    );
+  });
+
+  it('resolves a $ref to an array (non-object)', () => {
+    setupFiles({
+      '/project/config/groups.json': [
+        { group: 'Home', pages: ['index'] },
+        { group: 'API', pages: ['api/overview'] },
+      ],
+    });
+
+    const json = {
+      navigation: {
+        groups: { $ref: './config/groups.json' },
+      },
+    };
+
+    const { resolved } = resolveMintlifyRefs(json, '/project/docs.json');
+
+    expect(resolved).toEqual({
+      navigation: {
+        groups: [
+          { group: 'Home', pages: ['index'] },
+          { group: 'API', pages: ['api/overview'] },
+        ],
+      },
+    });
+  });
+
+  it('merges sibling keys on top when $ref resolves to an object', () => {
+    setupFiles({
+      '/project/config/appearance.json': {
+        default: 'system',
+        strict: false,
+      },
+    });
+
+    const json = {
+      appearance: {
+        $ref: './config/appearance.json',
+        strict: true,
+      },
+    };
+
+    const { resolved } = resolveMintlifyRefs(json, '/project/docs.json');
+
+    expect(resolved).toEqual({
+      appearance: {
+        default: 'system',
+        strict: true, // sibling overrides ref content
+      },
+    });
+  });
+
+  it('drops sibling keys when $ref resolves to a non-object', () => {
+    setupFiles({
+      '/project/config/groups.json': [
+        { group: 'Home', pages: ['index'] },
+      ],
+    });
+
+    const json = {
+      navigation: {
+        $ref: './config/groups.json',
+        extra: 'ignored',
+      },
+    };
+
+    const { resolved } = resolveMintlifyRefs(json, '/project/docs.json');
+
+    // Non-object: siblings are dropped
+    expect(resolved).toEqual({
+      navigation: [{ group: 'Home', pages: ['index'] }],
+    });
+  });
+
+  it('resolves nested $ref chains', () => {
+    setupFiles({
+      '/project/config/nav.json': {
+        groups: [{ $ref: './groups/api.json' }],
+      },
+      '/project/config/groups/api.json': {
+        group: 'API Reference',
+        pages: ['api/users', 'api/posts'],
+      },
+    });
+
+    const json = {
+      navigation: { $ref: './config/nav.json' },
+    };
+
+    const { resolved, refMap } = resolveMintlifyRefs(json, '/project/docs.json');
+
+    expect(resolved).toEqual({
+      navigation: {
+        groups: [
+          {
+            group: 'API Reference',
+            pages: ['api/users', 'api/posts'],
+          },
+        ],
+      },
+    });
+
+    // Both refs tracked
+    expect(refMap.size).toBe(2);
+    expect(refMap.has('/navigation')).toBe(true);
+    expect(refMap.has('/navigation/groups/0')).toBe(true);
+
+    // Nested ref resolves relative to its containing file
+    expect(refMap.get('/navigation/groups/0')!.sourceFile).toBe(
+      path.resolve('/project/config/groups/api.json')
+    );
+  });
+
+  it('detects circular references and warns', () => {
+    setupFiles({
+      '/project/config/a.json': { $ref: './b.json' },
+      '/project/config/b.json': { $ref: './a.json' },
+    });
+
+    const json = { data: { $ref: './config/a.json' } };
+
+    const { resolved } = resolveMintlifyRefs(json, '/project/docs.json');
+
+    // Should not throw — gracefully returns what it can
+    expect(resolved).toBeDefined();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Circular')
+    );
+  });
+
+  it('warns and skips non-relative paths', () => {
+    const json = {
+      navigation: { $ref: '/absolute/path.json' },
+    };
+
+    const { resolved } = resolveMintlifyRefs(json, '/project/docs.json');
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('non-relative')
+    );
+    // $ref removed, siblings preserved (empty object in this case)
+    expect(resolved).toEqual({ navigation: {} });
+  });
+
+  it('warns and skips URL refs', () => {
+    const json = {
+      navigation: { $ref: 'https://example.com/nav.json' },
+    };
+
+    const { resolved } = resolveMintlifyRefs(json, '/project/docs.json');
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('non-relative')
+    );
+  });
+
+  it('warns when referenced file does not exist', () => {
+    mockExists.mockReturnValue(false);
+
+    const json = {
+      navigation: { $ref: './missing.json' },
+    };
+
+    const { resolved } = resolveMintlifyRefs(json, '/project/docs.json');
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('not found')
+    );
+    expect(resolved).toEqual({ navigation: {} });
+  });
+
+  it('warns when referenced file is not valid JSON', () => {
+    mockExists.mockReturnValue(true);
+    mockRead.mockReturnValue('not json {{{');
+
+    const json = {
+      navigation: { $ref: './bad.json' },
+    };
+
+    const { resolved } = resolveMintlifyRefs(json, '/project/docs.json');
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('not valid JSON')
+    );
+  });
+
+  it('handles $ref inside arrays', () => {
+    setupFiles({
+      '/project/groups/home.json': {
+        group: 'Home',
+        pages: ['index', 'quickstart'],
+      },
+      '/project/groups/api.json': {
+        group: 'API',
+        pages: ['api/overview'],
+      },
+    });
+
+    const json = {
+      navigation: {
+        groups: [
+          { $ref: './groups/home.json' },
+          { $ref: './groups/api.json' },
+        ],
+      },
+    };
+
+    const { resolved, refMap } = resolveMintlifyRefs(json, '/project/docs.json');
+
+    expect(resolved).toEqual({
+      navigation: {
+        groups: [
+          { group: 'Home', pages: ['index', 'quickstart'] },
+          { group: 'API', pages: ['api/overview'] },
+        ],
+      },
+    });
+    expect(refMap.size).toBe(2);
+  });
+
+  it('preserves non-$ref objects untouched', () => {
+    const json = {
+      colors: { primary: '#ff0000', light: '#ffffff' },
+      name: 'Docs',
+      navigation: { groups: [] },
+    };
+
+    const { resolved } = resolveMintlifyRefs(json, '/project/docs.json');
+    expect(resolved).toEqual(json);
+  });
+
+  it('handles deeply nested structures', () => {
+    setupFiles({
+      '/project/config/nav.json': {
+        tabs: [
+          {
+            tab: 'Guides',
+            groups: [
+              {
+                group: 'Getting Started',
+                pages: ['intro'],
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const json = {
+      theme: 'mint',
+      navigation: {
+        $ref: './config/nav.json',
+        languages: [{ language: 'en' }],
+      },
+    };
+
+    const { resolved } = resolveMintlifyRefs(json, '/project/docs.json');
+
+    // $ref resolves to an object, so siblings merge on top
+    expect(resolved).toEqual({
+      theme: 'mint',
+      navigation: {
+        tabs: [
+          {
+            tab: 'Guides',
+            groups: [
+              {
+                group: 'Getting Started',
+                pages: ['intro'],
+              },
+            ],
+          },
+        ],
+        languages: [{ language: 'en' }],
+      },
+    });
+  });
+
+  it('records original (pre-resolution) content in refMap', () => {
+    const navContent = {
+      groups: [{ $ref: './groups/api.json' }],
+    };
+    const apiContent = {
+      group: 'API',
+      pages: ['api/users'],
+    };
+
+    setupFiles({
+      '/project/config/nav.json': navContent,
+      '/project/config/groups/api.json': apiContent,
+    });
+
+    const json = { navigation: { $ref: './config/nav.json' } };
+    const { refMap } = resolveMintlifyRefs(json, '/project/docs.json');
+
+    // originalContent is the raw parsed content before nested resolution
+    const navEntry = refMap.get('/navigation');
+    expect(navEntry).toBeDefined();
+    expect(navEntry!.originalContent).toEqual(navContent);
+  });
+});

--- a/packages/cli/src/utils/__tests__/splitMintlifyLanguageRefs.test.ts
+++ b/packages/cli/src/utils/__tests__/splitMintlifyLanguageRefs.test.ts
@@ -26,6 +26,7 @@ vi.mock('../../console/logger.js', () => ({
 let mockRefMap: RefMap | null = null;
 vi.mock('../../state/mintlifyRefMap.js', () => ({
   getStoredRefMap: () => mockRefMap,
+  clearStoredRefMap: vi.fn(),
 }));
 
 // Mock shouldResolveRefs to return true for the test docs.json path

--- a/packages/cli/src/utils/__tests__/splitMintlifyLanguageRefs.test.ts
+++ b/packages/cli/src/utils/__tests__/splitMintlifyLanguageRefs.test.ts
@@ -171,9 +171,10 @@ describe('splitMintlifyLanguageRefs', () => {
       $ref: './es/navigation.json',
     });
 
-    // es/navigation.json should have prefixed $ref for tabs
+    // es/navigation.json should have original $ref paths (not prefixed —
+    // the file is already in the locale dir, so relative resolution works)
     const esNav = getWritten('/project/config/es/navigation.json');
-    expect(esNav.tabs[0]).toEqual({ $ref: './es/tabs/guides.json' });
+    expect(esNav.tabs[0]).toEqual({ $ref: './tabs/guides.json' });
 
     // es locale ref file should be written with translated content
     const esGuides = getWritten('/project/config/es/tabs/guides.json');
@@ -261,9 +262,9 @@ describe('splitMintlifyLanguageRefs', () => {
       $ref: './es/navigation.json',
     });
 
-    // es/navigation.json should have prefixed top-level refs
+    // es/navigation.json should have original $ref paths (not prefixed)
     const esNav = getWritten('/project/config/es/navigation.json');
-    expect(esNav.tabs[0]).toEqual({ $ref: './es/tabs/guides.json' });
+    expect(esNav.tabs[0]).toEqual({ $ref: './tabs/guides.json' });
 
     // es guides file: nested ref keeps original path
     const esGuides = getWritten('/project/config/es/tabs/guides.json');
@@ -272,5 +273,205 @@ describe('splitMintlifyLanguageRefs', () => {
     // es api group should be written
     const esApi = getWritten('/project/config/es/groups/api.json');
     expect(esApi.group).toBe('API');
+  });
+
+  it('handles multiple target locales', async () => {
+    const mergedDocsJson = {
+      navigation: {
+        languages: [
+          { language: 'en', tabs: [{ tab: 'Guides', groups: [] }] },
+          { language: 'es', tabs: [{ tab: 'Guías', groups: [] }] },
+          { language: 'fr', tabs: [{ tab: 'Guides (fr)', groups: [] }] },
+          { language: 'de', tabs: [{ tab: 'Anleitungen', groups: [] }] },
+        ],
+      },
+    };
+
+    mockRead.mockImplementation((p) => {
+      const resolved = path.resolve(p as string);
+      if (resolved === path.resolve('/project/docs.json'))
+        return JSON.stringify(mergedDocsJson);
+      if (resolved === path.resolve('/project/config/navigation.json'))
+        return JSON.stringify(mergedDocsJson.navigation);
+      throw new Error('ENOENT');
+    });
+
+    mockRefMap = new Map([
+      [
+        '/navigation',
+        {
+          sourceFile: path.resolve('/project/config/navigation.json'),
+          refPath: './config/navigation.json',
+          containingDir: '/project',
+          originalContent: {},
+        },
+      ],
+    ]);
+
+    await splitMintlifyLanguageRefs(
+      makeSettings({ locales: ['en', 'es', 'fr', 'de'] })
+    );
+
+    const navResult = getWritten('/project/config/navigation.json');
+
+    // en stays inline
+    expect(navResult.languages[0].language).toBe('en');
+    expect(navResult.languages[0].tabs).toBeDefined();
+
+    // All non-default locales get their own ref file
+    expect(navResult.languages[1]).toEqual({
+      language: 'es',
+      $ref: './es/navigation.json',
+    });
+    expect(navResult.languages[2]).toEqual({
+      language: 'fr',
+      $ref: './fr/navigation.json',
+    });
+    expect(navResult.languages[3]).toEqual({
+      language: 'de',
+      $ref: './de/navigation.json',
+    });
+
+    // Each locale file should have translated content
+    const esNav = getWritten('/project/config/es/navigation.json');
+    expect(esNav.tabs[0].tab).toBe('Guías');
+    const frNav = getWritten('/project/config/fr/navigation.json');
+    expect(frNav.tabs[0].tab).toBe('Guides (fr)');
+    const deNav = getWritten('/project/config/de/navigation.json');
+    expect(deNav.tabs[0].tab).toBe('Anleitungen');
+  });
+
+  it('handles inline navigation (no $ref in source)', async () => {
+    const mergedDocsJson = {
+      navigation: {
+        languages: [
+          { language: 'en', groups: [{ group: 'Home', pages: ['index'] }] },
+          {
+            language: 'es',
+            groups: [{ group: 'Inicio', pages: ['es/index'] }],
+          },
+        ],
+      },
+    };
+
+    mockRead.mockImplementation((p) => {
+      if (path.resolve(p as string) === path.resolve('/project/docs.json'))
+        return JSON.stringify(mergedDocsJson);
+      throw new Error('ENOENT');
+    });
+
+    // No $ref entries — navigation is inline in docs.json
+    mockRefMap = new Map();
+
+    await splitMintlifyLanguageRefs(makeSettings());
+
+    // Empty refMap → function exits early, no writes
+    expect(mockWrite).not.toHaveBeenCalled();
+  });
+
+  it('handles default locale not being first in the array', async () => {
+    const mergedDocsJson = {
+      navigation: {
+        languages: [
+          { language: 'es', tabs: [{ tab: 'Guías', groups: [] }] },
+          { language: 'en', tabs: [{ tab: 'Guides', groups: [] }] },
+        ],
+      },
+    };
+
+    mockRead.mockImplementation((p) => {
+      const resolved = path.resolve(p as string);
+      if (resolved === path.resolve('/project/docs.json'))
+        return JSON.stringify(mergedDocsJson);
+      if (resolved === path.resolve('/project/config/navigation.json'))
+        return JSON.stringify(mergedDocsJson.navigation);
+      throw new Error('ENOENT');
+    });
+
+    mockRefMap = new Map([
+      [
+        '/navigation',
+        {
+          sourceFile: path.resolve('/project/config/navigation.json'),
+          refPath: './config/navigation.json',
+          containingDir: '/project',
+          originalContent: {},
+        },
+      ],
+      [
+        '/navigation/languages/1/tabs/0',
+        {
+          sourceFile: path.resolve('/project/config/tabs/guides.json'),
+          refPath: './tabs/guides.json',
+          containingDir: '/project/config',
+          originalContent: {},
+        },
+      ],
+    ]);
+
+    await splitMintlifyLanguageRefs(makeSettings());
+
+    const navResult = getWritten('/project/config/navigation.json');
+
+    // es (index 0) gets a ref file since it's not default
+    expect(navResult.languages[0]).toEqual({
+      language: 'es',
+      $ref: './es/navigation.json',
+    });
+
+    // en (index 1, default) keeps inline with restored $ref
+    expect(navResult.languages[1].language).toBe('en');
+    expect(navResult.languages[1].tabs[0]).toEqual({
+      $ref: './tabs/guides.json',
+    });
+  });
+
+  it('idempotent on re-run (locale ref files already exist)', async () => {
+    // Simulates state after a previous run: docs.json is inlined by merge,
+    // but the refMap still has the original topology from the read phase.
+    const mergedDocsJson = {
+      navigation: {
+        languages: [
+          { language: 'en', tabs: [{ tab: 'Guides', groups: [] }] },
+          { language: 'es', tabs: [{ tab: 'Guías', groups: [] }] },
+        ],
+      },
+    };
+
+    mockRead.mockImplementation((p) => {
+      const resolved = path.resolve(p as string);
+      if (resolved === path.resolve('/project/docs.json'))
+        return JSON.stringify(mergedDocsJson);
+      if (resolved === path.resolve('/project/config/navigation.json'))
+        return JSON.stringify(mergedDocsJson.navigation);
+      throw new Error('ENOENT');
+    });
+
+    mockRefMap = new Map([
+      [
+        '/navigation',
+        {
+          sourceFile: path.resolve('/project/config/navigation.json'),
+          refPath: './config/navigation.json',
+          containingDir: '/project',
+          originalContent: {},
+        },
+      ],
+    ]);
+
+    await splitMintlifyLanguageRefs(makeSettings());
+
+    const navResult = getWritten('/project/config/navigation.json');
+
+    // Should produce the same structure regardless of initial state
+    expect(navResult.languages[0].language).toBe('en');
+    expect(navResult.languages[0].tabs).toBeDefined();
+    expect(navResult.languages[1]).toEqual({
+      language: 'es',
+      $ref: './es/navigation.json',
+    });
+
+    const esNav = getWritten('/project/config/es/navigation.json');
+    expect(esNav.tabs[0].tab).toBe('Guías');
   });
 });

--- a/packages/cli/src/utils/__tests__/splitMintlifyLanguageRefs.test.ts
+++ b/packages/cli/src/utils/__tests__/splitMintlifyLanguageRefs.test.ts
@@ -30,11 +30,11 @@ vi.mock('../../state/mintlifyRefMap.js', () => ({
 
 // Mock shouldResolveRefs to return true for the test docs.json path
 vi.mock('../resolveMintlifyRefs.js', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../resolveMintlifyRefs.js')>();
+  const actual =
+    await importOriginal<typeof import('../resolveMintlifyRefs.js')>();
   return {
     ...actual,
-    shouldResolveRefs: (filePath: string) =>
-      filePath.includes('docs.json'),
+    shouldResolveRefs: (filePath: string) => filePath.includes('docs.json'),
   };
 });
 
@@ -74,9 +74,7 @@ beforeEach(() => {
 
 describe('splitMintlifyLanguageRefs', () => {
   it('skips when no mintlify options', async () => {
-    await splitMintlifyLanguageRefs(
-      makeSettings({ options: {} }) as Settings
-    );
+    await splitMintlifyLanguageRefs(makeSettings({ options: {} }) as Settings);
     expect(mockWrite).not.toHaveBeenCalled();
   });
 
@@ -191,9 +189,7 @@ describe('splitMintlifyLanguageRefs', () => {
             tabs: [
               {
                 tab: 'Guides',
-                groups: [
-                  { group: 'API', pages: ['api/users'] },
-                ],
+                groups: [{ group: 'API', pages: ['api/users'] }],
               },
             ],
           },
@@ -202,9 +198,7 @@ describe('splitMintlifyLanguageRefs', () => {
             tabs: [
               {
                 tab: 'Guías',
-                groups: [
-                  { group: 'API', pages: ['es/api/users'] },
-                ],
+                groups: [{ group: 'API', pages: ['es/api/users'] }],
               },
             ],
           },

--- a/packages/cli/src/utils/__tests__/splitMintlifyLanguageRefs.test.ts
+++ b/packages/cli/src/utils/__tests__/splitMintlifyLanguageRefs.test.ts
@@ -1,0 +1,281 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import path from 'node:path';
+import { splitMintlifyLanguageRefs } from '../splitMintlifyLanguageRefs';
+import type { Settings } from '../../types/index';
+import type { RefMap } from '../resolveMintlifyRefs';
+
+vi.mock('node:fs', () => ({
+  default: {
+    existsSync: vi.fn(),
+    readFileSync: vi.fn(),
+    writeFileSync: vi.fn(),
+    mkdirSync: vi.fn(),
+  },
+}));
+
+vi.mock('../../console/logger.js', () => ({
+  logger: {
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// Mock the stored refMap
+let mockRefMap: RefMap | null = null;
+vi.mock('../../state/mintlifyRefMap.js', () => ({
+  getStoredRefMap: () => mockRefMap,
+}));
+
+// Mock shouldResolveRefs to return true for the test docs.json path
+vi.mock('../resolveMintlifyRefs.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../resolveMintlifyRefs.js')>();
+  return {
+    ...actual,
+    shouldResolveRefs: (filePath: string) =>
+      filePath.includes('docs.json'),
+  };
+});
+
+import fs from 'node:fs';
+
+const mockExists = vi.mocked(fs.existsSync);
+const mockRead = vi.mocked(fs.readFileSync);
+const mockWrite = vi.mocked(fs.writeFileSync);
+
+function makeSettings(overrides: Partial<Settings> = {}): Settings {
+  return {
+    defaultLocale: 'en',
+    locales: ['en', 'es'],
+    files: {
+      resolvedPaths: { json: ['/project/docs.json'] },
+      placeholderPaths: {},
+    },
+    config: '/project/gt.config.json',
+    options: { mintlify: { inferTitleFromFilename: true } },
+    parsingOptions: {},
+    ...overrides,
+  } as Settings;
+}
+
+function getWritten(filePath: string): any {
+  const call = mockWrite.mock.calls.find(
+    (c) => path.resolve(c[0] as string) === path.resolve(filePath)
+  );
+  return call ? JSON.parse(call[1] as string) : undefined;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRefMap = null;
+  mockExists.mockReturnValue(true);
+});
+
+describe('splitMintlifyLanguageRefs', () => {
+  it('skips when no mintlify options', async () => {
+    await splitMintlifyLanguageRefs(
+      makeSettings({ options: {} }) as Settings
+    );
+    expect(mockWrite).not.toHaveBeenCalled();
+  });
+
+  it('skips when no stored refMap', async () => {
+    mockRefMap = null;
+    mockRead.mockReturnValue(JSON.stringify({ navigation: {} }));
+    await splitMintlifyLanguageRefs(makeSettings());
+    expect(mockWrite).not.toHaveBeenCalled();
+  });
+
+  it('restores top-level $ref and splits locale entries', async () => {
+    // Simulates post-merge state: docs.json is fully inlined
+    const mergedDocsJson = {
+      name: 'Acme',
+      navigation: {
+        languages: [
+          {
+            language: 'en',
+            tabs: [
+              { tab: 'Guides', groups: [{ group: 'Home', pages: ['intro'] }] },
+            ],
+          },
+          {
+            language: 'es',
+            tabs: [
+              {
+                tab: 'Guías',
+                groups: [{ group: 'Inicio', pages: ['es/intro'] }],
+              },
+            ],
+          },
+        ],
+      },
+      navbar: { links: [{ label: 'Support', href: '/support' }] },
+    };
+
+    mockRead.mockImplementation((p) => {
+      const resolved = path.resolve(p as string);
+      if (resolved === path.resolve('/project/docs.json'))
+        return JSON.stringify(mergedDocsJson);
+      if (resolved === path.resolve('/project/config/navigation.json'))
+        return JSON.stringify(mergedDocsJson.navigation);
+      throw new Error('ENOENT');
+    });
+
+    // RefMap from the read phase (before merge inlined everything)
+    mockRefMap = new Map([
+      [
+        '/navigation',
+        {
+          sourceFile: path.resolve('/project/config/navigation.json'),
+          refPath: './config/navigation.json',
+          containingDir: '/project',
+          originalContent: {},
+        },
+      ],
+      [
+        '/navbar',
+        {
+          sourceFile: path.resolve('/project/config/navbar.json'),
+          refPath: './config/navbar.json',
+          containingDir: '/project',
+          originalContent: {},
+        },
+      ],
+      [
+        '/navigation/languages/0/tabs/0',
+        {
+          sourceFile: path.resolve('/project/config/tabs/guides.json'),
+          refPath: './tabs/guides.json',
+          containingDir: '/project/config',
+          originalContent: {},
+        },
+      ],
+    ]);
+
+    await splitMintlifyLanguageRefs(makeSettings());
+
+    // docs.json should have $ref restored for navigation and navbar
+    const docsResult = getWritten('/project/docs.json');
+    expect(docsResult.navigation).toEqual({
+      $ref: './config/navigation.json',
+    });
+    expect(docsResult.navbar).toEqual({ $ref: './config/navbar.json' });
+
+    // navigation.json: en entry should have $ref restored, es should be a $ref
+    const navResult = getWritten('/project/config/navigation.json');
+    expect(navResult.languages[0].tabs[0]).toEqual({
+      $ref: './tabs/guides.json',
+    });
+    expect(navResult.languages[1]).toEqual({
+      language: 'es',
+      $ref: './es/navigation.json',
+    });
+
+    // es/navigation.json should have prefixed $ref for tabs
+    const esNav = getWritten('/project/config/es/navigation.json');
+    expect(esNav.tabs[0]).toEqual({ $ref: './es/tabs/guides.json' });
+
+    // es locale ref file should be written with translated content
+    const esGuides = getWritten('/project/config/es/tabs/guides.json');
+    expect(esGuides.tab).toBe('Guías');
+    expect(esGuides.groups[0].group).toBe('Inicio');
+  });
+
+  it('handles nested refs (refs within refs)', async () => {
+    const mergedDocsJson = {
+      navigation: {
+        languages: [
+          {
+            language: 'en',
+            tabs: [
+              {
+                tab: 'Guides',
+                groups: [
+                  { group: 'API', pages: ['api/users'] },
+                ],
+              },
+            ],
+          },
+          {
+            language: 'es',
+            tabs: [
+              {
+                tab: 'Guías',
+                groups: [
+                  { group: 'API', pages: ['es/api/users'] },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    mockRead.mockImplementation((p) => {
+      const resolved = path.resolve(p as string);
+      if (resolved === path.resolve('/project/docs.json'))
+        return JSON.stringify(mergedDocsJson);
+      if (resolved === path.resolve('/project/config/navigation.json'))
+        return JSON.stringify(mergedDocsJson.navigation);
+      throw new Error('ENOENT');
+    });
+
+    mockRefMap = new Map([
+      [
+        '/navigation',
+        {
+          sourceFile: path.resolve('/project/config/navigation.json'),
+          refPath: './config/navigation.json',
+          containingDir: '/project',
+          originalContent: {},
+        },
+      ],
+      [
+        '/navigation/languages/0/tabs/0',
+        {
+          sourceFile: path.resolve('/project/config/tabs/guides.json'),
+          refPath: './tabs/guides.json',
+          containingDir: '/project/config',
+          originalContent: {},
+        },
+      ],
+      [
+        '/navigation/languages/0/tabs/0/groups/0',
+        {
+          sourceFile: path.resolve('/project/config/groups/api.json'),
+          refPath: '../groups/api.json',
+          containingDir: '/project/config/tabs',
+          originalContent: {},
+        },
+      ],
+    ]);
+
+    await splitMintlifyLanguageRefs(makeSettings());
+
+    const navResult = getWritten('/project/config/navigation.json');
+
+    // en: nested refs restored
+    expect(navResult.languages[0].tabs[0]).toEqual({
+      $ref: './tabs/guides.json',
+    });
+
+    // es: entire entry is a $ref
+    expect(navResult.languages[1]).toEqual({
+      language: 'es',
+      $ref: './es/navigation.json',
+    });
+
+    // es/navigation.json should have prefixed top-level refs
+    const esNav = getWritten('/project/config/es/navigation.json');
+    expect(esNav.tabs[0]).toEqual({ $ref: './es/tabs/guides.json' });
+
+    // es guides file: nested ref keeps original path
+    const esGuides = getWritten('/project/config/es/tabs/guides.json');
+    expect(esGuides.groups[0]).toEqual({ $ref: '../groups/api.json' });
+
+    // es api group should be written
+    const esApi = getWritten('/project/config/es/groups/api.json');
+    expect(esApi.group).toBe('API');
+  });
+});

--- a/packages/cli/src/utils/resolveMintlifyRefs.ts
+++ b/packages/cli/src/utils/resolveMintlifyRefs.ts
@@ -1,0 +1,202 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { logger } from '../console/logger.js';
+import chalk from 'chalk';
+
+export type RefMapEntry = {
+  sourceFile: string;
+  refPath: string;
+  containingDir: string;
+  originalContent: unknown;
+};
+
+export type RefMap = Map<string, RefMapEntry>;
+
+export type ResolvedRefs = {
+  resolved: unknown;
+  refMap: RefMap;
+};
+
+/**
+ * Resolve all Mintlify $ref references in a parsed JSON object.
+ *
+ * Returns the fully-expanded JSON and a refMap that tracks which subtrees
+ * came from which files (used later to split translated output back into
+ * the same file topology).
+ */
+export function resolveMintlifyRefs(
+  json: unknown,
+  filePath: string
+): ResolvedRefs {
+  const refMap: RefMap = new Map();
+  const resolved = resolveNode(
+    json,
+    path.dirname(path.resolve(filePath)),
+    '',
+    new Set<string>(),
+    refMap
+  );
+  return { resolved, refMap };
+}
+
+function resolveNode(
+  node: unknown,
+  baseDir: string,
+  pointer: string,
+  visiting: Set<string>,
+  refMap: RefMap
+): unknown {
+  if (node === null || typeof node !== 'object') return node;
+
+  if (Array.isArray(node)) {
+    return node.map((item, i) =>
+      resolveNode(item, baseDir, `${pointer}/${i}`, visiting, refMap)
+    );
+  }
+
+  const obj = node as Record<string, unknown>;
+
+  if (typeof obj['$ref'] === 'string') {
+    return resolveRef(obj, baseDir, pointer, visiting, refMap);
+  }
+
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    result[key] = resolveNode(value, baseDir, `${pointer}/${key}`, visiting, refMap);
+  }
+  return result;
+}
+
+function resolveRef(
+  obj: Record<string, unknown>,
+  baseDir: string,
+  pointer: string,
+  visiting: Set<string>,
+  refMap: RefMap
+): unknown {
+  const refPath = obj['$ref'] as string;
+
+  if (!isRelativePath(refPath)) {
+    logger.warn(
+      chalk.yellow(
+        `Skipping non-relative $ref at ${pointer || '/'}: ${refPath}`
+      )
+    );
+    const { $ref: _, ...rest } = obj;
+    return rest;
+  }
+
+  const resolvedFilePath = path.resolve(baseDir, refPath);
+
+  if (visiting.has(resolvedFilePath)) {
+    logger.warn(
+      chalk.yellow(
+        `Circular $ref detected at ${pointer || '/'}: ${refPath}`
+      )
+    );
+    const { $ref: _, ...rest } = obj;
+    return rest;
+  }
+
+  if (!fs.existsSync(resolvedFilePath)) {
+    logger.warn(
+      chalk.yellow(
+        `$ref file not found at ${pointer || '/'}: ${refPath} (resolved to ${resolvedFilePath})`
+      )
+    );
+    const { $ref: _, ...rest } = obj;
+    return rest;
+  }
+
+  let fileContent: string;
+  try {
+    fileContent = fs.readFileSync(resolvedFilePath, 'utf-8');
+  } catch {
+    logger.warn(
+      chalk.yellow(`Failed to read $ref file: ${resolvedFilePath}`)
+    );
+    const { $ref: _, ...rest } = obj;
+    return rest;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fileContent);
+  } catch {
+    logger.warn(
+      chalk.yellow(`$ref file is not valid JSON: ${resolvedFilePath}`)
+    );
+    const { $ref: _, ...rest } = obj;
+    return rest;
+  }
+
+  // Record provenance before recursive resolution
+  refMap.set(pointer, {
+    sourceFile: resolvedFilePath,
+    refPath,
+    containingDir: baseDir,
+    originalContent: parsed,
+  });
+
+  // Recursively resolve nested $ref in the referenced file
+  const refFileDir = path.dirname(resolvedFilePath);
+  const nextVisiting = new Set(visiting);
+  nextVisiting.add(resolvedFilePath);
+
+  const resolvedContent = resolveNode(
+    parsed,
+    refFileDir,
+    pointer,
+    nextVisiting,
+    refMap
+  );
+
+  // Apply Mintlify merge rules
+  const { $ref: _, ...siblings } = obj;
+
+  if (
+    resolvedContent !== null &&
+    typeof resolvedContent === 'object' &&
+    !Array.isArray(resolvedContent)
+  ) {
+    // Object: merge siblings on top (siblings take precedence)
+    return { ...(resolvedContent as Record<string, unknown>), ...siblings };
+  }
+
+  // Non-object (array, string, number, etc.): replace entirely, drop siblings
+  return resolvedContent;
+}
+
+/**
+ * Check if a file should have $ref resolution applied based on the settings.
+ * Returns true if the file has mintlify options configured AND matches a
+ * composite jsonSchema entry.
+ */
+export function shouldResolveRefs(
+  filePath: string,
+  options?: { mintlify?: any; jsonSchema?: Record<string, any> }
+): boolean {
+  if (!options?.mintlify) return false;
+  if (!options.jsonSchema) return false;
+
+  const relative = path.relative(process.cwd(), filePath);
+  for (const [glob, schema] of Object.entries(options.jsonSchema)) {
+    if (schema?.composite && isGlobMatch(relative, glob)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isGlobMatch(filePath: string, glob: string): boolean {
+  // Simple glob matching: strip leading ./ from both and compare
+  const normalizedPath = filePath.replace(/^\.\//, '');
+  const normalizedGlob = glob.replace(/^\.\//, '');
+  return normalizedPath === normalizedGlob;
+}
+
+function isRelativePath(refPath: string): boolean {
+  if (path.isAbsolute(refPath)) return false;
+  if (/^[a-z]+:\/\//i.test(refPath)) return false;
+  return true;
+}

--- a/packages/cli/src/utils/resolveMintlifyRefs.ts
+++ b/packages/cli/src/utils/resolveMintlifyRefs.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { logger } from '../console/logger.js';
 import chalk from 'chalk';
+import micromatch from 'micromatch';
 
 export type RefMapEntry = {
   sourceFile: string;
@@ -183,18 +184,11 @@ export function shouldResolveRefs(
 
   const relative = path.relative(process.cwd(), filePath);
   for (const [glob, schema] of Object.entries(options.jsonSchema)) {
-    if (schema?.composite && isGlobMatch(relative, glob)) {
+    if (schema?.composite && micromatch.isMatch(relative, glob)) {
       return true;
     }
   }
   return false;
-}
-
-function isGlobMatch(filePath: string, glob: string): boolean {
-  // Simple glob matching: strip leading ./ from both and compare
-  const normalizedPath = filePath.replace(/^\.\//, '');
-  const normalizedGlob = glob.replace(/^\.\//, '');
-  return normalizedPath === normalizedGlob;
 }
 
 function isRelativePath(refPath: string): boolean {

--- a/packages/cli/src/utils/resolveMintlifyRefs.ts
+++ b/packages/cli/src/utils/resolveMintlifyRefs.ts
@@ -62,7 +62,13 @@ function resolveNode(
 
   const result: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(obj)) {
-    result[key] = resolveNode(value, baseDir, `${pointer}/${key}`, visiting, refMap);
+    result[key] = resolveNode(
+      value,
+      baseDir,
+      `${pointer}/${key}`,
+      visiting,
+      refMap
+    );
   }
   return result;
 }
@@ -90,9 +96,7 @@ function resolveRef(
 
   if (visiting.has(resolvedFilePath)) {
     logger.warn(
-      chalk.yellow(
-        `Circular $ref detected at ${pointer || '/'}: ${refPath}`
-      )
+      chalk.yellow(`Circular $ref detected at ${pointer || '/'}: ${refPath}`)
     );
     const { $ref: _, ...rest } = obj;
     return rest;
@@ -112,9 +116,7 @@ function resolveRef(
   try {
     fileContent = fs.readFileSync(resolvedFilePath, 'utf-8');
   } catch {
-    logger.warn(
-      chalk.yellow(`Failed to read $ref file: ${resolvedFilePath}`)
-    );
+    logger.warn(chalk.yellow(`Failed to read $ref file: ${resolvedFilePath}`));
     const { $ref: _, ...rest } = obj;
     return rest;
   }

--- a/packages/cli/src/utils/splitMintlifyLanguageRefs.ts
+++ b/packages/cli/src/utils/splitMintlifyLanguageRefs.ts
@@ -71,7 +71,11 @@ export async function splitMintlifyLanguageRefs(
 
   // Collect the default locale entry's internal $ref entries
   const defaultPointerPrefix = `/navigation/languages/${defaultIndex}`;
-  const internalRefs = collectInternalRefs(refMap, defaultPointerPrefix, navDir);
+  const internalRefs = collectInternalRefs(
+    refMap,
+    defaultPointerPrefix,
+    navDir
+  );
 
   if (internalRefs.length > 0) {
     // Restore default locale's refs (same paths as original)
@@ -105,9 +109,7 @@ export async function splitMintlifyLanguageRefs(
               !internalRefs.some(
                 (other) =>
                   other !== ref &&
-                  ref.relativePointer.startsWith(
-                    other.relativePointer + '/'
-                  )
+                  ref.relativePointer.startsWith(other.relativePointer + '/')
               )
           )
           .map((r) => r.relativePointer)
@@ -136,9 +138,7 @@ export async function splitMintlifyLanguageRefs(
       }
     }
 
-    logger.info(
-      `Restored $ref structure for source locale navigation`
-    );
+    logger.info(`Restored $ref structure for source locale navigation`);
   }
 
   // Wrap each non-default locale entry into its own ref file.
@@ -165,9 +165,7 @@ export async function splitMintlifyLanguageRefs(
     languages[i] = { language: locale, $ref: `./${entryFileName}` };
   }
 
-  logger.info(
-    `Split locale navigation entries into ref files`
-  );
+  logger.info(`Split locale navigation entries into ref files`);
 
   // Now restore top-level refs (navigation → file, navbar → file, etc.)
   // This must happen AFTER language processing so the nav file gets the
@@ -200,11 +198,7 @@ function restoreTopLevelRefs(
   }
 
   if (changed) {
-    fs.writeFileSync(
-      docsJsonPath,
-      JSON.stringify(docsJson, null, 2),
-      'utf-8'
-    );
+    fs.writeFileSync(docsJsonPath, JSON.stringify(docsJson, null, 2), 'utf-8');
   }
 }
 

--- a/packages/cli/src/utils/splitMintlifyLanguageRefs.ts
+++ b/packages/cli/src/utils/splitMintlifyLanguageRefs.ts
@@ -60,18 +60,17 @@ export async function splitMintlifyLanguageRefs(
     const defaultIndex = languages.findIndex(
       (e: any) => e?.language === defaultLocale
     );
-    if (defaultIndex < 0) return;
+    if (defaultIndex < 0) {
+      restoreTopLevelRefs(docsJson, refMap, docsJsonPath);
+      return;
+    }
 
     const navDir = navRefEntry
       ? path.dirname(navRefEntry.sourceFile)
       : path.dirname(docsJsonPath);
 
     const defaultPointerPrefix = `/navigation/languages/${defaultIndex}`;
-    const internalRefs = collectInternalRefs(
-      refMap,
-      defaultPointerPrefix,
-      navDir
-    );
+    const internalRefs = collectInternalRefs(refMap, defaultPointerPrefix);
 
     if (internalRefs.length > 0) {
       const defaultEntry = languages[defaultIndex];
@@ -86,19 +85,6 @@ export async function splitMintlifyLanguageRefs(
         const locale = entry.language;
         if (!locale) continue;
 
-        const topLevelPointers = new Set(
-          internalRefs
-            .filter(
-              (ref) =>
-                !internalRefs.some(
-                  (other) =>
-                    other !== ref &&
-                    ref.relativePointer.startsWith(other.relativePointer + '/')
-                )
-            )
-            .map((r) => r.relativePointer)
-        );
-
         for (const ref of internalRefs) {
           const subtree = getAtPointer(entry, ref.relativePointer);
           if (subtree === undefined) continue;
@@ -109,14 +95,10 @@ export async function splitMintlifyLanguageRefs(
           const outputPath = path.resolve(navDir, localeRelPath);
           writeJsonFile(outputPath, subtree);
 
-          if (topLevelPointers.has(ref.relativePointer)) {
-            const prefixedRefPath = prefixRefWithLocale(ref.refPath, locale);
-            setAtPointer(entry, ref.relativePointer, {
-              $ref: prefixedRefPath,
-            });
-          } else {
-            setAtPointer(entry, ref.relativePointer, { $ref: ref.refPath });
-          }
+          // All refs inside the locale's files use original paths — the locale
+          // directory mirrors the source structure, so relative resolution works.
+          // The locale prefix only appears in the parent navigation.json entry.
+          setAtPointer(entry, ref.relativePointer, { $ref: ref.refPath });
         }
       }
 
@@ -187,8 +169,7 @@ function restoreTopLevelRefs(
  */
 function collectInternalRefs(
   refMap: RefMap,
-  entryPointerPrefix: string,
-  navDir: string
+  entryPointerPrefix: string
 ): { relativePointer: string; refPath: string; resolvedDir: string }[] {
   const refs: {
     relativePointer: string;
@@ -208,23 +189,6 @@ function collectInternalRefs(
 
   refs.sort((a, b) => b.relativePointer.length - a.relativePointer.length);
   return refs;
-}
-
-/**
- * Prefix a $ref path with a locale directory.
- * "./tabs/guides.json" → "./es/tabs/guides.json"
- * "../groups/api.json" → "../es/groups/api.json"
- */
-function prefixRefWithLocale(refPath: string, locale: string): string {
-  if (refPath.startsWith('./')) {
-    return `./${locale}/${refPath.slice(2)}`;
-  }
-  // Handle ../ paths: preserve all leading ../ segments, insert locale after them
-  const match = refPath.match(/^((?:\.\.\/)+)(.*)$/);
-  if (match) {
-    return `${match[1]}${locale}/${match[2]}`;
-  }
-  return `./${locale}/${refPath}`;
 }
 
 function writeJsonFile(filePath: string, data: unknown): void {

--- a/packages/cli/src/utils/splitMintlifyLanguageRefs.ts
+++ b/packages/cli/src/utils/splitMintlifyLanguageRefs.ts
@@ -93,9 +93,7 @@ export async function splitMintlifyLanguageRefs(
                 !internalRefs.some(
                   (other) =>
                     other !== ref &&
-                    ref.relativePointer.startsWith(
-                      other.relativePointer + '/'
-                    )
+                    ref.relativePointer.startsWith(other.relativePointer + '/')
                 )
             )
             .map((r) => r.relativePointer)

--- a/packages/cli/src/utils/splitMintlifyLanguageRefs.ts
+++ b/packages/cli/src/utils/splitMintlifyLanguageRefs.ts
@@ -27,150 +27,128 @@ export async function splitMintlifyLanguageRefs(
   const refMap = getStoredRefMap();
   if (!refMap || refMap.size === 0) return;
 
-  const resolvedJsonPaths = settings.files?.resolvedPaths?.json;
-  if (!resolvedJsonPaths) return;
-
-  // Find the JSON file that has $ref resolution configured (composite schema + mintlify)
-  const docsJsonPath = resolvedJsonPaths.find((p) =>
-    shouldResolveRefs(p, settings.options)
-  );
-  if (!docsJsonPath) return;
-  if (!fs.existsSync(docsJsonPath)) return;
-
-  let docsJson: any;
   try {
-    docsJson = JSON.parse(fs.readFileSync(docsJsonPath, 'utf-8'));
-  } catch {
-    return;
-  }
+    const resolvedJsonPaths = settings.files?.resolvedPaths?.json;
+    if (!resolvedJsonPaths) return;
 
-  const defaultLocale = settings.defaultLocale;
+    const docsJsonPath = resolvedJsonPaths.find((p) =>
+      shouldResolveRefs(p, settings.options)
+    );
+    if (!docsJsonPath) return;
+    if (!fs.existsSync(docsJsonPath)) return;
 
-  // Find where the languages array lives
-  const navRefEntry = refMap.get('/navigation');
-  const navContent = navRefEntry
-    ? getAtPointer(docsJson, '/navigation')
-    : docsJson?.navigation;
-
-  const languages: any[] | undefined = navContent?.languages;
-  if (!Array.isArray(languages) || languages.length <= 1) {
-    // No language splitting needed, but still restore top-level refs
-    restoreTopLevelRefs(docsJson, refMap, docsJsonPath);
-    return;
-  }
-
-  // Find the default locale entry
-  const defaultIndex = languages.findIndex(
-    (e: any) => e?.language === defaultLocale
-  );
-  if (defaultIndex < 0) return;
-
-  const navDir = navRefEntry
-    ? path.dirname(navRefEntry.sourceFile)
-    : path.dirname(docsJsonPath);
-
-  // Collect the default locale entry's internal $ref entries
-  const defaultPointerPrefix = `/navigation/languages/${defaultIndex}`;
-  const internalRefs = collectInternalRefs(
-    refMap,
-    defaultPointerPrefix,
-    navDir
-  );
-
-  if (internalRefs.length > 0) {
-    // Restore default locale's refs (same paths as original)
-    const defaultEntry = languages[defaultIndex];
-    for (const ref of internalRefs) {
-      setAtPointer(defaultEntry, ref.relativePointer, { $ref: ref.refPath });
+    let docsJson: any;
+    try {
+      docsJson = JSON.parse(fs.readFileSync(docsJsonPath, 'utf-8'));
+    } catch {
+      return;
     }
 
-    // For each non-default locale: write translated content to locale-prefixed
-    // paths and insert $ref pointers. Deepest refs are processed first so their
-    // content is extracted before the parent replaces them.
-    //
-    // Only the shallowest refs (direct children of the language entry) get a
-    // locale-prefixed $ref path. Deeper nested refs keep their original relative
-    // paths because the parent file is already in the locale directory, so
-    // relative resolution works naturally.
-    for (const entry of languages) {
+    const defaultLocale = settings.defaultLocale;
+
+    const navRefEntry = refMap.get('/navigation');
+    const navContent = navRefEntry
+      ? getAtPointer(docsJson, '/navigation')
+      : docsJson?.navigation;
+
+    const languages: any[] | undefined = navContent?.languages;
+    if (!Array.isArray(languages) || languages.length <= 1) {
+      restoreTopLevelRefs(docsJson, refMap, docsJsonPath);
+      return;
+    }
+
+    const defaultIndex = languages.findIndex(
+      (e: any) => e?.language === defaultLocale
+    );
+    if (defaultIndex < 0) return;
+
+    const navDir = navRefEntry
+      ? path.dirname(navRefEntry.sourceFile)
+      : path.dirname(docsJsonPath);
+
+    const defaultPointerPrefix = `/navigation/languages/${defaultIndex}`;
+    const internalRefs = collectInternalRefs(
+      refMap,
+      defaultPointerPrefix,
+      navDir
+    );
+
+    if (internalRefs.length > 0) {
+      const defaultEntry = languages[defaultIndex];
+      for (const ref of internalRefs) {
+        setAtPointer(defaultEntry, ref.relativePointer, {
+          $ref: ref.refPath,
+        });
+      }
+
+      for (const entry of languages) {
+        if (!entry || entry.language === defaultLocale) continue;
+        const locale = entry.language;
+        if (!locale) continue;
+
+        const topLevelPointers = new Set(
+          internalRefs
+            .filter(
+              (ref) =>
+                !internalRefs.some(
+                  (other) =>
+                    other !== ref &&
+                    ref.relativePointer.startsWith(
+                      other.relativePointer + '/'
+                    )
+                )
+            )
+            .map((r) => r.relativePointer)
+        );
+
+        for (const ref of internalRefs) {
+          const subtree = getAtPointer(entry, ref.relativePointer);
+          if (subtree === undefined) continue;
+
+          const originalAbsPath = path.resolve(ref.resolvedDir, ref.refPath);
+          const relToNavDir = path.relative(navDir, originalAbsPath);
+          const localeRelPath = path.join(locale, relToNavDir);
+          const outputPath = path.resolve(navDir, localeRelPath);
+          writeJsonFile(outputPath, subtree);
+
+          if (topLevelPointers.has(ref.relativePointer)) {
+            const prefixedRefPath = prefixRefWithLocale(ref.refPath, locale);
+            setAtPointer(entry, ref.relativePointer, {
+              $ref: prefixedRefPath,
+            });
+          } else {
+            setAtPointer(entry, ref.relativePointer, { $ref: ref.refPath });
+          }
+        }
+      }
+
+      logger.info(`Restored $ref structure for source locale navigation`);
+    }
+
+    const navFileName = navRefEntry
+      ? path.basename(navRefEntry.sourceFile)
+      : 'navigation.json';
+
+    for (let i = 0; i < languages.length; i++) {
+      const entry = languages[i];
       if (!entry || entry.language === defaultLocale) continue;
       const locale = entry.language;
       if (!locale) continue;
 
-      // Determine which refs are "top-level" (direct children of the entry)
-      // vs nested (refs within other refs). A ref is top-level if no other
-      // ref's pointer is a prefix of its pointer.
-      const topLevelPointers = new Set(
-        internalRefs
-          .filter(
-            (ref) =>
-              !internalRefs.some(
-                (other) =>
-                  other !== ref &&
-                  ref.relativePointer.startsWith(other.relativePointer + '/')
-              )
-          )
-          .map((r) => r.relativePointer)
-      );
+      const { language, ...contentWithoutLanguage } = entry;
+      const entryFileName = `${locale}/${navFileName}`;
+      const entryFilePath = path.resolve(navDir, entryFileName);
+      writeJsonFile(entryFilePath, contentWithoutLanguage);
 
-      for (const ref of internalRefs) {
-        const subtree = getAtPointer(entry, ref.relativePointer);
-        if (subtree === undefined) continue;
-
-        // Resolve the original ref path from its containing directory,
-        // then compute the locale-prefixed output path
-        const originalAbsPath = path.resolve(ref.resolvedDir, ref.refPath);
-        const relToNavDir = path.relative(navDir, originalAbsPath);
-        const localeRelPath = path.join(locale, relToNavDir);
-        const outputPath = path.resolve(navDir, localeRelPath);
-        writeJsonFile(outputPath, subtree);
-
-        // Top-level refs get prefixed $ref; nested refs keep original path
-        // (because the parent file is already in the locale dir)
-        if (topLevelPointers.has(ref.relativePointer)) {
-          const prefixedRefPath = prefixRefWithLocale(ref.refPath, locale);
-          setAtPointer(entry, ref.relativePointer, { $ref: prefixedRefPath });
-        } else {
-          setAtPointer(entry, ref.relativePointer, { $ref: ref.refPath });
-        }
-      }
+      languages[i] = { language: locale, $ref: `./${entryFileName}` };
     }
 
-    logger.info(`Restored $ref structure for source locale navigation`);
+    logger.info(`Split locale navigation entries into ref files`);
+
+    restoreTopLevelRefs(docsJson, refMap, docsJsonPath);
+  } finally {
+    clearStoredRefMap();
   }
-
-  // Wrap each non-default locale entry into its own ref file.
-  // If internal refs were processed above, the entry already has $ref pointers
-  // so the file is compact. Mintlify's merge rule merges `language` on top.
-  //
-  // The file name is derived from the actual navigation file (if it's a $ref)
-  // or uses a generic name if navigation is inline in docs.json.
-  const navFileName = navRefEntry
-    ? path.basename(navRefEntry.sourceFile)
-    : 'navigation.json';
-
-  for (let i = 0; i < languages.length; i++) {
-    const entry = languages[i];
-    if (!entry || entry.language === defaultLocale) continue;
-    const locale = entry.language;
-    if (!locale) continue;
-
-    const { language, ...contentWithoutLanguage } = entry;
-    const entryFileName = `${locale}/${navFileName}`;
-    const entryFilePath = path.resolve(navDir, entryFileName);
-    writeJsonFile(entryFilePath, contentWithoutLanguage);
-
-    languages[i] = { language: locale, $ref: `./${entryFileName}` };
-  }
-
-  logger.info(`Split locale navigation entries into ref files`);
-
-  // Now restore top-level refs (navigation → file, navbar → file, etc.)
-  // This must happen AFTER language processing so the nav file gets the
-  // updated language entries with $ref.
-  restoreTopLevelRefs(docsJson, refMap, docsJsonPath);
-
-  clearStoredRefMap();
 }
 
 /**
@@ -243,8 +221,10 @@ function prefixRefWithLocale(refPath: string, locale: string): string {
   if (refPath.startsWith('./')) {
     return `./${locale}/${refPath.slice(2)}`;
   }
-  if (refPath.startsWith('../')) {
-    return `../${locale}/${refPath.slice(3)}`;
+  // Handle ../ paths: preserve all leading ../ segments, insert locale after them
+  const match = refPath.match(/^((?:\.\.\/)+)(.*)$/);
+  if (match) {
+    return `${match[1]}${locale}/${match[2]}`;
   }
   return `./${locale}/${refPath}`;
 }

--- a/packages/cli/src/utils/splitMintlifyLanguageRefs.ts
+++ b/packages/cli/src/utils/splitMintlifyLanguageRefs.ts
@@ -4,7 +4,7 @@ import { logger } from '../console/logger.js';
 import { Settings } from '../types/index.js';
 import type { RefMap } from './resolveMintlifyRefs.js';
 import { shouldResolveRefs } from './resolveMintlifyRefs.js';
-import { getStoredRefMap } from '../state/mintlifyRefMap.js';
+import { getStoredRefMap, clearStoredRefMap } from '../state/mintlifyRefMap.js';
 
 /**
  * Post-processing step for Mintlify docs.json.
@@ -78,8 +78,6 @@ export async function splitMintlifyLanguageRefs(
   );
 
   if (internalRefs.length > 0) {
-    // Restore default locale's refs (same paths as original)
-
     // Restore default locale's refs (same paths as original)
     const defaultEntry = languages[defaultIndex];
     for (const ref of internalRefs) {
@@ -171,6 +169,8 @@ export async function splitMintlifyLanguageRefs(
   // This must happen AFTER language processing so the nav file gets the
   // updated language entries with $ref.
   restoreTopLevelRefs(docsJson, refMap, docsJsonPath);
+
+  clearStoredRefMap();
 }
 
 /**
@@ -185,10 +185,13 @@ function restoreTopLevelRefs(
 ): void {
   let changed = false;
 
-  for (const [pointer, entry] of refMap.entries()) {
-    // Only handle refs directly in docs.json, not inside language entries
-    if (pointer.match(/^\/navigation\/languages\/\d+/)) continue;
+  // Sort deepest-first so nested refs are written before their parent
+  // replaces the ancestor subtree with a $ref pointer
+  const entries = [...refMap.entries()]
+    .filter(([pointer]) => !pointer.match(/^\/navigation\/languages\/\d+/))
+    .sort(([a], [b]) => b.length - a.length);
 
+  for (const [pointer, entry] of entries) {
     const subtree = getAtPointer(docsJson, pointer);
     if (subtree === undefined) continue;
 

--- a/packages/cli/src/utils/splitMintlifyLanguageRefs.ts
+++ b/packages/cli/src/utils/splitMintlifyLanguageRefs.ts
@@ -1,0 +1,287 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { logger } from '../console/logger.js';
+import { Settings } from '../types/index.js';
+import type { RefMap } from './resolveMintlifyRefs.js';
+import { shouldResolveRefs } from './resolveMintlifyRefs.js';
+import { getStoredRefMap } from '../state/mintlifyRefMap.js';
+
+/**
+ * Post-processing step for Mintlify docs.json.
+ *
+ * After mergeJson writes a fully-inlined docs.json, this function restores
+ * the original $ref structure:
+ *
+ * - Default locale: restores original $ref paths
+ * - Non-default locales: prefixes ref paths with {locale}/, writes translated
+ *   content to the prefixed paths
+ * - Top-level refs (navigation, navbar): restored in docs.json
+ */
+export async function splitMintlifyLanguageRefs(
+  settings: Settings
+): Promise<void> {
+  const isMintlify =
+    settings.framework === 'mintlify' || !!settings.options?.mintlify;
+  if (!isMintlify) return;
+
+  const refMap = getStoredRefMap();
+  if (!refMap || refMap.size === 0) return;
+
+  const resolvedJsonPaths = settings.files?.resolvedPaths?.json;
+  if (!resolvedJsonPaths) return;
+
+  // Find the JSON file that has $ref resolution configured (composite schema + mintlify)
+  const docsJsonPath = resolvedJsonPaths.find((p) =>
+    shouldResolveRefs(p, settings.options)
+  );
+  if (!docsJsonPath) return;
+  if (!fs.existsSync(docsJsonPath)) return;
+
+  let docsJson: any;
+  try {
+    docsJson = JSON.parse(fs.readFileSync(docsJsonPath, 'utf-8'));
+  } catch {
+    return;
+  }
+
+  const defaultLocale = settings.defaultLocale;
+
+  // Find where the languages array lives
+  const navRefEntry = refMap.get('/navigation');
+  const navContent = navRefEntry
+    ? getAtPointer(docsJson, '/navigation')
+    : docsJson?.navigation;
+
+  const languages: any[] | undefined = navContent?.languages;
+  if (!Array.isArray(languages) || languages.length <= 1) {
+    // No language splitting needed, but still restore top-level refs
+    restoreTopLevelRefs(docsJson, refMap, docsJsonPath);
+    return;
+  }
+
+  // Find the default locale entry
+  const defaultIndex = languages.findIndex(
+    (e: any) => e?.language === defaultLocale
+  );
+  if (defaultIndex < 0) return;
+
+  const navDir = navRefEntry
+    ? path.dirname(navRefEntry.sourceFile)
+    : path.dirname(docsJsonPath);
+
+  // Collect the default locale entry's internal $ref entries
+  const defaultPointerPrefix = `/navigation/languages/${defaultIndex}`;
+  const internalRefs = collectInternalRefs(refMap, defaultPointerPrefix, navDir);
+
+  if (internalRefs.length > 0) {
+    // Restore default locale's refs (same paths as original)
+
+    // Restore default locale's refs (same paths as original)
+    const defaultEntry = languages[defaultIndex];
+    for (const ref of internalRefs) {
+      setAtPointer(defaultEntry, ref.relativePointer, { $ref: ref.refPath });
+    }
+
+    // For each non-default locale: write translated content to locale-prefixed
+    // paths and insert $ref pointers. Deepest refs are processed first so their
+    // content is extracted before the parent replaces them.
+    //
+    // Only the shallowest refs (direct children of the language entry) get a
+    // locale-prefixed $ref path. Deeper nested refs keep their original relative
+    // paths because the parent file is already in the locale directory, so
+    // relative resolution works naturally.
+    for (const entry of languages) {
+      if (!entry || entry.language === defaultLocale) continue;
+      const locale = entry.language;
+      if (!locale) continue;
+
+      // Determine which refs are "top-level" (direct children of the entry)
+      // vs nested (refs within other refs). A ref is top-level if no other
+      // ref's pointer is a prefix of its pointer.
+      const topLevelPointers = new Set(
+        internalRefs
+          .filter(
+            (ref) =>
+              !internalRefs.some(
+                (other) =>
+                  other !== ref &&
+                  ref.relativePointer.startsWith(
+                    other.relativePointer + '/'
+                  )
+              )
+          )
+          .map((r) => r.relativePointer)
+      );
+
+      for (const ref of internalRefs) {
+        const subtree = getAtPointer(entry, ref.relativePointer);
+        if (subtree === undefined) continue;
+
+        // Resolve the original ref path from its containing directory,
+        // then compute the locale-prefixed output path
+        const originalAbsPath = path.resolve(ref.resolvedDir, ref.refPath);
+        const relToNavDir = path.relative(navDir, originalAbsPath);
+        const localeRelPath = path.join(locale, relToNavDir);
+        const outputPath = path.resolve(navDir, localeRelPath);
+        writeJsonFile(outputPath, subtree);
+
+        // Top-level refs get prefixed $ref; nested refs keep original path
+        // (because the parent file is already in the locale dir)
+        if (topLevelPointers.has(ref.relativePointer)) {
+          const prefixedRefPath = prefixRefWithLocale(ref.refPath, locale);
+          setAtPointer(entry, ref.relativePointer, { $ref: prefixedRefPath });
+        } else {
+          setAtPointer(entry, ref.relativePointer, { $ref: ref.refPath });
+        }
+      }
+    }
+
+    logger.info(
+      `Restored $ref structure for source locale navigation`
+    );
+  }
+
+  // Wrap each non-default locale entry into its own ref file.
+  // If internal refs were processed above, the entry already has $ref pointers
+  // so the file is compact. Mintlify's merge rule merges `language` on top.
+  //
+  // The file name is derived from the actual navigation file (if it's a $ref)
+  // or uses a generic name if navigation is inline in docs.json.
+  const navFileName = navRefEntry
+    ? path.basename(navRefEntry.sourceFile)
+    : 'navigation.json';
+
+  for (let i = 0; i < languages.length; i++) {
+    const entry = languages[i];
+    if (!entry || entry.language === defaultLocale) continue;
+    const locale = entry.language;
+    if (!locale) continue;
+
+    const { language, ...contentWithoutLanguage } = entry;
+    const entryFileName = `${locale}/${navFileName}`;
+    const entryFilePath = path.resolve(navDir, entryFileName);
+    writeJsonFile(entryFilePath, contentWithoutLanguage);
+
+    languages[i] = { language: locale, $ref: `./${entryFileName}` };
+  }
+
+  logger.info(
+    `Split locale navigation entries into ref files`
+  );
+
+  // Now restore top-level refs (navigation → file, navbar → file, etc.)
+  // This must happen AFTER language processing so the nav file gets the
+  // updated language entries with $ref.
+  restoreTopLevelRefs(docsJson, refMap, docsJsonPath);
+}
+
+/**
+ * Restore top-level $ref pointers in docs.json.
+ * Writes each resolved subtree to its original source file and replaces
+ * the subtree in docs.json with the $ref pointer.
+ */
+function restoreTopLevelRefs(
+  docsJson: any,
+  refMap: RefMap,
+  docsJsonPath: string
+): void {
+  let changed = false;
+
+  for (const [pointer, entry] of refMap.entries()) {
+    // Only handle refs directly in docs.json, not inside language entries
+    if (pointer.match(/^\/navigation\/languages\/\d+/)) continue;
+
+    const subtree = getAtPointer(docsJson, pointer);
+    if (subtree === undefined) continue;
+
+    writeJsonFile(entry.sourceFile, subtree);
+    setAtPointer(docsJson, pointer, { $ref: entry.refPath });
+    changed = true;
+  }
+
+  if (changed) {
+    fs.writeFileSync(
+      docsJsonPath,
+      JSON.stringify(docsJson, null, 2),
+      'utf-8'
+    );
+  }
+}
+
+/**
+ * Collect refMap entries that describe a language entry's internal $ref chain.
+ * Sorted deepest-first so nested content is extracted before parents.
+ */
+function collectInternalRefs(
+  refMap: RefMap,
+  entryPointerPrefix: string,
+  navDir: string
+): { relativePointer: string; refPath: string; resolvedDir: string }[] {
+  const refs: {
+    relativePointer: string;
+    refPath: string;
+    resolvedDir: string;
+  }[] = [];
+
+  for (const [pointer, entry] of refMap.entries()) {
+    if (!pointer.startsWith(entryPointerPrefix + '/')) continue;
+    refs.push({
+      relativePointer: pointer.slice(entryPointerPrefix.length),
+      refPath: entry.refPath,
+      // The directory from which this $ref path should be resolved
+      resolvedDir: entry.containingDir,
+    });
+  }
+
+  refs.sort((a, b) => b.relativePointer.length - a.relativePointer.length);
+  return refs;
+}
+
+/**
+ * Prefix a $ref path with a locale directory.
+ * "./tabs/guides.json" → "./es/tabs/guides.json"
+ * "../groups/api.json" → "../es/groups/api.json"
+ */
+function prefixRefWithLocale(refPath: string, locale: string): string {
+  if (refPath.startsWith('./')) {
+    return `./${locale}/${refPath.slice(2)}`;
+  }
+  if (refPath.startsWith('../')) {
+    return `../${locale}/${refPath.slice(3)}`;
+  }
+  return `./${locale}/${refPath}`;
+}
+
+function writeJsonFile(filePath: string, data: unknown): void {
+  const dir = path.dirname(filePath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  fs.writeFileSync(filePath, JSON.stringify(data, null, 2), 'utf-8');
+}
+
+function getAtPointer(obj: any, pointer: string): any {
+  if (!pointer || pointer === '/') return obj;
+  const parts = pointer.split('/').filter(Boolean);
+  let current = obj;
+  for (const part of parts) {
+    if (current === null || current === undefined) return undefined;
+    const index = /^\d+$/.test(part) ? parseInt(part) : part;
+    current = current[index];
+  }
+  return current;
+}
+
+function setAtPointer(obj: any, pointer: string, value: any): void {
+  if (!pointer || pointer === '/') return;
+  const parts = pointer.split('/').filter(Boolean);
+  let current = obj;
+  for (let i = 0; i < parts.length - 1; i++) {
+    const index = /^\d+$/.test(parts[i]) ? parseInt(parts[i]) : parts[i];
+    if (current[index] === undefined) return;
+    current = current[index];
+  }
+  const lastPart = parts[parts.length - 1];
+  const lastIndex = /^\d+$/.test(lastPart) ? parseInt(lastPart) : lastPart;
+  current[lastIndex] = value;
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds comprehensive Mintlify `$ref` resolution to the GT CLI: a new `resolveMintlifyRefs` utility expands `$ref` pointers before upload/download, a `mintlifyRefMap` module tracks provenance, and `splitMintlifyLanguageRefs` restores the original file topology after downloads (splitting locale navigation content into per-locale ref files). All seven previously-raised issues (shallow-first iteration, glob matching, duplicate comments, stale refMap on early returns, locale-prefixed paths, and `storeRefMap` overwriting) have been addressed in this version.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all previously raised P1 issues are resolved and the remaining findings are minor test-coverage and edge-case concerns.

All seven issues from prior review threads have been addressed. The only new findings are a missing positive test assertion for shouldResolveRefs and a path.relative edge case — both P2.

packages/cli/src/utils/__tests__/resolveMintlifyRefs.test.ts (missing positive shouldResolveRefs test); packages/cli/src/utils/resolveMintlifyRefs.ts (path.relative cwd edge case).
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/utils/resolveMintlifyRefs.ts | New utility: resolves Mintlify $ref pointers depth-first, builds a provenance refMap, handles circular refs, missing files, and non-relative paths gracefully. Uses micromatch (already a codebase dependency) for glob matching in shouldResolveRefs. |
| packages/cli/src/utils/splitMintlifyLanguageRefs.ts | New post-download step: restores $ref topology, splits locale navigation entries into per-locale files. Uses try/finally to ensure clearStoredRefMap always runs; deepest-first sorting prevents parent refs from clobbering children during restoration. |
| packages/cli/src/state/mintlifyRefMap.ts | New singleton state module. storeRefMap now accumulates entries (merge) rather than overwriting, and clearStoredRefMap resets to an empty Map. getStoredRefMap returns null when empty, correctly short-circuiting consumers. |
| packages/cli/src/formats/files/aggregateFiles.ts | Replaces the Mintlify-specific detectMintlifyUnsupportedFields call with the generic shouldResolveRefs/$ref resolution path; stores the refMap for use in the post-download split step. |
| packages/cli/src/api/downloadFileBatch.ts | Adds $ref resolution before mergeJson (source content) and before extractJson (existing locale output), silently falling through on errors. Changes are well-guarded. |
| packages/cli/src/utils/__tests__/resolveMintlifyRefs.test.ts | Good coverage of resolve paths, circular refs, error cases, and refMap metadata. Missing at least one positive test for shouldResolveRefs (all four assertions check false-returning branches). |
| packages/cli/src/utils/__tests__/splitMintlifyLanguageRefs.test.ts | Thorough tests covering locale splitting, nested refs, multiple locales, non-first default locale, and idempotency. Verifies deepest-first processing correctly re-embeds nested $ref paths inside translated locale files. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant CLI as CLI (base.ts)
    participant AGG as aggregateFiles
    participant RES as resolveMintlifyRefs
    participant STATE as mintlifyRefMap
    participant UP as GT Upload API
    participant DL as downloadFileBatch
    participant SPLIT as splitMintlifyLanguageRefs

    CLI->>AGG: aggregate source files
    AGG->>RES: shouldResolveRefs(filePath, options)
    RES-->>AGG: true (composite jsonSchema match)
    AGG->>RES: resolveMintlifyRefs(json, filePath)
    RES-->>AGG: { resolved, refMap }
    AGG->>STATE: storeRefMap(refMap)
    AGG-->>CLI: files with $refs expanded

    CLI->>UP: upload expanded content
    UP-->>CLI: translations ready

    CLI->>DL: downloadFileBatch()
    DL->>RES: resolveMintlifyRefs(sourceContent)
    DL->>RES: resolveMintlifyRefs(existingContent)
    DL-->>CLI: merged locale files written

    CLI->>SPLIT: splitMintlifyLanguageRefs(settings)
    SPLIT->>STATE: getStoredRefMap()
    STATE-->>SPLIT: refMap
    SPLIT->>SPLIT: collectInternalRefs (deepest-first)
    SPLIT->>SPLIT: write locale nav files
    SPLIT->>SPLIT: restoreTopLevelRefs (deepest-first)
    SPLIT->>STATE: clearStoredRefMap()
    SPLIT-->>CLI: docs.json $ref topology restored
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/cli/src/utils/__tests__/resolveMintlifyRefs.test.ts
Line: 670-686

Comment:
**Missing positive assertion for `shouldResolveRefs`**

All four `expect` calls in this test verify that the function returns `false`. There is no case that confirms the function actually returns `true` when a file path matches a `composite` `jsonSchema` entry — so a regression that always returns `false` would pass the suite undetected.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/cli/src/utils/resolveMintlifyRefs.ts
Line: 1361-1367

Comment:
**`path.relative` may produce `..`-prefixed paths that defeat glob matching**

`path.relative(process.cwd(), filePath)` returns a relative path from the working directory. If `filePath` is not underneath `process.cwd()` (e.g., when the CLI is invoked from a parent directory), the result starts with `../…`. `micromatch.isMatch('../project/docs.json', 'docs.json')` returns `false`, so `shouldResolveRefs` silently returns `false` and `$ref` resolution never runs. Consider using `path.basename(filePath)` as a fallback, or normalizing both sides to absolute paths before computing the relative fragment.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (5): Last reviewed commit: ["fix: review"](https://github.com/generaltranslation/gt/commit/54416086a20cfcb94ff610631f981270d6b79961) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29561231)</sub>

<!-- /greptile_comment -->