### PR TITLE
feat: add Toki Pona locale support

### DIFF
--- a/.changeset/add-toki-pona-locale.md
+++ b/.changeset/add-toki-pona-locale.md
@@ -1,0 +1,5 @@
+---
+'@generaltranslation/supported-locales': minor
+---
+
+Add Toki Pona to the supported locales list.

--- a/packages/supported-locales/src/__tests__/supportedLocales.test.ts
+++ b/packages/supported-locales/src/__tests__/supportedLocales.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { getSupportedLocale, listSupportedLocales } from '../index';
+
+describe('@generaltranslation/supported-locales', () => {
+  it('lists Toki Pona as a supported locale', () => {
+    expect(listSupportedLocales()).toContain('tok');
+  });
+
+  it('matches Toki Pona locale requests to the supported language code', () => {
+    expect(getSupportedLocale('tok')).toBe('tok');
+    expect(getSupportedLocale('tok-US')).toBe('tok');
+    expect(getSupportedLocale('tok-Latn')).toBe('tok');
+  });
+});

--- a/packages/supported-locales/src/supportedLocales.ts
+++ b/packages/supported-locales/src/supportedLocales.ts
@@ -143,6 +143,7 @@ const supportedLocales = {
   te: ['te'], // Telugu
   th: ['th'], // Thai
   tl: ['tl'], // Tagalog
+  tok: ['tok'], // Toki Pona
   tr: ['tr'], // Turkish
   uk: ['uk'], // Ukrainian
   ur: ['ur'], // Urdu


### PR DESCRIPTION
## Summary
- Add Toki Pona (`tok`) to `@generaltranslation/supported-locales`
- Add package tests covering list and fallback matching behavior
- Add a changeset for the supported locales package

## Tests
- `pnpm --filter @generaltranslation/supported-locales test`
- `pnpm --filter @generaltranslation/supported-locales typecheck`
- `pnpm --filter @generaltranslation/supported-locales build`
- `pnpm format -- packages/supported-locales/src/supportedLocales.ts packages/supported-locales/src/__tests__/supportedLocales.test.ts .changeset/add-toki-pona-locale.md`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1431"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->