### PR TITLE
fix(gt-i18n): pass maxChars instead of $maxChars to hashSource

### DIFF
--- a/.changeset/fix-hash-message-max-chars.md
+++ b/.changeset/fix-hash-message-max-chars.md
@@ -1,0 +1,5 @@
+---
+'gt-i18n': patch
+---
+
+fix: pass `maxChars` (not `$maxChars`) to `hashSource` so it factors into the hash

--- a/packages/i18n/src/utils/hashMessage.ts
+++ b/packages/i18n/src/utils/hashMessage.ts
@@ -18,7 +18,7 @@ export function hashMessage<T extends Translation>(
     ...(options?.$id && { id: options.$id }),
     ...('$maxChars' in options &&
       options.$maxChars != null && {
-        $maxChars: Math.abs(options.$maxChars),
+        maxChars: Math.abs(options.$maxChars),
       }),
     dataFormat: options.$format,
   });


### PR DESCRIPTION
## Bug

In `hashMessage.ts`, the `maxChars` option was passed to `hashSource()` as `$maxChars`:

```ts
$maxChars: Math.abs(options.$maxChars),
```

But `hashSource()` destructures `maxChars` (no `$` prefix), so the value was silently ignored — `maxChars` never factored into the hash.

## Fix

Rename the property from `$maxChars` to `maxChars` in the object passed to `hashSource()`.

## Changeset

Patch for `gt-i18n`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a silent key-name mismatch in `hashMessage.ts`: the property was passed as `$maxChars` to `hashSource()`, but `hashSource()` destructures `maxChars` (no `$` prefix), so the character limit was never included in the computed hash. The one-line rename corrects this, and a patch changeset for `gt-i18n` is included.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This PR is safe to merge — it is a targeted, well-scoped one-line bug fix with no side effects.

The change is minimal and correct: it aligns the key name passed to `hashSource()` with the parameter that function actually destructures. No new logic is introduced, no other call sites are affected, and the accompanying changeset is accurate. No P0/P1/P2 issues found.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/i18n/src/utils/hashMessage.ts | Single-line fix: renames `$maxChars` to `maxChars` in the object passed to `hashSource()`, matching the parameter name that function destructures, so the value now correctly factors into the hash. |
| .changeset/fix-hash-message-max-chars.md | New changeset file marking a patch release for `gt-i18n` with an accurate description of the fix. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant hashMessage
    participant hashSource

    Caller->>hashMessage: hashMessage(message, options)
    Note over hashMessage: options.$maxChars = N

    rect rgb(255, 220, 220)
        Note over hashMessage: ❌ Before fix
        hashMessage->>hashSource: { source, context, id, $maxChars: N, dataFormat }
        Note over hashSource: Destructures maxChars (undefined)<br/>$maxChars is silently ignored
        hashSource-->>hashMessage: hash (without maxChars)
    end

    rect rgb(220, 255, 220)
        Note over hashMessage: ✅ After fix
        hashMessage->>hashSource: { source, context, id, maxChars: N, dataFormat }
        Note over hashSource: Destructures maxChars = N<br/>Includes in hash computation
        hashSource-->>hashMessage: hash (with maxChars)
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(gt-i18n): pass maxChars instead of $..."](https://github.com/generaltranslation/gt/commit/d4127dff9562cf78f3af07c526b65eb49e202f5f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29688879)</sub>

<!-- /greptile_comment -->