### PR TITLE
refactor: rename react-core i18n cache symbols

### DIFF
--- a/packages/react-core/src/components/variables/Currency.tsx
+++ b/packages/react-core/src/components/variables/Currency.tsx
@@ -1,4 +1,4 @@
-import { getReactI18nManager } from '../../i18n-cache/singleton-operations';
+import { getReactI18nCache } from '../../i18n-cache/singleton-operations';
 import { useFormatLocales } from '../../hooks/utils';
 
 // ===== Component ===== //
@@ -16,7 +16,7 @@ function GtInternalCurrency({
   name?: string;
 }): string | null {
   const locales = useFormatLocales(localesProp);
-  const gt = getReactI18nManager().getGTClass();
+  const gt = getReactI18nCache().getGTClass();
   if (children == null) return null;
   const parsedNumber =
     typeof children === 'string' ? parseFloat(children) : children;

--- a/packages/react-core/src/components/variables/DateTime.tsx
+++ b/packages/react-core/src/components/variables/DateTime.tsx
@@ -1,4 +1,4 @@
-import { getReactI18nManager } from '../../i18n-cache/singleton-operations';
+import { getReactI18nCache } from '../../i18n-cache/singleton-operations';
 import { useFormatLocales } from '../../hooks/utils';
 
 // ===== Component ===== //
@@ -14,8 +14,8 @@ function GtInternalDateTime({
   name?: string;
 }): string | null {
   const locales = useFormatLocales(localesProp);
-  // TODO: theres a world in which we don't need the i18n manager, if user passes their own params
-  const gt = getReactI18nManager().getGTClass();
+  // TODO: theres a world in which we don't need the i18n cache, if user passes their own params
+  const gt = getReactI18nCache().getGTClass();
   if (children == null) return null;
   return gt
     .formatDateTime(children, { locales, ...options })

--- a/packages/react-core/src/components/variables/Num.tsx
+++ b/packages/react-core/src/components/variables/Num.tsx
@@ -1,4 +1,4 @@
-import { getReactI18nManager } from '../../i18n-cache/singleton-operations';
+import { getReactI18nCache } from '../../i18n-cache/singleton-operations';
 import { useFormatLocales } from '../../hooks/utils';
 
 // ===== Component ===== //
@@ -14,7 +14,7 @@ function GtInternalNum({
   name?: string;
 }): string | null {
   const locales = useFormatLocales(localesProp);
-  const gt = getReactI18nManager().getGTClass();
+  const gt = getReactI18nCache().getGTClass();
   if (children == null) return null;
   const parsedNumber =
     typeof children === 'string' ? parseFloat(children) : children;

--- a/packages/react-core/src/components/variables/RelativeTime.tsx
+++ b/packages/react-core/src/components/variables/RelativeTime.tsx
@@ -1,4 +1,4 @@
-import { getReactI18nManager } from '../../i18n-cache/singleton-operations';
+import { getReactI18nCache } from '../../i18n-cache/singleton-operations';
 import { useFormatLocales } from '../../hooks/utils';
 
 // ===== Component ===== //
@@ -22,7 +22,7 @@ function GtInternalRelativeTime({
   options?: Intl.RelativeTimeFormatOptions;
 }): string | null {
   const locales = useFormatLocales(localesProp);
-  const gt = getReactI18nManager().getGTClass();
+  const gt = getReactI18nCache().getGTClass();
   const resolvedDate = date ?? children;
 
   if (process.env.NODE_ENV === 'development' && value !== undefined && !unit) {

--- a/packages/react-core/src/context.ts
+++ b/packages/react-core/src/context.ts
@@ -55,13 +55,21 @@ export {
 export { WritableConditionStore } from 'gt-i18n/internal';
 export type { WritableConditionStoreParams } from 'gt-i18n/internal';
 export {
-  getReactI18nManager,
-  setReactI18nManager,
+  getReactI18nCache,
+  setReactI18nCache,
 } from './i18n-cache/singleton-operations';
+/** @deprecated use getReactI18nCache instead */
+export { getReactI18nCache as getReactI18nManager } from './i18n-cache/singleton-operations';
+/** @deprecated use setReactI18nCache instead */
+export { setReactI18nCache as setReactI18nManager } from './i18n-cache/singleton-operations';
 export { I18nStore } from './i18n-store/I18nStore';
 export type { I18nStoreParams } from './i18n-store/I18nStore';
 export type { InternalGTProviderProps } from './context/InternalGTProvider';
 export type {
-  ReactI18nManager,
-  ReactI18nManagerParams,
+  ReactI18nCache,
+  ReactI18nCacheParams,
 } from './i18n-cache/ReactI18nCache';
+/** @deprecated use ReactI18nCache instead */
+export type { ReactI18nCache as ReactI18nManager } from './i18n-cache/ReactI18nCache';
+/** @deprecated use ReactI18nCacheParams instead */
+export type { ReactI18nCacheParams as ReactI18nManagerParams } from './i18n-cache/ReactI18nCache';

--- a/packages/react-core/src/context/InternalGTProvider.tsx
+++ b/packages/react-core/src/context/InternalGTProvider.tsx
@@ -4,7 +4,7 @@ import {
   setI18nStore,
 } from '../i18n-store/singleton-operations';
 import { I18nStore, I18nStoreParams } from '../i18n-store/I18nStore';
-import { getI18nManager } from 'gt-i18n/internal';
+import { getI18nCache } from 'gt-i18n/internal';
 import type { Dictionary, Translation } from 'gt-i18n/types';
 import type { Locale, Hash } from 'gt-i18n/internal/types';
 
@@ -19,7 +19,7 @@ export type InternalGTProviderProps = I18nStoreParams & {
 
 /**
  * - Shared provider logic btwn client and server providers
- * - It is assumed that the I18nManager and ConditionStore are already initialized.
+ * - It is assumed that the I18nCache and ConditionStore are already initialized.
  * - This is not userfacing, it should be wrapped in a userfacing provider
  * - Locale and translations (and dictionaries if applicable) are required
  *
@@ -39,8 +39,8 @@ export function InternalGTProvider({
 
   // This represents an update from server, so bypass I18nStore
   useMemo(() => {
-    getI18nManager().updateTranslations(translations);
-    getI18nManager().updateDictionaries(dictionaries ?? {});
+    getI18nCache().updateTranslations(translations);
+    getI18nCache().updateDictionaries(dictionaries ?? {});
   }, [translations, dictionaries]);
 
   return children;

--- a/packages/react-core/src/deprecated/provider/__tests__/i18n-store.test.ts
+++ b/packages/react-core/src/deprecated/provider/__tests__/i18n-store.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
-import { I18nManager, WritableConditionStore } from 'gt-i18n/internal';
-import { setWritableConditionStore as setConditionStore } from '../../../condition-store/singleton-operations';
-import { setReactI18nManager } from '../../../i18n-cache/singleton-operations';
+import { I18nCache, WritableConditionStore } from 'gt-i18n/internal';
+import { setReadonlyConditionStore } from '../../../condition-store/singleton-operations';
+import { setReactI18nCache } from '../../../i18n-cache/singleton-operations';
 import { I18nStore } from '../../../i18n-store/I18nStore';
 
-function createManager() {
-  return new I18nManager({
+function createCache() {
+  return new I18nCache({
     defaultLocale: 'en',
     locales: ['en', 'fr', 'es'],
     dictionary: {
@@ -31,11 +31,11 @@ function createManager() {
 }
 
 function createStores(locale = 'en') {
-  const manager = createManager();
-  setReactI18nManager(manager);
+  const cache = createCache();
+  setReactI18nCache(cache);
 
   const conditionStore = new WritableConditionStore({ locale });
-  setConditionStore(conditionStore);
+  setReadonlyConditionStore(conditionStore);
 
   const i18nStore = new I18nStore({});
   return { i18nStore };

--- a/packages/react-core/src/functions/helpers/getTranslationsSnapshot.ts
+++ b/packages/react-core/src/functions/helpers/getTranslationsSnapshot.ts
@@ -1,6 +1,6 @@
 import { Hash, Locale } from 'gt-i18n/internal/types';
 import { Translation } from 'gt-i18n/types';
-import { getReactI18nManager } from '../../i18n-cache/singleton-operations';
+import { getReactI18nCache } from '../../i18n-cache/singleton-operations';
 
 /**
  * Returns a promise of serializable cached translations that
@@ -11,8 +11,8 @@ import { getReactI18nManager } from '../../i18n-cache/singleton-operations';
 export async function getTranslationsSnapshot(
   locale: Locale
 ): Promise<Record<Locale, Record<Hash, Translation>>> {
-  const i18nManager = getReactI18nManager();
-  const translations = await i18nManager.loadTranslations(locale);
+  const i18nCache = getReactI18nCache();
+  const translations = await i18nCache.loadTranslations(locale);
   // Only pass translations for the given locale to minimize the size of the snapshot
   return { [locale]: translations };
 }

--- a/packages/react-core/src/functions/translation/t.ts
+++ b/packages/react-core/src/functions/translation/t.ts
@@ -13,7 +13,7 @@ import {
   isReadonlyConditionStoreInitialized,
 } from '../../condition-store/singleton-operations';
 import { StringContent, StringFormat } from 'generaltranslation/types';
-import { getReactI18nManager } from '../../i18n-cache/singleton-operations';
+import { getReactI18nCache } from '../../i18n-cache/singleton-operations';
 import { getShouldTranslate } from '../../hooks/utils';
 import { createDiagnosticMessage } from 'generaltranslation/internal';
 
@@ -58,8 +58,8 @@ export function resolveStringContent(
   content: StringContent,
   options: ResolutionOptions<StringFormat> = {}
 ): StringContent {
-  const i18nManager = getReactI18nManager();
-  const defaultLocale = i18nManager.getDefaultLocale();
+  const i18nCache = getReactI18nCache();
+  const defaultLocale = i18nCache.getDefaultLocale();
   if (!getShouldTranslate()) {
     return interpolateMessage({
       options,
@@ -69,7 +69,7 @@ export function resolveStringContent(
   }
 
   const lookupOptions = createLookupOptions(locale, options, 'ICU');
-  const translation = i18nManager.lookupTranslation(
+  const translation = i18nCache.lookupTranslation(
     lookupOptions.$locale,
     content,
     lookupOptions
@@ -104,8 +104,8 @@ function handleTaggedTemplateLiteralTranslation(
     messageOrStrings,
     values
   );
-  const i18nManager = getReactI18nManager();
-  const translatedInterpolatedTemplate = i18nManager.lookupTranslation(
+  const i18nCache = getReactI18nCache();
+  const translatedInterpolatedTemplate = i18nCache.lookupTranslation(
     locale,
     interpolatedTemplate,
     { $format: 'STRING' }

--- a/packages/react-core/src/hooks/external-store-hooks.ts
+++ b/packages/react-core/src/hooks/external-store-hooks.ts
@@ -12,7 +12,7 @@ import type { CustomMapping } from 'generaltranslation/types';
 import { getI18nStore } from '../i18n-store/singleton-operations';
 import type { RuntimeTranslationScope } from '../i18n-store/RuntimeTranslationScope';
 import type { RuntimeDictionaryScope } from '../i18n-store/RuntimeDictionaryScope';
-import { getReactI18nManager } from '../i18n-cache/singleton-operations';
+import { getReactI18nCache } from '../i18n-cache/singleton-operations';
 
 /**
  * @internal
@@ -26,7 +26,7 @@ export function useTranslate<T extends Translation>(
     () => store.getTranslateSnapshot(lookup),
     () => store.getTranslateSnapshot(lookup)
   );
-  if (translation == null && getReactI18nManager().isDevHotReloadEnabled()) {
+  if (translation == null && getReactI18nCache().isDevHotReloadEnabled()) {
     store.translate(lookup);
   }
   return translation;
@@ -44,7 +44,7 @@ export function useTranslateMany<T extends Translation>(
     () => store.getTranslateManySnapshot(lookups),
     () => store.getTranslateManySnapshot(lookups)
   );
-  const devHotReloadEnabled = getReactI18nManager().isDevHotReloadEnabled();
+  const devHotReloadEnabled = getReactI18nCache().isDevHotReloadEnabled();
   translations.forEach((translation, index) => {
     if (translation == null && devHotReloadEnabled) {
       store.translate(lookups[index]);
@@ -65,10 +65,7 @@ export function useDictionaryEntry(
     () => store.getDictionaryEntrySnapshot(lookup),
     () => store.getDictionaryEntrySnapshot(lookup)
   );
-  if (
-    dictionaryEntry == null &&
-    getReactI18nManager().isDevHotReloadEnabled()
-  ) {
+  if (dictionaryEntry == null && getReactI18nCache().isDevHotReloadEnabled()) {
     store.translateDictionaryEntry(lookup);
   }
   return dictionaryEntry;
@@ -86,10 +83,7 @@ export function useDictionaryObject(
     () => store.getDictionaryObjectSnapshot(lookup),
     () => store.getDictionaryObjectSnapshot(lookup)
   );
-  if (
-    dictionaryObject == null &&
-    getReactI18nManager().isDevHotReloadEnabled()
-  ) {
+  if (dictionaryObject == null && getReactI18nCache().isDevHotReloadEnabled()) {
     store.translateDictionaryObject(lookup);
   }
   return dictionaryObject;

--- a/packages/react-core/src/hooks/useGT.ts
+++ b/packages/react-core/src/hooks/useGT.ts
@@ -8,7 +8,7 @@ import {
 } from './external-store-hooks';
 import { useLocale } from './condition-store';
 import { useShouldTranslate } from './utils';
-import { getReactI18nManager } from '../i18n-cache/singleton-operations';
+import { getReactI18nCache } from '../i18n-cache/singleton-operations';
 import type { TranslateLookup } from '../i18n-store/storeTypes';
 import type { GTFunctionType, InlineTranslationOptions } from 'gt-i18n/types';
 import type { StringFormat } from '@generaltranslation/format/types';
@@ -27,7 +27,7 @@ export function useGT(_messages?: Message[]): GTFunctionType {
   const defaultLocale = useDefaultLocale();
   const shouldTranslate = useShouldTranslate();
   const scope = useRuntimeTranslationScope();
-  const devHotReloadEnabled = getReactI18nManager().isDevHotReloadEnabled();
+  const devHotReloadEnabled = getReactI18nCache().isDevHotReloadEnabled();
 
   // Compiler optimization: pre-fetch translations
   useSubscribeToExtractedMessages(
@@ -55,7 +55,7 @@ export function useGT(_messages?: Message[]): GTFunctionType {
         options,
         'ICU'
       );
-      const translation = getReactI18nManager().lookupTranslation(
+      const translation = getReactI18nCache().lookupTranslation(
         lookupOptions.$locale,
         message,
         lookupOptions

--- a/packages/react-core/src/hooks/useTranslations.ts
+++ b/packages/react-core/src/hooks/useTranslations.ts
@@ -12,7 +12,7 @@ import {
 } from './external-store-hooks';
 import { useLocale } from './condition-store';
 import { useShouldTranslate } from './utils';
-import { getReactI18nManager } from '../i18n-cache/singleton-operations';
+import { getReactI18nCache } from '../i18n-cache/singleton-operations';
 import { useGT } from './useGT';
 import type {
   DictionaryObjectTranslation,
@@ -28,16 +28,16 @@ export function useTranslations(id?: string): UseTranslationsFunction {
   const scope = useRuntimeDictionaryScope();
   const gt = useGT();
   const rootId = id ?? '';
-  const devHotReloadEnabled = getReactI18nManager().isDevHotReloadEnabled();
+  const devHotReloadEnabled = getReactI18nCache().isDevHotReloadEnabled();
 
   useDictionaryObject({ locale: defaultLocale, id: rootId });
   useDictionaryObject({ locale, id: rootId });
 
   const translateEntry = useCallback(
     (suffix: string, options: DictionaryTranslationOptions = {}) => {
-      const i18nManager = getReactI18nManager();
+      const i18nCache = getReactI18nCache();
       const entryId = getEntryId(id, suffix);
-      const sourceEntry = i18nManager.lookupDictionary(defaultLocale, entryId);
+      const sourceEntry = i18nCache.lookupDictionary(defaultLocale, entryId);
       if (sourceEntry === undefined) {
         throw new Error(`Dictionary entry ${entryId} cannot be found`);
       }
@@ -49,7 +49,7 @@ export function useTranslations(id?: string): UseTranslationsFunction {
         });
       }
 
-      const targetEntry = i18nManager.lookupDictionary(locale, entryId);
+      const targetEntry = i18nCache.lookupDictionary(locale, entryId);
       if (targetEntry === undefined && devHotReloadEnabled) {
         scope.translateEntry({ locale, id: entryId });
       }
@@ -78,9 +78,9 @@ export function useTranslations(id?: string): UseTranslationsFunction {
 
   const translateObject = useCallback(
     (suffix: string) => {
-      const i18nManager = getReactI18nManager();
+      const i18nCache = getReactI18nCache();
       const entryId = getEntryId(id, suffix);
-      const sourceObject = i18nManager.lookupDictionaryObj(
+      const sourceObject = i18nCache.lookupDictionaryObj(
         defaultLocale,
         entryId
       );
@@ -90,7 +90,7 @@ export function useTranslations(id?: string): UseTranslationsFunction {
 
       let targetObject = undefined;
       if (shouldTranslate) {
-        targetObject = i18nManager.lookupDictionaryObj(locale, entryId);
+        targetObject = i18nCache.lookupDictionaryObj(locale, entryId);
         if (targetObject === undefined && devHotReloadEnabled) {
           scope.translateObject({ locale, id: entryId });
         }
@@ -100,7 +100,7 @@ export function useTranslations(id?: string): UseTranslationsFunction {
         sourceObject,
         targetObject,
         translate: (sourceEntry, dictionaryOptions) =>
-          i18nManager.lookupTranslation(
+          i18nCache.lookupTranslation(
             shouldTranslate ? locale : defaultLocale,
             sourceEntry.entry,
             dictionaryOptions

--- a/packages/react-core/src/hooks/utils.ts
+++ b/packages/react-core/src/hooks/utils.ts
@@ -2,7 +2,7 @@ import { useDefaultLocale } from './external-store-hooks';
 import { useLocale } from './condition-store';
 import { requiresTranslation } from 'generaltranslation/core';
 import { getReadonlyConditionStoreWithFallback } from '../condition-store/singleton-operations';
-import { getReactI18nManager } from '../i18n-cache/singleton-operations';
+import { getReactI18nCache } from '../i18n-cache/singleton-operations';
 
 export function useFormatLocales(localesProp: string[] = []): string[] {
   const locale = useLocale();
@@ -22,13 +22,13 @@ export function useShouldTranslate(): boolean {
  */
 export function getShouldTranslate(): boolean {
   const conditionStore = getReadonlyConditionStoreWithFallback();
-  const i18nManager = getReactI18nManager();
+  const i18nCache = getReactI18nCache();
 
   const enableI18n = conditionStore.getEnableI18n();
   const locale = conditionStore.getLocale();
-  const defaultLocale = i18nManager.getDefaultLocale();
-  const locales = i18nManager.getLocales();
-  const customMapping = i18nManager.getCustomMapping();
+  const defaultLocale = i18nCache.getDefaultLocale();
+  const locales = i18nCache.getLocales();
+  const customMapping = i18nCache.getCustomMapping();
   return (
     enableI18n &&
     requiresTranslation(defaultLocale, locale, [...locales], customMapping)

--- a/packages/react-core/src/i18n-cache/ReactI18nCache.ts
+++ b/packages/react-core/src/i18n-cache/ReactI18nCache.ts
@@ -1,9 +1,14 @@
-import type { I18nManager } from 'gt-i18n/internal';
-import type { I18nManagerConstructorParams } from 'gt-i18n/internal/types';
+import type { I18nCache } from 'gt-i18n/internal';
+import type { I18nCacheConstructorParams } from 'gt-i18n/internal/types';
 import type { Translation } from 'gt-i18n/types';
 
-export type ReactI18nManager = Pick<
-  I18nManager<Translation>,
-  keyof I18nManager<Translation>
+export type ReactI18nCache = Pick<
+  I18nCache<Translation>,
+  keyof I18nCache<Translation>
 >;
-export type ReactI18nManagerParams = I18nManagerConstructorParams<Translation>;
+export type ReactI18nCacheParams = I18nCacheConstructorParams<Translation>;
+
+/** @deprecated use ReactI18nCache instead */
+export type ReactI18nManager = ReactI18nCache;
+/** @deprecated use ReactI18nCacheParams instead */
+export type ReactI18nManagerParams = ReactI18nCacheParams;

--- a/packages/react-core/src/i18n-cache/singleton-operations.ts
+++ b/packages/react-core/src/i18n-cache/singleton-operations.ts
@@ -1,14 +1,19 @@
 import * as i18nInternal from 'gt-i18n/internal';
-import type { I18nManager } from 'gt-i18n/internal';
+import type { I18nCache } from 'gt-i18n/internal';
 import type { Translation } from 'gt-i18n/types';
-import type { ReactI18nManager } from './ReactI18nCache';
+import type { ReactI18nCache } from './ReactI18nCache';
 
-// ===== I18n Manager ===== //
+// ===== I18n Cache ===== //
 
-export function getReactI18nManager(): ReactI18nManager {
-  return i18nInternal.getI18nManager() as ReactI18nManager;
+export function getReactI18nCache(): ReactI18nCache {
+  return i18nInternal.getI18nCache() as ReactI18nCache;
 }
 
-export function setReactI18nManager(i18nManager: ReactI18nManager): void {
-  i18nInternal.setI18nManager(i18nManager as I18nManager<Translation>);
+export function setReactI18nCache(i18nCache: ReactI18nCache): void {
+  i18nInternal.setI18nCache(i18nCache as I18nCache<Translation>);
 }
+
+/** @deprecated use getReactI18nCache instead */
+export { getReactI18nCache as getReactI18nManager };
+/** @deprecated use setReactI18nCache instead */
+export { setReactI18nCache as setReactI18nManager };

--- a/packages/react-core/src/i18n-store/I18nStore.ts
+++ b/packages/react-core/src/i18n-store/I18nStore.ts
@@ -16,7 +16,7 @@ import type {
 } from './storeTypes';
 import type { Translation } from 'gt-i18n/types';
 import { getReadonlyConditionStoreWithFallback } from '../condition-store/singleton-operations';
-import { getReactI18nManager } from '../i18n-cache/singleton-operations';
+import { getReactI18nCache } from '../i18n-cache/singleton-operations';
 import { RuntimeTranslationScope } from './RuntimeTranslationScope';
 import { RuntimeDictionaryScope } from './RuntimeDictionaryScope';
 
@@ -31,9 +31,9 @@ type DictionaryStoreListener = (event: DictionaryStoreEvent) => void;
 export type I18nStoreParams = {};
 
 /**
- * A subscription wrapper around the I18nManager and the ConditionStore
+ * A subscription wrapper around the I18nCache and the ConditionStore
  *
- * It is assumed that the I18nManager and the ConditionStore are already initialized.
+ * It is assumed that the I18nCache and the ConditionStore are already initialized.
  * It is assumed that the locale and translations are already sync accessible.
  */
 export class I18nStore {
@@ -53,12 +53,12 @@ export class I18nStore {
   private localeListeners: ListenerSet = new Set();
 
   /**
-   * ConditionStore and I18nManager must be already initialized
+   * ConditionStore and I18nCache must be already initialized
    */
   constructor(_config: I18nStoreParams) {
     try {
       getReadonlyConditionStoreWithFallback();
-      getReactI18nManager();
+      getReactI18nCache();
     } catch (error) {
       throw new Error('Failed to initialize I18nStore. Reason: ' + error);
     }
@@ -88,7 +88,7 @@ export class I18nStore {
     return this.subscribeToStaticSet(this.enableI18nListeners, listener);
   };
 
-  // ===== I18nManager Subscriptions ===== //
+  // ===== I18nCache Subscriptions ===== //
 
   subscribeToTranslate<T extends Translation>(
     lookup: TranslateLookup<T>,
@@ -150,15 +150,15 @@ export class I18nStore {
   // ===== Manager Config Snapshots ===== //
 
   getDefaultLocaleSnapshot = (): string => {
-    return getReactI18nManager().getDefaultLocale();
+    return getReactI18nCache().getDefaultLocale();
   };
 
   getLocalesSnapshot = (): readonly string[] => {
-    return getReactI18nManager().getLocales();
+    return getReactI18nCache().getLocales();
   };
 
   getCustomMappingSnapshot = (): CustomMapping => {
-    return getReactI18nManager().getCustomMapping();
+    return getReactI18nCache().getCustomMapping();
   };
 
   // ===== ConditionStore Snapshots ===== //
@@ -171,14 +171,14 @@ export class I18nStore {
     return getReadonlyConditionStoreWithFallback().getEnableI18n();
   };
 
-  // ===== I18nManager Snapshots ===== //
+  // ===== I18nCache Snapshots ===== //
 
   getTranslateSnapshot = <T extends Translation>({
     locale,
     message,
     options,
   }: TranslateLookup<T>): TranslateSnapshot<T> => {
-    return getReactI18nManager().lookupTranslation<T>(locale, message, options);
+    return getReactI18nCache().lookupTranslation<T>(locale, message, options);
   };
 
   getTranslateManySnapshot = <T extends Translation>(
@@ -206,20 +206,20 @@ export class I18nStore {
     locale,
     id,
   }: DictionaryLookup): DictionaryEntrySnapshot => {
-    return getReactI18nManager().lookupDictionary(locale, id);
+    return getReactI18nCache().lookupDictionary(locale, id);
   };
 
   getDictionaryObjectSnapshot = ({
     locale,
     id,
   }: DictionaryLookup): DictionaryObjectSnapshot => {
-    return getReactI18nManager().lookupDictionaryObj(locale, id);
+    return getReactI18nCache().lookupDictionaryObj(locale, id);
   };
 
   // ===== runtime translation ===== //
 
   translate = <T extends Translation>(lookup: TranslateLookup<T>): void => {
-    getReactI18nManager()
+    getReactI18nCache()
       .lookupTranslationWithFallback(
         lookup.locale,
         lookup.message,
@@ -234,7 +234,7 @@ export class I18nStore {
   };
 
   translateDictionaryEntry = (lookup: DictionaryLookup): void => {
-    getReactI18nManager()
+    getReactI18nCache()
       .lookupDictionaryWithFallback(lookup.locale, lookup.id)
       .then((dictionaryEntry) => {
         if (dictionaryEntry == null) {
@@ -245,7 +245,7 @@ export class I18nStore {
   };
 
   translateDictionaryObject = (lookup: DictionaryLookup): void => {
-    getReactI18nManager()
+    getReactI18nCache()
       .lookupDictionaryObjWithFallback(lookup.locale, lookup.id)
       .then((dictionaryObject) => {
         if (dictionaryObject == null) {

--- a/packages/react-core/src/i18n-store/RuntimeDictionaryScope.ts
+++ b/packages/react-core/src/i18n-store/RuntimeDictionaryScope.ts
@@ -1,7 +1,7 @@
 import { getI18nStore } from './singleton-operations';
 import type { DictionaryLookup, Unsubscribe } from './storeTypes';
 import { getDictionaryListenerKey } from 'gt-i18n/internal';
-import { getReactI18nManager } from '../i18n-cache/singleton-operations';
+import { getReactI18nCache } from '../i18n-cache/singleton-operations';
 
 /**
  * Tracks dictionary lookups discovered by useTranslations callbacks.
@@ -13,7 +13,7 @@ export class RuntimeDictionaryScope {
   private pendingObjects = new Map<string, Unsubscribe>();
 
   translateEntry(lookup: DictionaryLookup) {
-    if (!getReactI18nManager().isDevHotReloadEnabled()) return;
+    if (!getReactI18nCache().isDevHotReloadEnabled()) return;
 
     const key = getDictionaryListenerKey(lookup);
     if (this.pendingEntries.has(key)) return;
@@ -27,7 +27,7 @@ export class RuntimeDictionaryScope {
   }
 
   translateObject(lookup: DictionaryLookup) {
-    if (!getReactI18nManager().isDevHotReloadEnabled()) return;
+    if (!getReactI18nCache().isDevHotReloadEnabled()) return;
 
     const key = getDictionaryListenerKey(lookup);
     if (this.pendingObjects.has(key)) return;

--- a/packages/react-core/src/i18n-store/RuntimeTranslationScope.ts
+++ b/packages/react-core/src/i18n-store/RuntimeTranslationScope.ts
@@ -1,7 +1,7 @@
 import { getI18nStore } from './singleton-operations';
 import type { TranslateLookup, Unsubscribe } from './storeTypes';
 import { getTranslateListenerKey } from 'gt-i18n/internal';
-import { getReactI18nManager } from '../i18n-cache/singleton-operations';
+import { getReactI18nCache } from '../i18n-cache/singleton-operations';
 
 /**
  * Owned by I18nStore, this should not be imported to any other files
@@ -12,7 +12,7 @@ export class RuntimeTranslationScope {
   private pendingKeys = new Map<string, Unsubscribe>();
 
   translate(lookup: TranslateLookup) {
-    if (!getReactI18nManager().isDevHotReloadEnabled()) return;
+    if (!getReactI18nCache().isDevHotReloadEnabled()) return;
 
     const key = getTranslateListenerKey(lookup);
     if (this.pendingKeys.has(key)) return;

--- a/packages/react-core/src/setup/initializeGTSPA.ts
+++ b/packages/react-core/src/setup/initializeGTSPA.ts
@@ -1,8 +1,8 @@
-import { I18nManager, WritableConditionStore } from 'gt-i18n/internal';
+import { I18nCache, WritableConditionStore } from 'gt-i18n/internal';
 import type { WritableConditionStoreParams } from 'gt-i18n/internal';
 import type { Translation } from 'gt-i18n/types';
-import { setReactI18nManager } from '../i18n-cache/singleton-operations';
-import type { ReactI18nManagerParams } from '../i18n-cache/ReactI18nCache';
+import { setReactI18nCache } from '../i18n-cache/singleton-operations';
+import type { ReactI18nCacheParams } from '../i18n-cache/ReactI18nCache';
 import { I18nStore, I18nStoreParams } from '../i18n-store/I18nStore';
 import { setRenderStrategy } from './globals';
 import { setReadonlyConditionStore } from '../condition-store/singleton-operations';
@@ -10,21 +10,19 @@ import { setI18nStore } from '../i18n-store/singleton-operations';
 
 /**
  * Initialize GT for an SPA
- * - i18nManager
+ * - i18nCache
  * - conditionStore
  * - i18nStore
  *
  * @deprecated moved to /react and /react-native
  */
 export function internalInitializeGTSPA(
-  config: I18nStoreParams &
-    ReactI18nManagerParams &
-    WritableConditionStoreParams
+  config: I18nStoreParams & ReactI18nCacheParams & WritableConditionStoreParams
 ): void {
   setRenderStrategy('SPA');
 
-  const i18nManager = new I18nManager<Translation>(config);
-  setReactI18nManager(i18nManager);
+  const i18nCache = new I18nCache<Translation>(config);
+  setReactI18nCache(i18nCache);
 
   const conditionStore = new WritableConditionStore(config);
   setReadonlyConditionStore(conditionStore);

--- a/packages/react-core/src/setup/initializeGTSSR.ts
+++ b/packages/react-core/src/setup/initializeGTSSR.ts
@@ -1,19 +1,19 @@
-import { I18nManager } from 'gt-i18n/internal';
+import { I18nCache } from 'gt-i18n/internal';
 import type { Translation } from 'gt-i18n/types';
-import type { ReactI18nManagerParams } from '../i18n-cache/ReactI18nCache';
+import type { ReactI18nCacheParams } from '../i18n-cache/ReactI18nCache';
 import { setRenderStrategy } from './globals';
-import { setReactI18nManager } from '../i18n-cache/singleton-operations';
+import { setReactI18nCache } from '../i18n-cache/singleton-operations';
 
 /**
  * Initialize GT for a server-side rendered application
- * - i18nManager
+ * - i18nCache
  *
  * ConditionStore and I18nStore are initialized in the provider at request time
  * TODO: auto detect if can find gt.config.json files
  */
-export function internalInitializeGTSSR(config: ReactI18nManagerParams): void {
+export function internalInitializeGTSSR(config: ReactI18nCacheParams): void {
   setRenderStrategy('server-render');
 
-  const i18nManager = new I18nManager<Translation>(config);
-  setReactI18nManager(i18nManager);
+  const i18nCache = new I18nCache<Translation>(config);
+  setReactI18nCache(i18nCache);
 }


### PR DESCRIPTION
Stack: 3/8

Base: e/i18n-cache-i18n-symbols

Summary:
- Rename react-core manager APIs to ReactI18nCache/getReactI18nCache/setReactI18nCache.
- Point react-core at the new gt-i18n cache names.
- Keep deprecated react-core manager aliases for remaining consumers in later PRs.

Validation:
- pnpm --filter @generaltranslation/react-core build
- pnpm --filter gt-react build

Note:
- pnpm --filter @generaltranslation/react-core test still has an unrelated pre-existing failing test around i18nStore.setLocale.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1472"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782424456&installation_id=127936663&pr_number=1472&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1472&signature=fc9440b94d53764a4b4a1661726812bd304815d6a346171a3b00d39e8660587f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR renames the `react-core` manager APIs (`ReactI18nManager`, `getReactI18nManager`, `setReactI18nManager`) to `ReactI18nCache`, `getReactI18nCache`, and `setReactI18nCache`, and updates all internal call sites to use the new `gt-i18n` cache symbols (`I18nCache`, `getI18nCache`, `setI18nCache`). Deprecated aliases for the old names are preserved in both the module-level singleton and the public `context.ts` re-exports.

- All 20 changed files are purely mechanical renames with no logic changes, and deprecated backward-compat aliases are added at every public export boundary.
- The test file in `deprecated/provider/__tests__/i18n-store.test.ts` also changes the condition store setup from `setWritableConditionStore` to `setReadonlyConditionStore`, which is a functional change beyond the rename and may be connected to the pre-existing `setLocale` test failure the PR describes.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the rename is mechanical, complete, and all public API names are kept as deprecated aliases.

The change is a consistent symbol rename across 20 files with no logic alterations; deprecated backward-compat aliases are present at every export boundary. The one non-rename change — replacing setWritableConditionStore with setReadonlyConditionStore in the test setup — is flagged in the PR description as tied to a pre-existing test failure, so it warrants a closer look but does not block the rename itself.

packages/react-core/src/deprecated/provider/__tests__/i18n-store.test.ts — specifically the condition store setter change and its relationship to the acknowledged setLocale test failure.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react-core/src/i18n-cache/ReactI18nCache.ts | Renames ReactI18nManager/ReactI18nManagerParams to ReactI18nCache/ReactI18nCacheParams, adds deprecated type aliases for backward compatibility. |
| packages/react-core/src/i18n-cache/singleton-operations.ts | Renames getReactI18nManager/setReactI18nManager to getReactI18nCache/setReactI18nCache; switches underlying calls to gt-i18n getI18nCache/setI18nCache; adds deprecated aliases. |
| packages/react-core/src/context.ts | Re-exports new ReactI18nCache names and deprecated Manager aliases for consumers; type aliases for ReactI18nManager/ReactI18nManagerParams preserved. |
| packages/react-core/src/deprecated/provider/__tests__/i18n-store.test.ts | Renames I18nManager→I18nCache and setReactI18nManager→setReactI18nCache; also switches condition store setup from setWritableConditionStore to setReadonlyConditionStore — a functional change beyond a rename. |
| packages/react-core/src/setup/initializeGTSPA.ts | Replaces I18nManager with I18nCache and updates function/type references accordingly; logic unchanged. |
| packages/react-core/src/setup/initializeGTSSR.ts | Replaces I18nManager with I18nCache and updates function/type references accordingly; logic unchanged. |
| packages/react-core/src/i18n-store/I18nStore.ts | All getReactI18nManager call sites replaced with getReactI18nCache; comment/doc updates to match; no logic changes. |
| packages/react-core/src/context/InternalGTProvider.tsx | Switches from getI18nManager (gt-i18n) to getI18nCache; comment updated to reflect I18nCache terminology. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[consumers / downstream packages] -->|imports| B[context.ts public API]

    subgraph context.ts exports
        B --> C[getReactI18nCache / setReactI18nCache]
        B --> D["@deprecated getReactI18nManager / setReactI18nManager"]
        B --> E[ReactI18nCache / ReactI18nCacheParams types]
        B --> F["@deprecated ReactI18nManager / ReactI18nManagerParams types"]
    end

    subgraph singleton-operations.ts
        C --> G[i18nInternal.getI18nCache / setI18nCache]
        D -->|alias| C
    end

    subgraph ReactI18nCache.ts
        E --> H["Pick&lt;I18nCache&lt;Translation&gt;, keyof I18nCache&lt;Translation&gt;&gt;"]
        F -->|type alias| E
    end

    G --> I[gt-i18n/internal I18nCache singleton]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Freact-core%2Fsrc%2Fdeprecated%2Fprovider%2F__tests__%2Fi18n-store.test.ts%3A38%0A**Test%20setup%20uses%20%60setReadonlyConditionStore%60%20with%20a%20%60WritableConditionStore%60**%0A%0AThis%20is%20a%20behavioral%20change%20beyond%20a%20rename%3A%20the%20old%20setup%20called%20%60setWritableConditionStore%60%2C%20which%20presumably%20registered%20the%20store%20in%20a%20way%20that%20allowed%20%60setLocale%60%20to%20be%20called%20through%20the%20%60I18nStore%60.%20The%20PR%20description%20explicitly%20notes%20a%20pre-existing%20failing%20test%20around%20%60i18nStore.setLocale%60%20%28line%2054%29%2C%20and%20this%20change%20may%20be%20contributing%20to%20or%20masking%20that%20failure.%20Worth%20verifying%20whether%20%60setReadonlyConditionStore%60%20is%20sufficient%20here%2C%20or%20whether%20the%20writable%20store%20needs%20to%20be%20registered%20via%20a%20dedicated%20setter%20so%20%60setLocale%60%20can%20dispatch%20properly.%0A%0A&repo=generaltranslation%2Fgt&pr=1472&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fi18n-cache-react-core%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fi18n-cache-react-core%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Freact-core%2Fsrc%2Fdeprecated%2Fprovider%2F__tests__%2Fi18n-store.test.ts%3A38%0A**Test%20setup%20uses%20%60setReadonlyConditionStore%60%20with%20a%20%60WritableConditionStore%60**%0A%0AThis%20is%20a%20behavioral%20change%20beyond%20a%20rename%3A%20the%20old%20setup%20called%20%60setWritableConditionStore%60%2C%20which%20presumably%20registered%20the%20store%20in%20a%20way%20that%20allowed%20%60setLocale%60%20to%20be%20called%20through%20the%20%60I18nStore%60.%20The%20PR%20description%20explicitly%20notes%20a%20pre-existing%20failing%20test%20around%20%60i18nStore.setLocale%60%20%28line%2054%29%2C%20and%20this%20change%20may%20be%20contributing%20to%20or%20masking%20that%20failure.%20Worth%20verifying%20whether%20%60setReadonlyConditionStore%60%20is%20sufficient%20here%2C%20or%20whether%20the%20writable%20store%20needs%20to%20be%20registered%20via%20a%20dedicated%20setter%20so%20%60setLocale%60%20can%20dispatch%20properly.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/react-core/src/deprecated/provider/__tests__/i18n-store.test.ts:38
**Test setup uses `setReadonlyConditionStore` with a `WritableConditionStore`**

This is a behavioral change beyond a rename: the old setup called `setWritableConditionStore`, which presumably registered the store in a way that allowed `setLocale` to be called through the `I18nStore`. The PR description explicitly notes a pre-existing failing test around `i18nStore.setLocale` (line 54), and this change may be contributing to or masking that failure. Worth verifying whether `setReadonlyConditionStore` is sufficient here, or whether the writable store needs to be registered via a dedicated setter so `setLocale` can dispatch properly.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: rename react-core i18n cache s..."](https://github.com/generaltranslation/gt/commit/ad7b3c51726746d8ecd5e57892784f91195f28e0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34048600)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->