### PR TITLE
refactor: use route params for Next locale resolution

### DIFF
--- a/packages/next/src/__tests__/config.test.ts
+++ b/packages/next/src/__tests__/config.test.ts
@@ -158,13 +158,12 @@ describe('withGTConfig', () => {
       });
     });
 
-    it('has default headers/cookies values', async () => {
+    it('has default cookie values', async () => {
       const withGTConfig = await getWithGTConfig();
       const result = withGTConfig();
       const params = parseConfigParams(result);
 
       expect(params.headersAndCookies).toMatchObject({
-        localeHeaderName: 'x-generaltranslation-locale',
         localeCookieName: 'generaltranslation.locale',
         referrerLocaleCookieName: 'generaltranslation.referrer-locale',
         localeRoutingEnabledCookieName:
@@ -1257,17 +1256,14 @@ describe('withGTConfig', () => {
   });
 
   // ==============================
-  // 15. Headers/cookies merging
+  // 15. Cookie merging
   // ==============================
-  describe('15. Headers/cookies merging', () => {
+  describe('15. Cookie merging', () => {
     it('default values used when none provided', async () => {
       const withGTConfig = await getWithGTConfig();
       const result = withGTConfig();
       const params = parseConfigParams(result);
 
-      expect(params.headersAndCookies.localeHeaderName).toBe(
-        'x-generaltranslation-locale'
-      );
       expect(params.headersAndCookies.localeCookieName).toBe(
         'generaltranslation.locale'
       );
@@ -1289,15 +1285,14 @@ describe('withGTConfig', () => {
         'my-custom-cookie'
       );
       // Other values should remain defaults
-      expect(params.headersAndCookies.localeHeaderName).toBe(
-        'x-generaltranslation-locale'
+      expect(params.headersAndCookies.referrerLocaleCookieName).toBe(
+        'generaltranslation.referrer-locale'
       );
     });
 
     it('full override replaces all values', async () => {
       const withGTConfig = await getWithGTConfig();
       const customHeaders = {
-        localeHeaderName: 'x-my-locale',
         localeCookieName: 'my-locale',
         referrerLocaleCookieName: 'my-referrer',
         localeRoutingEnabledCookieName: 'my-routing',

--- a/packages/next/src/config-dir/I18NConfiguration.ts
+++ b/packages/next/src/config-dir/I18NConfiguration.ts
@@ -18,7 +18,6 @@ import {
   defaultReferrerLocaleCookieName,
   defaultResetLocaleCookieName,
 } from '../utils/cookies';
-import { defaultLocaleHeaderName } from '../utils/headers';
 import { CustomMapping } from 'generaltranslation/types';
 import { GTTranslationError } from '../utils/errors';
 import type { TranslateManyEntry } from 'generaltranslation/types';
@@ -104,8 +103,7 @@ export default class I18NConfiguration {
   private _activeRequests: number;
   // Cache for ongoing translation requests
   private _translationCache: Map<string, Promise<any>>;
-  // Headers and cookies
-  private localeHeaderName: string;
+  // Cookies
   private localeCookieName: string;
   private referrerLocaleCookieName: string;
   private localeRoutingEnabledCookieName: string;
@@ -232,9 +230,7 @@ export default class I18NConfiguration {
     this._activeRequests = 0;
     this._translationCache = new Map(); // cache for ongoing promises, so things aren't translated twice
     this._startBatching();
-    // Headers and cookies
-    this.localeHeaderName =
-      headersAndCookies?.localeHeaderName || defaultLocaleHeaderName;
+    // Cookies
     this.localeCookieName =
       headersAndCookies?.localeCookieName || defaultLocaleCookieName;
     this.referrerLocaleCookieName =
@@ -332,14 +328,10 @@ export default class I18NConfiguration {
     return this._versionId;
   }
 
-  // ----- COOKIES AND HEADERS ----- //
+  // ----- COOKIES ----- //
 
   getLocaleCookieName(): string {
     return this.localeCookieName;
-  }
-
-  getLocaleHeaderName(): string {
-    return this.localeHeaderName;
   }
 
   // ----- FEATURE FLAGS ----- //

--- a/packages/next/src/config-dir/props/defaultWithGTConfigProps.ts
+++ b/packages/next/src/config-dir/props/defaultWithGTConfigProps.ts
@@ -8,7 +8,6 @@ import {
   getDefaultRenderSettings,
   RenderMethod,
 } from 'gt-react/internal';
-import { defaultLocaleHeaderName } from '../../utils/headers';
 import {
   defaultLocaleRoutingEnabledCookieName,
   defaultReferrerLocaleCookieName,
@@ -34,7 +33,6 @@ type DefaultGTConfigProps = {
   _usingPlugin: boolean;
   ignoreBrowserLocales: boolean;
   headersAndCookies: {
-    localeHeaderName: string;
     localeCookieName: string;
     referrerLocaleCookieName: string;
     localeRoutingEnabledCookieName: string;
@@ -61,7 +59,6 @@ const defaultWithGTConfigProps: DefaultGTConfigProps = {
   _usingPlugin: false,
   ignoreBrowserLocales: false,
   headersAndCookies: {
-    localeHeaderName: defaultLocaleHeaderName,
     localeCookieName: defaultLocaleCookieName,
     referrerLocaleCookieName: defaultReferrerLocaleCookieName,
     localeRoutingEnabledCookieName: defaultLocaleRoutingEnabledCookieName,

--- a/packages/next/src/config-dir/props/withGTConfigProps.ts
+++ b/packages/next/src/config-dir/props/withGTConfigProps.ts
@@ -2,7 +2,6 @@ import { CustomMapping } from 'generaltranslation/types';
 import { RenderMethod } from 'gt-react/internal';
 
 export type HeadersAndCookies = {
-  localeHeaderName?: string;
   localeCookieName?: string;
   referrerLocaleCookieName?: string;
   localeRoutingEnabledCookieName?: string;

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -72,7 +72,7 @@ import { cacheComponentsChecks } from './plugin/checks/cacheComponentsChecks';
  * @param {number} [maxBatchSize=defaultInitGTProps.maxBatchSize] - Maximum translation requests in the same batch.
  * @param {number} [batchInterval=defaultInitGTProps.batchInterval] - The interval in milliseconds between batched translation requests.
  * @param {boolean} [ignoreBrowserLocales=defaultWithGTConfigProps.ignoreBrowserLocales] - Whether to ignore browser's preferred locales.
- * @param {object} headersAndCookies - Additional headers and cookies that can be passed for extended configuration.
+ * @param {object} headersAndCookies - Additional cookie names that can be passed for extended configuration.
  * @param {boolean} [experimentalEnableSSG=false] - Whether to enable SSG.
  * @param {boolean} [disableSSGWarnings=defaultWithGTConfigProps.disableSSGWarnings] - Whether to disable SSG warnings. (deprecated)
  * @param {string|undefined} [getStaticLocalePath="getStaticLocale"] - The path to the static getLocale function. (deprecated)
@@ -194,7 +194,7 @@ export function withGTConfig(
 
   // ---------- MERGE CONFIGS ---------- //
 
-  // Merge cookie and header names
+  // Merge cookie names
   const mergedHeadersAndCookies = {
     ...defaultWithGTConfigProps.headersAndCookies,
     ...props.headersAndCookies,

--- a/packages/next/src/errors/createErrors.ts
+++ b/packages/next/src/errors/createErrors.ts
@@ -6,6 +6,9 @@ import { BABEL_PLUGIN_SUPPORT, SWC_PLUGIN_SUPPORT } from '../plugin/constants';
 export const remoteTranslationsError =
   'gt-next Error: fetching remote translation.';
 
+export const rootLocaleResolutionError =
+  'gt-next: Error resolving locale from route params. Error: ';
+
 export const customLoadTranslationsError = (locale: string = '') =>
   `gt-next Error: Failed to fetch locally stored translations. If using a custom loadTranslations("${locale}"), make sure it is correctly implemented.`;
 

--- a/packages/next/src/middleware-dir/__tests__/middleware.edge.test.ts
+++ b/packages/next/src/middleware-dir/__tests__/middleware.edge.test.ts
@@ -14,7 +14,6 @@ const LOCALE_COOKIE = 'generaltranslation.locale';
 const RESET_COOKIE = 'generaltranslation.locale-reset';
 const REFERRER_COOKIE = 'generaltranslation.referrer-locale';
 const ROUTING_COOKIE = 'generaltranslation.locale-routing-enabled';
-const LOCALE_HEADER = 'x-generaltranslation-locale';
 
 // ---- Helpers ----
 
@@ -128,7 +127,6 @@ describe('Middleware Integration Tests', () => {
 
       expect(getResponseType(res)).toBe('rewrite');
       expect(getResponsePath(res)).toBe('/en/about');
-      expect(res.headers.get(LOCALE_HEADER)).toBe('en');
       expect(res.cookies.get(ROUTING_COOKIE)?.value).toBe('true');
     });
 
@@ -141,7 +139,6 @@ describe('Middleware Integration Tests', () => {
       const res = middleware(createRequest('/en/about'));
 
       expect(getResponseType(res)).toBe('next');
-      expect(res.headers.get(LOCALE_HEADER)).toBe('en');
     });
 
     it('2.3: !prefixDefault, non-default locale, /fr/about → next()', () => {
@@ -153,7 +150,6 @@ describe('Middleware Integration Tests', () => {
       const res = middleware(createRequest('/fr/about'));
 
       expect(getResponseType(res)).toBe('next');
-      expect(res.headers.get(LOCALE_HEADER)).toBe('fr');
     });
 
     it('2.4: pathConfig, /fr/a-propos → rewrite /fr/about', () => {
@@ -170,7 +166,6 @@ describe('Middleware Integration Tests', () => {
 
       expect(getResponseType(res)).toBe('rewrite');
       expect(getResponsePath(res)).toBe('/fr/about');
-      expect(res.headers.get(LOCALE_HEADER)).toBe('fr');
     });
 
     it('2.5: pathConfig + !prefixDefault, /about-us → rewrite /en/about', () => {
@@ -187,7 +182,6 @@ describe('Middleware Integration Tests', () => {
 
       expect(getResponseType(res)).toBe('rewrite');
       expect(getResponsePath(res)).toBe('/en/about');
-      expect(res.headers.get(LOCALE_HEADER)).toBe('en');
     });
 
     it('2.6: localeRouting=false → next()', () => {
@@ -199,7 +193,6 @@ describe('Middleware Integration Tests', () => {
       const res = middleware(createRequest('/some/path'));
 
       expect(getResponseType(res)).toBe('next');
-      expect(res.headers.get(LOCALE_HEADER)).toBe('en');
       expect(res.cookies.get(ROUTING_COOKIE)?.value).toBe('false');
     });
 
@@ -212,8 +205,7 @@ describe('Middleware Integration Tests', () => {
       const res = middleware(createRequest('/__nextjs_source-map/main.js'));
 
       expect(getResponseType(res)).toBe('next');
-      // Source map next() is bare — no locale header or routing cookie
-      expect(res.headers.get(LOCALE_HEADER)).toBeNull();
+      // Source map next() is bare — no routing cookie
     });
   });
 
@@ -376,32 +368,6 @@ describe('Middleware Integration Tests', () => {
 
       expect(getResponseType(res)).toBe('redirect');
       expect(getResponseSearch(res)).toBe('?page=2');
-    });
-
-    it('sets locale header on rewrite responses', () => {
-      setEnvConfig();
-      const middleware = createNextMiddleware({
-        prefixDefaultLocale: false,
-      });
-
-      const res = middleware(createRequest('/about'));
-
-      expect(res.headers.get(LOCALE_HEADER)).toBe('en');
-    });
-
-    it('sets locale header on redirect responses', () => {
-      setEnvConfig();
-      const middleware = createNextMiddleware({
-        prefixDefaultLocale: false,
-      });
-
-      const res = middleware(
-        createRequest('/about', {
-          cookies: { [LOCALE_COOKIE]: 'fr' },
-        })
-      );
-
-      expect(res.headers.get(LOCALE_HEADER)).toBe('fr');
     });
 
     it('sets locale-routing-enabled cookie on routed responses', () => {

--- a/packages/next/src/middleware-dir/createNextMiddleware.ts
+++ b/packages/next/src/middleware-dir/createNextMiddleware.ts
@@ -19,7 +19,6 @@ import {
   getResponse,
   ResponseConfig,
 } from './utils';
-import { defaultLocaleHeaderName } from '../utils/headers';
 
 const NEXT_JS_SOURCE_MAP_PATH = '/__nextjs_source-map';
 
@@ -94,8 +93,6 @@ export default function createNextMiddleware({
     headersAndCookies?.localeCookieName || defaultLocaleCookieName;
   const resetLocaleCookieName =
     headersAndCookies?.resetLocaleCookieName || defaultResetLocaleCookieName;
-  const localeHeaderName =
-    headersAndCookies?.localeHeaderName || defaultLocaleHeaderName;
 
   if (!gt.isValidLocale(defaultLocale))
     throw new Error(
@@ -182,13 +179,11 @@ export default function createNextMiddleware({
     const responseConfig: Omit<ResponseConfig, 'type'> = {
       originalUrl: req.nextUrl,
       headerList,
-      userLocale,
       clearResetCookie,
       localeRouting,
       localeRoutingEnabledCookieName,
       localeCookieName,
       resetLocaleCookieName,
-      localeHeaderName,
     };
 
     const getRewriteResponse = (responsePath: string) =>

--- a/packages/next/src/middleware-dir/utils.ts
+++ b/packages/next/src/middleware-dir/utils.ts
@@ -10,28 +10,24 @@ export type ResponseConfig = {
   type: 'next' | 'rewrite' | 'redirect';
   responsePath?: string;
   originalUrl: NextURL;
-  userLocale: string;
   clearResetCookie: boolean;
   headerList: Headers;
   localeRouting: boolean;
   localeRoutingEnabledCookieName: string;
   localeCookieName: string;
   resetLocaleCookieName: string;
-  localeHeaderName: string;
 };
 
 export function getResponse({
   type,
   originalUrl,
   responsePath = originalUrl.pathname,
-  userLocale,
   clearResetCookie,
   headerList,
   localeRouting,
   localeRoutingEnabledCookieName,
   localeCookieName,
   resetLocaleCookieName,
-  localeHeaderName,
 }: ResponseConfig): NextResponse<unknown> {
   // Get Response
   let response;
@@ -54,8 +50,7 @@ export function getResponse({
         : NextResponse.redirect(responseUrl);
   }
 
-  // Set Headers & Cookies
-  response.headers.set(localeHeaderName, userLocale);
+  // Set Cookies
   response.cookies.set(
     localeRoutingEnabledCookieName,
     localeRouting.toString()
@@ -72,7 +67,7 @@ export function getResponse({
  * Extracts the locale from the given pathname.
  */
 export function extractLocale(pathname: string): string | null {
-  const matches = pathname.match(/^\/([^\/]+)(?:\/|$)/);
+  const matches = pathname.match(/^\/([^/]+)(?:\/|$)/);
   return matches ? matches[1] : null;
 }
 

--- a/packages/next/src/request/__tests__/getLocale.test.ts
+++ b/packages/next/src/request/__tests__/getLocale.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockGetRequestFunction,
+  mockGetRootParam,
+  mockRequestLocale,
+  mockRegisteredLocale,
+} = vi.hoisted(() => ({
+  mockGetRequestFunction: vi.fn(),
+  mockGetRootParam: vi.fn(),
+  mockRequestLocale: vi.fn(),
+  mockRegisteredLocale: vi.fn(),
+}));
+
+vi.mock('@generaltranslation/next-internal', () => ({
+  getRootParam: mockGetRootParam,
+}));
+
+vi.mock('../../config-dir/getI18NConfig', () => ({
+  default: () => ({
+    getDefaultLocale: () => 'en',
+    getGTClass: () => ({
+      isValidLocale: (locale: string) => locale !== 'invalid',
+      resolveAliasLocale: (locale: string) => locale,
+    }),
+  }),
+}));
+
+vi.mock('../utils/getRequestFunction', () => ({
+  getRequestFunction: mockGetRequestFunction,
+}));
+
+vi.mock('../utils/legacyGetLocaleFunction', () => ({
+  legacyGetLocaleFunction: () => async () => 'legacy',
+}));
+
+vi.mock('../localeStore', () => ({
+  localeStore: {
+    getStore: mockRegisteredLocale,
+  },
+}));
+
+vi.mock('../../utils/use', () => ({
+  default: (value: unknown) => value,
+}));
+
+describe('getLocale', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    process.env._GENERALTRANSLATION_ENABLE_SSG = 'false';
+    mockGetRequestFunction.mockReturnValue(mockRequestLocale);
+    mockRequestLocale.mockResolvedValue('en');
+    mockRegisteredLocale.mockReturnValue(undefined);
+  });
+
+  it('prefers the locale root param over request locale resolution', async () => {
+    mockGetRootParam.mockReturnValue('fr');
+
+    const { getLocale } = await import('../getLocale');
+
+    expect(await getLocale()).toBe('fr');
+  });
+
+  it('falls back to request locale resolution when the root param is invalid', async () => {
+    mockGetRootParam.mockReturnValue('invalid');
+    mockRequestLocale.mockResolvedValue('es');
+
+    const { getLocale } = await import('../getLocale');
+
+    expect(await getLocale()).toBe('es');
+  });
+
+  it('does not call request locale resolution in experimental mode after root param lookup', async () => {
+    process.env._GENERALTRANSLATION_EXPERIMENTAL_LOCALE_RESOLUTION = 'true';
+    mockGetRootParam.mockReturnValue(undefined);
+    mockRequestLocale.mockResolvedValue('es');
+
+    const { getLocale } = await import('../getLocale');
+
+    expect(await getLocale()).toBe('en');
+    expect(mockGetRootParam).toHaveBeenCalledTimes(1);
+    expect(mockGetRequestFunction).not.toHaveBeenCalled();
+    expect(mockRequestLocale).not.toHaveBeenCalled();
+  });
+
+  it('keeps registered locales highest priority', async () => {
+    mockRegisteredLocale.mockReturnValue('de');
+    mockGetRootParam.mockReturnValue('fr');
+
+    const { getLocale } = await import('../getLocale');
+
+    expect(await getLocale()).toBe('de');
+  });
+});

--- a/packages/next/src/request/getLocale.ts
+++ b/packages/next/src/request/getLocale.ts
@@ -3,6 +3,7 @@ import use from '../utils/use';
 import { legacyGetLocaleFunction } from './utils/legacyGetLocaleFunction';
 import { getRequestFunction } from './utils/getRequestFunction';
 import { localeStore } from './localeStore';
+import { getRootLocale } from './utils/getRootLocale';
 
 let getLocaleFunction: () => Promise<string>;
 
@@ -26,10 +27,16 @@ export async function getLocale(): Promise<string> {
   const gt = I18NConfig.getGTClass();
 
   if (process.env._GENERALTRANSLATION_ENABLE_SSG === 'false') {
-    const requestFunction = getRequestFunction('getLocale');
+    const useRootLocaleOnly =
+      process.env._GENERALTRANSLATION_EXPERIMENTAL_LOCALE_RESOLUTION === 'true';
+    const requestFunction = useRootLocaleOnly
+      ? undefined
+      : getRequestFunction('getLocale');
     // Support new behavior
     getLocaleFunction = async () => {
-      const requestLocale = await requestFunction();
+      const rootLocale = getRootLocale((locale) => gt.isValidLocale(locale));
+      const requestLocale =
+        rootLocale || (requestFunction ? await requestFunction() : undefined);
       return gt.resolveAliasLocale(
         requestLocale || I18NConfig.getDefaultLocale()
       );

--- a/packages/next/src/request/headers/getNextLocale.ts
+++ b/packages/next/src/request/headers/getNextLocale.ts
@@ -21,11 +21,6 @@ export async function getNextLocale(): Promise<RequestFunctionReturnType> {
 
   const preferredLocales: string[] = [];
 
-  // Language routed to by middleware
-  const headerLocale = headersList.get(I18NConfig.getLocaleHeaderName());
-  if (headerLocale) {
-    preferredLocales.push(headerLocale);
-  }
   const cookieLocale = cookieStore.get(I18NConfig.getLocaleCookieName());
   if (cookieLocale?.value) {
     preferredLocales.push(cookieLocale.value);

--- a/packages/next/src/request/utils/getRequestFunction.ts
+++ b/packages/next/src/request/utils/getRequestFunction.ts
@@ -3,10 +3,6 @@ import {
   createCustomGetRequestFunctionWarning,
   createGetRequestFunctionWarning,
 } from '../../errors/ssg';
-import { getRootParam } from '@generaltranslation/next-internal';
-import { defaultExperimentalLocaleResolutionParam } from '../../utils/constants';
-import { experimentalLocaleResolutionError } from '../../errors/cacheComponents';
-import getI18NConfig from '../../config-dir/getI18NConfig';
 
 /**
  * Given a function type, return the associated request function
@@ -18,7 +14,7 @@ export function getRequestFunction(
   if (
     process.env._GENERALTRANSLATION_EXPERIMENTAL_LOCALE_RESOLUTION === 'true'
   ) {
-    return handleExperimentalLocaleResolution(functionName);
+    return async () => undefined;
   }
 
   const { error: moduleError, module } = getModule(functionName);
@@ -26,10 +22,7 @@ export function getRequestFunction(
     return async () => undefined;
   }
 
-  // Is using custom getRequest function
-  const usingCustom = getUsingCustom(functionName);
-
-  if (usingCustom) {
+  if (getUsingCustom(functionName)) {
     // Extract an unknown function
     const { error: extractError, value } = extractCustomFunction(
       module,
@@ -44,37 +37,6 @@ export function getRequestFunction(
   return extractDefaultFunction(
     module as { default: () => Promise<RequestFunctionReturnType> }
   );
-}
-
-/* ========== HELPERS ========== */
-/**
- * Special handler for when experimentalLocaleResolution is enabled
- */
-function handleExperimentalLocaleResolution(
-  functionName: RequestFunctions
-): () => Promise<RequestFunctionReturnType> {
-  // handle getLocale
-  if (functionName === 'getLocale') {
-    return async () => {
-      try {
-        const unverifiedLocale = getRootParam(
-          process.env
-            ._GENERALTRANSLATION_EXPERIMENTAL_LOCALE_RESOLUTION_PARAM ??
-            defaultExperimentalLocaleResolutionParam
-        );
-        const I18NConfig = getI18NConfig();
-        const gt = I18NConfig.getGTClass();
-        return unverifiedLocale && gt.isValidLocale(unverifiedLocale)
-          ? unverifiedLocale
-          : undefined;
-      } catch (error) {
-        console.warn(experimentalLocaleResolutionError + error);
-        return undefined;
-      }
-    };
-  }
-  // disable other request functions
-  return async () => undefined;
 }
 /**
  * Given a function name, returns the module for the function

--- a/packages/next/src/request/utils/getRootLocale.ts
+++ b/packages/next/src/request/utils/getRootLocale.ts
@@ -1,0 +1,18 @@
+import { getRootParam } from '@generaltranslation/next-internal';
+import { rootLocaleResolutionError } from '../../errors/createErrors';
+import { defaultExperimentalLocaleResolutionParam } from '../../utils/constants';
+
+export function getRootLocale(
+  isValidLocale: (locale: string) => boolean
+): string | undefined {
+  try {
+    const locale = getRootParam(
+      process.env._GENERALTRANSLATION_EXPERIMENTAL_LOCALE_RESOLUTION_PARAM ??
+        defaultExperimentalLocaleResolutionParam
+    );
+    return locale && isValidLocale(locale) ? locale : undefined;
+  } catch (error) {
+    console.warn(rootLocaleResolutionError + error);
+    return undefined;
+  }
+}

--- a/packages/next/src/server-dir/buildtime/__tests__/getTranslations.test.ts
+++ b/packages/next/src/server-dir/buildtime/__tests__/getTranslations.test.ts
@@ -71,7 +71,6 @@ vi.mock('gt-react/internal', () => ({
   // Add other commonly needed exports to prevent missing export errors
   getDefaultRenderSettings: vi.fn(() => ({ method: 'replace' })),
   defaultLocaleCookieName: 'gt-locale',
-  defaultLocaleHeaderName: 'gt-locale',
   defaultReferrerLocaleCookieName: 'gt-referrer-locale',
   defaultLocaleRoutingEnabledCookieName: 'gt-locale-routing-enabled',
   DictionaryTranslationOptions: {},

--- a/packages/next/src/utils/headers.ts
+++ b/packages/next/src/utils/headers.ts
@@ -1,4 +1,0 @@
-/**
- * Header for locale selected by middleware
- */
-export const defaultLocaleHeaderName = 'x-generaltranslation-locale';


### PR DESCRIPTION
## Summary
- Resolve gt-next locale from the `[locale]` root param before falling back to request locale detection
- Remove middleware locale response header plumbing and related config surface
- Add focused tests for root-param locale precedence and experimental locale resolution

## Tests
- `PATH="/Users/bgub/.local/share/fnm/aliases/default/bin:$PATH" pnpm --dir packages/next exec tsc --noEmit --pretty false`
- `PATH="/Users/bgub/.local/share/fnm/aliases/default/bin:$PATH" pnpm --dir packages/next exec vitest run src/request/__tests__/getLocale.test.ts src/request/utils/__tests__/getRequestFunction.test.ts src/middleware-dir/__tests__/middleware.edge.test.ts src/__tests__/config.test.ts src/server-dir/buildtime/__tests__/getTranslations.test.ts`
- `PATH="/Users/bgub/.local/share/fnm/aliases/default/bin:$PATH" pnpm --dir packages/next exec eslint src/request/getLocale.ts src/request/__tests__/getLocale.test.ts src/request/utils/getRootLocale.ts src/request/utils/getRequestFunction.ts src/request/utils/__tests__/getRequestFunction.test.ts src/middleware-dir/createNextMiddleware.ts src/middleware-dir/utils.ts src/request/headers/getNextLocale.ts src/middleware-dir/__tests__/middleware.edge.test.ts src/config.ts src/config-dir/I18NConfiguration.ts src/config-dir/props/defaultWithGTConfigProps.ts src/config-dir/props/withGTConfigProps.ts src/__tests__/config.test.ts src/server-dir/buildtime/__tests__/getTranslations.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors locale resolution in `gt-next` to use the `[locale]` route param (via `getRootLocale`) as the primary source before falling back to cookie/`Accept-Language` detection. It removes the previous mechanism where the middleware injected a `x-generaltranslation-locale` response header and `getNextLocale` read from it, simplifying the plumbing significantly. The header-based locale passing, `localeHeaderName` config surface, and `handleExperimentalLocaleResolution` helper are all deleted in favour of the single `getRootLocale` utility called directly from `getLocale.ts`.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This PR is safe to merge — the refactor is well-scoped, all call sites are updated, and the new getRootLocale utility is correctly guarded against throws.

No P0 or P1 findings. The singleton getLocaleFunction correctly defers per-request reads to getRootParam/cookies/headers via async local storage on each invocation. The header removal is complete across middleware, config, and request layers. The experimental-mode guard in getRequestFunction is preserved for getRegion/getDomain. Tests cover the new precedence ordering.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/next/src/request/getLocale.ts | Core locale resolution - now calls getRootLocale first before falling back to requestFunction; experimental mode skips requestFunction entirely |
| packages/next/src/request/utils/getRootLocale.ts | New utility that reads the [locale] route param via getRootParam, validates it, and returns undefined on failure; used in both standard and experimental modes |
| packages/next/src/request/headers/getNextLocale.ts | Removed header-based locale reading; now only reads from locale cookie and Accept-Language header |
| packages/next/src/middleware-dir/createNextMiddleware.ts | Removed localeHeaderName config and stopped passing userLocale/localeHeaderName to ResponseConfig; no functional routing changes |
| packages/next/src/middleware-dir/utils.ts | Removed header injection from getResponse; also fixes a lint warning by changing escaped forward-slash in regex to unescaped / |
| packages/next/src/request/utils/getRequestFunction.ts | Removed handleExperimentalLocaleResolution; experimental guard now returns async () => undefined (still needed for getRegion/getDomain paths) |
| packages/next/src/config-dir/I18NConfiguration.ts | Removed localeHeaderName field and getLocaleHeaderName() accessor; clean removal with no lingering references |
| packages/next/src/request/__tests__/getLocale.test.ts | New test file covering root-param precedence, invalid param fallback, experimental mode no-op, and registered locale priority |
| packages/next/src/utils/headers.ts | Deleted file - defaultLocaleHeaderName constant removed; all references cleaned up across the codebase |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[getLocale called] --> B{localeStore registered?}
    B -- yes --> C[Return registered locale]
    B -- no --> D{getLocaleFunction cached?}
    D -- yes --> E[Invoke cached function]
    D -- no --> F{SSG disabled?}
    F -- no --> G[legacyGetLocaleFunction]
    F -- yes --> H{Experimental mode?}
    H -- yes --> I[requestFunction = undefined]
    H -- no --> J[requestFunction = getRequestFunction getLocale]
    I --> K[getLocaleFunction closure]
    J --> K
    K --> L[getRootLocale reads route param]
    L -- valid locale --> M[resolveAliasLocale and return]
    L -- undefined/invalid --> N{requestFunction exists?}
    N -- yes --> O[await requestFunction - cookie + Accept-Language]
    N -- no experimental mode --> P[Return defaultLocale]
    O --> M
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Use route params for Next locale resolut..."](https://github.com/generaltranslation/gt/commit/400d18d5bbfaf374685b807df806e54256f88ccd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30253019)</sub>

<!-- /greptile_comment -->