### PR TITLE
feat: enable dev hot reload for strings by default

### DIFF
--- a/.changeset/dev-hot-reload-default.md
+++ b/.changeset/dev-hot-reload-default.md
@@ -1,0 +1,6 @@
+---
+"gt-react": patch
+"@generaltranslation/compiler": patch
+---
+
+Enable dev hot reload for strings by default in the `gt-react/browser` import. JSX hot reload remains off by default (handled by the `<T>` component). When `devHotReload` is not explicitly configured, strings will now be enabled automatically in development mode.

--- a/packages/compiler/src/config.ts
+++ b/packages/compiler/src/config.ts
@@ -91,15 +91,19 @@ export function resolveAutoderive(
 
 /**
  * Resolves the devHotReload config value into separate strings and jsx flags.
+ * - `undefined` enables strings by default (JSX stays off)
  * - `true` enables strings only (JSX is handled at runtime via Suspense, no compiler injection needed)
  * - `false` disables both
- * - `{ strings?: boolean; jsx?: boolean }` enables selectively (missing keys default to false)
+ * - `{ strings?: boolean; jsx?: boolean }` enables selectively (strings defaults to true, jsx defaults to false)
  */
 export function resolveDevHotReload(
   value: boolean | { strings?: boolean; jsx?: boolean } | undefined
 ): { strings: boolean; jsx: boolean } {
-  if (value === undefined || typeof value === 'boolean') {
-    return { strings: !!value, jsx: false };
+  if (value === undefined) {
+    return { strings: true, jsx: false };
   }
-  return { strings: value.strings ?? false, jsx: value.jsx ?? false };
+  if (typeof value === 'boolean') {
+    return { strings: value, jsx: false };
+  }
+  return { strings: value.strings ?? true, jsx: value.jsx ?? false };
 }

--- a/packages/compiler/src/passes/__tests__/runtimeTranslatePass.test.ts
+++ b/packages/compiler/src/passes/__tests__/runtimeTranslatePass.test.ts
@@ -451,7 +451,7 @@ describe('runtimeTranslatePass', () => {
         'test.tsx'
       );
       expect(state.settings.devHotReload).toEqual({
-        strings: false,
+        strings: true,
         jsx: true,
       });
     });
@@ -650,10 +650,10 @@ describe('runtimeTranslatePass', () => {
       });
     });
 
-    // resolveDevHotReload(undefined) → { strings: false, jsx: false }
-    it('undefined disables both', () => {
+    // resolveDevHotReload(undefined) → { strings: true, jsx: false }
+    it('undefined enables strings by default', () => {
       expect(resolveDevHotReload(undefined)).toEqual({
-        strings: false,
+        strings: true,
         jsx: false,
       });
     });
@@ -666,10 +666,10 @@ describe('runtimeTranslatePass', () => {
       });
     });
 
-    // resolveDevHotReload({ jsx: true }) → { strings: false, jsx: true }
+    // resolveDevHotReload({ jsx: true }) → { strings: true, jsx: true }
     it('object with jsx only', () => {
       expect(resolveDevHotReload({ jsx: true })).toEqual({
-        strings: false,
+        strings: true,
         jsx: true,
       });
     });
@@ -682,10 +682,10 @@ describe('runtimeTranslatePass', () => {
       });
     });
 
-    // resolveDevHotReload({}) → { strings: false, jsx: false }
-    it('empty object disables both', () => {
+    // resolveDevHotReload({}) → { strings: true, jsx: false }
+    it('empty object enables strings by default', () => {
       expect(resolveDevHotReload({})).toEqual({
-        strings: false,
+        strings: true,
         jsx: false,
       });
     });

--- a/packages/compiler/src/state/utils/initializeState.ts
+++ b/packages/compiler/src/state/utils/initializeState.ts
@@ -39,7 +39,7 @@ export function initializeState(
   const enableAutoJsxInjection =
     gtConfig?.files?.gt?.parsingFlags?.enableAutoJsxInjection ?? false;
   const rawDevHotReload =
-    gtConfig?.files?.gt?.parsingFlags?.devHotReload ?? false;
+    gtConfig?.files?.gt?.parsingFlags?.devHotReload ?? undefined;
   const rawAutoderive =
     gtConfig?.files?.gt?.parsingFlags?.autoderive ??
     gtConfig?.files?.gt?.parsingFlags?.autoDerive ??

--- a/packages/react/src/i18n-context/browser-i18n-manager/BrowserI18nManager.ts
+++ b/packages/react/src/i18n-context/browser-i18n-manager/BrowserI18nManager.ts
@@ -227,10 +227,13 @@ function createLifecycleCallbacks(
 function resolveDevHotReload(
   value: boolean | { strings?: boolean; jsx?: boolean } | undefined
 ): { strings: boolean; jsx: boolean } {
-  if (value === undefined || typeof value === 'boolean') {
-    return { strings: !!value, jsx: !!value };
+  if (value === undefined) {
+    return { strings: true, jsx: false };
   }
-  return { strings: value.strings ?? false, jsx: value.jsx ?? false };
+  if (typeof value === 'boolean') {
+    return { strings: value, jsx: false };
+  }
+  return { strings: value.strings ?? true, jsx: value.jsx ?? false };
 }
 
 /**


### PR DESCRIPTION
## Summary

Enable `devHotReload.strings = true` by default when no explicit config is provided via `gt-react/browser`. JSX hot reload remains **off** by default — it is handled by the `<T>` component at runtime, so the only way to enable JSX hot reload is by explicitly setting `jsx: true` in the user's configuration.

### Dev-only behavior

This only affects development builds. In production:
- `BrowserI18nManager.isDevHotReloadEnabled()` gates on `import.meta.env.DEV` — if the environment is not dev, hot reload is completely disabled regardless of the resolved flags
- Additional requirements (`loadTranslations`, `projectId`, `devApiKey`) must all be present for hot reload to activate
- The compiler injects `GtInternalRuntimeTranslateString` calls at build time, but these only take effect when the runtime manager is in dev hot reload mode

## Changes

### `gt-react` (`packages/react`)
- `resolveDevHotReload()`: `undefined` now returns `{ strings: true, jsx: false }` instead of `{ strings: false, jsx: false }`
- Object form defaults `strings` to `true` (was `false`), `jsx` stays `false`

### `@generaltranslation/compiler` (`packages/compiler`)
- `resolveDevHotReload()`: same default change — strings defaults to `true`, jsx stays `false`
- `initializeState()`: falls through to `undefined` (not `false`) when gtConfig has no `devHotReload` set, so the resolver applies the new default
- Updated all affected tests

## Behavior

| Config | strings | jsx | Notes |
|--------|---------|-----|-------|
| Not set | ✅ | ❌ | **New default** — strings enabled, jsx off |
| `true` | ✅ | ❌ | No change — boolean true enables strings only |
| `false` | ❌ | ❌ | No change — explicitly disabled |
| `{ jsx: true }` | ✅ | ✅ | jsx only enabled when explicitly set |
| `{ strings: false }` | ❌ | ❌ | Can explicitly opt out of strings |
| `{}` | ✅ | ❌ | Empty object gets defaults |

JSX hot reload is **never** enabled unless the user explicitly passes `jsx: true`. This is by design — JSX hot reload is handled by the `<T>` component via Suspense, not the compiler injection.
