### PR TITLE
fix: handle whitespace derive children

### DIFF
--- a/.changeset/late-lamps-drop.md
+++ b/.changeset/late-lamps-drop.md
@@ -1,0 +1,5 @@
+---
+"gt": patch
+---
+
+Handle derived children with whitespace

--- a/packages/cli/src/react/jsx/utils/jsxParsing/__tests__/deriveVariableDeclaration.test.ts
+++ b/packages/cli/src/react/jsx/utils/jsxParsing/__tests__/deriveVariableDeclaration.test.ts
@@ -90,6 +90,64 @@ describe('Derive with variable declarations in JSX', () => {
 
   // ─── Happy path: basic derivable initializers ───────────────────
 
+  describe('direct conditional expression with empty branch', () => {
+    it('should preserve an empty string branch as a separate derive variant', () => {
+      const source = `
+        import { Branch, Derive, T, Var } from "gt-next";
+
+        export default function Page() {
+          const includeOptionalPrefix = false;
+          const showReviewerName = false;
+          const releaseName = "spring launch";
+          return (
+            <T>
+              <Derive>{includeOptionalPrefix ? "Optional prefix: " : ""}</Derive>
+              <Branch
+                branch={showReviewerName}
+                true={"Jordan"}
+                false={""}
+              />
+              {" approved the build for "}
+              <Var name="release-name">{releaseName}</Var>
+            </T>
+          );
+        }
+      `;
+
+      const { updates, errors } = parseDerive(source);
+
+      expect(errors).toHaveLength(0);
+      expect(updates).toHaveLength(2);
+
+      const branch = {
+        t: 'Branch',
+        i: 2,
+        d: {
+          t: 'b',
+          b: {
+            true: 'Jordan',
+            false: '',
+          },
+        },
+      };
+      const releaseNameVar = { i: 3, k: 'release-name', v: 'v' };
+
+      const sources = updates.map((u) => u.source);
+      expect(sources).toContainEqual([
+        { t: 'Derive', i: 1, c: 'Optional prefix: ' },
+        branch,
+        ' approved the build for ',
+        releaseNameVar,
+      ]);
+      expect(sources).toContainEqual([
+        { t: 'Derive', i: 1, c: '' },
+        branch,
+        ' approved the build for ',
+        releaseNameVar,
+      ]);
+    });
+  });
+
   describe('identifier referencing a const with conditional initializer', () => {
     it('should resolve a const ternary variable inside <Derive> and produce 2 branches', () => {
       const source = `

--- a/packages/cli/src/react/jsx/utils/jsxParsing/handleChildrenWhitespace.ts
+++ b/packages/cli/src/react/jsx/utils/jsxParsing/handleChildrenWhitespace.ts
@@ -152,7 +152,7 @@ export function handleChildrenWhitespace(
           if (parentNodeType === 'multiplication') {
             // This should be treated like a new tree (no parent here b/c its a new tree)
             const result = handleChildrenWhitespace(textNode);
-            if (result) newChildren.push(result);
+            if (result !== null) newChildren.push(result);
           } else {
             const string = trimJsxStringChild(textNode);
             if (string) newChildren.push(string);


### PR DESCRIPTION
<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1491"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782433050&installation_id=127936663&pr_number=1491&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1491&signature=2e8d91631e0c3adba496419a585c709927380c78a676f5232e8d8e3407418c6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug in `handleChildrenWhitespace` where empty-string Derive variants (e.g. the `""` branch of `condition ? "prefix: " : ""`) were silently dropped during whitespace processing.

- **Core fix**: In the `'multiplication'` text-node path, changes `if (result)` to `if (result !== null)`. The old truthy check discarded `""` returned by `trimJsxStringChild`, losing one branch of any Derive conditional with an empty string arm.
- **Intentional asymmetry preserved**: The parallel non-multiplication path at the next branch still uses `if (string)` — correctly dropping whitespace-only JSX text nodes that collapse to `""` during trim.
- **Test coverage**: Adds a regression test that parses a `<T>` component with a `<Derive>` ternary having an empty-string branch and asserts both variants appear in the output.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a one-line, tightly scoped fix in an isolated whitespace-processing utility, backed by a targeted regression test.

The fix is minimal and correct: switching from a falsy check to an explicit null check in one branch of a switch statement, with the parallel non-multiplication path intentionally left unchanged. The new test directly exercises the previously broken code path and confirms both Derive variants (empty-string and non-empty) are preserved. No unrelated code is touched.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/react/jsx/utils/jsxParsing/handleChildrenWhitespace.ts | Fixes falsy-check bug that dropped empty-string Derive branches by switching `if (result)` to `if (result !== null)` in the multiplication text-node path. |
| packages/cli/src/react/jsx/utils/jsxParsing/__tests__/deriveVariableDeclaration.test.ts | Adds a regression test for the empty-string Derive branch bug; verifies both variants ("Optional prefix: " and "") appear in the parsed output. |
| .changeset/late-lamps-drop.md | Changeset entry marking this as a patch fix for `gt`. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["handleChildrenWhitespace(textNode, 'multiplication')"] --> B{"parentNodeType\n=== 'multiplication'?"}
    B -- yes --> C["handleChildrenWhitespace(textNode)\n→ trimJsxStringChild(textNode)"]
    C --> D{"result !== null?\n(was: if result)"}
    D -- "result = ''\n(empty string branch)" --> E["✅ newChildren.push('')\nPreserves empty Derive variant"]
    D -- "result = 'text'" --> F["✅ newChildren.push('text')\nPreserves non-empty branch"]
    D -- "result = null" --> G["⛔ Skip — drop null"]
    B -- no --> H["trimJsxStringChild(textNode)"]
    H --> I{"if string\n(truthy check)"}
    I -- "string = ''" --> J["⛔ Skip — drop whitespace-only JSX text"]
    I -- "string = 'text'" --> K["✅ newChildren.push(string)"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: handle whitespace derive children"](https://github.com/generaltranslation/gt/commit/dc329c06e88ad0d5285c7e9dc82ecd69453c4046) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34070239)</sub>

<!-- /greptile_comment -->