### PR TITLE
refactor: rename gt-node i18n cache symbols

### DIFF
--- a/packages/node/src/async-i18n-cache/AsyncConditionStore.ts
+++ b/packages/node/src/async-i18n-cache/AsyncConditionStore.ts
@@ -3,7 +3,7 @@ import type {
   LocaleResolverConfig,
   ScopedConditionStore,
 } from 'gt-i18n/internal/types';
-import { getI18nManager } from 'gt-i18n/internal';
+import { getI18nCache } from 'gt-i18n/internal';
 
 type Store = {
   locale: string;
@@ -40,7 +40,7 @@ export class AsyncConditionStore implements ScopedConditionStore {
    * */
   run<T>(locale: string, callback: () => T): T {
     return this.store.run(
-      { locale: getI18nManager().determineLocale(locale) },
+      { locale: getI18nCache().determineLocale(locale) },
       callback
     );
   }
@@ -50,11 +50,11 @@ export class AsyncConditionStore implements ScopedConditionStore {
     if (!store) {
       if (process.env.NODE_ENV === 'production') {
         console.warn(OUTSIDE_SCOPE_MESSAGE);
-        return getI18nManager().determineLocale();
+        return getI18nCache().determineLocale();
       }
       throw new Error(OUTSIDE_SCOPE_MESSAGE);
     }
-    return getI18nManager().determineLocale(store.locale);
+    return getI18nCache().determineLocale(store.locale);
   }
 
   /**

--- a/packages/node/src/async-i18n-cache/__tests__/AsyncConditionStore.test.ts
+++ b/packages/node/src/async-i18n-cache/__tests__/AsyncConditionStore.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { I18nCache, setI18nCache } from 'gt-i18n/internal';
 import { AsyncConditionStore } from '../AsyncConditionStore';
 
 describe('AsyncConditionStore', () => {
@@ -7,7 +8,17 @@ describe('AsyncConditionStore', () => {
     vi.restoreAllMocks();
   });
 
+  function setTestCache() {
+    setI18nCache(
+      new I18nCache({
+        defaultLocale: 'en',
+        locales: ['en', 'fr'],
+      })
+    );
+  }
+
   it('throws when reading the locale outside a scoped context', () => {
+    setTestCache();
     const store = new AsyncConditionStore({
       defaultLocale: 'en',
       locales: ['en', 'fr'],
@@ -19,6 +30,7 @@ describe('AsyncConditionStore', () => {
   });
 
   it('warns and falls back outside a scoped context in production', () => {
+    setTestCache();
     vi.stubEnv('NODE_ENV', 'production');
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const store = new AsyncConditionStore({
@@ -33,6 +45,7 @@ describe('AsyncConditionStore', () => {
   });
 
   it('returns the scoped locale inside run()', () => {
+    setTestCache();
     const store = new AsyncConditionStore({
       defaultLocale: 'en',
       locales: ['en', 'fr'],

--- a/packages/node/src/helpers/getRequestLocale.ts
+++ b/packages/node/src/helpers/getRequestLocale.ts
@@ -1,4 +1,4 @@
-import { getI18nManager } from 'gt-i18n/internal';
+import { getI18nCache } from 'gt-i18n/internal';
 
 /**
  * A request object like interface
@@ -53,9 +53,9 @@ function parseAcceptLanguage(header: string): string[] {
  */
 export function getRequestLocale(request: RequestLike): string {
   // Setup
-  const i18nManager = getI18nManager<string>();
-  const defaultLocale = i18nManager.getDefaultLocale();
-  const gtInstance = i18nManager.getGTClass();
+  const i18nCache = getI18nCache<string>();
+  const defaultLocale = i18nCache.getDefaultLocale();
+  const gtInstance = i18nCache.getGTClass();
 
   // Get the accept-language header
   const acceptLanguage = request.headers['accept-language'];

--- a/packages/node/src/internal.ts
+++ b/packages/node/src/internal.ts
@@ -1,2 +1,8 @@
 export * from './async-i18n-cache';
-export { getI18nManager, setI18nManager, I18nManager } from 'gt-i18n/internal';
+export { getI18nCache, setI18nCache, I18nCache } from 'gt-i18n/internal';
+/** @deprecated use getI18nCache instead */
+export { getI18nCache as getI18nManager } from 'gt-i18n/internal';
+/** @deprecated use setI18nCache instead */
+export { setI18nCache as setI18nManager } from 'gt-i18n/internal';
+/** @deprecated use I18nCache instead */
+export { I18nCache as I18nManager } from 'gt-i18n/internal';

--- a/packages/node/src/setup/initializeGT.ts
+++ b/packages/node/src/setup/initializeGT.ts
@@ -1,6 +1,6 @@
 import { setAsyncConditionStore } from '../async-i18n-cache/singleton-operations';
 import type { InitializeGTParams } from './types';
-import { I18nManager, setI18nManager } from 'gt-i18n/internal';
+import { I18nCache, setI18nCache } from 'gt-i18n/internal';
 import { AsyncConditionStore } from '../async-i18n-cache/AsyncConditionStore';
 
 /**
@@ -9,13 +9,13 @@ import { AsyncConditionStore } from '../async-i18n-cache/AsyncConditionStore';
  * TODO: auto detect if can find gt.config.json files
  */
 export function initializeGT(params: InitializeGTParams): void {
-  const i18nManager = new I18nManager<string>(params);
+  const i18nCache = new I18nCache<string>(params);
   const conditionStore = new AsyncConditionStore({
-    defaultLocale: i18nManager.getDefaultLocale(),
-    locales: i18nManager.getLocales(),
-    customMapping: i18nManager.getCustomMapping(),
+    defaultLocale: i18nCache.getDefaultLocale(),
+    locales: i18nCache.getLocales(),
+    customMapping: i18nCache.getCustomMapping(),
   });
 
-  setI18nManager(i18nManager);
+  setI18nCache(i18nCache);
   setAsyncConditionStore(conditionStore);
 }


### PR DESCRIPTION
Stack: 6/8

Base: e/i18n-cache-tanstack-start

Summary:
- Update gt-node to consume and expose cache-named gt-i18n APIs.
- Rename async cache package-local references and tests.
- Keep deprecated manager aliases until the final cleanup PR.

Validation:
- pnpm --filter gt-node test
- pnpm --filter gt-node build

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1475"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782424471&installation_id=127936663&pr_number=1475&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1475&signature=f1c9d86c86c0276671cb826a16bd3bf882a8bfeb56923a07c01759521f79b2c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a mechanical rename of the `gt-i18n` cache symbols across the `gt-node` package, replacing `I18nManager`/`getI18nManager`/`setI18nManager` with `I18nCache`/`getI18nCache`/`setI18nCache`, and re-exporting the old names as `@deprecated` aliases for backward compatibility.

- **`internal.ts`** now exports both the new canonical names and the deprecated aliases, keeping downstream consumers working until the final cleanup PR.
- **`AsyncConditionStore.test.ts`** adds a `setTestCache()` helper and calls it at the top of every test to satisfy the singleton requirement that `getI18nCache()` now enforces at runtime.
- All other changed files (`AsyncConditionStore.ts`, `getRequestLocale.ts`, `initializeGT.ts`) are pure identifier renames with no logic changes.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — all changes are identifier renames with no logic alterations; the deprecated aliases in internal.ts preserve backward compatibility.

The rename is mechanical and consistent across all five files. The one notable gap is that the test suite afterEach does not reset the global i18nCache singleton, which leaves the cache set by setTestCache() alive across test boundaries; this is harmless today but reduces isolation for any future test that needs an uninitialized cache.

The test file AsyncConditionStore.test.ts would benefit from a singleton teardown in afterEach.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/node/src/internal.ts | Swaps primary exports to the new I18nCache/getI18nCache/setI18nCache names and re-exports the old names as deprecated aliases — clean backward-compatibility shim. |
| packages/node/src/async-i18n-cache/AsyncConditionStore.ts | Replaces all getI18nManager call-sites with getI18nCache; no behavioral changes. |
| packages/node/src/async-i18n-cache/__tests__/AsyncConditionStore.test.ts | Adds I18nCache/setI18nCache imports and a setTestCache() helper called at the top of each test, but the global singleton is never torn down between tests. |
| packages/node/src/helpers/getRequestLocale.ts | Mechanical rename of getI18nManager→getI18nCache and local variable i18nManager→i18nCache; no logic changes. |
| packages/node/src/setup/initializeGT.ts | Renames I18nManager/setI18nManager→I18nCache/setI18nCache and the local variable accordingly; initialization order and logic are unchanged. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant App
    participant initializeGT
    participant I18nCache
    participant setI18nCache
    participant AsyncConditionStore
    participant setAsyncConditionStore

    App->>initializeGT: initializeGT(params)
    initializeGT->>I18nCache: new I18nCache(params)
    I18nCache-->>initializeGT: i18nCache
    initializeGT->>AsyncConditionStore: "new AsyncConditionStore({defaultLocale, locales, customMapping})"
    AsyncConditionStore-->>initializeGT: conditionStore
    initializeGT->>setI18nCache: setI18nCache(i18nCache)
    initializeGT->>setAsyncConditionStore: setAsyncConditionStore(conditionStore)

    Note over App: Per-request flow
    App->>AsyncConditionStore: conditionStore.run(locale, callback)
    AsyncConditionStore->>getI18nCache: getI18nCache().determineLocale(locale)
    getI18nCache-->>AsyncConditionStore: resolvedLocale
    AsyncConditionStore-->>App: callback result

    App->>AsyncConditionStore: conditionStore.getLocale()
    AsyncConditionStore->>getI18nCache: getI18nCache().determineLocale(store.locale)
    getI18nCache-->>AsyncConditionStore: locale
    AsyncConditionStore-->>App: locale
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/node/src/async-i18n-cache/__tests__/AsyncConditionStore.test.ts`, line 6-9 ([link](https://github.com/generaltranslation/gt/blob/f00d36944fe84c470d520a7404a4256b5e3fa949/packages/node/src/async-i18n-cache/__tests__/AsyncConditionStore.test.ts#L6-L9)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> Missing teardown for the global `i18nCache` singleton. Each test calls `setTestCache()` up-front, so tests are currently deterministic, but no `afterEach` resets the singleton. If a future test expects the cache to be uninitialized (e.g., to cover the "not configured" error path), it could silently inherit the prior test's state and produce a false-positive result. Adding a reset call alongside the existing `vi.restoreAllMocks()` keeps the suite self-contained.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/node/src/async-i18n-cache/__tests__/AsyncConditionStore.test.ts
   Line: 6-9

   Comment:
   Missing teardown for the global `i18nCache` singleton. Each test calls `setTestCache()` up-front, so tests are currently deterministic, but no `afterEach` resets the singleton. If a future test expects the cache to be uninitialized (e.g., to cover the "not configured" error path), it could silently inherit the prior test's state and produce a false-positive result. Adding a reset call alongside the existing `vi.restoreAllMocks()` keeps the suite self-contained.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fnode%2Fsrc%2Fasync-i18n-cache%2F__tests__%2FAsyncConditionStore.test.ts%0ALine%3A%206-9%0A%0AComment%3A%0AMissing%20teardown%20for%20the%20global%20%60i18nCache%60%20singleton.%20Each%20test%20calls%20%60setTestCache%28%29%60%20up-front%2C%20so%20tests%20are%20currently%20deterministic%2C%20but%20no%20%60afterEach%60%20resets%20the%20singleton.%20If%20a%20future%20test%20expects%20the%20cache%20to%20be%20uninitialized%20%28e.g.%2C%20to%20cover%20the%20%22not%20configured%22%20error%20path%29%2C%20it%20could%20silently%20inherit%20the%20prior%20test's%20state%20and%20produce%20a%20false-positive%20result.%20Adding%20a%20reset%20call%20alongside%20the%20existing%20%60vi.restoreAllMocks%28%29%60%20keeps%20the%20suite%20self-contained.%0A%0A%60%60%60suggestion%0A%20%20afterEach%28%28%29%20%3D%3E%20%7B%0A%20%20%20%20vi.unstubAllEnvs%28%29%3B%0A%20%20%20%20vi.restoreAllMocks%28%29%3B%0A%20%20%20%20setI18nCache%28undefined%20as%20any%29%3B%0A%20%20%7D%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=generaltranslation%2Fgt&pr=1475&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fi18n-cache-node%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fi18n-cache-node%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fnode%2Fsrc%2Fasync-i18n-cache%2F__tests__%2FAsyncConditionStore.test.ts%0ALine%3A%206-9%0A%0AComment%3A%0AMissing%20teardown%20for%20the%20global%20%60i18nCache%60%20singleton.%20Each%20test%20calls%20%60setTestCache%28%29%60%20up-front%2C%20so%20tests%20are%20currently%20deterministic%2C%20but%20no%20%60afterEach%60%20resets%20the%20singleton.%20If%20a%20future%20test%20expects%20the%20cache%20to%20be%20uninitialized%20%28e.g.%2C%20to%20cover%20the%20%22not%20configured%22%20error%20path%29%2C%20it%20could%20silently%20inherit%20the%20prior%20test's%20state%20and%20produce%20a%20false-positive%20result.%20Adding%20a%20reset%20call%20alongside%20the%20existing%20%60vi.restoreAllMocks%28%29%60%20keeps%20the%20suite%20self-contained.%0A%0A%60%60%60suggestion%0A%20%20afterEach%28%28%29%20%3D%3E%20%7B%0A%20%20%20%20vi.unstubAllEnvs%28%29%3B%0A%20%20%20%20vi.restoreAllMocks%28%29%3B%0A%20%20%20%20setI18nCache%28undefined%20as%20any%29%3B%0A%20%20%7D%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fnode%2Fsrc%2Fasync-i18n-cache%2F__tests__%2FAsyncConditionStore.test.ts%3A6-9%0AMissing%20teardown%20for%20the%20global%20%60i18nCache%60%20singleton.%20Each%20test%20calls%20%60setTestCache%28%29%60%20up-front%2C%20so%20tests%20are%20currently%20deterministic%2C%20but%20no%20%60afterEach%60%20resets%20the%20singleton.%20If%20a%20future%20test%20expects%20the%20cache%20to%20be%20uninitialized%20%28e.g.%2C%20to%20cover%20the%20%22not%20configured%22%20error%20path%29%2C%20it%20could%20silently%20inherit%20the%20prior%20test's%20state%20and%20produce%20a%20false-positive%20result.%20Adding%20a%20reset%20call%20alongside%20the%20existing%20%60vi.restoreAllMocks%28%29%60%20keeps%20the%20suite%20self-contained.%0A%0A%60%60%60suggestion%0A%20%20afterEach%28%28%29%20%3D%3E%20%7B%0A%20%20%20%20vi.unstubAllEnvs%28%29%3B%0A%20%20%20%20vi.restoreAllMocks%28%29%3B%0A%20%20%20%20setI18nCache%28undefined%20as%20any%29%3B%0A%20%20%7D%29%3B%0A%60%60%60%0A%0A&repo=generaltranslation%2Fgt&pr=1475&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fi18n-cache-node%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fi18n-cache-node%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fnode%2Fsrc%2Fasync-i18n-cache%2F__tests__%2FAsyncConditionStore.test.ts%3A6-9%0AMissing%20teardown%20for%20the%20global%20%60i18nCache%60%20singleton.%20Each%20test%20calls%20%60setTestCache%28%29%60%20up-front%2C%20so%20tests%20are%20currently%20deterministic%2C%20but%20no%20%60afterEach%60%20resets%20the%20singleton.%20If%20a%20future%20test%20expects%20the%20cache%20to%20be%20uninitialized%20%28e.g.%2C%20to%20cover%20the%20%22not%20configured%22%20error%20path%29%2C%20it%20could%20silently%20inherit%20the%20prior%20test's%20state%20and%20produce%20a%20false-positive%20result.%20Adding%20a%20reset%20call%20alongside%20the%20existing%20%60vi.restoreAllMocks%28%29%60%20keeps%20the%20suite%20self-contained.%0A%0A%60%60%60suggestion%0A%20%20afterEach%28%28%29%20%3D%3E%20%7B%0A%20%20%20%20vi.unstubAllEnvs%28%29%3B%0A%20%20%20%20vi.restoreAllMocks%28%29%3B%0A%20%20%20%20setI18nCache%28undefined%20as%20any%29%3B%0A%20%20%7D%29%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/node/src/async-i18n-cache/__tests__/AsyncConditionStore.test.ts:6-9
Missing teardown for the global `i18nCache` singleton. Each test calls `setTestCache()` up-front, so tests are currently deterministic, but no `afterEach` resets the singleton. If a future test expects the cache to be uninitialized (e.g., to cover the "not configured" error path), it could silently inherit the prior test's state and produce a false-positive result. Adding a reset call alongside the existing `vi.restoreAllMocks()` keeps the suite self-contained.

```suggestion
  afterEach(() => {
    vi.unstubAllEnvs();
    vi.restoreAllMocks();
    setI18nCache(undefined as any);
  });
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: rename gt-node i18n cache symb..."](https://github.com/generaltranslation/gt/commit/f00d36944fe84c470d520a7404a4256b5e3fa949) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34048638)</sub>

<!-- /greptile_comment -->