### PR TITLE
refactor: rename gt-i18n manager symbols

### DIFF
--- a/packages/i18n/src/condition-store/ReadonlyConditionStore.ts
+++ b/packages/i18n/src/condition-store/ReadonlyConditionStore.ts
@@ -7,15 +7,15 @@ import { createLocaleResolver, type LocaleCandidates } from './localeResolver';
 
 export type ReadonlyConditionStoreParams = {
   /**
-   * @deprecated - this will be moved to a locale config manager
+   * @deprecated - this will be moved to a locale config cache
    */
   defaultLocale?: string;
   /**
-   * @deprecated - this will be moved to a locale config manager
+   * @deprecated - this will be moved to a locale config cache
    */
   locales?: string[];
   /**
-   * @deprecated - this will be moved to a locale config manager
+   * @deprecated - this will be moved to a locale config cache
    */
   customMapping?: CustomMapping;
   locale: LocaleCandidates;
@@ -24,7 +24,7 @@ export type ReadonlyConditionStoreParams = {
 
 export class ReadonlyConditionStore implements ReadonlyConditionStoreContract {
   /**
-   * @deprecated use getI18nManager().determineLocale() instead
+   * @deprecated use getI18nCache().determineLocale() instead
    */
   protected readonly resolveLocale: (candidates?: LocaleCandidates) => string;
   protected locale: string;
@@ -36,7 +36,7 @@ export class ReadonlyConditionStore implements ReadonlyConditionStoreContract {
     ...localeConfig
   }: ReadonlyConditionStoreParams) {
     /**
-     * TODO: change this to getI18nManager().determineLocale() but this
+     * TODO: change this to getI18nCache().determineLocale() but this
      * currently creates a circular dependency
      */
     this.resolveLocale = createLocaleResolver(localeConfig);

--- a/packages/i18n/src/helpers/locale.ts
+++ b/packages/i18n/src/helpers/locale.ts
@@ -1,5 +1,5 @@
 import { getWritableConditionStore } from '../condition-store/singleton-operations';
-import { getI18nManager } from '../i18n-cache/singleton-operations';
+import { getI18nCache } from '../i18n-cache/singleton-operations';
 
 /**
  * Get the current locale
@@ -22,8 +22,8 @@ export function getLocale() {
  * console.log(locales); // ['en-US', 'es-ES']
  */
 export function getLocales() {
-  const i18nManager = getI18nManager();
-  return i18nManager.getLocales();
+  const i18nCache = getI18nCache();
+  return i18nCache.getLocales();
 }
 
 /**
@@ -35,8 +35,8 @@ export function getLocales() {
  * console.log(defaultLocale); // 'en-US'
  */
 export function getDefaultLocale() {
-  const i18nManager = getI18nManager();
-  return i18nManager.getDefaultLocale();
+  const i18nCache = getI18nCache();
+  return i18nCache.getDefaultLocale();
 }
 
 /**
@@ -51,7 +51,7 @@ export function getDefaultLocale() {
  * const localeProperties = getLocaleProperties('en-US');
  */
 export function getLocaleProperties(locale = getLocale()) {
-  const i18nManager = getI18nManager();
-  const gtInstance = i18nManager.getGTClass();
+  const i18nCache = getI18nCache();
+  const gtInstance = i18nCache.getGTClass();
   return gtInstance.getLocaleProperties(locale);
 }

--- a/packages/i18n/src/helpers/versionId.ts
+++ b/packages/i18n/src/helpers/versionId.ts
@@ -1,4 +1,4 @@
-import { getI18nManager } from '../i18n-cache/singleton-operations';
+import { getI18nCache } from '../i18n-cache/singleton-operations';
 
 /**
  * Get the version ID for the current source
@@ -9,6 +9,6 @@ import { getI18nManager } from '../i18n-cache/singleton-operations';
  * console.log(versionId); // 'abc123'
  */
 export function getVersionId() {
-  const i18nManager = getI18nManager();
-  return i18nManager.getVersionId();
+  const i18nCache = getI18nCache();
+  return i18nCache.getVersionId();
 }

--- a/packages/i18n/src/i18n-cache/I18nCache.ts
+++ b/packages/i18n/src/i18n-cache/I18nCache.ts
@@ -1,6 +1,6 @@
 import { publishValidationResults } from './validation/publishValidationResults';
 import logger from '../logs/logger';
-import { I18nManagerConfig, I18nManagerConstructorParams } from './types';
+import { I18nCacheConfig, I18nCacheConstructorParams } from './types';
 import { validateConfig } from './validation/validateConfig';
 import { Translation } from './translations-manager/utils/types/translation-data';
 import { libraryDefaultLocale } from 'generaltranslation/internal';
@@ -72,10 +72,10 @@ type PrefetchEntry<TranslationType extends Translation> = {
  * Class for managing translation functionality
  * @template TranslationValue - The type of the translation that will be cached
  */
-class I18nManager<
+class I18nCache<
   TranslationValue extends Translation = Translation,
 > extends EventEmitter<I18nEvents<TranslationValue>> {
-  protected config: I18nManagerConfig;
+  protected config: I18nCacheConfig;
 
   /**
    * Locale-scoped caches for translations and dictionaries
@@ -90,17 +90,17 @@ class I18nManager<
   public determineLocale: (candidates?: LocaleCandidates) => string;
 
   /**
-   * Creates an instance of I18nManager.
+   * Creates an instance of I18nCache.
    * TODO: resolve gtConfig from just file path
-   * @param params - The parameters for the I18nManager constructor
-   * @param params.config - The configuration for the I18nManager
+   * @param params - The parameters for the I18nCache constructor
+   * @param params.config - The configuration for the I18nCache
    */
-  constructor(params: I18nManagerConstructorParams<TranslationValue>) {
+  constructor(params: I18nCacheConstructorParams<TranslationValue>) {
     super();
 
     // Validation
     const validationResults = validateConfig(params);
-    publishValidationResults(validationResults, 'I18nManager: ');
+    publishValidationResults(validationResults, 'I18nCache: ');
 
     // Setup
     this.config = standardizeConfig(params);
@@ -573,7 +573,7 @@ class I18nManager<
       );
       if (resolvedPrefetchEntries.length !== prefetchEntries.length) {
         logger.warn(
-          `I18nManager: getLookupTranslation(): prefetchEntries must all be the same locale, ignoring all entries that are not for ${translationLocale}`
+          `I18nCache: getLookupTranslation(): prefetchEntries must all be the same locale, ignoring all entries that are not for ${translationLocale}`
         );
       }
 
@@ -703,7 +703,7 @@ class I18nManager<
         throw error;
       case 'production':
       default:
-        logger.error('I18nManager: ' + error);
+        logger.error('I18nCache: ' + error);
         break;
     }
   }
@@ -816,7 +816,9 @@ class I18nManager<
   }
 }
 
-export { I18nManager };
+export { I18nCache };
+/** @deprecated use I18nCache instead */
+export { I18nCache as I18nManager };
 
 // ===== Helper Functions ===== //
 
@@ -826,7 +828,7 @@ export { I18nManager };
  * @returns The standardized config
  */
 function standardizeConfig<TranslationValue extends Translation>(
-  config: I18nManagerConstructorParams<TranslationValue>
+  config: I18nCacheConstructorParams<TranslationValue>
 ) {
   const gtServicesEnabled = getGTServicesEnabled(config);
 

--- a/packages/i18n/src/i18n-cache/__tests__/I18nCache.handleError.test.ts
+++ b/packages/i18n/src/i18n-cache/__tests__/I18nCache.handleError.test.ts
@@ -1,29 +1,29 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { I18nManager } from '../I18nCache';
+import { I18nCache } from '../I18nCache';
 
 // Mock createTranslateManyFactory so constructor doesn't need real GT
 vi.mock('../translations-manager/utils/createTranslateMany', () => ({
   createTranslateManyFactory: vi.fn().mockReturnValue(() => vi.fn()),
 }));
 
-describe('I18nManager.handleError', () => {
+describe('I18nCache.handleError', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   it('throws in development mode when error occurs', async () => {
-    const manager = new I18nManager({
+    const cache = new I18nCache({
       defaultLocale: 'en',
       locales: ['en', 'fr'],
       environment: 'development',
       loadTranslations: vi.fn().mockRejectedValue(new Error('Load failed')),
     });
 
-    await expect(manager.loadTranslations('fr')).rejects.toThrow('Load failed');
+    await expect(cache.loadTranslations('fr')).rejects.toThrow('Load failed');
   });
 
   it('logs and returns fallback in production mode', async () => {
-    const manager = new I18nManager({
+    const cache = new I18nCache({
       defaultLocale: 'en',
       locales: ['en', 'fr'],
       environment: 'production',
@@ -31,7 +31,7 @@ describe('I18nManager.handleError', () => {
     });
 
     // Should not throw, returns empty object
-    const result = await manager.loadTranslations('fr');
+    const result = await cache.loadTranslations('fr');
     expect(result).toEqual({});
   });
 });

--- a/packages/i18n/src/i18n-cache/__tests__/I18nCache.test.ts
+++ b/packages/i18n/src/i18n-cache/__tests__/I18nCache.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { I18nManager } from '../I18nCache';
+import { I18nCache } from '../I18nCache';
 import { createTranslateManyFactory } from '../translations-manager/utils/createTranslateMany';
 import { hashMessage } from '../../utils/hashMessage';
 import { LookupOptions } from '../../translation-functions/types/options';
@@ -19,8 +19,8 @@ const lookupOptions: LookupOptions = {
 const expectedHash = hashMessage(message, lookupOptions);
 const translatedString = 'Bonjour {name} !';
 
-function createManager(overrides: Record<string, unknown> = {}) {
-  return new I18nManager({
+function createCache(overrides: Record<string, unknown> = {}) {
+  return new I18nCache({
     defaultLocale: 'en',
     locales: ['en', 'fr', 'es'],
     loadTranslations: vi
@@ -30,7 +30,7 @@ function createManager(overrides: Record<string, unknown> = {}) {
   });
 }
 
-describe('I18nManager', () => {
+describe('I18nCache', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockTranslateMany.mockReset();
@@ -43,40 +43,40 @@ describe('I18nManager', () => {
   // ===== REGRESSION TESTS ===== //
 
   it('resolveTranslationSync returns translation after loadTranslations', async () => {
-    const manager = createManager();
+    const cache = createCache();
 
     // Load translations first
-    await manager.loadTranslations('fr');
+    await cache.loadTranslations('fr');
 
     // Now sync resolution should work
-    const result = manager.resolveTranslationSync('fr', message, lookupOptions);
+    const result = cache.resolveTranslationSync('fr', message, lookupOptions);
     expect(result).toBe(translatedString);
   });
 
   it('getTranslations returns empty object for invalid locale', async () => {
-    const manager = createManager();
+    const cache = createCache();
 
-    const result = await manager.getTranslations('zh');
+    const result = await cache.getTranslations('zh');
     expect(result).toEqual({});
   });
 
   it('getTranslationResolver returns a working resolver function', async () => {
-    const manager = createManager();
+    const cache = createCache();
 
-    const resolver = await manager.getTranslationResolver('fr');
+    const resolver = await cache.getTranslationResolver('fr');
     const result = resolver(message, lookupOptions);
 
     expect(result).toBe(translatedString);
   });
 
   it('enables dev hot reload with dev credentials, a project id, and development environment', () => {
-    const manager = createManager({
+    const cache = createCache({
       devApiKey: 'dev-key',
       projectId: 'project-id',
       environment: 'development',
     });
 
-    expect(manager.isDevHotReloadEnabled()).toBe(true);
+    expect(cache.isDevHotReloadEnabled()).toBe(true);
   });
 
   it.each([
@@ -112,31 +112,31 @@ describe('I18nManager', () => {
       },
     },
   ])('disables dev hot reload for $name', ({ config }) => {
-    const manager = createManager(config);
+    const cache = createCache(config);
 
-    expect(manager.isDevHotReloadEnabled()).toBe(false);
+    expect(cache.isDevHotReloadEnabled()).toBe(false);
   });
 
   // ===== NEW BEHAVIOR TESTS ===== //
 
   it('loadTranslations() returns Record<Hash, Translation>', async () => {
-    const manager = createManager();
+    const cache = createCache();
 
-    const translations = await manager.loadTranslations('fr');
+    const translations = await cache.loadTranslations('fr');
 
     expect(translations[expectedHash]).toBe(translatedString);
   });
 
   it('loadDictionary() returns source dictionary without loading when locale does not require translation', async () => {
     const loadDictionary = vi.fn().mockResolvedValue({ greeting: 'Bonjour' });
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         greeting: 'Hello',
       },
       loadDictionary,
     });
 
-    const dictionary = await manager.loadDictionary('en');
+    const dictionary = await cache.loadDictionary('en');
 
     expect(dictionary).toEqual({
       greeting: 'Hello',
@@ -146,7 +146,7 @@ describe('I18nManager', () => {
 
   it('loadDictionary() returns source dictionary without loading when i18n is disabled', async () => {
     const loadDictionary = vi.fn().mockResolvedValue({ greeting: 'Bonjour' });
-    const manager = createManager({
+    const cache = createCache({
       enableI18n: false,
       dictionary: {
         greeting: 'Hello',
@@ -154,7 +154,7 @@ describe('I18nManager', () => {
       loadDictionary,
     });
 
-    const dictionary = await manager.loadDictionary('fr');
+    const dictionary = await cache.loadDictionary('fr');
 
     expect(dictionary).toEqual({
       greeting: 'Hello',
@@ -169,15 +169,15 @@ describe('I18nManager', () => {
         name: 'Nom',
       },
     });
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         greeting: 'Hello',
       },
       loadDictionary,
     });
 
-    const dictionary = await manager.loadDictionary('fr');
-    const cachedDictionary = await manager.loadDictionary('fr');
+    const dictionary = await cache.loadDictionary('fr');
+    const cachedDictionary = await cache.loadDictionary('fr');
 
     expect(loadDictionary).toHaveBeenCalledTimes(1);
     expect(loadDictionary).toHaveBeenCalledWith('fr');
@@ -191,13 +191,13 @@ describe('I18nManager', () => {
     expect(cachedDictionary).not.toBe(dictionary);
 
     dictionary.greeting = 'Salut';
-    await expect(manager.loadDictionary('fr')).resolves.toMatchObject({
+    await expect(cache.loadDictionary('fr')).resolves.toMatchObject({
       greeting: 'Bonjour',
     });
   });
 
   it('loadDictionary() returns deep copies of cached dictionaries', async () => {
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         user: {
           profile: {
@@ -214,7 +214,7 @@ describe('I18nManager', () => {
       }),
     });
 
-    const dictionary = (await manager.loadDictionary('fr')) as {
+    const dictionary = (await cache.loadDictionary('fr')) as {
       user: {
         profile: {
           name: string;
@@ -223,7 +223,7 @@ describe('I18nManager', () => {
     };
     dictionary.user.profile.name = 'Changed';
 
-    await expect(manager.loadDictionary('fr')).resolves.toEqual({
+    await expect(cache.loadDictionary('fr')).resolves.toEqual({
       user: {
         profile: {
           name: 'Nom',
@@ -233,7 +233,7 @@ describe('I18nManager', () => {
   });
 
   it('updateDictionaries() updates locale dictionary lookups', () => {
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         greeting: 'Hello',
         cta: 'Click me',
@@ -243,7 +243,7 @@ describe('I18nManager', () => {
       },
     });
 
-    manager.updateDictionaries({
+    cache.updateDictionaries({
       en: {
         greeting: 'Hi',
         navigation: {
@@ -258,23 +258,23 @@ describe('I18nManager', () => {
       },
     });
 
-    expect(manager.lookupDictionary('en', 'greeting')).toEqual({
+    expect(cache.lookupDictionary('en', 'greeting')).toEqual({
       entry: 'Hi',
       options: {},
     });
-    expect(manager.lookupDictionaryObj('en', 'navigation')).toEqual({
+    expect(cache.lookupDictionaryObj('en', 'navigation')).toEqual({
       about: 'About',
       home: 'Home',
     });
-    expect(manager.lookupDictionary('en', 'cta')).toEqual({
+    expect(cache.lookupDictionary('en', 'cta')).toEqual({
       entry: 'Click me',
       options: {},
     });
-    expect(manager.lookupDictionary('fr', 'greeting')).toEqual({
+    expect(cache.lookupDictionary('fr', 'greeting')).toEqual({
       entry: 'Bonjour',
       options: {},
     });
-    expect(manager.lookupDictionaryObj('fr', 'navigation')).toEqual({
+    expect(cache.lookupDictionaryObj('fr', 'navigation')).toEqual({
       home: 'Accueil',
     });
   });
@@ -304,7 +304,7 @@ describe('I18nManager', () => {
     },
   ])('loadDictionary() uses cache locale for $name', async (testCase) => {
     const loadDictionary = vi.fn().mockResolvedValue(testCase.dictionary);
-    const manager = createManager({
+    const cache = createCache({
       defaultLocale: 'en-US',
       locales: ['en-US', 'en'],
       dictionary: {
@@ -316,19 +316,19 @@ describe('I18nManager', () => {
       }),
     });
 
-    const dictionary = await manager.loadDictionary(testCase.locale);
+    const dictionary = await cache.loadDictionary(testCase.locale);
 
     expect(loadDictionary).toHaveBeenCalledTimes(1);
     expect(loadDictionary).toHaveBeenCalledWith(testCase.dictionaryLocale);
     expect(dictionary).toEqual(testCase.dictionary);
-    expect(manager.lookupDictionary(testCase.locale, 'greeting')).toEqual({
+    expect(cache.lookupDictionary(testCase.locale, 'greeting')).toEqual({
       entry: testCase.dictionary.greeting,
       options: {},
     });
   });
 
   it('lookupDictionary() returns a loaded target locale leaf', async () => {
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         greeting: 'Hello',
       },
@@ -337,16 +337,16 @@ describe('I18nManager', () => {
       }),
     });
 
-    await manager.loadDictionary('fr');
+    await cache.loadDictionary('fr');
 
-    expect(manager.lookupDictionary('fr', 'greeting')).toEqual({
+    expect(cache.lookupDictionary('fr', 'greeting')).toEqual({
       entry: 'Bonjour',
       options: {},
     });
   });
 
   it('lookupDictionary() returns a loaded target locale nested leaf', async () => {
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         user: {
           name: 'Name',
@@ -359,16 +359,16 @@ describe('I18nManager', () => {
       }),
     });
 
-    await manager.loadDictionary('fr');
+    await cache.loadDictionary('fr');
 
-    expect(manager.lookupDictionary('fr', 'user.name')).toEqual({
+    expect(cache.lookupDictionary('fr', 'user.name')).toEqual({
       entry: 'Nom',
       options: {},
     });
   });
 
   it('lookupDictionary() returns the entry and options from a metadata tuple leaf', async () => {
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         greeting: ['Hello', { $context: 'homepage', $maxChars: 10 }],
       },
@@ -377,16 +377,16 @@ describe('I18nManager', () => {
       }),
     });
 
-    await manager.loadDictionary('fr');
+    await cache.loadDictionary('fr');
 
-    expect(manager.lookupDictionary('fr', 'greeting')).toEqual({
+    expect(cache.lookupDictionary('fr', 'greeting')).toEqual({
       entry: 'Bonjour',
       options: { context: 'homepage' },
     });
   });
 
   it('lookupDictionary() returns undefined when target locale is not loaded', () => {
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         greeting: 'Hello',
       },
@@ -395,53 +395,53 @@ describe('I18nManager', () => {
       }),
     });
 
-    expect(manager.lookupDictionary('fr', 'greeting')).toBeUndefined();
-    expect(manager.lookupDictionary('en', 'greeting')).toEqual({
+    expect(cache.lookupDictionary('fr', 'greeting')).toBeUndefined();
+    expect(cache.lookupDictionary('en', 'greeting')).toEqual({
       entry: 'Hello',
       options: {},
     });
   });
 
   it('lookupDictionary() returns undefined when source leaf is missing and translation is not required', () => {
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         greeting: 'Hello',
       },
     });
 
-    expect(manager.lookupDictionary('en', 'missing')).toBeUndefined();
+    expect(cache.lookupDictionary('en', 'missing')).toBeUndefined();
   });
 
   it('lookupDictionary() returns undefined when source leaf is missing and i18n is disabled', () => {
-    const manager = createManager({
+    const cache = createCache({
       enableI18n: false,
       dictionary: {
         greeting: 'Hello',
       },
     });
 
-    expect(manager.lookupDictionary('fr', 'missing')).toBeUndefined();
+    expect(cache.lookupDictionary('fr', 'missing')).toBeUndefined();
   });
 
   it('lookupDictionary() returns undefined when target leaf is missing', async () => {
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         greeting: 'Hello',
       },
       loadDictionary: vi.fn().mockResolvedValue({}),
     });
 
-    await manager.loadDictionary('fr');
+    await cache.loadDictionary('fr');
 
-    expect(manager.lookupDictionary('fr', 'greeting')).toBeUndefined();
-    expect(manager.lookupDictionary('en', 'greeting')).toEqual({
+    expect(cache.lookupDictionary('fr', 'greeting')).toBeUndefined();
+    expect(cache.lookupDictionary('en', 'greeting')).toEqual({
       entry: 'Hello',
       options: {},
     });
   });
 
   it('lookupDictionary() returns undefined when target nested leaf is missing', async () => {
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         user: {
           name: 'Name',
@@ -452,17 +452,17 @@ describe('I18nManager', () => {
       }),
     });
 
-    await manager.loadDictionary('fr');
+    await cache.loadDictionary('fr');
 
-    expect(manager.lookupDictionary('fr', 'user.name')).toBeUndefined();
-    expect(manager.lookupDictionary('en', 'user.name')).toEqual({
+    expect(cache.lookupDictionary('fr', 'user.name')).toBeUndefined();
+    expect(cache.lookupDictionary('en', 'user.name')).toEqual({
       entry: 'Name',
       options: {},
     });
   });
 
   it('lookupDictionary() does not return dictionary subtrees', async () => {
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         user: {
           name: 'Name',
@@ -475,13 +475,13 @@ describe('I18nManager', () => {
       }),
     });
 
-    await manager.loadDictionary('fr');
+    await cache.loadDictionary('fr');
 
-    expect(manager.lookupDictionary('fr', 'user')).toBeUndefined();
+    expect(cache.lookupDictionary('fr', 'user')).toBeUndefined();
   });
 
   it('lookupDictionaryObj() returns source leaves and subtrees', () => {
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         greeting: 'Hello',
         user: {
@@ -492,14 +492,14 @@ describe('I18nManager', () => {
       },
     });
 
-    expect(manager.lookupDictionaryObj('en', 'greeting')).toBe('Hello');
-    expect(manager.lookupDictionaryObj('en', 'user.profile')).toEqual({
+    expect(cache.lookupDictionaryObj('en', 'greeting')).toBe('Hello');
+    expect(cache.lookupDictionaryObj('en', 'user.profile')).toEqual({
       name: 'Name',
     });
   });
 
   it('lookupDictionaryObj() returns loaded target leaves and subtrees', async () => {
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         greeting: 'Hello',
       },
@@ -513,16 +513,16 @@ describe('I18nManager', () => {
       }),
     });
 
-    await manager.loadDictionary('fr');
+    await cache.loadDictionary('fr');
 
-    expect(manager.lookupDictionaryObj('fr', 'greeting')).toBe('Bonjour');
-    expect(manager.lookupDictionaryObj('fr', 'user.profile')).toEqual({
+    expect(cache.lookupDictionaryObj('fr', 'greeting')).toBe('Bonjour');
+    expect(cache.lookupDictionaryObj('fr', 'user.profile')).toEqual({
       name: 'Nom',
     });
   });
 
   it('lookupDictionaryObj() returns copies of dictionary subtrees', () => {
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         user: {
           profile: {
@@ -532,19 +532,19 @@ describe('I18nManager', () => {
       },
     });
 
-    const profile = manager.lookupDictionaryObj('en', 'user.profile');
+    const profile = cache.lookupDictionaryObj('en', 'user.profile');
     expect(profile).toEqual({
       name: 'Name',
     });
     (profile as { name: string }).name = 'Changed';
 
-    expect(manager.lookupDictionaryObj('en', 'user.profile')).toEqual({
+    expect(cache.lookupDictionaryObj('en', 'user.profile')).toEqual({
       name: 'Name',
     });
   });
 
   it('lookupDictionaryObj() returns undefined when target locale is not loaded', () => {
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         user: {
           profile: {
@@ -561,11 +561,11 @@ describe('I18nManager', () => {
       }),
     });
 
-    expect(manager.lookupDictionaryObj('fr', 'user.profile')).toBeUndefined();
+    expect(cache.lookupDictionaryObj('fr', 'user.profile')).toBeUndefined();
   });
 
   it('lookupDictionaryObj() returns undefined for missing paths', async () => {
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         greeting: 'Hello',
       },
@@ -574,14 +574,14 @@ describe('I18nManager', () => {
       }),
     });
 
-    await manager.loadDictionary('fr');
+    await cache.loadDictionary('fr');
 
-    expect(manager.lookupDictionaryObj('fr', 'missing')).toBeUndefined();
-    expect(manager.lookupDictionaryObj('en', 'missing')).toBeUndefined();
+    expect(cache.lookupDictionaryObj('fr', 'missing')).toBeUndefined();
+    expect(cache.lookupDictionaryObj('en', 'missing')).toBeUndefined();
   });
 
   it('lookupDictionaryObj() uses the source dictionary when i18n is disabled', () => {
-    const manager = createManager({
+    const cache = createCache({
       enableI18n: false,
       dictionary: {
         user: {
@@ -599,7 +599,7 @@ describe('I18nManager', () => {
       }),
     });
 
-    expect(manager.lookupDictionaryObj('fr', 'user.profile')).toEqual({
+    expect(cache.lookupDictionaryObj('fr', 'user.profile')).toEqual({
       name: 'Name',
     });
   });
@@ -608,7 +608,7 @@ describe('I18nManager', () => {
     const loadDictionary = vi.fn().mockResolvedValue({
       greeting: 'Bonjour',
     });
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         greeting: 'Hello',
       },
@@ -616,7 +616,7 @@ describe('I18nManager', () => {
     });
 
     await expect(
-      manager.lookupDictionaryWithFallback('en', 'greeting')
+      cache.lookupDictionaryWithFallback('en', 'greeting')
     ).resolves.toEqual({
       entry: 'Hello',
       options: {},
@@ -625,7 +625,7 @@ describe('I18nManager', () => {
   });
 
   it('lookupDictionaryWithFallback() throws when source entry is missing and translation is not required', async () => {
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         greeting: 'Hello',
       },
@@ -635,9 +635,9 @@ describe('I18nManager', () => {
     });
 
     await expect(
-      manager.lookupDictionaryWithFallback('en', 'missing')
+      cache.lookupDictionaryWithFallback('en', 'missing')
     ).rejects.toThrow(
-      'I18nManager: source dictionary entry missing is not defined'
+      'I18nCache: source dictionary entry missing is not defined'
     );
   });
 
@@ -645,7 +645,7 @@ describe('I18nManager', () => {
     const loadDictionary = vi.fn().mockResolvedValue({
       greeting: 'Bonjour',
     });
-    const manager = createManager({
+    const cache = createCache({
       enableI18n: false,
       dictionary: {
         greeting: 'Hello',
@@ -654,7 +654,7 @@ describe('I18nManager', () => {
     });
 
     await expect(
-      manager.lookupDictionaryWithFallback('fr', 'greeting')
+      cache.lookupDictionaryWithFallback('fr', 'greeting')
     ).resolves.toEqual({
       entry: 'Hello',
       options: {},
@@ -666,7 +666,7 @@ describe('I18nManager', () => {
     const loadDictionary = vi.fn().mockResolvedValue({
       greeting: 'Bonjour',
     });
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         greeting: 'Hello',
       },
@@ -674,7 +674,7 @@ describe('I18nManager', () => {
     });
 
     await expect(
-      manager.lookupDictionaryWithFallback('fr', 'greeting')
+      cache.lookupDictionaryWithFallback('fr', 'greeting')
     ).resolves.toEqual({
       entry: 'Bonjour',
       options: {},
@@ -710,7 +710,7 @@ describe('I18nManager', () => {
     'lookupDictionaryWithFallback() uses cache locale for $name',
     async (testCase) => {
       const loadDictionary = vi.fn().mockResolvedValue(testCase.dictionary);
-      const manager = createManager({
+      const cache = createCache({
         defaultLocale: 'en-US',
         locales: ['en-US', 'en'],
         dictionary: {
@@ -723,7 +723,7 @@ describe('I18nManager', () => {
       });
 
       await expect(
-        manager.lookupDictionaryWithFallback(testCase.locale, 'greeting')
+        cache.lookupDictionaryWithFallback(testCase.locale, 'greeting')
       ).resolves.toEqual({
         entry: testCase.dictionary.greeting,
         options: {},
@@ -737,7 +737,7 @@ describe('I18nManager', () => {
     const source = 'Hello';
     const sourceOptions: LookupOptions = { $format: 'ICU' };
     const sourceHash = hashMessage(source, sourceOptions);
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         greeting: source,
       },
@@ -753,19 +753,19 @@ describe('I18nManager', () => {
     });
 
     await expect(
-      manager.lookupDictionaryWithFallback('fr', 'greeting')
+      cache.lookupDictionaryWithFallback('fr', 'greeting')
     ).resolves.toEqual({
       entry: 'Bonjour',
       options: {},
     });
-    expect(manager.lookupDictionary('fr', 'greeting')).toEqual({
+    expect(cache.lookupDictionary('fr', 'greeting')).toEqual({
       entry: 'Bonjour',
       options: {},
     });
   });
 
   it('lookupDictionaryWithFallback() throws when source dictionary entry is missing', async () => {
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         greeting: 'Hello',
       },
@@ -774,9 +774,9 @@ describe('I18nManager', () => {
     });
 
     await expect(
-      manager.lookupDictionaryWithFallback('fr', 'missing')
+      cache.lookupDictionaryWithFallback('fr', 'missing')
     ).rejects.toThrow(
-      'I18nManager: source dictionary entry missing is not defined'
+      'I18nCache: source dictionary entry missing is not defined'
     );
   });
 
@@ -788,7 +788,7 @@ describe('I18nManager', () => {
         },
       },
     });
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         greeting: 'Hello',
         user: {
@@ -801,10 +801,10 @@ describe('I18nManager', () => {
     });
 
     await expect(
-      manager.lookupDictionaryObjWithFallback('en', 'greeting')
+      cache.lookupDictionaryObjWithFallback('en', 'greeting')
     ).resolves.toBe('Hello');
     await expect(
-      manager.lookupDictionaryObjWithFallback('en', 'user.profile')
+      cache.lookupDictionaryObjWithFallback('en', 'user.profile')
     ).resolves.toEqual({
       name: 'Name',
     });
@@ -819,7 +819,7 @@ describe('I18nManager', () => {
         },
       },
     });
-    const manager = createManager({
+    const cache = createCache({
       enableI18n: false,
       dictionary: {
         user: {
@@ -832,7 +832,7 @@ describe('I18nManager', () => {
     });
 
     await expect(
-      manager.lookupDictionaryObjWithFallback('fr', 'user.profile')
+      cache.lookupDictionaryObjWithFallback('fr', 'user.profile')
     ).resolves.toEqual({
       name: 'Name',
     });
@@ -847,7 +847,7 @@ describe('I18nManager', () => {
         },
       },
     });
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         user: {
           profile: {
@@ -859,7 +859,7 @@ describe('I18nManager', () => {
     });
 
     await expect(
-      manager.lookupDictionaryObjWithFallback('fr', 'user.profile')
+      cache.lookupDictionaryObjWithFallback('fr', 'user.profile')
     ).resolves.toEqual({
       name: 'Nom',
     });
@@ -872,7 +872,7 @@ describe('I18nManager', () => {
     const title = 'Title';
     const nameHash = hashMessage(name, { $format: 'ICU' });
     const titleHash = hashMessage(title, { $format: 'ICU' });
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         user: {
           profile: {
@@ -897,12 +897,12 @@ describe('I18nManager', () => {
     });
 
     await expect(
-      manager.lookupDictionaryObjWithFallback('fr', 'user.profile')
+      cache.lookupDictionaryObjWithFallback('fr', 'user.profile')
     ).resolves.toEqual({
       name: 'Nom',
       title: 'Titre',
     });
-    expect(manager.lookupDictionaryObj('fr', 'user.profile')).toEqual({
+    expect(cache.lookupDictionaryObj('fr', 'user.profile')).toEqual({
       name: 'Nom',
       title: 'Titre',
     });
@@ -912,7 +912,7 @@ describe('I18nManager', () => {
     const name = 'Name';
     const title = 'Title';
     const titleHash = hashMessage(title, { $format: 'ICU' });
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         user: {
           profile: {
@@ -939,19 +939,19 @@ describe('I18nManager', () => {
     });
 
     await expect(
-      manager.lookupDictionaryObjWithFallback('fr', 'user.profile')
+      cache.lookupDictionaryObjWithFallback('fr', 'user.profile')
     ).resolves.toEqual({
       name: 'Nom',
       title: 'Titre',
     });
-    expect(manager.lookupDictionaryObj('fr', 'user.profile')).toEqual({
+    expect(cache.lookupDictionaryObj('fr', 'user.profile')).toEqual({
       name: 'Nom',
       title: 'Titre',
     });
   });
 
   it('lookupDictionaryObjWithFallback() returns loaded target subtrees when source is missing', async () => {
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         greeting: 'Hello',
       },
@@ -964,7 +964,7 @@ describe('I18nManager', () => {
     });
 
     await expect(
-      manager.lookupDictionaryObjWithFallback('fr', 'extra')
+      cache.lookupDictionaryObjWithFallback('fr', 'extra')
     ).resolves.toEqual({
       label: 'Supplement',
     });
@@ -972,7 +972,7 @@ describe('I18nManager', () => {
   });
 
   it('lookupDictionaryObjWithFallback() throws when source dictionary object is missing', async () => {
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         greeting: 'Hello',
       },
@@ -981,9 +981,9 @@ describe('I18nManager', () => {
     });
 
     await expect(
-      manager.lookupDictionaryObjWithFallback('fr', 'missing')
+      cache.lookupDictionaryObjWithFallback('fr', 'missing')
     ).rejects.toThrow(
-      'I18nManager: source dictionary entry missing is not defined'
+      'I18nCache: source dictionary entry missing is not defined'
     );
   });
 
@@ -1022,7 +1022,7 @@ describe('I18nManager', () => {
     'lookupDictionaryObjWithFallback() uses cache locale for $name',
     async (testCase) => {
       const loadDictionary = vi.fn().mockResolvedValue(testCase.dictionary);
-      const manager = createManager({
+      const cache = createCache({
         defaultLocale: 'en-US',
         locales: ['en-US', 'en'],
         dictionary: {
@@ -1039,7 +1039,7 @@ describe('I18nManager', () => {
       });
 
       await expect(
-        manager.lookupDictionaryObjWithFallback(testCase.locale, 'user.profile')
+        cache.lookupDictionaryObjWithFallback(testCase.locale, 'user.profile')
       ).resolves.toEqual(testCase.dictionary.user.profile);
       expect(loadDictionary).toHaveBeenCalledTimes(1);
       expect(loadDictionary).toHaveBeenCalledWith(testCase.dictionaryLocale);
@@ -1047,17 +1047,17 @@ describe('I18nManager', () => {
   );
 
   it('lookupTranslation() returns undefined before load, translation after', async () => {
-    const manager = createManager();
+    const cache = createCache();
 
     // Before loading
-    const before = manager.lookupTranslation('fr', message, lookupOptions);
+    const before = cache.lookupTranslation('fr', message, lookupOptions);
     expect(before).toBeUndefined();
 
     // Load translations
-    await manager.loadTranslations('fr');
+    await cache.loadTranslations('fr');
 
     // After loading
-    const after = manager.lookupTranslation('fr', message, lookupOptions);
+    const after = cache.lookupTranslation('fr', message, lookupOptions);
     expect(after).toBe(translatedString);
   });
 
@@ -1085,22 +1085,22 @@ describe('I18nManager', () => {
       .fn()
       .mockResolvedValueOnce({ [expectedHash]: translatedString })
       .mockResolvedValueOnce({ [expectedHash]: 'Salut {name} !' });
-    const manager = createManager({
+    const cache = createCache({
       cacheExpiryTime: testCase.cacheExpiryTime,
       loadTranslations,
     });
 
-    await manager.loadTranslations('fr');
-    expect(manager.lookupTranslation('fr', message, lookupOptions)).toBe(
+    await cache.loadTranslations('fr');
+    expect(cache.lookupTranslation('fr', message, lookupOptions)).toBe(
       translatedString
     );
 
     vi.advanceTimersByTime(testCase.advanceBy);
-    expect(manager.lookupTranslation('fr', message, lookupOptions)).toBe(
+    expect(cache.lookupTranslation('fr', message, lookupOptions)).toBe(
       testCase.lookupAfter
     );
 
-    const translations = await manager.loadTranslations('fr');
+    const translations = await cache.loadTranslations('fr');
     expect(translations[expectedHash]).toBe(testCase.reloaded);
     expect(loadTranslations).toHaveBeenCalledTimes(testCase.calls);
   });
@@ -1142,7 +1142,7 @@ describe('I18nManager', () => {
       const loadTranslations = vi
         .fn()
         .mockResolvedValue({ [expectedHash]: testCase.translation });
-      const manager = createManager({
+      const cache = createCache({
         defaultLocale: 'en-US',
         locales: ['en-US', 'en'],
         loadTranslations,
@@ -1151,16 +1151,16 @@ describe('I18nManager', () => {
         }),
       });
 
-      expect(manager.requiresTranslation('en-GB')).toBe(true);
-      expect(manager.requiresDialectTranslation('en-GB')).toBe(true);
+      expect(cache.requiresTranslation('en-GB')).toBe(true);
+      expect(cache.requiresDialectTranslation('en-GB')).toBe(true);
 
-      const translations = await manager.loadTranslations(testCase.locale);
+      const translations = await cache.loadTranslations(testCase.locale);
 
       expect(loadTranslations).toHaveBeenCalledTimes(1);
       expect(loadTranslations).toHaveBeenCalledWith(testCase.translationLocale);
       expect(translations[expectedHash]).toBe(testCase.translation);
       expect(
-        manager.lookupTranslation(testCase.locale, message, lookupOptions)
+        cache.lookupTranslation(testCase.locale, message, lookupOptions)
       ).toBe(testCase.translation);
     }
   );
@@ -1171,7 +1171,7 @@ describe('I18nManager', () => {
     const unknownHash = hashMessage(unknownMessage, unknownOptions);
 
     // loadTranslations returns translations that do NOT include unknownMessage
-    const manager = createManager({
+    const cache = createCache({
       runtimeTranslation: {
         timeout: 4321,
         metadata: {
@@ -1190,7 +1190,7 @@ describe('I18nManager', () => {
       },
     });
 
-    const result = await manager.lookupTranslationWithFallback(
+    const result = await cache.lookupTranslationWithFallback(
       'fr',
       unknownMessage,
       unknownOptions
@@ -1216,7 +1216,7 @@ describe('I18nManager', () => {
       $context: 'homepage',
     };
     const sourceHash = hashMessage(source, sourceOptions);
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         greeting: [source, { $format: 'I18NEXT', context: 'homepage' }],
       },
@@ -1231,7 +1231,7 @@ describe('I18nManager', () => {
     });
 
     await expect(
-      manager.lookupDictionaryWithFallback('fr', 'greeting')
+      cache.lookupDictionaryWithFallback('fr', 'greeting')
     ).resolves.toEqual({
       entry: 'Bonjour {name}',
       options: {},
@@ -1245,7 +1245,7 @@ describe('I18nManager', () => {
       $context: 'homepage',
     };
     const sourceHash = hashMessage(source, sourceOptions);
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         greeting: [source, { context: 'homepage' }],
       },
@@ -1260,7 +1260,7 @@ describe('I18nManager', () => {
     });
 
     await expect(
-      manager.lookupDictionaryWithFallback('fr', 'greeting')
+      cache.lookupDictionaryWithFallback('fr', 'greeting')
     ).resolves.toEqual({
       entry: 'Bonjour {name}',
       options: {},
@@ -1271,7 +1271,7 @@ describe('I18nManager', () => {
     const source = 'Hello';
     const sourceOptions: LookupOptions = { $format: 'ICU' };
     const sourceHash = hashMessage(source, sourceOptions);
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         greeting: source,
       },
@@ -1287,14 +1287,14 @@ describe('I18nManager', () => {
     });
 
     await expect(
-      manager.lookupDictionaryWithFallback('fr', 'greeting')
+      cache.lookupDictionaryWithFallback('fr', 'greeting')
     ).rejects.toThrow(
       'Dictionary entry "greeting" could not be translated into a string. Check the source entry and translation loader output.'
     );
   });
 
   it('resolves custom aliases for locale metadata operations', () => {
-    const manager = createManager({
+    const cache = createCache({
       customMapping: {
         'brand-french': {
           code: 'fr',
@@ -1303,13 +1303,13 @@ describe('I18nManager', () => {
       },
     });
 
-    expect(manager.requiresTranslation('brand-french')).toBe(true);
-    expect(manager.requiresDialectTranslation('en-US')).toBe(false);
-    expect(() => manager.getGTClass('brand-french')).not.toThrow();
+    expect(cache.requiresTranslation('brand-french')).toBe(true);
+    expect(cache.requiresDialectTranslation('en-US')).toBe(false);
+    expect(() => cache.getGTClass('brand-french')).not.toThrow();
   });
 
   it('preserves alias target locale when creating a GT instance', () => {
-    const manager = createManager({
+    const cache = createCache({
       locales: ['en', 'brand-french'],
       customMapping: {
         'brand-french': {
@@ -1319,7 +1319,7 @@ describe('I18nManager', () => {
       },
     });
 
-    const gt = manager.getGTClass('fr');
+    const gt = cache.getGTClass('fr');
 
     expect(gt.targetLocale).toBe('brand-french');
     expect(gt.locales).toEqual(['en', 'fr']);
@@ -1329,7 +1329,7 @@ describe('I18nManager', () => {
     const loadTranslations = vi
       .fn()
       .mockResolvedValue({ [expectedHash]: translatedString });
-    const manager = createManager({
+    const cache = createCache({
       loadTranslations,
       customMapping: {
         'brand-french': {
@@ -1339,12 +1339,12 @@ describe('I18nManager', () => {
       },
     });
 
-    await manager.loadTranslations('brand-french');
+    await cache.loadTranslations('brand-french');
 
     expect(loadTranslations).toHaveBeenCalledTimes(1);
     expect(loadTranslations).toHaveBeenCalledWith('fr');
     expect(
-      manager.lookupTranslation('brand-french', message, lookupOptions)
+      cache.lookupTranslation('brand-french', message, lookupOptions)
     ).toBe(translatedString);
     expect(loadTranslations).toHaveBeenCalledTimes(1);
   });
@@ -1353,29 +1353,29 @@ describe('I18nManager', () => {
     const loadTranslations = vi
       .fn()
       .mockResolvedValue({ [expectedHash]: translatedString });
-    const manager = createManager({
+    const cache = createCache({
       loadTranslations,
     });
 
-    await manager.loadTranslations('fr');
+    await cache.loadTranslations('fr');
 
     expect(loadTranslations).toHaveBeenCalledWith('fr');
-    expect(manager.lookupTranslation('fr', message, lookupOptions)).toBe(
+    expect(cache.lookupTranslation('fr', message, lookupOptions)).toBe(
       translatedString
     );
     await expect(
-      manager.lookupTranslationWithFallback('fr', message, lookupOptions)
+      cache.lookupTranslationWithFallback('fr', message, lookupOptions)
     ).resolves.toBe(translatedString);
-    await expect(manager.getLookupTranslation('fr')).resolves.toEqual(
+    await expect(cache.getLookupTranslation('fr')).resolves.toEqual(
       expect.any(Function)
     );
-    expect(manager.requiresTranslation('fr')).toBe(true);
-    expect(manager.requiresDialectTranslation('fr')).toBe(false);
-    expect(() => manager.getGTClass('fr')).not.toThrow();
+    expect(cache.requiresTranslation('fr')).toBe(true);
+    expect(cache.requiresDialectTranslation('fr')).toBe(false);
+    expect(() => cache.getGTClass('fr')).not.toThrow();
   });
 
   it('does not clone loaded dictionaries for cache hit events without subscribers', async () => {
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         greeting: 'Hello',
       },
@@ -1387,10 +1387,10 @@ describe('I18nManager', () => {
       }),
     });
 
-    await manager.loadDictionary('fr');
+    await cache.loadDictionary('fr');
     const structuredCloneSpy = vi.spyOn(globalThis, 'structuredClone');
     try {
-      expect(manager.lookupDictionaryObj('fr', 'greeting')).toBe('Bonjour');
+      expect(cache.lookupDictionaryObj('fr', 'greeting')).toBe('Bonjour');
       expect(structuredCloneSpy).not.toHaveBeenCalled();
     } finally {
       structuredCloneSpy.mockRestore();
@@ -1398,7 +1398,7 @@ describe('I18nManager', () => {
   });
 
   it('emits dictionary cache lifecycle events', async () => {
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         greeting: 'Hello',
       },
@@ -1411,14 +1411,14 @@ describe('I18nManager', () => {
     const dictionaryCacheHit = vi.fn();
     const dictionaryCacheMiss = vi.fn();
 
-    manager.subscribe('locales-dictionary-cache-miss', localesDictionaryMiss);
-    manager.subscribe('locales-dictionary-cache-hit', localesDictionaryHit);
-    manager.subscribe('dictionary-cache-hit', dictionaryCacheHit);
-    manager.subscribe('dictionary-cache-miss', dictionaryCacheMiss);
+    cache.subscribe('locales-dictionary-cache-miss', localesDictionaryMiss);
+    cache.subscribe('locales-dictionary-cache-hit', localesDictionaryHit);
+    cache.subscribe('dictionary-cache-hit', dictionaryCacheHit);
+    cache.subscribe('dictionary-cache-miss', dictionaryCacheMiss);
 
-    await manager.loadDictionary('fr');
-    await manager.loadDictionary('fr');
-    expect(manager.lookupDictionary('fr', 'greeting')).toEqual({
+    await cache.loadDictionary('fr');
+    await cache.loadDictionary('fr');
+    expect(cache.lookupDictionary('fr', 'greeting')).toEqual({
       entry: 'Bonjour',
       options: {},
     });

--- a/packages/i18n/src/i18n-cache/__tests__/resolveTranslationSync.test.ts
+++ b/packages/i18n/src/i18n-cache/__tests__/resolveTranslationSync.test.ts
@@ -1,20 +1,20 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { I18nManager } from '../I18nCache';
+import { I18nCache } from '../I18nCache';
 import { hashMessage } from '../../utils/hashMessage';
 
-describe('I18nManager.resolveTranslationSync', () => {
+describe('I18nCache.resolveTranslationSync', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   it('should return undefined when no translations loaded for locale', () => {
-    const manager = new I18nManager({
+    const cache = new I18nCache({
       defaultLocale: 'en',
       locales: ['en', 'fr'],
       loadTranslations: vi.fn(),
     });
 
-    const result = manager.resolveTranslationSync('fr', 'Hello', {
+    const result = cache.resolveTranslationSync('fr', 'Hello', {
       $format: 'ICU',
     });
 
@@ -22,7 +22,7 @@ describe('I18nManager.resolveTranslationSync', () => {
   });
 
   it('does not throw without options in development', () => {
-    const manager = new I18nManager({
+    const cache = new I18nCache({
       defaultLocale: 'en',
       locales: ['en', 'fr'],
       loadTranslations: vi.fn(),
@@ -32,10 +32,10 @@ describe('I18nManager.resolveTranslationSync', () => {
     const options = { $format: 'ICU' as const };
 
     expect(() =>
-      manager.resolveTranslationSync('fr', 'Hello', options)
+      cache.resolveTranslationSync('fr', 'Hello', options)
     ).not.toThrow();
     expect(
-      manager.resolveTranslationSync('fr', 'Hello', options)
+      cache.resolveTranslationSync('fr', 'Hello', options)
     ).toBeUndefined();
   });
 
@@ -49,16 +49,16 @@ describe('I18nManager.resolveTranslationSync', () => {
       [expectedHash]: translatedString,
     };
 
-    const manager = new I18nManager({
+    const cache = new I18nCache({
       defaultLocale: 'en',
       locales: ['en', 'fr'],
       loadTranslations: vi.fn().mockResolvedValue(mockTranslations),
     });
 
     // Trigger async load to populate resolvedCache
-    await manager.getTranslations('fr');
+    await cache.getTranslations('fr');
 
-    const result = manager.resolveTranslationSync('fr', message, options);
+    const result = cache.resolveTranslationSync('fr', message, options);
 
     expect(result).toBe(translatedString);
   });

--- a/packages/i18n/src/i18n-cache/event-subscription/types.ts
+++ b/packages/i18n/src/i18n-cache/event-subscription/types.ts
@@ -35,7 +35,7 @@ export const DICTIONARY_OBJECT_CACHE_HIT_EVENT_NAME =
   'dictionary-object-cache-hit';
 
 /**
- * A base event for the I18nManagers
+ * A base event for the I18nCaches
  * @prop {locales-cache-hit} - Emitted when a locale cache hit occurs
  * @prop {locales-cache-miss} - Emitted when a locale cache miss occurs
  * @prop {translations-cache-hit} - Emitted when a translations cache hit occurs

--- a/packages/i18n/src/i18n-cache/index.ts
+++ b/packages/i18n/src/i18n-cache/index.ts
@@ -1,5 +1,7 @@
 // Classes
-export { I18nManager } from './I18nCache';
+export { I18nCache } from './I18nCache';
+/** @deprecated use I18nCache instead */
+export { I18nCache as I18nManager } from './I18nCache';
 export { ReadonlyConditionStore } from '../condition-store/ReadonlyConditionStore';
 export type { ReadonlyConditionStoreParams } from '../condition-store/ReadonlyConditionStore';
 export { WritableConditionStore } from '../condition-store/WritableConditionStore';
@@ -20,4 +22,8 @@ export {
 } from './event-subscription/types';
 
 // Functions
-export { getI18nManager, setI18nManager } from './singleton-operations';
+export { getI18nCache, setI18nCache } from './singleton-operations';
+/** @deprecated use getI18nCache instead */
+export { getI18nCache as getI18nManager } from './singleton-operations';
+/** @deprecated use setI18nCache instead */
+export { setI18nCache as setI18nManager } from './singleton-operations';

--- a/packages/i18n/src/i18n-cache/lifecycle-hooks/createLifecycleCallbacks.ts
+++ b/packages/i18n/src/i18n-cache/lifecycle-hooks/createLifecycleCallbacks.ts
@@ -11,7 +11,7 @@ import {
   TRANSLATIONS_CACHE_MISS_EVENT_NAME,
 } from '../event-subscription/types';
 import type { Translation } from '../translations-manager/utils/types/translation-data';
-import type { I18nManagerCacheLifecycleCallbacks } from './types';
+import type { I18nCacheLifecycleCallbacks } from './types';
 import type { I18nEvents } from '../event-subscription/types';
 /**
  * Maps consumer-facing lifecycle callbacks to internal locales cache lifecycle callbacks.
@@ -25,7 +25,7 @@ export function createLifecycleCallbacks<TranslationValue extends Translation>(
   hasListeners: <EventName extends keyof I18nEvents<TranslationValue>>(
     eventName: EventName
   ) => boolean = () => true
-): I18nManagerCacheLifecycleCallbacks<TranslationValue> {
+): I18nCacheLifecycleCallbacks<TranslationValue> {
   return {
     onLocalesCacheHit: (params) => {
       if (!hasListeners(LOCALES_CACHE_HIT_EVENT_NAME)) {

--- a/packages/i18n/src/i18n-cache/lifecycle-hooks/types.ts
+++ b/packages/i18n/src/i18n-cache/lifecycle-hooks/types.ts
@@ -122,17 +122,21 @@ export type LocalesDictionaryCacheLifecycleCallbacks = {
 };
 
 /**
- * Combined I18nManager cache lifecycle callbacks
+ * Combined I18nCache cache lifecycle callbacks
  */
+export type I18nCacheLifecycleCallbacks<TranslationValue extends Translation> =
+  LocalesTranslationsCacheLifecycleCallbacks<TranslationValue> &
+    LocalesDictionaryCacheLifecycleCallbacks;
+
+/** @deprecated use I18nCacheLifecycleCallbacks instead */
 export type I18nManagerCacheLifecycleCallbacks<
   TranslationValue extends Translation,
-> = LocalesTranslationsCacheLifecycleCallbacks<TranslationValue> &
-  LocalesDictionaryCacheLifecycleCallbacks;
+> = I18nCacheLifecycleCallbacks<TranslationValue>;
 
 // ===== Consumer API ===== //
 
 /**
- * Simplified lifecycle callbacks for I18nManager consumers.
+ * Simplified lifecycle callbacks for I18nCache consumers.
  * These provide a cleaner interface than the internal cache lifecycle types,
  * with locale and hash exposed directly instead of the full cache internals.
  *

--- a/packages/i18n/src/i18n-cache/singleton-operations.ts
+++ b/packages/i18n/src/i18n-cache/singleton-operations.ts
@@ -1,45 +1,50 @@
 import { libraryDefaultLocale } from 'generaltranslation/internal';
-import { I18nManager } from './I18nCache';
+import { I18nCache } from './I18nCache';
 import logger from '../logs/logger';
 import { Translation } from './translations-manager/utils/types/translation-data';
 import { createConditionStoreSingleton } from '../condition-store/createConditionStoreSingleton';
 import { WritableConditionStoreInterface } from './types';
 
-// Singleton instance of I18nManager
-let i18nManager: I18nManager | undefined = undefined;
+// Singleton instance of I18nCache
+let i18nCache: I18nCache | undefined = undefined;
 
 /**
- * Get the singleton instance of I18nManager
- * @returns The singleton instance of I18nManager
+ * Get the singleton instance of I18nCache
+ * @returns The singleton instance of I18nCache
  * @template U - The type of the translation that will be cached
  *
  * Note: should not be consumed by gt-react, consumers should use a wrapper
  */
-export function getI18nManager<U extends Translation = Translation>():
-  | I18nManager<U>
-  | I18nManager<Translation> {
-  if (!i18nManager) {
+export function getI18nCache<U extends Translation = Translation>():
+  | I18nCache<U>
+  | I18nCache<Translation> {
+  if (!i18nCache) {
     logger.warn(
-      'getI18nManager(): I18nManager was not initialized. Falling back to the default locale until initializeGT() configures translations.'
+      'getI18nCache(): I18nCache was not initialized. Falling back to the default locale until initializeGT() configures translations.'
     );
-    i18nManager = new I18nManager({
+    i18nCache = new I18nCache({
       defaultLocale: libraryDefaultLocale,
       locales: [libraryDefaultLocale],
     });
   }
-  return i18nManager;
+  return i18nCache;
 }
 
 /**
- * Configure the singleton instance of I18nManager
- * @param config - The configuration for the I18nManager
+ * Configure the singleton instance of I18nCache
+ * @param config - The configuration for the I18nCache
  *
  * Wrapper libraries will export a configure function that will call this function.
  *
  * Note: should not be consumed by gt-react, consumers should use a wrapper
  */
-export function setI18nManager<TranslationValue extends Translation>(
-  i18nManagerInstance: I18nManager<TranslationValue>
+export function setI18nCache<TranslationValue extends Translation>(
+  i18nCacheInstance: I18nCache<TranslationValue>
 ): void {
-  i18nManager = i18nManagerInstance as unknown as I18nManager;
+  i18nCache = i18nCacheInstance as unknown as I18nCache;
 }
+
+/** @deprecated use getI18nCache instead */
+export { getI18nCache as getI18nManager };
+/** @deprecated use setI18nCache instead */
+export { setI18nCache as setI18nManager };

--- a/packages/i18n/src/i18n-cache/translations-manager/LocalesCache.ts
+++ b/packages/i18n/src/i18n-cache/translations-manager/LocalesCache.ts
@@ -16,7 +16,7 @@ import type { CreateTranslateMany } from './utils/createTranslateMany';
 import type { Translation } from './utils/types/translation-data';
 import type { SafeTranslationsLoader } from './translations-loaders/types';
 import type {
-  I18nManagerCacheLifecycleCallbacks,
+  I18nCacheLifecycleCallbacks,
   LifecycleCallback,
   LifecycleParam,
 } from '../lifecycle-hooks/types';
@@ -41,7 +41,7 @@ type LocalesCacheParams<TranslationValue extends Translation> = {
   loadTranslations: SafeTranslationsLoader<TranslationValue>;
   loadDictionary: DictionaryLoader;
   translateDictionaryEntry: TranslateLocaleDictionaryEntry;
-  lifecycle: I18nManagerCacheLifecycleCallbacks<TranslationValue>;
+  lifecycle: I18nCacheLifecycleCallbacks<TranslationValue>;
 };
 
 export class LocalesCache<TranslationValue extends Translation> {
@@ -165,7 +165,7 @@ function createTranslationsCacheFactory<TranslationValue extends Translation>({
   createTranslateMany,
   batchConfig,
 }: {
-  lifecycle: I18nManagerCacheLifecycleCallbacks<TranslationValue>;
+  lifecycle: I18nCacheLifecycleCallbacks<TranslationValue>;
   createTranslateMany: CreateTranslateMany;
   batchConfig?: TranslationBatchConfig;
 }) {
@@ -180,7 +180,7 @@ function createTranslationsCacheFactory<TranslationValue extends Translation>({
 
 function createTranslationsCacheLifecycle<TranslationValue extends Translation>(
   locale: Locale,
-  lifecycle: I18nManagerCacheLifecycleCallbacks<TranslationValue>
+  lifecycle: I18nCacheLifecycleCallbacks<TranslationValue>
 ): LifecycleParam<
   TranslationKey<TranslationValue>,
   Hash,
@@ -202,7 +202,7 @@ function createDictionaryCache<TranslationValue extends Translation>({
   locale: Locale;
   dictionary: Dictionary;
   translate: TranslateLocaleDictionaryEntry;
-  lifecycle: I18nManagerCacheLifecycleCallbacks<TranslationValue>;
+  lifecycle: I18nCacheLifecycleCallbacks<TranslationValue>;
 }) {
   const {
     onDictionaryCacheHit,

--- a/packages/i18n/src/i18n-cache/translations-manager/__tests__/LocalesCache.test.ts
+++ b/packages/i18n/src/i18n-cache/translations-manager/__tests__/LocalesCache.test.ts
@@ -4,7 +4,7 @@ import { DEFAULT_CACHE_EXPIRY_TIME } from '../utils/constants';
 import type { Dictionary, DictionaryLoader } from '../DictionaryCache';
 import type { Hash } from '../TranslationsCache';
 import type { CreateTranslateMany } from '../utils/createTranslateMany';
-import type { I18nManagerCacheLifecycleCallbacks } from '../../lifecycle-hooks/types';
+import type { I18nCacheLifecycleCallbacks } from '../../lifecycle-hooks/types';
 import type { SafeTranslationsLoader } from '../translations-loaders/types';
 
 describe('LocalesCache', () => {
@@ -42,7 +42,7 @@ describe('LocalesCache', () => {
 
   function createCache(opts?: {
     ttl?: number | null;
-    lifecycle?: I18nManagerCacheLifecycleCallbacks<string>;
+    lifecycle?: I18nCacheLifecycleCallbacks<string>;
   }) {
     return new LocalesCache<string>({
       defaultLocale: 'en',

--- a/packages/i18n/src/i18n-cache/translations-manager/translations-loaders/routeCreateTranslationLoader.ts
+++ b/packages/i18n/src/i18n-cache/translations-manager/translations-loaders/routeCreateTranslationLoader.ts
@@ -31,7 +31,7 @@ export function routeCreateTranslationLoader({
   if (type === LoadTranslationsType.DISABLED) {
     // TODO: move this warning to validation layer
     logger.warn(
-      'I18nManager: No translation loader found. No translations will be loaded.'
+      'I18nCache: No translation loader found. No translations will be loaded.'
     );
   }
 

--- a/packages/i18n/src/i18n-cache/translations-manager/utils/DictionarySourceNotFoundError.ts
+++ b/packages/i18n/src/i18n-cache/translations-manager/utils/DictionarySourceNotFoundError.ts
@@ -1,6 +1,6 @@
 export class DictionarySourceNotFoundError extends Error {
   constructor(id: string) {
-    super(`I18nManager: source dictionary entry ${id} is not defined`);
+    super(`I18nCache: source dictionary entry ${id} is not defined`);
     this.name = 'DictionarySourceNotFoundError';
   }
 }

--- a/packages/i18n/src/i18n-cache/types.ts
+++ b/packages/i18n/src/i18n-cache/types.ts
@@ -26,9 +26,9 @@ type RuntimeTranslationConfig = {
 };
 
 /**
- * Parameters for the I18nManager constructor
+ * Parameters for the I18nCache constructor
  */
-export type I18nManagerConstructorParams<
+export type I18nCacheConstructorParams<
   TranslationValue extends Translation = Translation,
 > = DictionaryConfig &
   Omit<GTConfig, 'cacheExpiryTime'> & {
@@ -46,10 +46,15 @@ export type I18nManagerConstructorParams<
     lifecycle?: LifecycleCallbacks<TranslationValue>;
   };
 
+/** @deprecated use I18nCacheConstructorParams instead */
+export type I18nManagerConstructorParams<
+  TranslationValue extends Translation = Translation,
+> = I18nCacheConstructorParams<TranslationValue>;
+
 /**
- * I18nManager class configuration
+ * I18nCache class configuration
  */
-export type I18nManagerConfig = {
+export type I18nCacheConfig = {
   environment: 'development' | 'production';
   defaultLocale: string;
   locales: string[];
@@ -74,6 +79,9 @@ export type I18nManagerConfig = {
   runtimeTranslation?: RuntimeTranslationConfig;
   _versionId?: string;
 };
+
+/** @deprecated use I18nCacheConfig instead */
+export type I18nManagerConfig = I18nCacheConfig;
 
 /**
  * Shared configuration used by condition stores to resolve locales.

--- a/packages/i18n/src/i18n-cache/validation/config-validation/validateLoadTranslations.ts
+++ b/packages/i18n/src/i18n-cache/validation/config-validation/validateLoadTranslations.ts
@@ -40,7 +40,7 @@ export function validateLoadTranslations(params: {
           message: createDiagnosticMessage({
             whatHappened:
               'Loading translations from a remote store needs a projectId',
-            fix: 'Add projectId to the I18nManager config or disable remote translation loading',
+            fix: 'Add projectId to the I18nCache config or disable remote translation loading',
           }),
         });
       }

--- a/packages/i18n/src/i18n-cache/validation/config-validation/validateTranslationApi.ts
+++ b/packages/i18n/src/i18n-cache/validation/config-validation/validateTranslationApi.ts
@@ -43,7 +43,7 @@ export function validateTranslationApi(params: {
           type: 'warning',
           message: createDiagnosticMessage({
             whatHappened: 'Runtime translation needs a projectId',
-            fix: 'Add projectId to the I18nManager config or disable runtime translation',
+            fix: 'Add projectId to the I18nCache config or disable runtime translation',
           }),
         });
       }
@@ -52,7 +52,7 @@ export function validateTranslationApi(params: {
           type: 'warning',
           message: createDiagnosticMessage({
             whatHappened: 'Runtime translation needs devApiKey or apiKey',
-            fix: 'Add credentials to the I18nManager config or disable runtime translation',
+            fix: 'Add credentials to the I18nCache config or disable runtime translation',
           }),
         });
       }

--- a/packages/i18n/src/i18n-cache/validation/validateConfig.ts
+++ b/packages/i18n/src/i18n-cache/validation/validateConfig.ts
@@ -1,5 +1,5 @@
 import { ValidationResult } from './types';
-import { I18nManagerConstructorParams } from '../types';
+import { I18nCacheConstructorParams } from '../types';
 import { validateLoadTranslations } from './config-validation/validateLoadTranslations';
 import { validateTranslationApi } from './config-validation/validateTranslationApi';
 import { validateLocales } from './config-validation/validateLocales';
@@ -12,7 +12,7 @@ import type { Translation } from '../translations-manager/utils/types/translatio
  * @returns The validation results
  */
 export function validateConfig<TranslationValue extends Translation>(
-  config: I18nManagerConstructorParams<TranslationValue>
+  config: I18nCacheConstructorParams<TranslationValue>
 ): ValidationResult[] {
   const results: ValidationResult[] = [];
 

--- a/packages/i18n/src/internal-types.ts
+++ b/packages/i18n/src/internal-types.ts
@@ -1,8 +1,8 @@
-// I18nManager
+// I18nCache
 export type {
-  I18nManagerConstructorParams,
+  I18nCacheConstructorParams,
   TranslationsLoader,
-  I18nManagerConfig,
+  I18nCacheConfig,
   LifecycleCallbacks,
   LocaleResolverConfig,
   ReadonlyConditionStoreInterface,
@@ -12,6 +12,10 @@ export type {
   DictionaryLoader,
   DictionaryConfig,
 } from './i18n-cache/types';
+/** @deprecated use I18nCacheConstructorParams instead */
+export type { I18nCacheConstructorParams as I18nManagerConstructorParams } from './i18n-cache/types';
+/** @deprecated use I18nCacheConfig instead */
+export type { I18nCacheConfig as I18nManagerConfig } from './i18n-cache/types';
 export type { LocaleCandidates } from './condition-store/localeResolver';
 export type {
   DictionaryValue,

--- a/packages/i18n/src/internal.ts
+++ b/packages/i18n/src/internal.ts
@@ -21,9 +21,10 @@ export {
   resolveDictionaryLookupOptions,
 } from './i18n-cache/translations-manager/utils/dictionary-helpers';
 
-export {
-  getI18nManager,
-  setI18nManager,
-} from './i18n-cache/singleton-operations';
+export { getI18nCache, setI18nCache } from './i18n-cache/singleton-operations';
+/** @deprecated use getI18nCache instead */
+export { getI18nCache as getI18nManager } from './i18n-cache/singleton-operations';
+/** @deprecated use setI18nCache instead */
+export { setI18nCache as setI18nManager } from './i18n-cache/singleton-operations';
 export { createConditionStoreSingleton } from './condition-store/createConditionStoreSingleton';
 export { getRuntimeEnvironment } from './utils/getRuntimeEnvironment';

--- a/packages/i18n/src/translation-functions/__tests__/t.test.ts
+++ b/packages/i18n/src/translation-functions/__tests__/t.test.ts
@@ -1,21 +1,20 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { I18nManager } from '../../i18n-cache/I18nCache';
-import {
-  setI18nManager,
-  setConditionStore,
-} from '../../i18n-cache/singleton-operations';
+import { I18nCache } from '../../i18n-cache/I18nCache';
+import { setI18nCache } from '../../i18n-cache/singleton-operations';
+import { setWritableConditionStore } from '../../condition-store/singleton-operations';
 import { getLocale, getLocaleProperties } from '../../helpers/locale';
 import { hashMessage } from '../../utils/hashMessage';
 import { t } from '../t';
 
 describe('t', () => {
   afterEach(() => {
-    setConditionStore({ getLocale: () => 'en' });
+    setWritableConditionStore({ getLocale: () => 'en' });
   });
 
   it('works without an explicit locale', () => {
-    setI18nManager(
-      new I18nManager({
+    setWritableConditionStore({ getLocale: () => 'en' });
+    setI18nCache(
+      new I18nCache({
         defaultLocale: 'en',
         locales: ['en', 'fr'],
         loadTranslations: vi.fn(),
@@ -28,7 +27,7 @@ describe('t', () => {
   it('uses the configured fallback locale store when no locale is provided', async () => {
     const message = 'Hello {name}!';
     const translatedMessage = 'Bonjour {name} !';
-    const manager = new I18nManager({
+    const cache = new I18nCache({
       defaultLocale: 'en',
       locales: ['en', 'fr'],
       loadTranslations: vi.fn().mockResolvedValue({
@@ -37,16 +36,16 @@ describe('t', () => {
     });
     const conditionStore = { getLocale: () => 'fr' };
 
-    setI18nManager(manager);
-    setConditionStore(conditionStore);
-    await manager.loadTranslations('fr');
+    setI18nCache(cache);
+    setWritableConditionStore(conditionStore);
+    await cache.loadTranslations('fr');
 
     expect(t(message, { name: 'Alice' })).toBe('Bonjour Alice !');
   });
 
   it('allows an explicit $locale to override the current locale', async () => {
     const message = 'Hello {name}!';
-    const manager = new I18nManager({
+    const cache = new I18nCache({
       defaultLocale: 'en',
       locales: ['en', 'fr', 'es'],
       loadTranslations: vi.fn().mockImplementation((locale: string) => ({
@@ -55,16 +54,16 @@ describe('t', () => {
       })),
     });
 
-    setI18nManager(manager);
-    setConditionStore({ getLocale: () => 'fr' });
-    await manager.loadTranslations('es');
+    setI18nCache(cache);
+    setWritableConditionStore({ getLocale: () => 'fr' });
+    await cache.loadTranslations('es');
 
     expect(t(message, { $locale: 'es', name: 'Alice' })).toBe('Hola Alice!');
   });
 
   it('does not read the current locale when $locale is explicit', async () => {
     const message = 'Hello {name}!';
-    const manager = new I18nManager({
+    const cache = new I18nCache({
       defaultLocale: 'en',
       locales: ['en', 'fr'],
       loadTranslations: vi.fn().mockResolvedValue({
@@ -72,36 +71,36 @@ describe('t', () => {
       }),
     });
 
-    setI18nManager(manager);
-    setConditionStore({
+    setI18nCache(cache);
+    setWritableConditionStore({
       getLocale: () => {
         throw new Error('current locale should not be read');
       },
     });
-    await manager.loadTranslations('fr');
+    await cache.loadTranslations('fr');
 
     expect(t(message, { $locale: 'fr', name: 'Alice' })).toBe(
       'Bonjour Alice !'
     );
   });
 
-  it('resets stale condition stores when the singleton manager is replaced', () => {
-    setConditionStore({ getLocale: () => 'fr' });
+  it('keeps the configured condition store when the singleton cache is replaced', () => {
+    setWritableConditionStore({ getLocale: () => 'fr' });
 
-    setI18nManager(
-      new I18nManager({
+    setI18nCache(
+      new I18nCache({
         defaultLocale: 'es',
         locales: ['es'],
         loadTranslations: vi.fn(),
       })
     );
 
-    expect(getLocale()).toBe('es');
+    expect(getLocale()).toBe('fr');
   });
 
   it('returns locale properties outside configured translation locales', () => {
-    setI18nManager(
-      new I18nManager({
+    setI18nCache(
+      new I18nCache({
         defaultLocale: 'en',
         locales: ['fr'],
         loadTranslations: vi.fn(),

--- a/packages/i18n/src/translation-functions/internal/__tests__/helpers.integration.test.ts
+++ b/packages/i18n/src/translation-functions/internal/__tests__/helpers.integration.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { I18nManager } from '../../../i18n-cache/I18nCache';
-import { setI18nManager } from '../../../i18n-cache/singleton-operations';
+import { I18nCache } from '../../../i18n-cache/I18nCache';
+import { setI18nCache } from '../../../i18n-cache/singleton-operations';
 import { hashMessage } from '../../../utils/hashMessage';
 import { LookupOptions } from '../../types/options';
 import {
@@ -31,13 +31,13 @@ describe('translation helpers (deep integration)', () => {
   });
 
   function setupManager(preloadedTranslations: Record<string, string> = {}) {
-    const manager = new I18nManager({
+    const cache = new I18nCache({
       defaultLocale: 'en',
       locales: ['en', 'fr'],
       loadTranslations: vi.fn().mockResolvedValue(preloadedTranslations),
     });
-    setI18nManager(manager);
-    return manager;
+    setI18nCache(cache);
+    return cache;
   }
 
   it('resolveStringContentWithRuntimeFallback triggers translateMany when translation not preloaded', async () => {

--- a/packages/i18n/src/translation-functions/internal/__tests__/helpers.test.ts
+++ b/packages/i18n/src/translation-functions/internal/__tests__/helpers.test.ts
@@ -4,7 +4,7 @@ import {
   resolveStringContentWithFallback,
   resolveStringContentWithRuntimeFallback,
 } from '../helpers';
-import { getI18nManager } from '../../../i18n-cache/singleton-operations';
+import { getI18nCache } from '../../../i18n-cache/singleton-operations';
 import { interpolateMessage } from '../../utils/interpolation/interpolateMessage';
 
 vi.mock('../../../i18n-cache/singleton-operations');
@@ -19,12 +19,12 @@ describe('translation helpers', () => {
   // ===== REGRESSION ===== //
 
   it('resolveJsx returns undefined when lookupTranslation returns undefined', () => {
-    const mockManager = {
+    const mockCache = {
       getLocale: vi.fn().mockReturnValue('fr'),
       lookupTranslation: vi.fn().mockReturnValue(undefined),
     };
-    vi.mocked(getI18nManager).mockReturnValue(
-      mockManager as unknown as ReturnType<typeof getI18nManager>
+    vi.mocked(getI18nCache).mockReturnValue(
+      mockCache as unknown as ReturnType<typeof getI18nCache>
     );
 
     const result = resolveJsx('fr', ['Hello']);
@@ -32,16 +32,16 @@ describe('translation helpers', () => {
   });
 
   it('resolveJsx uses the provided locale', () => {
-    const mockManager = {
+    const mockCache = {
       lookupTranslation: vi.fn().mockReturnValue(undefined),
     };
-    vi.mocked(getI18nManager).mockReturnValue(
-      mockManager as unknown as ReturnType<typeof getI18nManager>
+    vi.mocked(getI18nCache).mockReturnValue(
+      mockCache as unknown as ReturnType<typeof getI18nCache>
     );
 
     resolveJsx('fr', ['Hello']);
 
-    expect(mockManager.lookupTranslation).toHaveBeenCalledWith(
+    expect(mockCache.lookupTranslation).toHaveBeenCalledWith(
       'fr',
       ['Hello'],
       expect.objectContaining({ $format: 'JSX', $locale: 'fr' })
@@ -51,20 +51,20 @@ describe('translation helpers', () => {
   // ===== NEW BEHAVIOR ===== //
 
   it('resolveStringContentWithRuntimeFallback calls lookupTranslationWithFallback and interpolates', async () => {
-    const mockManager = {
+    const mockCache = {
       getLocale: vi.fn().mockReturnValue('fr'),
       lookupTranslationWithFallback: vi
         .fn()
         .mockResolvedValue('Bonjour {name} !'),
       getDefaultLocale: vi.fn().mockReturnValue('en'),
     };
-    vi.mocked(getI18nManager).mockReturnValue(
-      mockManager as unknown as ReturnType<typeof getI18nManager>
+    vi.mocked(getI18nCache).mockReturnValue(
+      mockCache as unknown as ReturnType<typeof getI18nCache>
     );
 
     await resolveStringContentWithRuntimeFallback('fr', 'Hello {name}!');
 
-    expect(mockManager.lookupTranslationWithFallback).toHaveBeenCalled();
+    expect(mockCache.lookupTranslationWithFallback).toHaveBeenCalled();
     expect(interpolateMessage).toHaveBeenCalledWith({
       source: 'Hello {name}!',
       target: 'Bonjour {name} !',
@@ -74,13 +74,13 @@ describe('translation helpers', () => {
   });
 
   it('resolveStringContentWithFallback interpolates source when no translation found', () => {
-    const mockManager = {
+    const mockCache = {
       getLocale: vi.fn().mockReturnValue('fr'),
       lookupTranslation: vi.fn().mockReturnValue(undefined),
       getDefaultLocale: vi.fn().mockReturnValue('en'),
     };
-    vi.mocked(getI18nManager).mockReturnValue(
-      mockManager as unknown as ReturnType<typeof getI18nManager>
+    vi.mocked(getI18nCache).mockReturnValue(
+      mockCache as unknown as ReturnType<typeof getI18nCache>
     );
 
     resolveStringContentWithFallback('fr', 'Hello {name}!');

--- a/packages/i18n/src/translation-functions/internal/__tests__/locale-defaults.test.ts
+++ b/packages/i18n/src/translation-functions/internal/__tests__/locale-defaults.test.ts
@@ -1,9 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { I18nManager } from '../../../i18n-cache/I18nCache';
-import {
-  setConditionStore,
-  setI18nManager,
-} from '../../../i18n-cache/singleton-operations';
+import { I18nCache } from '../../../i18n-cache/I18nCache';
+import { setI18nCache } from '../../../i18n-cache/singleton-operations';
+import { setWritableConditionStore } from '../../../condition-store/singleton-operations';
 import { msg } from '../../msg';
 import { hashMessage } from '../../../utils/hashMessage';
 import { getGT } from '../getGT';
@@ -13,20 +11,20 @@ import { tx } from '../tx';
 
 describe('translation function locale defaults', () => {
   afterEach(() => {
-    setConditionStore({ getLocale: () => 'en' });
+    setWritableConditionStore({ getLocale: () => 'en' });
   });
 
   function setupManager(translations: Record<string, string>) {
-    const manager = new I18nManager({
+    const cache = new I18nCache({
       defaultLocale: 'en',
       locales: ['en', 'fr'],
       loadTranslations: vi.fn().mockResolvedValue(translations),
     });
 
-    setI18nManager(manager);
-    setConditionStore({ getLocale: () => 'fr' });
+    setI18nCache(cache);
+    setWritableConditionStore({ getLocale: () => 'fr' });
 
-    return manager;
+    return cache;
   }
 
   it('getGT uses the current locale without accepting a locale parameter', async () => {
@@ -42,7 +40,7 @@ describe('translation function locale defaults', () => {
 
   it('getGT allows $locale to select another loaded locale', async () => {
     const message = 'Hello {name}!';
-    const manager = new I18nManager({
+    const cache = new I18nCache({
       defaultLocale: 'en',
       locales: ['en', 'fr', 'es'],
       loadTranslations: vi.fn().mockImplementation((locale: string) => ({
@@ -50,17 +48,17 @@ describe('translation function locale defaults', () => {
           locale === 'es' ? 'Hola {name}!' : 'Bonjour {name} !',
       })),
     });
-    setI18nManager(manager);
-    setConditionStore({ getLocale: () => 'fr' });
+    setI18nCache(cache);
+    setWritableConditionStore({ getLocale: () => 'fr' });
 
     const gt = await getGT();
-    await manager.loadTranslations('es');
+    await cache.loadTranslations('es');
 
     expect(gt(message, { $locale: 'es', name: 'Alice' })).toBe('Hola Alice!');
   });
 
   it('getTranslations uses the current locale for dictionary entries', async () => {
-    const manager = new I18nManager({
+    const cache = new I18nCache({
       defaultLocale: 'en',
       locales: ['en', 'fr'],
       dictionary: {
@@ -70,8 +68,8 @@ describe('translation function locale defaults', () => {
         greeting: 'Bonjour {name} !',
       }),
     });
-    setI18nManager(manager);
-    setConditionStore({ getLocale: () => 'fr' });
+    setI18nCache(cache);
+    setWritableConditionStore({ getLocale: () => 'fr' });
 
     const t = await getTranslations();
 
@@ -79,7 +77,7 @@ describe('translation function locale defaults', () => {
   });
 
   it('getTranslations returns source dictionary entries when no target translation exists', async () => {
-    const manager = new I18nManager({
+    const cache = new I18nCache({
       defaultLocale: 'en',
       locales: ['en', 'fr'],
       dictionary: {
@@ -87,8 +85,8 @@ describe('translation function locale defaults', () => {
       },
       loadDictionary: vi.fn().mockResolvedValue({}),
     });
-    setI18nManager(manager);
-    setConditionStore({ getLocale: () => 'fr' });
+    setI18nCache(cache);
+    setWritableConditionStore({ getLocale: () => 'fr' });
 
     const t = await getTranslations();
 
@@ -101,7 +99,7 @@ describe('translation function locale defaults', () => {
     const loadTranslations = vi.fn().mockResolvedValue({
       [hashMessage(message, lookupOptions)]: 'Bonjour {name} !',
     });
-    const manager = new I18nManager({
+    const cache = new I18nCache({
       defaultLocale: 'en',
       locales: ['en', 'fr'],
       dictionary: {
@@ -110,8 +108,8 @@ describe('translation function locale defaults', () => {
       loadDictionary: vi.fn().mockResolvedValue({}),
       loadTranslations,
     });
-    setI18nManager(manager);
-    setConditionStore({ getLocale: () => 'fr' });
+    setI18nCache(cache);
+    setWritableConditionStore({ getLocale: () => 'fr' });
 
     const t = await getTranslations();
 
@@ -120,7 +118,7 @@ describe('translation function locale defaults', () => {
   });
 
   it('getTranslations throws when the source dictionary entry is missing', async () => {
-    const manager = new I18nManager({
+    const cache = new I18nCache({
       defaultLocale: 'en',
       locales: ['en', 'fr'],
       dictionary: {
@@ -128,8 +126,8 @@ describe('translation function locale defaults', () => {
       },
       loadDictionary: vi.fn().mockResolvedValue({}),
     });
-    setI18nManager(manager);
-    setConditionStore({ getLocale: () => 'fr' });
+    setI18nCache(cache);
+    setWritableConditionStore({ getLocale: () => 'fr' });
 
     const t = await getTranslations();
 
@@ -139,7 +137,7 @@ describe('translation function locale defaults', () => {
   });
 
   it('getTranslations obj throws when the source dictionary object is missing', async () => {
-    const manager = new I18nManager({
+    const cache = new I18nCache({
       defaultLocale: 'en',
       locales: ['en', 'fr'],
       dictionary: {
@@ -151,8 +149,8 @@ describe('translation function locale defaults', () => {
       },
       loadDictionary: vi.fn().mockResolvedValue({}),
     });
-    setI18nManager(manager);
-    setConditionStore({ getLocale: () => 'fr' });
+    setI18nCache(cache);
+    setWritableConditionStore({ getLocale: () => 'fr' });
 
     const t = await getTranslations();
 
@@ -162,7 +160,7 @@ describe('translation function locale defaults', () => {
   });
 
   it('getTranslations obj returns translated dictionary subtrees', async () => {
-    const manager = new I18nManager({
+    const cache = new I18nCache({
       defaultLocale: 'en',
       locales: ['en', 'fr'],
       dictionary: {
@@ -183,8 +181,8 @@ describe('translation function locale defaults', () => {
         },
       }),
     });
-    setI18nManager(manager);
-    setConditionStore({ getLocale: () => 'fr' });
+    setI18nCache(cache);
+    setWritableConditionStore({ getLocale: () => 'fr' });
 
     const t = await getTranslations();
 
@@ -204,7 +202,7 @@ describe('translation function locale defaults', () => {
     const loadTranslations = vi.fn().mockResolvedValue({
       [hashMessage(title, titleOptions)]: 'Titre',
     });
-    const manager = new I18nManager({
+    const cache = new I18nCache({
       defaultLocale: 'en',
       locales: ['en', 'fr'],
       dictionary: {
@@ -224,8 +222,8 @@ describe('translation function locale defaults', () => {
       }),
       loadTranslations,
     });
-    setI18nManager(manager);
-    setConditionStore({ getLocale: () => 'fr' });
+    setI18nCache(cache);
+    setWritableConditionStore({ getLocale: () => 'fr' });
 
     const t = await getTranslations();
 
@@ -258,7 +256,7 @@ describe('translation function locale defaults', () => {
 
   it('tx does not read the current locale when $locale is explicit', async () => {
     const message = 'Hello';
-    const manager = new I18nManager({
+    const cache = new I18nCache({
       defaultLocale: 'en',
       locales: ['en', 'fr'],
       loadTranslations: vi.fn().mockResolvedValue({
@@ -266,8 +264,8 @@ describe('translation function locale defaults', () => {
       }),
     });
 
-    setI18nManager(manager);
-    setConditionStore({
+    setI18nCache(cache);
+    setWritableConditionStore({
       getLocale: () => {
         throw new Error('current locale should not be read');
       },

--- a/packages/i18n/src/translation-functions/internal/__tests__/resolveTranslationSync.test.ts
+++ b/packages/i18n/src/translation-functions/internal/__tests__/resolveTranslationSync.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { resolveTranslationSync } from '../sync-translation-resolution';
-import { getI18nManager } from '../../../i18n-cache/singleton-operations';
+import { getI18nCache } from '../../../i18n-cache/singleton-operations';
 import { interpolateMessage } from '../../utils/interpolation/interpolateMessage';
 
 vi.mock('../../../i18n-cache/singleton-operations');
@@ -13,13 +13,13 @@ describe('resolveTranslationSync', () => {
   });
 
   it('should call interpolateMessage with source, target, and options when translation found', () => {
-    const mockManager = {
+    const mockCache = {
       getLocale: vi.fn().mockReturnValue('fr'),
       lookupTranslation: vi.fn().mockReturnValue('Bonjour {name} !'),
       getDefaultLocale: vi.fn().mockReturnValue('en'),
     };
-    vi.mocked(getI18nManager).mockReturnValue(
-      mockManager as unknown as ReturnType<typeof getI18nManager>
+    vi.mocked(getI18nCache).mockReturnValue(
+      mockCache as unknown as ReturnType<typeof getI18nCache>
     );
 
     const message = 'Hello {name}!';
@@ -40,12 +40,12 @@ describe('resolveTranslationSync', () => {
   });
 
   it('should return undefined when no translation found', () => {
-    const mockManager = {
+    const mockCache = {
       getLocale: vi.fn().mockReturnValue('fr'),
       lookupTranslation: vi.fn().mockReturnValue(undefined),
     };
-    vi.mocked(getI18nManager).mockReturnValue(
-      mockManager as unknown as ReturnType<typeof getI18nManager>
+    vi.mocked(getI18nCache).mockReturnValue(
+      mockCache as unknown as ReturnType<typeof getI18nCache>
     );
 
     const message = 'Hello {name}!';
@@ -58,13 +58,13 @@ describe('resolveTranslationSync', () => {
   });
 
   it('should preserve user options when translation found', () => {
-    const mockManager = {
+    const mockCache = {
       getLocale: vi.fn().mockReturnValue('fr'),
       lookupTranslation: vi.fn().mockReturnValue('Translated'),
       getDefaultLocale: vi.fn().mockReturnValue('en'),
     };
-    vi.mocked(getI18nManager).mockReturnValue(
-      mockManager as unknown as ReturnType<typeof getI18nManager>
+    vi.mocked(getI18nCache).mockReturnValue(
+      mockCache as unknown as ReturnType<typeof getI18nCache>
     );
 
     const message = 'Hello {name}!';
@@ -92,13 +92,13 @@ describe('resolveTranslationSync', () => {
   });
 
   it('should preserve $format in options passed to interpolateMessage', () => {
-    const mockManager = {
+    const mockCache = {
       getLocale: vi.fn().mockReturnValue('fr'),
       lookupTranslation: vi.fn().mockReturnValue('Translated'),
       getDefaultLocale: vi.fn().mockReturnValue('en'),
     };
-    vi.mocked(getI18nManager).mockReturnValue(
-      mockManager as unknown as ReturnType<typeof getI18nManager>
+    vi.mocked(getI18nCache).mockReturnValue(
+      mockCache as unknown as ReturnType<typeof getI18nCache>
     );
 
     const message = 'Hello {name}!';

--- a/packages/i18n/src/translation-functions/internal/getGT.ts
+++ b/packages/i18n/src/translation-functions/internal/getGT.ts
@@ -1,4 +1,4 @@
-import { getI18nManager } from '../../i18n-cache/singleton-operations';
+import { getI18nCache } from '../../i18n-cache/singleton-operations';
 import { InlineTranslationOptions } from '../types/options';
 import { GTFunctionType } from '../types/functions';
 import { interpolateMessage } from '../utils/interpolation/interpolateMessage';
@@ -16,10 +16,10 @@ import { getLocale } from '../../helpers/locale';
  */
 export async function getGT(): Promise<GTFunctionType> {
   // Get the translation resolver
-  const i18nManager = getI18nManager();
+  const i18nCache = getI18nCache();
   const locale = getLocale();
-  await i18nManager.loadTranslations(locale);
-  const sourceLocale = i18nManager.getDefaultLocale();
+  await i18nCache.loadTranslations(locale);
+  const sourceLocale = i18nCache.getDefaultLocale();
 
   /**
    * Registers a message at build time and resolves its translation at runtime.
@@ -49,7 +49,7 @@ export async function getGT(): Promise<GTFunctionType> {
     );
 
     // Lookup translation
-    const translation = i18nManager.lookupTranslation(
+    const translation = i18nCache.lookupTranslation(
       lookupOptions.$locale,
       message,
       lookupOptions

--- a/packages/i18n/src/translation-functions/internal/getTranslations.ts
+++ b/packages/i18n/src/translation-functions/internal/getTranslations.ts
@@ -1,4 +1,4 @@
-import { getI18nManager } from '../../i18n-cache/singleton-operations';
+import { getI18nCache } from '../../i18n-cache/singleton-operations';
 import { DictionaryTranslationOptions } from '../types/options';
 import { TFunctionType } from '../types/functions';
 import { renderDictionaryEntry } from './renderDictionaryEntry';
@@ -17,13 +17,13 @@ import { getLocale } from '../../helpers/locale';
  * const title = await t('page.title');
  */
 export async function getTranslations(): Promise<TFunctionType> {
-  const i18nManager = getI18nManager();
+  const i18nCache = getI18nCache();
   const locale = getLocale();
   await Promise.all([
-    i18nManager.loadDictionary(locale),
-    i18nManager.loadTranslations(locale),
+    i18nCache.loadDictionary(locale),
+    i18nCache.loadTranslations(locale),
   ]);
-  const sourceLocale = i18nManager.getDefaultLocale();
+  const sourceLocale = i18nCache.getDefaultLocale();
 
   /**
    * Dictionary resolution
@@ -45,21 +45,17 @@ export async function getTranslations(): Promise<TFunctionType> {
     id: string,
     options: DictionaryTranslationOptions = {}
   ): string => {
-    const sourceEntry = i18nManager.lookupDictionary(sourceLocale, id);
+    const sourceEntry = i18nCache.lookupDictionary(sourceLocale, id);
     if (sourceEntry === undefined) {
       throw new Error(`Dictionary entry ${id} cannot be found`);
     }
-    const targetEntry = i18nManager.lookupDictionary(locale, id);
+    const targetEntry = i18nCache.lookupDictionary(locale, id);
     const dictionaryOptions = resolveDictionaryLookupOptions(
       sourceEntry.options
     );
     const target =
       targetEntry?.entry ??
-      i18nManager.lookupTranslation(
-        locale,
-        sourceEntry.entry,
-        dictionaryOptions
-      );
+      i18nCache.lookupTranslation(locale, sourceEntry.entry, dictionaryOptions);
     return renderDictionaryEntry({
       sourceLocale,
       targetLocale: locale,
@@ -82,16 +78,16 @@ export async function getTranslations(): Promise<TFunctionType> {
    * // { greeting1: 'Hello', greeting2: 'Hi' }
    */
   t.obj = (id: string): DictionaryObjectTranslation => {
-    const sourceObject = i18nManager.lookupDictionaryObj(sourceLocale, id);
+    const sourceObject = i18nCache.lookupDictionaryObj(sourceLocale, id);
     if (sourceObject === undefined) {
       throw new Error(`Dictionary entry ${id} cannot be found`);
     }
-    const targetObject = i18nManager.lookupDictionaryObj(locale, id);
+    const targetObject = i18nCache.lookupDictionaryObj(locale, id);
     return renderDictionaryObject({
       sourceObject,
       targetObject,
       translate: (sourceEntry, dictionaryOptions) =>
-        i18nManager.lookupTranslation(
+        i18nCache.lookupTranslation(
           locale,
           sourceEntry.entry,
           dictionaryOptions

--- a/packages/i18n/src/translation-functions/internal/helpers.ts
+++ b/packages/i18n/src/translation-functions/internal/helpers.ts
@@ -1,4 +1,4 @@
-import { getI18nManager } from '../../i18n-cache/singleton-operations';
+import { getI18nCache } from '../../i18n-cache/singleton-operations';
 import { NormalizedLookupOptions, ResolutionOptions } from '../types/options';
 import { interpolateMessage } from '../utils/interpolation/interpolateMessage';
 import type {
@@ -18,9 +18,9 @@ export function resolveJsx(
   content: JsxChildren,
   options: ResolutionOptions<'JSX'> = {}
 ): JsxChildren | undefined {
-  const i18nManager = getI18nManager();
+  const i18nCache = getI18nCache();
   const lookupOptions = createLookupOptions(locale, options, 'JSX');
-  const translation = i18nManager.lookupTranslation(
+  const translation = i18nCache.lookupTranslation(
     lookupOptions.$locale,
     content,
     lookupOptions
@@ -50,9 +50,9 @@ export async function resolveJsxWithRuntimeFallback(
   content: JsxChildren,
   options: ResolutionOptions<'JSX'> = {}
 ): Promise<JsxChildren> {
-  const i18nManager = getI18nManager();
+  const i18nCache = getI18nCache();
   const lookupOptions = createLookupOptions(locale, options, 'JSX');
-  const translation = await i18nManager.lookupTranslationWithFallback(
+  const translation = await i18nCache.lookupTranslationWithFallback(
     lookupOptions.$locale,
     content,
     lookupOptions
@@ -71,9 +71,9 @@ export function resolveStringContent(
   content: StringContent,
   options: ResolutionOptions<StringFormat> = {}
 ): StringContent | undefined {
-  const i18nManager = getI18nManager();
+  const i18nCache = getI18nCache();
   const lookupOptions = createLookupOptions(locale, options, 'STRING');
-  const translation = i18nManager.lookupTranslation(
+  const translation = i18nCache.lookupTranslation(
     lookupOptions.$locale,
     content,
     lookupOptions
@@ -83,7 +83,7 @@ export function resolveStringContent(
     source: content,
     target: translation,
     options: lookupOptions,
-    sourceLocale: i18nManager.getDefaultLocale(),
+    sourceLocale: i18nCache.getDefaultLocale(),
   });
 }
 
@@ -95,9 +95,9 @@ export function resolveStringContentWithFallback(
   content: StringContent,
   options: ResolutionOptions<StringFormat> = {}
 ): StringContent {
-  const i18nManager = getI18nManager();
+  const i18nCache = getI18nCache();
   const lookupOptions = createLookupOptions(locale, options, 'STRING');
-  const translation = i18nManager.lookupTranslation(
+  const translation = i18nCache.lookupTranslation(
     lookupOptions.$locale,
     content,
     lookupOptions
@@ -106,7 +106,7 @@ export function resolveStringContentWithFallback(
     source: content,
     target: translation,
     options: lookupOptions,
-    sourceLocale: i18nManager.getDefaultLocale(),
+    sourceLocale: i18nCache.getDefaultLocale(),
   });
 }
 
@@ -120,9 +120,9 @@ export async function resolveStringContentWithRuntimeFallback(
   content: StringContent,
   options: ResolutionOptions<StringFormat> = {}
 ): Promise<StringContent> {
-  const i18nManager = getI18nManager();
+  const i18nCache = getI18nCache();
   const lookupOptions = createLookupOptions(locale, options, 'STRING');
-  const translation = await i18nManager.lookupTranslationWithFallback(
+  const translation = await i18nCache.lookupTranslationWithFallback(
     lookupOptions.$locale,
     content,
     lookupOptions
@@ -131,7 +131,7 @@ export async function resolveStringContentWithRuntimeFallback(
     source: content,
     target: translation,
     options: lookupOptions,
-    sourceLocale: i18nManager.getDefaultLocale(),
+    sourceLocale: i18nCache.getDefaultLocale(),
   });
 }
 /**

--- a/packages/i18n/src/translation-functions/msg/msg.ts
+++ b/packages/i18n/src/translation-functions/msg/msg.ts
@@ -46,7 +46,7 @@ import { RegisterableMessages } from '../types/message';
  * // "Hello, Alice!" id: "greetings.0"
  * // "Hello, Bob!" id: "greetings.1"
  *
- * @important Internal note: until other packages are updated to use i18n-context practices, msg cannot use any functions that use i18nManager at all!
+ * @important Internal note: until other packages are updated to use i18n-context practices, msg cannot use any functions that use i18nCache at all!
  */
 export function msg<T extends RegisterableMessages = string>(message: T): T;
 export function msg<T extends RegisterableMessages = string>(


### PR DESCRIPTION
Stack: 2/8

Base: e/i18n-cache-file-rename

Summary:
- Rename packages/i18n programming symbols from I18nManager/i18nManager to I18nCache/i18nCache.
- Export new cache names while keeping deprecated manager aliases for downstream packages.
- Update package-local tests for the renamed cache APIs.

Validation:
- pnpm --filter gt-i18n test
- pnpm --filter gt-i18n build
- pnpm --filter @generaltranslation/react-core build
- pnpm --filter gt-react build
- pnpm --filter gt-node build
- pnpm --filter gt-tanstack-start build

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1471"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782424452&installation_id=127936663&pr_number=1471&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1471&signature=7f168b40cfeff8484ed8140f7709ecd458ecff3e8238567e12f0c565b79ad3df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is part of a rename stack (2/8) that renames all `I18nManager`/`i18nManager` programming symbols to `I18nCache`/`i18nCache` within the `gt-i18n` package. All call sites, type definitions, log/error message prefixes, and JSDoc comments are updated, and deprecated backward-compatible aliases are added for every renamed class, function, and type so downstream packages continue to compile.

- **Core rename**: `I18nManager` class → `I18nCache`; `getI18nManager`/`setI18nManager` singletons → `getI18nCache`/`setI18nCache`; `I18nManagerConfig`/`I18nManagerConstructorParams` types → `I18nCacheConfig`/`I18nCacheConstructorParams`. Old names are re-exported as `@deprecated` aliases from every public barrel (`index.ts`, `internal.ts`, `internal-types.ts`).
- **Test updates**: All test files are updated to match the new names; `t.test.ts` also corrects a pre-existing broken import of `setConditionStore` from `i18n-cache/singleton-operations` (which that module never exported) to `setWritableConditionStore` from `condition-store/singleton-operations`, and the corresponding test assertion is updated to reflect the now-correct behaviour.
- **Minor cleanup opportunity**: `singleton-operations.ts` retains two unused imports (`createConditionStoreSingleton`, `WritableConditionStoreInterface`) that were presumably used in an earlier iteration of the file.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the rename is systematic, every old symbol is preserved as a deprecated alias, and the only non-trivial change (correcting the condition-store import in t.test.ts) moves toward correct behaviour.

The rename is thorough and the deprecated aliases ensure downstream packages won't break. The one leftover item is two unused imports in singleton-operations.ts that are harmless but should be cleaned up.

packages/i18n/src/i18n-cache/singleton-operations.ts — contains two unused imports that should be removed.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/i18n/src/i18n-cache/I18nCache.ts | Core class renamed from I18nManager to I18nCache, deprecated alias re-exported; all internal strings/log messages updated consistently |
| packages/i18n/src/i18n-cache/singleton-operations.ts | Renames getI18nManager/setI18nManager to getI18nCache/setI18nCache with deprecated aliases; retains two unused imports (createConditionStoreSingleton, WritableConditionStoreInterface) that are no longer referenced |
| packages/i18n/src/i18n-cache/index.ts | Public barrel updated to export new I18nCache/getI18nCache/setI18nCache names with deprecated I18nManager/getI18nManager/setI18nManager aliases |
| packages/i18n/src/i18n-cache/types.ts | I18nManagerConstructorParams → I18nCacheConstructorParams, I18nManagerConfig → I18nCacheConfig; deprecated type aliases preserved via re-export |
| packages/i18n/src/internal.ts | Internal barrel exports updated; deprecated aliases for getI18nManager and setI18nManager added alongside the new names |
| packages/i18n/src/internal-types.ts | Type exports updated to I18nCacheConstructorParams/I18nCacheConfig with deprecated aliases for old names |
| packages/i18n/src/translation-functions/__tests__/t.test.ts | Updated to use I18nCache/setI18nCache; fixes previously broken import of setConditionStore from i18n-cache/singleton-operations, now correctly uses setWritableConditionStore from condition-store/singleton-operations; test semantics intentionally updated |
| packages/i18n/src/i18n-cache/lifecycle-hooks/types.ts | I18nManagerCacheLifecycleCallbacks renamed to I18nCacheLifecycleCallbacks; deprecated alias kept as a type alias |
| packages/i18n/src/translation-functions/internal/helpers.ts | All getI18nManager() calls updated to getI18nCache(); logic unchanged |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[i18n-cache/index.ts] -->|exports new name| B["I18nCache (class)"]
    A -->|exports deprecated alias| C["I18nManager → I18nCache"]
    A -->|exports new name| D["getI18nCache / setI18nCache"]
    A -->|exports deprecated aliases| E["getI18nManager → getI18nCache\nsetI18nManager → setI18nCache"]

    F[internal.ts] -->|export * from| A
    F -->|explicit re-export| D
    F -->|explicit deprecated aliases| E

    G[internal-types.ts] -->|new types| H["I18nCacheConfig\nI18nCacheConstructorParams"]
    G -->|deprecated type aliases| I["I18nManagerConfig → I18nCacheConfig\nI18nManagerConstructorParams → I18nCacheConstructorParams"]

    J[singleton-operations.ts] --> D
    J --> E

    K[lifecycle-hooks/types.ts] -->|new type| L["I18nCacheLifecycleCallbacks"]
    K -->|deprecated alias| M["I18nManagerCacheLifecycleCallbacks → I18nCacheLifecycleCallbacks"]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fi18n%2Fsrc%2Fi18n-cache%2Fsingleton-operations.ts%3A5-6%0AThese%20two%20imports%20%E2%80%94%20%60createConditionStoreSingleton%60%20and%20%60WritableConditionStoreInterface%60%20%E2%80%94%20are%20unused%20in%20the%20current%20file.%20They%20appear%20to%20be%20leftovers%20from%20a%20previous%20version%20that%20also%20created%20and%20exported%20a%20condition-store%20singleton%20from%20this%20module.%20They%20should%20be%20removed%20to%20avoid%20misleading%20readers%20and%20to%20prevent%20any%20TypeScript%20%22unused%20imports%22%20linting%20warnings.%0A%0A%60%60%60suggestion%0A%0A%60%60%60%0A%0A&repo=generaltranslation%2Fgt&pr=1471&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fi18n-cache-i18n-symbols%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fi18n-cache-i18n-symbols%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fi18n%2Fsrc%2Fi18n-cache%2Fsingleton-operations.ts%3A5-6%0AThese%20two%20imports%20%E2%80%94%20%60createConditionStoreSingleton%60%20and%20%60WritableConditionStoreInterface%60%20%E2%80%94%20are%20unused%20in%20the%20current%20file.%20They%20appear%20to%20be%20leftovers%20from%20a%20previous%20version%20that%20also%20created%20and%20exported%20a%20condition-store%20singleton%20from%20this%20module.%20They%20should%20be%20removed%20to%20avoid%20misleading%20readers%20and%20to%20prevent%20any%20TypeScript%20%22unused%20imports%22%20linting%20warnings.%0A%0A%60%60%60suggestion%0A%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/i18n/src/i18n-cache/singleton-operations.ts:5-6
These two imports — `createConditionStoreSingleton` and `WritableConditionStoreInterface` — are unused in the current file. They appear to be leftovers from a previous version that also created and exported a condition-store singleton from this module. They should be removed to avoid misleading readers and to prevent any TypeScript "unused imports" linting warnings.

```suggestion

```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: rename gt-i18n manager symbols"](https://github.com/generaltranslation/gt/commit/038fade8b37d2301c3a9e73e1d80051a576c191b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34048592)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->