### PR TITLE
refactor: delegate client provider to react core

### DIFF
--- a/packages/react-core/src/provider/GTProvider.tsx
+++ b/packages/react-core/src/provider/GTProvider.tsx
@@ -21,14 +21,33 @@ import { resolveAliasLocale } from '@generaltranslation/format';
 import { GT } from 'generaltranslation';
 import { useLoadDictionary } from './hooks/useLoadDictionary';
 import { useLoadTranslations } from './hooks/useLoadTranslations';
-import { useCreateInternalUseTranslationsObjFunction } from './hooks/translation/useCreateInternalUseTranslationsObjFunction';
 import { useEnableI18n as _useEnableI18n } from './hooks/useEnableI18n';
+import { useCreateInternalUseTranslationsObjFunction } from './hooks/translation/useCreateInternalUseTranslationsObjFunction';
 
 // Deprecated functions, will be removed in a future version
 import { readAuthFromEnv as _readAuthFromEnv } from '../utils/utils';
 import { isSSREnabled } from './helpers/isSSREnabled';
 import { useDetermineLocale as _useDetermineLocale } from './hooks/locales/useDetermineLocale';
 import { useRegionState as _useRegionState } from './hooks/useRegionState';
+
+export function getTranslationRequirements({
+  translationRequiredOverride,
+  dialectTranslationRequiredOverride,
+  localeTranslationRequired,
+  localeDialectTranslationRequired,
+}: {
+  translationRequiredOverride?: boolean;
+  dialectTranslationRequiredOverride?: boolean;
+  localeTranslationRequired: boolean;
+  localeDialectTranslationRequired: boolean;
+}) {
+  const translationRequired =
+    translationRequiredOverride ?? localeTranslationRequired;
+  const dialectTranslationRequired = translationRequired
+    ? (dialectTranslationRequiredOverride ?? localeDialectTranslationRequired)
+    : false;
+  return { translationRequired, dialectTranslationRequired };
+}
 
 export default function GTProvider({
   children,
@@ -37,7 +56,8 @@ export default function GTProvider({
   projectId: _projectId = config?.projectId || '',
   devApiKey: _devApiKey = config?.devApiKey || '',
   _versionId = config?._versionId,
-  dictionary: _dictionary = {},
+  dictionary: _dictionary,
+  dictionaryTranslations: _dictionaryTranslations,
   locales = config?.locales || [],
   defaultLocale = config?.defaultLocale || libraryDefaultLocale,
   cacheUrl = config?.cacheUrl || defaultCacheUrl,
@@ -46,18 +66,23 @@ export default function GTProvider({
     getDefaultRenderSettings(environment),
   ssr = config?.ssr || isSSREnabled(),
   localeCookieName = config?.localeCookieName || defaultLocaleCookieName,
+  regionCookieName = defaultRegionCookieName,
   locale: _locale = '',
   region: _region,
   loadDictionary,
   loadTranslations,
   fallback = undefined,
   translations: _translations = null,
+  translationRequired: translationRequiredOverride,
+  dialectTranslationRequired: dialectTranslationRequiredOverride,
   customMapping = config?.customMapping,
   enableI18n: _enableI18n = config?.enableI18n !== undefined
     ? config.enableI18n
     : true,
   enableI18nLoaded,
   reloadOnLocaleUpdate,
+  onLocaleUpdate,
+  developmentApiEnabled: developmentApiEnabledOverride,
   useEnableI18n = _useEnableI18n,
   readAuthFromEnv = _readAuthFromEnv,
   useDetermineLocale = _useDetermineLocale,
@@ -93,8 +118,8 @@ export default function GTProvider({
     locale,
     setLocale,
     locales: approvedLocales,
-    translationRequired,
-    dialectTranslationRequired,
+    translationRequired: localeTranslationRequired,
+    dialectTranslationRequired: localeDialectTranslationRequired,
   } = useLocaleState({
     _locale,
     defaultLocale,
@@ -105,13 +130,21 @@ export default function GTProvider({
     useDetermineLocale,
     enableI18n,
     reloadOnLocaleUpdate,
+    onLocaleUpdate,
   });
+  const { translationRequired, dialectTranslationRequired } =
+    getTranslationRequirements({
+      translationRequiredOverride,
+      dialectTranslationRequiredOverride,
+      localeTranslationRequired,
+      localeDialectTranslationRequired,
+    });
 
   // Define the region instance
   const { region, setRegion } = useRegionState({
     _region,
     ssr,
-    regionCookieName: defaultRegionCookieName,
+    regionCookieName,
   });
 
   // Define the GT instance
@@ -126,7 +159,7 @@ export default function GTProvider({
         baseUrl: runtimeUrl || undefined,
         customMapping,
       }),
-    [devApiKey, defaultLocale, projectId, runtimeUrl, customMapping]
+    [devApiKey, defaultLocale, locale, projectId, runtimeUrl, customMapping]
   );
 
   // Determine the type of translation loading
@@ -142,6 +175,11 @@ export default function GTProvider({
   }, [loadTranslations, cacheUrl, projectId]);
 
   // ---------- LOAD DICTIONARY ---------- //
+  const dictionaryInput = useMemo(() => _dictionary ?? {}, [_dictionary]);
+  const dictionaryTranslationsInput = useMemo(
+    () => _dictionaryTranslations ?? {},
+    [_dictionaryTranslations]
+  );
 
   const {
     dictionary,
@@ -149,8 +187,8 @@ export default function GTProvider({
     dictionaryTranslations,
     setDictionaryTranslations,
   } = useLoadDictionary({
-    _dictionary,
-    _dictionaryTranslations: {},
+    _dictionary: dictionaryInput,
+    _dictionaryTranslations: dictionaryTranslationsInput,
     loadDictionary,
     locale,
     defaultLocale,
@@ -187,7 +225,7 @@ export default function GTProvider({
   const {
     registerIcuForTranslation,
     registerJsxForTranslation,
-    developmentApiEnabled,
+    developmentApiEnabled: runtimeDevelopmentApiEnabled,
   } = useRuntimeTranslation({
     gt,
     locale,
@@ -199,6 +237,9 @@ export default function GTProvider({
     environment,
     ...metadata,
   });
+
+  const developmentApiEnabled =
+    developmentApiEnabledOverride ?? runtimeDevelopmentApiEnabled;
 
   // ---------- USE GT ---------- //
 

--- a/packages/react-core/src/provider/__tests__/GTProvider.test.ts
+++ b/packages/react-core/src/provider/__tests__/GTProvider.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { getTranslationRequirements } from '../GTProvider';
+
+describe('getTranslationRequirements', () => {
+  it('uses server-provided translation requirements when available', () => {
+    expect(
+      getTranslationRequirements({
+        translationRequiredOverride: false,
+        dialectTranslationRequiredOverride: false,
+        localeTranslationRequired: true,
+        localeDialectTranslationRequired: true,
+      })
+    ).toEqual({
+      translationRequired: false,
+      dialectTranslationRequired: false,
+    });
+  });
+
+  it('falls back to locale-derived translation requirements', () => {
+    expect(
+      getTranslationRequirements({
+        localeTranslationRequired: true,
+        localeDialectTranslationRequired: true,
+      })
+    ).toEqual({
+      translationRequired: true,
+      dialectTranslationRequired: true,
+    });
+  });
+});

--- a/packages/react-core/src/provider/hooks/__tests__/useLoadTranslations.test.ts
+++ b/packages/react-core/src/provider/hooks/__tests__/useLoadTranslations.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { getTranslationsState } from '../useLoadTranslations';
+
+describe('getTranslationsState', () => {
+  it('preserves server-provided translations when loading is disabled', () => {
+    const translations = {
+      hello: 'Bonjour',
+    };
+
+    expect(
+      getTranslationsState({
+        _translations: translations,
+        translationRequired: true,
+        loadTranslationsType: 'disabled',
+      })
+    ).toBe(translations);
+  });
+
+  it('requests a load when translations are required and no translations are provided', () => {
+    expect(
+      getTranslationsState({
+        _translations: null,
+        translationRequired: true,
+        loadTranslationsType: 'default',
+      })
+    ).toBeNull();
+  });
+
+  it('uses an empty translation map when no loading is needed', () => {
+    expect(
+      getTranslationsState({
+        _translations: null,
+        translationRequired: false,
+        loadTranslationsType: 'disabled',
+      })
+    ).toEqual({});
+  });
+});

--- a/packages/react-core/src/provider/hooks/locales/types.ts
+++ b/packages/react-core/src/provider/hooks/locales/types.ts
@@ -9,6 +9,7 @@ export type UseDetermineLocaleParams = {
   ssr?: boolean;
   customMapping?: CustomMapping;
   reloadOnLocaleUpdate?: boolean;
+  onLocaleUpdate?: (locale: string) => void;
 };
 
 export type UseDetermineLocaleReturn = [string, (locale: string) => void];

--- a/packages/react-core/src/provider/hooks/locales/useLocaleState.ts
+++ b/packages/react-core/src/provider/hooks/locales/useLocaleState.ts
@@ -21,6 +21,7 @@ export function useLocaleState({
   useDetermineLocale,
   enableI18n,
   reloadOnLocaleUpdate,
+  onLocaleUpdate,
 }: {
   _locale: string;
   defaultLocale: string;
@@ -33,6 +34,7 @@ export function useLocaleState({
     params: UseDetermineLocaleParams
   ) => UseDetermineLocaleReturn;
   reloadOnLocaleUpdate?: boolean;
+  onLocaleUpdate?: (locale: string) => void;
 }) {
   // Locale standardization
   const locales = useMemo(() => {
@@ -50,6 +52,7 @@ export function useLocaleState({
     customMapping,
     enableI18n,
     reloadOnLocaleUpdate,
+    onLocaleUpdate,
   });
 
   const [translationRequired, dialectTranslationRequired] = useMemo(() => {

--- a/packages/react-core/src/provider/hooks/useLoadDictionary.ts
+++ b/packages/react-core/src/provider/hooks/useLoadDictionary.ts
@@ -1,6 +1,5 @@
-import { useEffect, useState } from 'react';
-import { CustomLoader } from '../../types-dir/types';
-import { Dictionary } from '../../types-dir/types';
+import { useEffect, useRef, useState } from 'react';
+import { CustomLoader, Dictionary } from '../../types-dir/types';
 import loadDictionaryHelper from '../../dictionaries/loadDictionaryHelper';
 
 export function useLoadDictionary({
@@ -23,9 +22,20 @@ export function useLoadDictionary({
     Dictionary | undefined
   >(_dictionaryTranslations);
 
+  // Update dictionary props when the provider receives new server data.
+  const didMount = useRef(false);
+  useEffect(() => {
+    if (!didMount.current) {
+      didMount.current = true;
+      return;
+    }
+    if (loadDictionary) return;
+    setDictionary(_dictionary);
+    setDictionaryTranslations(_dictionaryTranslations);
+  }, [_dictionary, _dictionaryTranslations, loadDictionary]);
+
   // Resolve dictionary when not provided, but using custom dictionary loader
   useEffect(() => {
-    // Early return if dictionary is provided or not loading translation dictionary
     if (!loadDictionary) return;
 
     let storeResults = true;
@@ -39,20 +49,10 @@ export function useLoadDictionary({
       const localeDictionary =
         (await loadDictionaryHelper(locale, loadDictionary)) || {};
 
-      // // Merge dictionaries
-      // const mergedDictionary = mergeDictionaries(
-      //   defaultLocaleDictionary,
-      //   localeDictionary
-      // );
-
-      // Update dictionary
+      // Update dictionary and dictionary translations
       if (storeResults) {
-        setDictionary(defaultLocaleDictionary || {});
-      }
-
-      // Update dictionary translations
-      if (storeResults) {
-        setDictionaryTranslations(localeDictionary || {});
+        setDictionary(defaultLocaleDictionary);
+        setDictionaryTranslations(localeDictionary);
       }
     })();
 

--- a/packages/react-core/src/provider/hooks/useLoadTranslations.ts
+++ b/packages/react-core/src/provider/hooks/useLoadTranslations.ts
@@ -1,7 +1,7 @@
 import { customLoadTranslationsError } from '../../errors-dir/createErrors';
 import fetchTranslations from '../../utils/fetchTranslations';
 import { CustomLoader, Translations } from '../../types-dir/types';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { GT } from 'generaltranslation';
 import { defaultCacheUrl } from 'generaltranslation/internal';
 
@@ -47,18 +47,12 @@ export function useLoadTranslations({
    * Cache Fail (for hash)    -> translations[hash] = undefined
    */
 
-  const nextTranslations = useMemo(
-    () =>
-      getTranslationsState({
-        _translations,
-        translationRequired,
-        loadTranslationsType,
-      }),
-    [_translations, translationRequired, loadTranslationsType]
-  );
-
   const [translations, setTranslations] = useState<Translations | null>(
-    nextTranslations
+    getTranslationsState({
+      _translations,
+      translationRequired,
+      loadTranslationsType,
+    })
   );
 
   /**
@@ -75,8 +69,14 @@ export function useLoadTranslations({
       return;
     }
 
-    setTranslations(nextTranslations);
-  }, [locale, nextTranslations]);
+    setTranslations(
+      getTranslationsState({
+        _translations,
+        translationRequired,
+        loadTranslationsType,
+      })
+    );
+  }, [locale, _translations, translationRequired, loadTranslationsType]);
 
   /**
    * Update translations

--- a/packages/react-core/src/provider/hooks/useLoadTranslations.ts
+++ b/packages/react-core/src/provider/hooks/useLoadTranslations.ts
@@ -1,9 +1,24 @@
 import { customLoadTranslationsError } from '../../errors-dir/createErrors';
 import fetchTranslations from '../../utils/fetchTranslations';
 import { CustomLoader, Translations } from '../../types-dir/types';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { GT } from 'generaltranslation';
 import { defaultCacheUrl } from 'generaltranslation/internal';
+
+export function getTranslationsState({
+  _translations,
+  translationRequired,
+  loadTranslationsType,
+}: {
+  _translations: Translations | null;
+  translationRequired: boolean;
+  loadTranslationsType: string;
+}) {
+  return (
+    _translations ??
+    (translationRequired && loadTranslationsType !== 'disabled' ? null : {})
+  );
+}
 
 export function useLoadTranslations({
   _translations,
@@ -32,26 +47,22 @@ export function useLoadTranslations({
    * Cache Fail (for hash)    -> translations[hash] = undefined
    */
 
-  /**
-   * Initialize translations
-   */
-  function initializeTranslations() {
-    if (_translations) {
-      return _translations;
-    } else if (translationRequired && loadTranslationsType !== 'disabled') {
-      return null;
-    } else {
-      // No need to load translations ever
-      return {};
-    }
-  }
+  const nextTranslations = useMemo(
+    () =>
+      getTranslationsState({
+        _translations,
+        translationRequired,
+        loadTranslationsType,
+      }),
+    [_translations, translationRequired, loadTranslationsType]
+  );
 
   const [translations, setTranslations] = useState<Translations | null>(
-    initializeTranslations()
+    nextTranslations
   );
 
   /**
-   * Reset translations if locale changes (null to trigger a new cache fetch)
+   * Sync server-provided translations and reset if locale changes.
    * Should never run on mount
    *
    * TODO: its possible that this adds an unnecessary re-render, perhaps the request could be embeded directly in this useEffect instead?
@@ -64,10 +75,8 @@ export function useLoadTranslations({
       return;
     }
 
-    setTranslations(
-      translationRequired && loadTranslationsType !== 'disabled' ? null : {}
-    );
-  }, [locale, loadTranslationsType]);
+    setTranslations(nextTranslations);
+  }, [locale, nextTranslations]);
 
   /**
    * Update translations
@@ -82,10 +91,10 @@ export function useLoadTranslations({
       return;
     }
 
-    // Fetch translations
     let storeResults = true;
     (async () => {
       let result;
+      // Fetch translations
       switch (loadTranslationsType) {
         case 'custom':
           // check is redundant, but makes ts happy

--- a/packages/react-core/src/types-dir/config.ts
+++ b/packages/react-core/src/types-dir/config.ts
@@ -50,6 +50,7 @@ export type InternalGTProviderProps = {
   projectId?: string;
   devApiKey?: string;
   dictionary?: Dictionary;
+  dictionaryTranslations?: Dictionary;
   locales?: string[];
   defaultLocale?: string;
   locale?: string;
@@ -63,7 +64,10 @@ export type InternalGTProviderProps = {
   _versionId?: string;
   ssr?: boolean;
   localeCookieName?: string;
+  regionCookieName?: string;
   translations?: Translations | null;
+  translationRequired?: boolean;
+  dialectTranslationRequired?: boolean;
   loadDictionary?: CustomLoader;
   loadTranslations?: CustomLoader;
   config?: GTConfig;
@@ -71,6 +75,7 @@ export type InternalGTProviderProps = {
   customMapping?: CustomMapping;
   modelProvider?: string;
   environment: 'development' | 'production' | 'test';
+  developmentApiEnabled?: boolean;
   /* flag to enable i18n, true by default */
   enableI18n?: boolean;
   /** Flag to indicate if the enableI18n flag is finished loading asynchronously */
@@ -82,5 +87,6 @@ export type InternalGTProviderProps = {
   useRegionState: (params: UseRegionStateParams) => UseRegionStateReturn;
   useEnableI18n?: (params: UseEnableI18nParams) => UseEnableI18nReturn;
   reloadOnLocaleUpdate?: boolean;
+  onLocaleUpdate?: (locale: string) => void;
   [key: string]: unknown;
 };

--- a/packages/react/src/react-context/provider/ClientProvider.tsx
+++ b/packages/react/src/react-context/provider/ClientProvider.tsx
@@ -1,255 +1,33 @@
 'use client';
 
-import { Suspense, useEffect, useMemo, useRef, useState } from 'react';
+import { GTProvider as CoreGTProvider } from '@generaltranslation/react-core';
 import type { JSX } from 'react';
-import { determineLocale } from '@generaltranslation/format';
-import { GT } from 'generaltranslation';
-import {
-  defaultLocaleCookieName,
-  defaultRegionCookieName,
-} from '@generaltranslation/react-core/internal';
-import {
-  GTContext,
-  useRuntimeTranslation,
-  useCreateInternalUseGTFunction,
-  useCreateInternalUseTranslationsFunction,
-  useCreateInternalUseTranslationsObjFunction,
-} from '@generaltranslation/react-core';
-import type {
-  Dictionary,
-  Translations,
-} from '@generaltranslation/react-core/types';
 import type { ClientProviderProps } from '../types/config';
-import { getCookieValue, setCookieValue } from '../../shared/cookies';
+import { setCookieValue } from '../../shared/cookies';
+import { readAuthFromEnv } from '../utils/readAuthFromEnv';
+import { useDetermineLocale } from './hooks/locales/useDetermineLocale';
+import { useRegionState } from './hooks/useRegionState';
 
 // meant to be used inside the server-side <GTProvider>
 export function ClientProvider({
-  children,
-  dictionary: _dictionary,
-  dictionaryTranslations: _dictionaryTranslations,
-  translations: _translations,
-  locale: _locale,
-  region: _region,
-  _versionId,
-  defaultLocale,
-  translationRequired,
-  dialectTranslationRequired,
-  locales = [],
-  renderSettings,
-  projectId,
-  devApiKey,
-  runtimeUrl,
-  developmentApiEnabled,
-  resetLocaleCookieName,
-  localeCookieName = defaultLocaleCookieName,
-  regionCookieName = defaultRegionCookieName,
-  customMapping,
   environment,
+  resetLocaleCookieName,
   reloadServer,
+  ...props
 }: ClientProviderProps): JSX.Element {
-  const didMount = useRef(false);
-  // ----- TRANSLATIONS STATE ----- //
-
-  const [translations, setTranslations] = useState<Translations | null>(
-    _translations // likely to induce hydration error
-  );
-
-  // Update the translations object when _translations changes
-  useEffect(() => {
-    // Skip on mount to avoid an extra set state after first render
-    if (!didMount.current) return;
-    // Translations must override to avoid situation where we maintain stale dev translations from other languages
-    // for example { abc123: '你好!', def456: 'bonjour' }
-    setTranslations(_translations);
-  }, [_translations]);
-
-  // ----- LOCALE STATE ----- //
-
-  // Maintain the locale state
-  const [locale, _setLocale] = useState<string>(
-    _locale ? determineLocale(_locale, locales, customMapping) || '' : ''
-  );
-
-  // Check for an invalid cookie and update it
-  useEffect(() => {
-    let cookieLocale = getCookieValue(localeCookieName);
-    if (cookieLocale) {
-      cookieLocale = gt.resolveAliasLocale(cookieLocale);
-    }
-    if (locale && cookieLocale && cookieLocale !== locale) {
-      setCookieValue(localeCookieName, '');
-    }
-  }, [locale, localeCookieName]);
-
-  // ----- DICTIONARY TRANSLATIONS STATE ----- //
-
-  const [dictionaryTranslations, setDictionaryTranslations] =
-    useState<Dictionary>(_dictionaryTranslations || {});
-  const [dictionary, setDictionary] = useState<Dictionary>(_dictionary || {});
-
-  // Update the dictionary translations when locale changes (see useEffect for translations above)
-  useEffect(() => {
-    if (!didMount.current) return;
-    setDictionaryTranslations(_dictionaryTranslations);
-    setDictionary(_dictionary);
-  }, [_dictionaryTranslations, _dictionary]);
-
-  // ----- REGION STATE ----- //
-
-  // Set region state
-  const [region, _setRegion] = useState(_region);
-
-  // Set the region via cookies. No page reload needed.
-  const setRegion = (newRegion: string | undefined) => {
-    // persist region
-    setCookieValue(regionCookieName, newRegion || '');
-    // set region
-    _setRegion(newRegion);
-  };
-
-  // Check for an invalid cookie and update it
-  useEffect(() => {
-    const cookieRegion = getCookieValue(regionCookieName);
-    if (region && cookieRegion && cookieRegion !== region) {
-      setCookieValue(regionCookieName, '');
-    }
-  }, [region, regionCookieName]);
-
-  // ----- GT SETUP ----- //
-
-  // Define the GT instance
-  // Used for custom mapping and as a driver for the runtime translation
-  const gt = useMemo(
-    () =>
-      new GT({
-        devApiKey,
-        sourceLocale: defaultLocale,
-        targetLocale: locale,
-        projectId,
-        baseUrl: runtimeUrl || undefined,
-        customMapping,
-      }),
-    [devApiKey, defaultLocale, locale, projectId, runtimeUrl, customMapping]
-  );
-
-  // Set the locale via cookies and refresh the page to reload server-side. Make sure the language is supported.
-  const setLocale = (newLocale: string) => {
-    // validate locale
-    newLocale =
-      determineLocale(newLocale, locales, customMapping) ||
-      locale ||
-      defaultLocale;
-    newLocale = gt.resolveAliasLocale(newLocale);
-    // persist locale
-    setCookieValue(localeCookieName, newLocale);
-    setCookieValue(resetLocaleCookieName, 'true');
-    // set locale
-    _setLocale(newLocale);
-    // re-render server components
-    reloadServer();
-  };
-
-  // ---------- TRANSLATION METHODS ---------- //
-
-  const { registerIcuForTranslation, registerJsxForTranslation } =
-    useRuntimeTranslation({
-      gt,
-      locale: locale,
-      versionId: _versionId,
-      runtimeUrl,
-      setTranslations,
-      defaultLocale,
-      renderSettings,
-      developmentApiEnabled,
-      environment,
-    });
-
-  // ---------- USE GT() TRANSLATION ---------- //
-
-  const {
-    _gtFunction,
-    _mFunction,
-    _filterMessagesForPreload,
-    _preloadMessages,
-  } = useCreateInternalUseGTFunction({
-    gt,
-    translations,
-    locale,
-    defaultLocale,
-    translationRequired,
-    developmentApiEnabled,
-    registerIcuForTranslation,
-    environment,
-  });
-
-  // ---------- DICTIONARY FUNCTIONS ---------- //
-
-  const _dictionaryFunction = useCreateInternalUseTranslationsFunction(
-    gt,
-    dictionary,
-    dictionaryTranslations,
-    translations,
-    locale,
-    defaultLocale,
-    translationRequired,
-    dialectTranslationRequired,
-    developmentApiEnabled,
-    registerIcuForTranslation,
-    environment
-  );
-
-  const _dictionaryObjFunction = useCreateInternalUseTranslationsObjFunction(
-    dictionary,
-    dictionaryTranslations,
-    setDictionary,
-    setDictionaryTranslations,
-    translations,
-    locale,
-    defaultLocale,
-    translationRequired,
-    dialectTranslationRequired,
-    developmentApiEnabled,
-    registerIcuForTranslation,
-    _dictionaryFunction
-  );
-
-  // ---------- RENDER LOGIC ---------- //
-
-  // Block rendering until all translations are resolved (IF YOU REMOVE THIS YOU WILL BE FIRED)
-  const display = !!(!translationRequired || translations) && locale;
-
-  // Update didMount ref
-  useEffect(() => {
-    didMount.current = true;
-  }, []);
-
   return (
-    <GTContext.Provider
-      value={{
-        gt,
-        registerIcuForTranslation,
-        registerJsxForTranslation,
-        setLocale,
-        _gtFunction,
-        _mFunction,
-        _filterMessagesForPreload,
-        _preloadMessages,
-        _dictionaryFunction,
-        _dictionaryObjFunction,
-        locale,
-        locales,
-        defaultLocale,
-        region,
-        setRegion,
-        translations,
-        translationRequired,
-        dialectTranslationRequired,
-        renderSettings,
-        developmentApiEnabled,
-        _versionId,
+    <CoreGTProvider
+      {...props}
+      ssr={true}
+      environment={environment}
+      cacheUrl={null}
+      readAuthFromEnv={readAuthFromEnv}
+      useDetermineLocale={useDetermineLocale}
+      useRegionState={useRegionState}
+      onLocaleUpdate={() => {
+        setCookieValue(resetLocaleCookieName, 'true');
+        reloadServer();
       }}
-    >
-      <Suspense fallback={display && children}>{display && children}</Suspense>
-    </GTContext.Provider>
+    />
   );
 }

--- a/packages/react/src/react-context/provider/ClientProvider.tsx
+++ b/packages/react/src/react-context/provider/ClientProvider.tsx
@@ -15,12 +15,18 @@ export function ClientProvider({
   reloadServer,
   ...props
 }: ClientProviderProps): JSX.Element {
+  const display = !!(
+    (!props.translationRequired || props.translations) &&
+    props.locale
+  );
+
   return (
     <CoreGTProvider
       {...props}
       ssr={true}
       environment={environment}
       cacheUrl={null}
+      fallback={display ? props.children : undefined}
       readAuthFromEnv={readAuthFromEnv}
       useDetermineLocale={useDetermineLocale}
       useRegionState={useRegionState}

--- a/packages/react/src/react-context/provider/__tests__/ClientProvider.test.ts
+++ b/packages/react/src/react-context/provider/__tests__/ClientProvider.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createElement } from 'react';
+import { renderToString } from 'react-dom/server';
+import type { ReactElement } from 'react';
+import type { InternalGTProviderProps } from '@generaltranslation/react-core/types';
+import { ClientProvider } from '../ClientProvider';
+import { useRegionState } from '../hooks/useRegionState';
+import type { ClientProviderProps } from '../../types/config';
+
+function getClientProviderProps(
+  overrides: Partial<ClientProviderProps> = {}
+): ClientProviderProps {
+  return {
+    children: 'Hello',
+    dictionary: {},
+    dictionaryTranslations: {},
+    translations: {},
+    locale: 'en',
+    locales: ['en', 'fr'],
+    defaultLocale: 'en',
+    translationRequired: false,
+    dialectTranslationRequired: false,
+    renderSettings: {
+      method: 'default',
+    },
+    developmentApiEnabled: false,
+    environment: 'test',
+    resetLocaleCookieName: 'gt-reset-locale',
+    reloadServer: vi.fn(),
+    ...overrides,
+  };
+}
+
+function RegionStateProbe({ region: _region }: { region: string }) {
+  const { region } = useRegionState({
+    _region,
+    ssr: true,
+    regionCookieName: 'gt-region',
+  });
+  return createElement('span', null, region ?? 'missing');
+}
+
+describe('ClientProvider', () => {
+  it('passes the wrapper ssr override to react-core', () => {
+    const element = ClientProvider(
+      getClientProviderProps()
+    ) as ReactElement<InternalGTProviderProps>;
+
+    expect(element.props.ssr).toBe(true);
+  });
+
+  it('passes server-provided translation requirement state to react-core', () => {
+    const element = ClientProvider(
+      getClientProviderProps({
+        locale: 'fr',
+        translationRequired: false,
+        dialectTranslationRequired: false,
+      })
+    ) as ReactElement<InternalGTProviderProps>;
+
+    expect(element.props.translationRequired).toBe(false);
+    expect(element.props.dialectTranslationRequired).toBe(false);
+  });
+
+  it('seeds the region from the server prop on first render', () => {
+    expect(
+      renderToString(createElement(RegionStateProbe, { region: 'CA' }))
+    ).toBe('<span>CA</span>');
+  });
+});

--- a/packages/react/src/react-context/provider/__tests__/ClientProvider.test.ts
+++ b/packages/react/src/react-context/provider/__tests__/ClientProvider.test.ts
@@ -62,6 +62,43 @@ describe('ClientProvider', () => {
     expect(element.props.dialectTranslationRequired).toBe(false);
   });
 
+  it('uses the current children as the suspense fallback after server data has loaded', () => {
+    const element = ClientProvider(
+      getClientProviderProps({
+        children: 'Current content',
+        locale: 'fr',
+        translationRequired: true,
+        translations: {
+          hello: 'Bonjour',
+        },
+      })
+    ) as ReactElement<InternalGTProviderProps>;
+
+    expect(element.props.fallback).toBe('Current content');
+  });
+
+  it('keeps the suspense fallback empty while waiting for initial server data', () => {
+    const element = ClientProvider(
+      getClientProviderProps({
+        locale: '',
+      })
+    ) as ReactElement<InternalGTProviderProps>;
+
+    expect(element.props.fallback).toBeUndefined();
+  });
+
+  it('keeps the suspense fallback empty while required translations are loading', () => {
+    const element = ClientProvider(
+      getClientProviderProps({
+        locale: 'fr',
+        translationRequired: true,
+        translations: null,
+      })
+    ) as ReactElement<InternalGTProviderProps>;
+
+    expect(element.props.fallback).toBeUndefined();
+  });
+
   it('seeds the region from the server prop on first render', () => {
     expect(
       renderToString(createElement(RegionStateProbe, { region: 'CA' }))

--- a/packages/react/src/react-context/provider/hooks/locales/__tests__/useDetermineLocale.test.ts
+++ b/packages/react/src/react-context/provider/hooks/locales/__tests__/useDetermineLocale.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { clearMismatchedLocaleCookie } from '../useDetermineLocale';
+
+describe('clearMismatchedLocaleCookie', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('clears a locale cookie that disagrees with the resolved locale', () => {
+    let cookie = 'gt-locale=fr; other=value';
+    vi.stubGlobal('document', {
+      get cookie() {
+        return cookie;
+      },
+      set cookie(value: string) {
+        cookie = value;
+      },
+    });
+
+    clearMismatchedLocaleCookie({
+      locale: 'en',
+      localeCookieName: 'gt-locale',
+    });
+
+    expect(cookie).toBe('gt-locale=;path=/');
+  });
+
+  it('preserves a locale cookie that matches by custom alias', () => {
+    let cookie = 'gt-locale=brand-french';
+    vi.stubGlobal('document', {
+      get cookie() {
+        return cookie;
+      },
+      set cookie(value: string) {
+        cookie = value;
+      },
+    });
+
+    clearMismatchedLocaleCookie({
+      locale: 'fr',
+      localeCookieName: 'gt-locale',
+      customMapping: {
+        'brand-french': {
+          code: 'fr',
+          name: 'Brand French',
+        },
+      },
+    });
+
+    expect(cookie).toBe('gt-locale=brand-french');
+  });
+});

--- a/packages/react/src/react-context/provider/hooks/locales/useDetermineLocale.ts
+++ b/packages/react/src/react-context/provider/hooks/locales/useDetermineLocale.ts
@@ -26,6 +26,7 @@ export function useDetermineLocale({
   enableI18n,
   // for syncing server locale with client locale
   reloadOnLocaleUpdate = false,
+  onLocaleUpdate,
 }: UseDetermineLocaleParams): UseDetermineLocaleReturn {
   // resolve alias locale
   const _locale = useMemo(
@@ -152,9 +153,10 @@ export function useDetermineLocale({
   // update locale and store it in cookie
   const setLocale = (newLocale: string): void => {
     if (!enableI18n) return;
-    newLocale = resolveAliasLocale(newLocale);
+    newLocale = resolveAliasLocale(newLocale, customMapping);
     const validatedLocale = setLocaleWithoutSettingCookie(newLocale);
     setCookieValue(localeCookieName, validatedLocale);
+    onLocaleUpdate?.(validatedLocale);
 
     if (
       typeof window !== 'undefined' &&

--- a/packages/react/src/react-context/provider/hooks/locales/useDetermineLocale.ts
+++ b/packages/react/src/react-context/provider/hooks/locales/useDetermineLocale.ts
@@ -14,6 +14,25 @@ import type {
 import { PACKAGE_NAME } from '../../../../shared/messages';
 import { getCookieValue, setCookieValue } from '../../../../shared/cookies';
 
+export function clearMismatchedLocaleCookie({
+  locale,
+  localeCookieName,
+  customMapping,
+}: {
+  locale: string;
+  localeCookieName: string;
+  customMapping?: CustomMapping;
+}) {
+  let cookieLocale = getCookieValue(localeCookieName);
+  if (cookieLocale) {
+    cookieLocale = resolveAliasLocale(cookieLocale, customMapping);
+  }
+  const resolvedLocale = resolveAliasLocale(locale, customMapping);
+  if (resolvedLocale && cookieLocale && cookieLocale !== resolvedLocale) {
+    setCookieValue(localeCookieName, '');
+  }
+}
+
 export function useDetermineLocale({
   locale: initialLocale = '',
   defaultLocale = libraryDefaultLocale,
@@ -173,6 +192,15 @@ export function useDetermineLocale({
   useEffect(() => {
     setLocaleWithoutSettingCookie(getNewLocale(locale));
   }, [locale, setLocaleWithoutSettingCookie, getNewLocale]);
+
+  // Clear stale locale cookies that disagree with the server-provided locale.
+  useEffect(() => {
+    clearMismatchedLocaleCookie({
+      locale,
+      localeCookieName,
+      customMapping,
+    });
+  }, [locale, localeCookieName, customMapping]);
 
   return [locale, setLocale];
 }

--- a/packages/react/src/react-context/provider/hooks/useRegionState.ts
+++ b/packages/react/src/react-context/provider/hooks/useRegionState.ts
@@ -23,7 +23,7 @@ export function useRegionState({
   regionCookieName: string;
 }) {
   const [region, _setRegion] = useState<string | undefined>(
-    ssr ? undefined : getNewRegion(_region, regionCookieName)
+    ssr && !_region ? undefined : getNewRegion(_region, regionCookieName)
   );
   const setRegion = (region: string | undefined) => {
     _setRegion(region);

--- a/packages/react/src/react-context/types/config.ts
+++ b/packages/react/src/react-context/types/config.ts
@@ -16,7 +16,7 @@ export type ClientProviderProps = {
   children: ReactNode;
   dictionary: Dictionary;
   dictionaryTranslations: Dictionary;
-  translations: Translations;
+  translations: Translations | null;
   locale: string;
   locales: string[];
   region?: string; // should be made mandatory if we ever make region a server-side variable


### PR DESCRIPTION
## Summary
- delegate `gt-react` client provider behavior to `@generaltranslation/react-core`
- add internal provider override props for server-provided translation, dictionary, locale, region, and dev API state
- add focused tests for translation requirement overrides, translation state initialization, and client provider delegation

## Verification
- `pnpm --filter @generaltranslation/react-core test -- packages/react-core/src/provider/__tests__/GTProvider.test.ts packages/react-core/src/provider/hooks/__tests__/useLoadTranslations.test.ts`
- `pnpm --filter gt-react test -- packages/react/src/react-context/provider/__tests__/ClientProvider.test.ts`
- `pnpm --filter @generaltranslation/react-core typecheck`
- `pnpm --filter gt-react typecheck`
- `pnpm --filter @generaltranslation/react-core build`
- `pnpm --filter gt-react build`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1438"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors `ClientProvider` in `gt-react` from a 255-line standalone implementation to a thin 39-line wrapper that delegates to `CoreGTProvider` from `@generaltranslation/react-core`. Server-computed state (translations, locale, region, dictionary, `developmentApiEnabled`, `translationRequired`) is now threaded through as override props rather than being managed independently on the client.

- `getTranslationRequirements` and `getTranslationsState` are extracted as testable pure functions, and the GT instance `useMemo` gains `locale` in its dependency array (fixing a stale `targetLocale` bug in `react-core`).
- `clearMismatchedLocaleCookie` is extracted from the old `ClientProvider` into `useDetermineLocale`, and both sides of the cookie comparison are now alias-resolved before comparison (fixing a latent bug where a valid alias cookie could be incorrectly cleared).
- `useRegionState` is updated to seed the initial region from the server prop even in SSR mode, avoiding a hydration gap when `_region` is explicitly provided.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the delegation to CoreGTProvider is mechanically equivalent to the removed ClientProvider code, and the two incidental bug fixes are verified by new tests.

The locale-change flow, translation state initialisation, and dictionary sync all behave the same as before. The only behavioral delta (children render with empty translations instead of nothing when the server passes null translations with loading disabled) is intentional. No data integrity, auth, or runtime-crash risk was found.

No files require special attention — the deleted ClientProvider logic is fully reproduced by CoreGTProvider given the new override props.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/react/src/react-context/provider/ClientProvider.tsx | Replaced 255-line standalone implementation with a 39-line CoreGTProvider delegation; display/fallback logic and locale-update callbacks correctly reproduced. |
| packages/react-core/src/provider/GTProvider.tsx | Added override props (translationRequired, dialectTranslationRequired, dictionaryTranslations, onLocaleUpdate, developmentApiEnabled, regionCookieName) and fixed missing locale dep in the GT useMemo. |
| packages/react-core/src/provider/hooks/useLoadTranslations.ts | Extracted getTranslationsState; sync effect now includes _translations in deps to pick up server-pushed translation updates, but unstable object references will fire it on every render (previously flagged). |
| packages/react-core/src/provider/hooks/useLoadDictionary.ts | Added a post-mount sync effect to propagate server-pushed dictionary/dictionaryTranslations updates; existing async loader path is unaffected. |
| packages/react/src/react-context/provider/hooks/locales/useDetermineLocale.ts | Extracted clearMismatchedLocaleCookie (now resolves both sides before comparison — bug fix) and added onLocaleUpdate callback support to setLocale. |
| packages/react/src/react-context/provider/hooks/useRegionState.ts | Changed initial region state to use server-provided _region even in SSR mode, fixing a hydration gap. |
| packages/react/src/react-context/provider/__tests__/ClientProvider.test.ts | Tests correctly verify prop forwarding and fallback logic; one test name is misleading about loading state. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Server as Server GTProvider
    participant CP as ClientProvider (gt-react)
    participant Core as CoreGTProvider (react-core)
    participant LS as useLocaleState / useDetermineLocale
    participant LT as useLoadTranslations
    participant LD as useLoadDictionary

    Server->>CP: props (locale, translations, translationRequired, dictionaryTranslations, developmentApiEnabled)
    CP->>CP: compute display
    CP->>Core: "{...props, ssr=true, cacheUrl=null, fallback, onLocaleUpdate, useDetermineLocale, useRegionState}"
    Core->>LS: _locale, translationRequiredOverride, onLocaleUpdate
    LS->>LS: getTranslationRequirements(override, locale-derived)
    LS-->>Core: translationRequired, dialectTranslationRequired
    Core->>LT: "_translations, translationRequired, loadTranslationsType=disabled"
    LT->>LT: getTranslationsState
    LT-->>Core: translations state
    Core->>LD: _dictionary, _dictionaryTranslations
    LD-->>Core: dictionary, dictionaryTranslations
    Core->>Core: render children or fallback
    Note over CP,Core: Locale change flow
    Core->>LS: setLocale(newLocale)
    LS->>LS: setCookieValue(localeCookieName)
    LS->>CP: onLocaleUpdate(validatedLocale)
    CP->>CP: setCookieValue(resetLocaleCookieName)
    CP->>Server: reloadServer()
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/react-core/src/provider/hooks/useLoadTranslations.ts`, line 71-79 ([link](https://github.com/generaltranslation/gt/blob/4a10925c2e8c6c8b23e1205480292980dc3d31e7/packages/react-core/src/provider/hooks/useLoadTranslations.ts#L71-L79)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> `nextTranslations` is returned by reference when `_translations` is non-null, so the sync effect fires on every render where the parent passes an unstable `_translations` reference (e.g. a new object created inline per render). Each fire calls `setTranslations` with a new reference, scheduling a React re-render even when the content is unchanged. The `ClientProvider` path is safe because `_translations` originates from a serialized server-component prop, but any direct `GTProvider` usage that passes `translations={{...}}` inline will accumulate superfluous re-renders. Using the primitive deps directly avoids the churn.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/react-core/src/provider/hooks/useLoadTranslations.ts
   Line: 71-79

   Comment:
   `nextTranslations` is returned by reference when `_translations` is non-null, so the sync effect fires on every render where the parent passes an unstable `_translations` reference (e.g. a new object created inline per render). Each fire calls `setTranslations` with a new reference, scheduling a React re-render even when the content is unchanged. The `ClientProvider` path is safe because `_translations` originates from a serialized server-component prop, but any direct `GTProvider` usage that passes `translations={{...}}` inline will accumulate superfluous re-renders. Using the primitive deps directly avoids the churn.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Freact-core%2Fsrc%2Fprovider%2Fhooks%2FuseLoadTranslations.ts%0ALine%3A%2071-79%0A%0AComment%3A%0A%60nextTranslations%60%20is%20returned%20by%20reference%20when%20%60_translations%60%20is%20non-null%2C%20so%20the%20sync%20effect%20fires%20on%20every%20render%20where%20the%20parent%20passes%20an%20unstable%20%60_translations%60%20reference%20%28e.g.%20a%20new%20object%20created%20inline%20per%20render%29.%20Each%20fire%20calls%20%60setTranslations%60%20with%20a%20new%20reference%2C%20scheduling%20a%20React%20re-render%20even%20when%20the%20content%20is%20unchanged.%20The%20%60ClientProvider%60%20path%20is%20safe%20because%20%60_translations%60%20originates%20from%20a%20serialized%20server-component%20prop%2C%20but%20any%20direct%20%60GTProvider%60%20usage%20that%20passes%20%60translations%3D%7B%7B...%7D%7D%60%20inline%20will%20accumulate%20superfluous%20re-renders.%20Using%20the%20primitive%20deps%20directly%20avoids%20the%20churn.%0A%0A%60%60%60suggestion%0A%20%20useEffect%28%28%29%20%3D%3E%20%7B%0A%20%20%20%20%2F%2F%20Reset%20should%20never%20run%20on%20mount%0A%20%20%20%20if%20%28!didMount.current%29%20%7B%0A%20%20%20%20%20%20didMount.current%20%3D%20true%3B%0A%20%20%20%20%20%20return%3B%0A%20%20%20%20%7D%0A%0A%20%20%20%20setTranslations%28nextTranslations%29%3B%0A%20%20%2F%2F%20eslint-disable-next-line%20react-hooks%2Fexhaustive-deps%0A%20%20%7D%2C%20%5Blocale%2C%20_translations%2C%20translationRequired%2C%20loadTranslationsType%5D%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=generaltranslation%2Fgt&pr=1438&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22bg%2Frefactor-client-provider-core%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22bg%2Frefactor-client-provider-core%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Freact-core%2Fsrc%2Fprovider%2Fhooks%2FuseLoadTranslations.ts%0ALine%3A%2071-79%0A%0AComment%3A%0A%60nextTranslations%60%20is%20returned%20by%20reference%20when%20%60_translations%60%20is%20non-null%2C%20so%20the%20sync%20effect%20fires%20on%20every%20render%20where%20the%20parent%20passes%20an%20unstable%20%60_translations%60%20reference%20%28e.g.%20a%20new%20object%20created%20inline%20per%20render%29.%20Each%20fire%20calls%20%60setTranslations%60%20with%20a%20new%20reference%2C%20scheduling%20a%20React%20re-render%20even%20when%20the%20content%20is%20unchanged.%20The%20%60ClientProvider%60%20path%20is%20safe%20because%20%60_translations%60%20originates%20from%20a%20serialized%20server-component%20prop%2C%20but%20any%20direct%20%60GTProvider%60%20usage%20that%20passes%20%60translations%3D%7B%7B...%7D%7D%60%20inline%20will%20accumulate%20superfluous%20re-renders.%20Using%20the%20primitive%20deps%20directly%20avoids%20the%20churn.%0A%0A%60%60%60suggestion%0A%20%20useEffect%28%28%29%20%3D%3E%20%7B%0A%20%20%20%20%2F%2F%20Reset%20should%20never%20run%20on%20mount%0A%20%20%20%20if%20%28!didMount.current%29%20%7B%0A%20%20%20%20%20%20didMount.current%20%3D%20true%3B%0A%20%20%20%20%20%20return%3B%0A%20%20%20%20%7D%0A%0A%20%20%20%20setTranslations%28nextTranslations%29%3B%0A%20%20%2F%2F%20eslint-disable-next-line%20react-hooks%2Fexhaustive-deps%0A%20%20%7D%2C%20%5Blocale%2C%20_translations%2C%20translationRequired%2C%20loadTranslationsType%5D%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Freact%2Fsrc%2Freact-context%2Fprovider%2F__tests__%2FClientProvider.test.ts%3A90%0AMisleading%20test%20description%20%E2%80%94%20with%20%60cacheUrl%3D%7Bnull%7D%60%20%28hardcoded%20in%20%60ClientProvider%60%29%20%60loadTranslationsType%60%20is%20always%20%60'disabled'%60%2C%20so%20%60getTranslationsState%60%20returns%20%60%7B%7D%60%20and%20%60CoreGTProvider%60's%20internal%20%60display%60%20evaluates%20to%20%60true%60%2C%20meaning%20children%20will%20actually%20render%20%28with%20empty%20translations%29.%20The%20fallback%20is%20indeed%20%60undefined%60%2C%20but%20the%20scenario%20is%20not%20a%20loading%20one%20%E2%80%94%20no%20fetch%20is%20pending.%20A%20name%20like%20%60'sets%20no%20suspense%20fallback%20when%20locale%20is%20present%20but%20server%20has%20not%20yet%20provided%20translations'%60%20more%20accurately%20describes%20the%20case.%0A%0A%60%60%60suggestion%0A%20%20it%28'sets%20no%20suspense%20fallback%20when%20locale%20is%20present%20but%20server%20has%20not%20yet%20provided%20translations'%2C%20%28%29%20%3D%3E%20%7B%0A%60%60%60%0A%0A&repo=generaltranslation%2Fgt&pr=1438&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22bg%2Frefactor-client-provider-core%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22bg%2Frefactor-client-provider-core%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Freact%2Fsrc%2Freact-context%2Fprovider%2F__tests__%2FClientProvider.test.ts%3A90%0AMisleading%20test%20description%20%E2%80%94%20with%20%60cacheUrl%3D%7Bnull%7D%60%20%28hardcoded%20in%20%60ClientProvider%60%29%20%60loadTranslationsType%60%20is%20always%20%60'disabled'%60%2C%20so%20%60getTranslationsState%60%20returns%20%60%7B%7D%60%20and%20%60CoreGTProvider%60's%20internal%20%60display%60%20evaluates%20to%20%60true%60%2C%20meaning%20children%20will%20actually%20render%20%28with%20empty%20translations%29.%20The%20fallback%20is%20indeed%20%60undefined%60%2C%20but%20the%20scenario%20is%20not%20a%20loading%20one%20%E2%80%94%20no%20fetch%20is%20pending.%20A%20name%20like%20%60'sets%20no%20suspense%20fallback%20when%20locale%20is%20present%20but%20server%20has%20not%20yet%20provided%20translations'%60%20more%20accurately%20describes%20the%20case.%0A%0A%60%60%60suggestion%0A%20%20it%28'sets%20no%20suspense%20fallback%20when%20locale%20is%20present%20but%20server%20has%20not%20yet%20provided%20translations'%2C%20%28%29%20%3D%3E%20%7B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/react/src/react-context/provider/__tests__/ClientProvider.test.ts:90
Misleading test description — with `cacheUrl={null}` (hardcoded in `ClientProvider`) `loadTranslationsType` is always `'disabled'`, so `getTranslationsState` returns `{}` and `CoreGTProvider`'s internal `display` evaluates to `true`, meaning children will actually render (with empty translations). The fallback is indeed `undefined`, but the scenario is not a loading one — no fetch is pending. A name like `'sets no suspense fallback when locale is present but server has not yet provided translations'` more accurately describes the case.

```suggestion
  it('sets no suspense fallback when locale is present but server has not yet provided translations', () => {
```


`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: preserve client provider locale sta..."](https://github.com/generaltranslation/gt/commit/d8735964d055776e243a71212de81570e2747260) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32946178)</sub>

<!-- /greptile_comment -->