### PR TITLE
feat(sanity): Add dedupeFields

### DIFF
--- a/.changeset/witty-humans-turn.md
+++ b/.changeset/witty-humans-turn.md
@@ -1,0 +1,5 @@
+---
+'gt-sanity': patch
+---
+
+Add dedupeFields option

--- a/packages/sanity/README.md
+++ b/packages/sanity/README.md
@@ -32,6 +32,9 @@ export default defineConfig({
     gtPlugin({
       sourceLocale: 'en',
       locales: ['es', 'fr'],
+      // Keep translated document slugs unique by copying the source slug
+      // and appending the target locale, e.g. "hello-world" -> "hello-world-es".
+      dedupeFields: [{ fields: [{ property: '$.slug' }] }],
     }),
   ],
 });

--- a/packages/sanity/README.md
+++ b/packages/sanity/README.md
@@ -32,8 +32,8 @@ export default defineConfig({
     gtPlugin({
       sourceLocale: 'en',
       locales: ['es', 'fr'],
-      // Keep translated document slugs unique by copying the source slug
-      // and appending the target locale, e.g. "hello-world" -> "hello-world-es".
+      // Initialize translated document slugs with a unique locale suffix,
+      // e.g. "hello-world" -> "hello-world-es".
       dedupeFields: [{ fields: [{ property: '$.slug' }] }],
     }),
   ],

--- a/packages/sanity/src/adapter/core.ts
+++ b/packages/sanity/src/adapter/core.ts
@@ -3,6 +3,7 @@ import { libraryDefaultLocale } from 'generaltranslation/internal';
 import type { Secrets } from '../types';
 import type {
   TranslateDocumentFilter,
+  DedupeFields,
   IgnoreFields,
   SkipFields,
 } from './types';
@@ -25,6 +26,7 @@ export class GTConfig {
   singletons: string[];
   singletonMapping: (sourceDocumentId: string, locale: string) => string;
   ignoreFields: IgnoreFields[];
+  dedupeFields: DedupeFields[];
   skipFields: SkipFields[];
   translateDocuments: TranslateDocumentFilter[];
   additionalStopTypes: string[];
@@ -41,6 +43,7 @@ export class GTConfig {
     singletons: string[],
     singletonMapping: (sourceDocumentId: string, locale: string) => string,
     ignoreFields: IgnoreFields[],
+    dedupeFields: DedupeFields[],
     skipFields: SkipFields[],
     translateDocuments: TranslateDocumentFilter[],
     additionalStopTypes: string[] = [],
@@ -55,6 +58,7 @@ export class GTConfig {
     this.singletons = singletons;
     this.singletonMapping = singletonMapping;
     this.ignoreFields = ignoreFields;
+    this.dedupeFields = dedupeFields;
     this.skipFields = skipFields;
     this.translateDocuments = translateDocuments;
     this.additionalStopTypes = additionalStopTypes;
@@ -76,6 +80,7 @@ export class GTConfig {
         [],
         [],
         [],
+        [],
         {},
         {},
         []
@@ -92,6 +97,7 @@ export class GTConfig {
     singletons: string[],
     singletonMapping: (sourceDocumentId: string, locale: string) => string,
     ignoreFields: IgnoreFields[],
+    dedupeFields: DedupeFields[],
     skipFields: SkipFields[],
     translateDocuments: TranslateDocumentFilter[],
     additionalStopTypes: string[] = [],
@@ -106,6 +112,7 @@ export class GTConfig {
     this.singletons = singletons;
     this.singletonMapping = singletonMapping;
     this.ignoreFields = ignoreFields;
+    this.dedupeFields = dedupeFields;
     this.skipFields = skipFields;
     this.translateDocuments = translateDocuments;
     this.additionalStopTypes = additionalStopTypes;
@@ -136,6 +143,9 @@ export class GTConfig {
   }
   getIgnoreFields() {
     return this.ignoreFields;
+  }
+  getDedupeFields() {
+    return this.dedupeFields;
   }
   getSkipFields() {
     return this.skipFields;

--- a/packages/sanity/src/adapter/types.ts
+++ b/packages/sanity/src/adapter/types.ts
@@ -1,12 +1,13 @@
-export type IgnoreFields = {
+export type FieldMatcher = {
   documentId?: string;
   fields?: { property: string; type?: string }[];
 };
 
-export type SkipFields = {
-  documentId?: string;
-  fields?: { property: string; type?: string }[];
-};
+export type IgnoreFields = FieldMatcher;
+
+export type DedupeFields = FieldMatcher;
+
+export type SkipFields = FieldMatcher;
 
 export type TranslateDocumentFilter = {
   documentId?: string;

--- a/packages/sanity/src/configuration/baseDocumentLevelConfig/documentLevelPatch.ts
+++ b/packages/sanity/src/configuration/baseDocumentLevelConfig/documentLevelPatch.ts
@@ -99,7 +99,8 @@ export const documentLevelPatch = async (
       baseDoc,
       merged,
       translatedFields,
-      client
+      client,
+      localeId
     );
   }
   //otherwise, create a new document

--- a/packages/sanity/src/configuration/baseDocumentLevelConfig/documentLevelPatch.ts
+++ b/packages/sanity/src/configuration/baseDocumentLevelConfig/documentLevelPatch.ts
@@ -100,7 +100,7 @@ export const documentLevelPatch = async (
       merged,
       translatedFields,
       client,
-      localeId
+      i18nDoc
     );
   }
   //otherwise, create a new document

--- a/packages/sanity/src/configuration/baseDocumentLevelConfig/helpers/createI18nDocAndPatchMetadata.ts
+++ b/packages/sanity/src/configuration/baseDocumentLevelConfig/helpers/createI18nDocAndPatchMetadata.ts
@@ -35,7 +35,9 @@ export async function createI18nDocAndPatchMetadata(
     sourceDocument,
     rest,
     pluginConfig.getIgnoreFields(),
-    pluginConfig.getSkipFields()
+    pluginConfig.getSkipFields(),
+    pluginConfig.getDedupeFields(),
+    localeId
   );
 
   // Check if this is a singleton document and apply singleton mapping

--- a/packages/sanity/src/configuration/baseDocumentLevelConfig/helpers/patchI18nDoc.test.ts
+++ b/packages/sanity/src/configuration/baseDocumentLevelConfig/helpers/patchI18nDoc.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { pluginConfig } from '../../../adapter/core';
+import { patchI18nDoc } from './patchI18nDoc';
+
+describe('patchI18nDoc', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('preserves existing translated dedupe fields during re-import', async () => {
+    vi.spyOn(pluginConfig, 'getIgnoreFields').mockReturnValue([]);
+    vi.spyOn(pluginConfig, 'getSkipFields').mockReturnValue([]);
+    vi.spyOn(pluginConfig, 'getDedupeFields').mockReturnValue([
+      { fields: [{ property: '$.slug', type: 'slug' }] },
+    ]);
+
+    const commit = vi.fn().mockResolvedValue({});
+    const patch = vi.fn().mockReturnValue({ commit });
+    const client = { patch } as any;
+
+    await patchI18nDoc(
+      'doc-1',
+      'drafts.doc-1-es',
+      {
+        _id: 'doc-1',
+        _type: 'article',
+        title: 'About',
+        slug: { _type: 'slug', current: 'about' },
+      },
+      {
+        _id: 'doc-1',
+        _type: 'article',
+        title: 'Acerca de',
+      },
+      { title: 'Acerca de' },
+      client,
+      {
+        _id: 'drafts.doc-1-es',
+        _type: 'article',
+        title: 'Acerca de',
+        slug: { _type: 'slug', current: 'custom-spanish-slug' },
+      }
+    );
+
+    expect(patch).toHaveBeenCalledWith('drafts.doc-1-es', {
+      set: expect.objectContaining({
+        title: 'Acerca de',
+        slug: { _type: 'slug', current: 'custom-spanish-slug' },
+      }),
+    });
+  });
+});

--- a/packages/sanity/src/configuration/baseDocumentLevelConfig/helpers/patchI18nDoc.ts
+++ b/packages/sanity/src/configuration/baseDocumentLevelConfig/helpers/patchI18nDoc.ts
@@ -14,7 +14,8 @@ export async function patchI18nDoc(
   sourceDocument: SanityDocumentLike,
   mergedDocument: SanityDocumentLike,
   translatedFields: Record<string, any>,
-  client: SanityClient
+  client: SanityClient,
+  localeId?: string
 ): Promise<void> {
   const cleanedMerge: Record<string, any> = {};
   Object.entries(mergedDocument).forEach(([key, value]) => {
@@ -41,7 +42,9 @@ export async function patchI18nDoc(
     cleanedSourceDocument,
     cleanedMerge,
     pluginConfig.getIgnoreFields(),
-    pluginConfig.getSkipFields()
+    pluginConfig.getSkipFields(),
+    pluginConfig.getDedupeFields(),
+    localeId
   );
   const newDocument = await client
     .patch(i18nDocId, { set: appliedDocument })

--- a/packages/sanity/src/configuration/baseDocumentLevelConfig/helpers/patchI18nDoc.ts
+++ b/packages/sanity/src/configuration/baseDocumentLevelConfig/helpers/patchI18nDoc.ts
@@ -1,7 +1,12 @@
 // adapted from https://github.com/sanity-io/sanity-translations-tab. See LICENSE.md for more details.
 
 import { SanityClient, SanityDocumentLike } from 'sanity';
-import { applyDocuments } from '../../../utils/applyDocuments';
+import JSONPointer from 'jsonpointer';
+import {
+  applyDocuments,
+  deleteMatchingFields,
+  forEachMatchingField,
+} from '../../../utils/applyDocuments';
 import { pluginConfig } from '../../../adapter/core';
 
 const SYSTEM_FIELDS = ['_id', '_rev', '_updatedAt', 'language'];
@@ -15,7 +20,7 @@ export async function patchI18nDoc(
   mergedDocument: SanityDocumentLike,
   translatedFields: Record<string, any>,
   client: SanityClient,
-  localeId?: string
+  existingDocument?: SanityDocumentLike
 ): Promise<void> {
   const cleanedMerge: Record<string, any> = {};
   Object.entries(mergedDocument).forEach(([key, value]) => {
@@ -42,10 +47,20 @@ export async function patchI18nDoc(
     cleanedSourceDocument,
     cleanedMerge,
     pluginConfig.getIgnoreFields(),
-    pluginConfig.getSkipFields(),
-    pluginConfig.getDedupeFields(),
-    localeId
+    pluginConfig.getSkipFields()
   );
+  const dedupeFields = pluginConfig.getDedupeFields();
+  deleteMatchingFields(sourceDocumentId, appliedDocument, dedupeFields);
+  if (existingDocument) {
+    forEachMatchingField(
+      sourceDocumentId,
+      existingDocument,
+      dedupeFields,
+      (result) => {
+        JSONPointer.set(appliedDocument, result.pointer, result.value);
+      }
+    );
+  }
   const newDocument = await client
     .patch(i18nDocId, { set: appliedDocument })
     .commit();

--- a/packages/sanity/src/index.ts
+++ b/packages/sanity/src/index.ts
@@ -61,6 +61,7 @@ import { gt, pluginConfig } from './adapter/core';
 import { libraryDefaultLocale } from 'generaltranslation/internal';
 import { getLocaleProperties } from 'generaltranslation';
 import type {
+  DedupeFields,
   IgnoreFields,
   SkipFields,
   TranslateDocumentFilter,
@@ -83,6 +84,7 @@ export type GTPluginConfig = Omit<
   // By default, the translated singleton document is is `${sourceDocumentId}-${locale}`
   singletonMapping?: (sourceDocumentId: string, locale: string) => string;
   ignoreFields?: IgnoreFields[];
+  dedupeFields?: DedupeFields[];
   skipFields?: SkipFields[];
   languageField?: string;
   translateDocuments?: TranslateDocumentFilter[] | string[];
@@ -122,6 +124,7 @@ export const gtPlugin = definePlugin<GTPluginConfig>(
     singletons,
     singletonMapping,
     ignoreFields,
+    dedupeFields,
     skipFields,
     translateDocuments,
     secretsNamespace = SECRETS_NAMESPACE,
@@ -153,6 +156,7 @@ export const gtPlugin = definePlugin<GTPluginConfig>(
       singletonMapping ||
         ((sourceDocumentId, locale) => `${sourceDocumentId}-${locale}`),
       ignoreFields || [],
+      dedupeFields || [],
       skipFields || [],
       normalizedTranslateDocuments || [],
       additionalStopTypes,

--- a/packages/sanity/src/utils/__tests__/forEachMatchingField.test.ts
+++ b/packages/sanity/src/utils/__tests__/forEachMatchingField.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, vi } from 'vitest';
-import { forEachMatchingField } from '../applyDocuments';
+import { applyDocuments, forEachMatchingField } from '../applyDocuments';
 import type { IgnoreFields } from '../../adapter/types';
 
 describe('forEachMatchingField', () => {
@@ -167,5 +167,75 @@ describe('forEachMatchingField', () => {
 
     expect(cb).toHaveBeenCalledTimes(1);
     expect(cb.mock.calls[0][0].pointer).toBe('/metadata/seo/title');
+  });
+});
+
+describe('applyDocuments dedupe fields', () => {
+  test('restores slug fields with a locale suffix', () => {
+    const sourceDoc = {
+      _id: 'doc-1',
+      title: 'Hello',
+      slug: { _type: 'slug', current: 'hello-world' },
+    };
+    const translatedDoc = {
+      _id: 'doc-1-es',
+      title: 'Hola',
+    };
+
+    const result = applyDocuments(
+      'doc-1',
+      sourceDoc,
+      translatedDoc,
+      [],
+      [],
+      [{ fields: [{ property: '$.slug' }] }],
+      'es'
+    );
+
+    expect(result).toEqual({
+      _id: 'doc-1-es',
+      title: 'Hola',
+      slug: { _type: 'slug', current: 'hello-world-es' },
+    });
+  });
+
+  test('dedupes string fields directly when the JSONPath targets a string', () => {
+    const sourceDoc = {
+      _id: 'doc-1',
+      title: 'Hello',
+      slug: { _type: 'slug', current: 'hello-world' },
+    };
+
+    const result = applyDocuments(
+      'doc-1',
+      sourceDoc,
+      { title: 'Bonjour' },
+      [],
+      [],
+      [{ fields: [{ property: '$.slug.current' }] }],
+      'fr-CA'
+    );
+
+    expect(result.slug.current).toBe('hello-world-fr-ca');
+  });
+
+  test('does not append the same locale suffix twice', () => {
+    const sourceDoc = {
+      _id: 'doc-1',
+      title: 'Hello',
+      slug: { _type: 'slug', current: 'hello-world-fr' },
+    };
+
+    const result = applyDocuments(
+      'doc-1',
+      sourceDoc,
+      { title: 'Bonjour' },
+      [],
+      [],
+      [{ fields: [{ property: '$.slug' }] }],
+      'fr'
+    );
+
+    expect(result.slug.current).toBe('hello-world-fr');
   });
 });

--- a/packages/sanity/src/utils/applyDocuments.ts
+++ b/packages/sanity/src/utils/applyDocuments.ts
@@ -1,11 +1,11 @@
 import { JSONPath } from 'jsonpath-plus';
 import JSONPointer from 'jsonpointer';
-import type { IgnoreFields, SkipFields } from '../adapter/types';
+import type { DedupeFields, FieldMatcher, SkipFields } from '../adapter/types';
 
 export function forEachMatchingField(
   documentId: string,
   document: Record<string, any>,
-  fields: IgnoreFields[],
+  fields: FieldMatcher[],
   callback: (result: {
     pointer: string;
     value: any;
@@ -67,7 +67,7 @@ export function forEachMatchingField(
 export function deleteMatchingFields(
   documentId: string,
   document: Record<string, any>,
-  fields: IgnoreFields[]
+  fields: FieldMatcher[]
 ): void {
   const arrayRemovals: Array<{ parent: any[]; index: number }> = [];
 
@@ -93,8 +93,10 @@ export function applyDocuments(
   documentId: string,
   sourceDocument: Record<string, any>,
   targetDocument: Record<string, any>,
-  ignore: IgnoreFields[],
-  skip: SkipFields[] = []
+  ignore: FieldMatcher[],
+  skip: SkipFields[] = [],
+  dedupe: DedupeFields[] = [],
+  localeId?: string
 ) {
   // Deep copy both documents so mutations (e.g. skip-field deletions) never affect the originals
   const mergedDocument = JSON.parse(JSON.stringify(sourceDocument));
@@ -110,8 +112,57 @@ export function applyDocuments(
     JSONPointer.set(mergedDocument, result.pointer, result.value);
   });
 
+  // Restore de-duped fields from the source document with a deterministic locale suffix.
+  forEachMatchingField(documentId, sourceDocument, dedupe, (result) => {
+    JSONPointer.set(
+      mergedDocument,
+      result.pointer,
+      dedupeFieldValue(result.value, localeId)
+    );
+  });
+
   // Remove skip fields from merged document
   deleteMatchingFields(documentId, mergedDocument, skip);
 
   return mergedDocument;
+}
+
+function dedupeFieldValue(value: any, localeId?: string): any {
+  if (!localeId) return value;
+
+  if (typeof value === 'string') {
+    return appendLocaleSuffix(value, localeId);
+  }
+
+  if (
+    value &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    typeof value.current === 'string'
+  ) {
+    return {
+      ...value,
+      current: appendLocaleSuffix(value.current, localeId),
+    };
+  }
+
+  return value;
+}
+
+function appendLocaleSuffix(value: string, localeId: string): string {
+  if (!value) return value;
+
+  const suffix = createLocaleSuffix(localeId);
+  if (!suffix || value.endsWith(suffix)) return value;
+
+  return `${value}${suffix}`;
+}
+
+function createLocaleSuffix(localeId: string): string {
+  const normalized = localeId
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+
+  return normalized ? `-${normalized}` : '';
 }

--- a/packages/sanity/src/utils/serialize.ts
+++ b/packages/sanity/src/utils/serialize.ts
@@ -10,7 +10,7 @@ import { PortableTextHtmlComponents } from '@portabletext/to-html';
 import { pluginConfig } from '../adapter/core';
 import merge from 'lodash.merge';
 import { deleteMatchingFields } from './applyDocuments';
-import type { IgnoreFields } from '../adapter/types';
+import type { FieldMatcher } from '../adapter/types';
 
 export function deserializeDocument(document: string) {
   const deserializers = merge(
@@ -45,7 +45,8 @@ export function serializeDocument(
 
   const docToSerialize = stripIgnoredFields(
     document,
-    pluginConfig.getIgnoreFields()
+    pluginConfig.getIgnoreFields(),
+    pluginConfig.getDedupeFields()
   );
 
   const serialized = BaseDocumentSerializer(schema).serializeDocument(
@@ -60,16 +61,18 @@ export function serializeDocument(
 
 function stripIgnoredFields(
   document: SanityDocument,
-  ignoreFields: IgnoreFields[]
+  ignoreFields: FieldMatcher[],
+  dedupeFields: FieldMatcher[]
 ): SanityDocument {
-  if (ignoreFields.length === 0) return document;
+  const fieldsToStrip = [...ignoreFields, ...dedupeFields];
+  if (fieldsToStrip.length === 0) return document;
 
   const strippedDoc = JSON.parse(JSON.stringify(document)) as SanityDocument;
 
   deleteMatchingFields(
     document._id.replace('drafts.', ''),
     strippedDoc,
-    ignoreFields
+    fieldsToStrip
   );
 
   return strippedDoc;


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `dedupeFields` option to the Sanity plugin, allowing specific fields (typically slugs) to be excluded from translation and instead automatically suffixed with the target locale identifier (e.g. `hello-world` → `hello-world-es`). The implementation follows the existing `ignoreFields`/`skipFields` pattern cleanly across config, serialization, and document-patch helpers.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge with minor caveats; no data loss or correctness bugs in the common case.

All findings are P2. The `endsWith` idempotency heuristic is a known limitation deliberately tested, the silent no-op for unsupported types is a UX concern, and the always-overwrite behaviour for re-translations may surprise users but is consistent with how `ignoreFields` works. No P0/P1 issues found.

packages/sanity/src/utils/applyDocuments.ts — `appendLocaleSuffix` idempotency check and `dedupeFieldValue` fallthrough behaviour.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/sanity/src/utils/applyDocuments.ts | Core logic for dedupeFields; adds `dedupeFieldValue`/`appendLocaleSuffix` helpers, but the `endsWith` idempotency check is a false positive for source slugs that naturally end with the locale suffix, and unsupported value types fall through silently. |
| packages/sanity/src/adapter/types.ts | Refactors `IgnoreFields` and `SkipFields` into a shared `FieldMatcher` base type; adds `DedupeFields` as an alias. Clean, no issues. |
| packages/sanity/src/utils/serialize.ts | Correctly strips `dedupeFields` alongside `ignoreFields` before serialization so slug-like fields are never sent for translation. |
| packages/sanity/src/configuration/baseDocumentLevelConfig/helpers/patchI18nDoc.ts | Passes `localeId` and `dedupeFields` through to `applyDocuments`; note that `localeId` is typed optional here but is always provided at call sites. |
| packages/sanity/src/utils/__tests__/forEachMatchingField.test.ts | Adds three tests for dedupe behaviour; test 3 ("does not append the same locale suffix twice") validates the false-positive `endsWith` scenario as intentional, which may not cover all edge cases. |
| packages/sanity/src/adapter/core.ts | Adds `dedupeFields` to `GTConfig` with constructor, setter, and getter — mirrors pattern used by `ignoreFields`/`skipFields` exactly. No issues. |
| packages/sanity/src/index.ts | Exposes `dedupeFields` as part of `GTPluginConfig` and wires it into `GTConfig` construction with a safe empty-array default. No issues. |
| packages/sanity/src/configuration/baseDocumentLevelConfig/documentLevelPatch.ts | Passes `localeId` to `patchI18nDoc` — the only change here. Correct and minimal. |
| packages/sanity/src/configuration/baseDocumentLevelConfig/helpers/createI18nDocAndPatchMetadata.ts | Correctly threads `dedupeFields` and `localeId` into `applyDocuments` for new document creation. No issues. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Document sent for translation] --> B[serializeDocument]
    B --> C[stripIgnoredFields\nignoreFields + dedupeFields stripped]
    C --> D[Translation API]
    D --> E[Translated fields returned]
    E --> F{i18n doc exists?}
    F -- Yes --> G[patchI18nDoc\napplyDocuments called]
    F -- No --> H[createI18nDocAndPatchMetadata\napplyDocuments called]
    G --> I[applyDocuments]
    H --> I
    I --> J[1. Start with source doc]
    J --> K[2. Merge translated fields on top]
    K --> L[3. Restore ignoreFields from source]
    L --> M[4. Restore dedupeFields from source + append locale suffix]
    M --> N[5. Remove skipFields]
    N --> O[Final document written to Sanity]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Apackages%2Fsanity%2Fsrc%2Futils%2FapplyDocuments.ts%3A152-158%0A**%60endsWith%60%20idempotency%20check%20can%20produce%20non-unique%20slugs**%0A%0A%60value.endsWith%28suffix%29%60%20checks%20the%20*source*%20document's%20slug%2C%20not%20the%20previously-generated%20translated%20slug.%20If%20the%20source%20slug%20happens%20to%20already%20end%20with%20the%20target%20locale%20code%20%28e.g.%20source%20slug%20%60hello-world-es%60%20translated%20to%20%60es%60%29%2C%20%60endsWith%28'-es'%29%60%20returns%20%60true%60%20and%20no%20suffix%20is%20appended%20%E2%80%94%20both%20the%20source%20and%20translated%20documents%20end%20up%20with%20identical%20slugs%2C%20defeating%20the%20deduplication.%0A%0ATest%203%20%28%22does%20not%20append%20the%20same%20locale%20suffix%20twice%22%29%20explicitly%20bakes%20in%20this%20behaviour%2C%20but%20that%20test%20scenario%20is%20actually%20a%20false%20positive%3A%20the%20source%20slug%20ends%20with%20the%20target%20locale%20for%20an%20unrelated%20reason%2C%20not%20because%20it%20was%20previously%20deduped.%20Consider%20checking%20a%20separate%20flag%20or%20comparing%20against%20a%20known-deduped%20value%20rather%20than%20an%20%60endsWith%60%20heuristic.%0A%0A%23%23%23%20Issue%202%20of%203%0Apackages%2Fsanity%2Fsrc%2Futils%2FapplyDocuments.ts%3A130-150%0A**Silent%20no-op%20for%20unsupported%20value%20types%20in%20%60dedupeFieldValue%60**%0A%0A%60dedupeFieldValue%60%20only%20modifies%20%60string%60%20values%20and%20objects%20with%20a%20%60current%3A%20string%60%20property%20%28Sanity%20slugs%29.%20Any%20other%20value%20type%20%E2%80%94%20arrays%2C%20numbers%2C%20plain%20objects%2C%20etc.%20%E2%80%94%20falls%20through%20to%20%60return%20value%60%20unchanged%2C%20with%20no%20warning%20or%20error.%20If%20a%20user%20configures%20a%20%60dedupeFields%60%20entry%20pointing%20to%20an%20unsupported%20field%20type%2C%20the%20field%20will%20silently%20receive%20the%20raw%20source%20value%20without%20a%20locale%20suffix%2C%20leaving%20the%20slug%20non-unique%20without%20any%20indication%20of%20what%20went%20wrong.%20A%20%60console.warn%60%20when%20the%20fallback%20branch%20is%20reached%20would%20help%20authors%20catch%20misconfigured%20entries.%0A%0A%23%23%23%20Issue%203%20of%203%0Apackages%2Fsanity%2Fsrc%2Futils%2FapplyDocuments.ts%3A115-122%0A**%60dedupeFields%60%20overwrites%20manually%20edited%20translated%20slugs%20on%20every%20re-translation**%0A%0A%60forEachMatchingField%60%20reads%20the%20slug%20from%20%60sourceDocument%60%20and%20writes%20%60%5Bsource-slug%5D-%5Blocale%5D%60%20to%20the%20merged%20document%20unconditionally.%20If%20a%20user%20has%20manually%20customised%20the%20slug%20on%20the%20translated%20document%20%28e.g.%20%60custom-spanish-slug%60%29%2C%20every%20subsequent%20translation%20update%20will%20silently%20reset%20it%20to%20%60%5Bsource-slug%5D-es%60.%20This%20is%20the%20same%20pattern%20used%20for%20%60ignoreFields%60%2C%20but%20%60ignoreFields%60%20is%20documented%20as%20%22always%20copy%20from%20source%22%20whereas%20%60dedupeFields%60%20may%20be%20understood%20as%20a%20one-time%20initialisation.%20If%20the%20intent%20is%20always-overwrite%2C%20it%20should%20be%20clearly%20documented%3B%20otherwise%20consider%20only%20applying%20the%20suffix%20during%20document%20creation%20%28not%20patching%29.%0A%0A&repo=generaltranslation%2Fgt&pr=1260&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/sanity/src/utils/applyDocuments.ts
Line: 152-158

Comment:
**`endsWith` idempotency check can produce non-unique slugs**

`value.endsWith(suffix)` checks the *source* document's slug, not the previously-generated translated slug. If the source slug happens to already end with the target locale code (e.g. source slug `hello-world-es` translated to `es`), `endsWith('-es')` returns `true` and no suffix is appended — both the source and translated documents end up with identical slugs, defeating the deduplication.

Test 3 ("does not append the same locale suffix twice") explicitly bakes in this behaviour, but that test scenario is actually a false positive: the source slug ends with the target locale for an unrelated reason, not because it was previously deduped. Consider checking a separate flag or comparing against a known-deduped value rather than an `endsWith` heuristic.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/sanity/src/utils/applyDocuments.ts
Line: 130-150

Comment:
**Silent no-op for unsupported value types in `dedupeFieldValue`**

`dedupeFieldValue` only modifies `string` values and objects with a `current: string` property (Sanity slugs). Any other value type — arrays, numbers, plain objects, etc. — falls through to `return value` unchanged, with no warning or error. If a user configures a `dedupeFields` entry pointing to an unsupported field type, the field will silently receive the raw source value without a locale suffix, leaving the slug non-unique without any indication of what went wrong. A `console.warn` when the fallback branch is reached would help authors catch misconfigured entries.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/sanity/src/utils/applyDocuments.ts
Line: 115-122

Comment:
**`dedupeFields` overwrites manually edited translated slugs on every re-translation**

`forEachMatchingField` reads the slug from `sourceDocument` and writes `[source-slug]-[locale]` to the merged document unconditionally. If a user has manually customised the slug on the translated document (e.g. `custom-spanish-slug`), every subsequent translation update will silently reset it to `[source-slug]-es`. This is the same pattern used for `ignoreFields`, but `ignoreFields` is documented as "always copy from source" whereas `dedupeFields` may be understood as a one-time initialisation. If the intent is always-overwrite, it should be clearly documented; otherwise consider only applying the suffix during document creation (not patching).

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["add dedupeFields"](https://github.com/generaltranslation/gt/commit/ba30a1627328d732e86e91ba6fd7e3048ab2efda) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29724258)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->