### PR TITLE
feat(i18n): add event system to I18nManager for useSyncExternalStore support

### DIFF
--- a/packages/i18n/src/i18n-manager/I18nManager.ts
+++ b/packages/i18n/src/i18n-manager/I18nManager.ts
@@ -21,6 +21,10 @@ import { getLoadTranslationsType } from './utils/getLoadTranslationsType';
 import { LocalesCache } from './translations-manager/LocalesCache';
 import { Hash } from './translations-manager/TranslationsCache';
 import { createLifecycleCallbacks } from './lifecycle-hooks/createLifecycleCallbacks';
+import {
+  I18nEventEmitter,
+  I18nEventListener,
+} from './events/EventEmitter';
 
 /**
  * Default translation timeout in milliseconds for a runtime translation request
@@ -77,6 +81,11 @@ class I18nManager<
   private localesCache: LocalesCache<TranslationValue>;
 
   /**
+   * Event emitter for subscribe/getVersion pattern
+   */
+  private _eventEmitter: I18nEventEmitter = new I18nEventEmitter();
+
+  /**
    * Creates an instance of I18nManager.
    * TODO: resolve gtConfig from just file path
    * @param params - The parameters for the I18nManager constructor
@@ -102,14 +111,37 @@ class I18nManager<
       DEFAULT_TRANSLATION_TIMEOUT
     );
 
+    // Create lifecycle callbacks that also emit events
+    const lifecycleCallbacks = createLifecycleCallbacks<TranslationValue>(
+      params.lifecycle ?? {}
+    );
+
+    // Wrap lifecycle callbacks to emit events
+    const originalOnLocalesCacheMiss = lifecycleCallbacks.onLocalesCacheMiss;
+    lifecycleCallbacks.onLocalesCacheMiss = (params) => {
+      originalOnLocalesCacheMiss?.(params);
+      this._eventEmitter.emit({
+        type: 'translationsLoaded',
+        locale: params.inputKey,
+      });
+    };
+
+    const originalOnTranslationsCacheMiss =
+      lifecycleCallbacks.onTranslationsCacheMiss;
+    lifecycleCallbacks.onTranslationsCacheMiss = (params) => {
+      originalOnTranslationsCacheMiss?.(params);
+      this._eventEmitter.emit({
+        type: 'translationResolved',
+        locale: params.locale,
+      });
+    };
+
     // Setup translations cache
     this.localesCache = new LocalesCache<TranslationValue>({
       loadTranslations:
         loadTranslations as SafeTranslationsLoader<TranslationValue>,
       createTranslateMany,
-      lifecycle: createLifecycleCallbacks<TranslationValue>(
-        params.lifecycle ?? {}
-      ),
+      lifecycle: lifecycleCallbacks,
     });
   }
 
@@ -143,7 +175,18 @@ class I18nManager<
     try {
       this.validateLocale(locale);
       const gtInstance = this.getGTClass();
-      this.storeAdapter.setItem('locale', gtInstance.determineLocale(locale)!);
+      const previousLocale = this.storeAdapter.getItem('locale') ?? undefined;
+      const newLocale = gtInstance.determineLocale(locale)!;
+      this.storeAdapter.setItem('locale', newLocale);
+
+      // Emit event only if locale actually changed
+      if (previousLocale !== newLocale) {
+        this._eventEmitter.emit({
+          type: 'localeChanged',
+          locale: newLocale,
+          previousLocale,
+        });
+      }
     } catch (error) {
       this.handleError(error);
     }
@@ -183,6 +226,37 @@ class I18nManager<
    */
   isTranslationEnabled(): boolean {
     return this.config.enableI18n;
+  }
+
+  // ========== Events ========== //
+
+  /**
+   * Subscribe to I18nManager events.
+   * Returns an unsubscribe function.
+   *
+   * Events:
+   * - `localeChanged` — fired when setLocale() changes the locale
+   * - `translationsLoaded` — fired when translations are loaded for a locale (CDN/cache)
+   * - `translationResolved` — fired when a runtime translation resolves
+   *
+   * Designed for use with React's useSyncExternalStore:
+   * ```ts
+   * const subscribe = (cb) => manager.subscribe(cb);
+   * const getSnapshot = () => manager.getVersion();
+   * useSyncExternalStore(subscribe, getSnapshot);
+   * ```
+   */
+  subscribe(listener: I18nEventListener): () => void {
+    return this._eventEmitter.subscribe(listener);
+  }
+
+  /**
+   * Get a monotonically increasing version number.
+   * Bumps on every event emission.
+   * Use as the snapshot value for useSyncExternalStore.
+   */
+  getVersion(): number {
+    return this._eventEmitter.getVersion();
   }
 
   // ========== Translation Loading ========== //

--- a/packages/i18n/src/i18n-manager/events/EventEmitter.ts
+++ b/packages/i18n/src/i18n-manager/events/EventEmitter.ts
@@ -1,0 +1,55 @@
+/**
+ * I18n event types
+ */
+export type I18nEvent =
+  | { type: 'localeChanged'; locale: string; previousLocale?: string }
+  | {
+      type: 'translationsLoaded';
+      locale: string;
+    }
+  | {
+      type: 'translationResolved';
+      locale: string;
+    };
+
+/**
+ * Listener function type
+ */
+export type I18nEventListener = (event: I18nEvent) => void;
+
+/**
+ * Simple event emitter for I18nManager events.
+ * Designed to support useSyncExternalStore in React-core.
+ */
+export class I18nEventEmitter {
+  private _listeners: Set<I18nEventListener> = new Set();
+  private _version: number = 0;
+
+  /**
+   * Subscribe to events. Returns an unsubscribe function.
+   */
+  subscribe(listener: I18nEventListener): () => void {
+    this._listeners.add(listener);
+    return () => {
+      this._listeners.delete(listener);
+    };
+  }
+
+  /**
+   * Emit an event to all listeners and bump the version.
+   */
+  emit(event: I18nEvent): void {
+    this._version++;
+    this._listeners.forEach((listener) => {
+      listener(event);
+    });
+  }
+
+  /**
+   * Get the current version (monotonic counter).
+   * Useful as a snapshot value for useSyncExternalStore.
+   */
+  getVersion(): number {
+    return this._version;
+  }
+}

--- a/packages/i18n/src/i18n-manager/events/__tests__/EventEmitter.test.ts
+++ b/packages/i18n/src/i18n-manager/events/__tests__/EventEmitter.test.ts
@@ -1,0 +1,56 @@
+import { I18nEventEmitter, I18nEvent } from '../EventEmitter';
+
+describe('I18nEventEmitter', () => {
+  let emitter: I18nEventEmitter;
+
+  beforeEach(() => {
+    emitter = new I18nEventEmitter();
+  });
+
+  it('starts at version 0', () => {
+    expect(emitter.getVersion()).toBe(0);
+  });
+
+  it('bumps version on emit', () => {
+    emitter.emit({ type: 'localeChanged', locale: 'fr' });
+    expect(emitter.getVersion()).toBe(1);
+    emitter.emit({ type: 'translationsLoaded', locale: 'fr' });
+    expect(emitter.getVersion()).toBe(2);
+  });
+
+  it('notifies subscribers', () => {
+    const events: I18nEvent[] = [];
+    emitter.subscribe((e) => events.push(e));
+
+    emitter.emit({ type: 'localeChanged', locale: 'de', previousLocale: 'en' });
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({
+      type: 'localeChanged',
+      locale: 'de',
+      previousLocale: 'en',
+    });
+  });
+
+  it('unsubscribe stops notifications', () => {
+    const events: I18nEvent[] = [];
+    const unsub = emitter.subscribe((e) => events.push(e));
+
+    emitter.emit({ type: 'translationsLoaded', locale: 'fr' });
+    expect(events).toHaveLength(1);
+
+    unsub();
+    emitter.emit({ type: 'translationsLoaded', locale: 'es' });
+    expect(events).toHaveLength(1); // no new event
+  });
+
+  it('supports multiple subscribers', () => {
+    const events1: I18nEvent[] = [];
+    const events2: I18nEvent[] = [];
+    emitter.subscribe((e) => events1.push(e));
+    emitter.subscribe((e) => events2.push(e));
+
+    emitter.emit({ type: 'translationResolved', locale: 'ja' });
+    expect(events1).toHaveLength(1);
+    expect(events2).toHaveLength(1);
+  });
+});

--- a/packages/i18n/src/i18n-manager/types.ts
+++ b/packages/i18n/src/i18n-manager/types.ts
@@ -42,3 +42,5 @@ export type {
   StorageAdapterType,
   LifecycleCallbacks,
 };
+
+export type { I18nEvent, I18nEventListener } from './events/EventEmitter';


### PR DESCRIPTION
## Summary

Adds a lightweight event system to `I18nManager` designed to support React's `useSyncExternalStore` pattern.

### New public API on I18nManager

```ts
manager.subscribe(listener: (event: I18nEvent) => void): () => void;
manager.getVersion(): number; // monotonic counter, bumps on every event
```

### Event types

| Event | Fires when |
|-------|-----------|
| `localeChanged` | `setLocale()` changes locale (guarded against no-ops) |
| `translationsLoaded` | Translations load from CDN/cache for a locale |
| `translationResolved` | A runtime translation resolves |

### How this enables useSyncExternalStore in React-core

```ts
const subscribe = (cb) => manager.subscribe(cb);
const getSnapshot = () => manager.getVersion();
useSyncExternalStore(subscribe, getSnapshot);
```

This eliminates the `useState`/`useEffect` dance in `GTProvider`, gives React proper tear-free reads, and makes `I18nManager` the single source of truth.

### Implementation

- Wraps existing lifecycle callbacks (non-breaking)
- `I18nEventEmitter` class with `subscribe()` returning an unsubscribe function
- Version counter bumps on every emission
- Unit tests for `EventEmitter`

### Known considerations for React-core integration

- **Batching**: `translationResolved` fires per-entry via the existing lifecycle hooks. React-core should rely on `getVersion()` to dedupe renders (React batches `useSyncExternalStore` notifications within the same tick).
- **Stale events**: If locale changes mid-flight, `translationsLoaded` may fire for the old locale. React-core should compare `event.locale` against current locale.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a lightweight `I18nEventEmitter` to `I18nManager`, exposing `subscribe()` and `getVersion()` to support React's `useSyncExternalStore` pattern. The implementation wraps existing lifecycle callbacks non-breakingly and covers the main event types (`localeChanged`, `translationsLoaded`, `translationResolved`).

- **P1 — listener error isolation**: `emit()` iterates listeners with `Set.prototype.forEach` without `try/catch`. A single throwing listener silently prevents all subsequent subscribers from receiving the event, which can leave React components on stale snapshots indefinitely.

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The P1 in emit() is a real defect for the primary use-case; safe to merge once listener error isolation is added.

A single P1 is present (no error isolation in emit), which caps the score at 4. The defect directly affects the stated purpose of the PR (useSyncExternalStore support), and the fix is straightforward, pulling the score to 3.

packages/i18n/src/i18n-manager/events/EventEmitter.ts — the emit() method needs per-listener try/catch before this is production-safe.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/i18n/src/i18n-manager/events/EventEmitter.ts | New lightweight event emitter for useSyncExternalStore support; lacks error isolation in emit() — a throwing listener prevents all subsequent subscribers from being notified |
| packages/i18n/src/i18n-manager/I18nManager.ts | Wraps existing lifecycle callbacks to emit events and exposes subscribe()/getVersion(); minor naming confusion with getVersionId() and variable shadowing of `params` |
| packages/i18n/src/i18n-manager/events/__tests__/EventEmitter.test.ts | Unit tests cover subscribe, unsubscribe, version bumping, and multi-subscriber scenarios; no test for error isolation during emit |
| packages/i18n/src/i18n-manager/types.ts | Re-exports I18nEvent and I18nEventListener types; non-breaking addition |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant App
    participant I18nManager
    participant I18nEventEmitter
    participant ReactUSES as useSyncExternalStore

    App->>I18nManager: subscribe(cb)
    I18nManager->>I18nEventEmitter: subscribe(cb)
    I18nEventEmitter-->>App: unsubscribe()

    App->>ReactUSES: useSyncExternalStore(subscribe, getSnapshot)
    ReactUSES->>I18nManager: subscribe(scheduleRerender)
    I18nManager->>I18nEventEmitter: subscribe(scheduleRerender)

    Note over I18nManager: setLocale() called
    I18nManager->>I18nEventEmitter: emit({ type: 'localeChanged', locale })
    I18nEventEmitter->>I18nEventEmitter: _version++
    I18nEventEmitter->>ReactUSES: scheduleRerender(event)
    ReactUSES->>I18nManager: getVersion() [getSnapshot]
    I18nManager->>I18nEventEmitter: getVersion()
    I18nEventEmitter-->>ReactUSES: version N

    Note over I18nManager: translationsLoaded (onLocalesCacheMiss)
    I18nManager->>I18nEventEmitter: emit({ type: 'translationsLoaded', locale })
    I18nEventEmitter->>I18nEventEmitter: _version++
    I18nEventEmitter->>ReactUSES: scheduleRerender(event)
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/i18n/src/i18n-manager/events/EventEmitter.ts
Line: 43-48

Comment:
**Listener error breaks subsequent subscribers**

`Set.prototype.forEach` does not catch exceptions — if any listener throws, the remaining listeners in the set never receive the notification. Since the explicit purpose of this emitter is `useSyncExternalStore`, where multiple React components can independently call `manager.subscribe(cb)`, a single misbehaving subscriber will silently leave all subsequent components stuck on a stale snapshot without triggering a re-render.

Wrap each invocation in a `try/catch` so that listener errors are isolated:

```suggestion
  emit(event: I18nEvent): void {
    this._version++;
    this._listeners.forEach((listener) => {
      try {
        listener(event);
      } catch (e) {
        // Isolate listener errors so other subscribers still receive the event
        console.error('[I18nEventEmitter] listener threw:', e);
      }
    });
  }
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/i18n/src/i18n-manager/I18nManager.ts
Line: 121-127

Comment:
**`params` shadows the constructor parameter**

Both the wrapped callbacks and the outer constructor use `params` as the identifier. While closures resolve it correctly, the shadowing makes the code harder to reason about and can trip up refactors. Renaming the inner `params` (e.g., `cbParams`) in both wrapped callbacks makes the scoping explicit.

```suggestion
    lifecycleCallbacks.onLocalesCacheMiss = (cbParams) => {
      originalOnLocalesCacheMiss?.(cbParams);
      this._eventEmitter.emit({
        type: 'translationsLoaded',
        locale: cbParams.inputKey,
      });
    };
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/i18n/src/i18n-manager/I18nManager.ts
Line: 257-260

Comment:
**Potential confusion with existing `getVersionId()`**

`I18nManager` already exposes `getVersionId(): string | undefined` which returns the CDN/config version string from `config._versionId`. The new `getVersion(): number` returns a completely different concept — an in-memory monotonic counter. Callers browsing the API surface may conflate the two. A more distinct name such as `getStoreVersion()` or `getEventVersion()` would make the intent clear.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(i18n): add event system to I18nMana..."](https://github.com/generaltranslation/gt/commit/606821cceac34df1cdc4edc07942e161b6541157) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29694197)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->