### PR TITLE
refactor: consolidate locale helpers on i18n config

### DIFF
--- a/packages/i18n/src/condition-store/ReadonlyConditionStore.ts
+++ b/packages/i18n/src/condition-store/ReadonlyConditionStore.ts
@@ -1,46 +1,18 @@
-import { CustomMapping } from 'generaltranslation/types';
-import type {
-  LocaleResolverConfig,
-  ReadonlyConditionStoreInterface as ReadonlyConditionStoreContract,
-} from '../i18n-cache/types';
-import { createLocaleResolver, type LocaleCandidates } from './localeResolver';
+import type { ReadonlyConditionStoreInterface as ReadonlyConditionStoreContract } from '../i18n-cache/types';
+import { getI18nConfig } from '../i18n-config/singleton-operations';
+import type { LocaleCandidates } from './localeResolver';
 
 export type ReadonlyConditionStoreParams = {
-  /**
-   * @deprecated - this will be moved to a locale config cache
-   */
-  defaultLocale?: string;
-  /**
-   * @deprecated - this will be moved to a locale config cache
-   */
-  locales?: string[];
-  /**
-   * @deprecated - this will be moved to a locale config cache
-   */
-  customMapping?: CustomMapping;
   locale: LocaleCandidates;
   enableI18n?: boolean;
 };
 
 export class ReadonlyConditionStore implements ReadonlyConditionStoreContract {
-  /**
-   * @deprecated use getI18nCache().determineLocale() instead
-   */
-  protected readonly resolveLocale: (candidates?: LocaleCandidates) => string;
   protected locale: string;
   protected enableI18n: boolean;
 
-  constructor({
-    locale,
-    enableI18n = true,
-    ...localeConfig
-  }: ReadonlyConditionStoreParams) {
-    /**
-     * TODO: change this to getI18nCache().determineLocale() but this
-     * currently creates a circular dependency
-     */
-    this.resolveLocale = createLocaleResolver(localeConfig);
-    this.locale = this.resolveLocale(locale);
+  constructor({ locale, enableI18n = true }: ReadonlyConditionStoreParams) {
+    this.locale = getI18nConfig().resolveSupportedLocale(locale);
     this.enableI18n = enableI18n;
   }
 

--- a/packages/i18n/src/condition-store/WritableConditionStore.ts
+++ b/packages/i18n/src/condition-store/WritableConditionStore.ts
@@ -1,5 +1,6 @@
 import type { LocaleCandidates } from '../i18n-cache';
 import type { WritableConditionStoreInterface } from '../i18n-cache/types';
+import { getI18nConfig } from '../i18n-config/singleton-operations';
 import {
   ReadonlyConditionStore,
   type ReadonlyConditionStoreParams,
@@ -12,7 +13,7 @@ export class WritableConditionStore
   implements WritableConditionStoreInterface
 {
   setLocale = (locale: LocaleCandidates): void => {
-    this.locale = this.resolveLocale(locale);
+    this.locale = getI18nConfig().resolveSupportedLocale(locale);
   };
 
   setEnableI18n = (enableI18n: boolean): void => {

--- a/packages/i18n/src/condition-store/localeResolver.ts
+++ b/packages/i18n/src/condition-store/localeResolver.ts
@@ -1,25 +1,8 @@
-import { LocaleConfig } from '@generaltranslation/format';
-import { libraryDefaultLocale } from 'generaltranslation/internal';
 import type { LocaleResolverConfig } from '../i18n-cache/types';
+import { I18nConfig } from '../i18n-config/I18nConfig';
+import { getI18nConfig } from '../i18n-config/singleton-operations';
 
 export type LocaleCandidates = string | string[] | undefined;
-
-function normalizeConditionStoreConfig({
-  defaultLocale,
-  locales,
-  customMapping,
-}: LocaleResolverConfig = {}) {
-  const fallbackLocale = defaultLocale || libraryDefaultLocale;
-  return {
-    defaultLocale: fallbackLocale,
-    locales: locales?.length ? locales : [fallbackLocale],
-    customMapping,
-  };
-}
-
-type NormalizedConditionStoreConfig = ReturnType<
-  typeof normalizeConditionStoreConfig
->;
 
 /**
  * Return the best supported locale for the candidates, or undefined when none match.
@@ -28,25 +11,7 @@ export function determineSupportedLocale(
   candidates: LocaleCandidates,
   config: LocaleResolverConfig = {}
 ): string | undefined {
-  return determineSupportedLocaleWithConfig(
-    candidates,
-    normalizeConditionStoreConfig(config)
-  );
-}
-
-function determineSupportedLocaleWithConfig(
-  candidates: LocaleCandidates,
-  config: NormalizedConditionStoreConfig
-): string | undefined {
-  if (
-    candidates == null ||
-    (Array.isArray(candidates) && candidates.length === 0)
-  ) {
-    return undefined;
-  }
-
-  const localeConfig = new LocaleConfig(config);
-  return localeConfig.determineLocale(candidates) || undefined;
+  return getLocaleResolverConfig(config).determineSupportedLocale(candidates);
 }
 
 /**
@@ -56,16 +21,26 @@ export function resolveSupportedLocale(
   candidates: LocaleCandidates,
   config: LocaleResolverConfig = {}
 ): string {
-  const normalizedConfig = normalizeConditionStoreConfig(config);
-  return (
-    determineSupportedLocaleWithConfig(candidates, normalizedConfig) ||
-    normalizedConfig.defaultLocale
-  );
+  return getLocaleResolverConfig(config).resolveSupportedLocale(candidates);
 }
 
 export function createLocaleResolver(config: LocaleResolverConfig = {}) {
-  const normalizedConfig = normalizeConditionStoreConfig(config);
+  const i18nConfig = getLocaleResolverConfig(config);
   return (candidates?: LocaleCandidates): string =>
-    determineSupportedLocaleWithConfig(candidates, normalizedConfig) ||
-    normalizedConfig.defaultLocale;
+    i18nConfig.resolveSupportedLocale(candidates);
+}
+
+function getLocaleResolverConfig(config: LocaleResolverConfig): I18nConfig {
+  if (hasLocaleResolverConfigParams(config)) {
+    return new I18nConfig(config);
+  }
+  return getI18nConfig();
+}
+
+function hasLocaleResolverConfigParams(config: LocaleResolverConfig): boolean {
+  return (
+    'defaultLocale' in config ||
+    'locales' in config ||
+    'customMapping' in config
+  );
 }

--- a/packages/i18n/src/helpers/locale.ts
+++ b/packages/i18n/src/helpers/locale.ts
@@ -1,5 +1,4 @@
 import { getWritableConditionStore } from '../condition-store/singleton-operations';
-import { getI18nCache } from '../i18n-cache/singleton-operations';
 import { getI18nConfig } from '../i18n-config/singleton-operations';
 
 /**
@@ -50,7 +49,5 @@ export function getDefaultLocale() {
  * const localeProperties = getLocaleProperties('en-US');
  */
 export function getLocaleProperties(locale = getLocale()) {
-  const i18nCache = getI18nCache();
-  const gtInstance = i18nCache.getGTClass();
-  return gtInstance.getLocaleProperties(locale);
+  return getI18nConfig().getLocaleProperties(locale);
 }

--- a/packages/i18n/src/helpers/locale.ts
+++ b/packages/i18n/src/helpers/locale.ts
@@ -1,5 +1,6 @@
 import { getWritableConditionStore } from '../condition-store/singleton-operations';
 import { getI18nCache } from '../i18n-cache/singleton-operations';
+import { getI18nConfig } from '../i18n-config/singleton-operations';
 
 /**
  * Get the current locale
@@ -22,8 +23,7 @@ export function getLocale() {
  * console.log(locales); // ['en-US', 'es-ES']
  */
 export function getLocales() {
-  const i18nCache = getI18nCache();
-  return i18nCache.getLocales();
+  return getI18nConfig().getLocales();
 }
 
 /**
@@ -35,8 +35,7 @@ export function getLocales() {
  * console.log(defaultLocale); // 'en-US'
  */
 export function getDefaultLocale() {
-  const i18nCache = getI18nCache();
-  return i18nCache.getDefaultLocale();
+  return getI18nConfig().getDefaultLocale();
 }
 
 /**

--- a/packages/i18n/src/i18n-cache/I18nCache.ts
+++ b/packages/i18n/src/i18n-cache/I18nCache.ts
@@ -2,6 +2,7 @@ import { publishValidationResults } from './validation/publishValidationResults'
 import logger from '../logs/logger';
 import { I18nCacheConfig, I18nCacheConstructorParams } from './types';
 import { validateConfig } from './validation/validateConfig';
+import { validateLocales } from './validation/config-validation/validateLocales';
 import { Translation } from './translations-manager/utils/types/translation-data';
 import { libraryDefaultLocale } from 'generaltranslation/internal';
 import { GT } from 'generaltranslation';
@@ -99,8 +100,11 @@ class I18nCache<
     super();
 
     // Validation
-    const validationResults = validateConfig(params);
-    publishValidationResults(validationResults, 'I18nCache: ');
+    publishValidationResults(
+      validateLocales(params, getGTServicesEnabled(params)),
+      'I18nCache: '
+    );
+    publishValidationResults(validateConfig(params), 'I18nCache: ');
 
     // Setup
     this.config = standardizeConfig(params);

--- a/packages/i18n/src/i18n-cache/I18nCache.ts
+++ b/packages/i18n/src/i18n-cache/I18nCache.ts
@@ -2,12 +2,8 @@ import { publishValidationResults } from './validation/publishValidationResults'
 import logger from '../logs/logger';
 import { I18nCacheConfig, I18nCacheConstructorParams } from './types';
 import { validateConfig } from './validation/validateConfig';
-import { validateLocales } from './validation/config-validation/validateLocales';
 import { Translation } from './translations-manager/utils/types/translation-data';
-import { libraryDefaultLocale } from 'generaltranslation/internal';
 import { GT } from 'generaltranslation';
-import { LocaleConfig, standardizeLocale } from '@generaltranslation/format';
-import type { CustomMapping } from '@generaltranslation/format/types';
 import { LookupOptions } from '../translation-functions/types/options';
 import { getGTServicesEnabled } from './utils/getGTServicesEnabled';
 import {
@@ -32,11 +28,13 @@ import { EventEmitter } from './event-subscription/EventEmitter';
 import { subscribeLifecycleCallbacks } from './lifecycle-hooks/subscribeLifecycleCallbacks';
 import { TRANSLATIONS_CACHE_MISS_EVENT_NAME } from './event-subscription/types';
 import type { I18nEvents } from './event-subscription/types';
-import {
-  createLocaleResolver,
-  LocaleCandidates,
-} from '../condition-store/localeResolver';
+import { LocaleCandidates } from '../condition-store/localeResolver';
 import { getRuntimeEnvironment } from '../utils/getRuntimeEnvironment';
+import {
+  getI18nConfig,
+  initializeI18nConfig,
+  isI18nConfigInitialized,
+} from '../i18n-config/singleton-operations';
 
 /**
  * Default translation timeout in milliseconds for a runtime translation request
@@ -84,13 +82,6 @@ class I18nCache<
   private localesCache: LocalesCache<TranslationValue>;
 
   /**
-   * Runtime-safe locale and formatting helpers
-   */
-  private localeConfig: LocaleConfig;
-
-  public determineLocale: (candidates?: LocaleCandidates) => string;
-
-  /**
    * Creates an instance of I18nCache.
    * TODO: resolve gtConfig from just file path
    * @param params - The parameters for the I18nCache constructor
@@ -100,24 +91,17 @@ class I18nCache<
     super();
 
     // Validation
-    publishValidationResults(
-      validateLocales(params, getGTServicesEnabled(params)),
-      'I18nCache: '
-    );
     publishValidationResults(validateConfig(params), 'I18nCache: ');
 
     // Setup
+    if (hasI18nConfigParams(params) || !isI18nConfigInitialized()) {
+      initializeI18nConfig(
+        params as Parameters<typeof initializeI18nConfig>[0],
+        getGTServicesEnabled(params)
+      );
+    }
     this.config = standardizeConfig(params);
-    this.localeConfig = new LocaleConfig({
-      defaultLocale: this.config.defaultLocale,
-      locales: this.config.locales,
-      customMapping: this.config.customMapping,
-    });
-    this.determineLocale = createLocaleResolver({
-      defaultLocale: this.config.defaultLocale,
-      locales: this.config.locales,
-      customMapping: this.config.customMapping,
-    });
+    const i18nConfig = getI18nConfig();
 
     // Create cache miss handlers
     const loadTranslations = routeCreateTranslationLoader({
@@ -128,7 +112,7 @@ class I18nCache<
         projectId: params.projectId,
         _versionId: params._versionId,
         _branchId: params._branchId,
-        customMapping: params.customMapping,
+        customMapping: i18nConfig.getCustomMapping(),
       },
     }) as SafeTranslationsLoader<TranslationValue>;
     const loadDictionary = params.loadDictionary ?? (() => Promise.resolve({}));
@@ -154,7 +138,7 @@ class I18nCache<
 
     // Setup locale-scoped caches
     this.localesCache = new LocalesCache<TranslationValue>({
-      defaultLocale: this.config.defaultLocale,
+      defaultLocale: i18nConfig.getDefaultLocale(),
       dictionary: params.dictionary,
       loadTranslations,
       loadDictionary,
@@ -199,21 +183,28 @@ class I18nCache<
    * Get the default locale
    */
   getDefaultLocale(): string {
-    return this.config.defaultLocale;
+    return getI18nConfig().getDefaultLocale();
   }
 
   /**
    * Get the locales
    */
   getLocales(): string[] {
-    return this.config.locales;
+    return getI18nConfig().getLocales();
   }
 
   /**
    * Get the custom locale mapping
    */
-  getCustomMapping(): CustomMapping {
-    return this.config.customMapping;
+  getCustomMapping() {
+    return getI18nConfig().getCustomMapping();
+  }
+
+  /**
+   * Determine the best locale match, falling back to the default locale.
+   */
+  determineLocale(candidates?: LocaleCandidates): string {
+    return getI18nConfig().resolveSupportedLocale(candidates);
   }
 
   /**
@@ -482,11 +473,13 @@ class I18nCache<
   }
 
   private getDefaultDictionaryCache() {
-    return this.localesCache.getDictionary(this.config.defaultLocale);
+    return this.localesCache.getDictionary(getI18nConfig().getDefaultLocale());
   }
 
   private resolveDictionaryCacheLocale(locale: string): Locale {
-    return this.resolveCacheLocale(locale) ?? this.config.defaultLocale;
+    return (
+      this.resolveCacheLocale(locale) ?? getI18nConfig().getDefaultLocale()
+    );
   }
 
   /**
@@ -663,11 +656,8 @@ class I18nCache<
    * @returns {boolean} True if translation is required, otherwise false
    */
   requiresTranslation(locale: string): boolean {
-    const defaultLocale = this.getDefaultLocale();
-    const locales = this.getLocales();
     return (
-      this.isTranslationEnabled() &&
-      this.localeConfig.requiresTranslation(locale, defaultLocale, locales)
+      this.isTranslationEnabled() && getI18nConfig().requiresTranslation(locale)
     );
   }
 
@@ -677,10 +667,9 @@ class I18nCache<
    * @returns {boolean} True if dialect translation is required, otherwise false
    */
   requiresDialectTranslation(locale: string): boolean {
-    const defaultLocale = this.getDefaultLocale();
     return (
       this.requiresTranslation(locale) &&
-      this.localeConfig.isSameLanguage(defaultLocale, locale)
+      getI18nConfig().requiresDialectTranslation(locale)
     );
   }
 
@@ -713,13 +702,7 @@ class I18nCache<
   }
 
   private _resolveLocale(locale: string) {
-    const resolvedLocale = this.localeConfig.determineLocale(locale);
-    if (!this.localeConfig.isValidLocale(locale) || !resolvedLocale) {
-      throw new Error(
-        `Locale "${locale}" is not valid. Use a valid BCP 47 locale code or add a custom mapping.`
-      );
-    }
-    return resolvedLocale;
+    return getI18nConfig().resolveLocale(locale);
   }
 
   /**
@@ -733,8 +716,9 @@ class I18nCache<
       return resolvedLocale;
     }
 
-    const aliasLocale = this.localeConfig.resolveAliasLocale(
-      standardizeLocale(locale)
+    const i18nConfig = getI18nConfig();
+    const aliasLocale = i18nConfig.resolveAliasLocale(
+      i18nConfig.standardizeLocale(locale)
     );
     if (this.requiresTranslation(aliasLocale)) {
       return aliasLocale;
@@ -790,7 +774,7 @@ class I18nCache<
     if (translation == null) {
       translation = await txCache.miss({ message, options: lookupOptions });
     }
-    return translation;
+    return translation ?? message;
   }
 
   /**
@@ -799,19 +783,20 @@ class I18nCache<
    * specific context
    */
   private getGTClassClean(locale?: string) {
+    const i18nConfig = getI18nConfig();
     return new GT({
-      sourceLocale: this.config.defaultLocale,
+      sourceLocale: i18nConfig.getDefaultLocale(),
       targetLocale: locale,
       // GT validates approved locales before constructing its LocaleConfig, so
       // pass canonical locales here while preserving alias target locales.
       locales: Array.from(
         new Set(
-          this.config.locales.map((locale) =>
-            this.localeConfig.resolveCanonicalLocale(locale)
-          )
+          i18nConfig
+            .getLocales()
+            .map((locale) => i18nConfig.resolveCanonicalLocale(locale))
         )
       ),
-      customMapping: this.config.customMapping,
+      customMapping: i18nConfig.getCustomMapping(),
       projectId: this.config.projectId,
       baseUrl: this.config.runtimeUrl || undefined,
       apiKey: this.config.apiKey,
@@ -832,14 +817,6 @@ export { I18nCache };
 function standardizeConfig<TranslationValue extends Translation>(
   config: I18nCacheConstructorParams<TranslationValue>
 ) {
-  const gtServicesEnabled = getGTServicesEnabled(config);
-
-  const dedupedLocales = dedupeLocales({
-    defaultLocale: config.defaultLocale || libraryDefaultLocale,
-    locales: config.locales || [libraryDefaultLocale],
-    customMapping: config.customMapping,
-  });
-
   return {
     environment: config.environment || getRuntimeEnvironment(),
     enableI18n: config.enableI18n !== undefined ? config.enableI18n : true,
@@ -851,72 +828,15 @@ function standardizeConfig<TranslationValue extends Translation>(
     batchConfig: config.batchConfig,
     runtimeTranslation: config.runtimeTranslation,
     _versionId: config._versionId,
-    ...(gtServicesEnabled
-      ? standardizeLocales(dedupedLocales)
-      : dedupedLocales),
   };
 }
 
-/**
- * Dedupe locales and add defaultLocale
- */
-function dedupeLocales({
-  defaultLocale,
-  locales,
-  customMapping,
-}: {
-  defaultLocale: string;
-  locales: string[];
-  customMapping?: CustomMapping;
-}) {
-  return {
-    defaultLocale,
-    locales: Array.from(new Set([defaultLocale, ...locales])),
-    customMapping: customMapping || {},
-  };
-}
-
-/**
- * Standardize all locales in config
- * Only apply if using GT services
- */
-function standardizeLocales(config: {
-  defaultLocale: string;
-  locales: string[];
-  customMapping: CustomMapping;
-}) {
-  // Sanitize defaultLocale and locales
-  const defaultLocale = standardizeLocale(config.defaultLocale);
-  const locales = config.locales.map((locale) => {
-    const mappedLocale =
-      typeof config.customMapping?.[locale] === 'string'
-        ? config.customMapping?.[locale]
-        : config.customMapping?.[locale]?.code;
-    if (mappedLocale) {
-      return locale;
-    } else {
-      return standardizeLocale(locale);
-    }
-  });
-
-  // Sanitize customMapping
-  const customMapping = Object.fromEntries(
-    Object.entries(config.customMapping || {}).map(([key, value]) => [
-      key,
-      typeof value === 'string'
-        ? standardizeLocale(value)
-        : {
-            ...value,
-            ...(value.code ? { code: standardizeLocale(value.code) } : {}),
-          },
-    ])
+function hasI18nConfigParams(params: object): boolean {
+  return (
+    'defaultLocale' in params ||
+    'locales' in params ||
+    'customMapping' in params
   );
-
-  return {
-    defaultLocale,
-    locales,
-    customMapping,
-  };
 }
 
 /**

--- a/packages/i18n/src/i18n-cache/index.ts
+++ b/packages/i18n/src/i18n-cache/index.ts
@@ -1,5 +1,7 @@
 // Classes
 export { I18nCache } from './I18nCache';
+export { I18nConfig } from '../i18n-config/I18nConfig';
+export type { I18nConfigParams } from '../i18n-config/I18nConfig';
 export { ReadonlyConditionStore } from '../condition-store/ReadonlyConditionStore';
 export type { ReadonlyConditionStoreParams } from '../condition-store/ReadonlyConditionStore';
 export { WritableConditionStore } from '../condition-store/WritableConditionStore';
@@ -21,3 +23,9 @@ export {
 
 // Functions
 export { getI18nCache, setI18nCache } from './singleton-operations';
+export {
+  getI18nConfig,
+  initializeI18nConfig,
+  isI18nConfigInitialized,
+  setI18nConfig,
+} from '../i18n-config/singleton-operations';

--- a/packages/i18n/src/i18n-cache/singleton-operations.ts
+++ b/packages/i18n/src/i18n-cache/singleton-operations.ts
@@ -1,9 +1,12 @@
-import { libraryDefaultLocale } from 'generaltranslation/internal';
 import { I18nCache } from './I18nCache';
 import logger from '../logs/logger';
 import { Translation } from './translations-manager/utils/types/translation-data';
 import { createConditionStoreSingleton } from '../condition-store/createConditionStoreSingleton';
 import { WritableConditionStoreInterface } from './types';
+import {
+  initializeI18nConfig,
+  isI18nConfigInitialized,
+} from '../i18n-config/singleton-operations';
 
 // Singleton instance of I18nCache
 let i18nCache: I18nCache | undefined = undefined;
@@ -22,10 +25,10 @@ export function getI18nCache<U extends Translation = Translation>():
     logger.warn(
       'getI18nCache(): I18nCache was not initialized. Falling back to the default locale until initializeGT() configures translations.'
     );
-    i18nCache = new I18nCache({
-      defaultLocale: libraryDefaultLocale,
-      locales: [libraryDefaultLocale],
-    });
+    if (!isI18nConfigInitialized()) {
+      initializeI18nConfig();
+    }
+    i18nCache = new I18nCache({});
   }
   return i18nCache;
 }

--- a/packages/i18n/src/i18n-cache/types.ts
+++ b/packages/i18n/src/i18n-cache/types.ts
@@ -1,6 +1,7 @@
 import type { RuntimeTranslateManyOptions } from 'generaltranslation/internal';
 import type { CustomMapping } from '@generaltranslation/format/types';
 import type { GTConfig } from '../config/types';
+import type { I18nConfigParams } from '../i18n-config/I18nConfig';
 import type { TranslationsLoader } from './translations-manager/translations-loaders/types';
 import type { Translation } from './translations-manager/utils/types/translation-data';
 import type { LifecycleCallbacks } from './lifecycle-hooks/types';
@@ -31,7 +32,7 @@ type RuntimeTranslationConfig = {
 export type I18nCacheConstructorParams<
   TranslationValue extends Translation = Translation,
 > = DictionaryConfig &
-  Omit<GTConfig, 'cacheExpiryTime'> & {
+  Omit<GTConfig, 'cacheExpiryTime' | keyof I18nConfigParams> & {
     /**
      * Locale cache TTL in milliseconds. Undefined uses the default TTL, null
      * disables expiry, and a number sets an explicit TTL.
@@ -51,9 +52,6 @@ export type I18nCacheConstructorParams<
  */
 export type I18nCacheConfig = {
   environment: 'development' | 'production';
-  defaultLocale: string;
-  locales: string[];
-  customMapping: CustomMapping;
   /**
    * @deprecated
    * Perhaps we can keep this around, but more for

--- a/packages/i18n/src/i18n-cache/validation/config-validation/__tests__/validateLocales.test.ts
+++ b/packages/i18n/src/i18n-cache/validation/config-validation/__tests__/validateLocales.test.ts
@@ -3,34 +3,27 @@ import { validateLocales } from '../validateLocales';
 
 describe('validateLocales', () => {
   it('validates invalid locale when GT services enabled', () => {
-    const result = validateLocales({
-      defaultLocale: 'invalid-locale',
-      projectId: 'test-project',
-      cacheUrl: undefined, // GT_REMOTE enabled
-    });
+    const result = validateLocales({ defaultLocale: 'invalid-locale' }, true);
     expect(result).toHaveLength(1);
     expect(result[0].type).toBe('error');
     expect(result[0].message).toContain('Locale "invalid-locale" is not valid');
   });
 
   it('validates multiple locales when GT services enabled', () => {
-    const result = validateLocales({
-      locales: ['en', 'invalid-locale'],
-      defaultLocale: 'en',
-      projectId: 'test-project',
-      runtimeUrl: undefined, // GT enabled
-    });
+    const result = validateLocales(
+      {
+        locales: ['en', 'invalid-locale'],
+        defaultLocale: 'en',
+      },
+      true
+    );
     expect(result).toHaveLength(1);
     expect(result[0].type).toBe('error');
     expect(result[0].message).toContain('Locale "invalid-locale" is not valid');
   });
 
   it('skips validation when GT services disabled', () => {
-    const result = validateLocales({
-      defaultLocale: 'invalid-locale',
-      cacheUrl: null,
-      runtimeUrl: null,
-    });
+    const result = validateLocales({ defaultLocale: 'invalid-locale' }, false);
     expect(result).toHaveLength(0);
   });
 });

--- a/packages/i18n/src/i18n-cache/validation/config-validation/validateLocales.ts
+++ b/packages/i18n/src/i18n-cache/validation/config-validation/validateLocales.ts
@@ -1,8 +1,7 @@
 import { isValidLocale } from '@generaltranslation/format';
 import { createDiagnosticMessage } from 'generaltranslation/internal';
-import { getGTServicesEnabled } from '../../utils/getGTServicesEnabled';
 import { ValidationResult } from '../types';
-import type { CustomMapping } from '@generaltranslation/format/types';
+import type { I18nConfigParams } from '../../../i18n-config/I18nConfig';
 
 /**
  * Validate the locales configuration
@@ -11,18 +10,12 @@ import type { CustomMapping } from '@generaltranslation/format/types';
  *
  * Only apply if using GT services
  */
-export function validateLocales(params: {
-  projectId?: string;
-  devApiKey?: string;
-  apiKey?: string;
-  defaultLocale?: string;
-  locales?: string[];
-  customMapping?: CustomMapping;
-  cacheUrl?: string | null;
-  runtimeUrl?: string | null;
-}): ValidationResult[] {
+export function validateLocales(
+  params: I18nConfigParams,
+  shouldValidate = true
+): ValidationResult[] {
   const results: ValidationResult[] = [];
-  if (!getGTServicesEnabled(params)) {
+  if (!shouldValidate) {
     return results;
   }
   const { defaultLocale, locales, customMapping } = params;

--- a/packages/i18n/src/i18n-cache/validation/validateConfig.ts
+++ b/packages/i18n/src/i18n-cache/validation/validateConfig.ts
@@ -2,7 +2,6 @@ import { ValidationResult } from './types';
 import { I18nCacheConstructorParams } from '../types';
 import { validateLoadTranslations } from './config-validation/validateLoadTranslations';
 import { validateTranslationApi } from './config-validation/validateTranslationApi';
-import { validateLocales } from './config-validation/validateLocales';
 import { validateDictionary } from './config-validation/validateDictionary';
 import type { Translation } from '../translations-manager/utils/types/translation-data';
 
@@ -18,7 +17,6 @@ export function validateConfig<TranslationValue extends Translation>(
 
   results.push(...validateLoadTranslations(config));
   results.push(...validateTranslationApi(config));
-  results.push(...validateLocales(config));
   results.push(...validateDictionary(config));
 
   return results;

--- a/packages/i18n/src/i18n-config/I18nConfig.ts
+++ b/packages/i18n/src/i18n-config/I18nConfig.ts
@@ -1,0 +1,97 @@
+import { LocaleConfig, standardizeLocale } from '@generaltranslation/format';
+import type { CustomMapping } from '@generaltranslation/format/types';
+import { libraryDefaultLocale } from 'generaltranslation/internal';
+import type { LocaleCandidates } from '../condition-store/localeResolver';
+
+export type I18nConfigParams = {
+  defaultLocale?: string;
+  locales?: string[];
+  customMapping?: CustomMapping;
+};
+
+export class I18nConfig extends LocaleConfig {
+  constructor(params: I18nConfigParams = {}, standardize = false) {
+    super(standardizeI18nConfigParams(params, standardize));
+  }
+
+  getDefaultLocale(): string {
+    return this.defaultLocale;
+  }
+
+  getLocales(): string[] {
+    return this.locales;
+  }
+
+  getCustomMapping(): CustomMapping {
+    return this.customMapping || {};
+  }
+
+  determineSupportedLocale(candidates: LocaleCandidates): string | undefined {
+    if (
+      candidates == null ||
+      (Array.isArray(candidates) && candidates.length === 0)
+    ) {
+      return undefined;
+    }
+    return this.determineLocale(candidates);
+  }
+
+  resolveSupportedLocale(candidates?: LocaleCandidates): string {
+    return this.determineSupportedLocale(candidates) || this.getDefaultLocale();
+  }
+
+  resolveLocale(locale: string): string {
+    const resolvedLocale = this.determineSupportedLocale(locale);
+    if (!this.isValidLocale(locale) || !resolvedLocale) {
+      throw new Error(
+        `Locale "${locale}" is not valid. Use a valid BCP 47 locale code or add a custom mapping.`
+      );
+    }
+    return resolvedLocale;
+  }
+
+  requiresDialectTranslation(locale: string): boolean {
+    return (
+      this.requiresTranslation(locale) &&
+      this.isSameLanguage(this.getDefaultLocale(), locale)
+    );
+  }
+}
+
+function standardizeI18nConfigParams(
+  {
+    defaultLocale = libraryDefaultLocale,
+    locales = [libraryDefaultLocale],
+    customMapping,
+  }: I18nConfigParams = {},
+  standardize = false
+): Required<I18nConfigParams> {
+  const dedupedConfig: Required<I18nConfigParams> = {
+    defaultLocale,
+    locales: Array.from(new Set([defaultLocale, ...locales])),
+    customMapping: customMapping || {},
+  };
+  if (!standardize) return dedupedConfig;
+
+  return {
+    defaultLocale: standardizeLocale(dedupedConfig.defaultLocale),
+    locales: dedupedConfig.locales.map((locale) => {
+      const mappedLocale =
+        typeof dedupedConfig.customMapping[locale] === 'string'
+          ? dedupedConfig.customMapping[locale]
+          : dedupedConfig.customMapping[locale]?.code;
+      return mappedLocale ? locale : standardizeLocale(locale);
+    }),
+    customMapping: Object.fromEntries(
+      Object.entries(dedupedConfig.customMapping).map(([key, value]) => [
+        key,
+        typeof value === 'string'
+          ? standardizeLocale(value)
+          : {
+              ...value,
+              ...(value?.code ? { code: standardizeLocale(value.code) } : {}),
+            },
+      ])
+    ),
+  };
+}

--- a/packages/i18n/src/i18n-config/singleton-operations.ts
+++ b/packages/i18n/src/i18n-config/singleton-operations.ts
@@ -1,0 +1,42 @@
+import { libraryDefaultLocale } from 'generaltranslation/internal';
+import logger from '../logs/logger';
+import { publishValidationResults } from '../i18n-cache/validation/publishValidationResults';
+import { validateLocales } from '../i18n-cache/validation/config-validation/validateLocales';
+import { I18nConfig, type I18nConfigParams } from './I18nConfig';
+
+let i18nConfig: I18nConfig | undefined = undefined;
+
+export function getI18nConfig(): I18nConfig {
+  if (!i18nConfig) {
+    logger.warn(
+      'getI18nConfig(): I18nConfig was not initialized. Falling back to the default locale until initializeGT() configures locales.'
+    );
+    i18nConfig = new I18nConfig({
+      defaultLocale: libraryDefaultLocale,
+      locales: [libraryDefaultLocale],
+    });
+  }
+  return i18nConfig;
+}
+
+export function setI18nConfig(nextI18nConfig: I18nConfig): void {
+  i18nConfig = nextI18nConfig;
+}
+
+export function initializeI18nConfig(
+  params: I18nConfigParams = {},
+  standardize = false
+): I18nConfig {
+  publishValidationResults(
+    validateLocales(params, standardize),
+    'I18nConfig: '
+  );
+
+  const nextI18nConfig = new I18nConfig(params, standardize);
+  setI18nConfig(nextI18nConfig);
+  return nextI18nConfig;
+}
+
+export function isI18nConfigInitialized(): boolean {
+  return i18nConfig !== undefined;
+}

--- a/packages/i18n/src/internal-types.ts
+++ b/packages/i18n/src/internal-types.ts
@@ -12,6 +12,7 @@ export type {
   DictionaryLoader,
   DictionaryConfig,
 } from './i18n-cache/types';
+export type { I18nConfigParams } from './i18n-config/I18nConfig';
 /** @deprecated use I18nCacheConstructorParams instead */
 export type { I18nCacheConstructorParams as I18nManagerConstructorParams } from './i18n-cache/types';
 /** @deprecated use I18nCacheConfig instead */

--- a/packages/i18n/src/internal.ts
+++ b/packages/i18n/src/internal.ts
@@ -24,6 +24,13 @@ export {
 /** @deprecated use I18nCache instead */
 export { I18nCache as I18nManager } from './i18n-cache/I18nCache';
 export { getI18nCache, setI18nCache } from './i18n-cache/singleton-operations';
+export {
+  getI18nConfig,
+  initializeI18nConfig,
+  isI18nConfigInitialized,
+  setI18nConfig,
+} from './i18n-config/singleton-operations';
+export { I18nConfig } from './i18n-config/I18nConfig';
 /** @deprecated use getI18nCache instead */
 export { getI18nCache as getI18nManager } from './i18n-cache/singleton-operations';
 /** @deprecated use setI18nCache instead */

--- a/packages/i18n/src/translation-functions/internal/getGT.ts
+++ b/packages/i18n/src/translation-functions/internal/getGT.ts
@@ -1,4 +1,5 @@
 import { getI18nCache } from '../../i18n-cache/singleton-operations';
+import { getI18nConfig } from '../../i18n-config/singleton-operations';
 import { InlineTranslationOptions } from '../types/options';
 import { GTFunctionType } from '../types/functions';
 import { interpolateMessage } from '../utils/interpolation/interpolateMessage';
@@ -19,7 +20,7 @@ export async function getGT(): Promise<GTFunctionType> {
   const i18nCache = getI18nCache();
   const locale = getLocale();
   await i18nCache.loadTranslations(locale);
-  const sourceLocale = i18nCache.getDefaultLocale();
+  const sourceLocale = getI18nConfig().getDefaultLocale();
 
   /**
    * Registers a message at build time and resolves its translation at runtime.

--- a/packages/i18n/src/translation-functions/internal/getTranslations.ts
+++ b/packages/i18n/src/translation-functions/internal/getTranslations.ts
@@ -1,4 +1,5 @@
 import { getI18nCache } from '../../i18n-cache/singleton-operations';
+import { getI18nConfig } from '../../i18n-config/singleton-operations';
 import { DictionaryTranslationOptions } from '../types/options';
 import { TFunctionType } from '../types/functions';
 import { renderDictionaryEntry } from './renderDictionaryEntry';
@@ -23,7 +24,7 @@ export async function getTranslations(): Promise<TFunctionType> {
     i18nCache.loadDictionary(locale),
     i18nCache.loadTranslations(locale),
   ]);
-  const sourceLocale = i18nCache.getDefaultLocale();
+  const sourceLocale = getI18nConfig().getDefaultLocale();
 
   /**
    * Dictionary resolution

--- a/packages/i18n/src/translation-functions/internal/helpers.ts
+++ b/packages/i18n/src/translation-functions/internal/helpers.ts
@@ -1,4 +1,5 @@
 import { getI18nCache } from '../../i18n-cache/singleton-operations';
+import { getI18nConfig } from '../../i18n-config/singleton-operations';
 import { NormalizedLookupOptions, ResolutionOptions } from '../types/options';
 import { interpolateMessage } from '../utils/interpolation/interpolateMessage';
 import type {
@@ -83,7 +84,7 @@ export function resolveStringContent(
     source: content,
     target: translation,
     options: lookupOptions,
-    sourceLocale: i18nCache.getDefaultLocale(),
+    sourceLocale: getI18nConfig().getDefaultLocale(),
   });
 }
 
@@ -106,7 +107,7 @@ export function resolveStringContentWithFallback(
     source: content,
     target: translation,
     options: lookupOptions,
-    sourceLocale: i18nCache.getDefaultLocale(),
+    sourceLocale: getI18nConfig().getDefaultLocale(),
   });
 }
 
@@ -131,7 +132,7 @@ export async function resolveStringContentWithRuntimeFallback(
     source: content,
     target: translation,
     options: lookupOptions,
-    sourceLocale: i18nCache.getDefaultLocale(),
+    sourceLocale: getI18nConfig().getDefaultLocale(),
   });
 }
 /**

--- a/packages/node/src/async-i18n-cache/AsyncConditionStore.ts
+++ b/packages/node/src/async-i18n-cache/AsyncConditionStore.ts
@@ -1,9 +1,6 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
-import type {
-  LocaleResolverConfig,
-  ScopedConditionStore,
-} from 'gt-i18n/internal/types';
-import { getI18nCache } from 'gt-i18n/internal';
+import type { ScopedConditionStore } from 'gt-i18n/internal/types';
+import { getI18nConfig } from 'gt-i18n/internal';
 
 type Store = {
   locale: string;
@@ -16,7 +13,7 @@ const OUTSIDE_SCOPE_MESSAGE =
 const ENABLE_I18N_MESSAGE =
   'AsyncConditionStore: getEnableI18n() called outside of a withGT() scope.';
 
-type AsyncConditionStoreConstructorParams = LocaleResolverConfig & {
+type AsyncConditionStoreConstructorParams = {
   store?: AsyncLocalStorage<Store>;
 };
 
@@ -26,12 +23,7 @@ type AsyncConditionStoreConstructorParams = LocaleResolverConfig & {
 export class AsyncConditionStore implements ScopedConditionStore {
   private store: AsyncLocalStorage<Store>;
 
-  constructor({
-    defaultLocale,
-    locales,
-    customMapping,
-    store,
-  }: AsyncConditionStoreConstructorParams = {}) {
+  constructor({ store }: AsyncConditionStoreConstructorParams = {}) {
     this.store = store ?? new AsyncLocalStorage();
   }
 
@@ -40,7 +32,7 @@ export class AsyncConditionStore implements ScopedConditionStore {
    * */
   run<T>(locale: string, callback: () => T): T {
     return this.store.run(
-      { locale: getI18nCache().determineLocale(locale) },
+      { locale: getI18nConfig().resolveSupportedLocale(locale) },
       callback
     );
   }
@@ -50,11 +42,11 @@ export class AsyncConditionStore implements ScopedConditionStore {
     if (!store) {
       if (process.env.NODE_ENV === 'production') {
         console.warn(OUTSIDE_SCOPE_MESSAGE);
-        return getI18nCache().determineLocale();
+        return getI18nConfig().resolveSupportedLocale();
       }
       throw new Error(OUTSIDE_SCOPE_MESSAGE);
     }
-    return getI18nCache().determineLocale(store.locale);
+    return getI18nConfig().resolveSupportedLocale(store.locale);
   }
 
   /**

--- a/packages/node/src/helpers/getRequestLocale.ts
+++ b/packages/node/src/helpers/getRequestLocale.ts
@@ -1,4 +1,4 @@
-import { getI18nCache } from 'gt-i18n/internal';
+import { getI18nConfig } from 'gt-i18n/internal';
 
 /**
  * A request object like interface
@@ -53,9 +53,8 @@ function parseAcceptLanguage(header: string): string[] {
  */
 export function getRequestLocale(request: RequestLike): string {
   // Setup
-  const i18nCache = getI18nCache<string>();
-  const defaultLocale = i18nCache.getDefaultLocale();
-  const gtInstance = i18nCache.getGTClass();
+  const i18nConfig = getI18nConfig();
+  const defaultLocale = i18nConfig.getDefaultLocale();
 
   // Get the accept-language header
   const acceptLanguage = request.headers['accept-language'];
@@ -66,5 +65,5 @@ export function getRequestLocale(request: RequestLike): string {
 
   // Parse the accept-language header
   const preferredLocales = parseAcceptLanguage(headerValue);
-  return gtInstance.determineLocale(preferredLocales) || defaultLocale;
+  return i18nConfig.resolveSupportedLocale(preferredLocales);
 }

--- a/packages/node/src/setup/initializeGT.ts
+++ b/packages/node/src/setup/initializeGT.ts
@@ -1,6 +1,10 @@
 import { setAsyncConditionStore } from '../async-i18n-cache/singleton-operations';
 import type { InitializeGTParams } from './types';
-import { I18nCache, setI18nCache } from 'gt-i18n/internal';
+import {
+  I18nCache,
+  initializeI18nConfig,
+  setI18nCache,
+} from 'gt-i18n/internal';
 import { AsyncConditionStore } from '../async-i18n-cache/AsyncConditionStore';
 
 /**
@@ -9,12 +13,10 @@ import { AsyncConditionStore } from '../async-i18n-cache/AsyncConditionStore';
  * TODO: auto detect if can find gt.config.json files
  */
 export function initializeGT(params: InitializeGTParams): void {
+  initializeI18nConfig(params);
+
   const i18nCache = new I18nCache<string>(params);
-  const conditionStore = new AsyncConditionStore({
-    defaultLocale: i18nCache.getDefaultLocale(),
-    locales: i18nCache.getLocales(),
-    customMapping: i18nCache.getCustomMapping(),
-  });
+  const conditionStore = new AsyncConditionStore();
 
   setI18nCache(i18nCache);
   setAsyncConditionStore(conditionStore);

--- a/packages/react-core/src/condition-store/singleton-operations.ts
+++ b/packages/react-core/src/condition-store/singleton-operations.ts
@@ -60,7 +60,6 @@ function getReadonlyConditionStoreWithFallback(): ReadonlyConditionStoreInterfac
     // Fallback to default configuration (important: do not set globally)
     return new ReadonlyConditionStore({
       locale: libraryDefaultLocale,
-      locales: [libraryDefaultLocale],
     });
   }
 }

--- a/packages/react-core/src/context.ts
+++ b/packages/react-core/src/context.ts
@@ -51,8 +51,11 @@ export {
   getReadonlyConditionStoreWithFallback,
   setReadonlyConditionStore,
 } from './condition-store/singleton-operations';
-export { WritableConditionStore } from 'gt-i18n/internal';
-export type { WritableConditionStoreParams } from 'gt-i18n/internal';
+export { initializeI18nConfig, WritableConditionStore } from 'gt-i18n/internal';
+export type {
+  I18nConfigParams,
+  WritableConditionStoreParams,
+} from 'gt-i18n/internal';
 export {
   getReactI18nCache,
   setReactI18nCache,

--- a/packages/react-core/src/functions/translation/t.ts
+++ b/packages/react-core/src/functions/translation/t.ts
@@ -1,6 +1,7 @@
 import {
   createLookupOptions,
   getRuntimeEnvironment,
+  getI18nConfig,
   interpolateMessage,
 } from 'gt-i18n/internal';
 import type {
@@ -59,7 +60,7 @@ export function resolveStringContent(
   options: ResolutionOptions<StringFormat> = {}
 ): StringContent {
   const i18nCache = getReactI18nCache();
-  const defaultLocale = i18nCache.getDefaultLocale();
+  const defaultLocale = getI18nConfig().getDefaultLocale();
   if (!getShouldTranslate()) {
     return interpolateMessage({
       options,

--- a/packages/react-core/src/hooks/utils.ts
+++ b/packages/react-core/src/hooks/utils.ts
@@ -2,7 +2,7 @@ import { useDefaultLocale } from './external-store-hooks';
 import { useLocale } from './condition-store';
 import { requiresTranslation } from 'generaltranslation/core';
 import { getReadonlyConditionStoreWithFallback } from '../condition-store/singleton-operations';
-import { getReactI18nCache } from '../i18n-cache/singleton-operations';
+import { getI18nConfig } from 'gt-i18n/internal';
 
 export function useFormatLocales(localesProp: string[] = []): string[] {
   const locale = useLocale();
@@ -22,13 +22,13 @@ export function useShouldTranslate(): boolean {
  */
 export function getShouldTranslate(): boolean {
   const conditionStore = getReadonlyConditionStoreWithFallback();
-  const i18nCache = getReactI18nCache();
+  const i18nConfig = getI18nConfig();
 
   const enableI18n = conditionStore.getEnableI18n();
   const locale = conditionStore.getLocale();
-  const defaultLocale = i18nCache.getDefaultLocale();
-  const locales = i18nCache.getLocales();
-  const customMapping = i18nCache.getCustomMapping();
+  const defaultLocale = i18nConfig.getDefaultLocale();
+  const locales = i18nConfig.getLocales();
+  const customMapping = i18nConfig.getCustomMapping();
   return (
     enableI18n &&
     requiresTranslation(defaultLocale, locale, [...locales], customMapping)

--- a/packages/react-core/src/i18n-store/I18nStore.ts
+++ b/packages/react-core/src/i18n-store/I18nStore.ts
@@ -18,6 +18,7 @@ import type { Translation } from 'gt-i18n/types';
 import { getReactI18nCache } from '../i18n-cache/singleton-operations';
 import { RuntimeTranslationScope } from './RuntimeTranslationScope';
 import { RuntimeDictionaryScope } from './RuntimeDictionaryScope';
+import { getI18nConfig } from 'gt-i18n/internal';
 
 type EntryCacheEvent = {
   locale: string;
@@ -138,15 +139,15 @@ export class I18nStore {
   // ===== Manager Config Snapshots ===== //
 
   getDefaultLocaleSnapshot = (): string => {
-    return getReactI18nCache().getDefaultLocale();
+    return getI18nConfig().getDefaultLocale();
   };
 
   getLocalesSnapshot = (): readonly string[] => {
-    return getReactI18nCache().getLocales();
+    return getI18nConfig().getLocales();
   };
 
   getCustomMappingSnapshot = (): CustomMapping => {
-    return getReactI18nCache().getCustomMapping();
+    return getI18nConfig().getCustomMapping();
   };
 
   // ===== I18nCache Snapshots ===== //

--- a/packages/react-core/src/setup/initializeGTSPA.ts
+++ b/packages/react-core/src/setup/initializeGTSPA.ts
@@ -1,5 +1,12 @@
-import { I18nCache, WritableConditionStore } from 'gt-i18n/internal';
-import type { WritableConditionStoreParams } from 'gt-i18n/internal';
+import {
+  I18nCache,
+  initializeI18nConfig,
+  WritableConditionStore,
+} from 'gt-i18n/internal';
+import type {
+  I18nConfigParams,
+  WritableConditionStoreParams,
+} from 'gt-i18n/internal';
 import type { Translation } from 'gt-i18n/types';
 import { setReactI18nCache } from '../i18n-cache/singleton-operations';
 import type { ReactI18nCacheParams } from '../i18n-cache/ReactI18nCache';
@@ -17,9 +24,14 @@ import { setI18nStore } from '../i18n-store/singleton-operations';
  * @deprecated moved to /react and /react-native
  */
 export function internalInitializeGTSPA(
-  config: I18nStoreParams & ReactI18nCacheParams & WritableConditionStoreParams
+  config: I18nStoreParams &
+    I18nConfigParams &
+    ReactI18nCacheParams &
+    WritableConditionStoreParams
 ): void {
   setRenderStrategy('SPA');
+
+  initializeI18nConfig(config);
 
   const i18nCache = new I18nCache<Translation>(config);
   setReactI18nCache(i18nCache);

--- a/packages/react-core/src/setup/initializeGTSSR.ts
+++ b/packages/react-core/src/setup/initializeGTSSR.ts
@@ -1,4 +1,5 @@
-import { I18nCache } from 'gt-i18n/internal';
+import { I18nCache, initializeI18nConfig } from 'gt-i18n/internal';
+import type { I18nConfigParams } from 'gt-i18n/internal';
 import type { Translation } from 'gt-i18n/types';
 import type { ReactI18nCacheParams } from '../i18n-cache/ReactI18nCache';
 import { setRenderStrategy } from './globals';
@@ -11,8 +12,12 @@ import { setReactI18nCache } from '../i18n-cache/singleton-operations';
  * ConditionStore and I18nStore are initialized in the provider at request time
  * TODO: auto detect if can find gt.config.json files
  */
-export function internalInitializeGTSSR(config: ReactI18nCacheParams): void {
+export function internalInitializeGTSSR(
+  config: I18nConfigParams & ReactI18nCacheParams
+): void {
   setRenderStrategy('server-render');
+
+  initializeI18nConfig(config);
 
   const i18nCache = new I18nCache<Translation>(config);
   setReactI18nCache(i18nCache);

--- a/packages/react/src/condition-store/BrowserConditionStore.ts
+++ b/packages/react/src/condition-store/BrowserConditionStore.ts
@@ -1,10 +1,8 @@
-import {
-  getReactI18nCache,
-  WritableConditionStoreParams,
-} from '@generaltranslation/react-core/context';
+import { WritableConditionStoreParams } from '@generaltranslation/react-core/context';
 import { getCookieValue, setCookieValue } from './cookies';
 import { readBrowserLocale } from './readBrowserLocale';
 import { GetEnableI18n, GetLocale } from '../i18n-cache/types';
+import { getI18nConfig } from 'gt-i18n/internal';
 import {
   LocaleCandidates,
   WritableConditionStoreInterface,
@@ -49,7 +47,7 @@ export class BrowserConditionStore implements WritableConditionStoreInterface {
     this.enableI18nCookieName = config.enableI18nCookieName;
     setCookieValue({
       cookieName: this.localeCookieName,
-      value: getReactI18nCache().determineLocale(config.locale),
+      value: getI18nConfig().resolveSupportedLocale(config.locale),
     });
   }
 
@@ -83,7 +81,7 @@ export class BrowserConditionStore implements WritableConditionStoreInterface {
   updateLocale = (locale: LocaleCandidates): void => {
     setCookieValue({
       cookieName: this.localeCookieName,
-      value: getReactI18nCache().determineLocale(locale),
+      value: getI18nConfig().resolveSupportedLocale(locale),
     });
   };
 
@@ -114,5 +112,5 @@ export class BrowserConditionStore implements WritableConditionStoreInterface {
 function getBrowserLocale(cookieName: string, getLocale?: GetLocale): string {
   const candidates = readBrowserLocale(cookieName);
   if (getLocale) candidates.push(getLocale());
-  return getReactI18nCache().determineLocale(candidates);
+  return getI18nConfig().resolveSupportedLocale(candidates);
 }

--- a/packages/react/src/condition-store/createBrowserConditionStore.ts
+++ b/packages/react/src/condition-store/createBrowserConditionStore.ts
@@ -1,5 +1,5 @@
-import { getReactI18nCache } from '@generaltranslation/react-core/context';
 import type { LocaleCandidates } from 'gt-i18n/internal';
+import { getI18nConfig } from 'gt-i18n/internal';
 import {
   BrowserConditionStore,
   BrowserConditionStoreParams,
@@ -66,7 +66,7 @@ function determineLocale({
   candidates.push(...readBrowserLocale(localeCookieName));
   if (locale) candidates.push(...locale);
   if (getLocale) candidates.push(getLocale());
-  return getReactI18nCache().determineLocale(candidates);
+  return getI18nConfig().resolveSupportedLocale(candidates);
 }
 
 function determineEnableI18n({

--- a/packages/react/src/i18n-cache/BrowserI18nCache.ts
+++ b/packages/react/src/i18n-cache/BrowserI18nCache.ts
@@ -2,7 +2,7 @@ import type {
   I18nCacheConstructorParams,
   TranslationsLoader,
 } from 'gt-i18n/internal/types';
-import { I18nCache } from 'gt-i18n/internal';
+import { getI18nConfig, I18nCache } from 'gt-i18n/internal';
 import type { HtmlTagOptions } from './types';
 import type { Translation } from 'gt-i18n/types';
 import { DEFAULT_HTML_TAG_OPTIONS } from './constants';
@@ -116,17 +116,17 @@ export class BrowserI18nCache extends I18nCache<Translation> {
   ): void {
     // Get parameters
     const htmlLocale = htmlTagOptions?.lang || locale;
-    const gtInstance = this.getGTClass();
-    const canonicalLocale = gtInstance.resolveCanonicalLocale(htmlLocale);
+    const i18nConfig = getI18nConfig();
+    const canonicalLocale = i18nConfig.resolveCanonicalLocale(htmlLocale);
 
     // Validate parameters
-    if (!gtInstance.isValidLocale(canonicalLocale)) {
+    if (!i18nConfig.isValidLocale(canonicalLocale)) {
       console.warn(createInvalidLocaleWarning(htmlLocale));
       return;
     }
 
     const localeDirection =
-      htmlTagOptions?.dir || gtInstance.getLocaleDirection(canonicalLocale);
+      htmlTagOptions?.dir || i18nConfig.getLocaleDirection(canonicalLocale);
 
     // Merge options
     const mergedHtmlTagOptions = {

--- a/packages/react/src/provider/CSRGTProvider.tsx
+++ b/packages/react/src/provider/CSRGTProvider.tsx
@@ -1,7 +1,4 @@
-import {
-  getReactI18nCache,
-  InternalGTProvider,
-} from '@generaltranslation/react-core/context';
+import { InternalGTProvider } from '@generaltranslation/react-core/context';
 import type { SharedGTProviderProps } from './SharedGTProviderProps';
 import { createOrUpdateBrowserConditionStore } from '../condition-store/createBrowserConditionStore';
 
@@ -10,21 +7,11 @@ import { createOrUpdateBrowserConditionStore } from '../condition-store/createBr
  * GTProvider because needs to syncrhonize any incoming
  * server-side translations
  */
-export function CSRGTProvider({
-  defaultLocale = getReactI18nCache().getDefaultLocale(),
-  locales = getReactI18nCache().getLocales(),
-  customMapping = getReactI18nCache().getCustomMapping(),
-  ...props
-}: SharedGTProviderProps) {
+export function CSRGTProvider(props: SharedGTProviderProps) {
   // TODO: if a specific translation entry changes, but not the locale, this does not trigger a re-render
   // TODO: optimize by skipping updateTranslations() if client is responsible for reloading translations
   // (eg reloadLocale === undefined), see getI18nStore().updateLocale() in InternalGTProvider
-  createOrUpdateBrowserConditionStore({
-    defaultLocale,
-    locales,
-    customMapping,
-    ...props,
-  });
+  createOrUpdateBrowserConditionStore(props);
 
   return <InternalGTProvider {...props} />;
 }

--- a/packages/react/src/provider/SSRGTProvider.tsx
+++ b/packages/react/src/provider/SSRGTProvider.tsx
@@ -4,10 +4,7 @@ import {
   setReadonlyConditionStore,
 } from '../condition-store/singleton-operations';
 import type { SharedGTProviderProps } from './SharedGTProviderProps';
-import {
-  getReactI18nCache,
-  InternalGTProvider,
-} from '@generaltranslation/react-core/context';
+import { InternalGTProvider } from '@generaltranslation/react-core/context';
 
 /**
  * For the server side GTProvider, we don't need to synchronize translations
@@ -15,20 +12,10 @@ import {
  *
  * TODO: find some way to enforce this is only imported on the server
  */
-export function SSRGTProvider({
-  defaultLocale = getReactI18nCache().getDefaultLocale(),
-  locales = getReactI18nCache().getLocales(),
-  customMapping = getReactI18nCache().getCustomMapping(),
-  ...props
-}: SharedGTProviderProps) {
+export function SSRGTProvider(props: SharedGTProviderProps) {
   // The condition store may already be created at the module level
   if (!isReadonlyConditionStoreInitialized()) {
-    const conditionStore = new ReadonlyConditionStore({
-      defaultLocale,
-      locales,
-      customMapping,
-      ...props,
-    });
+    const conditionStore = new ReadonlyConditionStore(props);
     setReadonlyConditionStore(conditionStore);
   }
   return <InternalGTProvider {...props} />;

--- a/packages/react/src/provider/SharedGTProviderProps.ts
+++ b/packages/react/src/provider/SharedGTProviderProps.ts
@@ -1,11 +1,12 @@
 import type { InternalGTProviderProps } from '@generaltranslation/react-core/context';
-import type { ReadonlyConditionStoreParams } from 'gt-i18n/internal/types';
+import type { LocaleCandidates } from 'gt-i18n/internal/types';
 
 /**
  * We force the user to pass translations so they can be synchronously accessed
  *
  * - {@link InternalGTProviderProps} - requires translations and dictionaries
- * - {@link ReadonlyConditionStoreParams} - requires locale
+ * - locale - request/browser locale candidates
  */
-export type SharedGTProviderProps = InternalGTProviderProps &
-  ReadonlyConditionStoreParams;
+export type SharedGTProviderProps = InternalGTProviderProps & {
+  locale: LocaleCandidates;
+};

--- a/packages/react/src/setup/initializeGTSPA.ts
+++ b/packages/react/src/setup/initializeGTSPA.ts
@@ -6,7 +6,9 @@ import {
   setI18nStore,
   setReactI18nCache,
   getReadonlyConditionStoreWithFallback,
+  initializeI18nConfig,
 } from '@generaltranslation/react-core/context';
+import type { I18nConfigParams } from 'gt-i18n/internal/types';
 import { BrowserI18nCache } from '../i18n-cache/BrowserI18nCache';
 import type { BrowserI18nCacheParams } from '../i18n-cache/BrowserI18nCache';
 import {
@@ -24,10 +26,13 @@ import {
  */
 export async function initializeGTSPA(
   config: I18nStoreParams &
+    I18nConfigParams &
     BrowserI18nCacheParams &
     CreateBrowserConditionStoreParams
 ) {
   setRenderStrategy('SPA');
+
+  initializeI18nConfig(config);
 
   const i18nCache = new BrowserI18nCache(config);
   setReactI18nCache(i18nCache);

--- a/packages/tanstack-start/src/provider/GTProvider.tsx
+++ b/packages/tanstack-start/src/provider/GTProvider.tsx
@@ -32,9 +32,6 @@ export function GTProvider(props: GTProviderProps): React.ReactNode {
   return (
     <GTReactProvider
       ssr={isSSREnabled()}
-      defaultLocale={i18nCache.getDefaultLocale()}
-      locales={i18nCache.getLocales()}
-      customMapping={i18nCache.getCustomMapping()}
       enableI18n={i18nCache.isTranslationEnabled()}
       loadTranslations={(locale: string) => i18nCache.loadTranslations(locale)}
       _versionId={i18nCache.getVersionId()}


### PR DESCRIPTION
## Summary

- Replace the duplicated `condition-store/localeResolver` `LocaleConfig` setup with `I18nConfig` delegation.
- Move `getLocaleProperties()` to read through `I18nConfig` instead of creating a GT class.
- Update browser HTML locale validation, canonicalization, and direction helpers to use `I18nConfig`.

## Stack

1. Previous: introduce the unused `I18nConfig` class and singleton operations.
2. Previous: move readonly locale value ownership to `I18nConfig`.
3. This PR: consolidate advanced locale helper logic onto `I18nConfig`.

## Verification

- `pnpm --filter gt-i18n build`
- `pnpm --filter gt-i18n test`
- `pnpm --filter gt-react build`