### PR TITLE
fix: key inline translations by content hash

### DIFF
--- a/.changeset/fresh-ids-wait.md
+++ b/.changeset/fresh-ids-wait.md
@@ -1,0 +1,7 @@
+---
+"gt": patch
+"@generaltranslation/react-core": patch
+"gt-next": patch
+---
+
+Key inline translations by content hash when custom ids are present so source updates refresh stale translations.

--- a/packages/cli/src/cli/inline.ts
+++ b/packages/cli/src/cli/inline.ts
@@ -121,11 +121,8 @@ export class InlineCLI extends BaseCLI {
     const newData: Record<string, unknown> = {};
     for (const update of updates) {
       const { source, metadata } = update;
-      const { hash, id } = metadata;
-      if (id) {
-        newData[id] = source;
-      } else if (hash) {
-        newData[hash] = source;
+      if (metadata.hash) {
+        newData[metadata.hash] = source;
       }
     }
 

--- a/packages/cli/src/extraction/__tests__/postProcess.test.ts
+++ b/packages/cli/src/extraction/__tests__/postProcess.test.ts
@@ -32,6 +32,23 @@ describe('calculateHashes', () => {
 
     expect(updates[0].metadata.hash).not.toBe(updates[1].metadata.hash);
   });
+
+  it('generates a new hash when source changes under the same custom id', async () => {
+    const updates: Updates = [
+      { dataFormat: 'ICU', source: 'hello', metadata: { id: 'custom-id' } },
+      {
+        dataFormat: 'ICU',
+        source: 'hello again',
+        metadata: { id: 'custom-id' },
+      },
+    ];
+
+    await calculateHashes(updates);
+
+    expect(updates[0].metadata.hash).toBeDefined();
+    expect(updates[1].metadata.hash).toBeDefined();
+    expect(updates[0].metadata.hash).not.toBe(updates[1].metadata.hash);
+  });
 });
 
 describe('dedupeUpdates', () => {

--- a/packages/cli/src/formats/files/collectFiles.ts
+++ b/packages/cli/src/formats/files/collectFiles.ts
@@ -45,13 +45,9 @@ export async function collectFiles(
       for (const update of updates) {
         const { source, metadata, dataFormat } = update;
         metadata.dataFormat = dataFormat; // add the data format to the metadata
-        const { hash, id } = metadata;
-        if (id) {
-          fileData[id] = source;
-          fileMetadata[id] = metadata;
-        } else if (hash) {
-          fileData[hash] = source;
-          fileMetadata[hash] = metadata;
+        if (metadata.hash) {
+          fileData[metadata.hash] = source;
+          fileMetadata[metadata.hash] = metadata;
         }
       }
       reactComponents = updates.length;

--- a/packages/cli/src/translation/parse.ts
+++ b/packages/cli/src/translation/parse.ts
@@ -92,7 +92,7 @@ export async function createUpdates(
   const idHashMap = new Map<string, string>();
   const hashlessIds = new Set<string>();
   const warnedHashlessDuplicateIds = new Set<string>();
-  const duplicateIds = new Set<string>();
+  const warnedDuplicateIds = new Set<string>();
 
   const warnHashlessDuplicateId = (id: string) => {
     if (warnedHashlessDuplicateIds.has(id)) return;
@@ -121,15 +121,15 @@ export async function createUpdates(
 
     const existingHash = idHashMap.get(id);
     if (existingHash !== undefined) {
-      if (existingHash !== hash) {
-        errors.push(
-          `Hashes don't match on two components with the same id: ${chalk.blue(
+      if (existingHash !== hash && !warnedDuplicateIds.has(id)) {
+        warnings.push(
+          `Found multiple entries with the same custom id ${chalk.blue(
             id
-          )}. Check your ${chalk.green(
+          )} but different hashes. Translations are keyed by hash, so both entries can be uploaded, but check your ${chalk.green(
             '<T>'
-          )} tags and dictionary entries and make sure you're not accidentally duplicating IDs.`
+          )} tags and dictionary entries to make sure you are not accidentally reusing an id.`
         );
-        duplicateIds.add(id);
+        warnedDuplicateIds.add(id);
       }
     } else {
       idHashMap.set(id, hash);
@@ -137,9 +137,5 @@ export async function createUpdates(
     return update;
   });
 
-  // Filter out updates with duplicate IDs
-  updates = updates.filter(
-    (update) => !update.metadata.id || !duplicateIds.has(update.metadata.id)
-  );
   return { updates, errors, warnings };
 }

--- a/packages/cli/src/types/data.ts
+++ b/packages/cli/src/types/data.ts
@@ -33,12 +33,12 @@ export type { FileFormat, FileToUpload } from 'generaltranslation/types';
 export type JsxChildren = string | string[] | unknown;
 
 export type Translations = {
-  // keys are sha256 hashes
+  // keys are current content hashes; custom ids live in metadata
   [key: string]: JsxChildren;
 };
 
 export type TranslationsMetadata = {
-  // keys are sha256 hashes
+  // keys are current content hashes; id is stable user metadata
   [key: string]: {
     id?: string;
     hash?: string;

--- a/packages/core/src/types-dir/api/entry.ts
+++ b/packages/core/src/types-dir/api/entry.ts
@@ -11,9 +11,9 @@ export type ActionType = 'fast'; // TODO: Add standard action type when availabl
  * EntryMetadata is the metadata for a GTRequest.
  *
  * @param context - The context of the request.
- * @param id - The ID of the request.
+ * @param id - Optional user-provided stable identifier for the request.
  * @param maxChars - The maxChars of the request.
- * @param hash - The hash of the request.
+ * @param hash - The current content hash used as the translation freshness key.
  */
 export type EntryMetadata = {
   id?: string;

--- a/packages/next/src/server-dir/buildtime/T.tsx
+++ b/packages/next/src/server-dir/buildtime/T.tsx
@@ -104,28 +104,18 @@ export async function T({
   // Get the translation entry object
   const translations = await translationsPromise;
 
-  let translationEntry = translations?.[id || ''];
-
-  let hash;
-  if (_hash && typeof translationEntry === 'undefined') {
-    translationEntry = translations?.[_hash];
-  }
-
-  let childrenAsObjects;
-
-  if (!translationEntry) {
-    // Turns tagged children into objects
-    // The hash is used to identify the translation
-    childrenAsObjects = writeChildrenAsObjects(taggedChildren);
-    hash = hashSource({
+  const childrenAsObjects = writeChildrenAsObjects(taggedChildren);
+  const hash =
+    _hash ||
+    hashSource({
       source: childrenAsObjects,
       ...(context && { context }),
       ...(maxChars != null && { maxChars: Math.abs(maxChars) }),
       ...(id && { id }),
       dataFormat: 'JSX',
     });
-    translationEntry = translations?.[hash];
-  }
+
+  const translationEntry = translations?.[hash];
 
   // ----- RENDERING FUNCTION #2: RENDER TRANSLATED CONTENT ----- //
 
@@ -166,16 +156,6 @@ export async function T({
   // (no entry has been found, this means that the translation is either (1) loading or (2) missing)
   const translationPromise = (async () => {
     try {
-      childrenAsObjects ||= writeChildrenAsObjects(taggedChildren);
-      hash ||=
-        _hash ||
-        hashSource({
-          source: childrenAsObjects,
-          ...(context && { context }),
-          ...(maxChars != null && { maxChars: Math.abs(maxChars) }),
-          ...(id && { id }),
-          dataFormat: 'JSX',
-        });
       const target = await I18NConfig.translate({
         // do on demand translation
         source: childrenAsObjects,

--- a/packages/next/src/server-dir/buildtime/getTranslationFunction.ts
+++ b/packages/next/src/server-dir/buildtime/getTranslationFunction.ts
@@ -193,23 +193,9 @@ async function createTranslator(_messages?: _Messages): Promise<Translator> {
     };
   }
 
-  function getTranslationData(
-    calculateHash: () => string,
-    id?: string,
-    _hash?: string
-  ) {
-    let translationEntry;
-    let hash = ''; // lazily computed if needed
-    if (id) translationEntry = translations?.[id];
-    if (!translationEntry && _hash && translations?.[_hash] !== undefined) {
-      hash = _hash;
-      translationEntry = translations?.[_hash];
-    }
-    if (!translationEntry) {
-      hash = calculateHash();
-      translationEntry = translations?.[hash];
-    }
-    return { translationEntry, hash };
+  function getTranslationData(calculateHash: () => string, _hash?: string) {
+    const hash = _hash || calculateHash();
+    return { translationEntry: translations?.[hash], hash };
   }
 
   function scheduleTranslateOnDemand(args: {
@@ -271,7 +257,6 @@ async function createTranslator(_messages?: _Messages): Promise<Translator> {
       const { id, context, maxChars, _hash, calculateHash } = init;
       const { translationEntry, hash } = getTranslationData(
         calculateHash,
-        id,
         _hash
       );
       if (translationEntry) return; // exists already
@@ -305,11 +290,7 @@ async function createTranslator(_messages?: _Messages): Promise<Translator> {
     // Early: no translation needed
     if (!translationRequired) return renderMessage(message, [defaultLocale]);
 
-    const { translationEntry, hash } = getTranslationData(
-      calculateHash,
-      id,
-      _hash
-    );
+    const { translationEntry, hash } = getTranslationData(calculateHash, _hash);
 
     if (translationEntry) {
       return renderMessage(

--- a/packages/next/src/server-dir/buildtime/getTranslations.tsx
+++ b/packages/next/src/server-dir/buildtime/getTranslations.tsx
@@ -240,28 +240,20 @@ export async function getTranslations(id?: string): Promise<
 
     // ---------- TRANSLATION ---------- //
 
-    let translationEntry = translations?.[id];
-    let hash = '';
-    const getHash = () => {
-      if (metadata?.$_hash) return metadata.$_hash;
-      const hash = hashSource({
-        source: indexVars(entry),
-        ...(metadata?.$context && { context: metadata.$context }),
-        ...(metadata?.$maxChars != null && {
-          maxChars: Math.abs(metadata.$maxChars),
-        }),
-        id,
-        dataFormat: 'ICU',
-      });
-      // Inject hash if not there yet
+    const hash = hashSource({
+      source: indexVars(entry),
+      ...(metadata?.$context && { context: metadata.$context }),
+      ...(metadata?.$maxChars != null && {
+        maxChars: Math.abs(metadata.$maxChars),
+      }),
+      id,
+      dataFormat: 'ICU',
+    });
+    if (metadata?.$_hash !== hash) {
       metadata = { ...metadata, $_hash: hash };
       injectEntry([entry, metadata], dictionary, id, dictionary);
-      return hash;
-    };
-    if (!translationEntry) {
-      hash = getHash();
-      translationEntry = translations?.[hash];
     }
+    const translationEntry = translations?.[hash];
 
     // ----- RENDER TRANSLATION ----- //
 
@@ -295,7 +287,7 @@ export async function getTranslations(id?: string): Promise<
             $maxChars: metadata.$maxChars,
           }),
           $id: id,
-          $_hash: getHash(),
+          $_hash: hash,
           $format: 'ICU',
         },
       }).then((result) => {

--- a/packages/react-core/src/dictionaries/__tests__/injectHashes.test.ts
+++ b/packages/react-core/src/dictionaries/__tests__/injectHashes.test.ts
@@ -59,7 +59,7 @@ describe('injectHashes', () => {
       expect(result.updateDictionary).toBe(true);
     });
 
-    it('should not modify entries that already have hashes', () => {
+    it('should refresh entries that already have stale hashes', () => {
       const dictionary: Dictionary = {
         greeting: ['Hello world', { $_hash: 'existing_hash' }],
         farewell: 'Goodbye',
@@ -68,7 +68,7 @@ describe('injectHashes', () => {
       const result = injectHashes(dictionary);
 
       expect(result.dictionary).toEqual({
-        greeting: ['Hello world', { $_hash: 'existing_hash' }],
+        greeting: ['Hello world', { $_hash: 'hash_Hello world_none_greeting' }],
         farewell: ['Goodbye', { $_hash: 'hash_Goodbye_none_farewell' }],
       });
       expect(result.updateDictionary).toBe(true);
@@ -168,7 +168,7 @@ describe('injectHashes', () => {
 
       expect(result.dictionary).toEqual({
         section1: {
-          item1: ['Item 1', { $_hash: 'existing_hash_1' }],
+          item1: ['Item 1', { $_hash: 'hash_Item 1_none_section1.item1' }],
           item2: ['Item 2', { $_hash: 'hash_Item 2_none_section1.item2' }],
         },
         section2: {
@@ -289,29 +289,35 @@ describe('injectHashes', () => {
   describe('should return correct updateDictionary flag', () => {
     it('should return false when no updates needed', () => {
       const dictionary: Dictionary = {
-        greeting: ['Hello world', { $_hash: 'existing_hash' }],
-        farewell: ['Goodbye', { $_hash: 'another_hash' }],
+        greeting: ['Hello world', { $_hash: 'hash_Hello world_none_greeting' }],
+        farewell: ['Goodbye', { $_hash: 'hash_Goodbye_none_farewell' }],
       };
 
       const result = injectHashes(dictionary);
 
       expect(result.dictionary).toEqual({
-        greeting: ['Hello world', { $_hash: 'existing_hash' }],
-        farewell: ['Goodbye', { $_hash: 'another_hash' }],
+        greeting: ['Hello world', { $_hash: 'hash_Hello world_none_greeting' }],
+        farewell: ['Goodbye', { $_hash: 'hash_Goodbye_none_farewell' }],
       });
       expect(result.updateDictionary).toBe(false);
     });
 
     it('should return true when some entries need hashes', () => {
       const dictionary: Dictionary = {
-        existing: ['Already has hash', { $_hash: 'existing' }],
+        existing: [
+          'Already has hash',
+          { $_hash: 'hash_Already has hash_none_existing' },
+        ],
         needsHash: 'Needs a hash',
       };
 
       const result = injectHashes(dictionary);
 
       expect(result.dictionary).toEqual({
-        existing: ['Already has hash', { $_hash: 'existing' }],
+        existing: [
+          'Already has hash',
+          { $_hash: 'hash_Already has hash_none_existing' },
+        ],
         needsHash: [
           'Needs a hash',
           { $_hash: 'hash_Needs a hash_none_needsHash' },
@@ -323,7 +329,10 @@ describe('injectHashes', () => {
     it('should return true when nested entries need hashes', () => {
       const dictionary: Dictionary = {
         section: {
-          withHash: ['Has hash', { $_hash: 'existing' }],
+          withHash: [
+            'Has hash',
+            { $_hash: 'hash_Has hash_none_section.withHash' },
+          ],
           nested: {
             needsHash: 'Needs hash',
           },
@@ -334,7 +343,10 @@ describe('injectHashes', () => {
 
       expect(result.dictionary).toEqual({
         section: {
-          withHash: ['Has hash', { $_hash: 'existing' }],
+          withHash: [
+            'Has hash',
+            { $_hash: 'hash_Has hash_none_section.withHash' },
+          ],
           nested: {
             needsHash: [
               'Needs hash',

--- a/packages/react-core/src/dictionaries/injectHashes.ts
+++ b/packages/react-core/src/dictionaries/injectHashes.ts
@@ -20,17 +20,18 @@ export function injectHashes(
     if (isDictionaryEntry(value)) {
       // eslint-disable-next-line prefer-const
       let { entry, metadata } = getEntryAndMetadata(value);
-      if (!metadata?.$_hash) {
+      const hash = hashSource({
+        source: indexVars(entry),
+        ...(metadata?.$context && { context: metadata.$context }),
+        ...(metadata?.$maxChars != null && {
+          maxChars: Math.abs(metadata.$maxChars),
+        }),
+        id: wholeId,
+        dataFormat: 'ICU',
+      });
+      if (metadata?.$_hash !== hash) {
         metadata ||= {};
-        metadata.$_hash = hashSource({
-          source: indexVars(entry),
-          ...(metadata?.$context && { context: metadata.$context }),
-          ...(metadata?.$maxChars != null && {
-            maxChars: Math.abs(metadata.$maxChars),
-          }),
-          id: wholeId,
-          dataFormat: 'ICU',
-        });
+        metadata.$_hash = hash;
         set(dictionary, key, [entry, metadata]);
         updateDictionary = true;
       }

--- a/packages/react-core/src/provider/hooks/translation/__tests__/useCreateInternalUseGTFunction.test.ts
+++ b/packages/react-core/src/provider/hooks/translation/__tests__/useCreateInternalUseGTFunction.test.ts
@@ -313,6 +313,29 @@ describe('useCreateInternalUseGTFunction', () => {
           },
         });
       });
+
+      it('should not use a stale id-keyed translation when the current hash is missing', () => {
+        const { _gtFunction } = useCreateInternalUseGTFunction({
+          gt: mockGT,
+          registerIcuForTranslation: mockRegisterIcuForTranslation,
+          ...defaultProps,
+          translations: {
+            greeting: 'Stale translation',
+          },
+        });
+
+        const result = _gtFunction('Hello World', { $id: 'greeting' });
+
+        expect(result).toBe('Hello World');
+        expect(mockRegisterIcuForTranslation).toHaveBeenCalledWith({
+          source: 'Hello World',
+          targetLocale: 'es',
+          metadata: {
+            id: 'greeting',
+            hash: 'hash-hello-world',
+          },
+        });
+      });
     });
 
     describe('error handling', () => {
@@ -513,8 +536,9 @@ describe('useCreateInternalUseGTFunction', () => {
       const result = await _preloadMessages(messages);
 
       expect(result).toEqual({
-        'hash-hello-world': 'Translated message',
+        'hash-hello-world': 'Existing translation',
       });
+      expect(mockRegisterIcuForTranslation).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/react-core/src/provider/hooks/translation/useCreateInternalUseGTFunction.ts
+++ b/packages/react-core/src/provider/hooks/translation/useCreateInternalUseGTFunction.ts
@@ -191,27 +191,10 @@ export default function useCreateInternalUseGTFunction({
     };
   }
 
-  function getTranslationData(
-    calculateHash: () => string,
-    id?: string,
-    _hash?: string
-  ) {
-    let translationEntry;
-    let hash = ''; // empty string because 1) it has to be a string but 2) we don't always need to calculate it
-    if (id) {
-      translationEntry = translations?.[id];
-    }
-    if (_hash && typeof translationEntry === 'undefined') {
-      hash = _hash;
-      translationEntry = translations?.[_hash];
-    }
-    // Use calculated hash to index
-    if (typeof translationEntry === 'undefined') {
-      hash = calculateHash();
-      translationEntry = translations?.[hash];
-    }
+  function getTranslationData(calculateHash: () => string, _hash?: string) {
+    const hash = _hash || calculateHash();
     return {
-      translationEntry,
+      translationEntry: translations?.[hash],
       hash,
     };
   }
@@ -221,10 +204,9 @@ export default function useCreateInternalUseGTFunction({
     for (const { message, ...options } of _messages) {
       const init = initializeGT(message, options);
       if (!init) continue;
-      const { id, _hash, calculateHash } = init;
+      const { _hash, calculateHash } = init;
       const { translationEntry, hash } = getTranslationData(
         calculateHash,
-        id,
         _hash
       );
       if (!translationEntry) {
@@ -243,12 +225,12 @@ export default function useCreateInternalUseGTFunction({
       const { id, context, maxChars, _hash, calculateHash } = init;
       const { translationEntry, hash } = getTranslationData(
         calculateHash,
-        id,
         _hash
       );
       // Return if no translation needed
       if (translationEntry) {
         preloadedTranslations[hash] = translationEntry;
+        return;
       }
       // Await the creation of the translation
       // Should update the translations object
@@ -283,11 +265,7 @@ export default function useCreateInternalUseGTFunction({
 
     // ----- GET TRANSLATION ----- //
 
-    const { translationEntry, hash } = getTranslationData(
-      calculateHash,
-      id,
-      _hash
-    );
+    const { translationEntry, hash } = getTranslationData(calculateHash, _hash);
 
     // ----- RENDER TRANSLATION ----- //
 
@@ -327,7 +305,7 @@ export default function useCreateInternalUseGTFunction({
         ...(context && { context }),
         ...(id && { id }),
         ...(maxChars != null && { maxChars }),
-        hash: hash || '',
+        hash,
       },
     });
 

--- a/packages/react-core/src/provider/hooks/translation/useCreateInternalUseTranslationsFunction.ts
+++ b/packages/react-core/src/provider/hooks/translation/useCreateInternalUseTranslationsFunction.ts
@@ -153,22 +153,16 @@ export default function useCreateInternalUseTranslationsFunction(
 
       // ----- CHECK TRANSLATIONS ----- //
 
-      let translationEntry = translations?.[id];
-      let hash = '';
-      const getHash = () =>
-        hashSource({
-          source: indexVars(entry),
-          ...(metadata?.$context && { context: metadata.$context }),
-          ...(metadata?.$maxChars != null && {
-            maxChars: Math.abs(metadata.$maxChars),
-          }),
-          id,
-          dataFormat: 'ICU',
-        });
-      if (!translationEntry) {
-        hash = getHash();
-        translationEntry = translations?.[hash];
-      }
+      const hash = hashSource({
+        source: indexVars(entry),
+        ...(metadata?.$context && { context: metadata.$context }),
+        ...(metadata?.$maxChars != null && {
+          maxChars: Math.abs(metadata.$maxChars),
+        }),
+        id,
+        dataFormat: 'ICU',
+      });
+      const translationEntry = translations?.[hash];
 
       // Check translation successful
       if (translationEntry) {
@@ -201,7 +195,7 @@ export default function useCreateInternalUseTranslationsFunction(
             maxChars: metadata.$maxChars,
           }),
           id,
-          hash: hash || getHash(),
+          hash,
         },
       });
 

--- a/packages/react-core/src/translation/T.tsx
+++ b/packages/react-core/src/translation/T.tsx
@@ -79,50 +79,26 @@ function T({
 
   // ----- FETCH TRANSLATION ----- //
 
-  // Dependency flag to avoid recalculating hash whenever translation object changes
-
-  let translationEntry: TranslatedChildren | null | undefined;
-
-  if (id) {
-    translationEntry = translations?.[id];
-  }
-
-  if (typeof translationEntry === 'undefined' && _hash) {
-    translationEntry = translations?.[_hash];
-  }
-
   // Calculate necessary info for fetching translation / generating translation
   const [childrenAsObjects, hash] = useMemo(() => {
-    // skip hashing:
-    if (
-      !translationRequired || // Translation not required
-      translationEntry // Translation already exists under the id
-    ) {
-      return [undefined, ''];
+    if (!translationRequired) {
+      return [undefined, _hash || ''];
     }
-    // calculate hash
-    const childrenAsObjects = writeChildrenAsObjects(taggedChildren);
-    const hash: string = hashSource({
-      source: childrenAsObjects,
-      ...(context && { context }),
-      ...(maxChars != null && { maxChars: Math.abs(maxChars) }),
-      ...(id && { id }),
-      dataFormat: 'JSX',
-    });
-    return [childrenAsObjects, hash];
-  }, [
-    taggedChildren,
-    context,
-    id,
-    maxChars,
-    translationRequired,
-    translationEntry,
-  ]);
 
-  // get translation entry on hash
-  if (typeof translationEntry === 'undefined') {
-    translationEntry = translations?.[hash];
-  }
+    const childrenAsObjects = writeChildrenAsObjects(taggedChildren);
+    const hash: string =
+      _hash ||
+      hashSource({
+        source: childrenAsObjects,
+        ...(context && { context }),
+        ...(maxChars != null && { maxChars: Math.abs(maxChars) }),
+        ...(id && { id }),
+        dataFormat: 'JSX',
+      });
+    return [childrenAsObjects, hash];
+  }, [taggedChildren, context, id, maxChars, translationRequired, _hash]);
+
+  const translationEntry = translations?.[hash];
 
   // ----- RENDER METHODS ----- //
 


### PR DESCRIPTION
## Summary
- key generated inline GTJSON entries by content hash even when custom ids are present
- resolve runtime and buildtime translations by the current hash while preserving custom ids as metadata
- refresh injected dictionary hashes when source metadata changes, and warn instead of erroring on reused custom ids with different hashes

## Tests
- `pnpm --filter gt exec vitest run src/extraction/__tests__/postProcess.test.ts --config=./vitest.config.ts`
- `pnpm --filter @generaltranslation/react-core exec vitest run src/dictionaries/__tests__/injectHashes.test.ts src/provider/hooks/translation/__tests__/useCreateInternalUseGTFunction.test.ts`
- `pnpm --filter gt-next exec vitest run src/server-dir/buildtime/__tests__/getTranslations.test.ts`
- `pnpm --filter gt typecheck`
- `pnpm --filter @generaltranslation/react-core typecheck`
- `pnpm --filter gt-next typecheck`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1432"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes how inline translations are keyed throughout the CLI, Next.js buildtime, and React client layers: instead of preferring a user-supplied custom `id` as the translation lookup key, every entry is now keyed by its **content hash** (`_hash || calculateHash()`), with the custom id preserved only as metadata. The `injectHashes` utility is updated to refresh stale hashes when source content changes under the same id, and the CLI's duplicate-id handling is downgraded from a hard error to a warning since hash-keyed entries no longer conflict.

- **CLI extraction** (`collectFiles`, `inline`, `parse`) now unconditionally keys uploads by content hash; a mismatch between two entries sharing a custom id emits a warning instead of dropping both entries.
- **Runtime/buildtime lookups** in `react-core` (`T.tsx`, `useCreateInternalUseGTFunction`, `useCreateInternalUseTranslationsFunction`) and `gt-next` (`T.tsx`, `getTranslationFunction`, `getTranslations`) all drop the `translations[id]` first-pass and resolve solely via `_hash || calculateHash()`.
- **`_preloadMessages`** gains an early `return` that prevents overwriting a known-good translation entry with a redundant API call — fixing a pre-existing bug where `registerIcuForTranslation` was unconditionally called even when the translation was already cached.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the change consistently applies hash-keyed lookups across all layers and the test suite covers the critical new and changed paths.

The PR is internally consistent and well-tested. One area worth watching: the client-side T.tsx useMemo now always calls writeChildrenAsObjects even when the translation is already cached, whereas the old code short-circuited that work as soon as an entry was found. In production builds _hash is always present so hashSource is skipped, but writeChildrenAsObjects still runs on every render cycle of a component that has a cached translation — a regression for complex JSX subtrees.

packages/react-core/src/translation/T.tsx — the useMemo short-circuit for cached translations was removed and may warrant a follow-up optimisation.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react-core/src/translation/T.tsx | Removes multi-step id→_hash→hash lookup in favour of direct hash lookup; introduces a performance regression where writeChildrenAsObjects is computed on every render even when a cached translation already exists. |
| packages/react-core/src/provider/hooks/translation/useCreateInternalUseGTFunction.ts | Simplifies getTranslationData to hash-only lookup; also fixes a pre-existing bug in _preloadMessages where registerIcuForTranslation was always called (overwriting an existing translation entry) instead of returning early. |
| packages/cli/src/translation/parse.ts | Demotes duplicate-id-with-different-hash from a hard error (with entry filtering) to a warning, allowing all entries through since keying is now by hash; dedup logic is correct. |
| packages/react-core/src/dictionaries/injectHashes.ts | Always computes the expected hash and refreshes stale entries instead of skipping entries that already have a hash value; required for detecting source-changed-under-same-id scenarios. |
| packages/next/src/server-dir/buildtime/getTranslations.tsx | Eagerly computes hash and refreshes the dictionary entry when stale, instead of deferring via a lazy getHash(); removes id-keyed translation lookup; hash is always passed to the on-demand translate call. |

</details>

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Freact-core%2Fsrc%2Ftranslation%2FT.tsx%3A83-99%0A**Unnecessary%20%60writeChildrenAsObjects%60%20on%20every%20render%20when%20translation%20is%20cached**%0A%0AWith%20the%20old%20code%2C%20the%20%60useMemo%60%20returned%20%60%5Bundefined%2C%20''%5D%60%20early%20when%20a%20%60translationEntry%60%20was%20already%20found%20%28via%20%60id%60%20or%20%60_hash%60%29%2C%20skipping%20the%20expensive%20%60writeChildrenAsObjects%60%20call.%20The%20new%20code%20always%20calls%20%60writeChildrenAsObjects%28taggedChildren%29%60%20%28and%20%60hashSource%60%20if%20no%20%60_hash%60%29%20whenever%20%60translationRequired%60%20is%20true%2C%20even%20when%20%60translations%3F.%5B_hash%5D%60%20will%20be%20a%20cache%20hit%20on%20the%20very%20next%20line.%20In%20production%20builds%2C%20%60_hash%60%20is%20always%20injected%2C%20so%20this%20work%20is%20wasted%20on%20every%20render%20of%20a%20%60%3CT%3E%60%20component%20that%20has%20a%20cached%20translation.%20For%20components%20with%20complex%20JSX%20subtrees%20this%20is%20a%20measurable%20per-render%20overhead.%0A%0A&repo=generaltranslation%2Fgt&pr=1432&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22bg%2Fseparate-id-and-hash%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22bg%2Fseparate-id-and-hash%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Freact-core%2Fsrc%2Ftranslation%2FT.tsx%3A83-99%0A**Unnecessary%20%60writeChildrenAsObjects%60%20on%20every%20render%20when%20translation%20is%20cached**%0A%0AWith%20the%20old%20code%2C%20the%20%60useMemo%60%20returned%20%60%5Bundefined%2C%20''%5D%60%20early%20when%20a%20%60translationEntry%60%20was%20already%20found%20%28via%20%60id%60%20or%20%60_hash%60%29%2C%20skipping%20the%20expensive%20%60writeChildrenAsObjects%60%20call.%20The%20new%20code%20always%20calls%20%60writeChildrenAsObjects%28taggedChildren%29%60%20%28and%20%60hashSource%60%20if%20no%20%60_hash%60%29%20whenever%20%60translationRequired%60%20is%20true%2C%20even%20when%20%60translations%3F.%5B_hash%5D%60%20will%20be%20a%20cache%20hit%20on%20the%20very%20next%20line.%20In%20production%20builds%2C%20%60_hash%60%20is%20always%20injected%2C%20so%20this%20work%20is%20wasted%20on%20every%20render%20of%20a%20%60%3CT%3E%60%20component%20that%20has%20a%20cached%20translation.%20For%20components%20with%20complex%20JSX%20subtrees%20this%20is%20a%20measurable%20per-render%20overhead.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/react-core/src/translation/T.tsx:83-99
**Unnecessary `writeChildrenAsObjects` on every render when translation is cached**

With the old code, the `useMemo` returned `[undefined, '']` early when a `translationEntry` was already found (via `id` or `_hash`), skipping the expensive `writeChildrenAsObjects` call. The new code always calls `writeChildrenAsObjects(taggedChildren)` (and `hashSource` if no `_hash`) whenever `translationRequired` is true, even when `translations?.[_hash]` will be a cache hit on the very next line. In production builds, `_hash` is always injected, so this work is wasted on every render of a `<T>` component that has a cached translation. For components with complex JSX subtrees this is a measurable per-render overhead.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: key inline translations by content ..."](https://github.com/generaltranslation/gt/commit/51ff0b8ec01889ae275e6cb4bea43ec0df895484) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32910884)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->