### PR TITLE
refactor: rename tanstack i18n cache symbols

### DIFF
--- a/packages/tanstack-start/src/index.client.ts
+++ b/packages/tanstack-start/src/index.client.ts
@@ -1,10 +1,10 @@
 'use client';
 
-import { I18nManager } from 'gt-i18n/internal';
+import { I18nCache } from 'gt-i18n/internal';
 import type { Translation } from 'gt-i18n/types';
 import {
-  setReactI18nManager,
-  type ReactI18nManagerParams,
+  setReactI18nCache,
+  type ReactI18nCacheParams,
 } from '@generaltranslation/react-core/context';
 
 export {

--- a/packages/tanstack-start/src/provider/GTProvider.tsx
+++ b/packages/tanstack-start/src/provider/GTProvider.tsx
@@ -3,7 +3,7 @@ import { GTProvider as GTReactProvider } from 'gt-react';
 import { GTProviderProps } from './types';
 import { isSSREnabled } from './utils/isSSREnabled';
 import { determineProviderLocale } from './utils/determineProviderLocale';
-import { getI18nManager } from 'gt-i18n/internal';
+import { getI18nCache } from 'gt-i18n/internal';
 
 /**
  * Provides General Translation context to its children, which can then access `useGT`, `useLocale`, and `useDefaultLocale`.
@@ -28,18 +28,16 @@ import { getI18nManager } from 'gt-i18n/internal';
  * @returns {JSX.Element} The provider component for General Translation context.
  */
 export function GTProvider(props: GTProviderProps): React.ReactNode {
-  const i18nManager = getI18nManager();
+  const i18nCache = getI18nCache();
   return (
     <GTReactProvider
       ssr={isSSREnabled()}
-      defaultLocale={i18nManager.getDefaultLocale()}
-      locales={i18nManager.getLocales()}
-      customMapping={i18nManager.getCustomMapping()}
-      enableI18n={i18nManager.isTranslationEnabled()}
-      loadTranslations={(locale: string) =>
-        i18nManager.loadTranslations(locale)
-      }
-      _versionId={i18nManager.getVersionId()}
+      defaultLocale={i18nCache.getDefaultLocale()}
+      locales={i18nCache.getLocales()}
+      customMapping={i18nCache.getCustomMapping()}
+      enableI18n={i18nCache.isTranslationEnabled()}
+      loadTranslations={(locale: string) => i18nCache.loadTranslations(locale)}
+      _versionId={i18nCache.getVersionId()}
       {...props}
       reloadOnLocaleUpdate={true}
       locale={determineProviderLocale(props)}


### PR DESCRIPTION
Stack: 5/8

Base: e/i18n-cache-react

Summary:
- Update gt-tanstack-start to consume the cache-named react APIs.
- Rename package-local variables and imports from manager to cache.

Validation:
- pnpm --filter gt-tanstack-start test
- pnpm --filter gt-tanstack-start build

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1474"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782424466&installation_id=127936663&pr_number=1474&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1474&signature=e9593d9b83c9803a14c5010a0be45bdf829b78240cacf29118f3874c03c6b09e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR renames `Manager`-suffixed symbols to `Cache`-suffixed equivalents throughout the `gt-tanstack-start` package, aligning the package with updated naming in the react-core layer.

- `index.client.ts`: imports renamed from `I18nManager`/`setReactI18nManager`/`ReactI18nManagerParams` to `I18nCache`/`setReactI18nCache`/`ReactI18nCacheParams`.
- `GTProvider.tsx`: `getI18nManager` → `getI18nCache`, local variable `i18nManager` → `i18nCache`, plus a minor one-line reformatting of the `loadTranslations` arrow function.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Pure symbol rename with no logic changes — safe to merge once the base branch lands.

All changes are mechanical identifier renames. No logic, control flow, or API surface is altered; the only functional-looking delta (condensing the loadTranslations arrow function to one line) is cosmetic. The rename is exhaustive within the package and no stale references to the old names remain.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/tanstack-start/src/index.client.ts | Renames Manager → Cache imports: I18nCache, setReactI18nCache, ReactI18nCacheParams — no logic changes. Note: these imports remain unused in the file (pre-existing). |
| packages/tanstack-start/src/provider/GTProvider.tsx | Renames getI18nManager → getI18nCache and local variable i18nManager → i18nCache; also condenses loadTranslations arrow function to a single line. No behavioral changes. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant TS as TanStack Start
    participant GTProvider as GTProvider.tsx
    participant Cache as getI18nCache()
    participant ReactProvider as GTReactProvider (gt-react)

    TS->>GTProvider: render GTProvider
    GTProvider->>Cache: getI18nCache()
    Cache-->>GTProvider: i18nCache instance
    GTProvider->>Cache: i18nCache.getDefaultLocale()
    GTProvider->>Cache: i18nCache.getLocales()
    GTProvider->>Cache: i18nCache.getCustomMapping()
    GTProvider->>Cache: i18nCache.isTranslationEnabled()
    GTProvider->>Cache: i18nCache.getVersionId()
    GTProvider->>ReactProvider: render with resolved props
    ReactProvider-->>TS: Translation context provided
```
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: rename tanstack i18n cache sym..."](https://github.com/generaltranslation/gt/commit/0ee9e8ac9a0cea78fd773e66ffe6cb69f597cce1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34048627)</sub>

<!-- /greptile_comment -->