### PR TITLE
fix: suppress expected tanstack type chunk warning

### DIFF
--- a/packages/tanstack-start/rollup.config.mjs
+++ b/packages/tanstack-start/rollup.config.mjs
@@ -26,6 +26,11 @@ const external = [
   '@tanstack/react-start/server',
 ];
 
+const suppressTypeOnlyEntryWarnings = (warning, warn) => {
+  if (warning.code === 'EMPTY_BUNDLE') return;
+  warn(warning);
+};
+
 export default [
   // Bundling for the main library (index.ts)
   {
@@ -66,6 +71,7 @@ export default [
   // Bundling for the types module
   {
     input: 'src/types.ts',
+    onwarn: suppressTypeOnlyEntryWarnings,
     output: [
       {
         file: 'dist/types.cjs.min.cjs',


### PR DESCRIPTION
## Summary
- add a TanStack Start Rollup warning handler for the type-only `src/types.ts` entry
- preserve the existing runtime `./types` files while suppressing the expected empty bundle warning

## Verification
- `pnpm --filter gt-tanstack-start build`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1367"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->