### PR TITLE
fix: normalize runtime translation metadata

### DIFF
--- a/packages/cli/src/react/jsx/utils/stringParsing/derivation/index.ts
+++ b/packages/cli/src/react/jsx/utils/stringParsing/derivation/index.ts
@@ -93,17 +93,19 @@ export function deriveExpression({
 
   const temporaryDeriveId = `derive-temp-id-${randomUUID()}`;
   const contexts = contextVariants ?? [metadata.context];
+  const { format, ...entryMetadata } = metadata;
+  const dataFormat = (format || 'ICU') as DataFormat;
   for (const string of strings) {
     for (const context of contexts) {
       output.updates.push({
-        dataFormat: (metadata.format || 'ICU') as DataFormat,
+        dataFormat,
         source: string,
         metadata: {
-          ...metadata,
+          ...entryMetadata,
           ...(context != null && { context }),
           // Add the index if an id and index is provided (for handling when registering an array of strings)
-          ...(metadata.id &&
-            index != null && { id: `${metadata.id}.${index}` }),
+          ...(entryMetadata.id &&
+            index != null && { id: `${entryMetadata.id}.${index}` }),
           staticId: temporaryDeriveId,
         },
       });

--- a/packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/__tests__/processTranslationCall.test.ts
+++ b/packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/__tests__/processTranslationCall.test.ts
@@ -242,6 +242,7 @@ describe('$format option support', () => {
       source: 'Hello',
       metadata: { id: 'greeting', context: 'home' },
     });
+    expect(output.updates[0].metadata).not.toHaveProperty('format');
   });
 
   it('should warn on invalid $format value', () => {
@@ -265,6 +266,8 @@ describe('$format option support', () => {
     expect(output.updates).toHaveLength(2);
     expect(output.updates[0]).toMatchObject({ dataFormat: 'STRING' });
     expect(output.updates[1]).toMatchObject({ dataFormat: 'STRING' });
+    expect(output.updates[0].metadata).not.toHaveProperty('format');
+    expect(output.updates[1].metadata).not.toHaveProperty('format');
   });
 
   it('should not warn on invalid ICU when $format is STRING', () => {

--- a/packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/extractStringEntryMetadata.ts
+++ b/packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/extractStringEntryMetadata.ts
@@ -184,8 +184,6 @@ function extractInlineMetadata({
                 );
               }
             } else {
-              // Add the $context or $id or other attributes value to the metadata
-              // TODO: why are we including everything? arent we only interested in relevant inline metadata?
               metadata[mappedKey] = result.value;
             }
           }

--- a/packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/handleLiteralTranslationCall.ts
+++ b/packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/handleLiteralTranslationCall.ts
@@ -54,29 +54,33 @@ export function handleLiteralTranslationCall({
     }
   }
 
+  const { format, ...entryMetadata } = metadata;
+  const dataFormat = (format || 'ICU') as DataFormat;
+
   if (contextVariants) {
     const staticId = `derive-temp-id-${randomUUID()}`;
     for (const context of contextVariants) {
       output.updates.push({
-        dataFormat: (metadata.format || 'ICU') as DataFormat,
+        dataFormat,
         source,
         metadata: {
-          ...metadata,
+          ...entryMetadata,
           context,
-          ...(metadata.id &&
-            index != null && { id: `${metadata.id}.${index}` }),
+          ...(entryMetadata.id &&
+            index != null && { id: `${entryMetadata.id}.${index}` }),
           staticId,
         },
       });
     }
   } else {
     output.updates.push({
-      dataFormat: (metadata.format || 'ICU') as DataFormat,
+      dataFormat,
       source,
       metadata: {
-        ...metadata,
+        ...entryMetadata,
         // Add the index if an id and index is provided (for handling when registering an array of strings)
-        ...(metadata.id && index != null && { id: `${metadata.id}.${index}` }),
+        ...(entryMetadata.id &&
+          index != null && { id: `${entryMetadata.id}.${index}` }),
       },
     });
   }

--- a/packages/next/src/config-dir/I18NConfiguration.ts
+++ b/packages/next/src/config-dir/I18NConfiguration.ts
@@ -78,6 +78,7 @@ export class I18NConfiguration {
   private referrerLocaleCookieName: string;
   private localeRoutingEnabledCookieName: string;
   private resetLocaleCookieName: string;
+  private runtimeTranslationMetadata: Record<string, unknown>;
   constructor({
     // Cloud integration
     apiKey,
@@ -106,8 +107,8 @@ export class I18NConfiguration {
     _usingPlugin,
     headersAndCookies,
     customMapping,
-    // Other metadata
-    ...metadata
+    // Runtime translation metadata
+    ...additionalMetadata
   }: I18NConfigurationParams) {
     void _dictionary;
 
@@ -160,6 +161,17 @@ export class I18NConfiguration {
     // Translation and dictionary managers
     const shouldLoadTranslations = loadTranslationsType !== 'disabled';
     const runtimeTranslationTimeout = this.renderSettings.timeout;
+    const runtimeTranslationMetadata = {
+      sourceLocale: defaultLocale,
+      ...(runtimeTranslationTimeout && {
+        timeout: runtimeTranslationTimeout,
+      }),
+      projectId,
+      publish: true,
+      fast: true,
+      ...additionalMetadata,
+    };
+    this.runtimeTranslationMetadata = runtimeTranslationMetadata;
     this._i18nManager = new I18nManager<TranslatedChildren>({
       apiKey,
       devApiKey,
@@ -179,17 +191,7 @@ export class I18NConfiguration {
       },
       runtimeTranslation: {
         timeout: runtimeTranslationTimeout,
-        // Other metadata
-        metadata: {
-          sourceLocale: defaultLocale,
-          ...(runtimeTranslationTimeout && {
-            timeout: runtimeTranslationTimeout,
-          }),
-          projectId,
-          publish: true,
-          fast: true,
-          ...metadata,
-        },
+        metadata: runtimeTranslationMetadata,
       },
       cacheUrl: shouldLoadTranslations ? cacheUrl : null,
       // Only apply cache expiry for remote translations; custom loaders manage
@@ -256,6 +258,7 @@ export class I18NConfiguration {
       referrerLocaleCookieName,
       localeCookieName,
       resetLocaleCookieName,
+      runtimeTranslationMetadata,
     } = this;
     const customMapping = this._i18nManager.getCustomMapping();
     const _versionId = this._i18nManager.getVersionId();
@@ -273,6 +276,7 @@ export class I18NConfiguration {
       resetLocaleCookieName,
       customMapping,
       _versionId,
+      runtimeTranslationMetadata,
     };
   }
 

--- a/packages/next/src/config-dir/__tests__/I18NConfiguration.test.ts
+++ b/packages/next/src/config-dir/__tests__/I18NConfiguration.test.ts
@@ -35,6 +35,14 @@ vi.mock('gt-i18n/internal', () => ({
     async lookupTranslationWithFallback(...args: unknown[]) {
       return mockLookupTranslationWithFallback(...args);
     }
+
+    getCustomMapping() {
+      return undefined;
+    }
+
+    getVersionId() {
+      return undefined;
+    }
   },
 }));
 
@@ -91,7 +99,16 @@ describe('I18NConfiguration', () => {
   });
 
   it('passes batch, runtime metadata, and timeout config to I18nManager', () => {
-    createConfig({
+    const runtimeTranslationMetadata = {
+      sourceLocale: 'en',
+      timeout: 4321,
+      projectId: 'project-id',
+      publish: true,
+      fast: true,
+      description: 'Translate for clinicians.',
+      modelProvider: 'openai',
+    };
+    const config = createConfig({
       maxConcurrentRequests: 7,
       maxBatchSize: 3,
       batchInterval: 11,
@@ -112,16 +129,11 @@ describe('I18NConfiguration', () => {
       },
       runtimeTranslation: {
         timeout: 4321,
-        metadata: {
-          sourceLocale: 'en',
-          timeout: 4321,
-          projectId: 'project-id',
-          publish: true,
-          fast: true,
-          description: 'Translate for clinicians.',
-          modelProvider: 'openai',
-        },
+        metadata: runtimeTranslationMetadata,
       },
+    });
+    expect(config.getClientSideConfig()).toMatchObject({
+      runtimeTranslationMetadata,
     });
   });
 

--- a/packages/react/src/react-context/provider/ClientProvider.tsx
+++ b/packages/react/src/react-context/provider/ClientProvider.tsx
@@ -35,6 +35,7 @@ export default function ClientProvider({
   projectId,
   devApiKey,
   runtimeUrl,
+  runtimeTranslationMetadata,
   developmentApiEnabled,
   resetLocaleCookieName,
   localeCookieName = defaultLocaleCookieName,
@@ -167,8 +168,8 @@ export default function ClientProvider({
       setTranslations,
       defaultLocale,
       renderSettings,
-      developmentApiEnabled,
       environment,
+      ...(runtimeTranslationMetadata ?? {}),
     });
 
   // ---------- USE GT() TRANSLATION ---------- //

--- a/packages/react/src/react-context/types/config.ts
+++ b/packages/react/src/react-context/types/config.ts
@@ -32,6 +32,7 @@ export type ClientProviderProps = {
   projectId?: string;
   devApiKey?: string;
   runtimeUrl?: string | null;
+  runtimeTranslationMetadata?: Record<string, unknown>;
   gtServicesEnabled?: boolean;
   localeCookieName?: string;
   resetLocaleCookieName: string;


### PR DESCRIPTION
## Summary
- reuse the same Next runtime translation metadata on the server and client
- pass runtime translation metadata through the React client provider without leaking internal flags
- keep CLI `$format` as `dataFormat` only instead of storing it in entry metadata

## Tests
- `pnpm exec oxfmt --check packages/next/src/config-dir/I18NConfiguration.ts packages/next/src/config-dir/__tests__/I18NConfiguration.test.ts packages/react/src/react-context/provider/ClientProvider.tsx packages/react/src/react-context/types/config.ts packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/handleLiteralTranslationCall.ts packages/cli/src/react/jsx/utils/stringParsing/derivation/index.ts packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/extractStringEntryMetadata.ts packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/__tests__/processTranslationCall.test.ts`
- `pnpm --filter gt-next typecheck`
- `pnpm --filter gt typecheck`
- `pnpm --filter gt-react typecheck`
- `pnpm --filter gt-next test:js -- src/config-dir/__tests__/I18NConfiguration.test.ts`
- `pnpm --filter gt test -- src/react/jsx/utils/stringParsing/processTranslationCall/__tests__/processTranslationCall.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1434"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->