### PR TITLE
fix: improve ink prompt compact layout

### DIFF
--- a/packages/cli/src/console/__tests__/inkUtils.test.ts
+++ b/packages/cli/src/console/__tests__/inkUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { truncate } from '../inkUtils.js';
+import { getContentWidth, limitLines, truncate } from '../inkUtils.js';
 
 describe('ink utils', () => {
   it('truncates without exceeding the requested width', () => {
@@ -7,5 +7,14 @@ describe('ink utils', () => {
     expect(truncate('abcdef', 5)).toBe('ab...');
     expect(truncate('abcdef', 3)).toBe('...');
     expect(truncate('abcdef', 1)).toBe('a');
+  });
+
+  it('keeps content width inside very narrow terminals', () => {
+    expect(getContentWidth(12)).toBe(12);
+    expect(getContentWidth(80)).toBe(76);
+  });
+
+  it('limits wrapped message lines with an ellipsis', () => {
+    expect(limitLines(['one', 'two', 'three'], 2, 5)).toEqual(['one', 'tw...']);
   });
 });

--- a/packages/cli/src/console/inkFields.tsx
+++ b/packages/cli/src/console/inkFields.tsx
@@ -105,6 +105,17 @@ function LocaleRow({
   const sameName = option.name === option.nativeName;
   const codeStr = option.code.padEnd(codeWidth);
   const reserved = 2 + codeWidth + 2;
+  if (width < reserved) {
+    const compactText = truncate(`${marker} ${option.code}`, width);
+    return active ? (
+      <Text color={INK_ACCENT_COLOR} bold>
+        {compactText}
+      </Text>
+    ) : (
+      <Text>{compactText}</Text>
+    );
+  }
+
   const remainingForName = Math.max(1, width - reserved);
   const nameMax = sameName
     ? remainingForName

--- a/packages/cli/src/console/inkLayout.tsx
+++ b/packages/cli/src/console/inkLayout.tsx
@@ -109,7 +109,6 @@ function ultraCompactFooter(footer: string) {
     .replace('enter done', 'done')
     .replace('enter choose', 'choose')
     .replace('enter save', 'save')
-    .replace('enter confirm', 'done')
     .replace('type to edit', 'type')
     .replace('y/n select', 'y/n')
     .replace('←→ choose', '←→');
@@ -145,9 +144,10 @@ export function InputBox({
   }
 
   const placeholderText = truncate(placeholder ?? '', innerWidth);
+  const cursorWidth = placeholderText ? 0 : 1;
   const padding = Math.max(
     0,
-    width - prefix.length - placeholderText.length
+    width - prefix.length - placeholderText.length - cursorWidth
   );
 
   return (

--- a/packages/cli/src/console/inkLayout.tsx
+++ b/packages/cli/src/console/inkLayout.tsx
@@ -5,6 +5,7 @@ import { INK_ACCENT_COLOR } from './inkTheme.js';
 import type { PromptFrameProps } from './inkTypes.js';
 import {
   getContentWidth,
+  limitLines,
   normalizedMessage,
   truncate,
   wrapText,
@@ -13,7 +14,8 @@ import {
 export function PromptFrame({ message, children, footer }: PromptFrameProps) {
   const { columns, rows } = useTerminalSize();
   const width = getContentWidth(columns);
-  const topPadding = Math.max(1, Math.min(5, Math.floor(rows * 0.1)));
+  const topPadding = rows >= 10 ? 1 : 0;
+  const showWizardTitle = rows >= 16;
   const showFeedback = columns >= 88;
   const footerText =
     columns < 50
@@ -21,16 +23,27 @@ export function PromptFrame({ message, children, footer }: PromptFrameProps) {
       : columns < 72
         ? compactFooter(footer)
         : footer;
-  const messageLines = wrapText(normalizedMessage(message), width);
-  const headerTitle = `  General Translation Wizard v${PACKAGE_VERSION}`;
+  const messageLineLimit = rows < 14 ? 1 : rows < 18 ? 2 : 4;
+  const messageLines = limitLines(
+    wrapText(normalizedMessage(message), width),
+    messageLineLimit,
+    width
+  );
+  const headerTitle =
+    columns < 44
+      ? `  GT Wizard v${PACKAGE_VERSION}`
+      : `  General Translation Wizard v${PACKAGE_VERSION}`;
   const headerFeedback = 'Feedback: support@generaltranslation.com  ';
   const headerGap = Math.max(
     1,
     columns - headerTitle.length - (showFeedback ? headerFeedback.length : 0)
   );
-  const headerText = `${headerTitle}${' '.repeat(headerGap)}${
-    showFeedback ? headerFeedback : ''
-  }`;
+  const headerText = truncate(
+    `${headerTitle}${' '.repeat(headerGap)}${
+      showFeedback ? headerFeedback : ''
+    }`,
+    columns
+  ).padEnd(columns, ' ');
   const footerLine = `  ${footerText}`.padEnd(columns, ' ');
 
   return (
@@ -48,17 +61,19 @@ export function PromptFrame({ message, children, footer }: PromptFrameProps) {
         flexShrink={1}
       >
         <Box width={width} flexDirection='column'>
-          <Box justifyContent='center'>
-            <Text bold color={INK_ACCENT_COLOR}>
-              GT Wizard
-            </Text>
-          </Box>
-          <Box flexDirection='column' marginTop={1}>
+          {showWizardTitle ? (
+            <Box justifyContent='center'>
+              <Text bold color={INK_ACCENT_COLOR}>
+                GT Wizard
+              </Text>
+            </Box>
+          ) : null}
+          <Box flexDirection='column' marginTop={showWizardTitle ? 1 : 0}>
             {messageLines.map((line, index) => (
               <Text key={`${index}-${line}`}>{line}</Text>
             ))}
           </Box>
-          <Box marginTop={2} flexDirection='column'>
+          <Box marginTop={1} flexDirection='column'>
             {children}
           </Box>
         </Box>
@@ -90,12 +105,12 @@ function ultraCompactFooter(footer: string) {
   return compactFooter(footer)
     .replace(/\s{2,}esc quit\s*$/, '')
     .replace('↑↓ move', '↑↓')
-    .replace('space toggle', 'spc')
-    .replace('enter done', 'enter')
-    .replace('enter choose', 'enter')
-    .replace('enter select', 'enter')
-    .replace('enter save', 'enter')
-    .replace('enter confirm', 'enter')
+    .replace('space toggle', 'space')
+    .replace('enter done', 'done')
+    .replace('enter choose', 'choose')
+    .replace('enter select', 'choose')
+    .replace('enter save', 'save')
+    .replace('enter confirm', 'done')
     .replace('type to edit', 'type')
     .replace('y/n select', 'y/n')
     .replace('←→ choose', '←→');
@@ -110,19 +125,19 @@ export function InputBox({
   width: number;
   placeholder?: string;
 }) {
-  const innerWidth = Math.max(1, width - 4);
+  const prefix = '> ';
+  const innerWidth = Math.max(1, width - prefix.length - 1);
   const hasValue = value.length > 0;
 
   if (hasValue) {
-    const visibleValue = truncate(value, Math.max(0, innerWidth - 1));
-    const padding = Math.max(0, innerWidth - visibleValue.length - 1);
+    const visibleValue = truncate(value, innerWidth);
+    const padding = Math.max(
+      0,
+      width - prefix.length - visibleValue.length - 1
+    );
     return (
-      <Box
-        width={width}
-        borderStyle='round'
-        borderColor={INK_ACCENT_COLOR}
-        paddingX={1}
-      >
+      <Box width={width}>
+        <Text color={INK_ACCENT_COLOR}>{prefix}</Text>
         <Text>{visibleValue}</Text>
         <Text inverse> </Text>
         <Text>{' '.repeat(padding)}</Text>
@@ -130,38 +145,24 @@ export function InputBox({
     );
   }
 
-  const placeholderText = truncate(
-    placeholder ?? '',
-    Math.max(0, innerWidth - 1)
+  const placeholderText = truncate(placeholder ?? '', innerWidth);
+  const padding = Math.max(
+    0,
+    width - prefix.length - placeholderText.length - 1
   );
 
-  if (!placeholderText) {
-    const padding = Math.max(0, innerWidth - 1);
-    return (
-      <Box
-        width={width}
-        borderStyle='round'
-        borderColor={INK_ACCENT_COLOR}
-        paddingX={1}
-      >
-        <Text inverse> </Text>
-        <Text>{' '.repeat(padding)}</Text>
-      </Box>
-    );
-  }
-
-  const padding = Math.max(0, innerWidth - placeholderText.length);
   return (
-    <Box
-      width={width}
-      borderStyle='round'
-      borderColor={INK_ACCENT_COLOR}
-      paddingX={1}
-    >
-      <Text inverse dimColor>
-        {placeholderText.slice(0, 1)}
-      </Text>
-      <Text dimColor>{placeholderText.slice(1)}</Text>
+    <Box width={width}>
+      <Text color={INK_ACCENT_COLOR}>{prefix}</Text>
+      {placeholderText ? (
+        <>
+          <Text inverse dimColor>
+            {placeholderText.slice(0, 1)}
+          </Text>
+          <Text dimColor>{placeholderText.slice(1)}</Text>
+        </>
+      ) : null}
+      <Text inverse>{placeholderText ? '' : ' '}</Text>
       <Text>{' '.repeat(padding)}</Text>
     </Box>
   );

--- a/packages/cli/src/console/inkLayout.tsx
+++ b/packages/cli/src/console/inkLayout.tsx
@@ -108,7 +108,6 @@ function ultraCompactFooter(footer: string) {
     .replace('space toggle', 'space')
     .replace('enter done', 'done')
     .replace('enter choose', 'choose')
-    .replace('enter select', 'choose')
     .replace('enter save', 'save')
     .replace('enter confirm', 'done')
     .replace('type to edit', 'type')
@@ -148,7 +147,7 @@ export function InputBox({
   const placeholderText = truncate(placeholder ?? '', innerWidth);
   const padding = Math.max(
     0,
-    width - prefix.length - placeholderText.length - 1
+    width - prefix.length - placeholderText.length
   );
 
   return (

--- a/packages/cli/src/console/inkPrompts.tsx
+++ b/packages/cli/src/console/inkPrompts.tsx
@@ -114,7 +114,8 @@ function LocalePrompt({
   const [error, setError] = useState<string | undefined>();
   const filteredOptions = getFilteredLocaleOptions(query);
   const activeIndex = getSafeIndex(index, filteredOptions.length);
-  const visibleCount = getVisibleCount(rows, 14);
+  const showRemaining = rows >= 16 && !error;
+  const visibleCount = getVisibleCount(rows, rows < 16 ? 12 : 14);
   const { start, visibleItems: visibleOptions } = getScrollWindow({
     items: filteredOptions,
     index: activeIndex,
@@ -181,7 +182,12 @@ function LocalePrompt({
         activeIndex={activeIndex - start}
         width={optionWidth}
       />
-      <RemainingMatches total={filteredOptions.length} visible={visibleCount} />
+      {showRemaining ? (
+        <RemainingMatches
+          total={filteredOptions.length}
+          visible={visibleCount}
+        />
+      ) : null}
       {error ? <Text color='red'>{error}</Text> : null}
     </PromptFrame>
   );
@@ -204,7 +210,11 @@ function LocaleMultiPrompt({
     (option) => !selected.has(option.code)
   );
   const activeOptionIndex = getSafeIndex(index, filteredOptions.length);
-  const visibleCount = getVisibleCount(rows, 16);
+  const showRemaining = rows >= 16 && !error;
+  const visibleCount = getVisibleCount(
+    rows,
+    rows < 16 ? 13 : selectedLocales.length > 0 ? 16 : 15
+  );
   const { start, visibleItems: visibleOptions } = getScrollWindow({
     items: filteredOptions,
     index: activeOptionIndex,
@@ -345,7 +355,7 @@ function LocaleMultiPrompt({
         width={inputWidth}
         placeholder='Search locales...'
       />
-      <Box marginTop={1}>
+      <Box marginTop={selectedLocales.length > 0 ? 1 : 0}>
         <SelectedTags
           selectedLocales={selectedLocales}
           active={index === SELECTED_TAG_ROW_INDEX}
@@ -362,7 +372,12 @@ function LocaleMultiPrompt({
         }
         width={optionWidth}
       />
-      <RemainingMatches total={filteredOptions.length} visible={visibleCount} />
+      {showRemaining ? (
+        <RemainingMatches
+          total={filteredOptions.length}
+          visible={visibleCount}
+        />
+      ) : null}
       {error ? <Text color='red'>{error}</Text> : null}
     </PromptFrame>
   );

--- a/packages/cli/src/console/inkUtils.ts
+++ b/packages/cli/src/console/inkUtils.ts
@@ -62,18 +62,20 @@ export function complete<T>(
 }
 
 export function getContentWidth(columns: number) {
-  return Math.min(Math.max(MIN_CONTENT_WIDTH, columns - 4), MAX_CONTENT_WIDTH);
-}
-
-export function getInputWidth(columns: number) {
-  return Math.max(
-    MIN_CONTENT_WIDTH,
-    getContentWidth(columns) - INPUT_HORIZONTAL_PADDING
+  const terminalWidth = Math.max(1, columns);
+  return Math.min(
+    Math.max(MIN_CONTENT_WIDTH, terminalWidth - 4),
+    MAX_CONTENT_WIDTH,
+    terminalWidth
   );
 }
 
+export function getInputWidth(columns: number) {
+  return Math.max(1, getContentWidth(columns) - INPUT_HORIZONTAL_PADDING);
+}
+
 export function getOptionWidth(columns: number) {
-  return Math.max(MIN_CONTENT_WIDTH, getContentWidth(columns) - 2);
+  return Math.max(1, getContentWidth(columns) - 2);
 }
 
 export function getVisibleCount(rows: number, reservedRows: number) {
@@ -95,6 +97,16 @@ export function truncate(value: string, width: number) {
   if (width <= 1) return value.slice(0, width);
   if (width <= 3) return '.'.repeat(width);
   return `${value.slice(0, width - 3)}...`;
+}
+
+export function limitLines(lines: string[], maxLines: number, width: number) {
+  const safeMaxLines = Math.max(1, maxLines);
+  const visibleLines = lines.slice(0, safeMaxLines);
+  if (lines.length > safeMaxLines) {
+    const lastIndex = visibleLines.length - 1;
+    visibleLines[lastIndex] = truncate(`${visibleLines[lastIndex]}...`, width);
+  }
+  return visibleLines;
 }
 
 export function getScrollWindow<T>({


### PR DESCRIPTION
## Summary
- keep Ink prompt content within narrow terminal widths
- reduce vertical chrome in short terminals while preserving selected locale chips
- cap long prompt messages and compact footer/header text

## Tests
- pnpm --filter gt typecheck
- pnpm exec oxfmt --check packages/cli/src/console/inkFields.tsx packages/cli/src/console/inkLayout.tsx packages/cli/src/console/inkPrompts.tsx packages/cli/src/console/inkUtils.ts packages/cli/src/console/__tests__/inkUtils.test.ts
- pnpm exec oxlint packages/cli/src/console/inkFields.tsx packages/cli/src/console/inkLayout.tsx packages/cli/src/console/inkPrompts.tsx packages/cli/src/console/inkUtils.ts packages/cli/src/console/__tests__/inkUtils.test.ts
- pnpm --filter gt test -- packages/cli/src/console/__tests__/inkUtils.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1462"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves the Ink-based CLI wizard prompts to stay readable within narrow (<50 col) and short (<16 row) terminals by capping content widths, limiting visible message lines, condensing header/footer text, and replacing the heavy rounded-border `InputBox` with a lightweight `> ` prefix style.

- **`inkUtils.ts`**: Adds `limitLines` (clips wrapped message lines with an ellipsis) and fixes `getContentWidth` to never exceed `terminalWidth`, so very narrow terminals no longer overflow.
- **`inkLayout.tsx`**: `PromptFrame` applies row-based thresholds for title visibility and message line count; `InputBox` drops the bordered box in favour of a `> ` prefix; `ultraCompactFooter` replacements are corrected (e.g., `'enter done'` → `'done'`) matching what `compactFooter` actually produces.
- **`inkPrompts.tsx` / `inkFields.tsx`**: Adjusted `visibleCount` reservations, conditional `RemainingMatches` visibility when an error is shown, and a compact fallback for `LocaleRow` when the terminal is too narrow to show the full locale name.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all changes are display-only layout adjustments for narrow/short terminals with no effect on data flow or prompt completion logic.

The changes touch only CLI rendering logic: column/row thresholds, text truncation utilities, and the InputBox visual style. The padding arithmetic in the new InputBox sums correctly to `width` in every branch, the `limitLines` helper is unit-tested, `getContentWidth` correctly clamps to `terminalWidth`, and the `ultraCompactFooter` replacement chain now correctly matches the strings that `compactFooter` actually produces. No data-mutating code was changed.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/console/inkUtils.ts | Adds limitLines helper and fixes getContentWidth to cap at terminalWidth; logic is correct and covered by new unit tests. |
| packages/cli/src/console/inkLayout.tsx | InputBox redesigned with '> ' prefix (border removed); padding arithmetic verified to sum to `width` in all branches. ultraCompactFooter replacements corrected to match compactFooter's output strings. |
| packages/cli/src/console/inkPrompts.tsx | Row-based thresholds adjust visibleCount and hide RemainingMatches in short terminals or when an error is displayed; logic is straightforward with no functional regressions. |
| packages/cli/src/console/inkFields.tsx | Adds compact fallback rendering for LocaleRow when terminal is too narrow to show locale name; handles the edge case cleanly. |
| packages/cli/src/console/__tests__/inkUtils.test.ts | New tests cover getContentWidth narrow-terminal clamping and limitLines ellipsis behaviour; all assertions match the implementation. |

</details>

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: address ink layout review comments"](https://github.com/generaltranslation/gt/commit/953c0ec01a2b43b03fd53cd0f7ccaaf2ae6dbf9d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32924133)</sub>

<!-- /greptile_comment -->