### PR TITLE
F/mint ref update

### DIFF
--- a/.changeset/breezy-ears-read.md
+++ b/.changeset/breezy-ears-read.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+Updating Mintlify $ref handling

--- a/packages/cli/src/config/optionPresets.ts
+++ b/packages/cli/src/config/optionPresets.ts
@@ -17,11 +17,13 @@ export function generatePreset(
       case 'mintlify':
         // https://mintlify.com/docs/navigation
         return {
+          resolveRefs: true,
           composite: {
             '$.navigation.languages': {
               type: 'array',
               key: '$.language',
               experimentalSort: 'localesAlphabetical',
+              splitEntries: true,
               include: [
                 '$..group',
                 '$..tab',

--- a/packages/cli/src/config/optionPresets.ts
+++ b/packages/cli/src/config/optionPresets.ts
@@ -55,6 +55,36 @@ export function generatePreset(
             },
           },
         };
+      case 'mintlify-hide-default':
+        // Mintlify with hideDefaultLocale — paths don't have locale prefix in source
+        return {
+          resolveRefs: true,
+          composite: {
+            '$.navigation.languages': {
+              type: 'array',
+              key: '$.language',
+              experimentalSort: 'localesAlphabetical',
+              splitEntries: true,
+              include: [
+                '$..group',
+                '$..tab',
+                '$..item',
+                '$..anchor',
+                '$..dropdown',
+              ],
+              transform: {
+                '$..pages[*]': {
+                  match: '^/?(.*)$',
+                  replace: '{locale}/$1',
+                },
+                '$..root': {
+                  match: '^/?(.*)$',
+                  replace: '{locale}/$1',
+                },
+              },
+            },
+          },
+        };
       case 'openapi':
         return {
           include: ['$..summary', '$..description'],

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.14.17';
+export const PACKAGE_VERSION = '2.14.18';

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -311,7 +311,7 @@ export type StructuralTransform = {
 };
 
 export type JsonSchema = {
-  preset?: 'mintlify' | 'openapi';
+  preset?: 'mintlify' | 'mintlify-hide-default' | 'openapi';
   structuralTransform?: StructuralTransform[];
 
   // when true, resolve $ref entries in this file before processing

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -314,6 +314,9 @@ export type JsonSchema = {
   preset?: 'mintlify' | 'openapi';
   structuralTransform?: StructuralTransform[];
 
+  // when true, resolve $ref entries in this file before processing
+  resolveRefs?: boolean;
+
   // exactly 1 of include or composite must be provided; not both
 
   // specify include if file is not composite
@@ -367,6 +370,11 @@ export type SourceObjectOptions = {
   // When set to 'localesAlphabetical', the default locale will be placed first
   // and the remaining locales will be ordered alphabetically by locale code
   experimentalSort?: 'locales' | 'localesAlphabetical';
+
+  // when true, non-default keyed entries in this composite array are extracted
+  // into separate files (using the key value as the directory name) and replaced
+  // with $ref pointers. Keeps the source file compact.
+  splitEntries?: boolean;
 };
 
 export type TransformOptions = {

--- a/packages/cli/src/utils/__tests__/splitMintlifyLanguageRefs.test.ts
+++ b/packages/cli/src/utils/__tests__/splitMintlifyLanguageRefs.test.ts
@@ -29,15 +29,25 @@ vi.mock('../../state/mintlifyRefMap.js', () => ({
   clearStoredRefMap: vi.fn(),
 }));
 
-// Mock shouldResolveRefs to return true for the test docs.json path
-vi.mock('../resolveMintlifyRefs.js', async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import('../resolveMintlifyRefs.js')>();
-  return {
-    ...actual,
-    shouldResolveRefs: (filePath: string) => filePath.includes('docs.json'),
-  };
-});
+// Mock validateJsonSchema to return the schema for docs.json
+vi.mock('../../formats/json/utils.js', () => ({
+  validateJsonSchema: (_options: any, filePath: string) => {
+    if (filePath.includes('docs.json')) {
+      return {
+        resolveRefs: true,
+        composite: {
+          '$.navigation.languages': {
+            type: 'array',
+            key: '$.language',
+            splitEntries: true,
+            include: ['$..group', '$..tab'],
+          },
+        },
+      };
+    }
+    return null;
+  },
+}));
 
 import fs from 'node:fs';
 
@@ -54,7 +64,21 @@ function makeSettings(overrides: Partial<Settings> = {}): Settings {
       placeholderPaths: {},
     },
     config: '/project/gt.config.json',
-    options: { mintlify: { inferTitleFromFilename: true } },
+    options: {
+      jsonSchema: {
+        './docs.json': {
+          resolveRefs: true,
+          composite: {
+            '$.navigation.languages': {
+              type: 'array',
+              key: '$.language',
+              splitEntries: true,
+              include: ['$..group', '$..tab'],
+            },
+          },
+        },
+      },
+    },
     parsingOptions: {},
     ...overrides,
   } as Settings;
@@ -74,16 +98,22 @@ beforeEach(() => {
 });
 
 describe('splitMintlifyLanguageRefs', () => {
-  it('skips when no mintlify options', async () => {
+  it('skips when no jsonSchema config', async () => {
     await splitMintlifyLanguageRefs(makeSettings({ options: {} }) as Settings);
     expect(mockWrite).not.toHaveBeenCalled();
   });
 
-  it('skips when no stored refMap', async () => {
+  it('skips splitting when no languages array exists', async () => {
     mockRefMap = null;
-    mockRead.mockReturnValue(JSON.stringify({ navigation: {} }));
+    mockRead.mockReturnValue(
+      JSON.stringify({ navigation: { groups: [{ group: 'Home' }] } })
+    );
     await splitMintlifyLanguageRefs(makeSettings());
-    expect(mockWrite).not.toHaveBeenCalled();
+    // No locale ref files created — only a write-back of the original file
+    const localeFiles = mockWrite.mock.calls.filter((c) =>
+      (c[0] as string).includes('/es/')
+    );
+    expect(localeFiles).toHaveLength(0);
   });
 
   it('restores top-level $ref and splits locale entries', async () => {

--- a/packages/cli/src/utils/__tests__/splitMintlifyLanguageRefs.test.ts
+++ b/packages/cli/src/utils/__tests__/splitMintlifyLanguageRefs.test.ts
@@ -365,8 +365,17 @@ describe('splitMintlifyLanguageRefs', () => {
 
     await splitMintlifyLanguageRefs(makeSettings());
 
-    // Empty refMap → function exits early, no writes
-    expect(mockWrite).not.toHaveBeenCalled();
+    // Even without $ref, locale entries should be split into their own files
+    const docsResult = getWritten('/project/docs.json');
+    expect(docsResult.navigation.languages[0].language).toBe('en');
+    expect(docsResult.navigation.languages[0].groups).toBeDefined();
+    expect(docsResult.navigation.languages[1]).toEqual({
+      language: 'es',
+      $ref: './es/docs.json',
+    });
+
+    const esNav = getWritten('/project/es/docs.json');
+    expect(esNav.groups[0].group).toBe('Inicio');
   });
 
   it('handles default locale not being first in the array', async () => {

--- a/packages/cli/src/utils/resolveMintlifyRefs.ts
+++ b/packages/cli/src/utils/resolveMintlifyRefs.ts
@@ -172,19 +172,17 @@ function resolveRef(
 
 /**
  * Check if a file should have $ref resolution applied based on the settings.
- * Returns true if the file has mintlify options configured AND matches a
- * composite jsonSchema entry.
+ * Returns true if the file matches a jsonSchema entry with resolveRefs: true.
  */
 export function shouldResolveRefs(
   filePath: string,
-  options?: { mintlify?: any; jsonSchema?: Record<string, any> }
+  options?: { jsonSchema?: Record<string, any> }
 ): boolean {
-  if (!options?.mintlify) return false;
-  if (!options.jsonSchema) return false;
+  if (!options?.jsonSchema) return false;
 
   const relative = path.relative(process.cwd(), filePath);
   for (const [glob, schema] of Object.entries(options.jsonSchema)) {
-    if (schema?.composite && micromatch.isMatch(relative, glob)) {
+    if (schema?.resolveRefs && micromatch.isMatch(relative, glob)) {
       return true;
     }
   }

--- a/packages/cli/src/utils/splitMintlifyLanguageRefs.ts
+++ b/packages/cli/src/utils/splitMintlifyLanguageRefs.ts
@@ -1,208 +1,323 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { logger } from '../console/logger.js';
-import { Settings } from '../types/index.js';
+import { Settings, JsonSchema, SourceObjectOptions } from '../types/index.js';
 import type { RefMap } from './resolveMintlifyRefs.js';
-import { shouldResolveRefs } from './resolveMintlifyRefs.js';
-import micromatch from 'micromatch';
+import { validateJsonSchema } from '../formats/json/utils.js';
 import { getStoredRefMap, clearStoredRefMap } from '../state/mintlifyRefMap.js';
+import { JSONPath } from 'jsonpath-plus';
+import { getLocaleProperties } from 'generaltranslation';
 
 /**
- * Post-processing step for Mintlify docs.json.
+ * Post-processing step for composite JSON files with splitEntries enabled.
  *
- * After mergeJson writes a fully-inlined docs.json, this function:
- * 1. Restores the original $ref structure (if the source used $ref)
- * 2. Wraps each non-default locale entry into its own ref file
- *    to keep the navigation file small
+ * After mergeJson writes a fully-inlined composite file, this function:
+ * 1. Restores the original $ref structure (if the source used $ref / resolveRefs)
+ * 2. Extracts non-default keyed entries into their own ref files
+ *    to keep the source file compact
+ *
+ * Driven entirely by the jsonSchema config — reads the composite path,
+ * key field, and splitEntries flag from the schema.
  */
 export async function splitMintlifyLanguageRefs(
   settings: Settings
 ): Promise<void> {
-  const isMintlify =
-    settings.framework === 'mintlify' || !!settings.options?.mintlify;
-  if (!isMintlify) return;
-
   const refMap = getStoredRefMap();
 
   try {
     const resolvedJsonPaths = settings.files?.resolvedPaths?.json;
     if (!resolvedJsonPaths) return;
 
-    // Find the composite JSON file — either via shouldResolveRefs (if refMap exists)
-    // or by checking for a composite jsonSchema entry directly
-    const docsJsonPath =
-      resolvedJsonPaths.find((p) => shouldResolveRefs(p, settings.options)) ??
-      findCompositeJsonFile(resolvedJsonPaths, settings.options);
-    if (!docsJsonPath) return;
-    if (!fs.existsSync(docsJsonPath)) return;
+    // Find a JSON file that has splitEntries enabled or resolveRefs
+    const targetFile = findTargetFile(resolvedJsonPaths, settings);
+    if (!targetFile) return;
 
-    let docsJson: any;
+    const { filePath: compositeFilePath, splitConfig } = targetFile;
+    if (!fs.existsSync(compositeFilePath)) return;
+
+    let fileJson: any;
     try {
-      docsJson = JSON.parse(fs.readFileSync(docsJsonPath, 'utf-8'));
+      fileJson = JSON.parse(fs.readFileSync(compositeFilePath, 'utf-8'));
     } catch {
       return;
     }
 
-    const defaultLocale = settings.defaultLocale;
-    const docsDir = path.dirname(docsJsonPath);
+    const docsDir = path.dirname(compositeFilePath);
 
-    // Determine where navigation lives
-    const navRefEntry = refMap?.get('/navigation');
-    const navContent = navRefEntry
-      ? getAtPointer(docsJson, '/navigation')
-      : docsJson?.navigation;
-
-    const languages: any[] | undefined = navContent?.languages;
-    if (!Array.isArray(languages) || languages.length <= 1) {
-      if (refMap && refMap.size > 0) {
-        restoreTopLevelRefs(docsJson, refMap, docsJsonPath);
-      }
-      return;
-    }
-
-    const defaultIndex = languages.findIndex(
-      (e: any) => e?.language === defaultLocale
-    );
-    if (defaultIndex < 0) {
-      if (refMap && refMap.size > 0) {
-        restoreTopLevelRefs(docsJson, refMap, docsJsonPath);
-      }
-      return;
-    }
-
-    const navDir = navRefEntry ? path.dirname(navRefEntry.sourceFile) : docsDir;
-
-    // Restore $ref structure if the source used $ref
-    if (refMap && refMap.size > 0) {
-      const defaultPointerPrefix = `/navigation/languages/${defaultIndex}`;
-      const internalRefs = collectInternalRefs(refMap, defaultPointerPrefix);
-
-      if (internalRefs.length > 0) {
-        // Restore default locale's refs
-        const defaultEntry = languages[defaultIndex];
-        for (const ref of internalRefs) {
-          setAtPointer(defaultEntry, ref.relativePointer, {
-            $ref: ref.refPath,
-          });
-        }
-
-        // Write locale ref files mirroring the source topology
-        for (const entry of languages) {
-          if (!entry || entry.language === defaultLocale) continue;
-          const locale = entry.language;
-          if (!locale) continue;
-
-          for (const ref of internalRefs) {
-            const subtree = getAtPointer(entry, ref.relativePointer);
-            if (subtree === undefined) continue;
-
-            const originalAbsPath = path.resolve(ref.resolvedDir, ref.refPath);
-            const relToNavDir = path.relative(navDir, originalAbsPath);
-            const localeRelPath = path.join(locale, relToNavDir);
-            const outputPath = path.resolve(navDir, localeRelPath);
-            writeJsonFile(outputPath, subtree);
-
-            setAtPointer(entry, ref.relativePointer, { $ref: ref.refPath });
-          }
-        }
-
-        logger.info(`Restored $ref structure for source locale navigation`);
-      }
-    }
-
-    // Wrap each non-default locale entry into its own ref file.
-    // This runs regardless of whether the source used $ref — it keeps
-    // the navigation file small by extracting locale content.
-    const navFileName = navRefEntry
-      ? path.basename(navRefEntry.sourceFile)
-      : path.basename(docsJsonPath);
-
-    for (let i = 0; i < languages.length; i++) {
-      const entry = languages[i];
-      if (!entry || entry.language === defaultLocale) continue;
-      const locale = entry.language;
-      if (!locale) continue;
-
-      const { language, ...contentWithoutLanguage } = entry;
-      const entryFileName = `${locale}/${navFileName}`;
-      const entryFilePath = path.resolve(navDir, entryFileName);
-      writeJsonFile(entryFilePath, contentWithoutLanguage);
-
-      languages[i] = { language: locale, $ref: `./${entryFileName}` };
-    }
-
-    logger.info(`Split locale navigation entries into ref files`);
-
-    // Restore top-level refs and write the final docs.json
-    if (refMap && refMap.size > 0) {
-      restoreTopLevelRefs(docsJson, refMap, docsJsonPath);
-    } else {
-      // No refMap — navigation is inline in docs.json, write it back directly
-      fs.writeFileSync(
-        docsJsonPath,
-        JSON.stringify(docsJson, null, 2),
-        'utf-8'
+    // If splitEntries is configured, process it
+    if (splitConfig) {
+      processSplitEntries(
+        fileJson,
+        compositeFilePath,
+        docsDir,
+        splitConfig,
+        settings,
+        refMap
       );
     }
+
+    // Restore top-level refs if any exist
+    if (refMap && refMap.size > 0) {
+      restoreTopLevelRefs(fileJson, refMap, splitConfig);
+    }
+
+    // Always write the composite file back — splitEntries modified the
+    // languages array, and restoreTopLevelRefs may not have written it
+    // (e.g., when all refs are inside language entries, not top-level)
+    fs.writeFileSync(
+      compositeFilePath,
+      JSON.stringify(fileJson, null, 2),
+      'utf-8'
+    );
   } finally {
     clearStoredRefMap();
   }
 }
 
+type SplitConfig = {
+  compositePath: string;
+  jsonPointer: string;
+  keyField: string;
+  keyJsonPath: string;
+  sourceObjectOptions: SourceObjectOptions;
+};
+
 /**
- * Find the composite JSON file from the jsonSchema config.
- * Used when no refMap exists (no $ref in source).
+ * Find the target file and extract split configuration from the schema.
  */
-function findCompositeJsonFile(
+function findTargetFile(
   resolvedPaths: string[],
-  options?: Record<string, any>
-): string | undefined {
-  if (!options?.jsonSchema) return undefined;
+  settings: Settings
+): {
+  filePath: string;
+  schema: JsonSchema;
+  splitConfig: SplitConfig | null;
+} | null {
+  if (!settings.options?.jsonSchema) return null;
 
   for (const filePath of resolvedPaths) {
-    const relative = path.relative(process.cwd(), filePath);
-    for (const [glob, schema] of Object.entries(
-      options.jsonSchema as Record<string, any>
-    )) {
-      if (schema?.composite && micromatch.isMatch(relative, glob)) {
-        return filePath;
+    const schema = validateJsonSchema(settings.options, filePath);
+    if (!schema) continue;
+
+    const hasSplitEntries = schema.composite
+      ? Object.entries(schema.composite).some(
+          ([, opts]) => opts.splitEntries
+        )
+      : false;
+
+    const hasResolveRefs = schema.resolveRefs;
+
+    if (!hasSplitEntries && !hasResolveRefs) continue;
+
+    // Extract split config if available
+    let splitConfig: SplitConfig | null = null;
+    if (schema.composite) {
+      for (const [compositePath, opts] of Object.entries(schema.composite)) {
+        if (opts.splitEntries && opts.type === 'array' && opts.key) {
+          splitConfig = {
+            compositePath,
+            jsonPointer: jsonPathToPointer(compositePath),
+            keyField: opts.key,
+            keyJsonPath: opts.key,
+            sourceObjectOptions: opts,
+          };
+          break;
+        }
       }
     }
+
+    return { filePath, schema, splitConfig };
   }
-  return undefined;
+
+  return null;
 }
 
 /**
- * Restore top-level $ref pointers in docs.json.
+ * Process splitEntries: extract non-default keyed entries into ref files.
+ */
+function processSplitEntries(
+  fileJson: any,
+  compositeFilePath: string,
+  docsDir: string,
+  splitConfig: SplitConfig,
+  settings: Settings,
+  refMap: RefMap | null
+): void {
+  const { jsonPointer, keyJsonPath } = splitConfig;
+
+  // Find the composite array — may be behind a $ref
+  const parentPointer = jsonPointer.split('/').slice(0, -1).join('/') || '';
+  const arrayKey = jsonPointer.split('/').pop() || '';
+  const navRefEntry = refMap?.get(parentPointer || undefined as any);
+
+  // Get the array from the file
+  const arrayContainer = parentPointer
+    ? getAtPointer(fileJson, parentPointer)
+    : fileJson;
+  if (!arrayContainer) return;
+
+  const entries: any[] = arrayContainer[arrayKey];
+  if (!Array.isArray(entries) || entries.length <= 1) return;
+
+  // Determine the default key value (the source entry)
+  const defaultKeyValue = getDefaultKeyValue(
+    settings.defaultLocale,
+    splitConfig.sourceObjectOptions
+  );
+
+  const defaultIndex = entries.findIndex((e: any) => {
+    if (!e || typeof e !== 'object') return false;
+    const values = JSONPath({
+      json: e,
+      path: keyJsonPath,
+      resultType: 'value',
+      flatten: true,
+      wrap: true,
+    });
+    return values?.[0] === defaultKeyValue;
+  });
+  if (defaultIndex < 0) return;
+
+  // Determine where the composite array actually lives on disk
+  const navDir = navRefEntry
+    ? path.dirname(navRefEntry.sourceFile)
+    : docsDir;
+
+  // Restore $ref structure if the source used $ref
+  if (refMap && refMap.size > 0) {
+    const defaultPointerPrefix = `${jsonPointer}/${defaultIndex}`;
+    const internalRefs = collectInternalRefs(refMap, defaultPointerPrefix);
+
+    if (internalRefs.length > 0) {
+      const defaultEntry = entries[defaultIndex];
+      for (const ref of internalRefs) {
+        setAtPointer(defaultEntry, ref.relativePointer, {
+          $ref: ref.refPath,
+        });
+      }
+
+      for (const entry of entries) {
+        const entryKeyValues = JSONPath({
+          json: entry,
+          path: keyJsonPath,
+          resultType: 'value',
+          flatten: true,
+          wrap: true,
+        });
+        if (entryKeyValues?.[0] === defaultKeyValue) continue;
+
+        for (const ref of internalRefs) {
+          const subtree = getAtPointer(entry, ref.relativePointer);
+          if (subtree === undefined) continue;
+
+          const originalAbsPath = path.resolve(ref.resolvedDir, ref.refPath);
+          const relToNavDir = path.relative(navDir, originalAbsPath);
+          const keyValue = entryKeyValues?.[0] || 'unknown';
+          const localeRelPath = path.join(keyValue, relToNavDir);
+          const outputPath = path.resolve(navDir, localeRelPath);
+          writeJsonFile(outputPath, subtree);
+
+          setAtPointer(entry, ref.relativePointer, { $ref: ref.refPath });
+        }
+      }
+
+      logger.info(`Restored $ref structure for default entry`);
+    }
+  }
+
+  // Extract each non-default entry into its own ref file
+  const navFileName = navRefEntry
+    ? path.basename(navRefEntry.sourceFile)
+    : path.basename(compositeFilePath);
+
+  // Get the actual property name from the key JSONPath (e.g., "$.language" → "language")
+  const keyPropertyName = keyJsonPath.replace(/^\$\.?/, '');
+
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i];
+    if (!entry || typeof entry !== 'object') continue;
+
+    const keyValues = JSONPath({
+      json: entry,
+      path: keyJsonPath,
+      resultType: 'value',
+      flatten: true,
+      wrap: true,
+    });
+    const keyValue = keyValues?.[0];
+    if (!keyValue || keyValue === defaultKeyValue) continue;
+
+    const { [keyPropertyName]: _, ...contentWithoutKey } = entry;
+    const entryFileName = `${keyValue}/${navFileName}`;
+    const entryFilePath = path.resolve(navDir, entryFileName);
+    writeJsonFile(entryFilePath, contentWithoutKey);
+
+    entries[i] = { [keyPropertyName]: keyValue, $ref: `./${entryFileName}` };
+  }
+
+  logger.info(`Split keyed entries into ref files`);
+}
+
+/**
+ * Get the identifying key value for the default locale.
+ */
+function getDefaultKeyValue(
+  defaultLocale: string,
+  sourceObjectOptions: SourceObjectOptions
+): string {
+  const localeProperty = sourceObjectOptions.localeProperty || 'code';
+  const localeProperties = getLocaleProperties(defaultLocale);
+  return (
+    (localeProperties as any)[localeProperty] ||
+    localeProperties.code ||
+    defaultLocale
+  );
+}
+
+/**
+ * Convert a JSONPath like "$.navigation.languages" to a JSON pointer like "/navigation/languages".
+ */
+function jsonPathToPointer(jsonPath: string): string {
+  return jsonPath
+    .replace(/^\$\.?/, '')
+    .split('.')
+    .filter(Boolean)
+    .map((segment) => `/${segment}`)
+    .join('');
+}
+
+/**
+ * Restore top-level $ref pointers in the composite file.
  * Sorted deepest-first so nested refs are written before parents.
  */
 function restoreTopLevelRefs(
-  docsJson: any,
+  fileJson: any,
   refMap: RefMap,
-  docsJsonPath: string
+  splitConfig: SplitConfig | null
 ): void {
-  let changed = false;
+
+  // Build a regex to exclude entries inside the composite array
+  const arrayPointerPattern = splitConfig
+    ? new RegExp(`^${splitConfig.jsonPointer.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\/\\d+`)
+    : null;
 
   const entries = [...refMap.entries()]
-    .filter(([pointer]) => !pointer.match(/^\/navigation\/languages\/\d+/))
+    .filter(
+      ([pointer]) => !arrayPointerPattern || !arrayPointerPattern.test(pointer)
+    )
     .sort(([a], [b]) => b.length - a.length);
 
   for (const [pointer, entry] of entries) {
-    const subtree = getAtPointer(docsJson, pointer);
+    const subtree = getAtPointer(fileJson, pointer);
     if (subtree === undefined) continue;
 
     writeJsonFile(entry.sourceFile, subtree);
-    setAtPointer(docsJson, pointer, { $ref: entry.refPath });
-    changed = true;
-  }
-
-  if (changed) {
-    fs.writeFileSync(docsJsonPath, JSON.stringify(docsJson, null, 2), 'utf-8');
+    setAtPointer(fileJson, pointer, { $ref: entry.refPath });
   }
 }
 
 /**
- * Collect refMap entries that describe a language entry's internal $ref chain.
+ * Collect refMap entries that describe an entry's internal $ref chain.
  * Sorted deepest-first so nested content is extracted before parents.
  */
 function collectInternalRefs(

--- a/packages/cli/src/utils/splitMintlifyLanguageRefs.ts
+++ b/packages/cli/src/utils/splitMintlifyLanguageRefs.ts
@@ -69,9 +69,7 @@ export async function splitMintlifyLanguageRefs(
       return;
     }
 
-    const navDir = navRefEntry
-      ? path.dirname(navRefEntry.sourceFile)
-      : docsDir;
+    const navDir = navRefEntry ? path.dirname(navRefEntry.sourceFile) : docsDir;
 
     // Restore $ref structure if the source used $ref
     if (refMap && refMap.size > 0) {
@@ -97,10 +95,7 @@ export async function splitMintlifyLanguageRefs(
             const subtree = getAtPointer(entry, ref.relativePointer);
             if (subtree === undefined) continue;
 
-            const originalAbsPath = path.resolve(
-              ref.resolvedDir,
-              ref.refPath
-            );
+            const originalAbsPath = path.resolve(ref.resolvedDir, ref.refPath);
             const relToNavDir = path.relative(navDir, originalAbsPath);
             const localeRelPath = path.join(locale, relToNavDir);
             const outputPath = path.resolve(navDir, localeRelPath);

--- a/packages/cli/src/utils/splitMintlifyLanguageRefs.ts
+++ b/packages/cli/src/utils/splitMintlifyLanguageRefs.ts
@@ -9,13 +9,10 @@ import { getStoredRefMap, clearStoredRefMap } from '../state/mintlifyRefMap.js';
 /**
  * Post-processing step for Mintlify docs.json.
  *
- * After mergeJson writes a fully-inlined docs.json, this function restores
- * the original $ref structure:
- *
- * - Default locale: restores original $ref paths
- * - Non-default locales: prefixes ref paths with {locale}/, writes translated
- *   content to the prefixed paths
- * - Top-level refs (navigation, navbar): restored in docs.json
+ * After mergeJson writes a fully-inlined docs.json, this function:
+ * 1. Restores the original $ref structure (if the source used $ref)
+ * 2. Wraps each non-default locale entry into its own ref file
+ *    to keep the navigation file small
  */
 export async function splitMintlifyLanguageRefs(
   settings: Settings
@@ -25,15 +22,16 @@ export async function splitMintlifyLanguageRefs(
   if (!isMintlify) return;
 
   const refMap = getStoredRefMap();
-  if (!refMap || refMap.size === 0) return;
 
   try {
     const resolvedJsonPaths = settings.files?.resolvedPaths?.json;
     if (!resolvedJsonPaths) return;
 
-    const docsJsonPath = resolvedJsonPaths.find((p) =>
-      shouldResolveRefs(p, settings.options)
-    );
+    // Find the composite JSON file — either via shouldResolveRefs (if refMap exists)
+    // or by checking for a composite jsonSchema entry directly
+    const docsJsonPath =
+      resolvedJsonPaths.find((p) => shouldResolveRefs(p, settings.options)) ??
+      findCompositeJsonFile(resolvedJsonPaths, settings.options);
     if (!docsJsonPath) return;
     if (!fs.existsSync(docsJsonPath)) return;
 
@@ -45,15 +43,19 @@ export async function splitMintlifyLanguageRefs(
     }
 
     const defaultLocale = settings.defaultLocale;
+    const docsDir = path.dirname(docsJsonPath);
 
-    const navRefEntry = refMap.get('/navigation');
+    // Determine where navigation lives
+    const navRefEntry = refMap?.get('/navigation');
     const navContent = navRefEntry
       ? getAtPointer(docsJson, '/navigation')
       : docsJson?.navigation;
 
     const languages: any[] | undefined = navContent?.languages;
     if (!Array.isArray(languages) || languages.length <= 1) {
-      restoreTopLevelRefs(docsJson, refMap, docsJsonPath);
+      if (refMap && refMap.size > 0) {
+        restoreTopLevelRefs(docsJson, refMap, docsJsonPath);
+      }
       return;
     }
 
@@ -61,53 +63,63 @@ export async function splitMintlifyLanguageRefs(
       (e: any) => e?.language === defaultLocale
     );
     if (defaultIndex < 0) {
-      restoreTopLevelRefs(docsJson, refMap, docsJsonPath);
+      if (refMap && refMap.size > 0) {
+        restoreTopLevelRefs(docsJson, refMap, docsJsonPath);
+      }
       return;
     }
 
     const navDir = navRefEntry
       ? path.dirname(navRefEntry.sourceFile)
-      : path.dirname(docsJsonPath);
+      : docsDir;
 
-    const defaultPointerPrefix = `/navigation/languages/${defaultIndex}`;
-    const internalRefs = collectInternalRefs(refMap, defaultPointerPrefix);
+    // Restore $ref structure if the source used $ref
+    if (refMap && refMap.size > 0) {
+      const defaultPointerPrefix = `/navigation/languages/${defaultIndex}`;
+      const internalRefs = collectInternalRefs(refMap, defaultPointerPrefix);
 
-    if (internalRefs.length > 0) {
-      const defaultEntry = languages[defaultIndex];
-      for (const ref of internalRefs) {
-        setAtPointer(defaultEntry, ref.relativePointer, {
-          $ref: ref.refPath,
-        });
-      }
-
-      for (const entry of languages) {
-        if (!entry || entry.language === defaultLocale) continue;
-        const locale = entry.language;
-        if (!locale) continue;
-
+      if (internalRefs.length > 0) {
+        // Restore default locale's refs
+        const defaultEntry = languages[defaultIndex];
         for (const ref of internalRefs) {
-          const subtree = getAtPointer(entry, ref.relativePointer);
-          if (subtree === undefined) continue;
-
-          const originalAbsPath = path.resolve(ref.resolvedDir, ref.refPath);
-          const relToNavDir = path.relative(navDir, originalAbsPath);
-          const localeRelPath = path.join(locale, relToNavDir);
-          const outputPath = path.resolve(navDir, localeRelPath);
-          writeJsonFile(outputPath, subtree);
-
-          // All refs inside the locale's files use original paths — the locale
-          // directory mirrors the source structure, so relative resolution works.
-          // The locale prefix only appears in the parent navigation.json entry.
-          setAtPointer(entry, ref.relativePointer, { $ref: ref.refPath });
+          setAtPointer(defaultEntry, ref.relativePointer, {
+            $ref: ref.refPath,
+          });
         }
-      }
 
-      logger.info(`Restored $ref structure for source locale navigation`);
+        // Write locale ref files mirroring the source topology
+        for (const entry of languages) {
+          if (!entry || entry.language === defaultLocale) continue;
+          const locale = entry.language;
+          if (!locale) continue;
+
+          for (const ref of internalRefs) {
+            const subtree = getAtPointer(entry, ref.relativePointer);
+            if (subtree === undefined) continue;
+
+            const originalAbsPath = path.resolve(
+              ref.resolvedDir,
+              ref.refPath
+            );
+            const relToNavDir = path.relative(navDir, originalAbsPath);
+            const localeRelPath = path.join(locale, relToNavDir);
+            const outputPath = path.resolve(navDir, localeRelPath);
+            writeJsonFile(outputPath, subtree);
+
+            setAtPointer(entry, ref.relativePointer, { $ref: ref.refPath });
+          }
+        }
+
+        logger.info(`Restored $ref structure for source locale navigation`);
+      }
     }
 
+    // Wrap each non-default locale entry into its own ref file.
+    // This runs regardless of whether the source used $ref — it keeps
+    // the navigation file small by extracting locale content.
     const navFileName = navRefEntry
       ? path.basename(navRefEntry.sourceFile)
-      : 'navigation.json';
+      : path.basename(docsJsonPath);
 
     for (let i = 0; i < languages.length; i++) {
       const entry = languages[i];
@@ -125,16 +137,50 @@ export async function splitMintlifyLanguageRefs(
 
     logger.info(`Split locale navigation entries into ref files`);
 
-    restoreTopLevelRefs(docsJson, refMap, docsJsonPath);
+    // Restore top-level refs and write the final docs.json
+    if (refMap && refMap.size > 0) {
+      restoreTopLevelRefs(docsJson, refMap, docsJsonPath);
+    } else {
+      // No refMap — navigation is inline in docs.json, write it back directly
+      fs.writeFileSync(
+        docsJsonPath,
+        JSON.stringify(docsJson, null, 2),
+        'utf-8'
+      );
+    }
   } finally {
     clearStoredRefMap();
   }
 }
 
 /**
+ * Find the composite JSON file from the jsonSchema config.
+ * Used when no refMap exists (no $ref in source).
+ */
+function findCompositeJsonFile(
+  resolvedPaths: string[],
+  options?: Record<string, any>
+): string | undefined {
+  if (!options?.jsonSchema) return undefined;
+
+  for (const filePath of resolvedPaths) {
+    const relative = path.relative(process.cwd(), filePath);
+    for (const [glob, schema] of Object.entries(
+      options.jsonSchema as Record<string, any>
+    )) {
+      const normalizedPath = relative.replace(/^\.\//, '');
+      const normalizedGlob = glob.replace(/^\.\//, '');
+      if (schema?.composite && normalizedPath === normalizedGlob) {
+        return filePath;
+      }
+    }
+  }
+  return undefined;
+}
+
+/**
  * Restore top-level $ref pointers in docs.json.
- * Writes each resolved subtree to its original source file and replaces
- * the subtree in docs.json with the $ref pointer.
+ * Sorted deepest-first so nested refs are written before parents.
  */
 function restoreTopLevelRefs(
   docsJson: any,
@@ -143,8 +189,6 @@ function restoreTopLevelRefs(
 ): void {
   let changed = false;
 
-  // Sort deepest-first so nested refs are written before their parent
-  // replaces the ancestor subtree with a $ref pointer
   const entries = [...refMap.entries()]
     .filter(([pointer]) => !pointer.match(/^\/navigation\/languages\/\d+/))
     .sort(([a], [b]) => b.length - a.length);
@@ -182,7 +226,6 @@ function collectInternalRefs(
     refs.push({
       relativePointer: pointer.slice(entryPointerPrefix.length),
       refPath: entry.refPath,
-      // The directory from which this $ref path should be resolved
       resolvedDir: entry.containingDir,
     });
   }

--- a/packages/cli/src/utils/splitMintlifyLanguageRefs.ts
+++ b/packages/cli/src/utils/splitMintlifyLanguageRefs.ts
@@ -4,6 +4,7 @@ import { logger } from '../console/logger.js';
 import { Settings } from '../types/index.js';
 import type { RefMap } from './resolveMintlifyRefs.js';
 import { shouldResolveRefs } from './resolveMintlifyRefs.js';
+import micromatch from 'micromatch';
 import { getStoredRefMap, clearStoredRefMap } from '../state/mintlifyRefMap.js';
 
 /**
@@ -163,9 +164,7 @@ function findCompositeJsonFile(
     for (const [glob, schema] of Object.entries(
       options.jsonSchema as Record<string, any>
     )) {
-      const normalizedPath = relative.replace(/^\.\//, '');
-      const normalizedGlob = glob.replace(/^\.\//, '');
-      if (schema?.composite && normalizedPath === normalizedGlob) {
+      if (schema?.composite && micromatch.isMatch(relative, glob)) {
         return filePath;
       }
     }

--- a/packages/cli/src/utils/splitMintlifyLanguageRefs.ts
+++ b/packages/cli/src/utils/splitMintlifyLanguageRefs.ts
@@ -100,9 +100,7 @@ function findTargetFile(
     if (!schema) continue;
 
     const hasSplitEntries = schema.composite
-      ? Object.entries(schema.composite).some(
-          ([, opts]) => opts.splitEntries
-        )
+      ? Object.entries(schema.composite).some(([, opts]) => opts.splitEntries)
       : false;
 
     const hasResolveRefs = schema.resolveRefs;
@@ -148,7 +146,7 @@ function processSplitEntries(
   // Find the composite array — may be behind a $ref
   const parentPointer = jsonPointer.split('/').slice(0, -1).join('/') || '';
   const arrayKey = jsonPointer.split('/').pop() || '';
-  const navRefEntry = refMap?.get(parentPointer || undefined as any);
+  const navRefEntry = refMap?.get(parentPointer || (undefined as any));
 
   // Get the array from the file
   const arrayContainer = parentPointer
@@ -179,9 +177,7 @@ function processSplitEntries(
   if (defaultIndex < 0) return;
 
   // Determine where the composite array actually lives on disk
-  const navDir = navRefEntry
-    ? path.dirname(navRefEntry.sourceFile)
-    : docsDir;
+  const navDir = navRefEntry ? path.dirname(navRefEntry.sourceFile) : docsDir;
 
   // Restore $ref structure if the source used $ref
   if (refMap && refMap.size > 0) {
@@ -295,10 +291,11 @@ function restoreTopLevelRefs(
   refMap: RefMap,
   splitConfig: SplitConfig | null
 ): void {
-
   // Build a regex to exclude entries inside the composite array
   const arrayPointerPattern = splitConfig
-    ? new RegExp(`^${splitConfig.jsonPointer.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\/\\d+`)
+    ? new RegExp(
+        `^${splitConfig.jsonPointer.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\/\\d+`
+      )
     : null;
 
   const entries = [...refMap.entries()]


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR generalises the Mintlify `$ref` post-processing step into a config-driven system: any composite JSON file can now declare `resolveRefs: true` and/or `splitEntries: true` in its `jsonSchema` config, decoupling the logic from the `mintlify` option. The Mintlify preset is updated to opt in automatically, and the split-entry extraction now works even when the source file had no `$ref` entries at all.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all remaining findings are minor P2 style/quality observations with no correctness impact.

The refactoring is well-structured with comprehensive tests covering nested refs, multiple locales, no-$ref inline navigation, and default-locale ordering. The two flagged issues (an `(undefined as any)` cast and a silent single-path limitation) do not affect runtime correctness for the documented use cases.

packages/cli/src/utils/splitMintlifyLanguageRefs.ts — minor type-safety cast and undocumented single-entry limitation.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/cli/src/utils/splitMintlifyLanguageRefs.ts | Major refactor: generalised from Mintlify-specific to config-driven composite JSON splitting; removes mintlify-option gate, adds JSONPath-based key lookup and per-entry file extraction. Two minor issues: unsafe `(undefined as any)` cast and silent single-entry-per-file limitation. |
| packages/cli/src/utils/resolveMintlifyRefs.ts | Narrowed `shouldResolveRefs` check from `mintlify option + composite` to `resolveRefs: true` flag; signature simplified to drop the `mintlify` branch. Clean change with no issues. |
| packages/cli/src/utils/__tests__/splitMintlifyLanguageRefs.test.ts | Tests updated to mock `validateJsonSchema` instead of `shouldResolveRefs`, settings updated to `jsonSchema` shape; test renamed and coverage extended for no-$ref inline navigation case. All tests accurately reflect new code paths. |
| packages/cli/src/config/optionPresets.ts | Mintlify preset gains `resolveRefs: true` at schema level and `splitEntries: true` on the languages composite entry — wires up the new generalised behaviour for Mintlify users automatically. |
| packages/cli/src/types/index.ts | Adds `resolveRefs?: boolean` to `JsonSchema` and `splitEntries?: boolean` to `SourceObjectOptions` with clear comments; both optional and backwards-compatible. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[splitMintlifyLanguageRefs called] --> B{resolvedPaths.json?}
    B -- no --> Z[return]
    B -- yes --> C[findTargetFile]
    C --> D{schema has splitEntries or resolveRefs?}
    D -- no --> Z
    D -- yes --> E[Read composite file JSON]
    E --> F{splitConfig present?}
    F -- yes --> G[processSplitEntries]
    G --> G1[Locate composite array via JSON pointer]
    G1 --> G2{refMap has entries?}
    G2 -- yes --> G3[Restore $ref in default entry / Write locale-prefixed ref files for non-default entries]
    G2 -- no --> G4
    G3 --> G4[Extract each non-default entry to keyValue/filename.json / Replace with $ref pointer]
    G4 --> H
    F -- no --> H{refMap non-empty?}
    H -- yes --> I[restoreTopLevelRefs excluding composite array pointers]
    H -- no --> J
    I --> J[Write composite file back]
    J --> K[clearStoredRefMap]
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/cli/src/utils/__tests__/splitMintlifyLanguageRefs.test.ts`, line 82-87 ([link](https://github.com/generaltranslation/gt/blob/f5579d362177eaa880a0237f01b134087b896b1e/packages/cli/src/utils/__tests__/splitMintlifyLanguageRefs.test.ts#L82-L87)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Misleading test name after early-exit removal**

   The test "skips when no stored refMap" still passes, but for the wrong reason: the function no longer returns early when `refMap` is `null` — it only exits early because the navigation object has no `languages` array. If `mockRead` were changed to return a multi-locale navigation, the function would proceed and produce writes, contradicting the test's documented intent. Consider renaming it (e.g. "skips when navigation has no languages") or adding a second case with multi-locale navigation and `refMap = null` to cover the new code path explicitly.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/cli/src/utils/__tests__/splitMintlifyLanguageRefs.test.ts
   Line: 82-87

   Comment:
   **Misleading test name after early-exit removal**

   The test "skips when no stored refMap" still passes, but for the wrong reason: the function no longer returns early when `refMap` is `null` — it only exits early because the navigation object has no `languages` array. If `mockRead` were changed to return a multi-locale navigation, the function would proceed and produce writes, contradicting the test's documented intent. Consider renaming it (e.g. "skips when navigation has no languages") or adding a second case with multi-locale navigation and `refMap = null` to cover the new code path explicitly.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/cli/src/utils/splitMintlifyLanguageRefs.ts
Line: 149

Comment:
The `(undefined as any)` cast bypasses TypeScript's type checker on `Map<string, RefMapEntry>.get()`. When `parentPointer` is an empty string (e.g., when the composite path is a top-level array like `$.languages`), this evaluates to `refMap.get(undefined)`, which silently returns `undefined`. While that is the functionally correct fallback here, the intent should be expressed explicitly without a type-unsafe cast.

```suggestion
  const navRefEntry = parentPointer ? refMap?.get(parentPointer) : undefined;
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/cli/src/utils/splitMintlifyLanguageRefs.ts
Line: 112-124

Comment:
**Only first `splitEntries` composite path is processed**

`findTargetFile` breaks after finding the first composite entry with `splitEntries: true`. If a schema config has two composite arrays both marked `splitEntries: true` (e.g., `$.navigation.languages` and `$.navigation.tabs`), only the first will be extracted; the second silently stays fully inlined. This limitation isn't documented in the type definition comment for `splitEntries`.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: lint"](https://github.com/generaltranslation/gt/commit/1b3637b358413e5b526ebb752da6e67cafb6fdc9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29635498)</sub>

<!-- /greptile_comment -->