### PR TITLE
refactor: initialize i18n config alongside caches

### DIFF
--- a/packages/i18n/src/i18n-config/I18nConfig.ts
+++ b/packages/i18n/src/i18n-config/I18nConfig.ts
@@ -11,12 +11,14 @@ export type I18nConfigParams = {
 export class I18nConfig extends LocaleConfig {
   constructor({
     defaultLocale = libraryDefaultLocale,
-    locales = [libraryDefaultLocale],
+    locales,
     customMapping,
   }: I18nConfigParams = {}) {
+    const resolvedLocales = locales ?? [defaultLocale];
+
     super({
       defaultLocale,
-      locales: Array.from(new Set([defaultLocale, ...locales])),
+      locales: Array.from(new Set([defaultLocale, ...resolvedLocales])),
       customMapping: customMapping || {},
     });
   }

--- a/packages/i18n/src/i18n-config/I18nConfig.ts
+++ b/packages/i18n/src/i18n-config/I18nConfig.ts
@@ -1,6 +1,7 @@
 import { LocaleConfig } from '@generaltranslation/format';
 import type { CustomMapping } from '@generaltranslation/format/types';
 import { libraryDefaultLocale } from 'generaltranslation/internal';
+import { validateI18nConfigParams } from './validation';
 
 export type I18nConfigParams = {
   defaultLocale?: string;
@@ -11,14 +12,14 @@ export type I18nConfigParams = {
 export class I18nConfig extends LocaleConfig {
   constructor({
     defaultLocale = libraryDefaultLocale,
-    locales,
+    locales = [defaultLocale],
     customMapping,
   }: I18nConfigParams = {}) {
-    const resolvedLocales = locales ?? [defaultLocale];
+    validateI18nConfigParams({ defaultLocale, locales, customMapping });
 
     super({
       defaultLocale,
-      locales: Array.from(new Set([defaultLocale, ...resolvedLocales])),
+      locales: Array.from(new Set([defaultLocale, ...locales])),
       customMapping: customMapping || {},
     });
   }

--- a/packages/i18n/src/i18n-config/I18nConfig.ts
+++ b/packages/i18n/src/i18n-config/I18nConfig.ts
@@ -1,0 +1,35 @@
+import { LocaleConfig } from '@generaltranslation/format';
+import type { CustomMapping } from '@generaltranslation/format/types';
+import { libraryDefaultLocale } from 'generaltranslation/internal';
+
+export type I18nConfigParams = {
+  defaultLocale?: string;
+  locales?: string[];
+  customMapping?: CustomMapping;
+};
+
+export class I18nConfig extends LocaleConfig {
+  constructor({
+    defaultLocale = libraryDefaultLocale,
+    locales = [libraryDefaultLocale],
+    customMapping,
+  }: I18nConfigParams = {}) {
+    super({
+      defaultLocale,
+      locales: Array.from(new Set([defaultLocale, ...locales])),
+      customMapping: customMapping || {},
+    });
+  }
+
+  getDefaultLocale(): string {
+    return this.defaultLocale;
+  }
+
+  getLocales(): string[] {
+    return this.locales;
+  }
+
+  getCustomMapping(): CustomMapping {
+    return this.customMapping || {};
+  }
+}

--- a/packages/i18n/src/i18n-config/I18nConfig.ts
+++ b/packages/i18n/src/i18n-config/I18nConfig.ts
@@ -7,15 +7,27 @@ export type I18nConfigParams = {
   defaultLocale?: string;
   locales?: string[];
   customMapping?: CustomMapping;
+  projectId?: string;
+  devApiKey?: string;
+  apiKey?: string;
+  cacheUrl?: string | null;
+  runtimeUrl?: string | null;
 };
 
 export class I18nConfig extends LocaleConfig {
-  constructor({
-    defaultLocale = libraryDefaultLocale,
-    locales = [defaultLocale],
-    customMapping,
-  }: I18nConfigParams = {}) {
-    validateI18nConfigParams({ defaultLocale, locales, customMapping });
+  constructor(params: I18nConfigParams = {}) {
+    const {
+      defaultLocale = libraryDefaultLocale,
+      locales = [defaultLocale],
+      customMapping,
+    } = params;
+
+    validateI18nConfigParams({
+      ...params,
+      defaultLocale,
+      locales,
+      customMapping,
+    });
 
     super({
       defaultLocale,

--- a/packages/i18n/src/i18n-config/__tests__/I18nConfig.test.ts
+++ b/packages/i18n/src/i18n-config/__tests__/I18nConfig.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from 'vitest';
+import { I18nConfig } from '../I18nConfig';
+
+describe('I18nConfig', () => {
+  it('defaults locales to the resolved default locale', () => {
+    const config = new I18nConfig({ defaultLocale: 'fr' });
+
+    expect(config.getLocales()).toEqual(['fr']);
+  });
+
+  it('validates configured locales', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(
+      () =>
+        new I18nConfig({
+          defaultLocale: 'invalid locale',
+        })
+    ).toThrow('Invalid I18nConfig locale configuration');
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Locale "invalid locale" is not valid')
+    );
+
+    errorSpy.mockRestore();
+  });
+});

--- a/packages/i18n/src/i18n-config/__tests__/I18nConfig.test.ts
+++ b/packages/i18n/src/i18n-config/__tests__/I18nConfig.test.ts
@@ -8,17 +8,28 @@ describe('I18nConfig', () => {
     expect(config.getLocales()).toEqual(['fr']);
   });
 
-  it('validates configured locales', () => {
+  it('skips locale validation when GT services are disabled', () => {
+    const config = new I18nConfig({
+      defaultLocale: 'invalid-locale',
+      cacheUrl: null,
+      runtimeUrl: null,
+    });
+
+    expect(config.getDefaultLocale()).toBe('invalid-locale');
+  });
+
+  it('validates configured locales when GT services are enabled', () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     expect(
       () =>
         new I18nConfig({
-          defaultLocale: 'invalid locale',
+          defaultLocale: 'invalid-locale',
+          projectId: 'test-project',
         })
     ).toThrow('Invalid I18nConfig locale configuration');
     expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Locale "invalid locale" is not valid')
+      expect.stringContaining('Locale "invalid-locale" is not valid')
     );
 
     errorSpy.mockRestore();

--- a/packages/i18n/src/i18n-config/__tests__/I18nConfig.test.ts
+++ b/packages/i18n/src/i18n-config/__tests__/I18nConfig.test.ts
@@ -34,4 +34,30 @@ describe('I18nConfig', () => {
 
     errorSpy.mockRestore();
   });
+
+  it('validates custom mapping locales when GT services are enabled', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(
+      () =>
+        new I18nConfig({
+          defaultLocale: 'en',
+          projectId: 'test-project',
+          customMapping: {
+            invalidStringMapping: 'invalid-locale',
+            invalidObjectMapping: {
+              code: 'invalid-object-locale',
+            },
+          },
+        })
+    ).toThrow('Invalid I18nConfig locale configuration');
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Locale "invalid-locale" is not valid')
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Locale "invalid-object-locale" is not valid')
+    );
+
+    errorSpy.mockRestore();
+  });
 });

--- a/packages/i18n/src/i18n-config/__tests__/singleton-operations.test.ts
+++ b/packages/i18n/src/i18n-config/__tests__/singleton-operations.test.ts
@@ -11,7 +11,7 @@ describe('i18n config singleton operations', () => {
 
     expect(isI18nConfigInitialized()).toBe(false);
     expect(() => getI18nConfig()).toThrow(
-      'getI18nConfig(): I18nConfig was not initialized.'
+      'Cannot read I18nConfig before it has been initialized'
     );
     expect(isI18nConfigInitialized()).toBe(false);
   });

--- a/packages/i18n/src/i18n-config/__tests__/singleton-operations.test.ts
+++ b/packages/i18n/src/i18n-config/__tests__/singleton-operations.test.ts
@@ -1,0 +1,31 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('i18n config singleton operations', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('throws when the config has not been initialized', async () => {
+    const { getI18nConfig, isI18nConfigInitialized } =
+      await import('../singleton-operations');
+
+    expect(isI18nConfigInitialized()).toBe(false);
+    expect(() => getI18nConfig()).toThrow(
+      'getI18nConfig(): I18nConfig was not initialized.'
+    );
+    expect(isI18nConfigInitialized()).toBe(false);
+  });
+
+  it('returns the initialized config', async () => {
+    const { getI18nConfig, initializeI18nConfig, isI18nConfigInitialized } =
+      await import('../singleton-operations');
+
+    const config = initializeI18nConfig({
+      defaultLocale: 'fr',
+    });
+
+    expect(isI18nConfigInitialized()).toBe(true);
+    expect(getI18nConfig()).toBe(config);
+    expect(getI18nConfig().getLocales()).toEqual(['fr']);
+  });
+});

--- a/packages/i18n/src/i18n-config/singleton-operations.ts
+++ b/packages/i18n/src/i18n-config/singleton-operations.ts
@@ -1,0 +1,34 @@
+import { libraryDefaultLocale } from 'generaltranslation/internal';
+import logger from '../logs/logger';
+import { I18nConfig, type I18nConfigParams } from './I18nConfig';
+
+let i18nConfig: I18nConfig | undefined = undefined;
+
+export function getI18nConfig(): I18nConfig {
+  if (!i18nConfig) {
+    logger.warn(
+      'getI18nConfig(): I18nConfig was not initialized. Falling back to the default locale until initializeGT() configures locales.'
+    );
+    i18nConfig = new I18nConfig({
+      defaultLocale: libraryDefaultLocale,
+      locales: [libraryDefaultLocale],
+    });
+  }
+  return i18nConfig;
+}
+
+export function setI18nConfig(nextI18nConfig: I18nConfig): void {
+  i18nConfig = nextI18nConfig;
+}
+
+export function initializeI18nConfig(
+  params: I18nConfigParams = {}
+): I18nConfig {
+  const nextI18nConfig = new I18nConfig(params);
+  setI18nConfig(nextI18nConfig);
+  return nextI18nConfig;
+}
+
+export function isI18nConfigInitialized(): boolean {
+  return i18nConfig !== undefined;
+}

--- a/packages/i18n/src/i18n-config/singleton-operations.ts
+++ b/packages/i18n/src/i18n-config/singleton-operations.ts
@@ -1,12 +1,11 @@
+import { createDiagnosticMessage } from 'generaltranslation/internal';
 import { I18nConfig, type I18nConfigParams } from './I18nConfig';
 
 let i18nConfig: I18nConfig | undefined = undefined;
 
 export function getI18nConfig(): I18nConfig {
   if (!i18nConfig) {
-    throw new Error(
-      'getI18nConfig(): I18nConfig was not initialized. Call initializeGT() before reading locale config.'
-    );
+    throw new Error(getI18nConfigNotInitializedError());
   }
   return i18nConfig;
 }
@@ -25,4 +24,14 @@ export function initializeI18nConfig(
 
 export function isI18nConfigInitialized(): boolean {
   return i18nConfig !== undefined;
+}
+
+function getI18nConfigNotInitializedError(): string {
+  return createDiagnosticMessage({
+    source: 'gt-i18n',
+    severity: 'Error',
+    whatHappened: 'Cannot read I18nConfig before it has been initialized',
+    why: 'the internal I18nConfig singleton is unavailable',
+    fix: 'Call initializeGT() before reading locale config.',
+  });
 }

--- a/packages/i18n/src/i18n-config/singleton-operations.ts
+++ b/packages/i18n/src/i18n-config/singleton-operations.ts
@@ -1,18 +1,12 @@
-import { libraryDefaultLocale } from 'generaltranslation/internal';
-import logger from '../logs/logger';
 import { I18nConfig, type I18nConfigParams } from './I18nConfig';
 
 let i18nConfig: I18nConfig | undefined = undefined;
 
 export function getI18nConfig(): I18nConfig {
   if (!i18nConfig) {
-    logger.warn(
-      'getI18nConfig(): I18nConfig was not initialized. Falling back to the default locale until initializeGT() configures locales.'
+    throw new Error(
+      'getI18nConfig(): I18nConfig was not initialized. Call initializeGT() before reading locale config.'
     );
-    i18nConfig = new I18nConfig({
-      defaultLocale: libraryDefaultLocale,
-      locales: [libraryDefaultLocale],
-    });
   }
   return i18nConfig;
 }

--- a/packages/i18n/src/i18n-config/validation.ts
+++ b/packages/i18n/src/i18n-config/validation.ts
@@ -13,18 +13,25 @@ export function validateI18nConfigParams(params: I18nConfigParams): void {
   }
 
   const invalidLocales = getInvalidLocales(params);
+  const invalidCustomMappingLocales = getInvalidCustomMappingLocales(params);
+  const invalidLocaleConfig = [
+    ...invalidLocales,
+    ...invalidCustomMappingLocales,
+  ];
 
-  invalidLocales.forEach((locale) => {
+  invalidLocaleConfig.forEach((locale) => {
     logger.error(`I18nConfig: ${getInvalidLocaleMessage(locale)}`);
   });
 
-  if (invalidLocales.length > 0) {
+  if (invalidLocaleConfig.length > 0) {
     throw new Error(
       createDiagnosticMessage({
         source: 'gt-i18n',
         severity: 'Error',
         whatHappened: 'Invalid I18nConfig locale configuration',
-        details: invalidLocales.map((locale) => `Invalid locale: ${locale}`),
+        details: invalidLocaleConfig.map(
+          (locale) => `Invalid locale: ${locale}`
+        ),
         fix: 'Use valid BCP 47 locale codes or add custom mappings.',
       })
     );
@@ -59,6 +66,15 @@ function getInvalidLocales({
   return Array.from(localesToValidate).filter(
     (locale) => !isValidLocale(locale, customMapping)
   );
+}
+
+function getInvalidCustomMappingLocales({
+  customMapping,
+}: I18nConfigParams): string[] {
+  return Object.values(customMapping || {}).flatMap((value) => {
+    const locale = typeof value === 'string' ? value : value.code;
+    return locale && !isValidLocale(locale) ? [locale] : [];
+  });
 }
 
 function getInvalidLocaleMessage(locale: string): string {

--- a/packages/i18n/src/i18n-config/validation.ts
+++ b/packages/i18n/src/i18n-config/validation.ts
@@ -1,0 +1,55 @@
+import { isValidLocale } from '@generaltranslation/format';
+import type { CustomMapping } from '@generaltranslation/format/types';
+import { createDiagnosticMessage } from 'generaltranslation/internal';
+import logger from '../logs/logger';
+import type { I18nConfigParams } from './I18nConfig';
+
+export function validateI18nConfigParams({
+  defaultLocale,
+  locales,
+  customMapping,
+}: I18nConfigParams): void {
+  const invalidLocales = getInvalidLocales({
+    defaultLocale,
+    locales,
+    customMapping,
+  });
+
+  invalidLocales.forEach((locale) => {
+    logger.error(`I18nConfig: ${getInvalidLocaleMessage(locale)}`);
+  });
+
+  if (invalidLocales.length > 0) {
+    throw new Error(
+      createDiagnosticMessage({
+        source: 'gt-i18n',
+        severity: 'Error',
+        whatHappened: 'Invalid I18nConfig locale configuration',
+        details: invalidLocales.map((locale) => `Invalid locale: ${locale}`),
+        fix: 'Use valid BCP 47 locale codes or add custom mappings.',
+      })
+    );
+  }
+}
+
+function getInvalidLocales({
+  defaultLocale,
+  locales,
+  customMapping,
+}: I18nConfigParams): string[] {
+  const localesToValidate = new Set([
+    ...(defaultLocale ? [defaultLocale] : []),
+    ...(locales || []),
+  ]);
+
+  return Array.from(localesToValidate).filter(
+    (locale) => !isValidLocale(locale, customMapping)
+  );
+}
+
+function getInvalidLocaleMessage(locale: string): string {
+  return createDiagnosticMessage({
+    whatHappened: `Locale "${locale}" is not valid`,
+    fix: 'Use a valid BCP 47 locale code or add a custom mapping',
+  });
+}

--- a/packages/i18n/src/i18n-config/validation.ts
+++ b/packages/i18n/src/i18n-config/validation.ts
@@ -1,19 +1,18 @@
 import { isValidLocale } from '@generaltranslation/format';
-import type { CustomMapping } from '@generaltranslation/format/types';
-import { createDiagnosticMessage } from 'generaltranslation/internal';
+import {
+  createDiagnosticMessage,
+  defaultCacheUrl,
+  defaultRuntimeApiUrl,
+} from 'generaltranslation/internal';
 import logger from '../logs/logger';
 import type { I18nConfigParams } from './I18nConfig';
 
-export function validateI18nConfigParams({
-  defaultLocale,
-  locales,
-  customMapping,
-}: I18nConfigParams): void {
-  const invalidLocales = getInvalidLocales({
-    defaultLocale,
-    locales,
-    customMapping,
-  });
+export function validateI18nConfigParams(params: I18nConfigParams): void {
+  if (!getGTServicesEnabled(params)) {
+    return;
+  }
+
+  const invalidLocales = getInvalidLocales(params);
 
   invalidLocales.forEach((locale) => {
     logger.error(`I18nConfig: ${getInvalidLocaleMessage(locale)}`);
@@ -30,6 +29,21 @@ export function validateI18nConfigParams({
       })
     );
   }
+}
+
+function getGTServicesEnabled({
+  projectId,
+  devApiKey,
+  apiKey,
+  cacheUrl,
+  runtimeUrl,
+}: I18nConfigParams): boolean {
+  return (
+    ((cacheUrl === undefined || cacheUrl === defaultCacheUrl) && !!projectId) ||
+    ((runtimeUrl === undefined || runtimeUrl === defaultRuntimeApiUrl) &&
+      !!projectId &&
+      !!(devApiKey || apiKey))
+  );
 }
 
 function getInvalidLocales({

--- a/packages/i18n/src/internal-types.ts
+++ b/packages/i18n/src/internal-types.ts
@@ -12,6 +12,7 @@ export type {
   DictionaryLoader,
   DictionaryConfig,
 } from './i18n-cache/types';
+export type { I18nConfigParams } from './i18n-config/I18nConfig';
 /** @deprecated use I18nCacheConstructorParams instead */
 export type { I18nCacheConstructorParams as I18nManagerConstructorParams } from './i18n-cache/types';
 /** @deprecated use I18nCacheConfig instead */

--- a/packages/i18n/src/internal.ts
+++ b/packages/i18n/src/internal.ts
@@ -24,6 +24,14 @@ export {
 /** @deprecated use I18nCache instead */
 export { I18nCache as I18nManager } from './i18n-cache/I18nCache';
 export { getI18nCache, setI18nCache } from './i18n-cache/singleton-operations';
+export {
+  getI18nConfig,
+  initializeI18nConfig,
+  isI18nConfigInitialized,
+  setI18nConfig,
+} from './i18n-config/singleton-operations';
+export { I18nConfig } from './i18n-config/I18nConfig';
+export type { I18nConfigParams } from './i18n-config/I18nConfig';
 /** @deprecated use getI18nCache instead */
 export { getI18nCache as getI18nManager } from './i18n-cache/singleton-operations';
 /** @deprecated use setI18nCache instead */

--- a/packages/next/src/config-dir/I18NConfiguration.ts
+++ b/packages/next/src/config-dir/I18NConfiguration.ts
@@ -19,7 +19,7 @@ import {
 } from '../utils/cookies';
 import { defaultLocaleHeaderName } from '../utils/headers';
 import type { CustomMapping } from '@generaltranslation/format/types';
-import { I18nCache } from 'gt-i18n/internal';
+import { I18nCache, initializeI18nConfig } from 'gt-i18n/internal';
 import type { LookupOptions } from 'gt-i18n/internal/types';
 import { loadTranslations } from './loadTranslation';
 
@@ -160,6 +160,7 @@ export class I18NConfiguration {
     // Translation and dictionary managers
     const shouldLoadTranslations = loadTranslationsType !== 'disabled';
     const runtimeTranslationTimeout = this.renderSettings.timeout;
+    initializeI18nConfig({ defaultLocale, locales, customMapping });
     this._i18nCache = new I18nCache<TranslatedChildren>({
       apiKey,
       devApiKey,

--- a/packages/next/src/config-dir/__tests__/I18NConfiguration.test.ts
+++ b/packages/next/src/config-dir/__tests__/I18NConfiguration.test.ts
@@ -13,6 +13,17 @@ const mockLocaleConfig = vi.hoisted(() => ({
 }));
 
 vi.mock('gt-i18n/internal', () => ({
+  initializeI18nConfig: (params: {
+    defaultLocale?: string;
+    locales?: string[];
+    customMapping?: Record<string, unknown>;
+  }) => {
+    mockLocaleConfig.defaultLocale =
+      params.defaultLocale ?? mockLocaleConfig.defaultLocale;
+    mockLocaleConfig.locales = params.locales ?? mockLocaleConfig.locales;
+    mockLocaleConfig.customMapping =
+      params.customMapping ?? mockLocaleConfig.customMapping;
+  },
   I18nCache: class {
     constructor(params: {
       defaultLocale?: string;

--- a/packages/node/src/setup/initializeGT.ts
+++ b/packages/node/src/setup/initializeGT.ts
@@ -1,6 +1,10 @@
 import { setAsyncConditionStore } from '../async-i18n-cache/singleton-operations';
 import type { InitializeGTParams } from './types';
-import { I18nCache, setI18nCache } from 'gt-i18n/internal';
+import {
+  I18nCache,
+  initializeI18nConfig,
+  setI18nCache,
+} from 'gt-i18n/internal';
 import { AsyncConditionStore } from '../async-i18n-cache/AsyncConditionStore';
 
 /**
@@ -9,6 +13,8 @@ import { AsyncConditionStore } from '../async-i18n-cache/AsyncConditionStore';
  * TODO: auto detect if can find gt.config.json files
  */
 export function initializeGT(params: InitializeGTParams): void {
+  initializeI18nConfig(params);
+
   const i18nCache = new I18nCache<string>(params);
   const conditionStore = new AsyncConditionStore({
     defaultLocale: i18nCache.getDefaultLocale(),

--- a/packages/react-core/src/context.ts
+++ b/packages/react-core/src/context.ts
@@ -52,7 +52,9 @@ export {
   setReadonlyConditionStore,
 } from './condition-store/singleton-operations';
 export { WritableConditionStore } from 'gt-i18n/internal';
+export { initializeI18nConfig } from 'gt-i18n/internal';
 export type { WritableConditionStoreParams } from 'gt-i18n/internal';
+export type { I18nConfigParams } from 'gt-i18n/internal';
 export {
   getReactI18nCache,
   setReactI18nCache,

--- a/packages/react-core/src/setup/initializeGTSPA.ts
+++ b/packages/react-core/src/setup/initializeGTSPA.ts
@@ -1,5 +1,12 @@
-import { I18nCache, WritableConditionStore } from 'gt-i18n/internal';
-import type { WritableConditionStoreParams } from 'gt-i18n/internal';
+import {
+  I18nCache,
+  initializeI18nConfig,
+  WritableConditionStore,
+} from 'gt-i18n/internal';
+import type {
+  I18nConfigParams,
+  WritableConditionStoreParams,
+} from 'gt-i18n/internal';
 import type { Translation } from 'gt-i18n/types';
 import { setReactI18nCache } from '../i18n-cache/singleton-operations';
 import type { ReactI18nCacheParams } from '../i18n-cache/ReactI18nCache';
@@ -17,9 +24,14 @@ import { setI18nStore } from '../i18n-store/singleton-operations';
  * @deprecated moved to /react and /react-native
  */
 export function internalInitializeGTSPA(
-  config: I18nStoreParams & ReactI18nCacheParams & WritableConditionStoreParams
+  config: I18nStoreParams &
+    I18nConfigParams &
+    ReactI18nCacheParams &
+    WritableConditionStoreParams
 ): void {
   setRenderStrategy('SPA');
+
+  initializeI18nConfig(config);
 
   const i18nCache = new I18nCache<Translation>(config);
   setReactI18nCache(i18nCache);

--- a/packages/react-core/src/setup/initializeGTSSR.ts
+++ b/packages/react-core/src/setup/initializeGTSSR.ts
@@ -1,4 +1,5 @@
-import { I18nCache } from 'gt-i18n/internal';
+import { I18nCache, initializeI18nConfig } from 'gt-i18n/internal';
+import type { I18nConfigParams } from 'gt-i18n/internal';
 import type { Translation } from 'gt-i18n/types';
 import type { ReactI18nCacheParams } from '../i18n-cache/ReactI18nCache';
 import { setRenderStrategy } from './globals';
@@ -11,8 +12,12 @@ import { setReactI18nCache } from '../i18n-cache/singleton-operations';
  * ConditionStore and I18nStore are initialized in the provider at request time
  * TODO: auto detect if can find gt.config.json files
  */
-export function internalInitializeGTSSR(config: ReactI18nCacheParams): void {
+export function internalInitializeGTSSR(
+  config: I18nConfigParams & ReactI18nCacheParams
+): void {
   setRenderStrategy('server-render');
+
+  initializeI18nConfig(config);
 
   const i18nCache = new I18nCache<Translation>(config);
   setReactI18nCache(i18nCache);

--- a/packages/react/src/setup/initializeGTSPA.ts
+++ b/packages/react/src/setup/initializeGTSPA.ts
@@ -6,7 +6,9 @@ import {
   setI18nStore,
   setReactI18nCache,
   getReadonlyConditionStoreWithFallback,
+  initializeI18nConfig,
 } from '@generaltranslation/react-core/context';
+import type { I18nConfigParams } from '@generaltranslation/react-core/context';
 import { BrowserI18nCache } from '../i18n-cache/BrowserI18nCache';
 import type { BrowserI18nCacheParams } from '../i18n-cache/BrowserI18nCache';
 import {
@@ -24,10 +26,13 @@ import {
  */
 export async function initializeGTSPA(
   config: I18nStoreParams &
+    I18nConfigParams &
     BrowserI18nCacheParams &
     CreateBrowserConditionStoreParams
 ) {
   setRenderStrategy('SPA');
+
+  initializeI18nConfig(config);
 
   const i18nCache = new BrowserI18nCache(config);
   setReactI18nCache(i18nCache);


### PR DESCRIPTION
## Summary

- Reexport `I18nConfig` and singleton operations from the internal `gt-i18n` entrypoint.
- Initialize `I18nConfig` alongside the existing cache setup in Node, React Core, and React SPA initialization paths.
- Attach `I18nConfigParams` to initialization parameter types.
- Leave all runtime locale reads on their existing cache/store paths for now.

## Stack

1. Previous: introduce the unused `I18nConfig` class and singleton operations.
2. This PR: initialize `I18nConfig` alongside existing setup.
3. Next: move `I18nCache` locale ownership to `I18nConfig`.

## Verification

- `pnpm --filter gt-i18n build`
- `pnpm --filter gt-react build`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires up the `I18nConfig` singleton — introduced in the previous stack item — by calling `initializeI18nConfig(params)` at the top of each existing initialization path (Node, React Core SPA/SSR, React SPA) and re-exporting the class and singleton helpers from the `gt-i18n/internal` entrypoint.

- Re-exports `I18nConfig`, `I18nConfigParams`, and four singleton operations (`getI18nConfig`, `initializeI18nConfig`, `isI18nConfigInitialized`, `setI18nConfig`) from `gt-i18n/internal` and `gt-i18n/internal-types`.
- Adds `I18nConfigParams` to the `config` type intersection for `internalInitializeGTSPA`, `internalInitializeGTSSR`, and `initializeGTSPA`, and calls `initializeI18nConfig` before constructing `I18nCache` in each path.
- The Node `InitializeGTParams` type is not explicitly intersected with `I18nConfigParams` (unlike its React counterparts), though structural compatibility is maintained through `GTConfig`.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change only adds `initializeI18nConfig` calls ahead of existing `I18nCache` construction and re-exports types; no runtime behaviour changes until the next stack item moves locale reads to `I18nConfig`.

All three init paths (Node, React Core SPA/SSR, React SPA) follow the same pattern and the new `initializeI18nConfig` function is a straightforward singleton setter with no side-effects beyond constructing `I18nConfig`. The Node `InitializeGTParams` type omission is a minor inconsistency with no runtime impact.

packages/node/src/setup/types.ts — `InitializeGTParams` was not explicitly intersected with `I18nConfigParams` unlike every React counterpart.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/i18n/src/internal.ts | Adds re-exports for I18nConfig class, I18nConfigParams type, and four singleton operations; clean and consistent with existing export pattern. |
| packages/i18n/src/internal-types.ts | Adds I18nConfigParams type re-export; minimal and correct change. |
| packages/node/src/setup/initializeGT.ts | Calls initializeI18nConfig(params) before I18nCache construction; params is structurally compatible with I18nConfigParams via GTConfig, but InitializeGTParams type is not explicitly intersected with I18nConfigParams unlike the react equivalents. |
| packages/react-core/src/setup/initializeGTSPA.ts | Adds I18nConfigParams to config type intersection and calls initializeI18nConfig before I18nCache construction; consistent with SSR counterpart. |
| packages/react-core/src/setup/initializeGTSSR.ts | Adds I18nConfigParams to config type and calls initializeI18nConfig; clean parallel change to the SPA path. |
| packages/react/src/setup/initializeGTSPA.ts | Imports and calls initializeI18nConfig, adds I18nConfigParams to config type; consistent with core SPA/SSR patterns. |
| packages/react-core/src/context.ts | Re-exports initializeI18nConfig and I18nConfigParams from gt-i18n/internal, consumed by packages/react for its own SPA init. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant App
    participant initializeGT as initializeGT / initializeGTSPA / initializeGTSSR
    participant I18nConfigSingleton as I18nConfig Singleton
    participant I18nCache
    participant ConditionStore

    App->>initializeGT: call with params (defaultLocale, locales, customMapping, ...)
    initializeGT->>I18nConfigSingleton: initializeI18nConfig(params)
    Note over I18nConfigSingleton: new I18nConfig(params) → setI18nConfig()
    initializeGT->>I18nCache: new I18nCache(params)
    initializeGT->>ConditionStore: new ConditionStore / I18nStore (from cache values)
    initializeGT->>I18nCache: setReactI18nCache / setI18nCache
    initializeGT->>ConditionStore: setReadonlyConditionStore / setAsyncConditionStore
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fnode%2Fsrc%2Fsetup%2Ftypes.ts%3A13-16%0AEvery%20React%20init%20path%20explicitly%20intersects%20%60I18nConfigParams%60%20into%20its%20config%20type%20%28see%20%60internalInitializeGTSSR%60%2C%20%60internalInitializeGTSPA%60%2C%20%60initializeGTSPA%60%29%2C%20but%20%60InitializeGTParams%60%20was%20not%20updated%20to%20follow%20the%20same%20pattern.%20The%20call%20to%20%60initializeI18nConfig%28params%29%60%20compiles%20today%20via%20structural%20compatibility%20through%20%60GTConfig%60%2C%20but%20the%20intent%20is%20not%20visible%20from%20the%20type%20declaration%20alone%20and%20any%20future%20refactoring%20of%20%60GTConfig%60%20could%20silently%20break%20the%20contract.%0A%0A%60%60%60suggestion%0Aexport%20type%20InitializeGTParams%20%3D%20DictionaryConfig%20%26%0A%20%20GTConfig%20%26%0A%20%20I18nConfigParams%20%26%20%7B%0A%20%20%20%20loadTranslations%3F%3A%20TranslationsLoader%3B%0A%20%20%7D%3B%0A%60%60%60%0A%0A&repo=generaltranslation%2Fgt&pr=1489&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fodysseus%2Fuse-i18n-config-values%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fodysseus%2Fuse-i18n-config-values%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fnode%2Fsrc%2Fsetup%2Ftypes.ts%3A13-16%0AEvery%20React%20init%20path%20explicitly%20intersects%20%60I18nConfigParams%60%20into%20its%20config%20type%20%28see%20%60internalInitializeGTSSR%60%2C%20%60internalInitializeGTSPA%60%2C%20%60initializeGTSPA%60%29%2C%20but%20%60InitializeGTParams%60%20was%20not%20updated%20to%20follow%20the%20same%20pattern.%20The%20call%20to%20%60initializeI18nConfig%28params%29%60%20compiles%20today%20via%20structural%20compatibility%20through%20%60GTConfig%60%2C%20but%20the%20intent%20is%20not%20visible%20from%20the%20type%20declaration%20alone%20and%20any%20future%20refactoring%20of%20%60GTConfig%60%20could%20silently%20break%20the%20contract.%0A%0A%60%60%60suggestion%0Aexport%20type%20InitializeGTParams%20%3D%20DictionaryConfig%20%26%0A%20%20GTConfig%20%26%0A%20%20I18nConfigParams%20%26%20%7B%0A%20%20%20%20loadTranslations%3F%3A%20TranslationsLoader%3B%0A%20%20%7D%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/node/src/setup/types.ts:13-16
Every React init path explicitly intersects `I18nConfigParams` into its config type (see `internalInitializeGTSSR`, `internalInitializeGTSPA`, `initializeGTSPA`), but `InitializeGTParams` was not updated to follow the same pattern. The call to `initializeI18nConfig(params)` compiles today via structural compatibility through `GTConfig`, but the intent is not visible from the type declaration alone and any future refactoring of `GTConfig` could silently break the contract.

```suggestion
export type InitializeGTParams = DictionaryConfig &
  GTConfig &
  I18nConfigParams & {
    loadTranslations?: TranslationsLoader;
  };
```

`````

</details>

<sub>Reviews (4): Last reviewed commit: ["refactor: initialize i18n config alongsi..."](https://github.com/generaltranslation/gt/commit/0d8823a920ec533eaa61ff4bae6a2416ec04c38d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34065332)</sub>

<!-- /greptile_comment -->