### PR TITLE
refactor: rename gt-react i18n cache symbols

### DIFF
--- a/packages/react/src/condition-store/BrowserConditionStore.ts
+++ b/packages/react/src/condition-store/BrowserConditionStore.ts
@@ -1,5 +1,5 @@
 import {
-  getReactI18nManager,
+  getReactI18nCache,
   WritableConditionStoreParams,
 } from '@generaltranslation/react-core/context';
 import { getCookieValue, setCookieValue } from './cookies';
@@ -49,7 +49,7 @@ export class BrowserConditionStore implements WritableConditionStoreInterface {
     this.enableI18nCookieName = config.enableI18nCookieName;
     setCookieValue({
       cookieName: this.localeCookieName,
-      value: getReactI18nManager().determineLocale(config.locale),
+      value: getReactI18nCache().determineLocale(config.locale),
     });
   }
 
@@ -83,7 +83,7 @@ export class BrowserConditionStore implements WritableConditionStoreInterface {
   updateLocale = (locale: LocaleCandidates): void => {
     setCookieValue({
       cookieName: this.localeCookieName,
-      value: getReactI18nManager().determineLocale(locale),
+      value: getReactI18nCache().determineLocale(locale),
     });
   };
 
@@ -114,5 +114,5 @@ export class BrowserConditionStore implements WritableConditionStoreInterface {
 function getBrowserLocale(cookieName: string, getLocale?: GetLocale): string {
   const candidates = readBrowserLocale(cookieName);
   if (getLocale) candidates.push(getLocale());
-  return getReactI18nManager().determineLocale(candidates);
+  return getReactI18nCache().determineLocale(candidates);
 }

--- a/packages/react/src/condition-store/createBrowserConditionStore.ts
+++ b/packages/react/src/condition-store/createBrowserConditionStore.ts
@@ -1,4 +1,4 @@
-import { getReactI18nManager } from '@generaltranslation/react-core/context';
+import { getReactI18nCache } from '@generaltranslation/react-core/context';
 import type { LocaleCandidates } from 'gt-i18n/internal';
 import {
   BrowserConditionStore,
@@ -66,7 +66,7 @@ function determineLocale({
   candidates.push(...readBrowserLocale(localeCookieName));
   if (locale) candidates.push(...locale);
   if (getLocale) candidates.push(getLocale());
-  return getReactI18nManager().determineLocale(candidates);
+  return getReactI18nCache().determineLocale(candidates);
 }
 
 function determineEnableI18n({

--- a/packages/react/src/context.client.ts
+++ b/packages/react/src/context.client.ts
@@ -37,8 +37,10 @@ export {
   mFallback,
   gtFallback,
   getTranslationsSnapshot,
-  getReactI18nManager,
-  setReactI18nManager,
+  getReactI18nCache,
+  getReactI18nCache as getReactI18nManager,
+  setReactI18nCache,
+  setReactI18nCache as setReactI18nManager,
   t,
   // ===== Setup ===== //
   internalInitializeGTSSR as initializeGT,

--- a/packages/react/src/context.server.ts
+++ b/packages/react/src/context.server.ts
@@ -37,8 +37,10 @@ export {
   mFallback,
   gtFallback,
   getTranslationsSnapshot,
-  getReactI18nManager,
-  setReactI18nManager,
+  getReactI18nCache,
+  getReactI18nCache as getReactI18nManager,
+  setReactI18nCache,
+  setReactI18nCache as setReactI18nManager,
   t,
   // ===== Setup ===== //
   internalInitializeGTSSR as initializeGT,

--- a/packages/react/src/context.types.ts
+++ b/packages/react/src/context.types.ts
@@ -51,6 +51,8 @@ export {
   t,
   // ===== Setup ===== //
   internalInitializeGTSSR as initializeGT,
-  getReactI18nManager,
-  setReactI18nManager,
+  getReactI18nCache,
+  getReactI18nCache as getReactI18nManager,
+  setReactI18nCache,
+  setReactI18nCache as setReactI18nManager,
 } from '@generaltranslation/react-core/context';

--- a/packages/react/src/deprecated/i18n-context/browser-i18n-cache/BrowserI18nCache.ts
+++ b/packages/react/src/deprecated/i18n-context/browser-i18n-cache/BrowserI18nCache.ts
@@ -1,6 +1,6 @@
-import { I18nManager } from 'gt-i18n/internal';
+import { I18nCache } from 'gt-i18n/internal';
 import type {
-  I18nManagerConstructorParams,
+  I18nCacheConstructorParams,
   TranslationsLoader,
 } from 'gt-i18n/internal/types';
 import type { HtmlTagOptions } from './utils/types';
@@ -10,17 +10,17 @@ import { LocalStorageTranslationCache } from './LocalStorageTranslationCache';
 import { createInvalidLocaleWarning } from '../../shared/messages';
 
 /**
- * The configuration for the BrowserI18nManager
+ * The configuration for the BrowserI18nCache
  */
-type BrowserI18nManagerConstructorParams =
-  I18nManagerConstructorParams<Translation> & {
+type BrowserI18nCacheConstructorParams =
+  I18nCacheConstructorParams<Translation> & {
     htmlTagOptions?: HtmlTagOptions;
   };
 
 /**
- * I18nManager implementation for Browser.
+ * I18nCache implementation for Browser.
  */
-export class BrowserI18nManager extends I18nManager<Translation> {
+export class BrowserI18nCache extends I18nCache<Translation> {
   /** Customize browser-related behavior */
   private htmlTagOptions?: HtmlTagOptions;
 
@@ -30,7 +30,7 @@ export class BrowserI18nManager extends I18nManager<Translation> {
   /** Whether dev hot reload JSX (Suspense-based <T>) is active */
   private _devHotReloadJsx = false;
 
-  constructor(config: BrowserI18nManagerConstructorParams) {
+  constructor(config: BrowserI18nCacheConstructorParams) {
     // Must be initialized before super()
     const { htmlTagOptions, ...managerConfig } = config;
     const localStorageCaches: Record<string, LocalStorageTranslationCache> = {};
@@ -46,7 +46,7 @@ export class BrowserI18nManager extends I18nManager<Translation> {
         )
       : config.loadTranslations;
 
-    // Initialize the I18nManager
+    // Initialize the I18nCache
     super({
       ...managerConfig,
       loadTranslations,
@@ -145,6 +145,9 @@ export class BrowserI18nManager extends I18nManager<Translation> {
   }
 }
 
+/** @deprecated use BrowserI18nCache instead */
+export { BrowserI18nCache as BrowserI18nManager };
+
 // ===== Helper Functions ===== //
 
 /**
@@ -186,7 +189,7 @@ function resolveDevHotReload(
  * @param config - The configuration
  * @returns True if dev hot reload is enabled, false otherwise
  */
-function isDevHotReloadEnabled(config: BrowserI18nManagerConstructorParams) {
+function isDevHotReloadEnabled(config: BrowserI18nCacheConstructorParams) {
   // TODO: this only works when you've defined a custom loadTranslations function
   // meaning CDN users will not have access to this feature
   const requirements: Record<string, boolean> = {

--- a/packages/react/src/deprecated/i18n-context/browser-i18n-cache/__tests__/BrowserI18nCache.test.ts
+++ b/packages/react/src/deprecated/i18n-context/browser-i18n-cache/__tests__/BrowserI18nCache.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { BrowserI18nManager } from '../BrowserI18nCache';
+import { BrowserI18nCache } from '../BrowserI18nCache';
 
-describe('BrowserI18nManager', () => {
+describe('BrowserI18nCache', () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
@@ -14,13 +14,13 @@ describe('BrowserI18nManager', () => {
     };
     vi.stubGlobal('document', { documentElement });
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const manager = new BrowserI18nManager({
+    const cache = new BrowserI18nCache({
       defaultLocale: 'en-US',
       locales: ['en-US'],
       loadTranslations: vi.fn(),
     });
 
-    manager.updateHtmlTag('en-US', {
+    cache.updateHtmlTag('en-US', {
       lang: 'en-GB',
       updateHtmlLangTag: true,
       updateHtmlDirTag: false,

--- a/packages/react/src/deprecated/i18n-context/browser-i18n-cache/singleton-operations.ts
+++ b/packages/react/src/deprecated/i18n-context/browser-i18n-cache/singleton-operations.ts
@@ -1,26 +1,26 @@
-import { BROWSER_I18N_MANAGER_NOT_INITIALIZED_ERROR } from '../../shared/messages';
-import { BrowserI18nManager } from './BrowserI18nCache';
+import { BROWSER_I18N_CACHE_NOT_INITIALIZED_ERROR } from '../../shared/messages';
+import { BrowserI18nCache } from './BrowserI18nCache';
 import type { BrowserConditionStore } from './BrowserConditionStore';
-import {
-  createConditionStoreSingleton,
-  getI18nManager,
-} from 'gt-i18n/internal';
+import { createConditionStoreSingleton, getI18nCache } from 'gt-i18n/internal';
 
 export const {
   getConditionStore: getBrowserConditionStore,
   setConditionStore: setBrowserConditionStore,
 } = createConditionStoreSingleton<BrowserConditionStore>(
-  BROWSER_I18N_MANAGER_NOT_INITIALIZED_ERROR
+  BROWSER_I18N_CACHE_NOT_INITIALIZED_ERROR
 );
 
 /**
- * Singleton instance of BrowserI18nManager
- * @returns The singleton instance of BrowserI18nManager
+ * Singleton instance of BrowserI18nCache
+ * @returns The singleton instance of BrowserI18nCache
  */
-export function getBrowserI18nManager(): BrowserI18nManager {
-  const i18nManager = getI18nManager();
-  if (!(i18nManager instanceof BrowserI18nManager)) {
-    throw new Error(BROWSER_I18N_MANAGER_NOT_INITIALIZED_ERROR);
+export function getBrowserI18nCache(): BrowserI18nCache {
+  const i18nCache = getI18nCache();
+  if (!(i18nCache instanceof BrowserI18nCache)) {
+    throw new Error(BROWSER_I18N_CACHE_NOT_INITIALIZED_ERROR);
   }
-  return i18nManager;
+  return i18nCache;
 }
+
+/** @deprecated use getBrowserI18nCache instead */
+export { getBrowserI18nCache as getBrowserI18nManager };

--- a/packages/react/src/deprecated/i18n-context/functions/html-tag-operations.ts
+++ b/packages/react/src/deprecated/i18n-context/functions/html-tag-operations.ts
@@ -1,4 +1,4 @@
-import { getBrowserI18nManager } from '../browser-i18n-cache/singleton-operations';
+import { getBrowserI18nCache } from '../browser-i18n-cache/singleton-operations';
 import { getLocale } from './locale-operations';
 
 /**
@@ -10,8 +10,8 @@ import { getLocale } from './locale-operations';
  * updateHtmlTagLang('en');
  */
 export function updateHtmlTagLang(locale: string): void {
-  const i18nManager = getBrowserI18nManager();
-  i18nManager.updateHtmlTag(locale, {
+  const i18nCache = getBrowserI18nCache();
+  i18nCache.updateHtmlTag(locale, {
     lang: locale,
     updateHtmlLangTag: true,
     updateHtmlDirTag: false,
@@ -27,8 +27,8 @@ export function updateHtmlTagLang(locale: string): void {
  * updateHtmlTagDir('ltr');
  */
 export function updateHtmlTagDir(dir: 'ltr' | 'rtl'): void {
-  const i18nManager = getBrowserI18nManager();
-  i18nManager.updateHtmlTag(getLocale(), {
+  const i18nCache = getBrowserI18nCache();
+  i18nCache.updateHtmlTag(getLocale(), {
     dir,
     updateHtmlLangTag: false,
     updateHtmlDirTag: true,

--- a/packages/react/src/deprecated/i18n-context/functions/locale-operations.ts
+++ b/packages/react/src/deprecated/i18n-context/functions/locale-operations.ts
@@ -1,6 +1,6 @@
 import { getBrowserConditionStore } from '../browser-i18n-cache/singleton-operations';
 import { createInvalidLocaleWarning } from '../../shared/messages';
-import { determineSupportedLocale, getI18nManager } from 'gt-i18n/internal';
+import { determineSupportedLocale, getI18nCache } from 'gt-i18n/internal';
 
 /**
  * Sets the user's current locale.
@@ -11,11 +11,11 @@ import { determineSupportedLocale, getI18nManager } from 'gt-i18n/internal';
  * setLocale('es-ES');
  */
 export function setLocale(locale: string) {
-  const i18nManager = getI18nManager();
+  const i18nCache = getI18nCache();
   const newLocale = determineSupportedLocale(locale, {
-    defaultLocale: i18nManager.getDefaultLocale(),
-    locales: i18nManager.getLocales(),
-    customMapping: i18nManager.getCustomMapping(),
+    defaultLocale: i18nCache.getDefaultLocale(),
+    locales: i18nCache.getLocales(),
+    customMapping: i18nCache.getCustomMapping(),
   });
   if (!newLocale) {
     console.warn(createInvalidLocaleWarning(locale));

--- a/packages/react/src/deprecated/i18n-context/functions/translation/GtInternalTranslateJsx.tsx
+++ b/packages/react/src/deprecated/i18n-context/functions/translation/GtInternalTranslateJsx.tsx
@@ -14,7 +14,7 @@ import { requiresTranslation } from '@generaltranslation/format';
 import { getDefaultLocale, getLocale } from '../locale-operations';
 import type { JsxChildren } from '@generaltranslation/format/types';
 import type { TaggedChildren } from '@generaltranslation/react-core/types';
-import { getBrowserI18nManager } from '../../browser-i18n-cache/singleton-operations';
+import { getBrowserI18nCache } from '../../browser-i18n-cache/singleton-operations';
 
 type TranslateJsxProps = {
   children: ReactNode;
@@ -111,7 +111,7 @@ function useComputeT({
   }
 
   // --- (3) Cache miss: dev hot reload suspends, prod falls back to source --- //
-  if (getBrowserI18nManager().isDevHotReloadJsx()) {
+  if (getBrowserI18nCache().isDevHotReloadJsx()) {
     return (
       <Suspense fallback={renderSourceChildren()}>
         <DevTranslationResolver

--- a/packages/react/src/deprecated/i18n-context/functions/variables/GtInternalCurrency.tsx
+++ b/packages/react/src/deprecated/i18n-context/functions/variables/GtInternalCurrency.tsx
@@ -1,4 +1,4 @@
-import { getI18nManager } from 'gt-i18n/internal';
+import { getI18nCache } from 'gt-i18n/internal';
 import { getDefaultLocale, getLocale } from '../locale-operations';
 
 type CurrencyProps = {
@@ -25,8 +25,8 @@ function GtInternalCurrency({
   const locales = [...localesProp, getLocale(), getDefaultLocale()];
 
   // Apply formatting
-  const i18nManager = getI18nManager();
-  const gt = i18nManager.getGTClass();
+  const i18nCache = getI18nCache();
+  const gt = i18nCache.getGTClass();
   const formattedCurrency = gt.formatCurrency(parsedNumber, currency, {
     locales,
     ...options,

--- a/packages/react/src/deprecated/i18n-context/functions/variables/GtInternalDateTime.tsx
+++ b/packages/react/src/deprecated/i18n-context/functions/variables/GtInternalDateTime.tsx
@@ -1,4 +1,4 @@
-import { getI18nManager } from 'gt-i18n/internal';
+import { getI18nCache } from 'gt-i18n/internal';
 import { getDefaultLocale, getLocale } from '../locale-operations';
 
 type DateTimeProps = {
@@ -21,8 +21,8 @@ function GtInternalDateTime({
   const locales = [...localesProp, getLocale(), getDefaultLocale()];
 
   // Apply formatting
-  const i18nManager = getI18nManager();
-  const gt = i18nManager.getGTClass();
+  const i18nCache = getI18nCache();
+  const gt = i18nCache.getGTClass();
   const result = gt
     .formatDateTime(children, { locales, ...options })
     .replace(/[\u200F\u202B\u202E]/g, '');

--- a/packages/react/src/deprecated/i18n-context/functions/variables/GtInternalNum.tsx
+++ b/packages/react/src/deprecated/i18n-context/functions/variables/GtInternalNum.tsx
@@ -1,4 +1,4 @@
-import { getI18nManager } from 'gt-i18n/internal';
+import { getI18nCache } from 'gt-i18n/internal';
 import { getDefaultLocale, getLocale } from '../locale-operations';
 
 type NumProps = {
@@ -23,8 +23,8 @@ function GtInternalNum({
   const locales = [...localesProp, getLocale(), getDefaultLocale()];
 
   // Apply formatting
-  const i18nManager = getI18nManager();
-  const gt = i18nManager.getGTClass();
+  const i18nCache = getI18nCache();
+  const gt = i18nCache.getGTClass();
   const formattedNumber = gt.formatNum(parsedNumber, { locales, ...options });
 
   // Return formatted number

--- a/packages/react/src/deprecated/i18n-context/functions/variables/GtInternalRelativeTime.tsx
+++ b/packages/react/src/deprecated/i18n-context/functions/variables/GtInternalRelativeTime.tsx
@@ -1,4 +1,4 @@
-import { getI18nManager } from 'gt-i18n/internal';
+import { getI18nCache } from 'gt-i18n/internal';
 import { getDefaultLocale, getLocale } from '../locale-operations';
 
 type RelativeTimeProps = {
@@ -26,8 +26,8 @@ function GtInternalRelativeTime({
   locales: localesProp = [],
   options = {},
 }: RelativeTimeProps): string | null {
-  const i18nManager = getI18nManager();
-  const gt = i18nManager.getGTClass();
+  const i18nCache = getI18nCache();
+  const gt = i18nCache.getGTClass();
   const locales = [...localesProp, getLocale(), getDefaultLocale()];
 
   // Resolve the date from either `date` prop or `children` (for backwards compat)

--- a/packages/react/src/deprecated/i18n-context/setup/bootstrap.ts
+++ b/packages/react/src/deprecated/i18n-context/setup/bootstrap.ts
@@ -1,5 +1,5 @@
 import { initializeGT } from './initializeGT';
-import { getBrowserI18nManager } from '../browser-i18n-cache/singleton-operations';
+import { getBrowserI18nCache } from '../browser-i18n-cache/singleton-operations';
 import type { InitializeGTParams } from './types';
 import { getLocale } from '../functions/locale-operations';
 
@@ -24,12 +24,12 @@ import { getLocale } from '../functions/locale-operations';
  */
 export async function bootstrap(params: InitializeGTParams): Promise<void> {
   initializeGT(params);
-  const i18nManager = getBrowserI18nManager();
+  const i18nCache = getBrowserI18nCache();
   const locale = getLocale();
 
   // Update the html tag
-  i18nManager.updateHtmlTag(locale);
+  i18nCache.updateHtmlTag(locale);
 
   // Load translations
-  await i18nManager.loadTranslations(locale);
+  await i18nCache.loadTranslations(locale);
 }

--- a/packages/react/src/deprecated/i18n-context/setup/initializeGT.ts
+++ b/packages/react/src/deprecated/i18n-context/setup/initializeGT.ts
@@ -1,7 +1,7 @@
-import { setI18nManager } from 'gt-i18n/internal';
+import { setI18nCache } from 'gt-i18n/internal';
 import type { InitializeGTParams } from './types';
 import { BrowserConditionStore } from '../browser-i18n-cache/BrowserConditionStore';
-import { BrowserI18nManager } from '../browser-i18n-cache/BrowserI18nCache';
+import { BrowserI18nCache } from '../browser-i18n-cache/BrowserI18nCache';
 import { setBrowserConditionStore } from '../browser-i18n-cache/singleton-operations';
 
 /**
@@ -9,14 +9,14 @@ import { setBrowserConditionStore } from '../browser-i18n-cache/singleton-operat
  * @param {InitializeGTParams} config - The configuration for the GT instance
  */
 export function initializeGT(params: InitializeGTParams): void {
-  const i18nManager = new BrowserI18nManager(params);
+  const i18nCache = new BrowserI18nCache(params);
   const conditionStore = new BrowserConditionStore({
-    defaultLocale: i18nManager.getDefaultLocale(),
-    locales: i18nManager.getLocales(),
-    customMapping: i18nManager.getCustomMapping(),
+    defaultLocale: i18nCache.getDefaultLocale(),
+    locales: i18nCache.getLocales(),
+    customMapping: i18nCache.getCustomMapping(),
     getLocale: params.getLocale,
   });
 
-  setI18nManager(i18nManager);
+  setI18nCache(i18nCache);
   setBrowserConditionStore(conditionStore);
 }

--- a/packages/react/src/deprecated/i18n-context/ui/LocaleSelector.tsx
+++ b/packages/react/src/deprecated/i18n-context/ui/LocaleSelector.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import type { JSX } from 'react';
 import type { CustomMapping } from '@generaltranslation/format/types';
 import { InternalLocaleSelector } from '../../shared/InternalLocaleSelector';
-import { getI18nManager } from 'gt-i18n/internal';
+import { getI18nCache } from 'gt-i18n/internal';
 import {
   getLocale as getBrowserLocale,
   setLocale as setBrowserLocale,
@@ -27,8 +27,8 @@ export function LocaleSelector({
   // Get the sorted locales, setLocale, and locale
   const { sortedLocales, setLocale, locale, getLocaleProperties } =
     useMemo(() => {
-      const i18nManager = getI18nManager();
-      const gt = i18nManager.getGTClass();
+      const i18nCache = getI18nCache();
+      const gt = i18nCache.getGTClass();
       const locale = getBrowserLocale();
       const getLocaleProperties = (locale: string) => {
         return gt.getLocaleProperties(locale);
@@ -40,7 +40,7 @@ export function LocaleSelector({
           sortedLocales: locales,
           getLocaleProperties,
         };
-      const sortedLocales = i18nManager
+      const sortedLocales = i18nCache
         .getLocales()
         .sort((a, b) =>
           new Intl.Collator().compare(

--- a/packages/react/src/deprecated/shared/messages.ts
+++ b/packages/react/src/deprecated/shared/messages.ts
@@ -16,13 +16,17 @@ export const GENERIC_BROWSER_ENVIRONMENT_ERROR = createDiagnosticMessage({
   whatHappened: 'A browser-only module was imported outside the browser',
   fix: 'Move this import to client-side code',
 });
-export const BROWSER_I18N_MANAGER_NOT_INITIALIZED_ERROR =
-  createDiagnosticMessage({
+export const BROWSER_I18N_CACHE_NOT_INITIALIZED_ERROR = createDiagnosticMessage(
+  {
     source: PACKAGE_NAME,
     severity: 'Error',
-    whatHappened: 'BrowserI18nManager is not initialized',
+    whatHappened: 'BrowserI18nCache is not initialized',
     fix: 'Call initializeGT() before using browser translation APIs',
-  });
+  }
+);
+/** @deprecated use BROWSER_I18N_CACHE_NOT_INITIALIZED_ERROR instead */
+export const BROWSER_I18N_MANAGER_NOT_INITIALIZED_ERROR =
+  BROWSER_I18N_CACHE_NOT_INITIALIZED_ERROR;
 
 // ---- Warnings ---- //
 export const createTranslationFailedDueToBrowserEnvironmentWarning = (

--- a/packages/react/src/i18n-cache/BrowserI18nCache.ts
+++ b/packages/react/src/i18n-cache/BrowserI18nCache.ts
@@ -1,8 +1,8 @@
 import type {
-  I18nManagerConstructorParams,
+  I18nCacheConstructorParams,
   TranslationsLoader,
 } from 'gt-i18n/internal/types';
-import { I18nManager } from 'gt-i18n/internal';
+import { I18nCache } from 'gt-i18n/internal';
 import type { HtmlTagOptions } from './types';
 import type { Translation } from 'gt-i18n/types';
 import { DEFAULT_HTML_TAG_OPTIONS } from './constants';
@@ -10,17 +10,19 @@ import { LocalStorageTranslationCache } from './LocalStorageTranslationCache';
 import { createDiagnosticMessage } from 'generaltranslation/internal';
 
 /**
- * The configuration for the BrowserI18nManager
+ * The configuration for the BrowserI18nCache
  */
-export type BrowserI18nManagerParams =
-  I18nManagerConstructorParams<Translation> & {
-    htmlTagOptions?: HtmlTagOptions;
-  };
+export type BrowserI18nCacheParams = I18nCacheConstructorParams<Translation> & {
+  htmlTagOptions?: HtmlTagOptions;
+};
+
+/** @deprecated use BrowserI18nCacheParams instead */
+export type BrowserI18nManagerParams = BrowserI18nCacheParams;
 
 /**
- * I18nManager implementation for Browser.
+ * I18nCache implementation for Browser.
  */
-export class BrowserI18nManager extends I18nManager<Translation> {
+export class BrowserI18nCache extends I18nCache<Translation> {
   /** Customize browser-related behavior */
   private htmlTagOptions?: HtmlTagOptions;
 
@@ -30,7 +32,7 @@ export class BrowserI18nManager extends I18nManager<Translation> {
   /** Whether dev hot reload JSX (Suspense-based <T>) is active */
   private _devHotReloadJsx = false;
 
-  constructor(config: BrowserI18nManagerParams) {
+  constructor(config: BrowserI18nCacheParams) {
     // Must be initialized before super()
     const { htmlTagOptions, ...managerConfig } = config;
     const localStorageCaches: Record<string, LocalStorageTranslationCache> = {};
@@ -43,7 +45,7 @@ export class BrowserI18nManager extends I18nManager<Translation> {
         )
       : config.loadTranslations;
 
-    // Initialize the I18nManager
+    // Initialize the I18nCache
     super({
       ...managerConfig,
       loadTranslations,
@@ -145,6 +147,9 @@ export class BrowserI18nManager extends I18nManager<Translation> {
   }
 }
 
+/** @deprecated use BrowserI18nCache instead */
+export { BrowserI18nCache as BrowserI18nManager };
+
 // ===== Helper Functions ===== //
 
 /**
@@ -176,7 +181,7 @@ function wrapLoaderWithLocalStorage(
  * @param config - The configuration
  * @returns True if dev hot reload is enabled, false otherwise
  */
-function isDevHotReloadEnabled(config: BrowserI18nManagerParams) {
+function isDevHotReloadEnabled(config: BrowserI18nCacheParams) {
   // TODO: this only works when you've defined a custom loadTranslations function
   // meaning CDN users will not have access to this feature
   return !!(

--- a/packages/react/src/provider/CSRGTProvider.tsx
+++ b/packages/react/src/provider/CSRGTProvider.tsx
@@ -1,5 +1,5 @@
 import {
-  getReactI18nManager,
+  getReactI18nCache,
   InternalGTProvider,
 } from '@generaltranslation/react-core/context';
 import type { SharedGTProviderProps } from './SharedGTProviderProps';
@@ -11,9 +11,9 @@ import { createOrUpdateBrowserConditionStore } from '../condition-store/createBr
  * server-side translations
  */
 export function CSRGTProvider({
-  defaultLocale = getReactI18nManager().getDefaultLocale(),
-  locales = getReactI18nManager().getLocales(),
-  customMapping = getReactI18nManager().getCustomMapping(),
+  defaultLocale = getReactI18nCache().getDefaultLocale(),
+  locales = getReactI18nCache().getLocales(),
+  customMapping = getReactI18nCache().getCustomMapping(),
   ...props
 }: SharedGTProviderProps) {
   // TODO: if a specific translation entry changes, but not the locale, this does not trigger a re-render

--- a/packages/react/src/provider/SSRGTProvider.tsx
+++ b/packages/react/src/provider/SSRGTProvider.tsx
@@ -5,7 +5,7 @@ import {
 } from '../condition-store/singleton-operations';
 import type { SharedGTProviderProps } from './SharedGTProviderProps';
 import {
-  getReactI18nManager,
+  getReactI18nCache,
   InternalGTProvider,
 } from '@generaltranslation/react-core/context';
 
@@ -16,9 +16,9 @@ import {
  * TODO: find some way to enforce this is only imported on the server
  */
 export function SSRGTProvider({
-  defaultLocale = getReactI18nManager().getDefaultLocale(),
-  locales = getReactI18nManager().getLocales(),
-  customMapping = getReactI18nManager().getCustomMapping(),
+  defaultLocale = getReactI18nCache().getDefaultLocale(),
+  locales = getReactI18nCache().getLocales(),
+  customMapping = getReactI18nCache().getCustomMapping(),
   ...props
 }: SharedGTProviderProps) {
   // The condition store may already be created at the module level

--- a/packages/react/src/setup/initializeGTSPA.ts
+++ b/packages/react/src/setup/initializeGTSPA.ts
@@ -4,11 +4,11 @@ import {
   setRenderStrategy,
   I18nStore,
   setI18nStore,
-  setReactI18nManager,
+  setReactI18nCache,
   getReadonlyConditionStoreWithFallback,
 } from '@generaltranslation/react-core/context';
-import { BrowserI18nManager } from '../i18n-cache/BrowserI18nCache';
-import type { BrowserI18nManagerParams } from '../i18n-cache/BrowserI18nCache';
+import { BrowserI18nCache } from '../i18n-cache/BrowserI18nCache';
+import type { BrowserI18nCacheParams } from '../i18n-cache/BrowserI18nCache';
 import {
   createOrUpdateBrowserConditionStore,
   CreateBrowserConditionStoreParams,
@@ -16,7 +16,7 @@ import {
 
 /**
  * Initialize GT for an SPA
- * - i18nManager
+ * - i18nCache
  * - conditionStore
  * - i18nStore
  *
@@ -24,13 +24,13 @@ import {
  */
 export async function initializeGTSPA(
   config: I18nStoreParams &
-    BrowserI18nManagerParams &
+    BrowserI18nCacheParams &
     CreateBrowserConditionStoreParams
 ) {
   setRenderStrategy('SPA');
 
-  const i18nManager = new BrowserI18nManager(config);
-  setReactI18nManager(i18nManager);
+  const i18nCache = new BrowserI18nCache(config);
+  setReactI18nCache(i18nCache);
 
   createOrUpdateBrowserConditionStore(config);
 


### PR DESCRIPTION
Stack: 4/8

Base: e/i18n-cache-react-core

Summary:
- Rename gt-react BrowserI18nManager symbols to BrowserI18nCache.
- Update gt-react consumers of react-core and gt-i18n cache APIs.
- Keep deprecated browser/manager aliases for packages later in the stack.

Validation:
- pnpm --filter gt-react test
- pnpm --filter gt-react build

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1473"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782424462&installation_id=127936663&pr_number=1473&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1473&signature=9abd5afb6bb496d4ab43f8ae7c5406f6103a0e5efdf21199805aa6da6e4cc5af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR renames the `BrowserI18nManager` symbol family to `BrowserI18nCache` across `gt-react`, updating all internal usages while preserving deprecated `*Manager` aliases for downstream packages in the same stack.

- `BrowserI18nManager`, `I18nManager`, `getReactI18nManager`, `setReactI18nManager`, `getBrowserI18nManager`, `getI18nManager`, `setI18nManager`, and their associated param types are all renamed to `*Cache` equivalents in both the `i18n-cache/` and `deprecated/` trees.
- Backward-compatible `@deprecated` aliases (class re-exports, function re-exports, and type aliases) are added in every relevant file so packages later in the stack continue to compile without changes.
- `BROWSER_I18N_MANAGER_NOT_INITIALIZED_ERROR` is kept as a deprecated re-export of the newly named constant.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — purely a rename with deprecated aliases preserving backward compatibility throughout.

Every renamed symbol gets a corresponding deprecated alias, so consumers further down the stack continue to work unchanged. The diff is mechanical and consistent across all 23 files. The only thing left untouched is the local variable managerConfig in two constructors, which is a cosmetic inconsistency and has no runtime impact.

No files require special attention. The two BrowserI18nCache.ts files (main and deprecated) each have a minor local variable name leftover from the old convention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react/src/i18n-cache/BrowserI18nCache.ts | Renames BrowserI18nManager → BrowserI18nCache, I18nManager → I18nCache; adds deprecated type alias BrowserI18nManagerParams and class alias BrowserI18nManager; one leftover managerConfig local variable name. |
| packages/react/src/deprecated/i18n-context/browser-i18n-cache/BrowserI18nCache.ts | Mirrors the same rename in the deprecated path; adds BrowserI18nManager class alias; local BrowserI18nManagerConstructorParams type was never public so no alias needed there. |
| packages/react/src/deprecated/i18n-context/browser-i18n-cache/singleton-operations.ts | Renames getBrowserI18nManager → getBrowserI18nCache and switches to getI18nCache; deprecated getBrowserI18nManager alias preserved. |
| packages/react/src/context.client.ts | Re-exports both getReactI18nCache/setReactI18nCache (new) and their getReactI18nManager/setReactI18nManager aliases (deprecated). |
| packages/react/src/context.server.ts | Same pattern as context.client.ts — both new and deprecated symbol aliases re-exported correctly. |
| packages/react/src/context.types.ts | Type-level re-exports updated in the same way as client/server entry points. |
| packages/react/src/setup/initializeGTSPA.ts | Switches to BrowserI18nCache, BrowserI18nCacheParams, and setReactI18nCache; local variable renamed consistently. |
| packages/react/src/deprecated/shared/messages.ts | BROWSER_I18N_MANAGER_NOT_INITIALIZED_ERROR kept as a deprecated re-export of the new BROWSER_I18N_CACHE_NOT_INITIALIZED_ERROR constant. |
| packages/react/src/provider/CSRGTProvider.tsx | Default parameter calls updated from getReactI18nManager() to getReactI18nCache(); no logic change. |
| packages/react/src/provider/SSRGTProvider.tsx | Same rename as CSRGTProvider.tsx; no functional change. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[initializeGT / initializeGTSPA] -->|"new BrowserI18nCache()"| B[BrowserI18nCache]
    B -->|"setI18nCache()"| C[(gt-i18n/internal singleton)]
    B -->|"setReactI18nCache()"| D[(react-core/context singleton)]
    A -->|"new BrowserConditionStore()"| E[BrowserConditionStore]
    E -->|"getReactI18nCache()"| D

    D -->|"getReactI18nCache()"| F[CSRGTProvider / SSRGTProvider]
    C -->|"getI18nCache()"| G[locale-operations / variables]
    C -->|"getBrowserI18nCache()"| H[html-tag-operations / TranslateJsx]

    subgraph Deprecated Aliases
        DA["getReactI18nManager (→ getReactI18nCache)"]
        DB["getBrowserI18nManager (→ getBrowserI18nCache)"]
        DC["BrowserI18nManager (→ BrowserI18nCache)"]
    end
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Freact%2Fsrc%2Fi18n-cache%2FBrowserI18nCache.ts%3A37%0AThe%20local%20variable%20%60managerConfig%60%20is%20a%20leftover%20from%20the%20old%20name.%20Since%20everything%20else%20in%20this%20class%20is%20now%20named%20after%20%22cache%22%2C%20renaming%20it%20keeps%20the%20file%20internally%20consistent.%0A%0A%60%60%60suggestion%0A%20%20%20%20const%20%7B%20htmlTagOptions%2C%20...cacheConfig%20%7D%20%3D%20config%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Freact%2Fsrc%2Fdeprecated%2Fi18n-context%2Fbrowser-i18n-cache%2FBrowserI18nCache.ts%3A35%0ASame%20leftover%20%60managerConfig%60%20variable%20in%20the%20deprecated%20copy%20of%20the%20constructor.%20Same%20rename%20applies%20here%20for%20consistency.%0A%0A%60%60%60suggestion%0A%20%20%20%20const%20%7B%20htmlTagOptions%2C%20...cacheConfig%20%7D%20%3D%20config%3B%0A%60%60%60%0A%0A&repo=generaltranslation%2Fgt&pr=1473&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fi18n-cache-react%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fi18n-cache-react%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Freact%2Fsrc%2Fi18n-cache%2FBrowserI18nCache.ts%3A37%0AThe%20local%20variable%20%60managerConfig%60%20is%20a%20leftover%20from%20the%20old%20name.%20Since%20everything%20else%20in%20this%20class%20is%20now%20named%20after%20%22cache%22%2C%20renaming%20it%20keeps%20the%20file%20internally%20consistent.%0A%0A%60%60%60suggestion%0A%20%20%20%20const%20%7B%20htmlTagOptions%2C%20...cacheConfig%20%7D%20%3D%20config%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Freact%2Fsrc%2Fdeprecated%2Fi18n-context%2Fbrowser-i18n-cache%2FBrowserI18nCache.ts%3A35%0ASame%20leftover%20%60managerConfig%60%20variable%20in%20the%20deprecated%20copy%20of%20the%20constructor.%20Same%20rename%20applies%20here%20for%20consistency.%0A%0A%60%60%60suggestion%0A%20%20%20%20const%20%7B%20htmlTagOptions%2C%20...cacheConfig%20%7D%20%3D%20config%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/react/src/i18n-cache/BrowserI18nCache.ts:37
The local variable `managerConfig` is a leftover from the old name. Since everything else in this class is now named after "cache", renaming it keeps the file internally consistent.

```suggestion
    const { htmlTagOptions, ...cacheConfig } = config;
```

### Issue 2 of 2
packages/react/src/deprecated/i18n-context/browser-i18n-cache/BrowserI18nCache.ts:35
Same leftover `managerConfig` variable in the deprecated copy of the constructor. Same rename applies here for consistency.

```suggestion
    const { htmlTagOptions, ...cacheConfig } = config;
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: rename gt-react i18n cache sym..."](https://github.com/generaltranslation/gt/commit/9e06976e74cb28c794e27676b83c3745f4e7ff36) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34048613)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->