### PR TITLE
fix: metadata and og support

### DIFF
--- a/.changeset/petite-goats-sniff.md
+++ b/.changeset/petite-goats-sniff.md
@@ -2,4 +2,4 @@
 'gt-next': patch
 ---
 
-fix: access locale for metadataa
+fix: access locale for metadata

--- a/.changeset/petite-goats-sniff.md
+++ b/.changeset/petite-goats-sniff.md
@@ -1,0 +1,5 @@
+---
+'gt-next': patch
+---
+
+fix: access locale for metadataa

--- a/packages/cli/src/generated/version.ts
+++ b/packages/cli/src/generated/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const PACKAGE_VERSION = '2.14.18';
+export const PACKAGE_VERSION = '2.14.20';

--- a/packages/next/src/request/getLocale.ts
+++ b/packages/next/src/request/getLocale.ts
@@ -2,6 +2,7 @@ import getI18NConfig from '../config-dir/getI18NConfig';
 import use from '../utils/use';
 import { legacyGetLocaleFunction } from './utils/legacyGetLocaleFunction';
 import { getRequestFunction } from './utils/getRequestFunction';
+import { localeStore } from './localeStore';
 
 let getLocaleFunction: () => Promise<string>;
 
@@ -15,6 +16,11 @@ let getLocaleFunction: () => Promise<string>;
  * console.log(locale); // 'en-US'
  */
 export async function getLocale(): Promise<string> {
+  // If a locale has been registered for this request, return it
+  const registeredLocale = localeStore.getStore();
+  if (registeredLocale) return registeredLocale;
+
+  // Use the request function to get the locale
   if (getLocaleFunction) return await getLocaleFunction();
   const I18NConfig = getI18NConfig();
   const gt = I18NConfig.getGTClass();

--- a/packages/next/src/request/localeStore.ts
+++ b/packages/next/src/request/localeStore.ts
@@ -1,3 +1,3 @@
-import { AsyncLocalStorage } from 'async_hooks';
+import { AsyncLocalStorage } from 'node:async_hooks';
 
 export const localeStore = new AsyncLocalStorage<string>();

--- a/packages/next/src/request/localeStore.ts
+++ b/packages/next/src/request/localeStore.ts
@@ -1,0 +1,3 @@
+import { AsyncLocalStorage } from 'async_hooks';
+
+export const localeStore = new AsyncLocalStorage<string>();

--- a/packages/next/src/request/registerLocale.ts
+++ b/packages/next/src/request/registerLocale.ts
@@ -1,11 +1,14 @@
+import getI18NConfig from '../config-dir/getI18NConfig';
 import { localeStore } from './localeStore';
 
 /**
  * Set the locale for the current request context.
  * Use this in Route Handlers and OG image handlers where next/root-params is unavailable.
+ * Must be called at the top of the request handler before any other gt-next functions.
  *
  * @param locale - A BCP-47 locale tag (e.g., 'en-US', 'de', 'fr')
  */
 export function registerLocale(locale: string): void {
-  localeStore.enterWith(locale);
+  const gt = getI18NConfig().getGTClass();
+  localeStore.enterWith(gt.resolveAliasLocale(locale));
 }

--- a/packages/next/src/request/registerLocale.ts
+++ b/packages/next/src/request/registerLocale.ts
@@ -1,0 +1,11 @@
+import { localeStore } from './localeStore';
+
+/**
+ * Set the locale for the current request context.
+ * Use this in Route Handlers and OG image handlers where next/root-params is unavailable.
+ *
+ * @param locale - A BCP-47 locale tag (e.g., 'en-US', 'de', 'fr')
+ */
+export function registerLocale(locale: string): void {
+  localeStore.enterWith(locale);
+}

--- a/packages/next/src/server.ts
+++ b/packages/next/src/server.ts
@@ -3,6 +3,7 @@ import 'server-only';
 import T from './server-dir/buildtime/T';
 import tx from './server-dir/runtime/tx';
 import { getLocale } from './request/getLocale';
+import { registerLocale } from './request/registerLocale';
 import { getRegion } from './request/getRegion';
 import getI18NConfig from './config-dir/getI18NConfig';
 import { getTranslations } from './server-dir/buildtime/getTranslations';
@@ -54,6 +55,7 @@ export {
   tx,
   Tx,
   getLocale,
+  registerLocale,
   getRegion,
   getLocaleDirection,
 };


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces `registerLocale()` — a new server-only utility that lets metadata and OG image handlers explicitly set the locale for the current request context via `AsyncLocalStorage.enterWith()`, solving the problem of locale access where `next/root-params` isn't available. The implementation correctly resolves locale aliases before storage and `getLocale()` short-circuits to the stored value before falling back to the normal resolution path.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — no new logic bugs introduced; previously flagged issues (alias bypass, bare specifier, changeset typo) are all resolved in this revision.

All three previously raised P1/P2 concerns are addressed: registerLocale now calls resolveAliasLocale before storing, localeStore uses the node: prefix, and the changeset typo is gone. No new P0/P1 issues found in the diff.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/next/src/request/registerLocale.ts | New file — registerLocale() resolves aliases before storing via resolveAliasLocale(), addressing the previously flagged bypass; uses enterWith() with documented trade-offs acknowledged upstream. |
| packages/next/src/request/localeStore.ts | New file — creates a module-level AsyncLocalStorage singleton for per-request locale storage; uses the canonical node: prefix. |
| packages/next/src/request/getLocale.ts | Added early-return for registered locales via localeStore.getStore() before normal resolution; alias resolution is handled in registerLocale so the stored value is already canonical. |
| packages/next/src/server.ts | Adds registerLocale to server-only exports; straightforward wiring change. |
| .changeset/petite-goats-sniff.md | New changeset file; prior 'metadataa' typo is gone, description is clean. |
| packages/cli/src/generated/version.ts | Auto-generated version bump from 2.14.18 → 2.14.20. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant H as OG/Route Handler
    participant RL as registerLocale()
    participant LS as localeStore (AsyncLocalStorage)
    participant GL as getLocale()
    participant NR as Normal Resolution Path

    H->>RL: registerLocale('zh')
    RL->>RL: gt.resolveAliasLocale('zh') → 'zh-CN'
    RL->>LS: enterWith('zh-CN')

    H->>GL: await getLocale()
    GL->>LS: getStore()
    LS-->>GL: 'zh-CN'
    GL-->>H: 'zh-CN' (early return)

    Note over H,NR: Without registerLocale()
    H->>GL: await getLocale()
    GL->>LS: getStore()
    LS-->>GL: undefined
    GL->>NR: getLocaleFunction() / requestFunction()
    NR-->>GL: resolved locale
    GL-->>H: locale
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: greptile"](https://github.com/generaltranslation/gt/commit/7bf0165257f9db33cfed4bdcfccc71a8424d522b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29789806)</sub>

<!-- /greptile_comment -->