### PR TITLE
chore: declare sideEffects in package.json across packages

### DIFF
--- a/.changeset/package-sideeffects.md
+++ b/.changeset/package-sideeffects.md
@@ -1,0 +1,12 @@
+---
+'generaltranslation': patch
+'gt-react': patch
+'@generaltranslation/react-core': patch
+'gt-i18n': patch
+'gt-next': patch
+'gt-react-native': patch
+'gt-tanstack-start': patch
+'gt-node': patch
+---
+
+Declare `sideEffects` in each package's `package.json` to enable tree-shaking in consumer bundlers (webpack, esbuild, Rollup). Packages with no module-scope side effects are marked `"sideEffects": false`. Packages with intentional side-effect entry points (`gt-react/browser`, `gt-react/macros`, `gt-next` server entries, `gt-react-native` TurboModule spec) list those files explicitly so they are preserved.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,6 +9,7 @@
     "dist",
     "CHANGELOG.md"
   ],
+  "sideEffects": false,
   "scripts": {
     "build:release": "pnpm run build:clean",
     "build:clean": "sh ../../scripts/clean.sh && pnpm run build",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -9,6 +9,7 @@
     "dist",
     "CHANGELOG.md"
   ],
+  "sideEffects": false,
   "scripts": {
     "build:release": "pnpm run build:clean",
     "build:clean": "sh ../../scripts/clean.sh && pnpm run build",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -12,6 +12,10 @@
     "dist",
     "CHANGELOG.md"
   ],
+  "sideEffects": [
+    "./dist/index.server.js",
+    "./dist/server.js"
+  ],
   "dependencies": {
     "@generaltranslation/supported-locales": "workspace:*",
     "@generaltranslation/compiler": "workspace:*",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -13,8 +13,8 @@
     "CHANGELOG.md"
   ],
   "sideEffects": [
-    "./dist/index.server.js",
-    "./dist/server.js"
+    "./dist/index.server.*",
+    "./dist/server.*"
   ],
   "dependencies": {
     "@generaltranslation/supported-locales": "workspace:*",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -9,6 +9,7 @@
     "dist",
     "CHANGELOG.md"
   ],
+  "sideEffects": false,
   "scripts": {
     "build:release": "pnpm run build:clean",
     "build:clean": "sh ../../scripts/clean.sh && pnpm run build",

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -9,6 +9,7 @@
     "dist",
     "CHANGELOG.md"
   ],
+  "sideEffects": false,
   "peerDependencies": {
     "react": ">=16.8.0"
   },

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -52,6 +52,11 @@
     "!**/__mocks__",
     "!**/.*"
   ],
+  "sideEffects": [
+    "./dist/commonjs/NativeGtReactNative.js",
+    "./dist/module/NativeGtReactNative.js",
+    "./src/NativeGtReactNative.ts"
+  ],
   "scripts": {
     "patch": "pnpm version patch",
     "transpile": "tsc",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -53,9 +53,9 @@
     "!**/.*"
   ],
   "sideEffects": [
-    "./dist/commonjs/NativeGtReactNative.js",
-    "./dist/module/NativeGtReactNative.js",
-    "./src/NativeGtReactNative.ts"
+    "./dist/commonjs/NativeGtReactNative.*",
+    "./dist/module/NativeGtReactNative.*",
+    "./src/NativeGtReactNative.*"
   ],
   "scripts": {
     "patch": "pnpm version patch",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -9,6 +9,12 @@
     "dist",
     "CHANGELOG.md"
   ],
+  "sideEffects": [
+    "./dist/browser.cjs.min.cjs",
+    "./dist/browser.esm.min.mjs",
+    "./dist/macros.cjs.min.cjs",
+    "./dist/macros.esm.min.mjs"
+  ],
   "peerDependencies": {
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -10,10 +10,8 @@
     "CHANGELOG.md"
   ],
   "sideEffects": [
-    "./dist/browser.cjs.min.cjs",
-    "./dist/browser.esm.min.mjs",
-    "./dist/macros.cjs.min.cjs",
-    "./dist/macros.esm.min.mjs"
+    "./dist/browser.*",
+    "./dist/macros.*"
   ],
   "peerDependencies": {
     "react": ">=16.8.0",

--- a/packages/tanstack-start/package.json
+++ b/packages/tanstack-start/package.json
@@ -9,6 +9,7 @@
     "dist",
     "CHANGELOG.md"
   ],
+  "sideEffects": false,
   "peerDependencies": {
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",


### PR DESCRIPTION
## Summary

Adds a `sideEffects` field to the eight publishable runtime packages so consumer bundlers (webpack, esbuild, Rollup) can tree-shake unused exports. No public API changes, no runtime behavior changes — only a hint to downstream bundlers.

### Values applied

| Package | `sideEffects` | Reason |
|---|---|---|
| `generaltranslation` | `false` | No module-scope side effects |
| `gt-react` | `[browser.*, macros.*]` | `globalThis.t =` and `enforceBrowser()` calls |
| `@generaltranslation/react-core` | `false` | Only self-mutating `Component._gtt = '...'` (safe) |
| `gt-i18n` | `false` | Clean |
| `gt-next` | `[index.server.js, server.js]` | `import 'server-only'` throws if bundled into a client chunk |
| `gt-react-native` | `[NativeGtReactNative.*]` | `TurboModuleRegistry.getEnforcing()` in spec file |
| `gt-tanstack-start` | `false` | Clean |
| `gt-node` | `false` | Clean |

`gt-sanity` already declared `"sideEffects": false` — unchanged.

### Audit methodology

For every `src/` tree, scanned for:
- CSS / bare side-effect imports
- Top-level `globalThis` / `window` / `document` / `global` / `self` mutations
- `addEventListener` at module scope
- Top-level function-call expression statements
- Top-level property assignments

The `Component._gtt = '...'` pattern (used in `react-core`, `gt-next`, `gt-react`) only mutates identifiers declared in the same module. If the export is unused, the whole module is tree-shaken together with the mutation; if used, the module is kept and the mutation runs at import time. Both outcomes are correct under `sideEffects: false`.

## Test plan

- [x] `pnpm build` passes cleanly (20/20 turbo tasks)
- [x] `gt-next` dist: `import 'server-only'` string preserved in `dist/index.server.js` and `dist/server.js`
- [x] `gt-react-native` dist: `TurboModuleRegistry` call preserved in both `dist/commonjs/NativeGtReactNative.js` and `dist/module/NativeGtReactNative.js`
- [x] `gt-react` dist (verified previously): inlined `enforceBrowser()` IIFE preserved in `dist/browser.esm.min.mjs`; `globalThis.t=` preserved in `dist/macros.esm.min.mjs`
- [ ] Downstream smoke test: bundle a simple consumer app with one import from `generaltranslation` and confirm unused exports drop from the bundle

Changeset: patch bump for all eight affected packages.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `sideEffects` declarations to eight publishable packages, enabling consumer bundlers (webpack, esbuild, Rollup) to tree-shake unused exports. The audit is thorough: `sideEffects: false` is applied where correct, and the packages with genuine module-scope side effects (`gt-react`, `gt-next`, `gt-react-native`) list their relevant entry points explicitly.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; only one P2 style suggestion about using glob patterns in gt-react's sideEffects array.

All sideEffects declarations were verified against the source — only index.server.ts and server.ts import 'server-only', the _gtt assignments in react-core are correctly reasoned as safe under sideEffects:false, and the react-native src path is valid because the package ships its src directory. The sole finding is a P2 robustness suggestion on exact filenames vs globs.

packages/react/package.json — sideEffects lists exact minified filenames instead of glob patterns.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react/package.json | Lists four exact dist filenames as side-effectful (browser + macros CJS/ESM); filenames match current exports but use exact paths instead of glob patterns, which is fragile if new output formats are added. |
| packages/next/package.json | Lists `index.server.js` and `server.js` as side-effectful (both import `server-only`); verified correct and complete against source. |
| packages/react-core/package.json | Adds `sideEffects: false`; top-level `Component._gtt` assignments are safe because they only mutate same-module identifiers that are tree-shaken together with the module. |
| packages/react-native/package.json | Lists three side-effectful paths (two dist outputs + src TypeScript); src is valid because the package ships its `src/` directory for Metro bundler. |
| packages/core/package.json | Adds `sideEffects: false`; package has no module-scope side effects. |
| packages/i18n/package.json | Adds `sideEffects: false`; package has no module-scope side effects. |
| packages/node/package.json | Adds `sideEffects: false`; clean package with no module-scope side effects. |
| packages/tanstack-start/package.json | Adds `sideEffects: false`; clean package with no module-scope side effects. |
| .changeset/package-sideeffects.md | Standard changeset file declaring patch bumps for all eight affected packages. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Consumer Bundler] --> B{sideEffects field?}
    B -->|false| C[Tree-shake all unused modules]
    B -->|array| D[Preserve listed files, tree-shake rest]
    B -->|absent| E[Assume all files have side effects — no tree-shaking]

    C --> F[generaltranslation\ngt-i18n\ngt-node\ngt-tanstack-start\nreact-core]
    D --> G[gt-react\nbrowser.* + macros.*\nglobalThis.t + enforceBrowser]
    D --> H[gt-next\nindex.server.js + server.js\nimport 'server-only']
    D --> I[gt-react-native\nNativeGtReactNative.*\nTurboModuleRegistry.getEnforcing]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/react/package.json
Line: 12-17

Comment:
**Exact filenames instead of globs for side-effect entries**

The four paths listed are exact minified-filename matches for the current build outputs. If the Rollup config ever emits a non-minified variant (e.g., `browser.cjs.cjs` for debugging) or a new format, those files won't be covered by `sideEffects` and a downstream bundler could incorrectly tree-shake them. Using glob patterns is more resilient to build-output changes.

```suggestion
  "sideEffects": [
    "./dist/browser.*",
    "./dist/macros.*"
  ],
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: declare sideEffects in package.js..."](https://github.com/generaltranslation/gt/commit/246c43f078de98be38cd040e66538eeffd982c35) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29687362)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->