### PR TITLE
refactor: rename gt-node i18n cache symbols

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -33,7 +33,7 @@
   },
   {
     "name": "gt-tanstack-start",
-    "path": "packages/tanstack-start/dist/index.esm.min.mjs",
+    "path": "packages/tanstack-start/dist/index.client.mjs",
     "limit": "56 kB",
     "brotli": true,
     "ignore": ["react", "react-dom", "@tanstack/react-start"]

--- a/packages/i18n/src/condition-store/ReadonlyConditionStore.ts
+++ b/packages/i18n/src/condition-store/ReadonlyConditionStore.ts
@@ -7,15 +7,15 @@ import { createLocaleResolver, type LocaleCandidates } from './localeResolver';
 
 export type ReadonlyConditionStoreParams = {
   /**
-   * @deprecated - this will be moved to a locale config manager
+   * @deprecated - this will be moved to a locale config cache
    */
   defaultLocale?: string;
   /**
-   * @deprecated - this will be moved to a locale config manager
+   * @deprecated - this will be moved to a locale config cache
    */
   locales?: string[];
   /**
-   * @deprecated - this will be moved to a locale config manager
+   * @deprecated - this will be moved to a locale config cache
    */
   customMapping?: CustomMapping;
   locale: LocaleCandidates;
@@ -24,7 +24,7 @@ export type ReadonlyConditionStoreParams = {
 
 export class ReadonlyConditionStore implements ReadonlyConditionStoreContract {
   /**
-   * @deprecated use getI18nManager().determineLocale() instead
+   * @deprecated use getI18nCache().determineLocale() instead
    */
   protected readonly resolveLocale: (candidates?: LocaleCandidates) => string;
   protected locale: string;
@@ -36,7 +36,7 @@ export class ReadonlyConditionStore implements ReadonlyConditionStoreContract {
     ...localeConfig
   }: ReadonlyConditionStoreParams) {
     /**
-     * TODO: change this to getI18nManager().determineLocale() but this
+     * TODO: change this to getI18nCache().determineLocale() but this
      * currently creates a circular dependency
      */
     this.resolveLocale = createLocaleResolver(localeConfig);

--- a/packages/i18n/src/helpers/locale.ts
+++ b/packages/i18n/src/helpers/locale.ts
@@ -1,5 +1,5 @@
 import { getWritableConditionStore } from '../condition-store/singleton-operations';
-import { getI18nManager } from '../i18n-cache/singleton-operations';
+import { getI18nCache } from '../i18n-cache/singleton-operations';
 
 /**
  * Get the current locale
@@ -22,8 +22,8 @@ export function getLocale() {
  * console.log(locales); // ['en-US', 'es-ES']
  */
 export function getLocales() {
-  const i18nManager = getI18nManager();
-  return i18nManager.getLocales();
+  const i18nCache = getI18nCache();
+  return i18nCache.getLocales();
 }
 
 /**
@@ -35,8 +35,8 @@ export function getLocales() {
  * console.log(defaultLocale); // 'en-US'
  */
 export function getDefaultLocale() {
-  const i18nManager = getI18nManager();
-  return i18nManager.getDefaultLocale();
+  const i18nCache = getI18nCache();
+  return i18nCache.getDefaultLocale();
 }
 
 /**
@@ -51,7 +51,7 @@ export function getDefaultLocale() {
  * const localeProperties = getLocaleProperties('en-US');
  */
 export function getLocaleProperties(locale = getLocale()) {
-  const i18nManager = getI18nManager();
-  const gtInstance = i18nManager.getGTClass();
+  const i18nCache = getI18nCache();
+  const gtInstance = i18nCache.getGTClass();
   return gtInstance.getLocaleProperties(locale);
 }

--- a/packages/i18n/src/helpers/versionId.ts
+++ b/packages/i18n/src/helpers/versionId.ts
@@ -1,4 +1,4 @@
-import { getI18nManager } from '../i18n-cache/singleton-operations';
+import { getI18nCache } from '../i18n-cache/singleton-operations';
 
 /**
  * Get the version ID for the current source
@@ -9,6 +9,6 @@ import { getI18nManager } from '../i18n-cache/singleton-operations';
  * console.log(versionId); // 'abc123'
  */
 export function getVersionId() {
-  const i18nManager = getI18nManager();
-  return i18nManager.getVersionId();
+  const i18nCache = getI18nCache();
+  return i18nCache.getVersionId();
 }

--- a/packages/i18n/src/i18n-cache/I18nCache.ts
+++ b/packages/i18n/src/i18n-cache/I18nCache.ts
@@ -1,6 +1,6 @@
 import { publishValidationResults } from './validation/publishValidationResults';
 import logger from '../logs/logger';
-import { I18nManagerConfig, I18nManagerConstructorParams } from './types';
+import { I18nCacheConfig, I18nCacheConstructorParams } from './types';
 import { validateConfig } from './validation/validateConfig';
 import { Translation } from './translations-manager/utils/types/translation-data';
 import { libraryDefaultLocale } from 'generaltranslation/internal';
@@ -72,10 +72,10 @@ type PrefetchEntry<TranslationType extends Translation> = {
  * Class for managing translation functionality
  * @template TranslationValue - The type of the translation that will be cached
  */
-class I18nManager<
+class I18nCache<
   TranslationValue extends Translation = Translation,
 > extends EventEmitter<I18nEvents<TranslationValue>> {
-  protected config: I18nManagerConfig;
+  protected config: I18nCacheConfig;
 
   /**
    * Locale-scoped caches for translations and dictionaries
@@ -90,17 +90,17 @@ class I18nManager<
   public determineLocale: (candidates?: LocaleCandidates) => string;
 
   /**
-   * Creates an instance of I18nManager.
+   * Creates an instance of I18nCache.
    * TODO: resolve gtConfig from just file path
-   * @param params - The parameters for the I18nManager constructor
-   * @param params.config - The configuration for the I18nManager
+   * @param params - The parameters for the I18nCache constructor
+   * @param params.config - The configuration for the I18nCache
    */
-  constructor(params: I18nManagerConstructorParams<TranslationValue>) {
+  constructor(params: I18nCacheConstructorParams<TranslationValue>) {
     super();
 
     // Validation
     const validationResults = validateConfig(params);
-    publishValidationResults(validationResults, 'I18nManager: ');
+    publishValidationResults(validationResults, 'I18nCache: ');
 
     // Setup
     this.config = standardizeConfig(params);
@@ -573,7 +573,7 @@ class I18nManager<
       );
       if (resolvedPrefetchEntries.length !== prefetchEntries.length) {
         logger.warn(
-          `I18nManager: getLookupTranslation(): prefetchEntries must all be the same locale, ignoring all entries that are not for ${translationLocale}`
+          `I18nCache: getLookupTranslation(): prefetchEntries must all be the same locale, ignoring all entries that are not for ${translationLocale}`
         );
       }
 
@@ -703,7 +703,7 @@ class I18nManager<
         throw error;
       case 'production':
       default:
-        logger.error('I18nManager: ' + error);
+        logger.error('I18nCache: ' + error);
         break;
     }
   }
@@ -816,7 +816,7 @@ class I18nManager<
   }
 }
 
-export { I18nManager };
+export { I18nCache };
 
 // ===== Helper Functions ===== //
 
@@ -826,7 +826,7 @@ export { I18nManager };
  * @returns The standardized config
  */
 function standardizeConfig<TranslationValue extends Translation>(
-  config: I18nManagerConstructorParams<TranslationValue>
+  config: I18nCacheConstructorParams<TranslationValue>
 ) {
   const gtServicesEnabled = getGTServicesEnabled(config);
 

--- a/packages/i18n/src/i18n-cache/__tests__/I18nCache.handleError.test.ts
+++ b/packages/i18n/src/i18n-cache/__tests__/I18nCache.handleError.test.ts
@@ -1,29 +1,29 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { I18nManager } from '../I18nCache';
+import { I18nCache } from '../I18nCache';
 
 // Mock createTranslateManyFactory so constructor doesn't need real GT
 vi.mock('../translations-manager/utils/createTranslateMany', () => ({
   createTranslateManyFactory: vi.fn().mockReturnValue(() => vi.fn()),
 }));
 
-describe('I18nManager.handleError', () => {
+describe('I18nCache.handleError', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   it('throws in development mode when error occurs', async () => {
-    const manager = new I18nManager({
+    const cache = new I18nCache({
       defaultLocale: 'en',
       locales: ['en', 'fr'],
       environment: 'development',
       loadTranslations: vi.fn().mockRejectedValue(new Error('Load failed')),
     });
 
-    await expect(manager.loadTranslations('fr')).rejects.toThrow('Load failed');
+    await expect(cache.loadTranslations('fr')).rejects.toThrow('Load failed');
   });
 
   it('logs and returns fallback in production mode', async () => {
-    const manager = new I18nManager({
+    const cache = new I18nCache({
       defaultLocale: 'en',
       locales: ['en', 'fr'],
       environment: 'production',
@@ -31,7 +31,7 @@ describe('I18nManager.handleError', () => {
     });
 
     // Should not throw, returns empty object
-    const result = await manager.loadTranslations('fr');
+    const result = await cache.loadTranslations('fr');
     expect(result).toEqual({});
   });
 });

--- a/packages/i18n/src/i18n-cache/__tests__/I18nCache.test.ts
+++ b/packages/i18n/src/i18n-cache/__tests__/I18nCache.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { I18nManager } from '../I18nCache';
+import { I18nCache } from '../I18nCache';
 import { createTranslateManyFactory } from '../translations-manager/utils/createTranslateMany';
 import { hashMessage } from '../../utils/hashMessage';
 import { LookupOptions } from '../../translation-functions/types/options';
@@ -19,8 +19,8 @@ const lookupOptions: LookupOptions = {
 const expectedHash = hashMessage(message, lookupOptions);
 const translatedString = 'Bonjour {name} !';
 
-function createManager(overrides: Record<string, unknown> = {}) {
-  return new I18nManager({
+function createCache(overrides: Record<string, unknown> = {}) {
+  return new I18nCache({
     defaultLocale: 'en',
     locales: ['en', 'fr', 'es'],
     loadTranslations: vi
@@ -30,7 +30,7 @@ function createManager(overrides: Record<string, unknown> = {}) {
   });
 }
 
-describe('I18nManager', () => {
+describe('I18nCache', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockTranslateMany.mockReset();
@@ -43,40 +43,40 @@ describe('I18nManager', () => {
   // ===== REGRESSION TESTS ===== //
 
   it('resolveTranslationSync returns translation after loadTranslations', async () => {
-    const manager = createManager();
+    const cache = createCache();
 
     // Load translations first
-    await manager.loadTranslations('fr');
+    await cache.loadTranslations('fr');
 
     // Now sync resolution should work
-    const result = manager.resolveTranslationSync('fr', message, lookupOptions);
+    const result = cache.resolveTranslationSync('fr', message, lookupOptions);
     expect(result).toBe(translatedString);
   });
 
   it('getTranslations returns empty object for invalid locale', async () => {
-    const manager = createManager();
+    const cache = createCache();
 
-    const result = await manager.getTranslations('zh');
+    const result = await cache.getTranslations('zh');
     expect(result).toEqual({});
   });
 
   it('getTranslationResolver returns a working resolver function', async () => {
-    const manager = createManager();
+    const cache = createCache();
 
-    const resolver = await manager.getTranslationResolver('fr');
+    const resolver = await cache.getTranslationResolver('fr');
     const result = resolver(message, lookupOptions);
 
     expect(result).toBe(translatedString);
   });
 
   it('enables dev hot reload with dev credentials, a project id, and development environment', () => {
-    const manager = createManager({
+    const cache = createCache({
       devApiKey: 'dev-key',
       projectId: 'project-id',
       environment: 'development',
     });
 
-    expect(manager.isDevHotReloadEnabled()).toBe(true);
+    expect(cache.isDevHotReloadEnabled()).toBe(true);
   });
 
   it.each([
@@ -112,31 +112,31 @@ describe('I18nManager', () => {
       },
     },
   ])('disables dev hot reload for $name', ({ config }) => {
-    const manager = createManager(config);
+    const cache = createCache(config);
 
-    expect(manager.isDevHotReloadEnabled()).toBe(false);
+    expect(cache.isDevHotReloadEnabled()).toBe(false);
   });
 
   // ===== NEW BEHAVIOR TESTS ===== //
 
   it('loadTranslations() returns Record<Hash, Translation>', async () => {
-    const manager = createManager();
+    const cache = createCache();
 
-    const translations = await manager.loadTranslations('fr');
+    const translations = await cache.loadTranslations('fr');
 
     expect(translations[expectedHash]).toBe(translatedString);
   });
 
   it('loadDictionary() returns source dictionary without loading when locale does not require translation', async () => {
     const loadDictionary = vi.fn().mockResolvedValue({ greeting: 'Bonjour' });
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         greeting: 'Hello',
       },
       loadDictionary,
     });
 
-    const dictionary = await manager.loadDictionary('en');
+    const dictionary = await cache.loadDictionary('en');
 
     expect(dictionary).toEqual({
       greeting: 'Hello',
@@ -146,7 +146,7 @@ describe('I18nManager', () => {
 
   it('loadDictionary() returns source dictionary without loading when i18n is disabled', async () => {
     const loadDictionary = vi.fn().mockResolvedValue({ greeting: 'Bonjour' });
-    const manager = createManager({
+    const cache = createCache({
       enableI18n: false,
       dictionary: {
         greeting: 'Hello',
@@ -154,7 +154,7 @@ describe('I18nManager', () => {
       loadDictionary,
     });
 
-    const dictionary = await manager.loadDictionary('fr');
+    const dictionary = await cache.loadDictionary('fr');
 
     expect(dictionary).toEqual({
       greeting: 'Hello',
@@ -169,15 +169,15 @@ describe('I18nManager', () => {
         name: 'Nom',
       },
     });
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         greeting: 'Hello',
       },
       loadDictionary,
     });
 
-    const dictionary = await manager.loadDictionary('fr');
-    const cachedDictionary = await manager.loadDictionary('fr');
+    const dictionary = await cache.loadDictionary('fr');
+    const cachedDictionary = await cache.loadDictionary('fr');
 
     expect(loadDictionary).toHaveBeenCalledTimes(1);
     expect(loadDictionary).toHaveBeenCalledWith('fr');
@@ -191,13 +191,13 @@ describe('I18nManager', () => {
     expect(cachedDictionary).not.toBe(dictionary);
 
     dictionary.greeting = 'Salut';
-    await expect(manager.loadDictionary('fr')).resolves.toMatchObject({
+    await expect(cache.loadDictionary('fr')).resolves.toMatchObject({
       greeting: 'Bonjour',
     });
   });
 
   it('loadDictionary() returns deep copies of cached dictionaries', async () => {
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         user: {
           profile: {
@@ -214,7 +214,7 @@ describe('I18nManager', () => {
       }),
     });
 
-    const dictionary = (await manager.loadDictionary('fr')) as {
+    const dictionary = (await cache.loadDictionary('fr')) as {
       user: {
         profile: {
           name: string;
@@ -223,7 +223,7 @@ describe('I18nManager', () => {
     };
     dictionary.user.profile.name = 'Changed';
 
-    await expect(manager.loadDictionary('fr')).resolves.toEqual({
+    await expect(cache.loadDictionary('fr')).resolves.toEqual({
       user: {
         profile: {
           name: 'Nom',
@@ -233,7 +233,7 @@ describe('I18nManager', () => {
   });
 
   it('updateDictionaries() updates locale dictionary lookups', () => {
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         greeting: 'Hello',
         cta: 'Click me',
@@ -243,7 +243,7 @@ describe('I18nManager', () => {
       },
     });
 
-    manager.updateDictionaries({
+    cache.updateDictionaries({
       en: {
         greeting: 'Hi',
         navigation: {
@@ -258,23 +258,23 @@ describe('I18nManager', () => {
       },
     });
 
-    expect(manager.lookupDictionary('en', 'greeting')).toEqual({
+    expect(cache.lookupDictionary('en', 'greeting')).toEqual({
       entry: 'Hi',
       options: {},
     });
-    expect(manager.lookupDictionaryObj('en', 'navigation')).toEqual({
+    expect(cache.lookupDictionaryObj('en', 'navigation')).toEqual({
       about: 'About',
       home: 'Home',
     });
-    expect(manager.lookupDictionary('en', 'cta')).toEqual({
+    expect(cache.lookupDictionary('en', 'cta')).toEqual({
       entry: 'Click me',
       options: {},
     });
-    expect(manager.lookupDictionary('fr', 'greeting')).toEqual({
+    expect(cache.lookupDictionary('fr', 'greeting')).toEqual({
       entry: 'Bonjour',
       options: {},
     });
-    expect(manager.lookupDictionaryObj('fr', 'navigation')).toEqual({
+    expect(cache.lookupDictionaryObj('fr', 'navigation')).toEqual({
       home: 'Accueil',
     });
   });
@@ -304,7 +304,7 @@ describe('I18nManager', () => {
     },
   ])('loadDictionary() uses cache locale for $name', async (testCase) => {
     const loadDictionary = vi.fn().mockResolvedValue(testCase.dictionary);
-    const manager = createManager({
+    const cache = createCache({
       defaultLocale: 'en-US',
       locales: ['en-US', 'en'],
       dictionary: {
@@ -316,19 +316,19 @@ describe('I18nManager', () => {
       }),
     });
 
-    const dictionary = await manager.loadDictionary(testCase.locale);
+    const dictionary = await cache.loadDictionary(testCase.locale);
 
     expect(loadDictionary).toHaveBeenCalledTimes(1);
     expect(loadDictionary).toHaveBeenCalledWith(testCase.dictionaryLocale);
     expect(dictionary).toEqual(testCase.dictionary);
-    expect(manager.lookupDictionary(testCase.locale, 'greeting')).toEqual({
+    expect(cache.lookupDictionary(testCase.locale, 'greeting')).toEqual({
       entry: testCase.dictionary.greeting,
       options: {},
     });
   });
 
   it('lookupDictionary() returns a loaded target locale leaf', async () => {
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         greeting: 'Hello',
       },
@@ -337,16 +337,16 @@ describe('I18nManager', () => {
       }),
     });
 
-    await manager.loadDictionary('fr');
+    await cache.loadDictionary('fr');
 
-    expect(manager.lookupDictionary('fr', 'greeting')).toEqual({
+    expect(cache.lookupDictionary('fr', 'greeting')).toEqual({
       entry: 'Bonjour',
       options: {},
     });
   });
 
   it('lookupDictionary() returns a loaded target locale nested leaf', async () => {
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         user: {
           name: 'Name',
@@ -359,16 +359,16 @@ describe('I18nManager', () => {
       }),
     });
 
-    await manager.loadDictionary('fr');
+    await cache.loadDictionary('fr');
 
-    expect(manager.lookupDictionary('fr', 'user.name')).toEqual({
+    expect(cache.lookupDictionary('fr', 'user.name')).toEqual({
       entry: 'Nom',
       options: {},
     });
   });
 
   it('lookupDictionary() returns the entry and options from a metadata tuple leaf', async () => {
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         greeting: ['Hello', { $context: 'homepage', $maxChars: 10 }],
       },
@@ -377,16 +377,16 @@ describe('I18nManager', () => {
       }),
     });
 
-    await manager.loadDictionary('fr');
+    await cache.loadDictionary('fr');
 
-    expect(manager.lookupDictionary('fr', 'greeting')).toEqual({
+    expect(cache.lookupDictionary('fr', 'greeting')).toEqual({
       entry: 'Bonjour',
       options: { context: 'homepage' },
     });
   });
 
   it('lookupDictionary() returns undefined when target locale is not loaded', () => {
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         greeting: 'Hello',
       },
@@ -395,53 +395,53 @@ describe('I18nManager', () => {
       }),
     });
 
-    expect(manager.lookupDictionary('fr', 'greeting')).toBeUndefined();
-    expect(manager.lookupDictionary('en', 'greeting')).toEqual({
+    expect(cache.lookupDictionary('fr', 'greeting')).toBeUndefined();
+    expect(cache.lookupDictionary('en', 'greeting')).toEqual({
       entry: 'Hello',
       options: {},
     });
   });
 
   it('lookupDictionary() returns undefined when source leaf is missing and translation is not required', () => {
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         greeting: 'Hello',
       },
     });
 
-    expect(manager.lookupDictionary('en', 'missing')).toBeUndefined();
+    expect(cache.lookupDictionary('en', 'missing')).toBeUndefined();
   });
 
   it('lookupDictionary() returns undefined when source leaf is missing and i18n is disabled', () => {
-    const manager = createManager({
+    const cache = createCache({
       enableI18n: false,
       dictionary: {
         greeting: 'Hello',
       },
     });
 
-    expect(manager.lookupDictionary('fr', 'missing')).toBeUndefined();
+    expect(cache.lookupDictionary('fr', 'missing')).toBeUndefined();
   });
 
   it('lookupDictionary() returns undefined when target leaf is missing', async () => {
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         greeting: 'Hello',
       },
       loadDictionary: vi.fn().mockResolvedValue({}),
     });
 
-    await manager.loadDictionary('fr');
+    await cache.loadDictionary('fr');
 
-    expect(manager.lookupDictionary('fr', 'greeting')).toBeUndefined();
-    expect(manager.lookupDictionary('en', 'greeting')).toEqual({
+    expect(cache.lookupDictionary('fr', 'greeting')).toBeUndefined();
+    expect(cache.lookupDictionary('en', 'greeting')).toEqual({
       entry: 'Hello',
       options: {},
     });
   });
 
   it('lookupDictionary() returns undefined when target nested leaf is missing', async () => {
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         user: {
           name: 'Name',
@@ -452,17 +452,17 @@ describe('I18nManager', () => {
       }),
     });
 
-    await manager.loadDictionary('fr');
+    await cache.loadDictionary('fr');
 
-    expect(manager.lookupDictionary('fr', 'user.name')).toBeUndefined();
-    expect(manager.lookupDictionary('en', 'user.name')).toEqual({
+    expect(cache.lookupDictionary('fr', 'user.name')).toBeUndefined();
+    expect(cache.lookupDictionary('en', 'user.name')).toEqual({
       entry: 'Name',
       options: {},
     });
   });
 
   it('lookupDictionary() does not return dictionary subtrees', async () => {
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         user: {
           name: 'Name',
@@ -475,13 +475,13 @@ describe('I18nManager', () => {
       }),
     });
 
-    await manager.loadDictionary('fr');
+    await cache.loadDictionary('fr');
 
-    expect(manager.lookupDictionary('fr', 'user')).toBeUndefined();
+    expect(cache.lookupDictionary('fr', 'user')).toBeUndefined();
   });
 
   it('lookupDictionaryObj() returns source leaves and subtrees', () => {
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         greeting: 'Hello',
         user: {
@@ -492,14 +492,14 @@ describe('I18nManager', () => {
       },
     });
 
-    expect(manager.lookupDictionaryObj('en', 'greeting')).toBe('Hello');
-    expect(manager.lookupDictionaryObj('en', 'user.profile')).toEqual({
+    expect(cache.lookupDictionaryObj('en', 'greeting')).toBe('Hello');
+    expect(cache.lookupDictionaryObj('en', 'user.profile')).toEqual({
       name: 'Name',
     });
   });
 
   it('lookupDictionaryObj() returns loaded target leaves and subtrees', async () => {
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         greeting: 'Hello',
       },
@@ -513,16 +513,16 @@ describe('I18nManager', () => {
       }),
     });
 
-    await manager.loadDictionary('fr');
+    await cache.loadDictionary('fr');
 
-    expect(manager.lookupDictionaryObj('fr', 'greeting')).toBe('Bonjour');
-    expect(manager.lookupDictionaryObj('fr', 'user.profile')).toEqual({
+    expect(cache.lookupDictionaryObj('fr', 'greeting')).toBe('Bonjour');
+    expect(cache.lookupDictionaryObj('fr', 'user.profile')).toEqual({
       name: 'Nom',
     });
   });
 
   it('lookupDictionaryObj() returns copies of dictionary subtrees', () => {
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         user: {
           profile: {
@@ -532,19 +532,19 @@ describe('I18nManager', () => {
       },
     });
 
-    const profile = manager.lookupDictionaryObj('en', 'user.profile');
+    const profile = cache.lookupDictionaryObj('en', 'user.profile');
     expect(profile).toEqual({
       name: 'Name',
     });
     (profile as { name: string }).name = 'Changed';
 
-    expect(manager.lookupDictionaryObj('en', 'user.profile')).toEqual({
+    expect(cache.lookupDictionaryObj('en', 'user.profile')).toEqual({
       name: 'Name',
     });
   });
 
   it('lookupDictionaryObj() returns undefined when target locale is not loaded', () => {
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         user: {
           profile: {
@@ -561,11 +561,11 @@ describe('I18nManager', () => {
       }),
     });
 
-    expect(manager.lookupDictionaryObj('fr', 'user.profile')).toBeUndefined();
+    expect(cache.lookupDictionaryObj('fr', 'user.profile')).toBeUndefined();
   });
 
   it('lookupDictionaryObj() returns undefined for missing paths', async () => {
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         greeting: 'Hello',
       },
@@ -574,14 +574,14 @@ describe('I18nManager', () => {
       }),
     });
 
-    await manager.loadDictionary('fr');
+    await cache.loadDictionary('fr');
 
-    expect(manager.lookupDictionaryObj('fr', 'missing')).toBeUndefined();
-    expect(manager.lookupDictionaryObj('en', 'missing')).toBeUndefined();
+    expect(cache.lookupDictionaryObj('fr', 'missing')).toBeUndefined();
+    expect(cache.lookupDictionaryObj('en', 'missing')).toBeUndefined();
   });
 
   it('lookupDictionaryObj() uses the source dictionary when i18n is disabled', () => {
-    const manager = createManager({
+    const cache = createCache({
       enableI18n: false,
       dictionary: {
         user: {
@@ -599,7 +599,7 @@ describe('I18nManager', () => {
       }),
     });
 
-    expect(manager.lookupDictionaryObj('fr', 'user.profile')).toEqual({
+    expect(cache.lookupDictionaryObj('fr', 'user.profile')).toEqual({
       name: 'Name',
     });
   });
@@ -608,7 +608,7 @@ describe('I18nManager', () => {
     const loadDictionary = vi.fn().mockResolvedValue({
       greeting: 'Bonjour',
     });
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         greeting: 'Hello',
       },
@@ -616,7 +616,7 @@ describe('I18nManager', () => {
     });
 
     await expect(
-      manager.lookupDictionaryWithFallback('en', 'greeting')
+      cache.lookupDictionaryWithFallback('en', 'greeting')
     ).resolves.toEqual({
       entry: 'Hello',
       options: {},
@@ -625,7 +625,7 @@ describe('I18nManager', () => {
   });
 
   it('lookupDictionaryWithFallback() throws when source entry is missing and translation is not required', async () => {
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         greeting: 'Hello',
       },
@@ -635,9 +635,9 @@ describe('I18nManager', () => {
     });
 
     await expect(
-      manager.lookupDictionaryWithFallback('en', 'missing')
+      cache.lookupDictionaryWithFallback('en', 'missing')
     ).rejects.toThrow(
-      'I18nManager: source dictionary entry missing is not defined'
+      'I18nCache: source dictionary entry missing is not defined'
     );
   });
 
@@ -645,7 +645,7 @@ describe('I18nManager', () => {
     const loadDictionary = vi.fn().mockResolvedValue({
       greeting: 'Bonjour',
     });
-    const manager = createManager({
+    const cache = createCache({
       enableI18n: false,
       dictionary: {
         greeting: 'Hello',
@@ -654,7 +654,7 @@ describe('I18nManager', () => {
     });
 
     await expect(
-      manager.lookupDictionaryWithFallback('fr', 'greeting')
+      cache.lookupDictionaryWithFallback('fr', 'greeting')
     ).resolves.toEqual({
       entry: 'Hello',
       options: {},
@@ -666,7 +666,7 @@ describe('I18nManager', () => {
     const loadDictionary = vi.fn().mockResolvedValue({
       greeting: 'Bonjour',
     });
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         greeting: 'Hello',
       },
@@ -674,7 +674,7 @@ describe('I18nManager', () => {
     });
 
     await expect(
-      manager.lookupDictionaryWithFallback('fr', 'greeting')
+      cache.lookupDictionaryWithFallback('fr', 'greeting')
     ).resolves.toEqual({
       entry: 'Bonjour',
       options: {},
@@ -710,7 +710,7 @@ describe('I18nManager', () => {
     'lookupDictionaryWithFallback() uses cache locale for $name',
     async (testCase) => {
       const loadDictionary = vi.fn().mockResolvedValue(testCase.dictionary);
-      const manager = createManager({
+      const cache = createCache({
         defaultLocale: 'en-US',
         locales: ['en-US', 'en'],
         dictionary: {
@@ -723,7 +723,7 @@ describe('I18nManager', () => {
       });
 
       await expect(
-        manager.lookupDictionaryWithFallback(testCase.locale, 'greeting')
+        cache.lookupDictionaryWithFallback(testCase.locale, 'greeting')
       ).resolves.toEqual({
         entry: testCase.dictionary.greeting,
         options: {},
@@ -737,7 +737,7 @@ describe('I18nManager', () => {
     const source = 'Hello';
     const sourceOptions: LookupOptions = { $format: 'ICU' };
     const sourceHash = hashMessage(source, sourceOptions);
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         greeting: source,
       },
@@ -753,19 +753,19 @@ describe('I18nManager', () => {
     });
 
     await expect(
-      manager.lookupDictionaryWithFallback('fr', 'greeting')
+      cache.lookupDictionaryWithFallback('fr', 'greeting')
     ).resolves.toEqual({
       entry: 'Bonjour',
       options: {},
     });
-    expect(manager.lookupDictionary('fr', 'greeting')).toEqual({
+    expect(cache.lookupDictionary('fr', 'greeting')).toEqual({
       entry: 'Bonjour',
       options: {},
     });
   });
 
   it('lookupDictionaryWithFallback() throws when source dictionary entry is missing', async () => {
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         greeting: 'Hello',
       },
@@ -774,9 +774,9 @@ describe('I18nManager', () => {
     });
 
     await expect(
-      manager.lookupDictionaryWithFallback('fr', 'missing')
+      cache.lookupDictionaryWithFallback('fr', 'missing')
     ).rejects.toThrow(
-      'I18nManager: source dictionary entry missing is not defined'
+      'I18nCache: source dictionary entry missing is not defined'
     );
   });
 
@@ -788,7 +788,7 @@ describe('I18nManager', () => {
         },
       },
     });
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         greeting: 'Hello',
         user: {
@@ -801,10 +801,10 @@ describe('I18nManager', () => {
     });
 
     await expect(
-      manager.lookupDictionaryObjWithFallback('en', 'greeting')
+      cache.lookupDictionaryObjWithFallback('en', 'greeting')
     ).resolves.toBe('Hello');
     await expect(
-      manager.lookupDictionaryObjWithFallback('en', 'user.profile')
+      cache.lookupDictionaryObjWithFallback('en', 'user.profile')
     ).resolves.toEqual({
       name: 'Name',
     });
@@ -819,7 +819,7 @@ describe('I18nManager', () => {
         },
       },
     });
-    const manager = createManager({
+    const cache = createCache({
       enableI18n: false,
       dictionary: {
         user: {
@@ -832,7 +832,7 @@ describe('I18nManager', () => {
     });
 
     await expect(
-      manager.lookupDictionaryObjWithFallback('fr', 'user.profile')
+      cache.lookupDictionaryObjWithFallback('fr', 'user.profile')
     ).resolves.toEqual({
       name: 'Name',
     });
@@ -847,7 +847,7 @@ describe('I18nManager', () => {
         },
       },
     });
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         user: {
           profile: {
@@ -859,7 +859,7 @@ describe('I18nManager', () => {
     });
 
     await expect(
-      manager.lookupDictionaryObjWithFallback('fr', 'user.profile')
+      cache.lookupDictionaryObjWithFallback('fr', 'user.profile')
     ).resolves.toEqual({
       name: 'Nom',
     });
@@ -872,7 +872,7 @@ describe('I18nManager', () => {
     const title = 'Title';
     const nameHash = hashMessage(name, { $format: 'ICU' });
     const titleHash = hashMessage(title, { $format: 'ICU' });
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         user: {
           profile: {
@@ -897,12 +897,12 @@ describe('I18nManager', () => {
     });
 
     await expect(
-      manager.lookupDictionaryObjWithFallback('fr', 'user.profile')
+      cache.lookupDictionaryObjWithFallback('fr', 'user.profile')
     ).resolves.toEqual({
       name: 'Nom',
       title: 'Titre',
     });
-    expect(manager.lookupDictionaryObj('fr', 'user.profile')).toEqual({
+    expect(cache.lookupDictionaryObj('fr', 'user.profile')).toEqual({
       name: 'Nom',
       title: 'Titre',
     });
@@ -912,7 +912,7 @@ describe('I18nManager', () => {
     const name = 'Name';
     const title = 'Title';
     const titleHash = hashMessage(title, { $format: 'ICU' });
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         user: {
           profile: {
@@ -939,19 +939,19 @@ describe('I18nManager', () => {
     });
 
     await expect(
-      manager.lookupDictionaryObjWithFallback('fr', 'user.profile')
+      cache.lookupDictionaryObjWithFallback('fr', 'user.profile')
     ).resolves.toEqual({
       name: 'Nom',
       title: 'Titre',
     });
-    expect(manager.lookupDictionaryObj('fr', 'user.profile')).toEqual({
+    expect(cache.lookupDictionaryObj('fr', 'user.profile')).toEqual({
       name: 'Nom',
       title: 'Titre',
     });
   });
 
   it('lookupDictionaryObjWithFallback() returns loaded target subtrees when source is missing', async () => {
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         greeting: 'Hello',
       },
@@ -964,7 +964,7 @@ describe('I18nManager', () => {
     });
 
     await expect(
-      manager.lookupDictionaryObjWithFallback('fr', 'extra')
+      cache.lookupDictionaryObjWithFallback('fr', 'extra')
     ).resolves.toEqual({
       label: 'Supplement',
     });
@@ -972,7 +972,7 @@ describe('I18nManager', () => {
   });
 
   it('lookupDictionaryObjWithFallback() throws when source dictionary object is missing', async () => {
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         greeting: 'Hello',
       },
@@ -981,9 +981,9 @@ describe('I18nManager', () => {
     });
 
     await expect(
-      manager.lookupDictionaryObjWithFallback('fr', 'missing')
+      cache.lookupDictionaryObjWithFallback('fr', 'missing')
     ).rejects.toThrow(
-      'I18nManager: source dictionary entry missing is not defined'
+      'I18nCache: source dictionary entry missing is not defined'
     );
   });
 
@@ -1022,7 +1022,7 @@ describe('I18nManager', () => {
     'lookupDictionaryObjWithFallback() uses cache locale for $name',
     async (testCase) => {
       const loadDictionary = vi.fn().mockResolvedValue(testCase.dictionary);
-      const manager = createManager({
+      const cache = createCache({
         defaultLocale: 'en-US',
         locales: ['en-US', 'en'],
         dictionary: {
@@ -1039,7 +1039,7 @@ describe('I18nManager', () => {
       });
 
       await expect(
-        manager.lookupDictionaryObjWithFallback(testCase.locale, 'user.profile')
+        cache.lookupDictionaryObjWithFallback(testCase.locale, 'user.profile')
       ).resolves.toEqual(testCase.dictionary.user.profile);
       expect(loadDictionary).toHaveBeenCalledTimes(1);
       expect(loadDictionary).toHaveBeenCalledWith(testCase.dictionaryLocale);
@@ -1047,17 +1047,17 @@ describe('I18nManager', () => {
   );
 
   it('lookupTranslation() returns undefined before load, translation after', async () => {
-    const manager = createManager();
+    const cache = createCache();
 
     // Before loading
-    const before = manager.lookupTranslation('fr', message, lookupOptions);
+    const before = cache.lookupTranslation('fr', message, lookupOptions);
     expect(before).toBeUndefined();
 
     // Load translations
-    await manager.loadTranslations('fr');
+    await cache.loadTranslations('fr');
 
     // After loading
-    const after = manager.lookupTranslation('fr', message, lookupOptions);
+    const after = cache.lookupTranslation('fr', message, lookupOptions);
     expect(after).toBe(translatedString);
   });
 
@@ -1085,22 +1085,22 @@ describe('I18nManager', () => {
       .fn()
       .mockResolvedValueOnce({ [expectedHash]: translatedString })
       .mockResolvedValueOnce({ [expectedHash]: 'Salut {name} !' });
-    const manager = createManager({
+    const cache = createCache({
       cacheExpiryTime: testCase.cacheExpiryTime,
       loadTranslations,
     });
 
-    await manager.loadTranslations('fr');
-    expect(manager.lookupTranslation('fr', message, lookupOptions)).toBe(
+    await cache.loadTranslations('fr');
+    expect(cache.lookupTranslation('fr', message, lookupOptions)).toBe(
       translatedString
     );
 
     vi.advanceTimersByTime(testCase.advanceBy);
-    expect(manager.lookupTranslation('fr', message, lookupOptions)).toBe(
+    expect(cache.lookupTranslation('fr', message, lookupOptions)).toBe(
       testCase.lookupAfter
     );
 
-    const translations = await manager.loadTranslations('fr');
+    const translations = await cache.loadTranslations('fr');
     expect(translations[expectedHash]).toBe(testCase.reloaded);
     expect(loadTranslations).toHaveBeenCalledTimes(testCase.calls);
   });
@@ -1142,7 +1142,7 @@ describe('I18nManager', () => {
       const loadTranslations = vi
         .fn()
         .mockResolvedValue({ [expectedHash]: testCase.translation });
-      const manager = createManager({
+      const cache = createCache({
         defaultLocale: 'en-US',
         locales: ['en-US', 'en'],
         loadTranslations,
@@ -1151,16 +1151,16 @@ describe('I18nManager', () => {
         }),
       });
 
-      expect(manager.requiresTranslation('en-GB')).toBe(true);
-      expect(manager.requiresDialectTranslation('en-GB')).toBe(true);
+      expect(cache.requiresTranslation('en-GB')).toBe(true);
+      expect(cache.requiresDialectTranslation('en-GB')).toBe(true);
 
-      const translations = await manager.loadTranslations(testCase.locale);
+      const translations = await cache.loadTranslations(testCase.locale);
 
       expect(loadTranslations).toHaveBeenCalledTimes(1);
       expect(loadTranslations).toHaveBeenCalledWith(testCase.translationLocale);
       expect(translations[expectedHash]).toBe(testCase.translation);
       expect(
-        manager.lookupTranslation(testCase.locale, message, lookupOptions)
+        cache.lookupTranslation(testCase.locale, message, lookupOptions)
       ).toBe(testCase.translation);
     }
   );
@@ -1171,7 +1171,7 @@ describe('I18nManager', () => {
     const unknownHash = hashMessage(unknownMessage, unknownOptions);
 
     // loadTranslations returns translations that do NOT include unknownMessage
-    const manager = createManager({
+    const cache = createCache({
       runtimeTranslation: {
         timeout: 4321,
         metadata: {
@@ -1190,7 +1190,7 @@ describe('I18nManager', () => {
       },
     });
 
-    const result = await manager.lookupTranslationWithFallback(
+    const result = await cache.lookupTranslationWithFallback(
       'fr',
       unknownMessage,
       unknownOptions
@@ -1216,7 +1216,7 @@ describe('I18nManager', () => {
       $context: 'homepage',
     };
     const sourceHash = hashMessage(source, sourceOptions);
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         greeting: [source, { $format: 'I18NEXT', context: 'homepage' }],
       },
@@ -1231,7 +1231,7 @@ describe('I18nManager', () => {
     });
 
     await expect(
-      manager.lookupDictionaryWithFallback('fr', 'greeting')
+      cache.lookupDictionaryWithFallback('fr', 'greeting')
     ).resolves.toEqual({
       entry: 'Bonjour {name}',
       options: {},
@@ -1245,7 +1245,7 @@ describe('I18nManager', () => {
       $context: 'homepage',
     };
     const sourceHash = hashMessage(source, sourceOptions);
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         greeting: [source, { context: 'homepage' }],
       },
@@ -1260,7 +1260,7 @@ describe('I18nManager', () => {
     });
 
     await expect(
-      manager.lookupDictionaryWithFallback('fr', 'greeting')
+      cache.lookupDictionaryWithFallback('fr', 'greeting')
     ).resolves.toEqual({
       entry: 'Bonjour {name}',
       options: {},
@@ -1271,7 +1271,7 @@ describe('I18nManager', () => {
     const source = 'Hello';
     const sourceOptions: LookupOptions = { $format: 'ICU' };
     const sourceHash = hashMessage(source, sourceOptions);
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         greeting: source,
       },
@@ -1287,14 +1287,14 @@ describe('I18nManager', () => {
     });
 
     await expect(
-      manager.lookupDictionaryWithFallback('fr', 'greeting')
+      cache.lookupDictionaryWithFallback('fr', 'greeting')
     ).rejects.toThrow(
       'Dictionary entry "greeting" could not be translated into a string. Check the source entry and translation loader output.'
     );
   });
 
   it('resolves custom aliases for locale metadata operations', () => {
-    const manager = createManager({
+    const cache = createCache({
       customMapping: {
         'brand-french': {
           code: 'fr',
@@ -1303,13 +1303,13 @@ describe('I18nManager', () => {
       },
     });
 
-    expect(manager.requiresTranslation('brand-french')).toBe(true);
-    expect(manager.requiresDialectTranslation('en-US')).toBe(false);
-    expect(() => manager.getGTClass('brand-french')).not.toThrow();
+    expect(cache.requiresTranslation('brand-french')).toBe(true);
+    expect(cache.requiresDialectTranslation('en-US')).toBe(false);
+    expect(() => cache.getGTClass('brand-french')).not.toThrow();
   });
 
   it('preserves alias target locale when creating a GT instance', () => {
-    const manager = createManager({
+    const cache = createCache({
       locales: ['en', 'brand-french'],
       customMapping: {
         'brand-french': {
@@ -1319,7 +1319,7 @@ describe('I18nManager', () => {
       },
     });
 
-    const gt = manager.getGTClass('fr');
+    const gt = cache.getGTClass('fr');
 
     expect(gt.targetLocale).toBe('brand-french');
     expect(gt.locales).toEqual(['en', 'fr']);
@@ -1329,7 +1329,7 @@ describe('I18nManager', () => {
     const loadTranslations = vi
       .fn()
       .mockResolvedValue({ [expectedHash]: translatedString });
-    const manager = createManager({
+    const cache = createCache({
       loadTranslations,
       customMapping: {
         'brand-french': {
@@ -1339,12 +1339,12 @@ describe('I18nManager', () => {
       },
     });
 
-    await manager.loadTranslations('brand-french');
+    await cache.loadTranslations('brand-french');
 
     expect(loadTranslations).toHaveBeenCalledTimes(1);
     expect(loadTranslations).toHaveBeenCalledWith('fr');
     expect(
-      manager.lookupTranslation('brand-french', message, lookupOptions)
+      cache.lookupTranslation('brand-french', message, lookupOptions)
     ).toBe(translatedString);
     expect(loadTranslations).toHaveBeenCalledTimes(1);
   });
@@ -1353,29 +1353,29 @@ describe('I18nManager', () => {
     const loadTranslations = vi
       .fn()
       .mockResolvedValue({ [expectedHash]: translatedString });
-    const manager = createManager({
+    const cache = createCache({
       loadTranslations,
     });
 
-    await manager.loadTranslations('fr');
+    await cache.loadTranslations('fr');
 
     expect(loadTranslations).toHaveBeenCalledWith('fr');
-    expect(manager.lookupTranslation('fr', message, lookupOptions)).toBe(
+    expect(cache.lookupTranslation('fr', message, lookupOptions)).toBe(
       translatedString
     );
     await expect(
-      manager.lookupTranslationWithFallback('fr', message, lookupOptions)
+      cache.lookupTranslationWithFallback('fr', message, lookupOptions)
     ).resolves.toBe(translatedString);
-    await expect(manager.getLookupTranslation('fr')).resolves.toEqual(
+    await expect(cache.getLookupTranslation('fr')).resolves.toEqual(
       expect.any(Function)
     );
-    expect(manager.requiresTranslation('fr')).toBe(true);
-    expect(manager.requiresDialectTranslation('fr')).toBe(false);
-    expect(() => manager.getGTClass('fr')).not.toThrow();
+    expect(cache.requiresTranslation('fr')).toBe(true);
+    expect(cache.requiresDialectTranslation('fr')).toBe(false);
+    expect(() => cache.getGTClass('fr')).not.toThrow();
   });
 
   it('does not clone loaded dictionaries for cache hit events without subscribers', async () => {
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         greeting: 'Hello',
       },
@@ -1387,10 +1387,10 @@ describe('I18nManager', () => {
       }),
     });
 
-    await manager.loadDictionary('fr');
+    await cache.loadDictionary('fr');
     const structuredCloneSpy = vi.spyOn(globalThis, 'structuredClone');
     try {
-      expect(manager.lookupDictionaryObj('fr', 'greeting')).toBe('Bonjour');
+      expect(cache.lookupDictionaryObj('fr', 'greeting')).toBe('Bonjour');
       expect(structuredCloneSpy).not.toHaveBeenCalled();
     } finally {
       structuredCloneSpy.mockRestore();
@@ -1398,7 +1398,7 @@ describe('I18nManager', () => {
   });
 
   it('emits dictionary cache lifecycle events', async () => {
-    const manager = createManager({
+    const cache = createCache({
       dictionary: {
         greeting: 'Hello',
       },
@@ -1411,14 +1411,14 @@ describe('I18nManager', () => {
     const dictionaryCacheHit = vi.fn();
     const dictionaryCacheMiss = vi.fn();
 
-    manager.subscribe('locales-dictionary-cache-miss', localesDictionaryMiss);
-    manager.subscribe('locales-dictionary-cache-hit', localesDictionaryHit);
-    manager.subscribe('dictionary-cache-hit', dictionaryCacheHit);
-    manager.subscribe('dictionary-cache-miss', dictionaryCacheMiss);
+    cache.subscribe('locales-dictionary-cache-miss', localesDictionaryMiss);
+    cache.subscribe('locales-dictionary-cache-hit', localesDictionaryHit);
+    cache.subscribe('dictionary-cache-hit', dictionaryCacheHit);
+    cache.subscribe('dictionary-cache-miss', dictionaryCacheMiss);
 
-    await manager.loadDictionary('fr');
-    await manager.loadDictionary('fr');
-    expect(manager.lookupDictionary('fr', 'greeting')).toEqual({
+    await cache.loadDictionary('fr');
+    await cache.loadDictionary('fr');
+    expect(cache.lookupDictionary('fr', 'greeting')).toEqual({
       entry: 'Bonjour',
       options: {},
     });

--- a/packages/i18n/src/i18n-cache/__tests__/resolveTranslationSync.test.ts
+++ b/packages/i18n/src/i18n-cache/__tests__/resolveTranslationSync.test.ts
@@ -1,20 +1,20 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { I18nManager } from '../I18nCache';
+import { I18nCache } from '../I18nCache';
 import { hashMessage } from '../../utils/hashMessage';
 
-describe('I18nManager.resolveTranslationSync', () => {
+describe('I18nCache.resolveTranslationSync', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   it('should return undefined when no translations loaded for locale', () => {
-    const manager = new I18nManager({
+    const cache = new I18nCache({
       defaultLocale: 'en',
       locales: ['en', 'fr'],
       loadTranslations: vi.fn(),
     });
 
-    const result = manager.resolveTranslationSync('fr', 'Hello', {
+    const result = cache.resolveTranslationSync('fr', 'Hello', {
       $format: 'ICU',
     });
 
@@ -22,7 +22,7 @@ describe('I18nManager.resolveTranslationSync', () => {
   });
 
   it('does not throw without options in development', () => {
-    const manager = new I18nManager({
+    const cache = new I18nCache({
       defaultLocale: 'en',
       locales: ['en', 'fr'],
       loadTranslations: vi.fn(),
@@ -32,10 +32,10 @@ describe('I18nManager.resolveTranslationSync', () => {
     const options = { $format: 'ICU' as const };
 
     expect(() =>
-      manager.resolveTranslationSync('fr', 'Hello', options)
+      cache.resolveTranslationSync('fr', 'Hello', options)
     ).not.toThrow();
     expect(
-      manager.resolveTranslationSync('fr', 'Hello', options)
+      cache.resolveTranslationSync('fr', 'Hello', options)
     ).toBeUndefined();
   });
 
@@ -49,16 +49,16 @@ describe('I18nManager.resolveTranslationSync', () => {
       [expectedHash]: translatedString,
     };
 
-    const manager = new I18nManager({
+    const cache = new I18nCache({
       defaultLocale: 'en',
       locales: ['en', 'fr'],
       loadTranslations: vi.fn().mockResolvedValue(mockTranslations),
     });
 
     // Trigger async load to populate resolvedCache
-    await manager.getTranslations('fr');
+    await cache.getTranslations('fr');
 
-    const result = manager.resolveTranslationSync('fr', message, options);
+    const result = cache.resolveTranslationSync('fr', message, options);
 
     expect(result).toBe(translatedString);
   });

--- a/packages/i18n/src/i18n-cache/event-subscription/types.ts
+++ b/packages/i18n/src/i18n-cache/event-subscription/types.ts
@@ -35,7 +35,7 @@ export const DICTIONARY_OBJECT_CACHE_HIT_EVENT_NAME =
   'dictionary-object-cache-hit';
 
 /**
- * A base event for the I18nManagers
+ * A base event for the I18nCaches
  * @prop {locales-cache-hit} - Emitted when a locale cache hit occurs
  * @prop {locales-cache-miss} - Emitted when a locale cache miss occurs
  * @prop {translations-cache-hit} - Emitted when a translations cache hit occurs

--- a/packages/i18n/src/i18n-cache/index.ts
+++ b/packages/i18n/src/i18n-cache/index.ts
@@ -1,5 +1,5 @@
 // Classes
-export { I18nManager } from './I18nCache';
+export { I18nCache } from './I18nCache';
 export { ReadonlyConditionStore } from '../condition-store/ReadonlyConditionStore';
 export type { ReadonlyConditionStoreParams } from '../condition-store/ReadonlyConditionStore';
 export { WritableConditionStore } from '../condition-store/WritableConditionStore';
@@ -20,4 +20,4 @@ export {
 } from './event-subscription/types';
 
 // Functions
-export { getI18nManager, setI18nManager } from './singleton-operations';
+export { getI18nCache, setI18nCache } from './singleton-operations';

--- a/packages/i18n/src/i18n-cache/lifecycle-hooks/createLifecycleCallbacks.ts
+++ b/packages/i18n/src/i18n-cache/lifecycle-hooks/createLifecycleCallbacks.ts
@@ -11,7 +11,7 @@ import {
   TRANSLATIONS_CACHE_MISS_EVENT_NAME,
 } from '../event-subscription/types';
 import type { Translation } from '../translations-manager/utils/types/translation-data';
-import type { I18nManagerCacheLifecycleCallbacks } from './types';
+import type { I18nCacheLifecycleCallbacks } from './types';
 import type { I18nEvents } from '../event-subscription/types';
 /**
  * Maps consumer-facing lifecycle callbacks to internal locales cache lifecycle callbacks.
@@ -25,7 +25,7 @@ export function createLifecycleCallbacks<TranslationValue extends Translation>(
   hasListeners: <EventName extends keyof I18nEvents<TranslationValue>>(
     eventName: EventName
   ) => boolean = () => true
-): I18nManagerCacheLifecycleCallbacks<TranslationValue> {
+): I18nCacheLifecycleCallbacks<TranslationValue> {
   return {
     onLocalesCacheHit: (params) => {
       if (!hasListeners(LOCALES_CACHE_HIT_EVENT_NAME)) {

--- a/packages/i18n/src/i18n-cache/lifecycle-hooks/types.ts
+++ b/packages/i18n/src/i18n-cache/lifecycle-hooks/types.ts
@@ -122,17 +122,16 @@ export type LocalesDictionaryCacheLifecycleCallbacks = {
 };
 
 /**
- * Combined I18nManager cache lifecycle callbacks
+ * Combined I18nCache cache lifecycle callbacks
  */
-export type I18nManagerCacheLifecycleCallbacks<
-  TranslationValue extends Translation,
-> = LocalesTranslationsCacheLifecycleCallbacks<TranslationValue> &
-  LocalesDictionaryCacheLifecycleCallbacks;
+export type I18nCacheLifecycleCallbacks<TranslationValue extends Translation> =
+  LocalesTranslationsCacheLifecycleCallbacks<TranslationValue> &
+    LocalesDictionaryCacheLifecycleCallbacks;
 
 // ===== Consumer API ===== //
 
 /**
- * Simplified lifecycle callbacks for I18nManager consumers.
+ * Simplified lifecycle callbacks for I18nCache consumers.
  * These provide a cleaner interface than the internal cache lifecycle types,
  * with locale and hash exposed directly instead of the full cache internals.
  *

--- a/packages/i18n/src/i18n-cache/singleton-operations.ts
+++ b/packages/i18n/src/i18n-cache/singleton-operations.ts
@@ -1,45 +1,45 @@
 import { libraryDefaultLocale } from 'generaltranslation/internal';
-import { I18nManager } from './I18nCache';
+import { I18nCache } from './I18nCache';
 import logger from '../logs/logger';
 import { Translation } from './translations-manager/utils/types/translation-data';
 import { createConditionStoreSingleton } from '../condition-store/createConditionStoreSingleton';
 import { WritableConditionStoreInterface } from './types';
 
-// Singleton instance of I18nManager
-let i18nManager: I18nManager | undefined = undefined;
+// Singleton instance of I18nCache
+let i18nCache: I18nCache | undefined = undefined;
 
 /**
- * Get the singleton instance of I18nManager
- * @returns The singleton instance of I18nManager
+ * Get the singleton instance of I18nCache
+ * @returns The singleton instance of I18nCache
  * @template U - The type of the translation that will be cached
  *
  * Note: should not be consumed by gt-react, consumers should use a wrapper
  */
-export function getI18nManager<U extends Translation = Translation>():
-  | I18nManager<U>
-  | I18nManager<Translation> {
-  if (!i18nManager) {
+export function getI18nCache<U extends Translation = Translation>():
+  | I18nCache<U>
+  | I18nCache<Translation> {
+  if (!i18nCache) {
     logger.warn(
-      'getI18nManager(): I18nManager was not initialized. Falling back to the default locale until initializeGT() configures translations.'
+      'getI18nCache(): I18nCache was not initialized. Falling back to the default locale until initializeGT() configures translations.'
     );
-    i18nManager = new I18nManager({
+    i18nCache = new I18nCache({
       defaultLocale: libraryDefaultLocale,
       locales: [libraryDefaultLocale],
     });
   }
-  return i18nManager;
+  return i18nCache;
 }
 
 /**
- * Configure the singleton instance of I18nManager
- * @param config - The configuration for the I18nManager
+ * Configure the singleton instance of I18nCache
+ * @param config - The configuration for the I18nCache
  *
  * Wrapper libraries will export a configure function that will call this function.
  *
  * Note: should not be consumed by gt-react, consumers should use a wrapper
  */
-export function setI18nManager<TranslationValue extends Translation>(
-  i18nManagerInstance: I18nManager<TranslationValue>
+export function setI18nCache<TranslationValue extends Translation>(
+  i18nCacheInstance: I18nCache<TranslationValue>
 ): void {
-  i18nManager = i18nManagerInstance as unknown as I18nManager;
+  i18nCache = i18nCacheInstance as unknown as I18nCache;
 }

--- a/packages/i18n/src/i18n-cache/translations-manager/LocalesCache.ts
+++ b/packages/i18n/src/i18n-cache/translations-manager/LocalesCache.ts
@@ -16,7 +16,7 @@ import type { CreateTranslateMany } from './utils/createTranslateMany';
 import type { Translation } from './utils/types/translation-data';
 import type { SafeTranslationsLoader } from './translations-loaders/types';
 import type {
-  I18nManagerCacheLifecycleCallbacks,
+  I18nCacheLifecycleCallbacks,
   LifecycleCallback,
   LifecycleParam,
 } from '../lifecycle-hooks/types';
@@ -41,7 +41,7 @@ type LocalesCacheParams<TranslationValue extends Translation> = {
   loadTranslations: SafeTranslationsLoader<TranslationValue>;
   loadDictionary: DictionaryLoader;
   translateDictionaryEntry: TranslateLocaleDictionaryEntry;
-  lifecycle: I18nManagerCacheLifecycleCallbacks<TranslationValue>;
+  lifecycle: I18nCacheLifecycleCallbacks<TranslationValue>;
 };
 
 export class LocalesCache<TranslationValue extends Translation> {
@@ -165,7 +165,7 @@ function createTranslationsCacheFactory<TranslationValue extends Translation>({
   createTranslateMany,
   batchConfig,
 }: {
-  lifecycle: I18nManagerCacheLifecycleCallbacks<TranslationValue>;
+  lifecycle: I18nCacheLifecycleCallbacks<TranslationValue>;
   createTranslateMany: CreateTranslateMany;
   batchConfig?: TranslationBatchConfig;
 }) {
@@ -180,7 +180,7 @@ function createTranslationsCacheFactory<TranslationValue extends Translation>({
 
 function createTranslationsCacheLifecycle<TranslationValue extends Translation>(
   locale: Locale,
-  lifecycle: I18nManagerCacheLifecycleCallbacks<TranslationValue>
+  lifecycle: I18nCacheLifecycleCallbacks<TranslationValue>
 ): LifecycleParam<
   TranslationKey<TranslationValue>,
   Hash,
@@ -202,7 +202,7 @@ function createDictionaryCache<TranslationValue extends Translation>({
   locale: Locale;
   dictionary: Dictionary;
   translate: TranslateLocaleDictionaryEntry;
-  lifecycle: I18nManagerCacheLifecycleCallbacks<TranslationValue>;
+  lifecycle: I18nCacheLifecycleCallbacks<TranslationValue>;
 }) {
   const {
     onDictionaryCacheHit,

--- a/packages/i18n/src/i18n-cache/translations-manager/__tests__/LocalesCache.test.ts
+++ b/packages/i18n/src/i18n-cache/translations-manager/__tests__/LocalesCache.test.ts
@@ -4,7 +4,7 @@ import { DEFAULT_CACHE_EXPIRY_TIME } from '../utils/constants';
 import type { Dictionary, DictionaryLoader } from '../DictionaryCache';
 import type { Hash } from '../TranslationsCache';
 import type { CreateTranslateMany } from '../utils/createTranslateMany';
-import type { I18nManagerCacheLifecycleCallbacks } from '../../lifecycle-hooks/types';
+import type { I18nCacheLifecycleCallbacks } from '../../lifecycle-hooks/types';
 import type { SafeTranslationsLoader } from '../translations-loaders/types';
 
 describe('LocalesCache', () => {
@@ -42,7 +42,7 @@ describe('LocalesCache', () => {
 
   function createCache(opts?: {
     ttl?: number | null;
-    lifecycle?: I18nManagerCacheLifecycleCallbacks<string>;
+    lifecycle?: I18nCacheLifecycleCallbacks<string>;
   }) {
     return new LocalesCache<string>({
       defaultLocale: 'en',

--- a/packages/i18n/src/i18n-cache/translations-manager/translations-loaders/routeCreateTranslationLoader.ts
+++ b/packages/i18n/src/i18n-cache/translations-manager/translations-loaders/routeCreateTranslationLoader.ts
@@ -31,7 +31,7 @@ export function routeCreateTranslationLoader({
   if (type === LoadTranslationsType.DISABLED) {
     // TODO: move this warning to validation layer
     logger.warn(
-      'I18nManager: No translation loader found. No translations will be loaded.'
+      'I18nCache: No translation loader found. No translations will be loaded.'
     );
   }
 

--- a/packages/i18n/src/i18n-cache/translations-manager/utils/DictionarySourceNotFoundError.ts
+++ b/packages/i18n/src/i18n-cache/translations-manager/utils/DictionarySourceNotFoundError.ts
@@ -1,6 +1,6 @@
 export class DictionarySourceNotFoundError extends Error {
   constructor(id: string) {
-    super(`I18nManager: source dictionary entry ${id} is not defined`);
+    super(`I18nCache: source dictionary entry ${id} is not defined`);
     this.name = 'DictionarySourceNotFoundError';
   }
 }

--- a/packages/i18n/src/i18n-cache/types.ts
+++ b/packages/i18n/src/i18n-cache/types.ts
@@ -26,9 +26,9 @@ type RuntimeTranslationConfig = {
 };
 
 /**
- * Parameters for the I18nManager constructor
+ * Parameters for the I18nCache constructor
  */
-export type I18nManagerConstructorParams<
+export type I18nCacheConstructorParams<
   TranslationValue extends Translation = Translation,
 > = DictionaryConfig &
   Omit<GTConfig, 'cacheExpiryTime'> & {
@@ -47,9 +47,9 @@ export type I18nManagerConstructorParams<
   };
 
 /**
- * I18nManager class configuration
+ * I18nCache class configuration
  */
-export type I18nManagerConfig = {
+export type I18nCacheConfig = {
   environment: 'development' | 'production';
   defaultLocale: string;
   locales: string[];

--- a/packages/i18n/src/i18n-cache/validation/config-validation/validateLoadTranslations.ts
+++ b/packages/i18n/src/i18n-cache/validation/config-validation/validateLoadTranslations.ts
@@ -40,7 +40,7 @@ export function validateLoadTranslations(params: {
           message: createDiagnosticMessage({
             whatHappened:
               'Loading translations from a remote store needs a projectId',
-            fix: 'Add projectId to the I18nManager config or disable remote translation loading',
+            fix: 'Add projectId to the I18nCache config or disable remote translation loading',
           }),
         });
       }

--- a/packages/i18n/src/i18n-cache/validation/config-validation/validateTranslationApi.ts
+++ b/packages/i18n/src/i18n-cache/validation/config-validation/validateTranslationApi.ts
@@ -43,7 +43,7 @@ export function validateTranslationApi(params: {
           type: 'warning',
           message: createDiagnosticMessage({
             whatHappened: 'Runtime translation needs a projectId',
-            fix: 'Add projectId to the I18nManager config or disable runtime translation',
+            fix: 'Add projectId to the I18nCache config or disable runtime translation',
           }),
         });
       }
@@ -52,7 +52,7 @@ export function validateTranslationApi(params: {
           type: 'warning',
           message: createDiagnosticMessage({
             whatHappened: 'Runtime translation needs devApiKey or apiKey',
-            fix: 'Add credentials to the I18nManager config or disable runtime translation',
+            fix: 'Add credentials to the I18nCache config or disable runtime translation',
           }),
         });
       }

--- a/packages/i18n/src/i18n-cache/validation/validateConfig.ts
+++ b/packages/i18n/src/i18n-cache/validation/validateConfig.ts
@@ -1,5 +1,5 @@
 import { ValidationResult } from './types';
-import { I18nManagerConstructorParams } from '../types';
+import { I18nCacheConstructorParams } from '../types';
 import { validateLoadTranslations } from './config-validation/validateLoadTranslations';
 import { validateTranslationApi } from './config-validation/validateTranslationApi';
 import { validateLocales } from './config-validation/validateLocales';
@@ -12,7 +12,7 @@ import type { Translation } from '../translations-manager/utils/types/translatio
  * @returns The validation results
  */
 export function validateConfig<TranslationValue extends Translation>(
-  config: I18nManagerConstructorParams<TranslationValue>
+  config: I18nCacheConstructorParams<TranslationValue>
 ): ValidationResult[] {
   const results: ValidationResult[] = [];
 

--- a/packages/i18n/src/internal-types.ts
+++ b/packages/i18n/src/internal-types.ts
@@ -1,8 +1,8 @@
-// I18nManager
+// I18nCache
 export type {
-  I18nManagerConstructorParams,
+  I18nCacheConstructorParams,
   TranslationsLoader,
-  I18nManagerConfig,
+  I18nCacheConfig,
   LifecycleCallbacks,
   LocaleResolverConfig,
   ReadonlyConditionStoreInterface,
@@ -12,6 +12,10 @@ export type {
   DictionaryLoader,
   DictionaryConfig,
 } from './i18n-cache/types';
+/** @deprecated use I18nCacheConstructorParams instead */
+export type { I18nCacheConstructorParams as I18nManagerConstructorParams } from './i18n-cache/types';
+/** @deprecated use I18nCacheConfig instead */
+export type { I18nCacheConfig as I18nManagerConfig } from './i18n-cache/types';
 export type { LocaleCandidates } from './condition-store/localeResolver';
 export type {
   DictionaryValue,

--- a/packages/i18n/src/internal.ts
+++ b/packages/i18n/src/internal.ts
@@ -21,9 +21,12 @@ export {
   resolveDictionaryLookupOptions,
 } from './i18n-cache/translations-manager/utils/dictionary-helpers';
 
-export {
-  getI18nManager,
-  setI18nManager,
-} from './i18n-cache/singleton-operations';
+/** @deprecated use I18nCache instead */
+export { I18nCache as I18nManager } from './i18n-cache/I18nCache';
+export { getI18nCache, setI18nCache } from './i18n-cache/singleton-operations';
+/** @deprecated use getI18nCache instead */
+export { getI18nCache as getI18nManager } from './i18n-cache/singleton-operations';
+/** @deprecated use setI18nCache instead */
+export { setI18nCache as setI18nManager } from './i18n-cache/singleton-operations';
 export { createConditionStoreSingleton } from './condition-store/createConditionStoreSingleton';
 export { getRuntimeEnvironment } from './utils/getRuntimeEnvironment';

--- a/packages/i18n/src/translation-functions/__tests__/t.test.ts
+++ b/packages/i18n/src/translation-functions/__tests__/t.test.ts
@@ -1,21 +1,20 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { I18nManager } from '../../i18n-cache/I18nCache';
-import {
-  setI18nManager,
-  setConditionStore,
-} from '../../i18n-cache/singleton-operations';
+import { I18nCache } from '../../i18n-cache/I18nCache';
+import { setI18nCache } from '../../i18n-cache/singleton-operations';
+import { setWritableConditionStore } from '../../condition-store/singleton-operations';
 import { getLocale, getLocaleProperties } from '../../helpers/locale';
 import { hashMessage } from '../../utils/hashMessage';
 import { t } from '../t';
 
 describe('t', () => {
   afterEach(() => {
-    setConditionStore({ getLocale: () => 'en' });
+    setWritableConditionStore({ getLocale: () => 'en' });
   });
 
   it('works without an explicit locale', () => {
-    setI18nManager(
-      new I18nManager({
+    setWritableConditionStore({ getLocale: () => 'en' });
+    setI18nCache(
+      new I18nCache({
         defaultLocale: 'en',
         locales: ['en', 'fr'],
         loadTranslations: vi.fn(),
@@ -28,7 +27,7 @@ describe('t', () => {
   it('uses the configured fallback locale store when no locale is provided', async () => {
     const message = 'Hello {name}!';
     const translatedMessage = 'Bonjour {name} !';
-    const manager = new I18nManager({
+    const cache = new I18nCache({
       defaultLocale: 'en',
       locales: ['en', 'fr'],
       loadTranslations: vi.fn().mockResolvedValue({
@@ -37,16 +36,16 @@ describe('t', () => {
     });
     const conditionStore = { getLocale: () => 'fr' };
 
-    setI18nManager(manager);
-    setConditionStore(conditionStore);
-    await manager.loadTranslations('fr');
+    setI18nCache(cache);
+    setWritableConditionStore(conditionStore);
+    await cache.loadTranslations('fr');
 
     expect(t(message, { name: 'Alice' })).toBe('Bonjour Alice !');
   });
 
   it('allows an explicit $locale to override the current locale', async () => {
     const message = 'Hello {name}!';
-    const manager = new I18nManager({
+    const cache = new I18nCache({
       defaultLocale: 'en',
       locales: ['en', 'fr', 'es'],
       loadTranslations: vi.fn().mockImplementation((locale: string) => ({
@@ -55,16 +54,16 @@ describe('t', () => {
       })),
     });
 
-    setI18nManager(manager);
-    setConditionStore({ getLocale: () => 'fr' });
-    await manager.loadTranslations('es');
+    setI18nCache(cache);
+    setWritableConditionStore({ getLocale: () => 'fr' });
+    await cache.loadTranslations('es');
 
     expect(t(message, { $locale: 'es', name: 'Alice' })).toBe('Hola Alice!');
   });
 
   it('does not read the current locale when $locale is explicit', async () => {
     const message = 'Hello {name}!';
-    const manager = new I18nManager({
+    const cache = new I18nCache({
       defaultLocale: 'en',
       locales: ['en', 'fr'],
       loadTranslations: vi.fn().mockResolvedValue({
@@ -72,36 +71,36 @@ describe('t', () => {
       }),
     });
 
-    setI18nManager(manager);
-    setConditionStore({
+    setI18nCache(cache);
+    setWritableConditionStore({
       getLocale: () => {
         throw new Error('current locale should not be read');
       },
     });
-    await manager.loadTranslations('fr');
+    await cache.loadTranslations('fr');
 
     expect(t(message, { $locale: 'fr', name: 'Alice' })).toBe(
       'Bonjour Alice !'
     );
   });
 
-  it('resets stale condition stores when the singleton manager is replaced', () => {
-    setConditionStore({ getLocale: () => 'fr' });
+  it('keeps the configured condition store when the singleton cache is replaced', () => {
+    setWritableConditionStore({ getLocale: () => 'fr' });
 
-    setI18nManager(
-      new I18nManager({
+    setI18nCache(
+      new I18nCache({
         defaultLocale: 'es',
         locales: ['es'],
         loadTranslations: vi.fn(),
       })
     );
 
-    expect(getLocale()).toBe('es');
+    expect(getLocale()).toBe('fr');
   });
 
   it('returns locale properties outside configured translation locales', () => {
-    setI18nManager(
-      new I18nManager({
+    setI18nCache(
+      new I18nCache({
         defaultLocale: 'en',
         locales: ['fr'],
         loadTranslations: vi.fn(),

--- a/packages/i18n/src/translation-functions/internal/__tests__/helpers.integration.test.ts
+++ b/packages/i18n/src/translation-functions/internal/__tests__/helpers.integration.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { I18nManager } from '../../../i18n-cache/I18nCache';
-import { setI18nManager } from '../../../i18n-cache/singleton-operations';
+import { I18nCache } from '../../../i18n-cache/I18nCache';
+import { setI18nCache } from '../../../i18n-cache/singleton-operations';
 import { hashMessage } from '../../../utils/hashMessage';
 import { LookupOptions } from '../../types/options';
 import {
@@ -31,13 +31,13 @@ describe('translation helpers (deep integration)', () => {
   });
 
   function setupManager(preloadedTranslations: Record<string, string> = {}) {
-    const manager = new I18nManager({
+    const cache = new I18nCache({
       defaultLocale: 'en',
       locales: ['en', 'fr'],
       loadTranslations: vi.fn().mockResolvedValue(preloadedTranslations),
     });
-    setI18nManager(manager);
-    return manager;
+    setI18nCache(cache);
+    return cache;
   }
 
   it('resolveStringContentWithRuntimeFallback triggers translateMany when translation not preloaded', async () => {

--- a/packages/i18n/src/translation-functions/internal/__tests__/helpers.test.ts
+++ b/packages/i18n/src/translation-functions/internal/__tests__/helpers.test.ts
@@ -4,7 +4,7 @@ import {
   resolveStringContentWithFallback,
   resolveStringContentWithRuntimeFallback,
 } from '../helpers';
-import { getI18nManager } from '../../../i18n-cache/singleton-operations';
+import { getI18nCache } from '../../../i18n-cache/singleton-operations';
 import { interpolateMessage } from '../../utils/interpolation/interpolateMessage';
 
 vi.mock('../../../i18n-cache/singleton-operations');
@@ -19,12 +19,12 @@ describe('translation helpers', () => {
   // ===== REGRESSION ===== //
 
   it('resolveJsx returns undefined when lookupTranslation returns undefined', () => {
-    const mockManager = {
+    const mockCache = {
       getLocale: vi.fn().mockReturnValue('fr'),
       lookupTranslation: vi.fn().mockReturnValue(undefined),
     };
-    vi.mocked(getI18nManager).mockReturnValue(
-      mockManager as unknown as ReturnType<typeof getI18nManager>
+    vi.mocked(getI18nCache).mockReturnValue(
+      mockCache as unknown as ReturnType<typeof getI18nCache>
     );
 
     const result = resolveJsx('fr', ['Hello']);
@@ -32,16 +32,16 @@ describe('translation helpers', () => {
   });
 
   it('resolveJsx uses the provided locale', () => {
-    const mockManager = {
+    const mockCache = {
       lookupTranslation: vi.fn().mockReturnValue(undefined),
     };
-    vi.mocked(getI18nManager).mockReturnValue(
-      mockManager as unknown as ReturnType<typeof getI18nManager>
+    vi.mocked(getI18nCache).mockReturnValue(
+      mockCache as unknown as ReturnType<typeof getI18nCache>
     );
 
     resolveJsx('fr', ['Hello']);
 
-    expect(mockManager.lookupTranslation).toHaveBeenCalledWith(
+    expect(mockCache.lookupTranslation).toHaveBeenCalledWith(
       'fr',
       ['Hello'],
       expect.objectContaining({ $format: 'JSX', $locale: 'fr' })
@@ -51,20 +51,20 @@ describe('translation helpers', () => {
   // ===== NEW BEHAVIOR ===== //
 
   it('resolveStringContentWithRuntimeFallback calls lookupTranslationWithFallback and interpolates', async () => {
-    const mockManager = {
+    const mockCache = {
       getLocale: vi.fn().mockReturnValue('fr'),
       lookupTranslationWithFallback: vi
         .fn()
         .mockResolvedValue('Bonjour {name} !'),
       getDefaultLocale: vi.fn().mockReturnValue('en'),
     };
-    vi.mocked(getI18nManager).mockReturnValue(
-      mockManager as unknown as ReturnType<typeof getI18nManager>
+    vi.mocked(getI18nCache).mockReturnValue(
+      mockCache as unknown as ReturnType<typeof getI18nCache>
     );
 
     await resolveStringContentWithRuntimeFallback('fr', 'Hello {name}!');
 
-    expect(mockManager.lookupTranslationWithFallback).toHaveBeenCalled();
+    expect(mockCache.lookupTranslationWithFallback).toHaveBeenCalled();
     expect(interpolateMessage).toHaveBeenCalledWith({
       source: 'Hello {name}!',
       target: 'Bonjour {name} !',
@@ -74,13 +74,13 @@ describe('translation helpers', () => {
   });
 
   it('resolveStringContentWithFallback interpolates source when no translation found', () => {
-    const mockManager = {
+    const mockCache = {
       getLocale: vi.fn().mockReturnValue('fr'),
       lookupTranslation: vi.fn().mockReturnValue(undefined),
       getDefaultLocale: vi.fn().mockReturnValue('en'),
     };
-    vi.mocked(getI18nManager).mockReturnValue(
-      mockManager as unknown as ReturnType<typeof getI18nManager>
+    vi.mocked(getI18nCache).mockReturnValue(
+      mockCache as unknown as ReturnType<typeof getI18nCache>
     );
 
     resolveStringContentWithFallback('fr', 'Hello {name}!');

--- a/packages/i18n/src/translation-functions/internal/__tests__/locale-defaults.test.ts
+++ b/packages/i18n/src/translation-functions/internal/__tests__/locale-defaults.test.ts
@@ -1,9 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { I18nManager } from '../../../i18n-cache/I18nCache';
-import {
-  setConditionStore,
-  setI18nManager,
-} from '../../../i18n-cache/singleton-operations';
+import { I18nCache } from '../../../i18n-cache/I18nCache';
+import { setI18nCache } from '../../../i18n-cache/singleton-operations';
+import { setWritableConditionStore } from '../../../condition-store/singleton-operations';
 import { msg } from '../../msg';
 import { hashMessage } from '../../../utils/hashMessage';
 import { getGT } from '../getGT';
@@ -13,20 +11,20 @@ import { tx } from '../tx';
 
 describe('translation function locale defaults', () => {
   afterEach(() => {
-    setConditionStore({ getLocale: () => 'en' });
+    setWritableConditionStore({ getLocale: () => 'en' });
   });
 
   function setupManager(translations: Record<string, string>) {
-    const manager = new I18nManager({
+    const cache = new I18nCache({
       defaultLocale: 'en',
       locales: ['en', 'fr'],
       loadTranslations: vi.fn().mockResolvedValue(translations),
     });
 
-    setI18nManager(manager);
-    setConditionStore({ getLocale: () => 'fr' });
+    setI18nCache(cache);
+    setWritableConditionStore({ getLocale: () => 'fr' });
 
-    return manager;
+    return cache;
   }
 
   it('getGT uses the current locale without accepting a locale parameter', async () => {
@@ -42,7 +40,7 @@ describe('translation function locale defaults', () => {
 
   it('getGT allows $locale to select another loaded locale', async () => {
     const message = 'Hello {name}!';
-    const manager = new I18nManager({
+    const cache = new I18nCache({
       defaultLocale: 'en',
       locales: ['en', 'fr', 'es'],
       loadTranslations: vi.fn().mockImplementation((locale: string) => ({
@@ -50,17 +48,17 @@ describe('translation function locale defaults', () => {
           locale === 'es' ? 'Hola {name}!' : 'Bonjour {name} !',
       })),
     });
-    setI18nManager(manager);
-    setConditionStore({ getLocale: () => 'fr' });
+    setI18nCache(cache);
+    setWritableConditionStore({ getLocale: () => 'fr' });
 
     const gt = await getGT();
-    await manager.loadTranslations('es');
+    await cache.loadTranslations('es');
 
     expect(gt(message, { $locale: 'es', name: 'Alice' })).toBe('Hola Alice!');
   });
 
   it('getTranslations uses the current locale for dictionary entries', async () => {
-    const manager = new I18nManager({
+    const cache = new I18nCache({
       defaultLocale: 'en',
       locales: ['en', 'fr'],
       dictionary: {
@@ -70,8 +68,8 @@ describe('translation function locale defaults', () => {
         greeting: 'Bonjour {name} !',
       }),
     });
-    setI18nManager(manager);
-    setConditionStore({ getLocale: () => 'fr' });
+    setI18nCache(cache);
+    setWritableConditionStore({ getLocale: () => 'fr' });
 
     const t = await getTranslations();
 
@@ -79,7 +77,7 @@ describe('translation function locale defaults', () => {
   });
 
   it('getTranslations returns source dictionary entries when no target translation exists', async () => {
-    const manager = new I18nManager({
+    const cache = new I18nCache({
       defaultLocale: 'en',
       locales: ['en', 'fr'],
       dictionary: {
@@ -87,8 +85,8 @@ describe('translation function locale defaults', () => {
       },
       loadDictionary: vi.fn().mockResolvedValue({}),
     });
-    setI18nManager(manager);
-    setConditionStore({ getLocale: () => 'fr' });
+    setI18nCache(cache);
+    setWritableConditionStore({ getLocale: () => 'fr' });
 
     const t = await getTranslations();
 
@@ -101,7 +99,7 @@ describe('translation function locale defaults', () => {
     const loadTranslations = vi.fn().mockResolvedValue({
       [hashMessage(message, lookupOptions)]: 'Bonjour {name} !',
     });
-    const manager = new I18nManager({
+    const cache = new I18nCache({
       defaultLocale: 'en',
       locales: ['en', 'fr'],
       dictionary: {
@@ -110,8 +108,8 @@ describe('translation function locale defaults', () => {
       loadDictionary: vi.fn().mockResolvedValue({}),
       loadTranslations,
     });
-    setI18nManager(manager);
-    setConditionStore({ getLocale: () => 'fr' });
+    setI18nCache(cache);
+    setWritableConditionStore({ getLocale: () => 'fr' });
 
     const t = await getTranslations();
 
@@ -120,7 +118,7 @@ describe('translation function locale defaults', () => {
   });
 
   it('getTranslations throws when the source dictionary entry is missing', async () => {
-    const manager = new I18nManager({
+    const cache = new I18nCache({
       defaultLocale: 'en',
       locales: ['en', 'fr'],
       dictionary: {
@@ -128,8 +126,8 @@ describe('translation function locale defaults', () => {
       },
       loadDictionary: vi.fn().mockResolvedValue({}),
     });
-    setI18nManager(manager);
-    setConditionStore({ getLocale: () => 'fr' });
+    setI18nCache(cache);
+    setWritableConditionStore({ getLocale: () => 'fr' });
 
     const t = await getTranslations();
 
@@ -139,7 +137,7 @@ describe('translation function locale defaults', () => {
   });
 
   it('getTranslations obj throws when the source dictionary object is missing', async () => {
-    const manager = new I18nManager({
+    const cache = new I18nCache({
       defaultLocale: 'en',
       locales: ['en', 'fr'],
       dictionary: {
@@ -151,8 +149,8 @@ describe('translation function locale defaults', () => {
       },
       loadDictionary: vi.fn().mockResolvedValue({}),
     });
-    setI18nManager(manager);
-    setConditionStore({ getLocale: () => 'fr' });
+    setI18nCache(cache);
+    setWritableConditionStore({ getLocale: () => 'fr' });
 
     const t = await getTranslations();
 
@@ -162,7 +160,7 @@ describe('translation function locale defaults', () => {
   });
 
   it('getTranslations obj returns translated dictionary subtrees', async () => {
-    const manager = new I18nManager({
+    const cache = new I18nCache({
       defaultLocale: 'en',
       locales: ['en', 'fr'],
       dictionary: {
@@ -183,8 +181,8 @@ describe('translation function locale defaults', () => {
         },
       }),
     });
-    setI18nManager(manager);
-    setConditionStore({ getLocale: () => 'fr' });
+    setI18nCache(cache);
+    setWritableConditionStore({ getLocale: () => 'fr' });
 
     const t = await getTranslations();
 
@@ -204,7 +202,7 @@ describe('translation function locale defaults', () => {
     const loadTranslations = vi.fn().mockResolvedValue({
       [hashMessage(title, titleOptions)]: 'Titre',
     });
-    const manager = new I18nManager({
+    const cache = new I18nCache({
       defaultLocale: 'en',
       locales: ['en', 'fr'],
       dictionary: {
@@ -224,8 +222,8 @@ describe('translation function locale defaults', () => {
       }),
       loadTranslations,
     });
-    setI18nManager(manager);
-    setConditionStore({ getLocale: () => 'fr' });
+    setI18nCache(cache);
+    setWritableConditionStore({ getLocale: () => 'fr' });
 
     const t = await getTranslations();
 
@@ -258,7 +256,7 @@ describe('translation function locale defaults', () => {
 
   it('tx does not read the current locale when $locale is explicit', async () => {
     const message = 'Hello';
-    const manager = new I18nManager({
+    const cache = new I18nCache({
       defaultLocale: 'en',
       locales: ['en', 'fr'],
       loadTranslations: vi.fn().mockResolvedValue({
@@ -266,8 +264,8 @@ describe('translation function locale defaults', () => {
       }),
     });
 
-    setI18nManager(manager);
-    setConditionStore({
+    setI18nCache(cache);
+    setWritableConditionStore({
       getLocale: () => {
         throw new Error('current locale should not be read');
       },

--- a/packages/i18n/src/translation-functions/internal/__tests__/resolveTranslationSync.test.ts
+++ b/packages/i18n/src/translation-functions/internal/__tests__/resolveTranslationSync.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { resolveTranslationSync } from '../sync-translation-resolution';
-import { getI18nManager } from '../../../i18n-cache/singleton-operations';
+import { getI18nCache } from '../../../i18n-cache/singleton-operations';
 import { interpolateMessage } from '../../utils/interpolation/interpolateMessage';
 
 vi.mock('../../../i18n-cache/singleton-operations');
@@ -13,13 +13,13 @@ describe('resolveTranslationSync', () => {
   });
 
   it('should call interpolateMessage with source, target, and options when translation found', () => {
-    const mockManager = {
+    const mockCache = {
       getLocale: vi.fn().mockReturnValue('fr'),
       lookupTranslation: vi.fn().mockReturnValue('Bonjour {name} !'),
       getDefaultLocale: vi.fn().mockReturnValue('en'),
     };
-    vi.mocked(getI18nManager).mockReturnValue(
-      mockManager as unknown as ReturnType<typeof getI18nManager>
+    vi.mocked(getI18nCache).mockReturnValue(
+      mockCache as unknown as ReturnType<typeof getI18nCache>
     );
 
     const message = 'Hello {name}!';
@@ -40,12 +40,12 @@ describe('resolveTranslationSync', () => {
   });
 
   it('should return undefined when no translation found', () => {
-    const mockManager = {
+    const mockCache = {
       getLocale: vi.fn().mockReturnValue('fr'),
       lookupTranslation: vi.fn().mockReturnValue(undefined),
     };
-    vi.mocked(getI18nManager).mockReturnValue(
-      mockManager as unknown as ReturnType<typeof getI18nManager>
+    vi.mocked(getI18nCache).mockReturnValue(
+      mockCache as unknown as ReturnType<typeof getI18nCache>
     );
 
     const message = 'Hello {name}!';
@@ -58,13 +58,13 @@ describe('resolveTranslationSync', () => {
   });
 
   it('should preserve user options when translation found', () => {
-    const mockManager = {
+    const mockCache = {
       getLocale: vi.fn().mockReturnValue('fr'),
       lookupTranslation: vi.fn().mockReturnValue('Translated'),
       getDefaultLocale: vi.fn().mockReturnValue('en'),
     };
-    vi.mocked(getI18nManager).mockReturnValue(
-      mockManager as unknown as ReturnType<typeof getI18nManager>
+    vi.mocked(getI18nCache).mockReturnValue(
+      mockCache as unknown as ReturnType<typeof getI18nCache>
     );
 
     const message = 'Hello {name}!';
@@ -92,13 +92,13 @@ describe('resolveTranslationSync', () => {
   });
 
   it('should preserve $format in options passed to interpolateMessage', () => {
-    const mockManager = {
+    const mockCache = {
       getLocale: vi.fn().mockReturnValue('fr'),
       lookupTranslation: vi.fn().mockReturnValue('Translated'),
       getDefaultLocale: vi.fn().mockReturnValue('en'),
     };
-    vi.mocked(getI18nManager).mockReturnValue(
-      mockManager as unknown as ReturnType<typeof getI18nManager>
+    vi.mocked(getI18nCache).mockReturnValue(
+      mockCache as unknown as ReturnType<typeof getI18nCache>
     );
 
     const message = 'Hello {name}!';

--- a/packages/i18n/src/translation-functions/internal/getGT.ts
+++ b/packages/i18n/src/translation-functions/internal/getGT.ts
@@ -1,4 +1,4 @@
-import { getI18nManager } from '../../i18n-cache/singleton-operations';
+import { getI18nCache } from '../../i18n-cache/singleton-operations';
 import { InlineTranslationOptions } from '../types/options';
 import { GTFunctionType } from '../types/functions';
 import { interpolateMessage } from '../utils/interpolation/interpolateMessage';
@@ -16,10 +16,10 @@ import { getLocale } from '../../helpers/locale';
  */
 export async function getGT(): Promise<GTFunctionType> {
   // Get the translation resolver
-  const i18nManager = getI18nManager();
+  const i18nCache = getI18nCache();
   const locale = getLocale();
-  await i18nManager.loadTranslations(locale);
-  const sourceLocale = i18nManager.getDefaultLocale();
+  await i18nCache.loadTranslations(locale);
+  const sourceLocale = i18nCache.getDefaultLocale();
 
   /**
    * Registers a message at build time and resolves its translation at runtime.
@@ -49,7 +49,7 @@ export async function getGT(): Promise<GTFunctionType> {
     );
 
     // Lookup translation
-    const translation = i18nManager.lookupTranslation(
+    const translation = i18nCache.lookupTranslation(
       lookupOptions.$locale,
       message,
       lookupOptions

--- a/packages/i18n/src/translation-functions/internal/getTranslations.ts
+++ b/packages/i18n/src/translation-functions/internal/getTranslations.ts
@@ -1,4 +1,4 @@
-import { getI18nManager } from '../../i18n-cache/singleton-operations';
+import { getI18nCache } from '../../i18n-cache/singleton-operations';
 import { DictionaryTranslationOptions } from '../types/options';
 import { TFunctionType } from '../types/functions';
 import { renderDictionaryEntry } from './renderDictionaryEntry';
@@ -17,13 +17,13 @@ import { getLocale } from '../../helpers/locale';
  * const title = await t('page.title');
  */
 export async function getTranslations(): Promise<TFunctionType> {
-  const i18nManager = getI18nManager();
+  const i18nCache = getI18nCache();
   const locale = getLocale();
   await Promise.all([
-    i18nManager.loadDictionary(locale),
-    i18nManager.loadTranslations(locale),
+    i18nCache.loadDictionary(locale),
+    i18nCache.loadTranslations(locale),
   ]);
-  const sourceLocale = i18nManager.getDefaultLocale();
+  const sourceLocale = i18nCache.getDefaultLocale();
 
   /**
    * Dictionary resolution
@@ -45,21 +45,17 @@ export async function getTranslations(): Promise<TFunctionType> {
     id: string,
     options: DictionaryTranslationOptions = {}
   ): string => {
-    const sourceEntry = i18nManager.lookupDictionary(sourceLocale, id);
+    const sourceEntry = i18nCache.lookupDictionary(sourceLocale, id);
     if (sourceEntry === undefined) {
       throw new Error(`Dictionary entry ${id} cannot be found`);
     }
-    const targetEntry = i18nManager.lookupDictionary(locale, id);
+    const targetEntry = i18nCache.lookupDictionary(locale, id);
     const dictionaryOptions = resolveDictionaryLookupOptions(
       sourceEntry.options
     );
     const target =
       targetEntry?.entry ??
-      i18nManager.lookupTranslation(
-        locale,
-        sourceEntry.entry,
-        dictionaryOptions
-      );
+      i18nCache.lookupTranslation(locale, sourceEntry.entry, dictionaryOptions);
     return renderDictionaryEntry({
       sourceLocale,
       targetLocale: locale,
@@ -82,16 +78,16 @@ export async function getTranslations(): Promise<TFunctionType> {
    * // { greeting1: 'Hello', greeting2: 'Hi' }
    */
   t.obj = (id: string): DictionaryObjectTranslation => {
-    const sourceObject = i18nManager.lookupDictionaryObj(sourceLocale, id);
+    const sourceObject = i18nCache.lookupDictionaryObj(sourceLocale, id);
     if (sourceObject === undefined) {
       throw new Error(`Dictionary entry ${id} cannot be found`);
     }
-    const targetObject = i18nManager.lookupDictionaryObj(locale, id);
+    const targetObject = i18nCache.lookupDictionaryObj(locale, id);
     return renderDictionaryObject({
       sourceObject,
       targetObject,
       translate: (sourceEntry, dictionaryOptions) =>
-        i18nManager.lookupTranslation(
+        i18nCache.lookupTranslation(
           locale,
           sourceEntry.entry,
           dictionaryOptions

--- a/packages/i18n/src/translation-functions/internal/helpers.ts
+++ b/packages/i18n/src/translation-functions/internal/helpers.ts
@@ -1,4 +1,4 @@
-import { getI18nManager } from '../../i18n-cache/singleton-operations';
+import { getI18nCache } from '../../i18n-cache/singleton-operations';
 import { NormalizedLookupOptions, ResolutionOptions } from '../types/options';
 import { interpolateMessage } from '../utils/interpolation/interpolateMessage';
 import type {
@@ -18,9 +18,9 @@ export function resolveJsx(
   content: JsxChildren,
   options: ResolutionOptions<'JSX'> = {}
 ): JsxChildren | undefined {
-  const i18nManager = getI18nManager();
+  const i18nCache = getI18nCache();
   const lookupOptions = createLookupOptions(locale, options, 'JSX');
-  const translation = i18nManager.lookupTranslation(
+  const translation = i18nCache.lookupTranslation(
     lookupOptions.$locale,
     content,
     lookupOptions
@@ -50,9 +50,9 @@ export async function resolveJsxWithRuntimeFallback(
   content: JsxChildren,
   options: ResolutionOptions<'JSX'> = {}
 ): Promise<JsxChildren> {
-  const i18nManager = getI18nManager();
+  const i18nCache = getI18nCache();
   const lookupOptions = createLookupOptions(locale, options, 'JSX');
-  const translation = await i18nManager.lookupTranslationWithFallback(
+  const translation = await i18nCache.lookupTranslationWithFallback(
     lookupOptions.$locale,
     content,
     lookupOptions
@@ -71,9 +71,9 @@ export function resolveStringContent(
   content: StringContent,
   options: ResolutionOptions<StringFormat> = {}
 ): StringContent | undefined {
-  const i18nManager = getI18nManager();
+  const i18nCache = getI18nCache();
   const lookupOptions = createLookupOptions(locale, options, 'STRING');
-  const translation = i18nManager.lookupTranslation(
+  const translation = i18nCache.lookupTranslation(
     lookupOptions.$locale,
     content,
     lookupOptions
@@ -83,7 +83,7 @@ export function resolveStringContent(
     source: content,
     target: translation,
     options: lookupOptions,
-    sourceLocale: i18nManager.getDefaultLocale(),
+    sourceLocale: i18nCache.getDefaultLocale(),
   });
 }
 
@@ -95,9 +95,9 @@ export function resolveStringContentWithFallback(
   content: StringContent,
   options: ResolutionOptions<StringFormat> = {}
 ): StringContent {
-  const i18nManager = getI18nManager();
+  const i18nCache = getI18nCache();
   const lookupOptions = createLookupOptions(locale, options, 'STRING');
-  const translation = i18nManager.lookupTranslation(
+  const translation = i18nCache.lookupTranslation(
     lookupOptions.$locale,
     content,
     lookupOptions
@@ -106,7 +106,7 @@ export function resolveStringContentWithFallback(
     source: content,
     target: translation,
     options: lookupOptions,
-    sourceLocale: i18nManager.getDefaultLocale(),
+    sourceLocale: i18nCache.getDefaultLocale(),
   });
 }
 
@@ -120,9 +120,9 @@ export async function resolveStringContentWithRuntimeFallback(
   content: StringContent,
   options: ResolutionOptions<StringFormat> = {}
 ): Promise<StringContent> {
-  const i18nManager = getI18nManager();
+  const i18nCache = getI18nCache();
   const lookupOptions = createLookupOptions(locale, options, 'STRING');
-  const translation = await i18nManager.lookupTranslationWithFallback(
+  const translation = await i18nCache.lookupTranslationWithFallback(
     lookupOptions.$locale,
     content,
     lookupOptions
@@ -131,7 +131,7 @@ export async function resolveStringContentWithRuntimeFallback(
     source: content,
     target: translation,
     options: lookupOptions,
-    sourceLocale: i18nManager.getDefaultLocale(),
+    sourceLocale: i18nCache.getDefaultLocale(),
   });
 }
 /**

--- a/packages/i18n/src/translation-functions/msg/msg.ts
+++ b/packages/i18n/src/translation-functions/msg/msg.ts
@@ -46,7 +46,7 @@ import { RegisterableMessages } from '../types/message';
  * // "Hello, Alice!" id: "greetings.0"
  * // "Hello, Bob!" id: "greetings.1"
  *
- * @important Internal note: until other packages are updated to use i18n-context practices, msg cannot use any functions that use i18nManager at all!
+ * @important Internal note: until other packages are updated to use i18n-context practices, msg cannot use any functions that use i18nCache at all!
  */
 export function msg<T extends RegisterableMessages = string>(message: T): T;
 export function msg<T extends RegisterableMessages = string>(

--- a/packages/node/src/async-i18n-cache/AsyncConditionStore.ts
+++ b/packages/node/src/async-i18n-cache/AsyncConditionStore.ts
@@ -3,7 +3,7 @@ import type {
   LocaleResolverConfig,
   ScopedConditionStore,
 } from 'gt-i18n/internal/types';
-import { getI18nManager } from 'gt-i18n/internal';
+import { getI18nCache } from 'gt-i18n/internal';
 
 type Store = {
   locale: string;
@@ -40,7 +40,7 @@ export class AsyncConditionStore implements ScopedConditionStore {
    * */
   run<T>(locale: string, callback: () => T): T {
     return this.store.run(
-      { locale: getI18nManager().determineLocale(locale) },
+      { locale: getI18nCache().determineLocale(locale) },
       callback
     );
   }
@@ -50,11 +50,11 @@ export class AsyncConditionStore implements ScopedConditionStore {
     if (!store) {
       if (process.env.NODE_ENV === 'production') {
         console.warn(OUTSIDE_SCOPE_MESSAGE);
-        return getI18nManager().determineLocale();
+        return getI18nCache().determineLocale();
       }
       throw new Error(OUTSIDE_SCOPE_MESSAGE);
     }
-    return getI18nManager().determineLocale(store.locale);
+    return getI18nCache().determineLocale(store.locale);
   }
 
   /**

--- a/packages/node/src/async-i18n-cache/__tests__/AsyncConditionStore.test.ts
+++ b/packages/node/src/async-i18n-cache/__tests__/AsyncConditionStore.test.ts
@@ -4,6 +4,7 @@ import { AsyncConditionStore } from '../AsyncConditionStore';
 
 describe('AsyncConditionStore', () => {
   afterEach(() => {
+    setTestCache();
     vi.unstubAllEnvs();
     vi.restoreAllMocks();
   });

--- a/packages/node/src/async-i18n-cache/__tests__/AsyncConditionStore.test.ts
+++ b/packages/node/src/async-i18n-cache/__tests__/AsyncConditionStore.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { I18nCache, setI18nCache } from 'gt-i18n/internal';
 import { AsyncConditionStore } from '../AsyncConditionStore';
 
 describe('AsyncConditionStore', () => {
@@ -7,7 +8,17 @@ describe('AsyncConditionStore', () => {
     vi.restoreAllMocks();
   });
 
+  function setTestCache() {
+    setI18nCache(
+      new I18nCache({
+        defaultLocale: 'en',
+        locales: ['en', 'fr'],
+      })
+    );
+  }
+
   it('throws when reading the locale outside a scoped context', () => {
+    setTestCache();
     const store = new AsyncConditionStore({
       defaultLocale: 'en',
       locales: ['en', 'fr'],
@@ -19,6 +30,7 @@ describe('AsyncConditionStore', () => {
   });
 
   it('warns and falls back outside a scoped context in production', () => {
+    setTestCache();
     vi.stubEnv('NODE_ENV', 'production');
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const store = new AsyncConditionStore({
@@ -33,6 +45,7 @@ describe('AsyncConditionStore', () => {
   });
 
   it('returns the scoped locale inside run()', () => {
+    setTestCache();
     const store = new AsyncConditionStore({
       defaultLocale: 'en',
       locales: ['en', 'fr'],

--- a/packages/node/src/helpers/getRequestLocale.ts
+++ b/packages/node/src/helpers/getRequestLocale.ts
@@ -1,4 +1,4 @@
-import { getI18nManager } from 'gt-i18n/internal';
+import { getI18nCache } from 'gt-i18n/internal';
 
 /**
  * A request object like interface
@@ -53,9 +53,9 @@ function parseAcceptLanguage(header: string): string[] {
  */
 export function getRequestLocale(request: RequestLike): string {
   // Setup
-  const i18nManager = getI18nManager<string>();
-  const defaultLocale = i18nManager.getDefaultLocale();
-  const gtInstance = i18nManager.getGTClass();
+  const i18nCache = getI18nCache<string>();
+  const defaultLocale = i18nCache.getDefaultLocale();
+  const gtInstance = i18nCache.getGTClass();
 
   // Get the accept-language header
   const acceptLanguage = request.headers['accept-language'];

--- a/packages/node/src/internal.ts
+++ b/packages/node/src/internal.ts
@@ -1,2 +1,8 @@
 export * from './async-i18n-cache';
-export { getI18nManager, setI18nManager, I18nManager } from 'gt-i18n/internal';
+export { getI18nCache, setI18nCache, I18nCache } from 'gt-i18n/internal';
+/** @deprecated use getI18nCache instead */
+export { getI18nCache as getI18nManager } from 'gt-i18n/internal';
+/** @deprecated use setI18nCache instead */
+export { setI18nCache as setI18nManager } from 'gt-i18n/internal';
+/** @deprecated use I18nCache instead */
+export { I18nCache as I18nManager } from 'gt-i18n/internal';

--- a/packages/node/src/setup/initializeGT.ts
+++ b/packages/node/src/setup/initializeGT.ts
@@ -1,6 +1,6 @@
 import { setAsyncConditionStore } from '../async-i18n-cache/singleton-operations';
 import type { InitializeGTParams } from './types';
-import { I18nManager, setI18nManager } from 'gt-i18n/internal';
+import { I18nCache, setI18nCache } from 'gt-i18n/internal';
 import { AsyncConditionStore } from '../async-i18n-cache/AsyncConditionStore';
 
 /**
@@ -9,13 +9,13 @@ import { AsyncConditionStore } from '../async-i18n-cache/AsyncConditionStore';
  * TODO: auto detect if can find gt.config.json files
  */
 export function initializeGT(params: InitializeGTParams): void {
-  const i18nManager = new I18nManager<string>(params);
+  const i18nCache = new I18nCache<string>(params);
   const conditionStore = new AsyncConditionStore({
-    defaultLocale: i18nManager.getDefaultLocale(),
-    locales: i18nManager.getLocales(),
-    customMapping: i18nManager.getCustomMapping(),
+    defaultLocale: i18nCache.getDefaultLocale(),
+    locales: i18nCache.getLocales(),
+    customMapping: i18nCache.getCustomMapping(),
   });
 
-  setI18nManager(i18nManager);
+  setI18nCache(i18nCache);
   setAsyncConditionStore(conditionStore);
 }

--- a/packages/react-core/src/components/variables/Currency.tsx
+++ b/packages/react-core/src/components/variables/Currency.tsx
@@ -1,4 +1,4 @@
-import { getReactI18nManager } from '../../i18n-cache/singleton-operations';
+import { getReactI18nCache } from '../../i18n-cache/singleton-operations';
 import { useFormatLocales } from '../../hooks/utils';
 
 type CurrencyProps = {
@@ -18,7 +18,7 @@ function GtInternalCurrency({
   locales: localesProp = [],
 }: CurrencyProps): string | null {
   const locales = useFormatLocales(localesProp);
-  const gt = getReactI18nManager().getGTClass();
+  const gt = getReactI18nCache().getGTClass();
   if (children == null) return null;
   const parsedNumber =
     typeof children === 'string' ? parseFloat(children) : children;

--- a/packages/react-core/src/components/variables/DateTime.tsx
+++ b/packages/react-core/src/components/variables/DateTime.tsx
@@ -1,4 +1,4 @@
-import { getReactI18nManager } from '../../i18n-cache/singleton-operations';
+import { getReactI18nCache } from '../../i18n-cache/singleton-operations';
 import { useFormatLocales } from '../../hooks/utils';
 
 type DateTimeProps = {
@@ -16,8 +16,8 @@ function GtInternalDateTime({
   locales: localesProp = [],
 }: DateTimeProps): string | null {
   const locales = useFormatLocales(localesProp);
-  // TODO: theres a world in which we don't need the i18n manager, if user passes their own params
-  const gt = getReactI18nManager().getGTClass();
+  // TODO: theres a world in which we don't need the i18n cache, if user passes their own params
+  const gt = getReactI18nCache().getGTClass();
   if (children == null) return null;
   return gt
     .formatDateTime(children, { locales, ...options })

--- a/packages/react-core/src/components/variables/Num.tsx
+++ b/packages/react-core/src/components/variables/Num.tsx
@@ -1,4 +1,4 @@
-import { getReactI18nManager } from '../../i18n-cache/singleton-operations';
+import { getReactI18nCache } from '../../i18n-cache/singleton-operations';
 import { useFormatLocales } from '../../hooks/utils';
 
 type NumProps = {
@@ -16,7 +16,7 @@ function GtInternalNum({
   locales: localesProp = [],
 }: NumProps): string | null {
   const locales = useFormatLocales(localesProp);
-  const gt = getReactI18nManager().getGTClass();
+  const gt = getReactI18nCache().getGTClass();
   if (children == null) return null;
   const parsedNumber =
     typeof children === 'string' ? parseFloat(children) : children;

--- a/packages/react-core/src/components/variables/RelativeTime.tsx
+++ b/packages/react-core/src/components/variables/RelativeTime.tsx
@@ -1,4 +1,4 @@
-import { getReactI18nManager } from '../../i18n-cache/singleton-operations';
+import { getReactI18nCache } from '../../i18n-cache/singleton-operations';
 import { useFormatLocales } from '../../hooks/utils';
 
 type RelativeTimeProps = {
@@ -24,7 +24,7 @@ function GtInternalRelativeTime({
   options = {},
 }: RelativeTimeProps): string | null {
   const locales = useFormatLocales(localesProp);
-  const gt = getReactI18nManager().getGTClass();
+  const gt = getReactI18nCache().getGTClass();
   const resolvedDate = date ?? children;
 
   if (process.env.NODE_ENV === 'development' && value !== undefined && !unit) {

--- a/packages/react-core/src/context.ts
+++ b/packages/react-core/src/context.ts
@@ -54,13 +54,21 @@ export {
 export { WritableConditionStore } from 'gt-i18n/internal';
 export type { WritableConditionStoreParams } from 'gt-i18n/internal';
 export {
-  getReactI18nManager,
-  setReactI18nManager,
+  getReactI18nCache,
+  setReactI18nCache,
 } from './i18n-cache/singleton-operations';
+/** @deprecated use getReactI18nCache instead */
+export { getReactI18nCache as getReactI18nManager } from './i18n-cache/singleton-operations';
+/** @deprecated use setReactI18nCache instead */
+export { setReactI18nCache as setReactI18nManager } from './i18n-cache/singleton-operations';
 export { I18nStore } from './i18n-store/I18nStore';
 export type { I18nStoreParams } from './i18n-store/I18nStore';
 export type { InternalGTProviderProps } from './context/InternalGTProvider';
 export type {
-  ReactI18nManager,
-  ReactI18nManagerParams,
+  ReactI18nCache,
+  ReactI18nCacheParams,
 } from './i18n-cache/ReactI18nCache';
+/** @deprecated use ReactI18nCache instead */
+export type { ReactI18nCache as ReactI18nManager } from './i18n-cache/ReactI18nCache';
+/** @deprecated use ReactI18nCacheParams instead */
+export type { ReactI18nCacheParams as ReactI18nManagerParams } from './i18n-cache/ReactI18nCache';

--- a/packages/react-core/src/context/InternalGTProvider.tsx
+++ b/packages/react-core/src/context/InternalGTProvider.tsx
@@ -4,7 +4,7 @@ import {
   setI18nStore,
 } from '../i18n-store/singleton-operations';
 import { I18nStore, I18nStoreParams } from '../i18n-store/I18nStore';
-import { getI18nManager } from 'gt-i18n/internal';
+import { getI18nCache } from 'gt-i18n/internal';
 import type { Dictionary, Translation } from 'gt-i18n/types';
 import type { Locale, Hash } from 'gt-i18n/internal/types';
 
@@ -19,7 +19,7 @@ export type InternalGTProviderProps = I18nStoreParams & {
 
 /**
  * - Shared provider logic btwn client and server providers
- * - It is assumed that the I18nManager and ConditionStore are already initialized.
+ * - It is assumed that the I18nCache and ConditionStore are already initialized.
  * - This is not userfacing, it should be wrapped in a userfacing provider
  * - Locale and translations (and dictionaries if applicable) are required
  *
@@ -39,8 +39,8 @@ export function InternalGTProvider({
 
   // This represents an update from server, so bypass I18nStore
   useMemo(() => {
-    getI18nManager().updateTranslations(translations);
-    getI18nManager().updateDictionaries(dictionaries ?? {});
+    getI18nCache().updateTranslations(translations);
+    getI18nCache().updateDictionaries(dictionaries ?? {});
   }, [translations, dictionaries]);
 
   return children;

--- a/packages/react-core/src/functions/helpers/getTranslationsSnapshot.ts
+++ b/packages/react-core/src/functions/helpers/getTranslationsSnapshot.ts
@@ -1,6 +1,6 @@
 import { Hash, Locale } from 'gt-i18n/internal/types';
 import { Translation } from 'gt-i18n/types';
-import { getReactI18nManager } from '../../i18n-cache/singleton-operations';
+import { getReactI18nCache } from '../../i18n-cache/singleton-operations';
 
 /**
  * Returns a promise of serializable cached translations that
@@ -11,8 +11,8 @@ import { getReactI18nManager } from '../../i18n-cache/singleton-operations';
 export async function getTranslationsSnapshot(
   locale: Locale
 ): Promise<Record<Locale, Record<Hash, Translation>>> {
-  const i18nManager = getReactI18nManager();
-  const translations = await i18nManager.loadTranslations(locale);
+  const i18nCache = getReactI18nCache();
+  const translations = await i18nCache.loadTranslations(locale);
   // Only pass translations for the given locale to minimize the size of the snapshot
   return { [locale]: translations };
 }

--- a/packages/react-core/src/functions/translation/t.ts
+++ b/packages/react-core/src/functions/translation/t.ts
@@ -13,7 +13,7 @@ import {
   isReadonlyConditionStoreInitialized,
 } from '../../condition-store/singleton-operations';
 import { StringContent, StringFormat } from 'generaltranslation/types';
-import { getReactI18nManager } from '../../i18n-cache/singleton-operations';
+import { getReactI18nCache } from '../../i18n-cache/singleton-operations';
 import { getShouldTranslate } from '../../hooks/utils';
 import { createDiagnosticMessage } from 'generaltranslation/internal';
 
@@ -58,8 +58,8 @@ export function resolveStringContent(
   content: StringContent,
   options: ResolutionOptions<StringFormat> = {}
 ): StringContent {
-  const i18nManager = getReactI18nManager();
-  const defaultLocale = i18nManager.getDefaultLocale();
+  const i18nCache = getReactI18nCache();
+  const defaultLocale = i18nCache.getDefaultLocale();
   if (!getShouldTranslate()) {
     return interpolateMessage({
       options,
@@ -69,7 +69,7 @@ export function resolveStringContent(
   }
 
   const lookupOptions = createLookupOptions(locale, options, 'ICU');
-  const translation = i18nManager.lookupTranslation(
+  const translation = i18nCache.lookupTranslation(
     lookupOptions.$locale,
     content,
     lookupOptions
@@ -104,8 +104,8 @@ function handleTaggedTemplateLiteralTranslation(
     messageOrStrings,
     values
   );
-  const i18nManager = getReactI18nManager();
-  const translatedInterpolatedTemplate = i18nManager.lookupTranslation(
+  const i18nCache = getReactI18nCache();
+  const translatedInterpolatedTemplate = i18nCache.lookupTranslation(
     locale,
     interpolatedTemplate,
     { $format: 'STRING' }

--- a/packages/react-core/src/hooks/external-store-hooks.ts
+++ b/packages/react-core/src/hooks/external-store-hooks.ts
@@ -12,7 +12,7 @@ import type { CustomMapping } from 'generaltranslation/types';
 import { getI18nStore } from '../i18n-store/singleton-operations';
 import type { RuntimeTranslationScope } from '../i18n-store/RuntimeTranslationScope';
 import type { RuntimeDictionaryScope } from '../i18n-store/RuntimeDictionaryScope';
-import { getReactI18nManager } from '../i18n-cache/singleton-operations';
+import { getReactI18nCache } from '../i18n-cache/singleton-operations';
 
 /**
  * @internal
@@ -26,7 +26,7 @@ export function useTranslate<T extends Translation>(
     () => store.getTranslateSnapshot(lookup),
     () => store.getTranslateSnapshot(lookup)
   );
-  if (translation == null && getReactI18nManager().isDevHotReloadEnabled()) {
+  if (translation == null && getReactI18nCache().isDevHotReloadEnabled()) {
     store.translate(lookup);
   }
   return translation;
@@ -44,7 +44,7 @@ export function useTranslateMany<T extends Translation>(
     () => store.getTranslateManySnapshot(lookups),
     () => store.getTranslateManySnapshot(lookups)
   );
-  const devHotReloadEnabled = getReactI18nManager().isDevHotReloadEnabled();
+  const devHotReloadEnabled = getReactI18nCache().isDevHotReloadEnabled();
   translations.forEach((translation, index) => {
     if (translation == null && devHotReloadEnabled) {
       store.translate(lookups[index]);
@@ -65,10 +65,7 @@ export function useDictionaryEntry(
     () => store.getDictionaryEntrySnapshot(lookup),
     () => store.getDictionaryEntrySnapshot(lookup)
   );
-  if (
-    dictionaryEntry == null &&
-    getReactI18nManager().isDevHotReloadEnabled()
-  ) {
+  if (dictionaryEntry == null && getReactI18nCache().isDevHotReloadEnabled()) {
     store.translateDictionaryEntry(lookup);
   }
   return dictionaryEntry;
@@ -86,10 +83,7 @@ export function useDictionaryObject(
     () => store.getDictionaryObjectSnapshot(lookup),
     () => store.getDictionaryObjectSnapshot(lookup)
   );
-  if (
-    dictionaryObject == null &&
-    getReactI18nManager().isDevHotReloadEnabled()
-  ) {
+  if (dictionaryObject == null && getReactI18nCache().isDevHotReloadEnabled()) {
     store.translateDictionaryObject(lookup);
   }
   return dictionaryObject;

--- a/packages/react-core/src/hooks/useGT.ts
+++ b/packages/react-core/src/hooks/useGT.ts
@@ -8,7 +8,7 @@ import {
 } from './external-store-hooks';
 import { useLocale } from './condition-store';
 import { useShouldTranslate } from './utils';
-import { getReactI18nManager } from '../i18n-cache/singleton-operations';
+import { getReactI18nCache } from '../i18n-cache/singleton-operations';
 import type { TranslateLookup } from '../i18n-store/storeTypes';
 import type { GTFunctionType, InlineTranslationOptions } from 'gt-i18n/types';
 import type { StringFormat } from '@generaltranslation/format/types';
@@ -27,7 +27,7 @@ export function useGT(_messages?: Message[]): GTFunctionType {
   const defaultLocale = useDefaultLocale();
   const shouldTranslate = useShouldTranslate();
   const scope = useRuntimeTranslationScope();
-  const devHotReloadEnabled = getReactI18nManager().isDevHotReloadEnabled();
+  const devHotReloadEnabled = getReactI18nCache().isDevHotReloadEnabled();
 
   // Compiler optimization: pre-fetch translations
   useSubscribeToExtractedMessages(
@@ -55,7 +55,7 @@ export function useGT(_messages?: Message[]): GTFunctionType {
         options,
         'ICU'
       );
-      const translation = getReactI18nManager().lookupTranslation(
+      const translation = getReactI18nCache().lookupTranslation(
         lookupOptions.$locale,
         message,
         lookupOptions

--- a/packages/react-core/src/hooks/useTranslations.ts
+++ b/packages/react-core/src/hooks/useTranslations.ts
@@ -12,7 +12,7 @@ import {
 } from './external-store-hooks';
 import { useLocale } from './condition-store';
 import { useShouldTranslate } from './utils';
-import { getReactI18nManager } from '../i18n-cache/singleton-operations';
+import { getReactI18nCache } from '../i18n-cache/singleton-operations';
 import { useGT } from './useGT';
 import type {
   DictionaryObjectTranslation,
@@ -28,16 +28,16 @@ export function useTranslations(id?: string): UseTranslationsFunction {
   const scope = useRuntimeDictionaryScope();
   const gt = useGT();
   const rootId = id ?? '';
-  const devHotReloadEnabled = getReactI18nManager().isDevHotReloadEnabled();
+  const devHotReloadEnabled = getReactI18nCache().isDevHotReloadEnabled();
 
   useDictionaryObject({ locale: defaultLocale, id: rootId });
   useDictionaryObject({ locale, id: rootId });
 
   const translateEntry = useCallback(
     (suffix: string, options: DictionaryTranslationOptions = {}) => {
-      const i18nManager = getReactI18nManager();
+      const i18nCache = getReactI18nCache();
       const entryId = getEntryId(id, suffix);
-      const sourceEntry = i18nManager.lookupDictionary(defaultLocale, entryId);
+      const sourceEntry = i18nCache.lookupDictionary(defaultLocale, entryId);
       if (sourceEntry === undefined) {
         throw new Error(`Dictionary entry ${entryId} cannot be found`);
       }
@@ -49,7 +49,7 @@ export function useTranslations(id?: string): UseTranslationsFunction {
         });
       }
 
-      const targetEntry = i18nManager.lookupDictionary(locale, entryId);
+      const targetEntry = i18nCache.lookupDictionary(locale, entryId);
       if (targetEntry === undefined && devHotReloadEnabled) {
         scope.translateEntry({ locale, id: entryId });
       }
@@ -78,9 +78,9 @@ export function useTranslations(id?: string): UseTranslationsFunction {
 
   const translateObject = useCallback(
     (suffix: string) => {
-      const i18nManager = getReactI18nManager();
+      const i18nCache = getReactI18nCache();
       const entryId = getEntryId(id, suffix);
-      const sourceObject = i18nManager.lookupDictionaryObj(
+      const sourceObject = i18nCache.lookupDictionaryObj(
         defaultLocale,
         entryId
       );
@@ -90,7 +90,7 @@ export function useTranslations(id?: string): UseTranslationsFunction {
 
       let targetObject = undefined;
       if (shouldTranslate) {
-        targetObject = i18nManager.lookupDictionaryObj(locale, entryId);
+        targetObject = i18nCache.lookupDictionaryObj(locale, entryId);
         if (targetObject === undefined && devHotReloadEnabled) {
           scope.translateObject({ locale, id: entryId });
         }
@@ -100,7 +100,7 @@ export function useTranslations(id?: string): UseTranslationsFunction {
         sourceObject,
         targetObject,
         translate: (sourceEntry, dictionaryOptions) =>
-          i18nManager.lookupTranslation(
+          i18nCache.lookupTranslation(
             shouldTranslate ? locale : defaultLocale,
             sourceEntry.entry,
             dictionaryOptions

--- a/packages/react-core/src/hooks/utils.ts
+++ b/packages/react-core/src/hooks/utils.ts
@@ -2,7 +2,7 @@ import { useDefaultLocale } from './external-store-hooks';
 import { useLocale } from './condition-store';
 import { requiresTranslation } from 'generaltranslation/core';
 import { getReadonlyConditionStoreWithFallback } from '../condition-store/singleton-operations';
-import { getReactI18nManager } from '../i18n-cache/singleton-operations';
+import { getReactI18nCache } from '../i18n-cache/singleton-operations';
 
 export function useFormatLocales(localesProp: string[] = []): string[] {
   const locale = useLocale();
@@ -22,13 +22,13 @@ export function useShouldTranslate(): boolean {
  */
 export function getShouldTranslate(): boolean {
   const conditionStore = getReadonlyConditionStoreWithFallback();
-  const i18nManager = getReactI18nManager();
+  const i18nCache = getReactI18nCache();
 
   const enableI18n = conditionStore.getEnableI18n();
   const locale = conditionStore.getLocale();
-  const defaultLocale = i18nManager.getDefaultLocale();
-  const locales = i18nManager.getLocales();
-  const customMapping = i18nManager.getCustomMapping();
+  const defaultLocale = i18nCache.getDefaultLocale();
+  const locales = i18nCache.getLocales();
+  const customMapping = i18nCache.getCustomMapping();
   return (
     enableI18n &&
     requiresTranslation(defaultLocale, locale, [...locales], customMapping)

--- a/packages/react-core/src/i18n-cache/ReactI18nCache.ts
+++ b/packages/react-core/src/i18n-cache/ReactI18nCache.ts
@@ -1,9 +1,9 @@
-import type { I18nManager } from 'gt-i18n/internal';
-import type { I18nManagerConstructorParams } from 'gt-i18n/internal/types';
+import type { I18nCache } from 'gt-i18n/internal';
+import type { I18nCacheConstructorParams } from 'gt-i18n/internal/types';
 import type { Translation } from 'gt-i18n/types';
 
-export type ReactI18nManager = Pick<
-  I18nManager<Translation>,
-  keyof I18nManager<Translation>
+export type ReactI18nCache = Pick<
+  I18nCache<Translation>,
+  keyof I18nCache<Translation>
 >;
-export type ReactI18nManagerParams = I18nManagerConstructorParams<Translation>;
+export type ReactI18nCacheParams = I18nCacheConstructorParams<Translation>;

--- a/packages/react-core/src/i18n-cache/singleton-operations.ts
+++ b/packages/react-core/src/i18n-cache/singleton-operations.ts
@@ -1,14 +1,14 @@
 import * as i18nInternal from 'gt-i18n/internal';
-import type { I18nManager } from 'gt-i18n/internal';
+import type { I18nCache } from 'gt-i18n/internal';
 import type { Translation } from 'gt-i18n/types';
-import type { ReactI18nManager } from './ReactI18nCache';
+import type { ReactI18nCache } from './ReactI18nCache';
 
-// ===== I18n Manager ===== //
+// ===== I18n Cache ===== //
 
-export function getReactI18nManager(): ReactI18nManager {
-  return i18nInternal.getI18nManager() as ReactI18nManager;
+export function getReactI18nCache(): ReactI18nCache {
+  return i18nInternal.getI18nCache() as ReactI18nCache;
 }
 
-export function setReactI18nManager(i18nManager: ReactI18nManager): void {
-  i18nInternal.setI18nManager(i18nManager as I18nManager<Translation>);
+export function setReactI18nCache(i18nCache: ReactI18nCache): void {
+  i18nInternal.setI18nCache(i18nCache as I18nCache<Translation>);
 }

--- a/packages/react-core/src/i18n-store/I18nStore.ts
+++ b/packages/react-core/src/i18n-store/I18nStore.ts
@@ -15,7 +15,7 @@ import type {
   Unsubscribe,
 } from './storeTypes';
 import type { Translation } from 'gt-i18n/types';
-import { getReactI18nManager } from '../i18n-cache/singleton-operations';
+import { getReactI18nCache } from '../i18n-cache/singleton-operations';
 import { RuntimeTranslationScope } from './RuntimeTranslationScope';
 import { RuntimeDictionaryScope } from './RuntimeDictionaryScope';
 
@@ -30,9 +30,9 @@ type DictionaryStoreListener = (event: DictionaryStoreEvent) => void;
 export type I18nStoreParams = {};
 
 /**
- * A subscription wrapper around the I18nManager and the ConditionStore
+ * A subscription wrapper around the I18nCache and the ConditionStore
  *
- * It is assumed that the I18nManager and the ConditionStore are already initialized.
+ * It is assumed that the I18nCache and the ConditionStore are already initialized.
  * It is assumed that the locale and translations are already sync accessible.
  */
 export class I18nStore {
@@ -52,11 +52,11 @@ export class I18nStore {
   private localeListeners: ListenerSet = new Set();
 
   /**
-   * I18nManager must be already initialized
+   * I18nCache must be already initialized
    */
   constructor(_config: I18nStoreParams) {
     try {
-      getReactI18nManager();
+      getReactI18nCache();
     } catch (error) {
       throw new Error('Failed to initialize I18nStore. Reason: ' + error);
     }
@@ -76,7 +76,7 @@ export class I18nStore {
     return this.subscribeToStaticSet(this.customMappingListeners, listener);
   };
 
-  // ===== I18nManager Subscriptions ===== //
+  // ===== I18nCache Subscriptions ===== //
 
   subscribeToTranslate<T extends Translation>(
     lookup: TranslateLookup<T>,
@@ -138,25 +138,25 @@ export class I18nStore {
   // ===== Manager Config Snapshots ===== //
 
   getDefaultLocaleSnapshot = (): string => {
-    return getReactI18nManager().getDefaultLocale();
+    return getReactI18nCache().getDefaultLocale();
   };
 
   getLocalesSnapshot = (): readonly string[] => {
-    return getReactI18nManager().getLocales();
+    return getReactI18nCache().getLocales();
   };
 
   getCustomMappingSnapshot = (): CustomMapping => {
-    return getReactI18nManager().getCustomMapping();
+    return getReactI18nCache().getCustomMapping();
   };
 
-  // ===== I18nManager Snapshots ===== //
+  // ===== I18nCache Snapshots ===== //
 
   getTranslateSnapshot = <T extends Translation>({
     locale,
     message,
     options,
   }: TranslateLookup<T>): TranslateSnapshot<T> => {
-    return getReactI18nManager().lookupTranslation<T>(locale, message, options);
+    return getReactI18nCache().lookupTranslation<T>(locale, message, options);
   };
 
   getTranslateManySnapshot = <T extends Translation>(
@@ -184,20 +184,20 @@ export class I18nStore {
     locale,
     id,
   }: DictionaryLookup): DictionaryEntrySnapshot => {
-    return getReactI18nManager().lookupDictionary(locale, id);
+    return getReactI18nCache().lookupDictionary(locale, id);
   };
 
   getDictionaryObjectSnapshot = ({
     locale,
     id,
   }: DictionaryLookup): DictionaryObjectSnapshot => {
-    return getReactI18nManager().lookupDictionaryObj(locale, id);
+    return getReactI18nCache().lookupDictionaryObj(locale, id);
   };
 
   // ===== runtime translation ===== //
 
   translate = <T extends Translation>(lookup: TranslateLookup<T>): void => {
-    getReactI18nManager()
+    getReactI18nCache()
       .lookupTranslationWithFallback(
         lookup.locale,
         lookup.message,
@@ -212,7 +212,7 @@ export class I18nStore {
   };
 
   translateDictionaryEntry = (lookup: DictionaryLookup): void => {
-    getReactI18nManager()
+    getReactI18nCache()
       .lookupDictionaryWithFallback(lookup.locale, lookup.id)
       .then((dictionaryEntry) => {
         if (dictionaryEntry == null) {
@@ -223,7 +223,7 @@ export class I18nStore {
   };
 
   translateDictionaryObject = (lookup: DictionaryLookup): void => {
-    getReactI18nManager()
+    getReactI18nCache()
       .lookupDictionaryObjWithFallback(lookup.locale, lookup.id)
       .then((dictionaryObject) => {
         if (dictionaryObject == null) {

--- a/packages/react-core/src/i18n-store/RuntimeDictionaryScope.ts
+++ b/packages/react-core/src/i18n-store/RuntimeDictionaryScope.ts
@@ -1,7 +1,7 @@
 import { getI18nStore } from './singleton-operations';
 import type { DictionaryLookup, Unsubscribe } from './storeTypes';
 import { getDictionaryListenerKey } from 'gt-i18n/internal';
-import { getReactI18nManager } from '../i18n-cache/singleton-operations';
+import { getReactI18nCache } from '../i18n-cache/singleton-operations';
 
 /**
  * Tracks dictionary lookups discovered by useTranslations callbacks.
@@ -13,7 +13,7 @@ export class RuntimeDictionaryScope {
   private pendingObjects = new Map<string, Unsubscribe>();
 
   translateEntry(lookup: DictionaryLookup) {
-    if (!getReactI18nManager().isDevHotReloadEnabled()) return;
+    if (!getReactI18nCache().isDevHotReloadEnabled()) return;
 
     const key = getDictionaryListenerKey(lookup);
     if (this.pendingEntries.has(key)) return;
@@ -27,7 +27,7 @@ export class RuntimeDictionaryScope {
   }
 
   translateObject(lookup: DictionaryLookup) {
-    if (!getReactI18nManager().isDevHotReloadEnabled()) return;
+    if (!getReactI18nCache().isDevHotReloadEnabled()) return;
 
     const key = getDictionaryListenerKey(lookup);
     if (this.pendingObjects.has(key)) return;

--- a/packages/react-core/src/i18n-store/RuntimeTranslationScope.ts
+++ b/packages/react-core/src/i18n-store/RuntimeTranslationScope.ts
@@ -1,7 +1,7 @@
 import { getI18nStore } from './singleton-operations';
 import type { TranslateLookup, Unsubscribe } from './storeTypes';
 import { getTranslateListenerKey } from 'gt-i18n/internal';
-import { getReactI18nManager } from '../i18n-cache/singleton-operations';
+import { getReactI18nCache } from '../i18n-cache/singleton-operations';
 
 /**
  * Owned by I18nStore, this should not be imported to any other files
@@ -12,7 +12,7 @@ export class RuntimeTranslationScope {
   private pendingKeys = new Map<string, Unsubscribe>();
 
   translate(lookup: TranslateLookup) {
-    if (!getReactI18nManager().isDevHotReloadEnabled()) return;
+    if (!getReactI18nCache().isDevHotReloadEnabled()) return;
 
     const key = getTranslateListenerKey(lookup);
     if (this.pendingKeys.has(key)) return;

--- a/packages/react-core/src/setup/initializeGTSPA.ts
+++ b/packages/react-core/src/setup/initializeGTSPA.ts
@@ -1,8 +1,8 @@
-import { I18nManager, WritableConditionStore } from 'gt-i18n/internal';
+import { I18nCache, WritableConditionStore } from 'gt-i18n/internal';
 import type { WritableConditionStoreParams } from 'gt-i18n/internal';
 import type { Translation } from 'gt-i18n/types';
-import { setReactI18nManager } from '../i18n-cache/singleton-operations';
-import type { ReactI18nManagerParams } from '../i18n-cache/ReactI18nCache';
+import { setReactI18nCache } from '../i18n-cache/singleton-operations';
+import type { ReactI18nCacheParams } from '../i18n-cache/ReactI18nCache';
 import { I18nStore, I18nStoreParams } from '../i18n-store/I18nStore';
 import { setRenderStrategy } from './globals';
 import { setReadonlyConditionStore } from '../condition-store/singleton-operations';
@@ -10,21 +10,19 @@ import { setI18nStore } from '../i18n-store/singleton-operations';
 
 /**
  * Initialize GT for an SPA
- * - i18nManager
+ * - i18nCache
  * - conditionStore
  * - i18nStore
  *
  * @deprecated moved to /react and /react-native
  */
 export function internalInitializeGTSPA(
-  config: I18nStoreParams &
-    ReactI18nManagerParams &
-    WritableConditionStoreParams
+  config: I18nStoreParams & ReactI18nCacheParams & WritableConditionStoreParams
 ): void {
   setRenderStrategy('SPA');
 
-  const i18nManager = new I18nManager<Translation>(config);
-  setReactI18nManager(i18nManager);
+  const i18nCache = new I18nCache<Translation>(config);
+  setReactI18nCache(i18nCache);
 
   const conditionStore = new WritableConditionStore(config);
   setReadonlyConditionStore(conditionStore);

--- a/packages/react-core/src/setup/initializeGTSSR.ts
+++ b/packages/react-core/src/setup/initializeGTSSR.ts
@@ -1,19 +1,19 @@
-import { I18nManager } from 'gt-i18n/internal';
+import { I18nCache } from 'gt-i18n/internal';
 import type { Translation } from 'gt-i18n/types';
-import type { ReactI18nManagerParams } from '../i18n-cache/ReactI18nCache';
+import type { ReactI18nCacheParams } from '../i18n-cache/ReactI18nCache';
 import { setRenderStrategy } from './globals';
-import { setReactI18nManager } from '../i18n-cache/singleton-operations';
+import { setReactI18nCache } from '../i18n-cache/singleton-operations';
 
 /**
  * Initialize GT for a server-side rendered application
- * - i18nManager
+ * - i18nCache
  *
  * ConditionStore and I18nStore are initialized in the provider at request time
  * TODO: auto detect if can find gt.config.json files
  */
-export function internalInitializeGTSSR(config: ReactI18nManagerParams): void {
+export function internalInitializeGTSSR(config: ReactI18nCacheParams): void {
   setRenderStrategy('server-render');
 
-  const i18nManager = new I18nManager<Translation>(config);
-  setReactI18nManager(i18nManager);
+  const i18nCache = new I18nCache<Translation>(config);
+  setReactI18nCache(i18nCache);
 }

--- a/packages/react/src/condition-store/BrowserConditionStore.ts
+++ b/packages/react/src/condition-store/BrowserConditionStore.ts
@@ -1,5 +1,5 @@
 import {
-  getReactI18nManager,
+  getReactI18nCache,
   WritableConditionStoreParams,
 } from '@generaltranslation/react-core/context';
 import { getCookieValue, setCookieValue } from './cookies';
@@ -49,7 +49,7 @@ export class BrowserConditionStore implements WritableConditionStoreInterface {
     this.enableI18nCookieName = config.enableI18nCookieName;
     setCookieValue({
       cookieName: this.localeCookieName,
-      value: getReactI18nManager().determineLocale(config.locale),
+      value: getReactI18nCache().determineLocale(config.locale),
     });
   }
 
@@ -83,7 +83,7 @@ export class BrowserConditionStore implements WritableConditionStoreInterface {
   updateLocale = (locale: LocaleCandidates): void => {
     setCookieValue({
       cookieName: this.localeCookieName,
-      value: getReactI18nManager().determineLocale(locale),
+      value: getReactI18nCache().determineLocale(locale),
     });
   };
 
@@ -114,5 +114,5 @@ export class BrowserConditionStore implements WritableConditionStoreInterface {
 function getBrowserLocale(cookieName: string, getLocale?: GetLocale): string {
   const candidates = readBrowserLocale(cookieName);
   if (getLocale) candidates.push(getLocale());
-  return getReactI18nManager().determineLocale(candidates);
+  return getReactI18nCache().determineLocale(candidates);
 }

--- a/packages/react/src/condition-store/createBrowserConditionStore.ts
+++ b/packages/react/src/condition-store/createBrowserConditionStore.ts
@@ -1,4 +1,4 @@
-import { getReactI18nManager } from '@generaltranslation/react-core/context';
+import { getReactI18nCache } from '@generaltranslation/react-core/context';
 import type { LocaleCandidates } from 'gt-i18n/internal';
 import {
   BrowserConditionStore,
@@ -66,7 +66,7 @@ function determineLocale({
   candidates.push(...readBrowserLocale(localeCookieName));
   if (locale) candidates.push(...locale);
   if (getLocale) candidates.push(getLocale());
-  return getReactI18nManager().determineLocale(candidates);
+  return getReactI18nCache().determineLocale(candidates);
 }
 
 function determineEnableI18n({

--- a/packages/react/src/context.client.ts
+++ b/packages/react/src/context.client.ts
@@ -42,9 +42,14 @@ export {
   mFallback,
   gtFallback,
   getTranslationsSnapshot,
-  getReactI18nManager,
-  setReactI18nManager,
+  getReactI18nCache,
+  setReactI18nCache,
   t,
   // ===== Setup ===== //
   internalInitializeGTSSR as initializeGT,
 } from '@generaltranslation/react-core/context';
+
+/** @deprecated use getReactI18nCache instead */
+export { getReactI18nCache as getReactI18nManager } from '@generaltranslation/react-core/context';
+/** @deprecated use setReactI18nCache instead */
+export { setReactI18nCache as setReactI18nManager } from '@generaltranslation/react-core/context';

--- a/packages/react/src/context.server.ts
+++ b/packages/react/src/context.server.ts
@@ -42,10 +42,15 @@ export {
   mFallback,
   gtFallback,
   getTranslationsSnapshot,
-  getReactI18nManager,
-  setReactI18nManager,
+  getReactI18nCache,
+  setReactI18nCache,
   t,
   // ===== Setup ===== //
   internalInitializeGTSSR as initializeGT,
   internalInitializeGTSPA,
 } from '@generaltranslation/react-core/context';
+
+/** @deprecated use getReactI18nCache instead */
+export { getReactI18nCache as getReactI18nManager } from '@generaltranslation/react-core/context';
+/** @deprecated use setReactI18nCache instead */
+export { setReactI18nCache as setReactI18nManager } from '@generaltranslation/react-core/context';

--- a/packages/react/src/context.types.ts
+++ b/packages/react/src/context.types.ts
@@ -56,6 +56,11 @@ export {
   t,
   // ===== Setup ===== //
   internalInitializeGTSSR as initializeGT,
-  getReactI18nManager,
-  setReactI18nManager,
+  getReactI18nCache,
+  setReactI18nCache,
 } from '@generaltranslation/react-core/context';
+
+/** @deprecated use getReactI18nCache instead */
+export { getReactI18nCache as getReactI18nManager } from '@generaltranslation/react-core/context';
+/** @deprecated use setReactI18nCache instead */
+export { setReactI18nCache as setReactI18nManager } from '@generaltranslation/react-core/context';

--- a/packages/react/src/i18n-cache/BrowserI18nCache.ts
+++ b/packages/react/src/i18n-cache/BrowserI18nCache.ts
@@ -1,8 +1,8 @@
 import type {
-  I18nManagerConstructorParams,
+  I18nCacheConstructorParams,
   TranslationsLoader,
 } from 'gt-i18n/internal/types';
-import { I18nManager } from 'gt-i18n/internal';
+import { I18nCache } from 'gt-i18n/internal';
 import type { HtmlTagOptions } from './types';
 import type { Translation } from 'gt-i18n/types';
 import { DEFAULT_HTML_TAG_OPTIONS } from './constants';
@@ -10,17 +10,16 @@ import { LocalStorageTranslationCache } from './LocalStorageTranslationCache';
 import { createDiagnosticMessage } from 'generaltranslation/internal';
 
 /**
- * The configuration for the BrowserI18nManager
+ * The configuration for the BrowserI18nCache
  */
-export type BrowserI18nManagerParams =
-  I18nManagerConstructorParams<Translation> & {
-    htmlTagOptions?: HtmlTagOptions;
-  };
+export type BrowserI18nCacheParams = I18nCacheConstructorParams<Translation> & {
+  htmlTagOptions?: HtmlTagOptions;
+};
 
 /**
- * I18nManager implementation for Browser.
+ * I18nCache implementation for Browser.
  */
-export class BrowserI18nManager extends I18nManager<Translation> {
+export class BrowserI18nCache extends I18nCache<Translation> {
   /** Customize browser-related behavior */
   private htmlTagOptions?: HtmlTagOptions;
 
@@ -30,7 +29,7 @@ export class BrowserI18nManager extends I18nManager<Translation> {
   /** Whether dev hot reload JSX (Suspense-based <T>) is active */
   private _devHotReloadJsx = false;
 
-  constructor(config: BrowserI18nManagerParams) {
+  constructor(config: BrowserI18nCacheParams) {
     // Must be initialized before super()
     const { htmlTagOptions, ...managerConfig } = config;
     const localStorageCaches: Record<string, LocalStorageTranslationCache> = {};
@@ -43,7 +42,7 @@ export class BrowserI18nManager extends I18nManager<Translation> {
         )
       : config.loadTranslations;
 
-    // Initialize the I18nManager
+    // Initialize the I18nCache
     super({
       ...managerConfig,
       loadTranslations,
@@ -176,7 +175,7 @@ function wrapLoaderWithLocalStorage(
  * @param config - The configuration
  * @returns True if dev hot reload is enabled, false otherwise
  */
-function isDevHotReloadEnabled(config: BrowserI18nManagerParams) {
+function isDevHotReloadEnabled(config: BrowserI18nCacheParams) {
   // TODO: this only works when you've defined a custom loadTranslations function
   // meaning CDN users will not have access to this feature
   return !!(

--- a/packages/react/src/provider/CSRGTProvider.tsx
+++ b/packages/react/src/provider/CSRGTProvider.tsx
@@ -1,5 +1,5 @@
 import {
-  getReactI18nManager,
+  getReactI18nCache,
   InternalGTProvider,
 } from '@generaltranslation/react-core/context';
 import type { SharedGTProviderProps } from './SharedGTProviderProps';
@@ -11,9 +11,9 @@ import { createOrUpdateBrowserConditionStore } from '../condition-store/createBr
  * server-side translations
  */
 export function CSRGTProvider({
-  defaultLocale = getReactI18nManager().getDefaultLocale(),
-  locales = getReactI18nManager().getLocales(),
-  customMapping = getReactI18nManager().getCustomMapping(),
+  defaultLocale = getReactI18nCache().getDefaultLocale(),
+  locales = getReactI18nCache().getLocales(),
+  customMapping = getReactI18nCache().getCustomMapping(),
   ...props
 }: SharedGTProviderProps) {
   // TODO: if a specific translation entry changes, but not the locale, this does not trigger a re-render

--- a/packages/react/src/provider/SSRGTProvider.tsx
+++ b/packages/react/src/provider/SSRGTProvider.tsx
@@ -5,7 +5,7 @@ import {
 } from '../condition-store/singleton-operations';
 import type { SharedGTProviderProps } from './SharedGTProviderProps';
 import {
-  getReactI18nManager,
+  getReactI18nCache,
   InternalGTProvider,
 } from '@generaltranslation/react-core/context';
 
@@ -16,9 +16,9 @@ import {
  * TODO: find some way to enforce this is only imported on the server
  */
 export function SSRGTProvider({
-  defaultLocale = getReactI18nManager().getDefaultLocale(),
-  locales = getReactI18nManager().getLocales(),
-  customMapping = getReactI18nManager().getCustomMapping(),
+  defaultLocale = getReactI18nCache().getDefaultLocale(),
+  locales = getReactI18nCache().getLocales(),
+  customMapping = getReactI18nCache().getCustomMapping(),
   ...props
 }: SharedGTProviderProps) {
   // The condition store may already be created at the module level

--- a/packages/react/src/setup/initializeGTSPA.ts
+++ b/packages/react/src/setup/initializeGTSPA.ts
@@ -4,11 +4,11 @@ import {
   setRenderStrategy,
   I18nStore,
   setI18nStore,
-  setReactI18nManager,
+  setReactI18nCache,
   getReadonlyConditionStoreWithFallback,
 } from '@generaltranslation/react-core/context';
-import { BrowserI18nManager } from '../i18n-cache/BrowserI18nCache';
-import type { BrowserI18nManagerParams } from '../i18n-cache/BrowserI18nCache';
+import { BrowserI18nCache } from '../i18n-cache/BrowserI18nCache';
+import type { BrowserI18nCacheParams } from '../i18n-cache/BrowserI18nCache';
 import {
   createOrUpdateBrowserConditionStore,
   CreateBrowserConditionStoreParams,
@@ -16,7 +16,7 @@ import {
 
 /**
  * Initialize GT for an SPA
- * - i18nManager
+ * - i18nCache
  * - conditionStore
  * - i18nStore
  *
@@ -24,13 +24,13 @@ import {
  */
 export async function initializeGTSPA(
   config: I18nStoreParams &
-    BrowserI18nManagerParams &
+    BrowserI18nCacheParams &
     CreateBrowserConditionStoreParams
 ) {
   setRenderStrategy('SPA');
 
-  const i18nManager = new BrowserI18nManager(config);
-  setReactI18nManager(i18nManager);
+  const i18nCache = new BrowserI18nCache(config);
+  setReactI18nCache(i18nCache);
 
   createOrUpdateBrowserConditionStore(config);
 

--- a/packages/tanstack-start/src/index.client.ts
+++ b/packages/tanstack-start/src/index.client.ts
@@ -1,10 +1,10 @@
 'use client';
 
-import { I18nManager } from 'gt-i18n/internal';
+import { I18nCache } from 'gt-i18n/internal';
 import type { Translation } from 'gt-i18n/types';
 import {
-  setReactI18nManager,
-  type ReactI18nManagerParams,
+  setReactI18nCache,
+  type ReactI18nCacheParams,
 } from '@generaltranslation/react-core/context';
 
 export {

--- a/packages/tanstack-start/src/provider/GTProvider.tsx
+++ b/packages/tanstack-start/src/provider/GTProvider.tsx
@@ -3,7 +3,7 @@ import { GTProvider as GTReactProvider } from 'gt-react';
 import { GTProviderProps } from './types';
 import { isSSREnabled } from './utils/isSSREnabled';
 import { determineProviderLocale } from './utils/determineProviderLocale';
-import { getI18nManager } from 'gt-i18n/internal';
+import { getI18nCache } from 'gt-i18n/internal';
 
 /**
  * Provides General Translation context to its children, which can then access `useGT`, `useLocale`, and `useDefaultLocale`.
@@ -28,18 +28,16 @@ import { getI18nManager } from 'gt-i18n/internal';
  * @returns {JSX.Element} The provider component for General Translation context.
  */
 export function GTProvider(props: GTProviderProps): React.ReactNode {
-  const i18nManager = getI18nManager();
+  const i18nCache = getI18nCache();
   return (
     <GTReactProvider
       ssr={isSSREnabled()}
-      defaultLocale={i18nManager.getDefaultLocale()}
-      locales={i18nManager.getLocales()}
-      customMapping={i18nManager.getCustomMapping()}
-      enableI18n={i18nManager.isTranslationEnabled()}
-      loadTranslations={(locale: string) =>
-        i18nManager.loadTranslations(locale)
-      }
-      _versionId={i18nManager.getVersionId()}
+      defaultLocale={i18nCache.getDefaultLocale()}
+      locales={i18nCache.getLocales()}
+      customMapping={i18nCache.getCustomMapping()}
+      enableI18n={i18nCache.isTranslationEnabled()}
+      loadTranslations={(locale: string) => i18nCache.loadTranslations(locale)}
+      _versionId={i18nCache.getVersionId()}
       {...props}
       reloadOnLocaleUpdate={true}
       locale={determineProviderLocale(props)}


### PR DESCRIPTION
Stack PR 6/7.\n\nSummary:\n- Updates gt-node to consume I18nCache/getI18nCache/setI18nCache.\n- Updates async-i18n-cache internal consumers and tests.\n- Keeps deprecated compatibility aliases on gt-node/internal until PR 7.\n\nVerification:\n- pnpm --filter gt-node test passes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1483"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782425453&installation_id=127936663&pr_number=1483&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1483&signature=0b2928c1ba0a340ef4ec247f3aa6e758345a6eca4fde820fa50cec800b33a59f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR renames the `I18nManager`/`getI18nManager`/`setI18nManager` symbols to `I18nCache`/`getI18nCache`/`setI18nCache` throughout the `gt-node` package, with deprecated re-export aliases kept in `internal.ts` for backwards compatibility until the next PR in the stack.

- **`AsyncConditionStore.ts` / `getRequestLocale.ts` / `initializeGT.ts`**: Purely mechanical rename of import and local variable names; no logic changes.
- **`internal.ts`**: Exports the canonical new names and adds `@deprecated` aliases so existing consumers of the old names continue to work.
- **Test file**: Updated to use `I18nCache`/`setI18nCache` and adds `setTestCache()` to `afterEach` to reset the module-level singleton after each test, addressing the prior isolation concern.
- **`.size-limit.json`**: Updates the `gt-tanstack-start` size-limit path from `index.esm.min.mjs` to `index.client.mjs` to match the updated build output.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all changes are purely mechanical symbol renames with no logic or behavioral modifications.

Every change is a consistent find-and-replace of I18nManager → I18nCache across four files, with backwards-compatible deprecated aliases preserved in the public internal.ts surface. The test file correctly resets the global cache singleton in afterEach. No logic paths were altered.

No files require special attention.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/node/src/async-i18n-cache/AsyncConditionStore.ts | Renames three getI18nManager() call sites to getI18nCache(); no logic changes. |
| packages/node/src/async-i18n-cache/__tests__/AsyncConditionStore.test.ts | Switches to I18nCache/setI18nCache imports and adds setTestCache() to afterEach to reset the global singleton, addressing the previous isolation concern. |
| packages/node/src/helpers/getRequestLocale.ts | Renames getI18nManager import and local variable to getI18nCache/i18nCache; purely mechanical rename. |
| packages/node/src/internal.ts | Exports new I18nCache/getI18nCache/setI18nCache names and adds deprecated aliases for the old I18nManager names for backwards compatibility. |
| packages/node/src/setup/initializeGT.ts | Replaces I18nManager/setI18nManager with I18nCache/setI18nCache; no behavioral change. |
| .size-limit.json | Updates gt-tanstack-start size-limit path from index.esm.min.mjs to index.client.mjs to match the updated build output filename. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[initializeGT] -->|creates| B[I18nCache]
    A -->|calls| C[setI18nCache - module singleton]
    A -->|creates| D[AsyncConditionStore]
    A -->|calls| E[setAsyncConditionStore]

    F[getRequestLocale] -->|calls| G[getI18nCache]
    G --> C

    H[AsyncConditionStore.run] -->|calls| G
    I[AsyncConditionStore.getLocale] -->|calls| G

    J[internal.ts exports] --> K[I18nCache]
    J --> L[getI18nCache]
    J --> M[setI18nCache]
    J --> N["@deprecated I18nManager alias"]
    J --> O["@deprecated getI18nManager alias"]
    J --> P["@deprecated setI18nManager alias"]
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/node/src/async-i18n-cache/__tests__/AsyncConditionStore.test.ts`, line 6-9 ([link](https://github.com/generaltranslation/gt/blob/452f5a902271a9e154ef839156e9e232bc26e271/packages/node/src/async-i18n-cache/__tests__/AsyncConditionStore.test.ts#L6-L9)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Global cache singleton not reset between tests**

   `setI18nCache` writes to a module-level singleton, and `afterEach` only stubs env vars and mocks — it never resets the cache. Every test here starts with `setTestCache()`, so current tests are isolated from each other, but any future test added without that call will silently inherit whatever cache was set by a previous test. Consider adding a cache-reset call (e.g. `setI18nCache(null)` or a dedicated `resetI18nCache()`) to `afterEach` if the upstream module exposes one, to guard against unintended ordering dependencies as the suite grows.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/node/src/async-i18n-cache/__tests__/AsyncConditionStore.test.ts
   Line: 6-9

   Comment:
   **Global cache singleton not reset between tests**

   `setI18nCache` writes to a module-level singleton, and `afterEach` only stubs env vars and mocks — it never resets the cache. Every test here starts with `setTestCache()`, so current tests are isolated from each other, but any future test added without that call will silently inherit whatever cache was set by a previous test. Consider adding a cache-reset call (e.g. `setI18nCache(null)` or a dedicated `resetI18nCache()`) to `afterEach` if the upstream module exposes one, to guard against unintended ordering dependencies as the suite grows.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fnode%2Fsrc%2Fasync-i18n-cache%2F__tests__%2FAsyncConditionStore.test.ts%0ALine%3A%206-9%0A%0AComment%3A%0A**Global%20cache%20singleton%20not%20reset%20between%20tests**%0A%0A%60setI18nCache%60%20writes%20to%20a%20module-level%20singleton%2C%20and%20%60afterEach%60%20only%20stubs%20env%20vars%20and%20mocks%20%E2%80%94%20it%20never%20resets%20the%20cache.%20Every%20test%20here%20starts%20with%20%60setTestCache%28%29%60%2C%20so%20current%20tests%20are%20isolated%20from%20each%20other%2C%20but%20any%20future%20test%20added%20without%20that%20call%20will%20silently%20inherit%20whatever%20cache%20was%20set%20by%20a%20previous%20test.%20Consider%20adding%20a%20cache-reset%20call%20%28e.g.%20%60setI18nCache%28null%29%60%20or%20a%20dedicated%20%60resetI18nCache%28%29%60%29%20to%20%60afterEach%60%20if%20the%20upstream%20module%20exposes%20one%2C%20to%20guard%20against%20unintended%20ordering%20dependencies%20as%20the%20suite%20grows.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=generaltranslation%2Fgt&pr=1483&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fcodex%2Fi18n-cache-node%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fcodex%2Fi18n-cache-node%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fnode%2Fsrc%2Fasync-i18n-cache%2F__tests__%2FAsyncConditionStore.test.ts%0ALine%3A%206-9%0A%0AComment%3A%0A**Global%20cache%20singleton%20not%20reset%20between%20tests**%0A%0A%60setI18nCache%60%20writes%20to%20a%20module-level%20singleton%2C%20and%20%60afterEach%60%20only%20stubs%20env%20vars%20and%20mocks%20%E2%80%94%20it%20never%20resets%20the%20cache.%20Every%20test%20here%20starts%20with%20%60setTestCache%28%29%60%2C%20so%20current%20tests%20are%20isolated%20from%20each%20other%2C%20but%20any%20future%20test%20added%20without%20that%20call%20will%20silently%20inherit%20whatever%20cache%20was%20set%20by%20a%20previous%20test.%20Consider%20adding%20a%20cache-reset%20call%20%28e.g.%20%60setI18nCache%28null%29%60%20or%20a%20dedicated%20%60resetI18nCache%28%29%60%29%20to%20%60afterEach%60%20if%20the%20upstream%20module%20exposes%20one%2C%20to%20guard%20against%20unintended%20ordering%20dependencies%20as%20the%20suite%20grows.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["test: reset node i18n cache singleton"](https://github.com/generaltranslation/gt/commit/01628ad1eba52e74aa3a7c279783a09023755bf5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34051398)</sub>

<!-- /greptile_comment -->