### PR TITLE
refactor: rename gt-next i18n cache symbols

### DIFF
--- a/packages/next/src/config-dir/I18NConfiguration.ts
+++ b/packages/next/src/config-dir/I18NConfiguration.ts
@@ -19,7 +19,7 @@ import {
 } from '../utils/cookies';
 import { defaultLocaleHeaderName } from '../utils/headers';
 import type { CustomMapping } from '@generaltranslation/format/types';
-import { I18nManager } from 'gt-i18n/internal';
+import { I18nCache } from 'gt-i18n/internal';
 import type { LookupOptions } from 'gt-i18n/internal/types';
 import { loadTranslations } from './loadTranslation';
 
@@ -70,7 +70,7 @@ export class I18NConfiguration {
     timeout?: number;
   };
   // Dictionaries
-  private _i18nManager: I18nManager<TranslatedChildren>;
+  private _i18nCache: I18nCache<TranslatedChildren>;
   private _dictionaryManager: DictionaryManager | undefined;
   // Headers and cookies
   private localeHeaderName: string;
@@ -117,7 +117,7 @@ export class I18NConfiguration {
     this.projectId = projectId;
     this.runtimeUrl = runtimeUrl;
 
-    // Enables locale-based translation lookups through I18nManager. Runtime API
+    // Enables locale-based translation lookups through I18nCache. Runtime API
     // availability is tracked separately by developmentApiEnabled/productionApiEnabled.
     this.translationEnabled = !!(
       (
@@ -157,10 +157,10 @@ export class I18NConfiguration {
         timeout: renderSettings?.timeout || defaultRenderSettings.timeout,
       }),
     };
-    // Translation and dictionary managers
+    // Translation cache and dictionary manager
     const shouldLoadTranslations = loadTranslationsType !== 'disabled';
     const runtimeTranslationTimeout = this.renderSettings.timeout;
-    this._i18nManager = new I18nManager<TranslatedChildren>({
+    this._i18nCache = new I18nCache<TranslatedChildren>({
       apiKey,
       devApiKey,
       projectId,
@@ -257,8 +257,8 @@ export class I18NConfiguration {
       localeCookieName,
       resetLocaleCookieName,
     } = this;
-    const customMapping = this._i18nManager.getCustomMapping();
-    const _versionId = this._i18nManager.getVersionId();
+    const customMapping = this._i18nCache.getCustomMapping();
+    const _versionId = this._i18nCache.getVersionId();
     return {
       projectId,
       translationEnabled,
@@ -281,7 +281,7 @@ export class I18NConfiguration {
    * @returns {GT} The GT class instance
    */
   getGTClass(): GT {
-    return this._i18nManager.getGTClass();
+    return this._i18nCache.getGTClass();
   }
 
   // ----- LOCALES ----- //
@@ -291,7 +291,7 @@ export class I18NConfiguration {
    * @returns {string} A BCP-47 locale tag
    */
   getDefaultLocale(): string {
-    return this._i18nManager.getDefaultLocale();
+    return this._i18nCache.getDefaultLocale();
   }
 
   /**
@@ -299,7 +299,7 @@ export class I18NConfiguration {
    * @returns {string[]} A list of BCP-47 locale tags, or undefined if none were provided
    */
   getLocales(): string[] {
-    return this._i18nManager.getLocales();
+    return this._i18nCache.getLocales();
   }
 
   /**
@@ -307,7 +307,7 @@ export class I18NConfiguration {
    * @returns {string | undefined} The version ID, if set
    */
   getVersionId(): string | undefined {
-    return this._i18nManager.getVersionId();
+    return this._i18nCache.getVersionId();
   }
 
   // ----- COOKIES AND HEADERS ----- //
@@ -359,8 +359,8 @@ export class I18NConfiguration {
    */
   requiresTranslation(locale: string): [boolean, boolean] {
     return [
-      this._i18nManager.requiresTranslation(locale),
-      this._i18nManager.requiresDialectTranslation(locale),
+      this._i18nCache.requiresTranslation(locale),
+      this._i18nCache.requiresDialectTranslation(locale),
     ];
   }
 
@@ -396,7 +396,7 @@ export class I18NConfiguration {
    * @returns A promise that resolves to the translations.
    */
   async getCachedTranslations(locale: string): Promise<Translations> {
-    return (await this._i18nManager.loadTranslations(locale)) as Translations;
+    return (await this._i18nCache.loadTranslations(locale)) as Translations;
   }
 
   // ----- RUNTIME TRANSLATION ----- //
@@ -406,7 +406,7 @@ export class I18NConfiguration {
     targetLocale,
     options,
   }: RuntimeTranslationParams): TranslatedChildren | undefined {
-    return this._i18nManager.lookupTranslation(targetLocale, source, options);
+    return this._i18nCache.lookupTranslation(targetLocale, source, options);
   }
 
   async translate({
@@ -414,7 +414,7 @@ export class I18NConfiguration {
     targetLocale,
     options,
   }: RuntimeTranslationParams): Promise<TranslatedChildren> {
-    const translation = await this._i18nManager.lookupTranslationWithFallback(
+    const translation = await this._i18nCache.lookupTranslationWithFallback(
       targetLocale,
       source,
       options

--- a/packages/next/src/config-dir/__tests__/I18NConfiguration.test.ts
+++ b/packages/next/src/config-dir/__tests__/I18NConfiguration.test.ts
@@ -1,13 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { I18NConfiguration } from '../I18NConfiguration';
 
-const mockI18nManagerParams = vi.hoisted(() => vi.fn());
+const mockI18nCacheParams = vi.hoisted(() => vi.fn());
 const mockLookupTranslationWithFallback = vi.hoisted(() => vi.fn());
 
 vi.mock('gt-i18n/internal', () => ({
-  I18nManager: class {
+  I18nCache: class {
     constructor(params: unknown) {
-      mockI18nManagerParams(params);
+      mockI18nCacheParams(params);
     }
 
     getGTClass() {
@@ -60,15 +60,15 @@ function createConfig(overrides: Partial<ConfigParams> = {}) {
   });
 }
 
-function expectManagerParams(expected: unknown) {
-  expect(mockI18nManagerParams).toHaveBeenLastCalledWith(
+function expectCacheParams(expected: unknown) {
+  expect(mockI18nCacheParams).toHaveBeenLastCalledWith(
     expect.objectContaining(expected)
   );
 }
 
 describe('I18NConfiguration', () => {
   beforeEach(() => {
-    mockI18nManagerParams.mockReset();
+    mockI18nCacheParams.mockReset();
     mockLookupTranslationWithFallback.mockReset();
     mockLookupTranslationWithFallback.mockResolvedValue('translated');
   });
@@ -87,10 +87,10 @@ describe('I18NConfiguration', () => {
     ],
   ])('sets %s cache expiry config', (_name, overrides, cacheExpiryTime) => {
     createConfig(overrides);
-    expectManagerParams({ cacheExpiryTime });
+    expectCacheParams({ cacheExpiryTime });
   });
 
-  it('passes batch, runtime metadata, and timeout config to I18nManager', () => {
+  it('passes batch, runtime metadata, and timeout config to I18nCache', () => {
     createConfig({
       maxConcurrentRequests: 7,
       maxBatchSize: 3,
@@ -104,7 +104,7 @@ describe('I18NConfiguration', () => {
       modelProvider: 'openai',
     });
 
-    expectManagerParams({
+    expectCacheParams({
       batchConfig: {
         maxConcurrentRequests: 7,
         maxBatchSize: 3,
@@ -125,7 +125,7 @@ describe('I18NConfiguration', () => {
     });
   });
 
-  it('passes runtime fallback options directly to I18nManager lookups', async () => {
+  it('passes runtime fallback options directly to I18nCache lookups', async () => {
     const config = createConfig();
 
     await config.translate({


### PR DESCRIPTION
Stack: 7/8

Base: e/i18n-cache-node

Summary:
- Update gt-next cache configuration and tests from manager terminology to cache terminology.
- Rename package-local mocks/expectations and internal I18nCache call sites.

Validation:
- pnpm --filter @generaltranslation/next-internal build
- pnpm --filter gt-next test:js
- pnpm --filter gt-next build:no-swc-plugin

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1476"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782424476&installation_id=127936663&pr_number=1476&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1476&signature=450822e2bd49598b0cf80743ddbec52abf5d790b90e3d3d58136b464ca1080b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR renames the `I18nManager` symbol to `I18nCache` (and its associated private field `_i18nManager` → `_i18nCache`) across `I18NConfiguration.ts` and its test file, aligning the gt-next package with the `I18nCache` terminology introduced in the parent stack branch.

- **`I18NConfiguration.ts`**: Import, private field declaration, constructor initialisation, and every call-site updated; one inline comment updated accordingly.
- **`I18NConfiguration.test.ts`**: Mock class name, constructor spy variable, helper function, and all affected `it()` description strings updated to match.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This PR is safe to merge — it is a pure symbol rename with no behavioural changes.

Every change is a mechanical find-and-replace of I18nManager/_i18nManager to I18nCache/_i18nCache. No logic, control flow, or public API surface was altered, and a grep confirms no stale references remain in the changed directory.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/next/src/config-dir/I18NConfiguration.ts | Pure rename of import symbol `I18nManager` → `I18nCache` and private field `_i18nManager` → `_i18nCache`; no logic or behaviour changes. |
| packages/next/src/config-dir/__tests__/I18NConfiguration.test.ts | Test file updated to match renamed symbols: mock variable, helper function, and test-description strings all consistently updated from Manager to Cache terminology. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant App as Next.js App
    participant I18NConfig as I18NConfiguration
    participant Cache as I18nCache (gt-i18n/internal)

    App->>I18NConfig: new I18NConfiguration(config)
    I18NConfig->>Cache: "new I18nCache({ apiKey, projectId, ... })"
    App->>I18NConfig: getCachedTranslations(locale)
    I18NConfig->>Cache: loadTranslations(locale)
    Cache-->>I18NConfig: Translations
    I18NConfig-->>App: Translations
    App->>I18NConfig: "translate({ source, targetLocale, options })"
    I18NConfig->>Cache: lookupTranslationWithFallback(targetLocale, source, options)
    Cache-->>I18NConfig: TranslatedChildren
    I18NConfig-->>App: TranslatedChildren
```
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: rename gt-next i18n cache symb..."](https://github.com/generaltranslation/gt/commit/3928bf193c5e3dd4443219e26b66935eaa113a85) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34048648)</sub>

<!-- /greptile_comment -->