### PR TITLE
fix(sanity): Fix bulk translations page

### DIFF
--- a/.changeset/fix-sanity-bulk-translation-duplicates.md
+++ b/.changeset/fix-sanity-bulk-translation-duplicates.md
@@ -1,0 +1,5 @@
+---
+'gt-sanity': patch
+---
+
+Fix bulk translation imports creating duplicate translated documents when draft and published source documents are both present or multiple ready versions target the same source locale pair.

--- a/packages/sanity/src/components/TranslationsProvider.tsx
+++ b/packages/sanity/src/components/TranslationsProvider.tsx
@@ -4,6 +4,7 @@ import React, {
   useState,
   useCallback,
   useEffect,
+  useRef,
   ReactNode,
 } from 'react';
 import { SanityDocument, useSchema } from 'sanity';
@@ -137,6 +138,7 @@ export const TranslationsProvider: React.FC<TranslationsProviderProps> = ({
     failed: new Set<string>(),
     skipped: new Set<string>(),
   });
+  const downloadStatusRef = useRef(downloadStatus);
   const [translationStatuses, setTranslationStatuses] = useState<
     Map<string, TranslationStatus>
   >(new Map());
@@ -150,6 +152,10 @@ export const TranslationsProvider: React.FC<TranslationsProviderProps> = ({
     pluginConfig.getSecretsNamespace()
   );
   const [branchId, setBranchId] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    downloadStatusRef.current = downloadStatus;
+  }, [downloadStatus]);
 
   const fetchDocuments = useCallback(async () => {
     setLoadingDocuments(true);
@@ -577,7 +583,7 @@ export const TranslationsProvider: React.FC<TranslationsProviderProps> = ({
 
       const readyTranslations = await checkTranslationStatus(
         fileQueryData,
-        downloadStatus,
+        downloadStatusRef.current,
         secrets
       );
 
@@ -637,7 +643,7 @@ export const TranslationsProvider: React.FC<TranslationsProviderProps> = ({
     } finally {
       setIsRefreshing(false);
     }
-  }, [secrets, documents, locales, branchId, downloadStatus]);
+  }, [secrets, documents, locales, branchId]);
 
   const handleImportDocument = useCallback(
     async (documentId: string, versionId: string, localeId: string) => {

--- a/packages/sanity/src/components/TranslationsProvider.tsx
+++ b/packages/sanity/src/components/TranslationsProvider.tsx
@@ -35,6 +35,13 @@ import { processBatch } from '../utils/batchProcessor';
 import { publishTranslations } from '../sanity-api/publishDocuments';
 import { getLocales } from '../adapter/getLocales';
 import type { FileProperties, TranslationStatus } from '../adapter/types';
+import {
+  createStableTranslationKey,
+  createTranslationStatusKey,
+  dedupeDocumentsPreferDraft,
+  getDocumentPublishedId,
+  getPublishedId,
+} from '../utils/documentIds';
 
 interface ImportProgress {
   current: number;
@@ -180,7 +187,7 @@ export const TranslationsProvider: React.FC<TranslationsProviderProps> = ({
       }
 
       const docs = await client.fetch(query);
-      setDocuments(docs);
+      setDocuments(dedupeDocumentsPreferDraft(docs));
     } catch {
       toast.push({
         title: 'Error fetching documents',
@@ -215,9 +222,7 @@ export const TranslationsProvider: React.FC<TranslationsProviderProps> = ({
         .filter((locale) => locale.enabled !== false)
         .map((locale) => locale.localeId);
 
-      const documentIds = documents.map(
-        (doc) => doc._id?.replace('drafts.', '') || doc._id
-      );
+      const documentIds = documents.map(getDocumentPublishedId);
 
       const query = `*[
         _type == 'translation.metadata' &&
@@ -237,7 +242,13 @@ export const TranslationsProvider: React.FC<TranslationsProviderProps> = ({
       existingMetadata.forEach((metadata: any) => {
         metadata.existingTranslations?.forEach((localeId: string) => {
           if (localeId !== sourceLocale) {
-            existing.add(`${metadata.sourceDocId}:${localeId}`);
+            existing.add(
+              createStableTranslationKey(
+                undefined,
+                metadata.sourceDocId,
+                localeId
+              )
+            );
           }
         });
       });
@@ -275,7 +286,7 @@ export const TranslationsProvider: React.FC<TranslationsProviderProps> = ({
             );
             return {
               info: {
-                documentId: doc._id?.replace('drafts.', '') || doc._id,
+                documentId: getDocumentPublishedId(doc),
                 versionId: doc._rev,
               },
               serializedDocument: serialized,
@@ -413,7 +424,11 @@ export const TranslationsProvider: React.FC<TranslationsProviderProps> = ({
         metadata.existingTranslations?.forEach((localeId: string) => {
           if (localeId !== sourceLocale) {
             existing.add(
-              `${branchId}:${metadata.sourceDocId}:${metadata._rev}:${localeId}`
+              createStableTranslationKey(
+                branchId,
+                metadata.sourceDocId,
+                localeId
+              )
             );
           }
         });
@@ -434,9 +449,7 @@ export const TranslationsProvider: React.FC<TranslationsProviderProps> = ({
         .filter((locale) => locale.enabled !== false)
         .map((locale) => locale.localeId);
 
-      const documentIds = documents.map(
-        (doc) => doc._id?.replace('drafts.', '') || doc._id
-      );
+      const documentIds = documents.map(getDocumentPublishedId);
 
       const existingTranslations = await getExistingTranslations(
         documentIds,
@@ -445,7 +458,14 @@ export const TranslationsProvider: React.FC<TranslationsProviderProps> = ({
       );
 
       const readyFiles = await getReadyFilesForImport(translationStatuses, {
-        filterReadyFiles: (key) => !existingTranslations.has(key),
+        filterReadyFiles: (_key, status) =>
+          !existingTranslations.has(
+            createStableTranslationKey(
+              branchId,
+              status.fileData.fileId,
+              status.fileData.locale
+            )
+          ),
       });
 
       if (readyFiles.length === 0) {
@@ -545,7 +565,7 @@ export const TranslationsProvider: React.FC<TranslationsProviderProps> = ({
       const fileQueryData: FileProperties[] = [];
       for (const doc of documents) {
         for (const localeId of availableLocaleIds) {
-          const documentId = doc._id?.replace('drafts.', '') || doc._id;
+          const documentId = getDocumentPublishedId(doc);
           fileQueryData.push({
             versionId: doc._rev,
             fileId: documentId,
@@ -566,16 +586,26 @@ export const TranslationsProvider: React.FC<TranslationsProviderProps> = ({
 
         for (const doc of documents) {
           for (const localeId of availableLocaleIds) {
-            const documentId = doc._id?.replace('drafts.', '') || doc._id;
+            const documentId = getDocumentPublishedId(doc);
             const versionId = doc._rev;
-            const key = `${branchId}:${documentId}:${versionId}:${localeId}`;
+            const key = createTranslationStatusKey(
+              branchId,
+              documentId,
+              versionId,
+              localeId
+            );
             newStatuses.set(key, { progress: 0, isReady: false });
           }
         }
 
         if (Array.isArray(readyTranslations)) {
           for (const translation of readyTranslations) {
-            const key = `${branchId}:${translation.fileId}:${translation.versionId}:${translation.locale}`;
+            const key = createTranslationStatusKey(
+              branchId,
+              translation.fileId,
+              translation.versionId,
+              translation.locale
+            );
             newStatuses.set(key, {
               progress: 100,
               isReady: true,
@@ -607,13 +637,18 @@ export const TranslationsProvider: React.FC<TranslationsProviderProps> = ({
     } finally {
       setIsRefreshing(false);
     }
-  }, [secrets, documents, locales, branchId]);
+  }, [secrets, documents, locales, branchId, downloadStatus]);
 
   const handleImportDocument = useCallback(
     async (documentId: string, versionId: string, localeId: string) => {
       if (!secrets) return;
 
-      const key = `${branchId}:${documentId}:${versionId}:${localeId}`;
+      const key = createTranslationStatusKey(
+        branchId,
+        documentId,
+        versionId,
+        localeId
+      );
       const status = translationStatuses.get(key);
 
       if (!status?.isReady || !status.fileData) {
@@ -626,7 +661,7 @@ export const TranslationsProvider: React.FC<TranslationsProviderProps> = ({
       }
 
       const document = documents.find(
-        (doc) => (doc._id?.replace('drafts.', '') || doc._id) === documentId
+        (doc) => getDocumentPublishedId(doc) === getPublishedId(documentId)
       );
 
       if (!document) {
@@ -654,7 +689,7 @@ export const TranslationsProvider: React.FC<TranslationsProviderProps> = ({
         if (downloadedFiles.length > 0) {
           try {
             const docInfo: GTFile = {
-              documentId,
+              documentId: getPublishedId(documentId),
               versionId: document._rev,
             };
 
@@ -671,6 +706,13 @@ export const TranslationsProvider: React.FC<TranslationsProviderProps> = ({
               downloaded: new Set([...prev.downloaded, key]),
             }));
             setImportedTranslations((prev) => new Set([...prev, key]));
+            setExistingTranslations(
+              (prev) =>
+                new Set([
+                  ...prev,
+                  createStableTranslationKey(branchId, documentId, localeId),
+                ])
+            );
 
             toast.push({
               title: `Successfully imported translation for ${documentId} (${localeId})`,
@@ -817,9 +859,11 @@ export const TranslationsProvider: React.FC<TranslationsProviderProps> = ({
 
     try {
       const sourceLocale = pluginConfig.getSourceLocale();
-      const publishedDocumentIds = documents
-        .filter((doc) => !doc._id.startsWith('drafts.'))
-        .map((doc) => doc._id);
+      const sourceDocumentIds = documents.map(getDocumentPublishedId);
+      const publishedDocumentIds = await client.fetch(
+        `*[_id in $sourceDocumentIds]._id`,
+        { sourceDocumentIds }
+      );
 
       if (publishedDocumentIds.length === 0) {
         toast.push({
@@ -847,16 +891,16 @@ export const TranslationsProvider: React.FC<TranslationsProviderProps> = ({
         publishedDocumentIds,
       });
 
-      const translationDocIds: string[] = [];
+      const translationDocIds = new Set<string>();
       translationMetadata.forEach((metadata: any) => {
         metadata.translationDocs?.forEach((translation: any) => {
           if (translation.docId) {
-            translationDocIds.push(translation.docId);
+            translationDocIds.add(translation.docId);
           }
         });
       });
 
-      if (translationDocIds.length === 0) {
+      if (translationDocIds.size === 0) {
         toast.push({
           title: 'No translation documents found to publish',
           status: 'warning',
@@ -866,7 +910,7 @@ export const TranslationsProvider: React.FC<TranslationsProviderProps> = ({
       }
 
       const translatedDocumentIds = await publishTranslations(
-        translationDocIds,
+        Array.from(translationDocIds),
         client
       );
 
@@ -911,11 +955,19 @@ export const TranslationsProvider: React.FC<TranslationsProviderProps> = ({
       documents.length > 0 &&
       locales.length > 0 &&
       secrets &&
-      !loadingDocuments
+      !loadingDocuments &&
+      branchId
     ) {
       handleRefreshAll();
     }
-  }, [documents]);
+  }, [
+    documents,
+    locales,
+    secrets,
+    loadingDocuments,
+    branchId,
+    handleRefreshAll,
+  ]);
 
   useEffect(() => {
     if (!autoRefresh || documents.length === 0 || !secrets) return;

--- a/packages/sanity/src/components/page/TranslationsTable.tsx
+++ b/packages/sanity/src/components/page/TranslationsTable.tsx
@@ -2,6 +2,10 @@ import React from 'react';
 import { Box, Card, Stack, Text, Flex, Spinner } from '@sanity/ui';
 import { LanguageStatus } from '../shared/LanguageStatus';
 import { useTranslations } from '../TranslationsProvider';
+import {
+  createTranslationStatusKey,
+  getDocumentPublishedId,
+} from '../../utils/documentIds';
 
 export const TranslationsTable: React.FC = () => {
   const {
@@ -32,7 +36,7 @@ export const TranslationsTable: React.FC = () => {
               <Flex justify='space-between' align='flex-start'>
                 <Box flex={1}>
                   <Text weight='semibold' size={1}>
-                    {document._id?.replace('drafts.', '') || document._id}
+                    {getDocumentPublishedId(document)}
                   </Text>
                   <Text size={0} muted style={{ marginTop: '2px' }}>
                     {document._type}
@@ -45,9 +49,13 @@ export const TranslationsTable: React.FC = () => {
                   locales
                     .filter((locale) => locale.enabled !== false)
                     .map((locale) => {
-                      const documentId =
-                        document._id?.replace('drafts.', '') || document._id;
-                      const key = `${branchId}:${documentId}:${document._rev}:${locale.localeId}`;
+                      const documentId = getDocumentPublishedId(document);
+                      const key = createTranslationStatusKey(
+                        branchId,
+                        documentId,
+                        document._rev,
+                        locale.localeId
+                      );
                       const status = translationStatuses.get(key);
                       const isDownloaded = downloadStatus.downloaded.has(key);
                       const isImported = importedTranslations.has(key);

--- a/packages/sanity/src/components/shared/LanguageStatus.tsx
+++ b/packages/sanity/src/components/shared/LanguageStatus.tsx
@@ -19,6 +19,7 @@ export const LanguageStatus = ({
   isImported = false,
 }: LanguageStatusProps) => {
   const [isBusy, setIsBusy] = useState(false);
+  const displayedProgress = isImported && progress < 100 ? 100 : progress;
 
   const handleImport = useCallback(async () => {
     setIsBusy(true);
@@ -37,9 +38,9 @@ export const LanguageStatus = ({
             {title}
           </Text>
         </Flex>
-        {typeof progress === 'number' ? (
+        {typeof displayedProgress === 'number' ? (
           <Flex columnStart={3} columnEnd={5} align='center'>
-            <ProgressBar progress={progress} />
+            <ProgressBar progress={displayedProgress} />
           </Flex>
         ) : null}
         <Box columnStart={5} columnEnd={6}>

--- a/packages/sanity/src/components/shared/SingleDocumentView.tsx
+++ b/packages/sanity/src/components/shared/SingleDocumentView.tsx
@@ -3,6 +3,10 @@ import { Stack, Box, Card, Text, Flex, Spinner } from '@sanity/ui';
 import { LanguageStatus } from './LanguageStatus';
 import { useTranslations } from '../TranslationsProvider';
 import { pluginConfig } from '../../adapter/core';
+import {
+  createTranslationStatusKey,
+  getDocumentPublishedId,
+} from '../../utils/documentIds';
 
 export const SingleDocumentView: React.FC = () => {
   const {
@@ -60,7 +64,7 @@ export const SingleDocumentView: React.FC = () => {
             <Flex justify='space-between' align='flex-start'>
               <Box flex={1}>
                 <Text weight='semibold' size={1}>
-                  {document._id?.replace('drafts.', '') || document._id}
+                  {getDocumentPublishedId(document)}
                 </Text>
                 <Text size={0} muted style={{ marginTop: '2px' }}>
                   {document._type}
@@ -73,9 +77,13 @@ export const SingleDocumentView: React.FC = () => {
                 locales
                   .filter((locale) => locale.enabled !== false)
                   .map((locale) => {
-                    const documentId =
-                      document._id?.replace('drafts.', '') || document._id;
-                    const key = `${branchId}:${documentId}:${document._rev}:${locale.localeId}`;
+                    const documentId = getDocumentPublishedId(document);
+                    const key = createTranslationStatusKey(
+                      branchId,
+                      documentId,
+                      document._rev,
+                      locale.localeId
+                    );
                     const status = translationStatuses.get(key);
                     const isDownloaded = downloadStatus.downloaded.has(key);
                     const isImported = importedTranslations.has(key);

--- a/packages/sanity/src/components/tab/TranslationView.tsx
+++ b/packages/sanity/src/components/tab/TranslationView.tsx
@@ -22,6 +22,10 @@ import { useTranslations } from '../TranslationsProvider';
 import { LanguageStatus } from '../shared/LanguageStatus';
 import { LocaleCheckbox } from '../shared/LocaleCheckbox';
 import { DownloadIcon, LinkIcon, PublishIcon } from '@sanity/icons';
+import {
+  createTranslationStatusKey,
+  getDocumentPublishedId,
+} from '../../utils/documentIds';
 
 export const TranslationView = () => {
   const {
@@ -85,7 +89,7 @@ export const TranslationView = () => {
   // Get document ID for status tracking
   const documentId = useMemo(() => {
     if (!document) return null;
-    return document._id?.replace('drafts.', '') || document._id;
+    return getDocumentPublishedId(document);
   }, [document]);
 
   // Unified import functionality
@@ -99,7 +103,12 @@ export const TranslationView = () => {
 
       // Find translations ready to import
       const readyTranslations = availableLocales.filter((locale) => {
-        const key = `${branchId}:${documentId}:${document._rev}:${locale.localeId}`;
+        const key = createTranslationStatusKey(
+          branchId,
+          documentId,
+          document._rev,
+          locale.localeId
+        );
         const status = translationStatuses.get(key);
         return status?.isReady && !importedTranslations.has(key);
       });
@@ -278,7 +287,12 @@ export const TranslationView = () => {
 
           <Box>
             {availableLocales.map((locale) => {
-              const key = `${branchId}:${documentId}:${document._rev}:${locale.localeId}`;
+              const key = createTranslationStatusKey(
+                branchId,
+                documentId,
+                document._rev,
+                locale.localeId
+              );
               const status = translationStatuses.get(key);
               const progress = status?.progress || 0;
               const isImported = importedTranslations.has(key);
@@ -316,7 +330,12 @@ export const TranslationView = () => {
                   disabled={
                     isImporting ||
                     availableLocales.every((locale) => {
-                      const key = `${branchId}:${documentId}:${document._rev}:${locale.localeId}`;
+                      const key = createTranslationStatusKey(
+                        branchId,
+                        documentId,
+                        document._rev,
+                        locale.localeId
+                      );
                       const status = translationStatuses.get(key);
                       return !status?.isReady || importedTranslations.has(key);
                     })
@@ -336,14 +355,24 @@ export const TranslationView = () => {
                 Imported{' '}
                 {
                   availableLocales.filter((locale) => {
-                    const key = `${branchId}:${documentId}:${document._rev}:${locale.localeId}`;
+                    const key = createTranslationStatusKey(
+                      branchId,
+                      documentId,
+                      document._rev,
+                      locale.localeId
+                    );
                     return importedTranslations.has(key);
                   }).length
                 }
                 /
                 {
                   availableLocales.filter((locale) => {
-                    const key = `${branchId}:${documentId}:${document._rev}:${locale.localeId}`;
+                    const key = createTranslationStatusKey(
+                      branchId,
+                      documentId,
+                      document._rev,
+                      locale.localeId
+                    );
                     const status = translationStatuses.get(key);
                     return status?.isReady;
                   }).length

--- a/packages/sanity/src/configuration/baseDocumentLevelConfig/documentLevelPatch.test.ts
+++ b/packages/sanity/src/configuration/baseDocumentLevelConfig/documentLevelPatch.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { pluginConfig } from '../../adapter/core';
+import { documentLevelPatch } from './documentLevelPatch';
+
+describe('documentLevelPatch', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('rechecks metadata before creating a translated document', async () => {
+    vi.spyOn(pluginConfig, 'getSourceLocale').mockReturnValue('en');
+    vi.spyOn(pluginConfig, 'getIgnoreFields').mockReturnValue([]);
+    vi.spyOn(pluginConfig, 'getSkipFields').mockReturnValue([]);
+    vi.spyOn(pluginConfig, 'getDedupeFields').mockReturnValue([]);
+
+    const sourceDoc = {
+      _id: 'article-1',
+      _type: 'article',
+      _rev: 'source-rev',
+      title: 'Hello',
+    };
+    const existingTargetDoc = {
+      _id: 'drafts.article-1-es',
+      _type: 'article',
+      _rev: 'target-rev',
+      title: 'Hola',
+      language: 'es',
+    };
+
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce([sourceDoc])
+      .mockResolvedValueOnce({
+        _id: 'translation.metadata.article-1',
+        _type: 'translation.metadata',
+        translations: [
+          {
+            language: 'en',
+            value: { _type: 'reference', _ref: 'article-1' },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        _id: 'translation.metadata.article-1',
+        _type: 'translation.metadata',
+        translations: [
+          {
+            language: 'en',
+            value: { _type: 'reference', _ref: 'article-1' },
+          },
+          {
+            language: 'es',
+            value: { _type: 'reference', _ref: 'article-1-es' },
+          },
+        ],
+      })
+      .mockResolvedValueOnce([existingTargetDoc]);
+    const commit = vi.fn().mockResolvedValue({});
+    const patch = vi.fn().mockReturnValue({ commit });
+    const create = vi.fn();
+
+    const client = { fetch, patch, create } as any;
+
+    await documentLevelPatch(
+      { documentId: 'article-1' },
+      { _id: 'article-1', _type: 'article', title: 'Hola' } as any,
+      'es',
+      client
+    );
+
+    expect(create).not.toHaveBeenCalled();
+    expect(patch).toHaveBeenCalledWith('drafts.article-1-es', {
+      set: expect.objectContaining({ title: 'Hola' }),
+    });
+  });
+});

--- a/packages/sanity/src/configuration/baseDocumentLevelConfig/documentLevelPatch.ts
+++ b/packages/sanity/src/configuration/baseDocumentLevelConfig/documentLevelPatch.ts
@@ -106,12 +106,36 @@ export const documentLevelPatch = async (
   //otherwise, create a new document
   //and add the document reference to the metadata document
   else {
+    const freshTranslationMetadata = await getOrCreateTranslationMetadata(
+      docInfo.documentId,
+      baseDoc,
+      client,
+      baseLanguage
+    );
+    const freshI18nDocId = (
+      freshTranslationMetadata.translations as Array<Record<string, any>>
+    ).find((translation) => translation.language === localeId)?.value?._ref;
+
+    if (freshI18nDocId) {
+      const freshI18nDoc = await findLatestDraft(freshI18nDocId, client);
+      await patchI18nDoc(
+        docInfo.documentId,
+        freshI18nDoc._id,
+        baseDoc,
+        merged,
+        translatedFields,
+        client,
+        freshI18nDoc
+      );
+      return;
+    }
+
     await createI18nDocAndPatchMetadata(
       baseDoc,
       merged,
       localeId,
       client,
-      translationMetadata,
+      freshTranslationMetadata,
       docInfo.documentId,
       languageField
     );

--- a/packages/sanity/src/configuration/baseDocumentLevelConfig/helpers/createI18nDocAndPatchMetadata.ts
+++ b/packages/sanity/src/configuration/baseDocumentLevelConfig/helpers/createI18nDocAndPatchMetadata.ts
@@ -3,6 +3,7 @@
 import { SanityClient, SanityDocumentLike } from 'sanity';
 import { pluginConfig } from '../../../adapter/core';
 import { applyDocuments } from '../../../utils/applyDocuments';
+import { getPublishedId } from '../../../utils/documentIds';
 import { randomKey } from '../../../utils/randomKey';
 
 export async function createI18nDocAndPatchMetadata(
@@ -14,6 +15,7 @@ export async function createI18nDocAndPatchMetadata(
   sourceDocumentId: string,
   languageField: string = 'language'
 ): Promise<void> {
+  const publishedSourceDocumentId = getPublishedId(sourceDocumentId);
   translatedDoc[languageField] = localeId;
   const translations = translationMetadata.translations as Record<
     string,
@@ -31,7 +33,7 @@ export async function createI18nDocAndPatchMetadata(
   const { _updatedAt, _createdAt, ...rest } = translatedDoc;
 
   const appliedDocument = applyDocuments(
-    sourceDocumentId,
+    publishedSourceDocumentId,
     sourceDocument,
     rest,
     pluginConfig.getIgnoreFields(),
@@ -42,12 +44,15 @@ export async function createI18nDocAndPatchMetadata(
 
   // Check if this is a singleton document and apply singleton mapping
   const singletons = pluginConfig.getSingletons();
-  const isSingleton = singletons.includes(sourceDocumentId);
+  const isSingleton = singletons.includes(publishedSourceDocumentId);
 
   let createDocumentPromise;
   if (isSingleton) {
     const singletonMapping = pluginConfig.getSingletonMapping();
-    const translatedDocId = singletonMapping(sourceDocumentId, localeId);
+    const translatedDocId = singletonMapping(
+      publishedSourceDocumentId,
+      localeId
+    );
     createDocumentPromise = client.create({
       ...appliedDocument,
       _type: rest._type,
@@ -62,7 +67,7 @@ export async function createI18nDocAndPatchMetadata(
   }
 
   const doc = await createDocumentPromise;
-  const _ref = doc._id.replace('drafts.', '');
+  const _ref = getPublishedId(doc._id);
   const result = await client
     .transaction()
     .patch(translationMetadata._id, (p) =>

--- a/packages/sanity/src/configuration/baseDocumentLevelConfig/helpers/createTranslationMetadata.ts
+++ b/packages/sanity/src/configuration/baseDocumentLevelConfig/helpers/createTranslationMetadata.ts
@@ -7,6 +7,7 @@ import {
   SanityDocumentLike,
 } from 'sanity';
 import { randomKey } from '../../../utils/randomKey';
+import { getPublishedId } from '../../../utils/documentIds';
 
 type TranslationReference = KeyedObject & {
   _type: 'internationalizedArrayReferenceValue';
@@ -24,7 +25,7 @@ export const createTranslationMetadata = (
     _type: 'internationalizedArrayReferenceValue',
     value: {
       _type: 'reference',
-      _ref: document._id.replace('drafts.', ''),
+      _ref: getPublishedId(document._id),
     },
   };
 

--- a/packages/sanity/src/configuration/baseDocumentLevelConfig/helpers/getOrCreateTranslationMetadata.ts
+++ b/packages/sanity/src/configuration/baseDocumentLevelConfig/helpers/getOrCreateTranslationMetadata.ts
@@ -7,6 +7,7 @@ import {
   SanityDocumentLike,
 } from 'sanity';
 import { randomKey } from '../../../utils/randomKey';
+import { getPublishedId } from '../../../utils/documentIds';
 
 type TranslationReference = KeyedObject & {
   _type: 'internationalizedArrayReferenceValue';
@@ -19,13 +20,15 @@ export const getOrCreateTranslationMetadata = async (
   client: SanityClient,
   baseLanguage: string
 ): Promise<SanityDocumentLike> => {
+  const publishedId = getPublishedId(documentId);
+
   // First, try to get existing metadata
   const existingMetadata = await client.fetch(
     `*[
         _type == 'translation.metadata' &&
         translations[language == $baseLanguage][0].value._ref == $id
       ][0]`,
-    { baseLanguage, id: documentId.replace('drafts.', '') }
+    { baseLanguage, id: publishedId }
   );
 
   if (existingMetadata) {
@@ -39,7 +42,7 @@ export const getOrCreateTranslationMetadata = async (
     _type: 'internationalizedArrayReferenceValue',
     value: {
       _type: 'reference',
-      _ref: baseDocument._id.replace('drafts.', ''),
+      _ref: getPublishedId(baseDocument._id),
     },
   };
 
@@ -58,7 +61,7 @@ export const getOrCreateTranslationMetadata = async (
   try {
     // Use createIfNotExists to handle race conditions
     return await client.createIfNotExists({
-      _id: `translation.metadata.${documentId.replace('drafts.', '')}`,
+      _id: `translation.metadata.${publishedId}`,
       _type: 'translation.metadata',
       translations: [baseLangEntry],
     });
@@ -69,7 +72,7 @@ export const getOrCreateTranslationMetadata = async (
           _type == 'translation.metadata' &&
           translations[language == $baseLanguage][0].value._ref == $id
         ][0]`,
-      { baseLanguage, id: documentId.replace('drafts.', '') }
+      { baseLanguage, id: publishedId }
     );
 
     if (metadata) {

--- a/packages/sanity/src/configuration/baseDocumentLevelConfig/helpers/getTranslationMetadata.ts
+++ b/packages/sanity/src/configuration/baseDocumentLevelConfig/helpers/getTranslationMetadata.ts
@@ -1,6 +1,7 @@
 // adapted from https://github.com/sanity-io/sanity-translations-tab. See LICENSE.md for more details.
 
 import { SanityClient, SanityDocumentLike } from 'sanity';
+import { getPublishedId } from '../../../utils/documentIds';
 
 export const getTranslationMetadata = (
   id: string,
@@ -12,6 +13,6 @@ export const getTranslationMetadata = (
         _type == 'translation.metadata' &&
         translations[language == $baseLanguage][0].value._ref == $id
       ][0]`,
-    { baseLanguage, id: id.replace('drafts.', '') }
+    { baseLanguage, id: getPublishedId(id) }
   );
 };

--- a/packages/sanity/src/configuration/utils/findLatestDraft.ts
+++ b/packages/sanity/src/configuration/utils/findLatestDraft.ts
@@ -1,14 +1,16 @@
 // adapted from https://github.com/sanity-io/sanity-translations-tab. See LICENSE.md for more details.
 
 import { SanityClient, SanityDocument } from 'sanity';
+import { getPublishedId } from '../../utils/documentIds';
 
 //use perspectives in the future
 export const findLatestDraft = (
   documentId: string,
   client: SanityClient
 ): Promise<SanityDocument> => {
+  const publishedId = getPublishedId(documentId);
   const query = `*[_id == $id || _id == $draftId]`;
-  const params = { id: documentId, draftId: `drafts.${documentId}` };
+  const params = { id: publishedId, draftId: `drafts.${publishedId}` };
   return client
     .fetch(query, params)
     .then(

--- a/packages/sanity/src/sanity-api/findDocuments.ts
+++ b/packages/sanity/src/sanity-api/findDocuments.ts
@@ -1,5 +1,7 @@
 import { SanityClient } from 'sanity';
 import { pluginConfig } from '../adapter/core';
+import { getPublishedId } from '../utils/documentIds';
+import { findLatestDraft } from '../configuration/utils/findLatestDraft';
 
 export async function findTranslatedDocuments(
   documentId: string,
@@ -16,24 +18,28 @@ export async function findTranslatedDocumentForLocale(
   localeId: string,
   client: SanityClient
 ) {
-  const cleanDocId = sourceDocumentId.replace('drafts.', '');
+  const cleanDocId = getPublishedId(sourceDocumentId);
 
-  // Try both clean and original IDs to be safe, and use -> to directly fetch the translated doc
+  // Use the last locale entry defensively. Older versions could create
+  // duplicate locale entries when bulk imports raced.
   const query = `*[
     _type == "translation.metadata" &&
     (
       translations[language == $sourceLocale][0].value._ref == $cleanDocId
     ) &&
     defined(translations[language == $localeId])
-  ][0].translations[language == $localeId][0].value->`;
+  ][0].translations[language == $localeId].value._ref`;
 
-  const translatedDoc = await client.fetch(query, {
+  const translatedDocIds = await client.fetch(query, {
     sourceLocale: pluginConfig.getSourceLocale(),
     cleanDocId,
     localeId,
   });
 
-  return translatedDoc || null;
+  const translatedDocId = translatedDocIds?.[translatedDocIds.length - 1];
+  if (!translatedDocId) return null;
+
+  return (await findLatestDraft(translatedDocId, client)) || null;
 }
 
 export async function findDocument(documentId: string, client: SanityClient) {

--- a/packages/sanity/src/sanity-api/publishDocuments.ts
+++ b/packages/sanity/src/sanity-api/publishDocuments.ts
@@ -1,6 +1,7 @@
 import { SanityClient } from 'sanity';
 import { processBatch } from '../utils/batchProcessor';
 import { findDocument } from './findDocuments';
+import { getPublishedId } from '../utils/documentIds';
 
 export async function publishDocument(
   documentId: string,
@@ -13,7 +14,7 @@ export async function publishDocument(
         {
           actionType: 'sanity.action.document.publish',
           draftId: documentId,
-          publishedId: documentId.replace('drafts.', ''),
+          publishedId: getPublishedId(documentId),
         },
         {}
       );

--- a/packages/sanity/src/sanity-api/resolveRefs.ts
+++ b/packages/sanity/src/sanity-api/resolveRefs.ts
@@ -92,14 +92,15 @@ async function resolveTranslatedReferences(
   // Optimized GROQ query that directly returns only the needed translation pairs
   const query = `*[_type == "translation.metadata" && count(translations[language == $sourceLocale && value._ref in $refIds]) > 0] {
     "originalRef": translations[language == $sourceLocale][0].value._ref,
-    "translatedRef": translations[language == $locale][0].value._ref
-  }[defined(originalRef) && defined(translatedRef)]`;
+    "translatedRefs": translations[language == $locale].value._ref
+  }[defined(originalRef) && count(translatedRefs) > 0]`;
 
-  const translationPairs: { originalRef: string; translatedRef: string }[] =
+  const translationPairs: { originalRef: string; translatedRefs: string[] }[] =
     await client.fetch(query, { refIds, sourceLocale, locale });
 
   // Build the translation map
-  for (const { originalRef, translatedRef } of translationPairs) {
+  for (const { originalRef, translatedRefs: localeRefs } of translationPairs) {
+    const translatedRef = localeRefs[localeRefs.length - 1];
     translatedRefs.set(originalRef, translatedRef);
   }
 

--- a/packages/sanity/src/translation/checkTranslationStatus.ts
+++ b/packages/sanity/src/translation/checkTranslationStatus.ts
@@ -1,6 +1,10 @@
 import type { Secrets } from '../types';
 import { gt, overrideConfig } from '../adapter/core';
 import { FileProperties } from '../adapter/types';
+import {
+  createStableTranslationKey,
+  createTranslationStatusKey,
+} from '../utils/documentIds';
 
 export async function checkTranslationStatus(
   fileQueryData: FileProperties[],
@@ -14,12 +18,27 @@ export async function checkTranslationStatus(
   overrideConfig(secrets);
   try {
     // Only query for files that haven't been downloaded yet
-    const currentQueryData = fileQueryData.filter(
-      (item) =>
-        !downloadStatus.downloaded.has(`${item.fileId}:${item.locale}`) &&
-        !downloadStatus.failed.has(`${item.fileId}:${item.locale}`) &&
-        !downloadStatus.skipped.has(`${item.fileId}:${item.locale}`)
-    );
+    const currentQueryData = fileQueryData.filter((item) => {
+      const statusKey = createTranslationStatusKey(
+        item.branchId,
+        item.fileId,
+        item.versionId,
+        item.locale
+      );
+      const stableKey = createStableTranslationKey(
+        item.branchId,
+        item.fileId,
+        item.locale
+      );
+      return (
+        !downloadStatus.downloaded.has(statusKey) &&
+        !downloadStatus.downloaded.has(stableKey) &&
+        !downloadStatus.failed.has(statusKey) &&
+        !downloadStatus.failed.has(stableKey) &&
+        !downloadStatus.skipped.has(statusKey) &&
+        !downloadStatus.skipped.has(stableKey)
+      );
+    });
 
     // If all files have been downloaded, we're done
     if (currentQueryData.length === 0) {

--- a/packages/sanity/src/utils/__tests__/batchProcessor.test.ts
+++ b/packages/sanity/src/utils/__tests__/batchProcessor.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'vitest';
+import { processBatch } from '../batchProcessor';
+
+describe('processBatch', () => {
+  test('serializes items with the same concurrency key', async () => {
+    let activeForKey = 0;
+    let maxActiveForKey = 0;
+
+    await processBatch(
+      ['first', 'second', 'third'],
+      async () => {
+        activeForKey++;
+        maxActiveForKey = Math.max(maxActiveForKey, activeForKey);
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        activeForKey--;
+      },
+      {
+        getConcurrencyKey: () => 'article-1:es',
+      }
+    );
+
+    expect(maxActiveForKey).toBe(1);
+  });
+
+  test('keeps unrelated concurrency keys parallel', async () => {
+    let active = 0;
+    let maxActive = 0;
+
+    await processBatch(
+      ['article-1', 'article-2'],
+      async () => {
+        active++;
+        maxActive = Math.max(maxActive, active);
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        active--;
+      },
+      {
+        getConcurrencyKey: (item) => item,
+      }
+    );
+
+    expect(maxActive).toBe(2);
+  });
+});

--- a/packages/sanity/src/utils/__tests__/documentIds.test.ts
+++ b/packages/sanity/src/utils/__tests__/documentIds.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'vitest';
+import {
+  createStableTranslationKey,
+  createTranslationStatusKey,
+  dedupeDocumentsPreferDraft,
+  getPublishedId,
+} from '../documentIds';
+
+describe('document ID helpers', () => {
+  test('normalizes only draft prefixes', () => {
+    expect(getPublishedId('drafts.article-1')).toBe('article-1');
+    expect(getPublishedId('article-drafts-copy')).toBe('article-drafts-copy');
+  });
+
+  test('dedupes draft and published documents by preferring the draft', () => {
+    const result = dedupeDocumentsPreferDraft([
+      { _id: 'article-1', _type: 'article', _rev: 'published' },
+      { _id: 'drafts.article-1', _type: 'article', _rev: 'draft' },
+      { _id: 'article-2', _type: 'article', _rev: 'published-2' },
+    ] as any);
+
+    expect(result).toEqual([
+      { _id: 'drafts.article-1', _type: 'article', _rev: 'draft' },
+      { _id: 'article-2', _type: 'article', _rev: 'published-2' },
+    ]);
+  });
+
+  test('builds keys from the published document id', () => {
+    expect(
+      createTranslationStatusKey('branch', 'drafts.article-1', 'rev', 'es')
+    ).toBe('branch:article-1:rev:es');
+    expect(createStableTranslationKey('branch', 'drafts.article-1', 'es')).toBe(
+      'branch:article-1:es'
+    );
+    expect(createStableTranslationKey(undefined, 'drafts.article-1', 'es')).toBe(
+      'article-1:es'
+    );
+  });
+});

--- a/packages/sanity/src/utils/__tests__/documentIds.test.ts
+++ b/packages/sanity/src/utils/__tests__/documentIds.test.ts
@@ -32,8 +32,8 @@ describe('document ID helpers', () => {
     expect(createStableTranslationKey('branch', 'drafts.article-1', 'es')).toBe(
       'branch:article-1:es'
     );
-    expect(createStableTranslationKey(undefined, 'drafts.article-1', 'es')).toBe(
-      'article-1:es'
-    );
+    expect(
+      createStableTranslationKey(undefined, 'drafts.article-1', 'es')
+    ).toBe('article-1:es');
   });
 });

--- a/packages/sanity/src/utils/__tests__/documentIds.test.ts
+++ b/packages/sanity/src/utils/__tests__/documentIds.test.ts
@@ -33,6 +33,9 @@ describe('document ID helpers', () => {
       'branch:article-1:es'
     );
     expect(
+      createTranslationStatusKey(undefined, 'drafts.article-1', 'rev', 'es')
+    ).toBe('article-1:rev:es');
+    expect(
       createStableTranslationKey(undefined, 'drafts.article-1', 'es')
     ).toBe('article-1:es');
   });

--- a/packages/sanity/src/utils/__tests__/importUtils.test.ts
+++ b/packages/sanity/src/utils/__tests__/importUtils.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, test } from 'vitest';
+import type { TranslationStatus } from '../../adapter/types';
 import { getReadyFilesForImport } from '../importUtils';
 
 describe('getReadyFilesForImport', () => {
   test('dedupes ready files by branch, source document, and locale', async () => {
-    const statuses = new Map([
+    const statuses = new Map<string, TranslationStatus>([
       [
         'branch:article-1:rev-1:es',
         {
@@ -43,7 +44,7 @@ describe('getReadyFilesForImport', () => {
           },
         },
       ],
-    ] as any);
+    ]);
 
     const readyFiles = await getReadyFilesForImport(statuses);
 

--- a/packages/sanity/src/utils/__tests__/importUtils.test.ts
+++ b/packages/sanity/src/utils/__tests__/importUtils.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from 'vitest';
+import { getReadyFilesForImport } from '../importUtils';
+
+describe('getReadyFilesForImport', () => {
+  test('dedupes ready files by branch, source document, and locale', async () => {
+    const statuses = new Map([
+      [
+        'branch:article-1:rev-1:es',
+        {
+          progress: 100,
+          isReady: true,
+          fileData: {
+            branchId: 'branch',
+            fileId: 'article-1',
+            versionId: 'rev-1',
+            locale: 'es',
+          },
+        },
+      ],
+      [
+        'branch:article-1:rev-2:es',
+        {
+          progress: 100,
+          isReady: true,
+          fileData: {
+            branchId: 'branch',
+            fileId: 'drafts.article-1',
+            versionId: 'rev-2',
+            locale: 'es',
+          },
+        },
+      ],
+      [
+        'branch:article-1:rev-2:fr',
+        {
+          progress: 100,
+          isReady: true,
+          fileData: {
+            branchId: 'branch',
+            fileId: 'article-1',
+            versionId: 'rev-2',
+            locale: 'fr',
+          },
+        },
+      ],
+    ] as any);
+
+    const readyFiles = await getReadyFilesForImport(statuses);
+
+    expect(readyFiles).toEqual([
+      {
+        branchId: 'branch',
+        fileId: 'article-1',
+        versionId: 'rev-2',
+        locale: 'es',
+      },
+      {
+        branchId: 'branch',
+        fileId: 'article-1',
+        versionId: 'rev-2',
+        locale: 'fr',
+      },
+    ]);
+  });
+});

--- a/packages/sanity/src/utils/batchProcessor.ts
+++ b/packages/sanity/src/utils/batchProcessor.ts
@@ -1,8 +1,10 @@
 import { GTFile, TranslationFunctionContext } from '../types';
 import { importDocument } from '../translation/importDocument';
+import { createStableTranslationKey } from './documentIds';
 
 export interface BatchProcessorOptions {
   batchSize?: number;
+  getConcurrencyKey?: (item: any) => string | undefined;
   onProgress?: (current: number, total: number) => void;
   onItemSuccess?: (item: any, result: any) => void;
   onItemFailure?: (item: any, error: any) => void;
@@ -26,7 +28,13 @@ export async function processBatch<T>(
   successfulItems: any[];
   failedItems: { item: T; error: any }[];
 }> {
-  const { batchSize = 20, onProgress, onItemSuccess, onItemFailure } = options;
+  const {
+    batchSize = 20,
+    getConcurrencyKey,
+    onProgress,
+    onItemSuccess,
+    onItemFailure,
+  } = options;
 
   let successCount = 0;
   let failureCount = 0;
@@ -36,14 +44,39 @@ export async function processBatch<T>(
   for (let i = 0; i < items.length; i += batchSize) {
     const batch = items.slice(i, i + batchSize);
 
+    const pendingByKey = new Map<string, Promise<void>>();
+
     const batchPromises = batch.map(async (item) => {
+      const concurrencyKey = getConcurrencyKey?.(item);
+      const pending = concurrencyKey
+        ? pendingByKey.get(concurrencyKey)
+        : undefined;
+
+      let release: () => void = () => {};
+      const current = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+
+      if (concurrencyKey) {
+        pendingByKey.set(concurrencyKey, current);
+      }
+
       try {
+        if (pending) {
+          await pending;
+        }
+
         const result = await processor(item);
         onItemSuccess?.(item, result);
         return { success: true, item, result };
       } catch (error) {
         onItemFailure?.(item, error);
         return { success: false, item, error };
+      } finally {
+        release();
+        if (concurrencyKey && pendingByKey.get(concurrencyKey) === current) {
+          pendingByKey.delete(concurrencyKey);
+        }
       }
     });
 
@@ -90,6 +123,12 @@ export async function processImportBatch(
     },
     {
       ...options,
+      getConcurrencyKey: (item: ImportBatchItem) =>
+        createStableTranslationKey(
+          undefined,
+          item.docInfo.documentId,
+          item.locale
+        ),
       onItemSuccess: (item: ImportBatchItem, key: string) => {
         successfulImports.push(key);
         options.onItemSuccess?.(item, key);

--- a/packages/sanity/src/utils/documentIds.ts
+++ b/packages/sanity/src/utils/documentIds.ts
@@ -31,7 +31,10 @@ export function createTranslationStatusKey(
   versionId: string,
   localeId: string
 ): string {
-  return `${branchId}:${getPublishedId(documentId)}:${versionId}:${localeId}`;
+  const publishedId = getPublishedId(documentId);
+  return branchId
+    ? `${branchId}:${publishedId}:${versionId}:${localeId}`
+    : `${publishedId}:${versionId}:${localeId}`;
 }
 
 export function createStableTranslationKey(

--- a/packages/sanity/src/utils/documentIds.ts
+++ b/packages/sanity/src/utils/documentIds.ts
@@ -1,0 +1,46 @@
+import type { SanityDocument } from 'sanity';
+
+export function getPublishedId(documentId: string): string {
+  return documentId.startsWith('drafts.') ? documentId.slice(7) : documentId;
+}
+
+export function getDocumentPublishedId(document: SanityDocument): string {
+  return getPublishedId(document._id);
+}
+
+export function dedupeDocumentsPreferDraft<T extends SanityDocument>(
+  documents: T[]
+): T[] {
+  const byPublishedId = new Map<string, T>();
+
+  for (const document of documents) {
+    const publishedId = getDocumentPublishedId(document);
+    const existing = byPublishedId.get(publishedId);
+
+    if (!existing || document._id.startsWith('drafts.')) {
+      byPublishedId.set(publishedId, document);
+    }
+  }
+
+  return Array.from(byPublishedId.values());
+}
+
+export function createTranslationStatusKey(
+  branchId: string | undefined,
+  documentId: string,
+  versionId: string,
+  localeId: string
+): string {
+  return `${branchId}:${getPublishedId(documentId)}:${versionId}:${localeId}`;
+}
+
+export function createStableTranslationKey(
+  branchId: string | undefined,
+  documentId: string,
+  localeId: string
+): string {
+  const publishedId = getPublishedId(documentId);
+  return branchId
+    ? `${branchId}:${publishedId}:${localeId}`
+    : `${publishedId}:${localeId}`;
+}

--- a/packages/sanity/src/utils/importUtils.ts
+++ b/packages/sanity/src/utils/importUtils.ts
@@ -1,8 +1,8 @@
-import { SanityDocument } from 'sanity';
 import { Secrets, TranslationFunctionContext } from '../types';
 import { downloadTranslations } from '../translation/downloadTranslations';
 import { processImportBatch, ImportBatchItem } from './batchProcessor';
 import type { FileProperties, TranslationStatus } from '../adapter/types';
+import { createStableTranslationKey, getPublishedId } from './documentIds';
 
 export interface ImportResult {
   successCount: number;
@@ -21,20 +21,28 @@ export async function getReadyFilesForImport(
   options: ImportOptions = {}
 ): Promise<FileProperties[]> {
   const { filterReadyFiles = () => true } = options;
-  const readyFiles: FileProperties[] = [];
+  const readyFilesByDocumentLocale = new Map<string, FileProperties>();
 
   for (const [key, status] of translationStatuses.entries()) {
-    if (status.isReady && filterReadyFiles(key, status)) {
-      readyFiles.push({
-        fileId: status.fileData.fileId,
+    if (status.isReady && status.fileData && filterReadyFiles(key, status)) {
+      const fileData = {
+        fileId: getPublishedId(status.fileData.fileId),
         versionId: status.fileData.versionId,
         branchId: status.fileData.branchId,
         locale: status.fileData.locale,
-      });
+      };
+      readyFilesByDocumentLocale.set(
+        createStableTranslationKey(
+          fileData.branchId,
+          fileData.fileId,
+          fileData.locale
+        ),
+        fileData
+      );
     }
   }
 
-  return readyFiles;
+  return Array.from(readyFilesByDocumentLocale.values());
 }
 
 export async function importTranslations(

--- a/packages/sanity/src/utils/serialize.ts
+++ b/packages/sanity/src/utils/serialize.ts
@@ -11,6 +11,7 @@ import { pluginConfig } from '../adapter/core';
 import merge from 'lodash.merge';
 import { deleteMatchingFields } from './applyDocuments';
 import type { FieldMatcher } from '../adapter/types';
+import { getPublishedId } from './documentIds';
 
 export function deserializeDocument(document: string) {
   const deserializers = merge(
@@ -70,7 +71,7 @@ function stripIgnoredFields(
   const strippedDoc = JSON.parse(JSON.stringify(document)) as SanityDocument;
 
   deleteMatchingFields(
-    document._id.replace('drafts.', ''),
+    getPublishedId(document._id),
     strippedDoc,
     fieldsToStrip
   );


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes duplicate translated documents on the bulk translations page by introducing a centralized `documentIds.ts` utility (ID normalization, deduplication, stable key builders), adding per-key concurrency serialization in `batchProcessor`, deduplicating ready files in `importUtils`, and re-checking metadata before creating i18n documents in `documentLevelPatch`. The changes also correct a `handlePublishAll` regression where draft-preferred deduplication would have filtered out all documents from the old published-only filter.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; only P2 findings that do not affect correctness of the primary duplicate-prevention logic.

All P0/P1 defects addressed; two P2 concerns (inconsistent undefined handling in createTranslationStatusKey and potential excess refresh calls from downloadStatus dep) are non-blocking quality issues.

packages/sanity/src/utils/documentIds.ts (key format inconsistency) and packages/sanity/src/components/TranslationsProvider.tsx (downloadStatus dependency triggering excess refreshes).
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/sanity/src/utils/documentIds.ts | New utility module centralizing document ID normalization and key construction; minor asymmetry in createTranslationStatusKey when branchId is undefined. |
| packages/sanity/src/components/TranslationsProvider.tsx | Core provider refactored to use centralized ID helpers, deduplicates fetched documents, fixes handlePublishAll to query Sanity for real published IDs; downloadStatus in handleRefreshAll deps may cause excess refresh calls per download. |
| packages/sanity/src/utils/batchProcessor.ts | Adds per-key concurrency serialization via a promise-chain pattern to prevent duplicate writes for the same document/locale pair; logic verified by new unit tests. |
| packages/sanity/src/utils/importUtils.ts | Deduplicates ready files by stable (branch, document, locale) key before batching, ensuring one import per locale regardless of how many ready versions exist. |
| packages/sanity/src/configuration/baseDocumentLevelConfig/documentLevelPatch.ts | Adds a metadata re-check before creating a new i18n document, patching the existing doc instead if it was already created by a concurrent request. |
| packages/sanity/src/sanity-api/findDocuments.ts | Defensively fetches the last entry from potentially duplicated locale translation arrays and resolves via findLatestDraft to return the most current draft/published version. |
| packages/sanity/src/sanity-api/resolveRefs.ts | Returns the last entry from duplicate locale ref arrays when building the translation map, consistent with the findDocuments defensive approach. |
| packages/sanity/src/translation/checkTranslationStatus.ts | Filters already-processed files using both version-specific and stable keys to correctly skip items downloaded under either key format. |
| packages/sanity/src/components/shared/LanguageStatus.tsx | Shows 100% progress immediately after a successful import even if the underlying progress value hasn't caught up yet. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Fetch documents from Sanity] --> B[dedupeDocumentsPreferDraft]
    B --> C[translationStatuses Map\nkeyed by createTranslationStatusKey]
    C --> D{handleBulkImport}
    D --> E[getExistingTranslations\nfrom Sanity metadata]
    E --> F[getReadyFilesForImport\ndeduped by stable key]
    F --> G{filterReadyFiles\ncreateStableTranslationKey}
    G -->|already exists| H[Skip]
    G -->|new| I[processBatch with\nconcurrencyKey per doc+locale]
    I --> J{documentLevelPatch}
    J --> K[getOrCreateTranslationMetadata\nfresh re-check]
    K -->|locale already exists| L[patchI18nDoc existing]
    K -->|locale missing| M[createI18nDocAndPatchMetadata]
    L --> N[setExistingTranslations\nstable key added to state]
    M --> N
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fsanity%2Fsrc%2Futils%2FdocumentIds.ts%3A28-35%0A**Inconsistent%20%60undefined%60%20handling%20vs%20%60createStableTranslationKey%60**%0A%0A%60createTranslationStatusKey%60%20serializes%20an%20%60undefined%60%20%60branchId%60%20as%20the%20literal%20string%20%60%22undefined%22%60%20%28e.g.%20%60%22undefined%3Adoc%3Arev%3Alocale%22%60%29%2C%20while%20%60createStableTranslationKey%60%20with%20an%20%60undefined%60%20%60branchId%60%20omits%20the%20prefix%20entirely%20%28%60%22doc%3Alocale%22%60%29.%20This%20asymmetry%20is%20observable%20in%20%60checkTranslationStatus.ts%60%20where%20both%20key%20forms%20are%20checked%20against%20the%20same%20sets.%20Any%20code%20that%20accidentally%20crosses%20these%20two%20formats%20%28e.g.%20storing%20with%20%60createStableTranslationKey%60%20and%20looking%20up%20with%20%60createTranslationStatusKey%60%20while%20%60branchId%60%20is%20undefined%29%20will%20silently%20miss.%20Aligning%20the%20two%20functions%20to%20apply%20the%20same%20%60branchId%60%20guard%20would%20eliminate%20the%20footgun.%0A%0A%60%60%60suggestion%0Aexport%20function%20createTranslationStatusKey%28%0A%20%20branchId%3A%20string%20%7C%20undefined%2C%0A%20%20documentId%3A%20string%2C%0A%20%20versionId%3A%20string%2C%0A%20%20localeId%3A%20string%0A%29%3A%20string%20%7B%0A%20%20const%20publishedId%20%3D%20getPublishedId%28documentId%29%3B%0A%20%20return%20branchId%0A%20%20%20%20%3F%20%60%24%7BbranchId%7D%3A%24%7BpublishedId%7D%3A%24%7BversionId%7D%3A%24%7BlocaleId%7D%60%0A%20%20%20%20%3A%20%60%24%7BpublishedId%7D%3A%24%7BversionId%7D%3A%24%7BlocaleId%7D%60%3B%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fsanity%2Fsrc%2Fcomponents%2FTranslationsProvider.tsx%3A637%0A**%60downloadStatus%60%20in%20%60handleRefreshAll%60%20deps%20triggers%20excess%20status%20refreshes**%0A%0A%60downloadStatus%60%20was%20added%20to%20the%20%60useCallback%60%20dependency%20array%20of%20%60handleRefreshAll%60.%20Because%20the%20%60useEffect%60%20that%20auto-fires%20on%20mount%20now%20lists%20%60handleRefreshAll%60%20as%20a%20dependency%2C%20every%20completed%20download%20%28which%20updates%20%60downloadStatus%60%29%20causes%20%60handleRefreshAll%60%20to%20be%20recreated%20and%20then%20immediately%20re-invoked%20by%20the%20effect.%20This%20means%20a%20bulk%20import%20of%20N%20locales%20generates%20N%2B1%20full%20status%20refreshes%20instead%20of%20one.%20Separating%20the%20concern%20%E2%80%94%20e.g.%20capturing%20%60downloadStatus%60%20via%20a%20ref%20inside%20%60handleRefreshAll%60%20or%20splitting%20the%20auto-run%20effect%20from%20the%20refresh%20logic%20%E2%80%94%20would%20prevent%20the%20cascade.%0A%0A&repo=generaltranslation%2Fgt&pr=1265&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/sanity/src/utils/documentIds.ts
Line: 28-35

Comment:
**Inconsistent `undefined` handling vs `createStableTranslationKey`**

`createTranslationStatusKey` serializes an `undefined` `branchId` as the literal string `"undefined"` (e.g. `"undefined:doc:rev:locale"`), while `createStableTranslationKey` with an `undefined` `branchId` omits the prefix entirely (`"doc:locale"`). This asymmetry is observable in `checkTranslationStatus.ts` where both key forms are checked against the same sets. Any code that accidentally crosses these two formats (e.g. storing with `createStableTranslationKey` and looking up with `createTranslationStatusKey` while `branchId` is undefined) will silently miss. Aligning the two functions to apply the same `branchId` guard would eliminate the footgun.

```suggestion
export function createTranslationStatusKey(
  branchId: string | undefined,
  documentId: string,
  versionId: string,
  localeId: string
): string {
  const publishedId = getPublishedId(documentId);
  return branchId
    ? `${branchId}:${publishedId}:${versionId}:${localeId}`
    : `${publishedId}:${versionId}:${localeId}`;
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/sanity/src/components/TranslationsProvider.tsx
Line: 637

Comment:
**`downloadStatus` in `handleRefreshAll` deps triggers excess status refreshes**

`downloadStatus` was added to the `useCallback` dependency array of `handleRefreshAll`. Because the `useEffect` that auto-fires on mount now lists `handleRefreshAll` as a dependency, every completed download (which updates `downloadStatus`) causes `handleRefreshAll` to be recreated and then immediately re-invoked by the effect. This means a bulk import of N locales generates N+1 full status refreshes instead of one. Separating the concern — e.g. capturing `downloadStatus` via a ref inside `handleRefreshAll` or splitting the auto-run effect from the refresh logic — would prevent the cascade.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix display"](https://github.com/generaltranslation/gt/commit/734dafb4da2894ff38a5c2a57b6f5aaf41af9f4a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29783105)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->