### PR TITLE
refactor: extract shared BatchingQueue across i18n, react-core, gt-next

### DIFF
--- a/.changeset/batching-queue.md
+++ b/.changeset/batching-queue.md
@@ -1,5 +1,9 @@
 ---
 'gt-i18n': patch
+'@generaltranslation/react-core': patch
+'gt-next': patch
 ---
 
-Extract the translation batching queue out of `TranslationsCache` into a standalone `BatchingQueue<TItem, TResult>` class, exposed via `gt-i18n/internal`. Behavior unchanged (same defaults: `maxBatchSize=25`, `batchInterval=50ms`, `maxConcurrent=100`). This is the foundation for unifying the duplicated batching implementations in `@generaltranslation/react-core` and `gt-next` in subsequent PRs.
+Unify the translation batching queue across `gt-i18n`, `@generaltranslation/react-core`, and `gt-next`. Pulls the queue/timer/concurrency logic out of three independent reimplementations into a single `BatchingQueue<TItem, TResult>` class exposed via `gt-i18n/internal`. Same defaults (`maxBatchSize=25`, `batchInterval=50ms`, `maxConcurrent=100`).
+
+Behavior note: `react-core` and `gt-next` previously processed batches sequentially despite the `maxConcurrent=100` constant — an artifact of their implementations rather than an explicit design choice. They now fan out batches concurrently up to that cap, matching `gt-i18n`'s long-standing behavior. `gt-next` also no longer runs a permanent `setInterval` polling the queue; the queue self-schedules only when work exists.

--- a/.changeset/batching-queue.md
+++ b/.changeset/batching-queue.md
@@ -1,0 +1,5 @@
+---
+'gt-i18n': patch
+---
+
+Extract the translation batching queue out of `TranslationsCache` into a standalone `BatchingQueue<TItem, TResult>` class, exposed via `gt-i18n/internal`. Behavior unchanged (same defaults: `maxBatchSize=25`, `batchInterval=50ms`, `maxConcurrent=100`). This is the foundation for unifying the duplicated batching implementations in `@generaltranslation/react-core` and `gt-next` in subsequent PRs.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,8 +281,37 @@ jobs:
         shell: bash
         run: cd tests/apps/cli-test-app && pnpm install && pnpm gtx-cli --help
 
+  size:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: 'pnpm'
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-wasip1
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build packages
+        run: pnpm build
+
+      - name: Check bundle sizes
+        run: pnpm size
+
   run-tests:
-    needs: [lint, tests, test-builds, test-cli-binaries, test-gtx-cli-binaries]
+    needs: [lint, tests, test-builds, test-cli-binaries, test-gtx-cli-binaries, size]
     runs-on: ubuntu-latest
     steps:
       - run: echo "All tests passed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,37 +281,8 @@ jobs:
         shell: bash
         run: cd tests/apps/cli-test-app && pnpm install && pnpm gtx-cli --help
 
-  size:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - uses: pnpm/action-setup@v4
-        name: Install pnpm
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          cache: 'pnpm'
-
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: wasm32-wasip1
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Build packages
-        run: pnpm build
-
-      - name: Check bundle sizes
-        run: pnpm size
-
   run-tests:
-    needs: [lint, tests, test-builds, test-cli-binaries, test-gtx-cli-binaries, size]
+    needs: [lint, tests, test-builds, test-cli-binaries, test-gtx-cli-binaries]
     runs-on: ubuntu-latest
     steps:
       - run: echo "All tests passed"

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -1,0 +1,34 @@
+name: size-limit
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+env:
+  CI: true
+
+jobs:
+  size:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: 'pnpm'
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-wasip1
+
+      - uses: andresz1/size-limit-action@v1.8.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          package_manager: pnpm

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,0 +1,42 @@
+[
+  {
+    "name": "generaltranslation",
+    "path": "packages/core/dist/index.mjs",
+    "limit": "30 kB",
+    "brotli": true
+  },
+  {
+    "name": "gt-i18n",
+    "path": "packages/i18n/dist/index.mjs",
+    "limit": "35 kB",
+    "brotli": true
+  },
+  {
+    "name": "@generaltranslation/react-core",
+    "path": "packages/react-core/dist/index.esm.min.mjs",
+    "limit": "48 kB",
+    "brotli": true,
+    "ignore": ["react"]
+  },
+  {
+    "name": "gt-react",
+    "path": "packages/react/dist/index.esm.min.mjs",
+    "limit": "50 kB",
+    "brotli": true,
+    "ignore": ["react", "react-dom"]
+  },
+  {
+    "name": "gt-tanstack-start",
+    "path": "packages/tanstack-start/dist/index.esm.min.mjs",
+    "limit": "55 kB",
+    "brotli": true,
+    "ignore": ["react", "react-dom", "@tanstack/react-start"]
+  },
+  {
+    "name": "gt-next/client",
+    "path": "packages/next/dist/client.js",
+    "limit": "55 kB",
+    "brotli": true,
+    "ignore": ["next", "react", "react-dom", "server-only"]
+  }
+]

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "build:clean": "turbo run build:clean --filter='./packages/*'",
     "build:release": "turbo run build:release --filter='./packages/*'",
     "bench": "turbo run bench",
+    "size": "size-limit",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md,yml,yaml}\"",
     "changeset": "changeset",
     "version-packages": "changeset version"
@@ -44,6 +45,7 @@
     "@changesets/changelog-github": "^0.5.1",
     "@changesets/cli": "^2.27.9",
     "@eslint/js": "^9.17.0",
+    "@size-limit/preset-small-lib": "^12.1.0",
     "@typescript-eslint/eslint-plugin": "^8.18.1",
     "@typescript-eslint/parser": "^8.18.1",
     "@vitejs/plugin-react": "^5.1.2",
@@ -55,6 +57,7 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "globals": "^15.14.0",
     "prettier": "^3.6.2",
+    "size-limit": "^12.1.0",
     "turbo": "^2.5.3",
     "typescript": "^5.9.2",
     "vitest": "^3.2.4"

--- a/packages/i18n/src/i18n-manager/translations-manager/TranslationsCache.ts
+++ b/packages/i18n/src/i18n-manager/translations-manager/TranslationsCache.ts
@@ -9,11 +9,7 @@ import {
   EntryMetadata,
   TranslateManyEntry,
 } from 'generaltranslation/types';
-
-// See gt-next
-const MAX_BATCH_SIZE = 25;
-const MAX_CONCURRENT_REQUESTS = 100;
-const BATCH_INTERVAL = 50;
+import { BatchingQueue, BatchingQueueEntry } from '../../utils/BatchingQueue';
 
 /**
  * InputKey type for lookups
@@ -32,14 +28,14 @@ export type TranslationKey<TranslationValue extends Translation> = {
 export type Hash = string;
 
 /**
- * A queue entry for batching, used to also handle reject and resolve
+ * Per-entry payload pushed onto the batching queue. Holds the request shape
+ * we need to assemble a translateMany call and the cache key to look up the
+ * matching response.
  */
-type QueueEntry<TranslationValue extends Translation> = {
+type QueueItem<TranslationValue extends Translation> = {
   key: Hash;
   source: TranslationValue;
   metadata: EntryMetadata;
-  resolve: (value: Translation) => void;
-  reject: (reason?: unknown) => void;
 };
 
 /**
@@ -65,33 +61,9 @@ export class TranslationsCache<
   TranslationValue,
   TranslationValue
 > {
-  /**
-   * Queue of translation requests
-   */
-  private _queue: Array<QueueEntry<TranslationValue>> = [];
-
-  /**
-   * Timer for batching
-   */
-  // eslint-disable-next-line no-undef
-  private _batchTimer: ReturnType<typeof setTimeout> | null = null;
-
-  /**
-   * Number of active requests
-   */
-  private _activeRequests = 0;
-
-  /**
-   * Translate many function
-   */
   private _translateMany: TranslateMany;
+  private _queue: BatchingQueue<QueueItem<TranslationValue>, TranslationValue>;
 
-  /**
-   * Constructor
-   * @param {Object} params - The parameters for the cache
-   * @param {Record<Hash, TranslationValue>} params.init - The initial cache
-   * @param {Function} params.fallback - Get the fallback value for a cache miss
-   */
   constructor({
     init,
     translateMany,
@@ -108,13 +80,11 @@ export class TranslationsCache<
   }) {
     super(init, lifecycle);
     this._translateMany = translateMany;
+    this._queue = new BatchingQueue({
+      sendBatch: (entries) => this._sendBatch(entries),
+    });
   }
 
-  /**
-   * Get the translation value for a given key
-   * @param key - The translation key
-   * @returns The translation value
-   */
   public get<T extends TranslationValue>(
     key: TranslationKey<T>
   ): T | undefined {
@@ -130,11 +100,6 @@ export class TranslationsCache<
     return value;
   }
 
-  /**
-   * Miss the cache
-   * @param key - The translation key
-   * @returns The translation value
-   */
   public async miss<T extends TranslationValue>(
     key: TranslationKey<T>
   ): Promise<T | undefined> {
@@ -150,163 +115,52 @@ export class TranslationsCache<
     return value as T | undefined;
   }
 
-  /**
-   * Generate a key for the cache
-   * @param key - The translation key
-   * @returns The key
-   */
   protected genKey(key: TranslationKey<TranslationValue>): Hash {
     return hashMessage(key.message, key.options);
   }
 
   /**
-   * Get the fallback value for a cache miss
-   * @param key - The translation key
-   * @returns The fallback value
+   * Cache miss path: enqueue the request and let BatchingQueue dispatch it
+   * along with any other concurrent misses.
    */
   protected fallback(
     key: TranslationKey<TranslationValue>
   ): Promise<TranslationValue> {
-    // Add translation request to queue
-    const translationPromise = this._enqueueTranslation(key);
-
-    // If batch is full, flush now
-    if (this._queue.length >= MAX_BATCH_SIZE) {
-      this._flushNow();
-    } else {
-      this._scheduleBatch();
-    }
-
-    return translationPromise;
-  }
-
-  // ===== PRIVATE METHODS ===== //
-
-  // --- QUEUE MANAGEMENT --- //
-
-  /**
-   * Flush the queue now
-   */
-  private _flushNow(): void {
-    if (this._batchTimer) {
-      // eslint-disable-next-line no-undef
-      clearTimeout(this._batchTimer);
-      this._batchTimer = null;
-    }
-    this._drainQueue();
-  }
-
-  /**
-   * Schedule a batch of translations
-   */
-  private _scheduleBatch(): void {
-    if (this._batchTimer) return; // already scheduled
-    // eslint-disable-next-line no-undef
-    this._batchTimer = setTimeout(() => {
-      this._batchTimer = null;
-      this._drainQueue();
-    }, BATCH_INTERVAL);
-  }
-
-  /**
-   * Drain the queue
-   */
-  private _drainQueue(): void {
-    while (
-      this._queue.length > 0 &&
-      this._activeRequests < MAX_CONCURRENT_REQUESTS
-    ) {
-      const batch = this._queue.splice(0, MAX_BATCH_SIZE);
-      this._sendBatchRequest(batch);
-    }
-    // If items remain (hit concurrency limit), schedule again
-    if (this._queue.length > 0) {
-      this._scheduleBatch();
-    }
-  }
-
-  /**
-   * Enqueue translation request and return a promise that resolves when the translation is ready
-   * @param {TranslationKey<TranslationValue>} key - The translation key
-   * @returns {Promise<TranslationValue>} The translation promise
-   */
-  private _enqueueTranslation(
-    key: TranslationKey<TranslationValue>
-  ): Promise<TranslationValue> {
     const cacheKey = this.genKey(key);
     const options = key.options;
-    return new Promise<TranslationValue>((resolve, reject) => {
-      this._queue.push({
-        key: cacheKey,
-        source: key.message,
-        metadata: {
-          ...(options?.$context && { context: options.$context }),
-          ...(options?.$id && { id: options.$id }),
-          ...('$maxChars' in options &&
-            options.$maxChars != null && {
-              $maxChars: Math.abs(options.$maxChars),
-            }),
-          dataFormat: options.$format,
-        },
-        resolve: (value) => resolve(value as TranslationValue),
-        reject,
-      });
+    return this._queue.enqueue({
+      key: cacheKey,
+      source: key.message,
+      metadata: {
+        ...(options?.$context && { context: options.$context }),
+        ...(options?.$id && { id: options.$id }),
+        ...('$maxChars' in options &&
+          options.$maxChars != null && {
+            $maxChars: Math.abs(options.$maxChars),
+          }),
+        dataFormat: options.$format,
+      },
     });
   }
 
-  // --- SEND REQUESTS --- //
-
   /**
-   * Send a batch request for translations
-   * @param {QueueEntry<TranslationValue>[]} batch - The batch of requests to send
+   * Send a single batch through translateMany and route each response back
+   * to the matching queue entry. Errors thrown here are caught by the queue
+   * and rejected onto every entry in the batch.
    */
-  private async _sendBatchRequest(
-    batch: QueueEntry<TranslationValue>[]
+  private async _sendBatch(
+    entries: BatchingQueueEntry<
+      QueueItem<TranslationValue>,
+      TranslationValue
+    >[]
   ): Promise<void> {
-    this._activeRequests++;
-
-    const requests = convertBatchToTranslateManyParams(batch);
-    const response = await this._sendBatchRequestWithErrorHandling(
-      batch,
-      requests
-    );
-    if (response) {
-      this._handleTranslationResponse(batch, response);
-    }
-
-    this._activeRequests--;
-  }
-
-  /**
-   * Send a translation request with error handling
-   */
-  private async _sendBatchRequestWithErrorHandling(
-    batch: QueueEntry<TranslationValue>[],
-    requests: Record<Hash, TranslateManyEntry>
-  ): Promise<ReturnType<TranslateMany> | undefined> {
-    try {
-      return await this._translateMany(requests);
-    } catch (error) {
-      for (const entry of batch) {
-        entry.reject(error);
-      }
-      return undefined;
-    }
-  }
-
-  /**
-   * Handle a translation response
-   */
-  private _handleTranslationResponse(
-    batch: QueueEntry<TranslationValue>[],
-    response: Awaited<ReturnType<TranslateMany>>
-  ): void {
-    for (const entry of batch) {
-      const { key } = entry;
-      const result = response[key];
+    const requests = convertBatchToTranslateManyParams(entries);
+    const response = await this._translateMany(requests);
+    for (const entry of entries) {
+      const result = response[entry.item.key];
       if (result && result.success) {
         const translation = result.translation as TranslationValue;
-        this.setCache(key, translation);
+        this.setCache(entry.item.key, translation);
         entry.resolve(translation);
       } else {
         entry.reject(result?.error);
@@ -315,16 +169,15 @@ export class TranslationsCache<
   }
 }
 
-/**
- * Convert a TranslationKey to a TranslateManyEntry
- */
 function convertBatchToTranslateManyParams<
   TranslationValue extends Translation,
->(batch: QueueEntry<TranslationValue>[]): Record<Hash, TranslateManyEntry> {
-  return batch.reduce<Record<Hash, TranslateManyEntry>>((acc, entry) => {
-    acc[entry.key] = {
-      source: entry.source as Content,
-      metadata: entry.metadata,
+>(
+  entries: BatchingQueueEntry<QueueItem<TranslationValue>, TranslationValue>[]
+): Record<Hash, TranslateManyEntry> {
+  return entries.reduce<Record<Hash, TranslateManyEntry>>((acc, entry) => {
+    acc[entry.item.key] = {
+      source: entry.item.source as Content,
+      metadata: entry.item.metadata,
     };
     return acc;
   }, {});

--- a/packages/i18n/src/internal.ts
+++ b/packages/i18n/src/internal.ts
@@ -1,3 +1,8 @@
 export * from './translation-functions/internal';
 export * from './i18n-manager';
 export * from './translation-functions/utils/interpolation/interpolateIcuMessage';
+export {
+  BatchingQueue,
+  type BatchingQueueEntry,
+  type BatchingQueueOptions,
+} from './utils/BatchingQueue';

--- a/packages/i18n/src/utils/BatchingQueue.ts
+++ b/packages/i18n/src/utils/BatchingQueue.ts
@@ -1,0 +1,120 @@
+/**
+ * Default batching parameters. Match the values originally hard-coded in
+ * TranslationsCache, react-core's useRuntimeTranslation, and gt-next's
+ * I18NConfiguration so behavior stays unchanged after the refactor.
+ */
+const DEFAULT_MAX_BATCH_SIZE = 25;
+const DEFAULT_BATCH_INTERVAL = 50;
+const DEFAULT_MAX_CONCURRENT = 100;
+
+export type BatchingQueueEntry<TItem, TResult> = {
+  item: TItem;
+  resolve: (value: TResult) => void;
+  reject: (reason?: unknown) => void;
+};
+
+export type BatchingQueueOptions<TItem, TResult> = {
+  /**
+   * Process a batch. The caller is responsible for resolving or rejecting
+   * each entry. If sendBatch throws, the queue will reject all entries in
+   * the batch with the thrown error as a safety net.
+   */
+  sendBatch: (
+    entries: BatchingQueueEntry<TItem, TResult>[]
+  ) => Promise<void> | void;
+  /** Maximum items per batch. Reaching it flushes immediately. */
+  maxBatchSize?: number;
+  /** Time in ms to wait before flushing a non-full batch. */
+  batchInterval?: number;
+  /** Maximum concurrent in-flight sendBatch calls. */
+  maxConcurrent?: number;
+};
+
+/**
+ * Generic queue that collects items, groups them into batches, and dispatches
+ * them via a caller-provided sendBatch function. Used by translation caches
+ * that need to coalesce many small lookups into fewer network requests.
+ */
+export class BatchingQueue<TItem, TResult = unknown> {
+  private _queue: BatchingQueueEntry<TItem, TResult>[] = [];
+  // eslint-disable-next-line no-undef
+  private _timer: ReturnType<typeof setTimeout> | null = null;
+  private _activeRequests = 0;
+  private readonly _sendBatch: BatchingQueueOptions<
+    TItem,
+    TResult
+  >['sendBatch'];
+  private readonly _maxBatchSize: number;
+  private readonly _batchInterval: number;
+  private readonly _maxConcurrent: number;
+
+  constructor(opts: BatchingQueueOptions<TItem, TResult>) {
+    this._sendBatch = opts.sendBatch;
+    this._maxBatchSize = opts.maxBatchSize ?? DEFAULT_MAX_BATCH_SIZE;
+    this._batchInterval = opts.batchInterval ?? DEFAULT_BATCH_INTERVAL;
+    this._maxConcurrent = opts.maxConcurrent ?? DEFAULT_MAX_CONCURRENT;
+  }
+
+  /**
+   * Enqueue an item. Returns a promise that resolves or rejects when the
+   * caller's sendBatch processes the entry.
+   */
+  enqueue(item: TItem): Promise<TResult> {
+    return new Promise<TResult>((resolve, reject) => {
+      this._queue.push({ item, resolve, reject });
+      if (this._queue.length >= this._maxBatchSize) {
+        this._flushNow();
+      } else {
+        this._schedule();
+      }
+    });
+  }
+
+  private _flushNow(): void {
+    if (this._timer) {
+      // eslint-disable-next-line no-undef
+      clearTimeout(this._timer);
+      this._timer = null;
+    }
+    this._drain();
+  }
+
+  private _schedule(): void {
+    if (this._timer) return;
+    // eslint-disable-next-line no-undef
+    this._timer = setTimeout(() => {
+      this._timer = null;
+      this._drain();
+    }, this._batchInterval);
+  }
+
+  private _drain(): void {
+    while (
+      this._queue.length > 0 &&
+      this._activeRequests < this._maxConcurrent
+    ) {
+      const batch = this._queue.splice(0, this._maxBatchSize);
+      this._send(batch);
+    }
+    if (this._queue.length > 0) {
+      this._schedule();
+    }
+  }
+
+  private async _send(
+    batch: BatchingQueueEntry<TItem, TResult>[]
+  ): Promise<void> {
+    this._activeRequests++;
+    try {
+      await this._sendBatch(batch);
+    } catch (error) {
+      // Safety net: if sendBatch throws without resolving entries, reject
+      // them. Already-resolved entries ignore subsequent reject() calls.
+      for (const entry of batch) {
+        entry.reject(error);
+      }
+    } finally {
+      this._activeRequests--;
+    }
+  }
+}

--- a/packages/i18n/src/utils/__tests__/BatchingQueue.test.ts
+++ b/packages/i18n/src/utils/__tests__/BatchingQueue.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { BatchingQueue, BatchingQueueEntry } from '../BatchingQueue';
+
+describe('BatchingQueue', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('batches enqueues that arrive within the interval into a single sendBatch call', async () => {
+    const sendBatch = vi.fn(
+      async (entries: BatchingQueueEntry<string, string>[]) => {
+        for (const e of entries) e.resolve(e.item.toUpperCase());
+      }
+    );
+    const q = new BatchingQueue<string, string>({ sendBatch });
+
+    const p1 = q.enqueue('a');
+    const p2 = q.enqueue('b');
+    const p3 = q.enqueue('c');
+
+    expect(sendBatch).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(50);
+    const results = await Promise.all([p1, p2, p3]);
+
+    expect(sendBatch).toHaveBeenCalledTimes(1);
+    expect(sendBatch.mock.calls[0][0].map((e) => e.item)).toEqual([
+      'a',
+      'b',
+      'c',
+    ]);
+    expect(results).toEqual(['A', 'B', 'C']);
+  });
+
+  it('flushes immediately when batch reaches maxBatchSize', async () => {
+    const sendBatch = vi.fn(
+      async (entries: BatchingQueueEntry<number, number>[]) => {
+        for (const e of entries) e.resolve(e.item * 2);
+      }
+    );
+    const q = new BatchingQueue<number, number>({
+      sendBatch,
+      maxBatchSize: 3,
+    });
+
+    const p1 = q.enqueue(1);
+    const p2 = q.enqueue(2);
+    const p3 = q.enqueue(3);
+
+    expect(sendBatch).toHaveBeenCalledTimes(1);
+    const results = await Promise.all([p1, p2, p3]);
+    expect(results).toEqual([2, 4, 6]);
+  });
+
+  it('splits enqueues exceeding maxBatchSize across multiple batches', async () => {
+    const sendBatch = vi.fn(
+      async (entries: BatchingQueueEntry<number, number>[]) => {
+        for (const e of entries) e.resolve(e.item);
+      }
+    );
+    const q = new BatchingQueue<number, number>({
+      sendBatch,
+      maxBatchSize: 2,
+    });
+
+    const ps = [1, 2, 3, 4, 5].map((n) => q.enqueue(n));
+    vi.advanceTimersByTime(50);
+    await Promise.all(ps);
+
+    expect(sendBatch).toHaveBeenCalledTimes(3);
+    const callItems = sendBatch.mock.calls.map((call) =>
+      call[0].map((e) => e.item)
+    );
+    expect(callItems).toEqual([[1, 2], [3, 4], [5]]);
+  });
+
+  it('rejects all entries in batch when sendBatch throws', async () => {
+    const sendBatch = vi.fn(async () => {
+      throw new Error('boom');
+    });
+    const q = new BatchingQueue<string, string>({ sendBatch });
+
+    const p1 = q.enqueue('a');
+    const p2 = q.enqueue('b');
+
+    vi.advanceTimersByTime(50);
+
+    await expect(p1).rejects.toThrow('boom');
+    await expect(p2).rejects.toThrow('boom');
+  });
+
+  it('lets caller resolve some entries and reject others within a batch', async () => {
+    const sendBatch = vi.fn(
+      async (entries: BatchingQueueEntry<string, string>[]) => {
+        for (const e of entries) {
+          if (e.item === 'bad') e.reject(new Error('per-entry'));
+          else e.resolve(e.item.toUpperCase());
+        }
+      }
+    );
+    const q = new BatchingQueue<string, string>({ sendBatch });
+
+    const p1 = q.enqueue('a');
+    const p2 = q.enqueue('bad');
+    const p3 = q.enqueue('c');
+
+    vi.advanceTimersByTime(50);
+
+    await expect(p1).resolves.toBe('A');
+    await expect(p2).rejects.toThrow('per-entry');
+    await expect(p3).resolves.toBe('C');
+  });
+
+  it('respects maxConcurrent and reschedules remaining items', async () => {
+    let release!: () => void;
+    const blocker = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    const sendBatch = vi.fn(
+      async (entries: BatchingQueueEntry<number, number>[]) => {
+        await blocker;
+        for (const e of entries) e.resolve(e.item);
+      }
+    );
+
+    const q = new BatchingQueue<number, number>({
+      sendBatch,
+      maxBatchSize: 1,
+      maxConcurrent: 1,
+    });
+
+    // Enqueue 3 items; with maxConcurrent=1 only the first batch goes out
+    // immediately. Items 2 and 3 are queued behind a scheduled timer.
+    const p1 = q.enqueue(1);
+    const p2 = q.enqueue(2);
+    const p3 = q.enqueue(3);
+
+    expect(sendBatch).toHaveBeenCalledTimes(1);
+
+    // Release the in-flight batch and let all subsequent timers fire.
+    release();
+    await vi.runAllTimersAsync();
+    await Promise.all([p1, p2, p3]);
+
+    // Each item went out as its own batch (maxBatchSize=1).
+    expect(sendBatch).toHaveBeenCalledTimes(3);
+  });
+});

--- a/packages/next/src/config-dir/I18NConfiguration.ts
+++ b/packages/next/src/config-dir/I18NConfiguration.ts
@@ -22,6 +22,7 @@ import { defaultLocaleHeaderName } from '../utils/headers';
 import { CustomMapping } from 'generaltranslation/types';
 import { GTTranslationError } from '../utils/errors';
 import type { TranslateManyEntry } from 'generaltranslation/types';
+import { BatchingQueue, BatchingQueueEntry } from 'gt-i18n/internal';
 
 type I18NConfigurationParams = {
   apiKey?: string;
@@ -47,26 +48,18 @@ type I18NConfigurationParams = {
   [key: string]: any;
 };
 
-type QueueEntry =
+type QueueItem =
   | {
       dataFormat: 'I18NEXT' | 'ICU';
       source: _Content;
       targetLocale: string;
       metadata: { hash: string } & Record<string, any>;
-      resolve: (
-        value: TranslatedChildren | PromiseLike<TranslatedChildren>
-      ) => void;
-      reject: (reason?: any) => void;
     }
   | {
       dataFormat: 'JSX';
       source: JsxChildren;
       targetLocale: string;
       metadata: { hash: string } & Record<string, any>;
-      resolve: (
-        value: TranslatedChildren | PromiseLike<TranslatedChildren>
-      ) => void;
-      reject: (reason?: any) => void;
     };
 
 export default class I18NConfiguration {
@@ -100,8 +93,7 @@ export default class I18NConfiguration {
   maxConcurrentRequests: number;
   maxBatchSize: number;
   batchInterval: number;
-  private _queue: Array<QueueEntry>;
-  private _activeRequests: number;
+  private _queue!: BatchingQueue<QueueItem, TranslatedChildren>;
   // Cache for ongoing translation requests
   private _translationCache: Map<string, Promise<any>>;
   // Headers and cookies
@@ -228,10 +220,13 @@ export default class I18NConfiguration {
     this.maxConcurrentRequests = maxConcurrentRequests;
     this.maxBatchSize = maxBatchSize;
     this.batchInterval = batchInterval;
-    this._queue = [];
-    this._activeRequests = 0;
     this._translationCache = new Map(); // cache for ongoing promises, so things aren't translated twice
-    this._startBatching();
+    this._queue = new BatchingQueue<QueueItem, TranslatedChildren>({
+      maxBatchSize,
+      maxConcurrent: maxConcurrentRequests,
+      batchInterval,
+      sendBatch: (entries) => this._sendBatch(entries),
+    });
     // Headers and cookies
     this.localeHeaderName =
       headersAndCookies?.localeHeaderName || defaultLocaleHeaderName;
@@ -447,37 +442,13 @@ export default class I18NConfiguration {
     },
     dataFormat: 'I18NEXT' | 'ICU'
   ): Promise<TranslatedChildren> {
-    // check internal cache
     const cacheKey = constructCacheKey(params.targetLocale, params.options);
-    if (this._translationCache.has(cacheKey)) {
-      return this._translationCache.get(cacheKey);
-    }
-
-    // add to tx queue
-    const { source, targetLocale, options } = params;
-    const translationPromise = new Promise<TranslatedChildren>(
-      (resolve, reject) => {
-        this._queue.push({
-          dataFormat,
-          source,
-          targetLocale,
-          metadata: {
-            ...options,
-            ...(options.maxChars != null && {
-              maxChars: Math.abs(options.maxChars),
-            }),
-          },
-          resolve,
-          reject,
-        });
-      }
-    ).catch((error) => {
-      this._translationCache.delete(cacheKey);
-      throw new Error(error);
+    return this._enqueue(cacheKey, {
+      dataFormat,
+      source: params.source,
+      targetLocale: params.targetLocale,
+      metadata: normalizeMetadata(params.options),
     });
-
-    this._translationCache.set(cacheKey, translationPromise);
-    return translationPromise;
   }
 
   /**
@@ -516,49 +487,45 @@ export default class I18NConfiguration {
     targetLocale: string;
     options: { hash: string } & Record<string, any>;
   }): Promise<TranslatedChildren> {
-    // In memory cache to make sure the same translation isn't requested twice
-    const { source, targetLocale, options } = params;
-    const cacheKey = constructCacheKey(targetLocale, options);
-    if (this._translationCache.has(cacheKey)) {
-      return this._translationCache.get(cacheKey);
-    }
-    // Add to translation queue
-    const translationPromise = new Promise<TranslatedChildren>(
-      (resolve, reject) => {
-        // In memory queue to batch requests
-        this._queue.push({
-          dataFormat: 'JSX',
-          source,
-          targetLocale,
-          metadata: {
-            ...options,
-            ...(options.maxChars != null && {
-              maxChars: Math.abs(options.maxChars),
-            }),
-          },
-          resolve,
-          reject,
-        });
-      }
-    ).catch((error) => {
-      this._translationCache.delete(cacheKey);
-      throw new Error(error);
+    const cacheKey = constructCacheKey(params.targetLocale, params.options);
+    return this._enqueue(cacheKey, {
+      dataFormat: 'JSX',
+      source: params.source,
+      targetLocale: params.targetLocale,
+      metadata: normalizeMetadata(params.options),
     });
-    this._translationCache.set(cacheKey, translationPromise);
-    return translationPromise;
   }
 
   /**
-   * Send a batch request for React translation
-   * @param batch - The batch of requests to be sent
+   * Dedupe identical concurrent requests, then enqueue. The local cache
+   * holds the in-flight Promise so a second caller for the same key joins
+   * the existing request instead of issuing a duplicate.
    */
-  private async _sendBatchRequest(batch: Array<QueueEntry>): Promise<void> {
-    this._activeRequests++;
+  private _enqueue(
+    cacheKey: string,
+    item: QueueItem
+  ): Promise<TranslatedChildren> {
+    const existing = this._translationCache.get(cacheKey);
+    if (existing) return existing;
+    const promise = this._queue.enqueue(item).catch((error) => {
+      this._translationCache.delete(cacheKey);
+      throw new Error(error);
+    });
+    this._translationCache.set(cacheKey, promise);
+    return promise;
+  }
+
+  /**
+   * Process one batch: send to translateMany, write successful results into
+   * the long-term TranslationManager cache, and resolve/reject each entry.
+   */
+  private async _sendBatch(
+    entries: BatchingQueueEntry<QueueItem, TranslatedChildren>[]
+  ): Promise<void> {
     try {
-      // ----- TRANSLATION REQUEST WITH ABORT CONTROLLER ----- //
       const requests: Record<string, TranslateManyEntry> = {};
-      for (const item of batch) {
-        const { source, metadata, dataFormat } = item;
+      for (const e of entries) {
+        const { source, metadata, dataFormat } = e.item;
         requests[metadata.hash] = {
           source,
           metadata: { ...metadata, dataFormat },
@@ -567,64 +534,49 @@ export default class I18NConfiguration {
 
       const results = await this.gt.translateMany(
         requests,
-        {
-          ...this.metadata,
-          targetLocale: batch[0].targetLocale,
-        },
+        { ...this.metadata, targetLocale: entries[0].item.targetLocale },
         this.renderSettings.timeout
       );
 
-      // ----- PROCESS RESPONSE ----- //
-      batch.forEach((request) => {
-        const hash = request.metadata.hash;
+      for (const e of entries) {
+        const hash = e.item.metadata.hash;
         const result = results[hash];
-
         if (result && result.success) {
-          // record translations
-          if (this._translationManager) {
-            this._translationManager.setTranslations(
-              request.targetLocale,
-              hash,
-              result.translation
-            );
-          }
-          return request.resolve(result.translation);
+          this._translationManager?.setTranslations(
+            e.item.targetLocale,
+            hash,
+            result.translation
+          );
+          e.resolve(result.translation);
+        } else {
+          e.reject(new GTTranslationError('Translation failed.', 500));
         }
-        return request.reject(
-          new GTTranslationError('Translation failed.', 500)
-        );
-      });
+      }
     } catch (error) {
-      // Error logging
       if (error instanceof Error && error.name === 'AbortError') {
-        console.warn(runtimeTranslationTimeoutWarning); // Warning for timeout
+        console.warn(runtimeTranslationTimeoutWarning);
       } else {
         console.warn(error);
       }
-      // Reject all promises
-      batch.forEach((request) => {
-        return request.reject(new GTTranslationError(String(error), 500));
-      });
-    } finally {
-      this._activeRequests--;
+      for (const e of entries) {
+        e.reject(new GTTranslationError(String(error), 500));
+      }
     }
   }
+}
 
-  /**
-   * Start the batching process with a set interval
-   */
-  private _startBatching(): void {
-    setInterval(() => {
-      if (
-        this._queue.length > 0 &&
-        this._activeRequests < this.maxConcurrentRequests
-      ) {
-        const batchSize = Math.min(this.maxBatchSize, this._queue.length);
-        this._sendBatchRequest(this._queue.slice(0, batchSize));
-        this._queue = this._queue.slice(batchSize);
-      }
-    }, this.batchInterval);
-  }
+/**
+ * Strip the maxChars sign so callers can pass either form.
+ */
+function normalizeMetadata(
+  options: { hash: string } & Record<string, any>
+): { hash: string } & Record<string, any> {
+  return {
+    ...options,
+    ...(options.maxChars != null && {
+      maxChars: Math.abs(options.maxChars),
+    }),
+  };
 }
 
 // Constructs the unique identification key for the map which is the in-memory same-render-cycle cache

--- a/packages/react-core/src/provider/hooks/useRuntimeTranslation.ts
+++ b/packages/react-core/src/provider/hooks/useRuntimeTranslation.ts
@@ -22,6 +22,7 @@ import {
 } from '../config/defaultProps';
 import { GT } from 'generaltranslation';
 import type { TranslateManyEntry } from 'generaltranslation/types';
+import { BatchingQueue } from 'gt-i18n/internal';
 
 type TranslationRequestMetadata = {
   hash: string;
@@ -30,20 +31,16 @@ type TranslationRequestMetadata = {
   [attr: string]: any;
 };
 
-type TranslationRequestQueueItem =
+type QueueItem =
   | {
       dataFormat: 'ICU';
       source: string;
       metadata: TranslationRequestMetadata;
-      resolve: (value: TranslatedChildren) => void;
-      reject: (error: any) => void; // kept for API compatibility (unused after change)
     }
   | {
       dataFormat: 'JSX';
       source: JsxChildren;
       metadata: TranslationRequestMetadata;
-      resolve: (value: TranslatedChildren) => void;
-      reject: (error: any) => void; // kept for API compatibility (unused after change)
     };
 
 export default function useRuntimeTranslation({
@@ -173,164 +170,74 @@ export default function useRuntimeTranslation({
     }
   }, [flushTick, mergeIntoTranslations]);
 
-  // ---------- REQUEST/QUEUE STATE ---------- //
-  const activeRequestsRef = useRef(0);
-  const requestQueueRef = useRef<Map<string, TranslationRequestQueueItem>>(
+  // ---------- DEDUP MAP (separate from queue: same key can map to one in-flight Promise) ---------- //
+  const pendingRequestsRef = useRef<Map<string, Promise<TranslatedChildren>>>(
     new Map()
   );
-  const pendingRequestQueueRef = useRef<
-    Map<string, Promise<TranslatedChildren>>
-  >(new Map());
 
-  // ---------- BATCH SENDER (no state writes here) ---------- //
-  const sendBatchRequest = useCallback(
-    async (
-      batch: Map<string, TranslationRequestQueueItem>
-    ): Promise<Translations> => {
-      if (batch.size === 0) return {};
-      activeRequestsRef.current += 1;
+  // ---------- BATCHING QUEUE ---------- //
+  // Lazy-init via useState so the queue is constructed once. The sendBatch
+  // closure captures cfgRef (mutable, always current) and stageAndRequestFlush
+  // (stable useCallback identity), so it stays valid across renders.
+  const [queue] = useState(
+    () =>
+      new BatchingQueue<QueueItem, TranslatedChildren | null>({
+        maxBatchSize,
+        batchInterval,
+        maxConcurrent: maxConcurrentRequests,
+        sendBatch: async (entries) => {
+          const { gt, locale, baseMetadata, timeout } = cfgRef.current;
 
-      const { gt, locale, baseMetadata, timeout } = cfgRef.current;
-      const requests = Array.from(batch.values());
-      const newTranslations: Translations = {};
-      const resultsMap = new Map<string, TranslatedChildren | null>();
-
-      try {
-        const requestsRecord: Record<string, TranslateManyEntry> = {};
-        for (const req of requests) {
-          const { source, metadata } = req;
-          requestsRecord[metadata.hash] = {
-            source,
-            metadata: { ...metadata, dataFormat: req.dataFormat },
-          };
-        }
-
-        const results = await gt.translateMany(
-          requestsRecord,
-          {
-            ...baseMetadata,
-            targetLocale: locale,
-          },
-          timeout
-        );
-
-        for (const req of requests) {
-          const { hash, id } = req.metadata;
-          const result = results[hash];
-          if (result && result.success) {
-            const value = result.translation;
-            newTranslations[hash] = value;
-            resultsMap.set(hash, value);
-          } else if (result && result.error) {
-            const msg = createGenericRuntimeTranslationError(id, hash);
-            console.warn(
-              `${msg} ${result.error || 'An upstream error occurred.'}`
-            );
-            newTranslations[hash] = null;
-            resultsMap.set(hash, null);
-          } else {
-            const msg = createGenericRuntimeTranslationError(id, hash);
-            console.warn(`${msg} Unknown response format.`, result);
-            newTranslations[hash] = null;
-            resultsMap.set(hash, null);
+          const requestsRecord: Record<string, TranslateManyEntry> = {};
+          for (const e of entries) {
+            requestsRecord[e.item.metadata.hash] = {
+              source: e.item.source,
+              metadata: { ...e.item.metadata, dataFormat: e.item.dataFormat },
+            };
           }
-        }
-      } catch (e: any) {
-        if (e?.name === 'AbortError') {
-          console.warn(runtimeTranslationTimeoutWarning);
-        } else {
-          console.warn(dynamicTranslationError, e);
-        }
-        // Mark every request in this batch as null, and warn.
-        requests.forEach((r) => {
-          newTranslations[r.metadata.hash] = null;
-          resultsMap.set(r.metadata.hash, null);
-        });
-      } finally {
-        activeRequestsRef.current -= 1;
-        // Resolve the promises for this batch (never reject).
-        requests.forEach((r) => {
-          const res = resultsMap.get(r.metadata.hash);
-          if (res === undefined) {
-            console.warn(
-              `No translation result for ${r.metadata.hash}; resolving as null.`
+
+          const newTranslations: Translations = {};
+          try {
+            const results = await gt.translateMany(
+              requestsRecord,
+              { ...baseMetadata, targetLocale: locale },
+              timeout
             );
-            r.resolve(null as unknown as TranslatedChildren);
-          } else {
-            r.resolve(res as TranslatedChildren);
+            for (const e of entries) {
+              const { hash, id } = e.item.metadata;
+              const result = results[hash];
+              if (result && result.success) {
+                const value = result.translation;
+                newTranslations[hash] = value;
+                e.resolve(value);
+              } else {
+                const msg = createGenericRuntimeTranslationError(id, hash);
+                console.warn(
+                  result?.error
+                    ? `${msg} ${result.error}`
+                    : `${msg} Unknown response format.`,
+                  result?.error ? undefined : result
+                );
+                newTranslations[hash] = null;
+                e.resolve(null);
+              }
+            }
+          } catch (err: any) {
+            if (err?.name === 'AbortError') {
+              console.warn(runtimeTranslationTimeoutWarning);
+            } else {
+              console.warn(dynamicTranslationError, err);
+            }
+            // Never reject — preserve the original "always resolve, null on failure" contract.
+            for (const e of entries) {
+              newTranslations[e.item.metadata.hash] = null;
+              e.resolve(null);
+            }
           }
-        });
-      }
 
-      return newTranslations;
-    },
-    []
-  );
-
-  // ---------- TIMER-DRIVEN FLUSHER (no polling effect) ---------- //
-  const flushTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const tickRef = useRef<() => Promise<void>>(async () => {});
-
-  const stageAndScheduleNext = useCallback(
-    (batchResult: Translations) => {
-      // Stage results and request the commit effect to run
-      stageAndRequestFlush(batchResult);
-
-      // If more work remains, schedule another flush cycle
-      if (requestQueueRef.current.size > 0) {
-        flushTimerRef.current = setTimeout(() => {
-          flushTimerRef.current = null;
-          void tickRef.current();
-        }, batchInterval);
-      }
-    },
-    [stageAndRequestFlush]
-  );
-
-  const installTick = useCallback(() => {
-    tickRef.current = async () => {
-      // Respect concurrency cap
-      if (activeRequestsRef.current >= maxConcurrentRequests) {
-        flushTimerRef.current = setTimeout(() => {
-          flushTimerRef.current = null;
-          void tickRef.current();
-        }, batchInterval);
-        return;
-      }
-
-      const q = requestQueueRef.current;
-      if (q.size === 0) return;
-
-      const batchEntries = Array.from(q.entries()).slice(
-        0,
-        Math.min(maxBatchSize, q.size)
-      );
-      const batch = new Map(batchEntries);
-      batchEntries.forEach(([k]) => q.delete(k));
-
-      const batchResult = await sendBatchRequest(batch);
-      stageAndScheduleNext(batchResult);
-    };
-  }, [sendBatchRequest, stageAndScheduleNext]);
-
-  const scheduleFlush = useCallback(
-    (immediate = false) => {
-      installTick();
-      if (immediate) {
-        if (flushTimerRef.current) {
-          clearTimeout(flushTimerRef.current);
-          flushTimerRef.current = null;
-        }
-        void tickRef.current(); // Safe pre-mount: will only stage results
-        return;
-      }
-      if (flushTimerRef.current) return; // already armed
-      flushTimerRef.current = setTimeout(() => {
-        flushTimerRef.current = null;
-        void tickRef.current();
-      }, batchInterval);
-    },
-    [installTick]
+          stageAndRequestFlush(newTranslations);
+        },
+      })
   );
 
   // ---------- REGISTRATION (returns Promises for Suspense) ---------- //
@@ -343,53 +250,40 @@ export default function useRuntimeTranslation({
       }): Promise<TranslatedChildren> => {
         const key = `${params.metadata.hash}:${params.targetLocale}`;
 
-        const existing = pendingRequestQueueRef.current.get(key);
+        const existing = pendingRequestsRef.current.get(key);
         if (existing) return existing;
 
-        const p = new Promise<TranslatedChildren>((resolve /*, reject */) => {
-          const item: TranslationRequestQueueItem =
-            dataFormat === 'JSX'
-              ? {
-                  dataFormat: 'JSX',
-                  source: params.source as JsxChildren,
-                  metadata: {
-                    ...params.metadata,
-                    ...(params.metadata.maxChars != null && {
-                      maxChars: Math.abs(params.metadata.maxChars),
-                    }),
-                  },
-                  resolve,
-                  reject: () => {}, // no-op; we no longer reject
-                }
-              : {
-                  dataFormat: 'ICU',
-                  source: params.source as string,
-                  metadata: {
-                    ...params.metadata,
-                    ...(params.metadata.maxChars != null && {
-                      maxChars: Math.abs(params.metadata.maxChars),
-                    }),
-                  },
-                  resolve,
-                  reject: () => {}, // no-op; we no longer reject
-                };
+        const metadata = {
+          ...params.metadata,
+          ...(params.metadata.maxChars != null && {
+            maxChars: Math.abs(params.metadata.maxChars),
+          }),
+        };
 
-          requestQueueRef.current.set(key, item);
+        const item: QueueItem =
+          dataFormat === 'JSX'
+            ? {
+                dataFormat: 'JSX',
+                source: params.source as JsxChildren,
+                metadata,
+              }
+            : {
+                dataFormat: 'ICU',
+                source: params.source as string,
+                metadata,
+              };
 
-          const canFlushNow =
-            requestQueueRef.current.size >= maxBatchSize &&
-            activeRequestsRef.current < maxConcurrentRequests;
+        const p = queue
+          .enqueue(item)
+          .then((value) => value as TranslatedChildren)
+          .finally(() => {
+            pendingRequestsRef.current.delete(key);
+          });
 
-          // Kick the scheduler; immediate is safe (no state writes pre-mount)
-          scheduleFlush(canFlushNow);
-        }).finally(() => {
-          pendingRequestQueueRef.current.delete(key);
-        });
-
-        pendingRequestQueueRef.current.set(key, p);
+        pendingRequestsRef.current.set(key, p);
         return p;
       },
-    [scheduleFlush]
+    [queue]
   );
 
   const registerIcuForTranslation = useMemo(
@@ -400,13 +294,6 @@ export default function useRuntimeTranslation({
     () => createRegistration('JSX'),
     [createRegistration]
   );
-
-  // Cleanup any stray timer on unmount (does not drive batching)
-  useEffect(() => {
-    return () => {
-      if (flushTimerRef.current) clearTimeout(flushTimerRef.current);
-    };
-  }, []);
 
   return {
     developmentApiEnabled,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       '@eslint/js':
         specifier: ^9.17.0
         version: 9.36.0
+      '@size-limit/preset-small-lib':
+        specifier: ^12.1.0
+        version: 12.1.0(size-limit@12.1.0(jiti@2.6.1))
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.18.1
         version: 8.44.1(@typescript-eslint/parser@8.44.1(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.2))(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.2)
@@ -63,6 +66,9 @@ importers:
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
+      size-limit:
+        specifier: ^12.1.0
+        version: 12.1.0(jiti@2.6.1)
       turbo:
         specifier: ^2.5.3
         version: 2.5.8
@@ -2563,6 +2569,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.0':
+    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.21.5':
     resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
@@ -2583,6 +2595,12 @@ packages:
 
   '@esbuild/android-arm64@0.27.4':
     resolution: {integrity: sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.0':
+    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -2611,6 +2629,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.0':
+    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.21.5':
     resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
@@ -2631,6 +2655,12 @@ packages:
 
   '@esbuild/android-x64@0.27.4':
     resolution: {integrity: sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.0':
+    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -2659,6 +2689,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.28.0':
+    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.21.5':
     resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
@@ -2679,6 +2715,12 @@ packages:
 
   '@esbuild/darwin-x64@0.27.4':
     resolution: {integrity: sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.0':
+    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -2707,6 +2749,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.21.5':
     resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
@@ -2727,6 +2775,12 @@ packages:
 
   '@esbuild/freebsd-x64@0.27.4':
     resolution: {integrity: sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.0':
+    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -2755,6 +2809,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.28.0':
+    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.21.5':
     resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
@@ -2775,6 +2835,12 @@ packages:
 
   '@esbuild/linux-arm@0.27.4':
     resolution: {integrity: sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.0':
+    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -2803,6 +2869,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.0':
+    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.21.5':
     resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
@@ -2823,6 +2895,12 @@ packages:
 
   '@esbuild/linux-loong64@0.27.4':
     resolution: {integrity: sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.0':
+    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -2851,6 +2929,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.0':
+    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.21.5':
     resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
@@ -2871,6 +2955,12 @@ packages:
 
   '@esbuild/linux-ppc64@0.27.4':
     resolution: {integrity: sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.0':
+    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -2899,6 +2989,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.0':
+    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.21.5':
     resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
@@ -2919,6 +3015,12 @@ packages:
 
   '@esbuild/linux-s390x@0.27.4':
     resolution: {integrity: sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.0':
+    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -2947,6 +3049,12 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.0':
+    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.25.10':
     resolution: {integrity: sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==}
     engines: {node: '>=18'}
@@ -2961,6 +3069,12 @@ packages:
 
   '@esbuild/netbsd-arm64@0.27.4':
     resolution: {integrity: sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -2989,6 +3103,12 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.28.0':
+    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.25.10':
     resolution: {integrity: sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==}
     engines: {node: '>=18'}
@@ -3003,6 +3123,12 @@ packages:
 
   '@esbuild/openbsd-arm64@0.27.4':
     resolution: {integrity: sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -3031,6 +3157,12 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.0':
+    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.25.10':
     resolution: {integrity: sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==}
     engines: {node: '>=18'}
@@ -3045,6 +3177,12 @@ packages:
 
   '@esbuild/openharmony-arm64@0.27.4':
     resolution: {integrity: sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -3073,6 +3211,12 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.28.0':
+    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.21.5':
     resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
     engines: {node: '>=12'}
@@ -3093,6 +3237,12 @@ packages:
 
   '@esbuild/win32-arm64@0.27.4':
     resolution: {integrity: sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.0':
+    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -3121,6 +3271,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.0':
+    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.21.5':
     resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
@@ -3141,6 +3297,12 @@ packages:
 
   '@esbuild/win32-x64@0.27.4':
     resolution: {integrity: sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.0':
+    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -6236,6 +6398,23 @@ packages:
   '@sinonjs/fake-timers@10.3.0':
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
 
+  '@size-limit/esbuild@12.1.0':
+    resolution: {integrity: sha512-Um6MVrX+05kIxI4+zk0ZByG9dA/Th1f+sfGc571D95BnCPc90/pl2+2OdsQuOyoWEbeAMqfcTKo0v07i+E65Vw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      size-limit: 12.1.0
+
+  '@size-limit/file@12.1.0':
+    resolution: {integrity: sha512-eGwDcIufnNnvJRzv3liDOn6MAOGgmOTUdpeGQ2KuRTlgIgO54AJH1ilvktlJc6PIjNfwpYY0dOGyap1QgM1swQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      size-limit: 12.1.0
+
+  '@size-limit/preset-small-lib@12.1.0':
+    resolution: {integrity: sha512-TVVQ/iuHbaGtHJrjur5s4XKYEyGk0nIwUAqhuzhKPbTyV9nYOH/laDelQ4vg3cGmm8sayRx998wxEdnwM/Yewg==}
+    peerDependencies:
+      size-limit: 12.1.0
+
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
 
@@ -7568,6 +7747,10 @@ packages:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
     engines: {node: '>=10.16.0'}
 
+  bytes-iec@3.1.1:
+    resolution: {integrity: sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA==}
+    engines: {node: '>= 0.8'}
+
   bytes@3.0.0:
     resolution: {integrity: sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==}
     engines: {node: '>= 0.8'}
@@ -8468,6 +8651,11 @@ packages:
 
   esbuild@0.27.4:
     resolution: {integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.28.0:
+    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -10944,6 +11132,14 @@ packages:
     engines: {node: ^18 || >=20}
     hasBin: true
 
+  nanoid@5.1.9:
+    resolution: {integrity: sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw==}
+    engines: {node: ^18 || >=20}
+    hasBin: true
+
+  nanospinner@1.2.2:
+    resolution: {integrity: sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA==}
+
   napi-postinstall@0.3.3:
     resolution: {integrity: sha512-uTp172LLXSxuSYHv/kou+f6KW3SMppU9ivthaVTXian9sOt3XM/zHYHpRZiLgQoxeWfYUnslNWQHF1+G71xcow==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
@@ -12762,6 +12958,16 @@ packages:
 
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
+  size-limit@12.1.0:
+    resolution: {integrity: sha512-VnDS2fycANrJFVPQwjaD+h+hkISY7EB3LsPsYWje4lBCjQwwsZLxjwwRwVJKHrcj2ZqyG+DdXykWm9mbZklZrw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      jiti: ^2.0.0
+    peerDependenciesMeta:
+      jiti:
+        optional: true
 
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
@@ -15895,6 +16101,9 @@ snapshots:
   '@esbuild/aix-ppc64@0.27.4':
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
   '@esbuild/android-arm64@0.21.5':
     optional: true
 
@@ -15905,6 +16114,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.0':
     optional: true
 
   '@esbuild/android-arm@0.21.5':
@@ -15919,6 +16131,9 @@ snapshots:
   '@esbuild/android-arm@0.27.4':
     optional: true
 
+  '@esbuild/android-arm@0.28.0':
+    optional: true
+
   '@esbuild/android-x64@0.21.5':
     optional: true
 
@@ -15929,6 +16144,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-x64@0.27.4':
+    optional: true
+
+  '@esbuild/android-x64@0.28.0':
     optional: true
 
   '@esbuild/darwin-arm64@0.21.5':
@@ -15943,6 +16161,9 @@ snapshots:
   '@esbuild/darwin-arm64@0.27.4':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
   '@esbuild/darwin-x64@0.21.5':
     optional: true
 
@@ -15953,6 +16174,9 @@ snapshots:
     optional: true
 
   '@esbuild/darwin-x64@0.27.4':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.0':
     optional: true
 
   '@esbuild/freebsd-arm64@0.21.5':
@@ -15967,6 +16191,9 @@ snapshots:
   '@esbuild/freebsd-arm64@0.27.4':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
   '@esbuild/freebsd-x64@0.21.5':
     optional: true
 
@@ -15977,6 +16204,9 @@ snapshots:
     optional: true
 
   '@esbuild/freebsd-x64@0.27.4':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.0':
     optional: true
 
   '@esbuild/linux-arm64@0.21.5':
@@ -15991,6 +16221,9 @@ snapshots:
   '@esbuild/linux-arm64@0.27.4':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
   '@esbuild/linux-arm@0.21.5':
     optional: true
 
@@ -16001,6 +16234,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-arm@0.27.4':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.0':
     optional: true
 
   '@esbuild/linux-ia32@0.21.5':
@@ -16015,6 +16251,9 @@ snapshots:
   '@esbuild/linux-ia32@0.27.4':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
   '@esbuild/linux-loong64@0.21.5':
     optional: true
 
@@ -16025,6 +16264,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-loong64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.0':
     optional: true
 
   '@esbuild/linux-mips64el@0.21.5':
@@ -16039,6 +16281,9 @@ snapshots:
   '@esbuild/linux-mips64el@0.27.4':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
   '@esbuild/linux-ppc64@0.21.5':
     optional: true
 
@@ -16049,6 +16294,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-ppc64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.0':
     optional: true
 
   '@esbuild/linux-riscv64@0.21.5':
@@ -16063,6 +16311,9 @@ snapshots:
   '@esbuild/linux-riscv64@0.27.4':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
   '@esbuild/linux-s390x@0.21.5':
     optional: true
 
@@ -16073,6 +16324,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-s390x@0.27.4':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.0':
     optional: true
 
   '@esbuild/linux-x64@0.21.5':
@@ -16087,6 +16341,9 @@ snapshots:
   '@esbuild/linux-x64@0.27.4':
     optional: true
 
+  '@esbuild/linux-x64@0.28.0':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.25.10':
     optional: true
 
@@ -16094,6 +16351,9 @@ snapshots:
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/netbsd-x64@0.21.5':
@@ -16108,6 +16368,9 @@ snapshots:
   '@esbuild/netbsd-x64@0.27.4':
     optional: true
 
+  '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.25.10':
     optional: true
 
@@ -16115,6 +16378,9 @@ snapshots:
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/openbsd-x64@0.21.5':
@@ -16129,6 +16395,9 @@ snapshots:
   '@esbuild/openbsd-x64@0.27.4':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.25.10':
     optional: true
 
@@ -16136,6 +16405,9 @@ snapshots:
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.0':
     optional: true
 
   '@esbuild/sunos-x64@0.21.5':
@@ -16150,6 +16422,9 @@ snapshots:
   '@esbuild/sunos-x64@0.27.4':
     optional: true
 
+  '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
   '@esbuild/win32-arm64@0.21.5':
     optional: true
 
@@ -16160,6 +16435,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.0':
     optional: true
 
   '@esbuild/win32-ia32@0.21.5':
@@ -16174,6 +16452,9 @@ snapshots:
   '@esbuild/win32-ia32@0.27.4':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
   '@esbuild/win32-x64@0.21.5':
     optional: true
 
@@ -16184,6 +16465,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-x64@0.27.4':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.0':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.0(eslint@8.57.1)':
@@ -19701,6 +19985,22 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
+  '@size-limit/esbuild@12.1.0(size-limit@12.1.0(jiti@2.6.1))':
+    dependencies:
+      esbuild: 0.28.0
+      nanoid: 5.1.9
+      size-limit: 12.1.0(jiti@2.6.1)
+
+  '@size-limit/file@12.1.0(size-limit@12.1.0(jiti@2.6.1))':
+    dependencies:
+      size-limit: 12.1.0(jiti@2.6.1)
+
+  '@size-limit/preset-small-lib@12.1.0(size-limit@12.1.0(jiti@2.6.1))':
+    dependencies:
+      '@size-limit/esbuild': 12.1.0(size-limit@12.1.0(jiti@2.6.1))
+      '@size-limit/file': 12.1.0(size-limit@12.1.0(jiti@2.6.1))
+      size-limit: 12.1.0(jiti@2.6.1)
+
   '@swc/counter@0.1.3': {}
 
   '@swc/helpers@0.5.15':
@@ -21464,6 +21764,8 @@ snapshots:
     dependencies:
       streamsearch: 1.1.0
 
+  bytes-iec@3.1.1: {}
+
   bytes@3.0.0: {}
 
   bytes@3.1.2: {}
@@ -22556,6 +22858,35 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.4
       '@esbuild/win32-x64': 0.27.4
 
+  esbuild@0.28.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.0
+      '@esbuild/android-arm': 0.28.0
+      '@esbuild/android-arm64': 0.28.0
+      '@esbuild/android-x64': 0.28.0
+      '@esbuild/darwin-arm64': 0.28.0
+      '@esbuild/darwin-x64': 0.28.0
+      '@esbuild/freebsd-arm64': 0.28.0
+      '@esbuild/freebsd-x64': 0.28.0
+      '@esbuild/linux-arm': 0.28.0
+      '@esbuild/linux-arm64': 0.28.0
+      '@esbuild/linux-ia32': 0.28.0
+      '@esbuild/linux-loong64': 0.28.0
+      '@esbuild/linux-mips64el': 0.28.0
+      '@esbuild/linux-ppc64': 0.28.0
+      '@esbuild/linux-riscv64': 0.28.0
+      '@esbuild/linux-s390x': 0.28.0
+      '@esbuild/linux-x64': 0.28.0
+      '@esbuild/netbsd-arm64': 0.28.0
+      '@esbuild/netbsd-x64': 0.28.0
+      '@esbuild/openbsd-arm64': 0.28.0
+      '@esbuild/openbsd-x64': 0.28.0
+      '@esbuild/openharmony-arm64': 0.28.0
+      '@esbuild/sunos-x64': 0.28.0
+      '@esbuild/win32-arm64': 0.28.0
+      '@esbuild/win32-ia32': 0.28.0
+      '@esbuild/win32-x64': 0.28.0
+
   escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
@@ -22639,7 +22970,7 @@ snapshots:
       get-tsconfig: 4.10.1
       is-bun-module: 2.0.0
       stable-hash: 0.0.5
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.36.0(jiti@2.6.1))
@@ -25726,6 +26057,12 @@ snapshots:
 
   nanoid@5.1.6: {}
 
+  nanoid@5.1.9: {}
+
+  nanospinner@1.2.2:
+    dependencies:
+      picocolors: 1.1.1
+
   napi-postinstall@0.3.3: {}
 
   natural-compare@1.4.0: {}
@@ -28051,6 +28388,16 @@ snapshots:
 
   sisteransi@1.0.5: {}
 
+  size-limit@12.1.0(jiti@2.6.1):
+    dependencies:
+      bytes-iec: 3.1.1
+      lilconfig: 3.1.3
+      nanospinner: 1.2.2
+      picocolors: 1.1.1
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      jiti: 2.6.1
+
   slash@3.0.0: {}
 
   slash@5.1.0: {}
@@ -29363,7 +29710,7 @@ snapshots:
 
   vite@7.3.1(@types/node@22.13.10)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
-      esbuild: 0.27.2
+      esbuild: 0.27.4
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
       postcss: 8.5.6
@@ -29380,7 +29727,7 @@ snapshots:
 
   vite@7.3.1(@types/node@24.8.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
-      esbuild: 0.27.2
+      esbuild: 0.27.4
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
       postcss: 8.5.6


### PR DESCRIPTION
## Summary

Unifies the translation batching code across `gt-i18n`, `@generaltranslation/react-core`, and `gt-next`. All three previously reimplemented the same queue/timer/drain loop with identical constants (`maxBatchSize=25`, `batchInterval=50ms`, `maxConcurrent=100`). This PR extracts a single generic [BatchingQueue<TItem, TResult>](packages/i18n/src/utils/BatchingQueue.ts) class into `gt-i18n/internal` and rewires the three consumers to use it.

## Changes

- **New** [packages/i18n/src/utils/BatchingQueue.ts](packages/i18n/src/utils/BatchingQueue.ts) — generic class, ~115 lines, pluggable `sendBatch` callback.
- **New** [packages/i18n/src/utils/__tests__/BatchingQueue.test.ts](packages/i18n/src/utils/__tests__/BatchingQueue.test.ts) — 6 unit tests covering interval batching, immediate flush at maxBatchSize, batch splitting, error propagation, mixed resolve/reject, maxConcurrent + rescheduling.
- **Refactored** [TranslationsCache.ts](packages/i18n/src/i18n-manager/translations-manager/TranslationsCache.ts) — drops ~140 lines of inline queue logic.
- **Refactored** [useRuntimeTranslation.ts](packages/react-core/src/provider/hooks/useRuntimeTranslation.ts) — drops ~150 lines (sendBatchRequest, installTick, scheduleFlush, stageAndScheduleNext, request queue refs). React lifecycle / staging / dedup logic stays.
- **Refactored** [I18NConfiguration.ts](packages/next/src/config-dir/I18NConfiguration.ts) — drops ~80 lines (`_sendBatchRequest`, `_startBatching`, manual queue array). Adds small `_enqueue` helper for dedup-cache plumbing.
- **Exposed** `BatchingQueue`, `BatchingQueueEntry`, `BatchingQueueOptions` from `gt-i18n/internal`.

**Net:** ~250 lines of source removed.

## Behavior change worth flagging

Both `react-core` and `gt-next` previously processed batches **sequentially** despite the `maxConcurrent=100` constant — their batching loops awaited each send before starting the next, so steady-state activeRequests rarely exceeded 1. They now **fan out concurrently up to the cap**, matching `gt-i18n`'s long-standing behavior.

For an app with >25 unique strings translated at once:
- Before: 4 batches × 50ms apart = ~200ms minimum
- After: 4 batches concurrent = ~50ms (one network round trip)

`gt-next` also no longer runs a permanent `setInterval` polling the queue. The queue self-schedules only when work exists, so an idle config no longer ticks every 50ms forever.

## Bundle-size delta (brotli)

| Entry | Before | After | Δ |
|---|---:|---:|---:|
| `generaltranslation` | 26.51 kB | 26.51 kB | — |
| `gt-i18n` | 30.69 kB | 30.77 kB | +0.08 kB |
| `@generaltranslation/react-core` | 42.49 kB | 42.45 kB | -0.04 kB |
| `gt-react` | 45.21 kB | 45.21 kB | — |
| `gt-tanstack-start` | 49.50 kB | 49.30 kB | -0.20 kB |
| `gt-next/client` | 50.35 kB | 50.26 kB | -0.09 kB |

**Honest read:** the per-bundle savings are smaller than the upfront analysis suggested. Brotli was already compressing the duplicated patterns very efficiently within each package. The real win here is on the source side — ~250 fewer lines, single source of truth for batching constants, single place to evolve the algorithm. `gt-i18n` grows ~80 bytes from the abstraction overhead with one consumer in-package; the React and Next consumers nearly cancel that out at the system level.

If we want bigger bundle wins, the next target is the core `index.ts` barrel — importing just `getLocaleProperties` still pulls 15.8 kB because the ICU parser/formatter ride along. That's a different shape of cleanup.

## Test plan

- [x] `pnpm --filter gt-i18n test` — 88 passed (incl. all `TranslationsCache` regressions)
- [x] `pnpm --filter @generaltranslation/react-core test` — 289 passed
- [x] `pnpm --filter gt-react test` — 12 passed
- [x] `pnpm --filter gt-next test:js` — 187 passed
- [x] `pnpm build` — 20/20 turbo tasks pass
- [x] `pnpm size` — within budgets
- [ ] CI runs and posts size-diff comment

## Stacked on

`perf/size-limit-pr-comments` (#1255). Merge order: #1253 → #1255 → this.