### PR TITLE
feat: add i18n config singleton

### DIFF
--- a/packages/i18n/src/i18n-config/I18nConfig.ts
+++ b/packages/i18n/src/i18n-config/I18nConfig.ts
@@ -11,12 +11,14 @@ export type I18nConfigParams = {
 export class I18nConfig extends LocaleConfig {
   constructor({
     defaultLocale = libraryDefaultLocale,
-    locales = [libraryDefaultLocale],
+    locales,
     customMapping,
   }: I18nConfigParams = {}) {
+    const resolvedLocales = locales ?? [defaultLocale];
+
     super({
       defaultLocale,
-      locales: Array.from(new Set([defaultLocale, ...locales])),
+      locales: Array.from(new Set([defaultLocale, ...resolvedLocales])),
       customMapping: customMapping || {},
     });
   }

--- a/packages/i18n/src/i18n-config/I18nConfig.ts
+++ b/packages/i18n/src/i18n-config/I18nConfig.ts
@@ -1,6 +1,7 @@
 import { LocaleConfig } from '@generaltranslation/format';
 import type { CustomMapping } from '@generaltranslation/format/types';
 import { libraryDefaultLocale } from 'generaltranslation/internal';
+import { validateI18nConfigParams } from './validation';
 
 export type I18nConfigParams = {
   defaultLocale?: string;
@@ -11,14 +12,14 @@ export type I18nConfigParams = {
 export class I18nConfig extends LocaleConfig {
   constructor({
     defaultLocale = libraryDefaultLocale,
-    locales,
+    locales = [defaultLocale],
     customMapping,
   }: I18nConfigParams = {}) {
-    const resolvedLocales = locales ?? [defaultLocale];
+    validateI18nConfigParams({ defaultLocale, locales, customMapping });
 
     super({
       defaultLocale,
-      locales: Array.from(new Set([defaultLocale, ...resolvedLocales])),
+      locales: Array.from(new Set([defaultLocale, ...locales])),
       customMapping: customMapping || {},
     });
   }

--- a/packages/i18n/src/i18n-config/I18nConfig.ts
+++ b/packages/i18n/src/i18n-config/I18nConfig.ts
@@ -1,0 +1,35 @@
+import { LocaleConfig } from '@generaltranslation/format';
+import type { CustomMapping } from '@generaltranslation/format/types';
+import { libraryDefaultLocale } from 'generaltranslation/internal';
+
+export type I18nConfigParams = {
+  defaultLocale?: string;
+  locales?: string[];
+  customMapping?: CustomMapping;
+};
+
+export class I18nConfig extends LocaleConfig {
+  constructor({
+    defaultLocale = libraryDefaultLocale,
+    locales = [libraryDefaultLocale],
+    customMapping,
+  }: I18nConfigParams = {}) {
+    super({
+      defaultLocale,
+      locales: Array.from(new Set([defaultLocale, ...locales])),
+      customMapping: customMapping || {},
+    });
+  }
+
+  getDefaultLocale(): string {
+    return this.defaultLocale;
+  }
+
+  getLocales(): string[] {
+    return this.locales;
+  }
+
+  getCustomMapping(): CustomMapping {
+    return this.customMapping || {};
+  }
+}

--- a/packages/i18n/src/i18n-config/I18nConfig.ts
+++ b/packages/i18n/src/i18n-config/I18nConfig.ts
@@ -7,15 +7,27 @@ export type I18nConfigParams = {
   defaultLocale?: string;
   locales?: string[];
   customMapping?: CustomMapping;
+  projectId?: string;
+  devApiKey?: string;
+  apiKey?: string;
+  cacheUrl?: string | null;
+  runtimeUrl?: string | null;
 };
 
 export class I18nConfig extends LocaleConfig {
-  constructor({
-    defaultLocale = libraryDefaultLocale,
-    locales = [defaultLocale],
-    customMapping,
-  }: I18nConfigParams = {}) {
-    validateI18nConfigParams({ defaultLocale, locales, customMapping });
+  constructor(params: I18nConfigParams = {}) {
+    const {
+      defaultLocale = libraryDefaultLocale,
+      locales = [defaultLocale],
+      customMapping,
+    } = params;
+
+    validateI18nConfigParams({
+      ...params,
+      defaultLocale,
+      locales,
+      customMapping,
+    });
 
     super({
       defaultLocale,

--- a/packages/i18n/src/i18n-config/__tests__/I18nConfig.test.ts
+++ b/packages/i18n/src/i18n-config/__tests__/I18nConfig.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from 'vitest';
+import { I18nConfig } from '../I18nConfig';
+
+describe('I18nConfig', () => {
+  it('defaults locales to the resolved default locale', () => {
+    const config = new I18nConfig({ defaultLocale: 'fr' });
+
+    expect(config.getLocales()).toEqual(['fr']);
+  });
+
+  it('validates configured locales', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(
+      () =>
+        new I18nConfig({
+          defaultLocale: 'invalid locale',
+        })
+    ).toThrow('Invalid I18nConfig locale configuration');
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Locale "invalid locale" is not valid')
+    );
+
+    errorSpy.mockRestore();
+  });
+});

--- a/packages/i18n/src/i18n-config/__tests__/I18nConfig.test.ts
+++ b/packages/i18n/src/i18n-config/__tests__/I18nConfig.test.ts
@@ -8,17 +8,28 @@ describe('I18nConfig', () => {
     expect(config.getLocales()).toEqual(['fr']);
   });
 
-  it('validates configured locales', () => {
+  it('skips locale validation when GT services are disabled', () => {
+    const config = new I18nConfig({
+      defaultLocale: 'invalid-locale',
+      cacheUrl: null,
+      runtimeUrl: null,
+    });
+
+    expect(config.getDefaultLocale()).toBe('invalid-locale');
+  });
+
+  it('validates configured locales when GT services are enabled', () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     expect(
       () =>
         new I18nConfig({
-          defaultLocale: 'invalid locale',
+          defaultLocale: 'invalid-locale',
+          projectId: 'test-project',
         })
     ).toThrow('Invalid I18nConfig locale configuration');
     expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Locale "invalid locale" is not valid')
+      expect.stringContaining('Locale "invalid-locale" is not valid')
     );
 
     errorSpy.mockRestore();

--- a/packages/i18n/src/i18n-config/__tests__/I18nConfig.test.ts
+++ b/packages/i18n/src/i18n-config/__tests__/I18nConfig.test.ts
@@ -34,4 +34,30 @@ describe('I18nConfig', () => {
 
     errorSpy.mockRestore();
   });
+
+  it('validates custom mapping locales when GT services are enabled', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(
+      () =>
+        new I18nConfig({
+          defaultLocale: 'en',
+          projectId: 'test-project',
+          customMapping: {
+            invalidStringMapping: 'invalid-locale',
+            invalidObjectMapping: {
+              code: 'invalid-object-locale',
+            },
+          },
+        })
+    ).toThrow('Invalid I18nConfig locale configuration');
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Locale "invalid-locale" is not valid')
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Locale "invalid-object-locale" is not valid')
+    );
+
+    errorSpy.mockRestore();
+  });
 });

--- a/packages/i18n/src/i18n-config/__tests__/singleton-operations.test.ts
+++ b/packages/i18n/src/i18n-config/__tests__/singleton-operations.test.ts
@@ -11,7 +11,7 @@ describe('i18n config singleton operations', () => {
 
     expect(isI18nConfigInitialized()).toBe(false);
     expect(() => getI18nConfig()).toThrow(
-      'getI18nConfig(): I18nConfig was not initialized.'
+      'Cannot read I18nConfig before it has been initialized'
     );
     expect(isI18nConfigInitialized()).toBe(false);
   });

--- a/packages/i18n/src/i18n-config/__tests__/singleton-operations.test.ts
+++ b/packages/i18n/src/i18n-config/__tests__/singleton-operations.test.ts
@@ -1,0 +1,31 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('i18n config singleton operations', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('throws when the config has not been initialized', async () => {
+    const { getI18nConfig, isI18nConfigInitialized } =
+      await import('../singleton-operations');
+
+    expect(isI18nConfigInitialized()).toBe(false);
+    expect(() => getI18nConfig()).toThrow(
+      'getI18nConfig(): I18nConfig was not initialized.'
+    );
+    expect(isI18nConfigInitialized()).toBe(false);
+  });
+
+  it('returns the initialized config', async () => {
+    const { getI18nConfig, initializeI18nConfig, isI18nConfigInitialized } =
+      await import('../singleton-operations');
+
+    const config = initializeI18nConfig({
+      defaultLocale: 'fr',
+    });
+
+    expect(isI18nConfigInitialized()).toBe(true);
+    expect(getI18nConfig()).toBe(config);
+    expect(getI18nConfig().getLocales()).toEqual(['fr']);
+  });
+});

--- a/packages/i18n/src/i18n-config/singleton-operations.ts
+++ b/packages/i18n/src/i18n-config/singleton-operations.ts
@@ -1,0 +1,34 @@
+import { libraryDefaultLocale } from 'generaltranslation/internal';
+import logger from '../logs/logger';
+import { I18nConfig, type I18nConfigParams } from './I18nConfig';
+
+let i18nConfig: I18nConfig | undefined = undefined;
+
+export function getI18nConfig(): I18nConfig {
+  if (!i18nConfig) {
+    logger.warn(
+      'getI18nConfig(): I18nConfig was not initialized. Falling back to the default locale until initializeGT() configures locales.'
+    );
+    i18nConfig = new I18nConfig({
+      defaultLocale: libraryDefaultLocale,
+      locales: [libraryDefaultLocale],
+    });
+  }
+  return i18nConfig;
+}
+
+export function setI18nConfig(nextI18nConfig: I18nConfig): void {
+  i18nConfig = nextI18nConfig;
+}
+
+export function initializeI18nConfig(
+  params: I18nConfigParams = {}
+): I18nConfig {
+  const nextI18nConfig = new I18nConfig(params);
+  setI18nConfig(nextI18nConfig);
+  return nextI18nConfig;
+}
+
+export function isI18nConfigInitialized(): boolean {
+  return i18nConfig !== undefined;
+}

--- a/packages/i18n/src/i18n-config/singleton-operations.ts
+++ b/packages/i18n/src/i18n-config/singleton-operations.ts
@@ -1,12 +1,11 @@
+import { createDiagnosticMessage } from 'generaltranslation/internal';
 import { I18nConfig, type I18nConfigParams } from './I18nConfig';
 
 let i18nConfig: I18nConfig | undefined = undefined;
 
 export function getI18nConfig(): I18nConfig {
   if (!i18nConfig) {
-    throw new Error(
-      'getI18nConfig(): I18nConfig was not initialized. Call initializeGT() before reading locale config.'
-    );
+    throw new Error(getI18nConfigNotInitializedError());
   }
   return i18nConfig;
 }
@@ -25,4 +24,14 @@ export function initializeI18nConfig(
 
 export function isI18nConfigInitialized(): boolean {
   return i18nConfig !== undefined;
+}
+
+function getI18nConfigNotInitializedError(): string {
+  return createDiagnosticMessage({
+    source: 'gt-i18n',
+    severity: 'Error',
+    whatHappened: 'Cannot read I18nConfig before it has been initialized',
+    why: 'the internal I18nConfig singleton is unavailable',
+    fix: 'Call initializeGT() before reading locale config.',
+  });
 }

--- a/packages/i18n/src/i18n-config/singleton-operations.ts
+++ b/packages/i18n/src/i18n-config/singleton-operations.ts
@@ -1,18 +1,12 @@
-import { libraryDefaultLocale } from 'generaltranslation/internal';
-import logger from '../logs/logger';
 import { I18nConfig, type I18nConfigParams } from './I18nConfig';
 
 let i18nConfig: I18nConfig | undefined = undefined;
 
 export function getI18nConfig(): I18nConfig {
   if (!i18nConfig) {
-    logger.warn(
-      'getI18nConfig(): I18nConfig was not initialized. Falling back to the default locale until initializeGT() configures locales.'
+    throw new Error(
+      'getI18nConfig(): I18nConfig was not initialized. Call initializeGT() before reading locale config.'
     );
-    i18nConfig = new I18nConfig({
-      defaultLocale: libraryDefaultLocale,
-      locales: [libraryDefaultLocale],
-    });
   }
   return i18nConfig;
 }

--- a/packages/i18n/src/i18n-config/validation.ts
+++ b/packages/i18n/src/i18n-config/validation.ts
@@ -13,18 +13,25 @@ export function validateI18nConfigParams(params: I18nConfigParams): void {
   }
 
   const invalidLocales = getInvalidLocales(params);
+  const invalidCustomMappingLocales = getInvalidCustomMappingLocales(params);
+  const invalidLocaleConfig = [
+    ...invalidLocales,
+    ...invalidCustomMappingLocales,
+  ];
 
-  invalidLocales.forEach((locale) => {
+  invalidLocaleConfig.forEach((locale) => {
     logger.error(`I18nConfig: ${getInvalidLocaleMessage(locale)}`);
   });
 
-  if (invalidLocales.length > 0) {
+  if (invalidLocaleConfig.length > 0) {
     throw new Error(
       createDiagnosticMessage({
         source: 'gt-i18n',
         severity: 'Error',
         whatHappened: 'Invalid I18nConfig locale configuration',
-        details: invalidLocales.map((locale) => `Invalid locale: ${locale}`),
+        details: invalidLocaleConfig.map(
+          (locale) => `Invalid locale: ${locale}`
+        ),
         fix: 'Use valid BCP 47 locale codes or add custom mappings.',
       })
     );
@@ -59,6 +66,15 @@ function getInvalidLocales({
   return Array.from(localesToValidate).filter(
     (locale) => !isValidLocale(locale, customMapping)
   );
+}
+
+function getInvalidCustomMappingLocales({
+  customMapping,
+}: I18nConfigParams): string[] {
+  return Object.values(customMapping || {}).flatMap((value) => {
+    const locale = typeof value === 'string' ? value : value.code;
+    return locale && !isValidLocale(locale) ? [locale] : [];
+  });
 }
 
 function getInvalidLocaleMessage(locale: string): string {

--- a/packages/i18n/src/i18n-config/validation.ts
+++ b/packages/i18n/src/i18n-config/validation.ts
@@ -1,0 +1,55 @@
+import { isValidLocale } from '@generaltranslation/format';
+import type { CustomMapping } from '@generaltranslation/format/types';
+import { createDiagnosticMessage } from 'generaltranslation/internal';
+import logger from '../logs/logger';
+import type { I18nConfigParams } from './I18nConfig';
+
+export function validateI18nConfigParams({
+  defaultLocale,
+  locales,
+  customMapping,
+}: I18nConfigParams): void {
+  const invalidLocales = getInvalidLocales({
+    defaultLocale,
+    locales,
+    customMapping,
+  });
+
+  invalidLocales.forEach((locale) => {
+    logger.error(`I18nConfig: ${getInvalidLocaleMessage(locale)}`);
+  });
+
+  if (invalidLocales.length > 0) {
+    throw new Error(
+      createDiagnosticMessage({
+        source: 'gt-i18n',
+        severity: 'Error',
+        whatHappened: 'Invalid I18nConfig locale configuration',
+        details: invalidLocales.map((locale) => `Invalid locale: ${locale}`),
+        fix: 'Use valid BCP 47 locale codes or add custom mappings.',
+      })
+    );
+  }
+}
+
+function getInvalidLocales({
+  defaultLocale,
+  locales,
+  customMapping,
+}: I18nConfigParams): string[] {
+  const localesToValidate = new Set([
+    ...(defaultLocale ? [defaultLocale] : []),
+    ...(locales || []),
+  ]);
+
+  return Array.from(localesToValidate).filter(
+    (locale) => !isValidLocale(locale, customMapping)
+  );
+}
+
+function getInvalidLocaleMessage(locale: string): string {
+  return createDiagnosticMessage({
+    whatHappened: `Locale "${locale}" is not valid`,
+    fix: 'Use a valid BCP 47 locale code or add a custom mapping',
+  });
+}

--- a/packages/i18n/src/i18n-config/validation.ts
+++ b/packages/i18n/src/i18n-config/validation.ts
@@ -1,19 +1,18 @@
 import { isValidLocale } from '@generaltranslation/format';
-import type { CustomMapping } from '@generaltranslation/format/types';
-import { createDiagnosticMessage } from 'generaltranslation/internal';
+import {
+  createDiagnosticMessage,
+  defaultCacheUrl,
+  defaultRuntimeApiUrl,
+} from 'generaltranslation/internal';
 import logger from '../logs/logger';
 import type { I18nConfigParams } from './I18nConfig';
 
-export function validateI18nConfigParams({
-  defaultLocale,
-  locales,
-  customMapping,
-}: I18nConfigParams): void {
-  const invalidLocales = getInvalidLocales({
-    defaultLocale,
-    locales,
-    customMapping,
-  });
+export function validateI18nConfigParams(params: I18nConfigParams): void {
+  if (!getGTServicesEnabled(params)) {
+    return;
+  }
+
+  const invalidLocales = getInvalidLocales(params);
 
   invalidLocales.forEach((locale) => {
     logger.error(`I18nConfig: ${getInvalidLocaleMessage(locale)}`);
@@ -30,6 +29,21 @@ export function validateI18nConfigParams({
       })
     );
   }
+}
+
+function getGTServicesEnabled({
+  projectId,
+  devApiKey,
+  apiKey,
+  cacheUrl,
+  runtimeUrl,
+}: I18nConfigParams): boolean {
+  return (
+    ((cacheUrl === undefined || cacheUrl === defaultCacheUrl) && !!projectId) ||
+    ((runtimeUrl === undefined || runtimeUrl === defaultRuntimeApiUrl) &&
+      !!projectId &&
+      !!(devApiKey || apiKey))
+  );
 }
 
 function getInvalidLocales({


### PR DESCRIPTION
## Summary

- Add `I18nConfig` under `packages/i18n/src/i18n-config` as a `LocaleConfig` subclass.
- Add singleton operations for getting, setting, initializing, and checking initialization state.
- Do not change existing validation behavior in this PR.
- Do not add locale standardization beyond the existing `LocaleConfig` behavior.
- Do not add an `i18n-config/index.ts` barrel in this PR.
- Keep the new config singleton unused by existing runtime code so the introduction is isolated.

## Stack

1. This PR: introduce the unused `I18nConfig` class and singleton operations.
2. Next: initialize `I18nConfig` alongside existing cache/store setup.
3. Later: migrate cache, condition stores, remaining consumers, and helper consolidation in smaller PRs.

## Verification

- `pnpm --filter gt-i18n build`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Introduces the `I18nConfig` class (a `LocaleConfig` subclass) and its module-level singleton operations (`getI18nConfig`, `setI18nConfig`, `initializeI18nConfig`, `isI18nConfigInitialized`) as an isolated, as-yet-unwired foundation for the upcoming config migration.

- **`I18nConfig`** validates all locales via BCP 47 / `customMapping`, deduplicates `defaultLocale` into the `locales` set via `Array.from(new Set([...]))`, and exposes typed getters over the `LocaleConfig` base.
- **Singleton operations** correctly throw on uninitialized access (no lazy fallback), keeping `isI18nConfigInitialized()` honest; the previous concern about a poisoned initialization sentinel is resolved.
- **`initializeI18nConfig`** has no guard against double-initialization — silently overwrites the singleton — which is low-risk now but worth hardening before this is wired into `initializeGT()`.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the new code is unused by existing runtime paths and the singleton correctly throws rather than returning a stale fallback.

All five files are new additions with no changes to existing runtime behaviour. The singleton guard is correctly implemented (throw on uninitialized access), validation logic is straightforward, and tests properly isolate module state with vi.resetModules(). The only notable gap — no double-init warning in initializeI18nConfig — is low-risk while the singleton remains unwired.

No files require special attention, though singleton-operations.ts should be hardened with a double-initialization warning before initializeI18nConfig is wired into initializeGT().
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/i18n/src/i18n-config/I18nConfig.ts | Introduces I18nConfig extending LocaleConfig; constructor correctly deduplicates defaultLocale into locales, validates before super(), and the destructuring default `locales = [defaultLocale]` is well-formed. |
| packages/i18n/src/i18n-config/singleton-operations.ts | Clean singleton pattern; getI18nConfig() correctly throws instead of returning a lazy fallback, keeping isI18nConfigInitialized() honest. initializeI18nConfig silently allows double-initialization without warning. |
| packages/i18n/src/i18n-config/validation.ts | Validates all locales (defaultLocale + locales) against BCP 47 / customMapping, logs per-locale errors before throwing a single aggregated diagnostic error. |
| packages/i18n/src/i18n-config/__tests__/I18nConfig.test.ts | Tests default-locale seeding and invalid-locale error path; does not cover explicit locales array or customMapping, but adequate for the PR scope. |
| packages/i18n/src/i18n-config/__tests__/singleton-operations.test.ts | Correctly uses vi.resetModules() + dynamic imports to isolate singleton state per test; covers uninitialized throw and successful init paths. |

</details>

</details>

<details><summary><h3>Class Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
classDiagram
    class LocaleConfig {
        +readonly defaultLocale: string
        +readonly locales: string[]
        +readonly customMapping?: CustomMapping
        +getLocaleName(locale)
        +determineLocale(locales, approvedLocales)
        +isValidLocale(locale)
        +requiresTranslation(target, source, approved)
    }

    class I18nConfig {
        +constructor(params: I18nConfigParams)
        +getDefaultLocale() string
        +getLocales() string[]
        +getCustomMapping() CustomMapping
    }

    class SingletonOps {
        -i18nConfig: I18nConfig | undefined
        +getI18nConfig() I18nConfig
        +setI18nConfig(config) void
        +initializeI18nConfig(params) I18nConfig
        +isI18nConfigInitialized() boolean
    }

    class validation {
        +validateI18nConfigParams(params) void
        -getInvalidLocales(params) string[]
        -getInvalidLocaleMessage(locale) string
    }

    LocaleConfig <|-- I18nConfig : extends
    I18nConfig ..> validation : calls validateI18nConfigParams
    SingletonOps --> I18nConfig : creates / holds
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fi18n%2Fsrc%2Fi18n-config%2Fsingleton-operations.ts%3A17-23%0A%60initializeI18nConfig%60%20silently%20replaces%20an%20already-initialized%20singleton%20without%20any%20warning.%20When%20this%20is%20later%20wired%20into%20%60initializeGT%28%29%60%2C%20accidental%20double-calls%20%28e.g.%2C%20from%20HMR%2C%20duplicate%20module%20evaluation%2C%20or%20eager%20test%20imports%29%20will%20silently%20produce%20two%20distinct%20%60I18nConfig%60%20objects%20%E2%80%94%20callers%20that%20hold%20a%20reference%20from%20the%20first%20call%20continue%20using%20stale%20config%20while%20new%20callers%20get%20a%20fresh%20one.%20A%20%60console.warn%60%20or%20early-return%20guard%20would%20surface%20this%20at%20the%20call%20site%20rather%20than%20during%20confusing%20downstream%20behaviour.%0A%0A%60%60%60suggestion%0Aexport%20function%20initializeI18nConfig%28%0A%20%20params%3A%20I18nConfigParams%20%3D%20%7B%7D%0A%29%3A%20I18nConfig%20%7B%0A%20%20if%20%28i18nConfig%20!%3D%3D%20undefined%29%20%7B%0A%20%20%20%20logger.warn%28%0A%20%20%20%20%20%20'initializeI18nConfig%28%29%3A%20I18nConfig%20has%20already%20been%20initialized.%20Overwriting%20the%20existing%20config.'%0A%20%20%20%20%29%3B%0A%20%20%7D%0A%20%20const%20nextI18nConfig%20%3D%20new%20I18nConfig%28params%29%3B%0A%20%20setI18nConfig%28nextI18nConfig%29%3B%0A%20%20return%20nextI18nConfig%3B%0A%7D%0A%60%60%60%0A%0A&repo=generaltranslation%2Fgt&pr=1488&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fodysseus%2Fadd-i18n-config-class%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fodysseus%2Fadd-i18n-config-class%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fi18n%2Fsrc%2Fi18n-config%2Fsingleton-operations.ts%3A17-23%0A%60initializeI18nConfig%60%20silently%20replaces%20an%20already-initialized%20singleton%20without%20any%20warning.%20When%20this%20is%20later%20wired%20into%20%60initializeGT%28%29%60%2C%20accidental%20double-calls%20%28e.g.%2C%20from%20HMR%2C%20duplicate%20module%20evaluation%2C%20or%20eager%20test%20imports%29%20will%20silently%20produce%20two%20distinct%20%60I18nConfig%60%20objects%20%E2%80%94%20callers%20that%20hold%20a%20reference%20from%20the%20first%20call%20continue%20using%20stale%20config%20while%20new%20callers%20get%20a%20fresh%20one.%20A%20%60console.warn%60%20or%20early-return%20guard%20would%20surface%20this%20at%20the%20call%20site%20rather%20than%20during%20confusing%20downstream%20behaviour.%0A%0A%60%60%60suggestion%0Aexport%20function%20initializeI18nConfig%28%0A%20%20params%3A%20I18nConfigParams%20%3D%20%7B%7D%0A%29%3A%20I18nConfig%20%7B%0A%20%20if%20%28i18nConfig%20!%3D%3D%20undefined%29%20%7B%0A%20%20%20%20logger.warn%28%0A%20%20%20%20%20%20'initializeI18nConfig%28%29%3A%20I18nConfig%20has%20already%20been%20initialized.%20Overwriting%20the%20existing%20config.'%0A%20%20%20%20%29%3B%0A%20%20%7D%0A%20%20const%20nextI18nConfig%20%3D%20new%20I18nConfig%28params%29%3B%0A%20%20setI18nConfig%28nextI18nConfig%29%3B%0A%20%20return%20nextI18nConfig%3B%0A%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/i18n/src/i18n-config/singleton-operations.ts:17-23
`initializeI18nConfig` silently replaces an already-initialized singleton without any warning. When this is later wired into `initializeGT()`, accidental double-calls (e.g., from HMR, duplicate module evaluation, or eager test imports) will silently produce two distinct `I18nConfig` objects — callers that hold a reference from the first call continue using stale config while new callers get a fresh one. A `console.warn` or early-return guard would surface this at the call site rather than during confusing downstream behaviour.

```suggestion
export function initializeI18nConfig(
  params: I18nConfigParams = {}
): I18nConfig {
  if (i18nConfig !== undefined) {
    logger.warn(
      'initializeI18nConfig(): I18nConfig has already been initialized. Overwriting the existing config.'
    );
  }
  const nextI18nConfig = new I18nConfig(params);
  setI18nConfig(nextI18nConfig);
  return nextI18nConfig;
}
```

`````

</details>

<sub>Reviews (7): Last reviewed commit: ["fix: validate i18n config initialization"](https://github.com/generaltranslation/gt/commit/a4928bc2281fb2e63c7b9699efad0be6ba113bdf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34065324)</sub>

<!-- /greptile_comment -->