### PR TITLE
refactor: move dictionary utilities from react-core to gt-i18n

### DIFF
--- a/packages/i18n/src/i18n-manager/I18nManager.ts
+++ b/packages/i18n/src/i18n-manager/I18nManager.ts
@@ -21,6 +21,10 @@ import { getLoadTranslationsType } from './utils/getLoadTranslationsType';
 import { LocalesCache } from './translations-manager/LocalesCache';
 import { Hash } from './translations-manager/TranslationsCache';
 import { createLifecycleCallbacks } from './lifecycle-hooks/createLifecycleCallbacks';
+import {
+  I18nEventEmitter,
+  I18nEventListener,
+} from './events/EventEmitter';
 
 /**
  * Default translation timeout in milliseconds for a runtime translation request
@@ -77,6 +81,11 @@ class I18nManager<
   private localesCache: LocalesCache<TranslationValue>;
 
   /**
+   * Event emitter for subscribe/getVersion pattern
+   */
+  private _eventEmitter: I18nEventEmitter = new I18nEventEmitter();
+
+  /**
    * Creates an instance of I18nManager.
    * TODO: resolve gtConfig from just file path
    * @param params - The parameters for the I18nManager constructor
@@ -102,14 +111,37 @@ class I18nManager<
       DEFAULT_TRANSLATION_TIMEOUT
     );
 
+    // Create lifecycle callbacks that also emit events
+    const lifecycleCallbacks = createLifecycleCallbacks<TranslationValue>(
+      params.lifecycle ?? {}
+    );
+
+    // Wrap lifecycle callbacks to emit events
+    const originalOnLocalesCacheMiss = lifecycleCallbacks.onLocalesCacheMiss;
+    lifecycleCallbacks.onLocalesCacheMiss = (params) => {
+      originalOnLocalesCacheMiss?.(params);
+      this._eventEmitter.emit({
+        type: 'translationsLoaded',
+        locale: params.inputKey,
+      });
+    };
+
+    const originalOnTranslationsCacheMiss =
+      lifecycleCallbacks.onTranslationsCacheMiss;
+    lifecycleCallbacks.onTranslationsCacheMiss = (params) => {
+      originalOnTranslationsCacheMiss?.(params);
+      this._eventEmitter.emit({
+        type: 'translationResolved',
+        locale: params.locale,
+      });
+    };
+
     // Setup translations cache
     this.localesCache = new LocalesCache<TranslationValue>({
       loadTranslations:
         loadTranslations as SafeTranslationsLoader<TranslationValue>,
       createTranslateMany,
-      lifecycle: createLifecycleCallbacks<TranslationValue>(
-        params.lifecycle ?? {}
-      ),
+      lifecycle: lifecycleCallbacks,
     });
   }
 
@@ -143,7 +175,18 @@ class I18nManager<
     try {
       this.validateLocale(locale);
       const gtInstance = this.getGTClass();
-      this.storeAdapter.setItem('locale', gtInstance.determineLocale(locale)!);
+      const previousLocale = this.storeAdapter.getItem('locale') ?? undefined;
+      const newLocale = gtInstance.determineLocale(locale)!;
+      this.storeAdapter.setItem('locale', newLocale);
+
+      // Emit event only if locale actually changed
+      if (previousLocale !== newLocale) {
+        this._eventEmitter.emit({
+          type: 'localeChanged',
+          locale: newLocale,
+          previousLocale,
+        });
+      }
     } catch (error) {
       this.handleError(error);
     }
@@ -183,6 +226,37 @@ class I18nManager<
    */
   isTranslationEnabled(): boolean {
     return this.config.enableI18n;
+  }
+
+  // ========== Events ========== //
+
+  /**
+   * Subscribe to I18nManager events.
+   * Returns an unsubscribe function.
+   *
+   * Events:
+   * - `localeChanged` — fired when setLocale() changes the locale
+   * - `translationsLoaded` — fired when translations are loaded for a locale (CDN/cache)
+   * - `translationResolved` — fired when a runtime translation resolves
+   *
+   * Designed for use with React's useSyncExternalStore:
+   * ```ts
+   * const subscribe = (cb) => manager.subscribe(cb);
+   * const getSnapshot = () => manager.getVersion();
+   * useSyncExternalStore(subscribe, getSnapshot);
+   * ```
+   */
+  subscribe(listener: I18nEventListener): () => void {
+    return this._eventEmitter.subscribe(listener);
+  }
+
+  /**
+   * Get a monotonically increasing version number.
+   * Bumps on every event emission.
+   * Use as the snapshot value for useSyncExternalStore.
+   */
+  getVersion(): number {
+    return this._eventEmitter.getVersion();
   }
 
   // ========== Translation Loading ========== //

--- a/packages/i18n/src/i18n-manager/events/EventEmitter.ts
+++ b/packages/i18n/src/i18n-manager/events/EventEmitter.ts
@@ -1,0 +1,55 @@
+/**
+ * I18n event types
+ */
+export type I18nEvent =
+  | { type: 'localeChanged'; locale: string; previousLocale?: string }
+  | {
+      type: 'translationsLoaded';
+      locale: string;
+    }
+  | {
+      type: 'translationResolved';
+      locale: string;
+    };
+
+/**
+ * Listener function type
+ */
+export type I18nEventListener = (event: I18nEvent) => void;
+
+/**
+ * Simple event emitter for I18nManager events.
+ * Designed to support useSyncExternalStore in React-core.
+ */
+export class I18nEventEmitter {
+  private _listeners: Set<I18nEventListener> = new Set();
+  private _version: number = 0;
+
+  /**
+   * Subscribe to events. Returns an unsubscribe function.
+   */
+  subscribe(listener: I18nEventListener): () => void {
+    this._listeners.add(listener);
+    return () => {
+      this._listeners.delete(listener);
+    };
+  }
+
+  /**
+   * Emit an event to all listeners and bump the version.
+   */
+  emit(event: I18nEvent): void {
+    this._version++;
+    this._listeners.forEach((listener) => {
+      listener(event);
+    });
+  }
+
+  /**
+   * Get the current version (monotonic counter).
+   * Useful as a snapshot value for useSyncExternalStore.
+   */
+  getVersion(): number {
+    return this._version;
+  }
+}

--- a/packages/i18n/src/i18n-manager/events/__tests__/EventEmitter.test.ts
+++ b/packages/i18n/src/i18n-manager/events/__tests__/EventEmitter.test.ts
@@ -1,0 +1,56 @@
+import { I18nEventEmitter, I18nEvent } from '../EventEmitter';
+
+describe('I18nEventEmitter', () => {
+  let emitter: I18nEventEmitter;
+
+  beforeEach(() => {
+    emitter = new I18nEventEmitter();
+  });
+
+  it('starts at version 0', () => {
+    expect(emitter.getVersion()).toBe(0);
+  });
+
+  it('bumps version on emit', () => {
+    emitter.emit({ type: 'localeChanged', locale: 'fr' });
+    expect(emitter.getVersion()).toBe(1);
+    emitter.emit({ type: 'translationsLoaded', locale: 'fr' });
+    expect(emitter.getVersion()).toBe(2);
+  });
+
+  it('notifies subscribers', () => {
+    const events: I18nEvent[] = [];
+    emitter.subscribe((e) => events.push(e));
+
+    emitter.emit({ type: 'localeChanged', locale: 'de', previousLocale: 'en' });
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({
+      type: 'localeChanged',
+      locale: 'de',
+      previousLocale: 'en',
+    });
+  });
+
+  it('unsubscribe stops notifications', () => {
+    const events: I18nEvent[] = [];
+    const unsub = emitter.subscribe((e) => events.push(e));
+
+    emitter.emit({ type: 'translationsLoaded', locale: 'fr' });
+    expect(events).toHaveLength(1);
+
+    unsub();
+    emitter.emit({ type: 'translationsLoaded', locale: 'es' });
+    expect(events).toHaveLength(1); // no new event
+  });
+
+  it('supports multiple subscribers', () => {
+    const events1: I18nEvent[] = [];
+    const events2: I18nEvent[] = [];
+    emitter.subscribe((e) => events1.push(e));
+    emitter.subscribe((e) => events2.push(e));
+
+    emitter.emit({ type: 'translationResolved', locale: 'ja' });
+    expect(events1).toHaveLength(1);
+    expect(events2).toHaveLength(1);
+  });
+});

--- a/packages/i18n/src/i18n-manager/types.ts
+++ b/packages/i18n/src/i18n-manager/types.ts
@@ -42,3 +42,5 @@ export type {
   StorageAdapterType,
   LifecycleCallbacks,
 };
+
+export type { I18nEvent, I18nEventListener } from './events/EventEmitter';


### PR DESCRIPTION
## Summary

Moves all dictionary helper functions and types from `@generaltranslation/react-core` to `gt-i18n/internal`, reducing react-core's footprint and making dictionary operations available to non-React consumers.

### What moved

**14 source files + 14 test files** from `packages/react-core/src/dictionaries/` → `packages/i18n/src/dictionaries/`:

- `getDictionaryEntry`, `getSubtree`, `getSubtreeWithCreation`
- `injectHashes`, `injectTranslations`, `injectFallbacks`, `injectEntry`
- `injectAndMerge`, `collectUntranslatedEntries`
- `mergeDictionaries`, `stripMetadataFromEntries`
- `isDictionaryEntry`, `getEntryAndMetadata`, `loadDictionaryHelper`
- `Dictionary`, `DictionaryEntry`, `MetaEntry`, `FlattenedDictionary` types

### Backward compatibility

react-core re-exports everything from `gt-i18n/internal` — no breaking changes for downstream packages (gt-react, gt-next, gt-tanstack-start).

### Verified

- `gt-i18n`: builds ✅, 340 tests pass ✅
- `react-core`: builds ✅, 36 tests pass ✅  
- `gt-react`: builds ✅
- `gt-next`: builds ✅

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a subscribe/getVersion event API to `I18nManager` backed by a new `I18nEventEmitter`, designed to power React's `useSyncExternalStore` in `react-core`. The lifecycle callbacks for locales/translation cache misses are wrapped to emit events, and `setLocale()` now emits `localeChanged` only when the locale actually changes.

- **P1** — `emit()` does not guard individual listener calls; a throwing listener will abort `forEach` and leave all subsequent subscribers unnotified, which can cause silent stale-state bugs for `useSyncExternalStore` consumers.
- The PR title/description mentions moving dictionary utilities from `react-core` to `gt-i18n`, but the actual diff only contains the event emitter additions — the description appears to belong to a different change.

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Mergeable but the P1 listener-exception issue should be addressed first to prevent silent stale-state in React consumers.

One P1 finding (uncaught listener exception skips remaining subscribers in emit()) pulls the score below the P1 ceiling of 4; the additional P2 concern about translationsLoaded never firing on cache hits further reduces confidence.

packages/i18n/src/i18n-manager/events/EventEmitter.ts — the emit() method needs per-listener error handling.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/i18n/src/i18n-manager/events/EventEmitter.ts | New I18nEventEmitter class; listener exception propagation in emit() can skip subsequent subscribers |
| packages/i18n/src/i18n-manager/I18nManager.ts | Adds subscribe/getVersion API and wraps lifecycle callbacks to emit events; translationsLoaded only fires on cache miss |
| packages/i18n/src/i18n-manager/events/__tests__/EventEmitter.test.ts | Good unit test coverage for subscribe/unsubscribe/multi-listener/version increment; no test for listener-throws-during-emit scenario |
| packages/i18n/src/i18n-manager/types.ts | Trivial addition re-exporting I18nEvent and I18nEventListener from the new EventEmitter module |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Consumer as React Consumer
    participant Manager as I18nManager
    participant Emitter as I18nEventEmitter
    participant Cache as LocalesCache

    Consumer->>Manager: subscribe(listener)
    Manager->>Emitter: subscribe(listener)
    Emitter-->>Consumer: unsubscribe fn

    Consumer->>Manager: setLocale("fr")
    Manager->>Manager: determineLocale()
    Manager->>Emitter: emit({ type: 'localeChanged', locale: 'fr' })
    Emitter->>Emitter: version++
    Emitter->>Consumer: listener({ type: 'localeChanged' })

    Consumer->>Manager: getVersion()
    Manager->>Emitter: getVersion()
    Emitter-->>Consumer: version (snapshot)

    Manager->>Cache: miss(locale)
    Cache-->>Manager: onLocalesCacheMiss callback
    Manager->>Emitter: emit({ type: 'translationsLoaded', locale })
    Emitter->>Emitter: version++
    Emitter->>Consumer: listener({ type: 'translationsLoaded' })

    Cache-->>Manager: onTranslationsCacheMiss callback
    Manager->>Emitter: emit({ type: 'translationResolved', locale })
    Emitter->>Emitter: version++
    Emitter->>Consumer: listener({ type: 'translationResolved' })
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/i18n/src/i18n-manager/events/EventEmitter.ts
Line: 42-46

Comment:
**Throwing listener skips remaining subscribers**

If any listener throws during `emit()`, `forEach` re-throws immediately and all subsequent listeners are silently skipped. For `useSyncExternalStore`, this means some React components will never receive the notification and will render stale state until the next unrelated re-render.

```suggestion
  emit(event: I18nEvent): void {
    this._version++;
    this._listeners.forEach((listener) => {
      try {
        listener(event);
      } catch (e) {
        // Prevent one bad listener from silencing others
      }
    });
  }
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/i18n/src/i18n-manager/I18nManager.ts
Line: 119-137

Comment:
**`translationsLoaded` fires on cache miss only, not cache hit**

The wrapper only patches `onLocalesCacheMiss`, so `translationsLoaded` is never emitted when translations are already cached (hit path). On a cold-start with a warm cache — e.g. service worker or SSR hydration — the event is never fired and any subscriber relying on it (e.g. a `useSyncExternalStore` consumer waiting for translations to be "ready") will not be notified. Consider also emitting on `onLocalesCacheHit` if the goal is "translations are available for this locale", or rename the event to make the miss-only semantics explicit (e.g. `translationsFetched`).

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(i18n): add event system to I18nMana..."](https://github.com/generaltranslation/gt/commit/4bf9edf782debd8d7e7abbe858b5b1b2001e6b60) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29694285)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->