### PR TITLE
refactor: read cache locale config from i18n config

### DIFF
--- a/packages/i18n/src/condition-store/ReadonlyConditionStore.ts
+++ b/packages/i18n/src/condition-store/ReadonlyConditionStore.ts
@@ -24,7 +24,7 @@ export type ReadonlyConditionStoreParams = {
 
 export class ReadonlyConditionStore implements ReadonlyConditionStoreContract {
   /**
-   * @deprecated use getI18nCache().determineLocale() instead
+   * @deprecated use I18nConfig instead
    */
   protected readonly resolveLocale: (candidates?: LocaleCandidates) => string;
   protected locale: string;
@@ -36,8 +36,7 @@ export class ReadonlyConditionStore implements ReadonlyConditionStoreContract {
     ...localeConfig
   }: ReadonlyConditionStoreParams) {
     /**
-     * TODO: change this to getI18nCache().determineLocale() but this
-     * currently creates a circular dependency
+     * TODO: change this to I18nConfig once condition stores are migrated.
      */
     this.resolveLocale = createLocaleResolver(localeConfig);
     this.locale = this.resolveLocale(locale);

--- a/packages/i18n/src/i18n-cache/I18nCache.ts
+++ b/packages/i18n/src/i18n-cache/I18nCache.ts
@@ -86,10 +86,10 @@ class I18nCache<
     super();
 
     // Validation
-    publishValidationResults(validateConfig(params), 'I18nCache: ');
+    const validationResults = validateConfig(params);
+    publishValidationResults(validationResults, 'I18nCache: ');
 
     this.config = standardizeConfig(params);
-    const i18nConfig = getI18nConfig();
 
     // Create cache miss handlers
     const loadTranslations = routeCreateTranslationLoader({
@@ -100,7 +100,6 @@ class I18nCache<
         projectId: params.projectId,
         _versionId: params._versionId,
         _branchId: params._branchId,
-        customMapping: i18nConfig.getCustomMapping(),
       },
     }) as SafeTranslationsLoader<TranslationValue>;
     const loadDictionary = params.loadDictionary ?? (() => Promise.resolve({}));
@@ -126,7 +125,6 @@ class I18nCache<
 
     // Setup locale-scoped caches
     this.localesCache = new LocalesCache<TranslationValue>({
-      defaultLocale: i18nConfig.getDefaultLocale(),
       dictionary: params.dictionary,
       loadTranslations,
       loadDictionary,
@@ -169,6 +167,7 @@ class I18nCache<
 
   /**
    * Get the default locale
+   * @deprecated use I18nConfig instead
    */
   getDefaultLocale(): string {
     return getI18nConfig().getDefaultLocale();
@@ -176,6 +175,7 @@ class I18nCache<
 
   /**
    * Get the locales
+   * @deprecated use I18nConfig instead
    */
   getLocales(): string[] {
     return getI18nConfig().getLocales();
@@ -183,6 +183,7 @@ class I18nCache<
 
   /**
    * Get the custom locale mapping
+   * @deprecated use I18nConfig instead
    */
   getCustomMapping() {
     return getI18nConfig().getCustomMapping();
@@ -190,9 +191,13 @@ class I18nCache<
 
   /**
    * Determine the best locale match, falling back to the default locale.
+   * @deprecated use I18nConfig instead
    */
   determineLocale(candidates?: LocaleCandidates): string {
-    return getI18nConfig().resolveSupportedLocale(candidates);
+    const i18nConfig = getI18nConfig();
+    return (
+      i18nConfig.determineLocale(candidates) || i18nConfig.getDefaultLocale()
+    );
   }
 
   /**
@@ -642,10 +647,14 @@ class I18nCache<
    * Returns true if translation is required
    * @param {string} locale - The user's locale
    * @returns {boolean} True if translation is required, otherwise false
+   * @deprecated use I18nConfig instead
    */
   requiresTranslation(locale: string): boolean {
+    const defaultLocale = this.getDefaultLocale();
+    const locales = this.getLocales();
     return (
-      this.isTranslationEnabled() && getI18nConfig().requiresTranslation(locale)
+      this.isTranslationEnabled() &&
+      getI18nConfig().requiresTranslation(locale, defaultLocale, locales)
     );
   }
 
@@ -653,14 +662,19 @@ class I18nCache<
    * Returns true if dialect translation is required
    * @param {string} locale - The user's locale
    * @returns {boolean} True if dialect translation is required, otherwise false
+   * @deprecated use I18nConfig instead
    */
   requiresDialectTranslation(locale: string): boolean {
+    const defaultLocale = this.getDefaultLocale();
     return (
-      this.isTranslationEnabled() &&
-      getI18nConfig().requiresDialectTranslation(locale)
+      this.requiresTranslation(locale) &&
+      getI18nConfig().isSameLanguage(defaultLocale, locale)
     );
   }
 
+  /**
+   * @deprecated use I18nConfig instead
+   */
   public sanitizeLocale(locale: string): string | undefined {
     try {
       return this._resolveLocale(locale);
@@ -690,7 +704,14 @@ class I18nCache<
   }
 
   private _resolveLocale(locale: string) {
-    return getI18nConfig().resolveLocale(locale);
+    const i18nConfig = getI18nConfig();
+    const resolvedLocale = i18nConfig.determineLocale(locale);
+    if (!i18nConfig.isValidLocale(locale) || !resolvedLocale) {
+      throw new Error(
+        `Locale "${locale}" is not valid. Use a valid BCP 47 locale code or add a custom mapping.`
+      );
+    }
+    return resolvedLocale;
   }
 
   /**

--- a/packages/i18n/src/i18n-cache/I18nCache.ts
+++ b/packages/i18n/src/i18n-cache/I18nCache.ts
@@ -29,11 +29,7 @@ import { TRANSLATIONS_CACHE_MISS_EVENT_NAME } from './event-subscription/types';
 import type { I18nEvents } from './event-subscription/types';
 import { LocaleCandidates } from '../condition-store/localeResolver';
 import { getRuntimeEnvironment } from '../utils/getRuntimeEnvironment';
-import {
-  getI18nConfig,
-  initializeI18nConfig,
-  isI18nConfigInitialized,
-} from '../i18n-config/singleton-operations';
+import { getI18nConfig } from '../i18n-config/singleton-operations';
 
 /**
  * Default translation timeout in milliseconds for a runtime translation request
@@ -92,12 +88,6 @@ class I18nCache<
     // Validation
     publishValidationResults(validateConfig(params), 'I18nCache: ');
 
-    // Setup
-    if (hasI18nConfigParams(params) || !isI18nConfigInitialized()) {
-      initializeI18nConfig(
-        params as Parameters<typeof initializeI18nConfig>[0]
-      );
-    }
     this.config = standardizeConfig(params);
     const i18nConfig = getI18nConfig();
 
@@ -827,14 +817,6 @@ function standardizeConfig<TranslationValue extends Translation>(
     runtimeTranslation: config.runtimeTranslation,
     _versionId: config._versionId,
   };
-}
-
-function hasI18nConfigParams(params: object): boolean {
-  return (
-    'defaultLocale' in params ||
-    'locales' in params ||
-    'customMapping' in params
-  );
 }
 
 /**

--- a/packages/i18n/src/i18n-cache/I18nCache.ts
+++ b/packages/i18n/src/i18n-cache/I18nCache.ts
@@ -656,7 +656,7 @@ class I18nCache<
    */
   requiresDialectTranslation(locale: string): boolean {
     return (
-      this.requiresTranslation(locale) &&
+      this.isTranslationEnabled() &&
       getI18nConfig().requiresDialectTranslation(locale)
     );
   }

--- a/packages/i18n/src/i18n-cache/I18nCache.ts
+++ b/packages/i18n/src/i18n-cache/I18nCache.ts
@@ -3,12 +3,8 @@ import logger from '../logs/logger';
 import { I18nCacheConfig, I18nCacheConstructorParams } from './types';
 import { validateConfig } from './validation/validateConfig';
 import { Translation } from './translations-manager/utils/types/translation-data';
-import { libraryDefaultLocale } from 'generaltranslation/internal';
 import { GT } from 'generaltranslation';
-import { LocaleConfig, standardizeLocale } from '@generaltranslation/format';
-import type { CustomMapping } from '@generaltranslation/format/types';
 import { LookupOptions } from '../translation-functions/types/options';
-import { getGTServicesEnabled } from './utils/getGTServicesEnabled';
 import {
   SafeTranslationsLoader,
   TranslationsLoader,
@@ -31,11 +27,13 @@ import { EventEmitter } from './event-subscription/EventEmitter';
 import { subscribeLifecycleCallbacks } from './lifecycle-hooks/subscribeLifecycleCallbacks';
 import { TRANSLATIONS_CACHE_MISS_EVENT_NAME } from './event-subscription/types';
 import type { I18nEvents } from './event-subscription/types';
-import {
-  createLocaleResolver,
-  LocaleCandidates,
-} from '../condition-store/localeResolver';
+import { LocaleCandidates } from '../condition-store/localeResolver';
 import { getRuntimeEnvironment } from '../utils/getRuntimeEnvironment';
+import {
+  getI18nConfig,
+  initializeI18nConfig,
+  isI18nConfigInitialized,
+} from '../i18n-config/singleton-operations';
 
 /**
  * Default translation timeout in milliseconds for a runtime translation request
@@ -83,13 +81,6 @@ class I18nCache<
   private localesCache: LocalesCache<TranslationValue>;
 
   /**
-   * Runtime-safe locale and formatting helpers
-   */
-  private localeConfig: LocaleConfig;
-
-  public determineLocale: (candidates?: LocaleCandidates) => string;
-
-  /**
    * Creates an instance of I18nCache.
    * TODO: resolve gtConfig from just file path
    * @param params - The parameters for the I18nCache constructor
@@ -99,21 +90,16 @@ class I18nCache<
     super();
 
     // Validation
-    const validationResults = validateConfig(params);
-    publishValidationResults(validationResults, 'I18nCache: ');
+    publishValidationResults(validateConfig(params), 'I18nCache: ');
 
     // Setup
+    if (hasI18nConfigParams(params) || !isI18nConfigInitialized()) {
+      initializeI18nConfig(
+        params as Parameters<typeof initializeI18nConfig>[0]
+      );
+    }
     this.config = standardizeConfig(params);
-    this.localeConfig = new LocaleConfig({
-      defaultLocale: this.config.defaultLocale,
-      locales: this.config.locales,
-      customMapping: this.config.customMapping,
-    });
-    this.determineLocale = createLocaleResolver({
-      defaultLocale: this.config.defaultLocale,
-      locales: this.config.locales,
-      customMapping: this.config.customMapping,
-    });
+    const i18nConfig = getI18nConfig();
 
     // Create cache miss handlers
     const loadTranslations = routeCreateTranslationLoader({
@@ -124,7 +110,7 @@ class I18nCache<
         projectId: params.projectId,
         _versionId: params._versionId,
         _branchId: params._branchId,
-        customMapping: params.customMapping,
+        customMapping: i18nConfig.getCustomMapping(),
       },
     }) as SafeTranslationsLoader<TranslationValue>;
     const loadDictionary = params.loadDictionary ?? (() => Promise.resolve({}));
@@ -150,7 +136,7 @@ class I18nCache<
 
     // Setup locale-scoped caches
     this.localesCache = new LocalesCache<TranslationValue>({
-      defaultLocale: this.config.defaultLocale,
+      defaultLocale: i18nConfig.getDefaultLocale(),
       dictionary: params.dictionary,
       loadTranslations,
       loadDictionary,
@@ -195,21 +181,28 @@ class I18nCache<
    * Get the default locale
    */
   getDefaultLocale(): string {
-    return this.config.defaultLocale;
+    return getI18nConfig().getDefaultLocale();
   }
 
   /**
    * Get the locales
    */
   getLocales(): string[] {
-    return this.config.locales;
+    return getI18nConfig().getLocales();
   }
 
   /**
    * Get the custom locale mapping
    */
-  getCustomMapping(): CustomMapping {
-    return this.config.customMapping;
+  getCustomMapping() {
+    return getI18nConfig().getCustomMapping();
+  }
+
+  /**
+   * Determine the best locale match, falling back to the default locale.
+   */
+  determineLocale(candidates?: LocaleCandidates): string {
+    return getI18nConfig().resolveSupportedLocale(candidates);
   }
 
   /**
@@ -478,11 +471,13 @@ class I18nCache<
   }
 
   private getDefaultDictionaryCache() {
-    return this.localesCache.getDictionary(this.config.defaultLocale);
+    return this.localesCache.getDictionary(getI18nConfig().getDefaultLocale());
   }
 
   private resolveDictionaryCacheLocale(locale: string): Locale {
-    return this.resolveCacheLocale(locale) ?? this.config.defaultLocale;
+    return (
+      this.resolveCacheLocale(locale) ?? getI18nConfig().getDefaultLocale()
+    );
   }
 
   /**
@@ -659,11 +654,8 @@ class I18nCache<
    * @returns {boolean} True if translation is required, otherwise false
    */
   requiresTranslation(locale: string): boolean {
-    const defaultLocale = this.getDefaultLocale();
-    const locales = this.getLocales();
     return (
-      this.isTranslationEnabled() &&
-      this.localeConfig.requiresTranslation(locale, defaultLocale, locales)
+      this.isTranslationEnabled() && getI18nConfig().requiresTranslation(locale)
     );
   }
 
@@ -673,10 +665,9 @@ class I18nCache<
    * @returns {boolean} True if dialect translation is required, otherwise false
    */
   requiresDialectTranslation(locale: string): boolean {
-    const defaultLocale = this.getDefaultLocale();
     return (
       this.requiresTranslation(locale) &&
-      this.localeConfig.isSameLanguage(defaultLocale, locale)
+      getI18nConfig().requiresDialectTranslation(locale)
     );
   }
 
@@ -709,13 +700,7 @@ class I18nCache<
   }
 
   private _resolveLocale(locale: string) {
-    const resolvedLocale = this.localeConfig.determineLocale(locale);
-    if (!this.localeConfig.isValidLocale(locale) || !resolvedLocale) {
-      throw new Error(
-        `Locale "${locale}" is not valid. Use a valid BCP 47 locale code or add a custom mapping.`
-      );
-    }
-    return resolvedLocale;
+    return getI18nConfig().resolveLocale(locale);
   }
 
   /**
@@ -729,8 +714,9 @@ class I18nCache<
       return resolvedLocale;
     }
 
-    const aliasLocale = this.localeConfig.resolveAliasLocale(
-      standardizeLocale(locale)
+    const i18nConfig = getI18nConfig();
+    const aliasLocale = i18nConfig.resolveAliasLocale(
+      i18nConfig.standardizeLocale(locale)
     );
     if (this.requiresTranslation(aliasLocale)) {
       return aliasLocale;
@@ -795,19 +781,20 @@ class I18nCache<
    * specific context
    */
   private getGTClassClean(locale?: string) {
+    const i18nConfig = getI18nConfig();
     return new GT({
-      sourceLocale: this.config.defaultLocale,
+      sourceLocale: i18nConfig.getDefaultLocale(),
       targetLocale: locale,
       // GT validates approved locales before constructing its LocaleConfig, so
       // pass canonical locales here while preserving alias target locales.
       locales: Array.from(
         new Set(
-          this.config.locales.map((locale) =>
-            this.localeConfig.resolveCanonicalLocale(locale)
-          )
+          i18nConfig
+            .getLocales()
+            .map((locale) => i18nConfig.resolveCanonicalLocale(locale))
         )
       ),
-      customMapping: this.config.customMapping,
+      customMapping: i18nConfig.getCustomMapping(),
       projectId: this.config.projectId,
       baseUrl: this.config.runtimeUrl || undefined,
       apiKey: this.config.apiKey,
@@ -828,14 +815,6 @@ export { I18nCache };
 function standardizeConfig<TranslationValue extends Translation>(
   config: I18nCacheConstructorParams<TranslationValue>
 ) {
-  const gtServicesEnabled = getGTServicesEnabled(config);
-
-  const dedupedLocales = dedupeLocales({
-    defaultLocale: config.defaultLocale || libraryDefaultLocale,
-    locales: config.locales || [libraryDefaultLocale],
-    customMapping: config.customMapping,
-  });
-
   return {
     environment: config.environment || getRuntimeEnvironment(),
     enableI18n: config.enableI18n !== undefined ? config.enableI18n : true,
@@ -847,72 +826,15 @@ function standardizeConfig<TranslationValue extends Translation>(
     batchConfig: config.batchConfig,
     runtimeTranslation: config.runtimeTranslation,
     _versionId: config._versionId,
-    ...(gtServicesEnabled
-      ? standardizeLocales(dedupedLocales)
-      : dedupedLocales),
   };
 }
 
-/**
- * Dedupe locales and add defaultLocale
- */
-function dedupeLocales({
-  defaultLocale,
-  locales,
-  customMapping,
-}: {
-  defaultLocale: string;
-  locales: string[];
-  customMapping?: CustomMapping;
-}) {
-  return {
-    defaultLocale,
-    locales: Array.from(new Set([defaultLocale, ...locales])),
-    customMapping: customMapping || {},
-  };
-}
-
-/**
- * Standardize all locales in config
- * Only apply if using GT services
- */
-function standardizeLocales(config: {
-  defaultLocale: string;
-  locales: string[];
-  customMapping: CustomMapping;
-}) {
-  // Sanitize defaultLocale and locales
-  const defaultLocale = standardizeLocale(config.defaultLocale);
-  const locales = config.locales.map((locale) => {
-    const mappedLocale =
-      typeof config.customMapping?.[locale] === 'string'
-        ? config.customMapping?.[locale]
-        : config.customMapping?.[locale]?.code;
-    if (mappedLocale) {
-      return locale;
-    } else {
-      return standardizeLocale(locale);
-    }
-  });
-
-  // Sanitize customMapping
-  const customMapping = Object.fromEntries(
-    Object.entries(config.customMapping || {}).map(([key, value]) => [
-      key,
-      typeof value === 'string'
-        ? standardizeLocale(value)
-        : {
-            ...value,
-            ...(value.code ? { code: standardizeLocale(value.code) } : {}),
-          },
-    ])
+function hasI18nConfigParams(params: object): boolean {
+  return (
+    'defaultLocale' in params ||
+    'locales' in params ||
+    'customMapping' in params
   );
-
-  return {
-    defaultLocale,
-    locales,
-    customMapping,
-  };
 }
 
 /**

--- a/packages/i18n/src/i18n-cache/I18nCache.ts
+++ b/packages/i18n/src/i18n-cache/I18nCache.ts
@@ -27,7 +27,6 @@ import { EventEmitter } from './event-subscription/EventEmitter';
 import { subscribeLifecycleCallbacks } from './lifecycle-hooks/subscribeLifecycleCallbacks';
 import { TRANSLATIONS_CACHE_MISS_EVENT_NAME } from './event-subscription/types';
 import type { I18nEvents } from './event-subscription/types';
-import { LocaleCandidates } from '../condition-store/localeResolver';
 import { getRuntimeEnvironment } from '../utils/getRuntimeEnvironment';
 import { getI18nConfig } from '../i18n-config/singleton-operations';
 
@@ -187,17 +186,6 @@ class I18nCache<
    */
   getCustomMapping() {
     return getI18nConfig().getCustomMapping();
-  }
-
-  /**
-   * Determine the best locale match, falling back to the default locale.
-   * @deprecated use I18nConfig instead
-   */
-  determineLocale(candidates?: LocaleCandidates): string {
-    const i18nConfig = getI18nConfig();
-    return (
-      i18nConfig.determineLocale(candidates) || i18nConfig.getDefaultLocale()
-    );
   }
 
   /**

--- a/packages/i18n/src/i18n-cache/__tests__/I18nCache.handleError.test.ts
+++ b/packages/i18n/src/i18n-cache/__tests__/I18nCache.handleError.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { I18nCache } from '../I18nCache';
+import { initializeI18nConfig } from '../../i18n-config/singleton-operations';
 
 // Mock createTranslateManyFactory so constructor doesn't need real GT
 vi.mock('../translations-manager/utils/createTranslateMany', () => ({
@@ -8,13 +9,15 @@ vi.mock('../translations-manager/utils/createTranslateMany', () => ({
 
 describe('I18nCache.handleError', () => {
   beforeEach(() => {
+    initializeI18nConfig({
+      defaultLocale: 'en',
+      locales: ['en', 'fr'],
+    });
     vi.clearAllMocks();
   });
 
   it('throws in development mode when error occurs', async () => {
     const cache = new I18nCache({
-      defaultLocale: 'en',
-      locales: ['en', 'fr'],
       environment: 'development',
       loadTranslations: vi.fn().mockRejectedValue(new Error('Load failed')),
     });
@@ -24,8 +27,6 @@ describe('I18nCache.handleError', () => {
 
   it('logs and returns fallback in production mode', async () => {
     const cache = new I18nCache({
-      defaultLocale: 'en',
-      locales: ['en', 'fr'],
       environment: 'production',
       loadTranslations: vi.fn().mockRejectedValue(new Error('Load failed')),
     });

--- a/packages/i18n/src/i18n-cache/__tests__/I18nCache.test.ts
+++ b/packages/i18n/src/i18n-cache/__tests__/I18nCache.test.ts
@@ -3,6 +3,8 @@ import { I18nCache } from '../I18nCache';
 import { createTranslateManyFactory } from '../translations-manager/utils/createTranslateMany';
 import { hashMessage } from '../../utils/hashMessage';
 import { LookupOptions } from '../../translation-functions/types/options';
+import { initializeI18nConfig } from '../../i18n-config/singleton-operations';
+import type { CustomMapping } from '@generaltranslation/format/types';
 
 // Mock createTranslateManyFactory to inject a controlled translateMany
 const mockTranslateMany = vi.fn();
@@ -20,18 +22,32 @@ const expectedHash = hashMessage(message, lookupOptions);
 const translatedString = 'Bonjour {name} !';
 
 function createCache(overrides: Record<string, unknown> = {}) {
+  const {
+    defaultLocale = 'en',
+    locales = ['en', 'fr', 'es'],
+    customMapping,
+    ...cacheOverrides
+  } = overrides;
+  initializeI18nConfig({
+    defaultLocale: defaultLocale as string,
+    locales: locales as string[],
+    customMapping: customMapping as CustomMapping | undefined,
+  });
+
   return new I18nCache({
-    defaultLocale: 'en',
-    locales: ['en', 'fr', 'es'],
     loadTranslations: vi
       .fn()
       .mockResolvedValue({ [expectedHash]: translatedString }),
-    ...overrides,
+    ...cacheOverrides,
   });
 }
 
 describe('I18nCache', () => {
   beforeEach(() => {
+    initializeI18nConfig({
+      defaultLocale: 'en',
+      locales: ['en', 'fr', 'es'],
+    });
     vi.clearAllMocks();
     mockTranslateMany.mockReset();
   });

--- a/packages/i18n/src/i18n-cache/__tests__/resolveTranslationSync.test.ts
+++ b/packages/i18n/src/i18n-cache/__tests__/resolveTranslationSync.test.ts
@@ -1,16 +1,19 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { I18nCache } from '../I18nCache';
 import { hashMessage } from '../../utils/hashMessage';
+import { initializeI18nConfig } from '../../i18n-config/singleton-operations';
 
 describe('I18nCache.resolveTranslationSync', () => {
   beforeEach(() => {
+    initializeI18nConfig({
+      defaultLocale: 'en',
+      locales: ['en', 'fr'],
+    });
     vi.clearAllMocks();
   });
 
   it('should return undefined when no translations loaded for locale', () => {
     const cache = new I18nCache({
-      defaultLocale: 'en',
-      locales: ['en', 'fr'],
       loadTranslations: vi.fn(),
     });
 
@@ -23,8 +26,6 @@ describe('I18nCache.resolveTranslationSync', () => {
 
   it('does not throw without options in development', () => {
     const cache = new I18nCache({
-      defaultLocale: 'en',
-      locales: ['en', 'fr'],
       loadTranslations: vi.fn(),
       environment: 'development',
     });
@@ -50,8 +51,6 @@ describe('I18nCache.resolveTranslationSync', () => {
     };
 
     const cache = new I18nCache({
-      defaultLocale: 'en',
-      locales: ['en', 'fr'],
       loadTranslations: vi.fn().mockResolvedValue(mockTranslations),
     });
 

--- a/packages/i18n/src/i18n-cache/__tests__/singleton-operations.test.ts
+++ b/packages/i18n/src/i18n-cache/__tests__/singleton-operations.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it, vi } from 'vitest';
+
+describe('i18n cache singleton operations', () => {
+  it('throws when the i18n cache has not been initialized', async () => {
+    vi.resetModules();
+    const { getI18nCache } = await import('../singleton-operations');
+
+    expect(() => getI18nCache()).toThrow(
+      'getI18nCache(): I18nCache was not initialized. Call initializeGT() before accessing I18nCache.'
+    );
+  });
+});

--- a/packages/i18n/src/i18n-cache/singleton-operations.ts
+++ b/packages/i18n/src/i18n-cache/singleton-operations.ts
@@ -1,12 +1,7 @@
 import { I18nCache } from './I18nCache';
-import logger from '../logs/logger';
 import { Translation } from './translations-manager/utils/types/translation-data';
 import { createConditionStoreSingleton } from '../condition-store/createConditionStoreSingleton';
 import { WritableConditionStoreInterface } from './types';
-import {
-  initializeI18nConfig,
-  isI18nConfigInitialized,
-} from '../i18n-config/singleton-operations';
 
 // Singleton instance of I18nCache
 let i18nCache: I18nCache | undefined = undefined;
@@ -22,13 +17,9 @@ export function getI18nCache<U extends Translation = Translation>():
   | I18nCache<U>
   | I18nCache<Translation> {
   if (!i18nCache) {
-    logger.warn(
-      'getI18nCache(): I18nCache was not initialized. Falling back to the default locale until initializeGT() configures translations.'
+    throw new Error(
+      'getI18nCache(): I18nCache was not initialized. Call initializeGT() before accessing I18nCache.'
     );
-    if (!isI18nConfigInitialized()) {
-      initializeI18nConfig();
-    }
-    i18nCache = new I18nCache({});
   }
   return i18nCache;
 }

--- a/packages/i18n/src/i18n-cache/singleton-operations.ts
+++ b/packages/i18n/src/i18n-cache/singleton-operations.ts
@@ -1,4 +1,3 @@
-import { libraryDefaultLocale } from 'generaltranslation/internal';
 import { I18nCache } from './I18nCache';
 import logger from '../logs/logger';
 import { Translation } from './translations-manager/utils/types/translation-data';
@@ -22,10 +21,7 @@ export function getI18nCache<U extends Translation = Translation>():
     logger.warn(
       'getI18nCache(): I18nCache was not initialized. Falling back to the default locale until initializeGT() configures translations.'
     );
-    i18nCache = new I18nCache({
-      defaultLocale: libraryDefaultLocale,
-      locales: [libraryDefaultLocale],
-    });
+    i18nCache = new I18nCache({});
   }
   return i18nCache;
 }

--- a/packages/i18n/src/i18n-cache/singleton-operations.ts
+++ b/packages/i18n/src/i18n-cache/singleton-operations.ts
@@ -3,6 +3,10 @@ import logger from '../logs/logger';
 import { Translation } from './translations-manager/utils/types/translation-data';
 import { createConditionStoreSingleton } from '../condition-store/createConditionStoreSingleton';
 import { WritableConditionStoreInterface } from './types';
+import {
+  initializeI18nConfig,
+  isI18nConfigInitialized,
+} from '../i18n-config/singleton-operations';
 
 // Singleton instance of I18nCache
 let i18nCache: I18nCache | undefined = undefined;
@@ -21,6 +25,9 @@ export function getI18nCache<U extends Translation = Translation>():
     logger.warn(
       'getI18nCache(): I18nCache was not initialized. Falling back to the default locale until initializeGT() configures translations.'
     );
+    if (!isI18nConfigInitialized()) {
+      initializeI18nConfig();
+    }
     i18nCache = new I18nCache({});
   }
   return i18nCache;

--- a/packages/i18n/src/i18n-cache/translations-manager/LocalesCache.ts
+++ b/packages/i18n/src/i18n-cache/translations-manager/LocalesCache.ts
@@ -20,6 +20,7 @@ import type {
   LifecycleCallback,
   LifecycleParam,
 } from '../lifecycle-hooks/types';
+import { getI18nConfig } from '../../i18n-config/singleton-operations';
 
 /**
  * Just being explicit about the purpose of this type
@@ -35,7 +36,6 @@ type TranslateLocaleDictionaryEntry = (
 type LocalesCacheParams<TranslationValue extends Translation> = {
   ttl?: number | null;
   batchConfig?: TranslationBatchConfig;
-  defaultLocale: Locale;
   dictionary?: Dictionary;
   createTranslateMany: CreateTranslateMany;
   loadTranslations: SafeTranslationsLoader<TranslationValue>;
@@ -62,7 +62,6 @@ export class LocalesCache<TranslationValue extends Translation> {
   constructor({
     ttl,
     batchConfig,
-    defaultLocale,
     dictionary = {},
     loadTranslations,
     loadDictionary,
@@ -102,6 +101,7 @@ export class LocalesCache<TranslationValue extends Translation> {
       },
     });
 
+    const defaultLocale = getI18nConfig().getDefaultLocale();
     this.dictionaries.set(
       defaultLocale,
       this.createDictionaryCache(defaultLocale, dictionary),

--- a/packages/i18n/src/i18n-cache/translations-manager/__tests__/LocalesCache.test.ts
+++ b/packages/i18n/src/i18n-cache/translations-manager/__tests__/LocalesCache.test.ts
@@ -6,6 +6,7 @@ import type { Hash } from '../TranslationsCache';
 import type { CreateTranslateMany } from '../utils/createTranslateMany';
 import type { I18nCacheLifecycleCallbacks } from '../../lifecycle-hooks/types';
 import type { SafeTranslationsLoader } from '../translations-loaders/types';
+import { initializeI18nConfig } from '../../../i18n-config/singleton-operations';
 
 describe('LocalesCache', () => {
   let mockLoadTranslations: ReturnType<typeof vi.fn>;
@@ -30,6 +31,7 @@ describe('LocalesCache', () => {
 
   beforeEach(() => {
     vi.useFakeTimers();
+    initializeI18nConfig({ defaultLocale: 'en', locales: ['en', 'fr'] });
     mockLoadTranslations = vi.fn().mockResolvedValue(frTranslations);
     mockLoadDictionary = vi.fn().mockResolvedValue(frDictionary);
     mockCreateTranslateMany = vi.fn().mockReturnValue(vi.fn());
@@ -45,7 +47,6 @@ describe('LocalesCache', () => {
     lifecycle?: I18nCacheLifecycleCallbacks<string>;
   }) {
     return new LocalesCache<string>({
-      defaultLocale: 'en',
       dictionary: enDictionary,
       loadTranslations: mockLoadTranslations as SafeTranslationsLoader<string>,
       loadDictionary: mockLoadDictionary as DictionaryLoader,

--- a/packages/i18n/src/i18n-cache/translations-manager/translations-loaders/routeCreateTranslationLoader.ts
+++ b/packages/i18n/src/i18n-cache/translations-manager/translations-loaders/routeCreateTranslationLoader.ts
@@ -1,9 +1,9 @@
-import type { CustomMapping } from '@generaltranslation/format/types';
 import { TranslationsLoader } from './types';
 import { LoadTranslationsType } from '../../utils/getLoadTranslationsType';
 import logger from '../../../logs/logger';
 import { createRemoteTranslationLoader } from './createRemoteTranslationLoader';
 import { createFallbackTranslationLoader } from './createFallbackTranslationLoader';
+import { getI18nConfig } from '../../../i18n-config/singleton-operations';
 
 /**
  * Creates a translation loader function that loads translations from a remote store (CDN or other)
@@ -24,7 +24,6 @@ export function routeCreateTranslationLoader({
     projectId?: string;
     _versionId?: string;
     _branchId?: string;
-    customMapping?: CustomMapping;
   };
   loadTranslations?: TranslationsLoader;
 }): TranslationsLoader {
@@ -35,7 +34,7 @@ export function routeCreateTranslationLoader({
     );
   }
 
-  const { cacheUrl, projectId, _versionId, _branchId, customMapping } =
+  const { cacheUrl, projectId, _versionId, _branchId } =
     remoteTranslationLoaderParams;
 
   switch (type) {
@@ -46,7 +45,7 @@ export function routeCreateTranslationLoader({
         projectId: projectId || '',
         _versionId,
         _branchId,
-        customMapping,
+        customMapping: getI18nConfig().getCustomMapping(),
       });
     case LoadTranslationsType.CUSTOM:
       return loadTranslations!;

--- a/packages/i18n/src/i18n-cache/types.ts
+++ b/packages/i18n/src/i18n-cache/types.ts
@@ -1,7 +1,6 @@
 import type { RuntimeTranslateManyOptions } from 'generaltranslation/internal';
 import type { CustomMapping } from '@generaltranslation/format/types';
 import type { GTConfig } from '../config/types';
-import type { I18nConfigParams } from '../i18n-config/I18nConfig';
 import type { TranslationsLoader } from './translations-manager/translations-loaders/types';
 import type { Translation } from './translations-manager/utils/types/translation-data';
 import type { LifecycleCallbacks } from './lifecycle-hooks/types';
@@ -32,7 +31,10 @@ type RuntimeTranslationConfig = {
 export type I18nCacheConstructorParams<
   TranslationValue extends Translation = Translation,
 > = DictionaryConfig &
-  Omit<GTConfig, 'cacheExpiryTime' | keyof I18nConfigParams> & {
+  Omit<
+    GTConfig,
+    'cacheExpiryTime' | 'defaultLocale' | 'locales' | 'customMapping'
+  > & {
     /**
      * Locale cache TTL in milliseconds. Undefined uses the default TTL, null
      * disables expiry, and a number sets an explicit TTL.

--- a/packages/i18n/src/i18n-cache/types.ts
+++ b/packages/i18n/src/i18n-cache/types.ts
@@ -1,6 +1,7 @@
 import type { RuntimeTranslateManyOptions } from 'generaltranslation/internal';
 import type { CustomMapping } from '@generaltranslation/format/types';
 import type { GTConfig } from '../config/types';
+import type { I18nConfigParams } from '../i18n-config/I18nConfig';
 import type { TranslationsLoader } from './translations-manager/translations-loaders/types';
 import type { Translation } from './translations-manager/utils/types/translation-data';
 import type { LifecycleCallbacks } from './lifecycle-hooks/types';
@@ -31,7 +32,7 @@ type RuntimeTranslationConfig = {
 export type I18nCacheConstructorParams<
   TranslationValue extends Translation = Translation,
 > = DictionaryConfig &
-  Omit<GTConfig, 'cacheExpiryTime'> & {
+  Omit<GTConfig, 'cacheExpiryTime' | keyof I18nConfigParams> & {
     /**
      * Locale cache TTL in milliseconds. Undefined uses the default TTL, null
      * disables expiry, and a number sets an explicit TTL.
@@ -51,9 +52,6 @@ export type I18nCacheConstructorParams<
  */
 export type I18nCacheConfig = {
   environment: 'development' | 'production';
-  defaultLocale: string;
-  locales: string[];
-  customMapping: CustomMapping;
   /**
    * @deprecated
    * Perhaps we can keep this around, but more for

--- a/packages/i18n/src/i18n-config/I18nConfig.ts
+++ b/packages/i18n/src/i18n-config/I18nConfig.ts
@@ -1,6 +1,7 @@
 import { LocaleConfig } from '@generaltranslation/format';
 import type { CustomMapping } from '@generaltranslation/format/types';
 import { libraryDefaultLocale } from 'generaltranslation/internal';
+import type { LocaleCandidates } from '../condition-store/localeResolver';
 import { validateI18nConfigParams } from './validation';
 
 export type I18nConfigParams = {
@@ -46,5 +47,36 @@ export class I18nConfig extends LocaleConfig {
 
   getCustomMapping(): CustomMapping {
     return this.customMapping || {};
+  }
+
+  determineSupportedLocale(candidates: LocaleCandidates): string | undefined {
+    if (
+      candidates == null ||
+      (Array.isArray(candidates) && candidates.length === 0)
+    ) {
+      return undefined;
+    }
+    return this.determineLocale(candidates);
+  }
+
+  resolveSupportedLocale(candidates?: LocaleCandidates): string {
+    return this.determineSupportedLocale(candidates) || this.getDefaultLocale();
+  }
+
+  resolveLocale(locale: string): string {
+    const resolvedLocale = this.determineSupportedLocale(locale);
+    if (!this.isValidLocale(locale) || !resolvedLocale) {
+      throw new Error(
+        `Locale "${locale}" is not valid. Use a valid BCP 47 locale code or add a custom mapping.`
+      );
+    }
+    return resolvedLocale;
+  }
+
+  requiresDialectTranslation(locale: string): boolean {
+    return (
+      this.requiresTranslation(locale) &&
+      this.isSameLanguage(this.getDefaultLocale(), locale)
+    );
   }
 }

--- a/packages/i18n/src/i18n-config/I18nConfig.ts
+++ b/packages/i18n/src/i18n-config/I18nConfig.ts
@@ -1,7 +1,6 @@
 import { LocaleConfig } from '@generaltranslation/format';
 import type { CustomMapping } from '@generaltranslation/format/types';
 import { libraryDefaultLocale } from 'generaltranslation/internal';
-import type { LocaleCandidates } from '../condition-store/localeResolver';
 import { validateI18nConfigParams } from './validation';
 
 export type I18nConfigParams = {
@@ -47,36 +46,5 @@ export class I18nConfig extends LocaleConfig {
 
   getCustomMapping(): CustomMapping {
     return this.customMapping || {};
-  }
-
-  determineSupportedLocale(candidates: LocaleCandidates): string | undefined {
-    if (
-      candidates == null ||
-      (Array.isArray(candidates) && candidates.length === 0)
-    ) {
-      return undefined;
-    }
-    return this.determineLocale(candidates);
-  }
-
-  resolveSupportedLocale(candidates?: LocaleCandidates): string {
-    return this.determineSupportedLocale(candidates) || this.getDefaultLocale();
-  }
-
-  resolveLocale(locale: string): string {
-    const resolvedLocale = this.determineSupportedLocale(locale);
-    if (!this.isValidLocale(locale) || !resolvedLocale) {
-      throw new Error(
-        `Locale "${locale}" is not valid. Use a valid BCP 47 locale code or add a custom mapping.`
-      );
-    }
-    return resolvedLocale;
-  }
-
-  requiresDialectTranslation(locale: string): boolean {
-    return (
-      this.requiresTranslation(locale) &&
-      this.isSameLanguage(this.getDefaultLocale(), locale)
-    );
   }
 }

--- a/packages/i18n/src/i18n-config/__tests__/I18nConfig.test.ts
+++ b/packages/i18n/src/i18n-config/__tests__/I18nConfig.test.ts
@@ -60,14 +60,4 @@ describe('I18nConfig', () => {
 
     errorSpy.mockRestore();
   });
-
-  it('treats an empty string locale candidate as unsupported', () => {
-    const config = new I18nConfig({
-      defaultLocale: 'en',
-      locales: ['en', 'fr'],
-    });
-
-    expect(config.determineSupportedLocale('')).toBeUndefined();
-    expect(config.resolveSupportedLocale('')).toBe('en');
-  });
 });

--- a/packages/i18n/src/i18n-config/__tests__/I18nConfig.test.ts
+++ b/packages/i18n/src/i18n-config/__tests__/I18nConfig.test.ts
@@ -60,4 +60,14 @@ describe('I18nConfig', () => {
 
     errorSpy.mockRestore();
   });
+
+  it('treats an empty string locale candidate as unsupported', () => {
+    const config = new I18nConfig({
+      defaultLocale: 'en',
+      locales: ['en', 'fr'],
+    });
+
+    expect(config.determineSupportedLocale('')).toBeUndefined();
+    expect(config.resolveSupportedLocale('')).toBe('en');
+  });
 });

--- a/packages/i18n/src/translation-functions/__tests__/t.test.ts
+++ b/packages/i18n/src/translation-functions/__tests__/t.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { I18nCache } from '../../i18n-cache/I18nCache';
 import { setI18nCache } from '../../i18n-cache/singleton-operations';
+import type { I18nCacheConstructorParams } from '../../i18n-cache/types';
 import { setWritableConditionStore } from '../../condition-store/singleton-operations';
+import { initializeI18nConfig } from '../../i18n-config/singleton-operations';
+import type { I18nConfigParams } from '../../i18n-config/I18nConfig';
 import {
   getDefaultLocale,
   getLocale,
@@ -12,6 +15,14 @@ import { hashMessage } from '../../utils/hashMessage';
 import { t } from '../t';
 
 describe('t', () => {
+  function createCache(
+    i18nConfig: I18nConfigParams,
+    cacheConfig: I18nCacheConstructorParams = {}
+  ) {
+    initializeI18nConfig(i18nConfig);
+    return new I18nCache(cacheConfig);
+  }
+
   afterEach(() => {
     setWritableConditionStore({ getLocale: () => 'en' });
   });
@@ -19,11 +30,12 @@ describe('t', () => {
   it('works without an explicit locale', () => {
     setWritableConditionStore({ getLocale: () => 'en' });
     setI18nCache(
-      new I18nCache({
-        defaultLocale: 'en',
-        locales: ['en', 'fr'],
-        loadTranslations: vi.fn(),
-      })
+      createCache(
+        { defaultLocale: 'en', locales: ['en', 'fr'] },
+        {
+          loadTranslations: vi.fn(),
+        }
+      )
     );
 
     expect(t('Hello')).toBe('Hello');
@@ -32,13 +44,14 @@ describe('t', () => {
   it('uses the configured fallback locale store when no locale is provided', async () => {
     const message = 'Hello {name}!';
     const translatedMessage = 'Bonjour {name} !';
-    const cache = new I18nCache({
-      defaultLocale: 'en',
-      locales: ['en', 'fr'],
-      loadTranslations: vi.fn().mockResolvedValue({
-        [hashMessage(message, { $format: 'ICU' })]: translatedMessage,
-      }),
-    });
+    const cache = createCache(
+      { defaultLocale: 'en', locales: ['en', 'fr'] },
+      {
+        loadTranslations: vi.fn().mockResolvedValue({
+          [hashMessage(message, { $format: 'ICU' })]: translatedMessage,
+        }),
+      }
+    );
     const conditionStore = { getLocale: () => 'fr' };
 
     setI18nCache(cache);
@@ -50,14 +63,15 @@ describe('t', () => {
 
   it('allows an explicit $locale to override the current locale', async () => {
     const message = 'Hello {name}!';
-    const cache = new I18nCache({
-      defaultLocale: 'en',
-      locales: ['en', 'fr', 'es'],
-      loadTranslations: vi.fn().mockImplementation((locale: string) => ({
-        [hashMessage(message, { $format: 'ICU' })]:
-          locale === 'es' ? 'Hola {name}!' : 'Bonjour {name} !',
-      })),
-    });
+    const cache = createCache(
+      { defaultLocale: 'en', locales: ['en', 'fr', 'es'] },
+      {
+        loadTranslations: vi.fn().mockImplementation((locale: string) => ({
+          [hashMessage(message, { $format: 'ICU' })]:
+            locale === 'es' ? 'Hola {name}!' : 'Bonjour {name} !',
+        })),
+      }
+    );
 
     setI18nCache(cache);
     setWritableConditionStore({ getLocale: () => 'fr' });
@@ -68,13 +82,14 @@ describe('t', () => {
 
   it('does not read the current locale when $locale is explicit', async () => {
     const message = 'Hello {name}!';
-    const cache = new I18nCache({
-      defaultLocale: 'en',
-      locales: ['en', 'fr'],
-      loadTranslations: vi.fn().mockResolvedValue({
-        [hashMessage(message, { $format: 'ICU' })]: 'Bonjour {name} !',
-      }),
-    });
+    const cache = createCache(
+      { defaultLocale: 'en', locales: ['en', 'fr'] },
+      {
+        loadTranslations: vi.fn().mockResolvedValue({
+          [hashMessage(message, { $format: 'ICU' })]: 'Bonjour {name} !',
+        }),
+      }
+    );
 
     setI18nCache(cache);
     setWritableConditionStore({
@@ -93,11 +108,10 @@ describe('t', () => {
     setWritableConditionStore({ getLocale: () => 'fr' });
 
     setI18nCache(
-      new I18nCache({
-        defaultLocale: 'es',
-        locales: ['es'],
-        loadTranslations: vi.fn(),
-      })
+      createCache(
+        { defaultLocale: 'es', locales: ['es'] },
+        { loadTranslations: vi.fn() }
+      )
     );
 
     expect(getLocale()).toBe('fr');
@@ -105,11 +119,10 @@ describe('t', () => {
 
   it('returns locale properties outside configured translation locales', () => {
     setI18nCache(
-      new I18nCache({
-        defaultLocale: 'en',
-        locales: ['fr'],
-        loadTranslations: vi.fn(),
-      })
+      createCache(
+        { defaultLocale: 'en', locales: ['fr'] },
+        { loadTranslations: vi.fn() }
+      )
     );
 
     expect(getLocaleProperties('de-DE').code).toBe('de-DE');
@@ -117,17 +130,19 @@ describe('t', () => {
 
   it('exposes configured locale helper values', () => {
     setI18nCache(
-      new I18nCache({
-        defaultLocale: 'en-US',
-        locales: ['en-US', 'fr', 'brand-french'],
-        customMapping: {
-          'brand-french': {
-            code: 'fr',
-            name: 'Brand French',
+      createCache(
+        {
+          defaultLocale: 'en-US',
+          locales: ['en-US', 'fr', 'brand-french'],
+          customMapping: {
+            'brand-french': {
+              code: 'fr',
+              name: 'Brand French',
+            },
           },
         },
-        loadTranslations: vi.fn(),
-      })
+        { loadTranslations: vi.fn() }
+      )
     );
 
     expect(getDefaultLocale()).toBe('en-US');

--- a/packages/i18n/src/translation-functions/internal/__tests__/helpers.integration.test.ts
+++ b/packages/i18n/src/translation-functions/internal/__tests__/helpers.integration.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { I18nCache } from '../../../i18n-cache/I18nCache';
 import { setI18nCache } from '../../../i18n-cache/singleton-operations';
+import { initializeI18nConfig } from '../../../i18n-config/singleton-operations';
 import { hashMessage } from '../../../utils/hashMessage';
 import { LookupOptions } from '../../types/options';
 import {
@@ -31,9 +32,11 @@ describe('translation helpers (deep integration)', () => {
   });
 
   function setupManager(preloadedTranslations: Record<string, string> = {}) {
-    const cache = new I18nCache({
+    initializeI18nConfig({
       defaultLocale: 'en',
       locales: ['en', 'fr'],
+    });
+    const cache = new I18nCache({
       loadTranslations: vi.fn().mockResolvedValue(preloadedTranslations),
     });
     setI18nCache(cache);

--- a/packages/i18n/src/translation-functions/internal/__tests__/locale-defaults.test.ts
+++ b/packages/i18n/src/translation-functions/internal/__tests__/locale-defaults.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { I18nCache } from '../../../i18n-cache/I18nCache';
+import type { I18nCacheConstructorParams } from '../../../i18n-cache/types';
 import { setI18nCache } from '../../../i18n-cache/singleton-operations';
 import { setWritableConditionStore } from '../../../condition-store/singleton-operations';
+import { initializeI18nConfig } from '../../../i18n-config/singleton-operations';
+import type { I18nConfigParams } from '../../../i18n-config/I18nConfig';
 import { msg } from '../../msg';
 import { hashMessage } from '../../../utils/hashMessage';
 import { getGT } from '../getGT';
@@ -14,12 +17,21 @@ describe('translation function locale defaults', () => {
     setWritableConditionStore({ getLocale: () => 'en' });
   });
 
+  function createCache(
+    i18nConfig: I18nConfigParams,
+    cacheConfig: I18nCacheConstructorParams = {}
+  ) {
+    initializeI18nConfig(i18nConfig);
+    return new I18nCache(cacheConfig);
+  }
+
   function setupManager(translations: Record<string, string>) {
-    const cache = new I18nCache({
-      defaultLocale: 'en',
-      locales: ['en', 'fr'],
-      loadTranslations: vi.fn().mockResolvedValue(translations),
-    });
+    const cache = createCache(
+      { defaultLocale: 'en', locales: ['en', 'fr'] },
+      {
+        loadTranslations: vi.fn().mockResolvedValue(translations),
+      }
+    );
 
     setI18nCache(cache);
     setWritableConditionStore({ getLocale: () => 'fr' });
@@ -40,14 +52,15 @@ describe('translation function locale defaults', () => {
 
   it('getGT allows $locale to select another loaded locale', async () => {
     const message = 'Hello {name}!';
-    const cache = new I18nCache({
-      defaultLocale: 'en',
-      locales: ['en', 'fr', 'es'],
-      loadTranslations: vi.fn().mockImplementation((locale: string) => ({
-        [hashMessage(message, { $format: 'ICU' })]:
-          locale === 'es' ? 'Hola {name}!' : 'Bonjour {name} !',
-      })),
-    });
+    const cache = createCache(
+      { defaultLocale: 'en', locales: ['en', 'fr', 'es'] },
+      {
+        loadTranslations: vi.fn().mockImplementation((locale: string) => ({
+          [hashMessage(message, { $format: 'ICU' })]:
+            locale === 'es' ? 'Hola {name}!' : 'Bonjour {name} !',
+        })),
+      }
+    );
     setI18nCache(cache);
     setWritableConditionStore({ getLocale: () => 'fr' });
 
@@ -58,16 +71,17 @@ describe('translation function locale defaults', () => {
   });
 
   it('getTranslations uses the current locale for dictionary entries', async () => {
-    const cache = new I18nCache({
-      defaultLocale: 'en',
-      locales: ['en', 'fr'],
-      dictionary: {
-        greeting: 'Hello {name}!',
-      },
-      loadDictionary: vi.fn().mockResolvedValue({
-        greeting: 'Bonjour {name} !',
-      }),
-    });
+    const cache = createCache(
+      { defaultLocale: 'en', locales: ['en', 'fr'] },
+      {
+        dictionary: {
+          greeting: 'Hello {name}!',
+        },
+        loadDictionary: vi.fn().mockResolvedValue({
+          greeting: 'Bonjour {name} !',
+        }),
+      }
+    );
     setI18nCache(cache);
     setWritableConditionStore({ getLocale: () => 'fr' });
 
@@ -77,14 +91,15 @@ describe('translation function locale defaults', () => {
   });
 
   it('getTranslations returns source dictionary entries when no target translation exists', async () => {
-    const cache = new I18nCache({
-      defaultLocale: 'en',
-      locales: ['en', 'fr'],
-      dictionary: {
-        greeting: 'Hello {name}!',
-      },
-      loadDictionary: vi.fn().mockResolvedValue({}),
-    });
+    const cache = createCache(
+      { defaultLocale: 'en', locales: ['en', 'fr'] },
+      {
+        dictionary: {
+          greeting: 'Hello {name}!',
+        },
+        loadDictionary: vi.fn().mockResolvedValue({}),
+      }
+    );
     setI18nCache(cache);
     setWritableConditionStore({ getLocale: () => 'fr' });
 
@@ -99,15 +114,16 @@ describe('translation function locale defaults', () => {
     const loadTranslations = vi.fn().mockResolvedValue({
       [hashMessage(message, lookupOptions)]: 'Bonjour {name} !',
     });
-    const cache = new I18nCache({
-      defaultLocale: 'en',
-      locales: ['en', 'fr'],
-      dictionary: {
-        greeting: [message, { context: 'homepage' }],
-      },
-      loadDictionary: vi.fn().mockResolvedValue({}),
-      loadTranslations,
-    });
+    const cache = createCache(
+      { defaultLocale: 'en', locales: ['en', 'fr'] },
+      {
+        dictionary: {
+          greeting: [message, { context: 'homepage' }],
+        },
+        loadDictionary: vi.fn().mockResolvedValue({}),
+        loadTranslations,
+      }
+    );
     setI18nCache(cache);
     setWritableConditionStore({ getLocale: () => 'fr' });
 
@@ -118,14 +134,15 @@ describe('translation function locale defaults', () => {
   });
 
   it('getTranslations throws when the source dictionary entry is missing', async () => {
-    const cache = new I18nCache({
-      defaultLocale: 'en',
-      locales: ['en', 'fr'],
-      dictionary: {
-        greeting: 'Hello',
-      },
-      loadDictionary: vi.fn().mockResolvedValue({}),
-    });
+    const cache = createCache(
+      { defaultLocale: 'en', locales: ['en', 'fr'] },
+      {
+        dictionary: {
+          greeting: 'Hello',
+        },
+        loadDictionary: vi.fn().mockResolvedValue({}),
+      }
+    );
     setI18nCache(cache);
     setWritableConditionStore({ getLocale: () => 'fr' });
 
@@ -137,18 +154,19 @@ describe('translation function locale defaults', () => {
   });
 
   it('getTranslations obj throws when the source dictionary object is missing', async () => {
-    const cache = new I18nCache({
-      defaultLocale: 'en',
-      locales: ['en', 'fr'],
-      dictionary: {
-        user: {
-          profile: {
-            name: 'Name',
+    const cache = createCache(
+      { defaultLocale: 'en', locales: ['en', 'fr'] },
+      {
+        dictionary: {
+          user: {
+            profile: {
+              name: 'Name',
+            },
           },
         },
-      },
-      loadDictionary: vi.fn().mockResolvedValue({}),
-    });
+        loadDictionary: vi.fn().mockResolvedValue({}),
+      }
+    );
     setI18nCache(cache);
     setWritableConditionStore({ getLocale: () => 'fr' });
 
@@ -160,27 +178,28 @@ describe('translation function locale defaults', () => {
   });
 
   it('getTranslations obj returns translated dictionary subtrees', async () => {
-    const cache = new I18nCache({
-      defaultLocale: 'en',
-      locales: ['en', 'fr'],
-      dictionary: {
-        user: {
-          profile: {
-            name: 'Name',
-            greeting: 'Hello {name}!',
-            title: ['Title', { $context: 'profile title' }],
+    const cache = createCache(
+      { defaultLocale: 'en', locales: ['en', 'fr'] },
+      {
+        dictionary: {
+          user: {
+            profile: {
+              name: 'Name',
+              greeting: 'Hello {name}!',
+              title: ['Title', { $context: 'profile title' }],
+            },
           },
         },
-      },
-      loadDictionary: vi.fn().mockResolvedValue({
-        user: {
-          profile: {
-            name: 'Nom',
-            greeting: 'Bonjour {name} !',
+        loadDictionary: vi.fn().mockResolvedValue({
+          user: {
+            profile: {
+              name: 'Nom',
+              greeting: 'Bonjour {name} !',
+            },
           },
-        },
-      }),
-    });
+        }),
+      }
+    );
     setI18nCache(cache);
     setWritableConditionStore({ getLocale: () => 'fr' });
 
@@ -202,26 +221,27 @@ describe('translation function locale defaults', () => {
     const loadTranslations = vi.fn().mockResolvedValue({
       [hashMessage(title, titleOptions)]: 'Titre',
     });
-    const cache = new I18nCache({
-      defaultLocale: 'en',
-      locales: ['en', 'fr'],
-      dictionary: {
-        user: {
-          profile: {
-            name: 'Name',
-            title: [title, { context: 'profile title' }],
+    const cache = createCache(
+      { defaultLocale: 'en', locales: ['en', 'fr'] },
+      {
+        dictionary: {
+          user: {
+            profile: {
+              name: 'Name',
+              title: [title, { context: 'profile title' }],
+            },
           },
         },
-      },
-      loadDictionary: vi.fn().mockResolvedValue({
-        user: {
-          profile: {
-            name: 'Nom',
+        loadDictionary: vi.fn().mockResolvedValue({
+          user: {
+            profile: {
+              name: 'Nom',
+            },
           },
-        },
-      }),
-      loadTranslations,
-    });
+        }),
+        loadTranslations,
+      }
+    );
     setI18nCache(cache);
     setWritableConditionStore({ getLocale: () => 'fr' });
 
@@ -256,13 +276,14 @@ describe('translation function locale defaults', () => {
 
   it('tx does not read the current locale when $locale is explicit', async () => {
     const message = 'Hello';
-    const cache = new I18nCache({
-      defaultLocale: 'en',
-      locales: ['en', 'fr'],
-      loadTranslations: vi.fn().mockResolvedValue({
-        [hashMessage(message, { $format: 'STRING' })]: 'Bonjour',
-      }),
-    });
+    const cache = createCache(
+      { defaultLocale: 'en', locales: ['en', 'fr'] },
+      {
+        loadTranslations: vi.fn().mockResolvedValue({
+          [hashMessage(message, { $format: 'STRING' })]: 'Bonjour',
+        }),
+      }
+    );
 
     setI18nCache(cache);
     setWritableConditionStore({

--- a/packages/next/src/config-dir/I18NConfiguration.ts
+++ b/packages/next/src/config-dir/I18NConfiguration.ts
@@ -166,11 +166,6 @@ export class I18NConfiguration {
       devApiKey,
       projectId,
       runtimeUrl,
-      // Locale info
-      defaultLocale,
-      locales,
-      // Custom mapping
-      customMapping,
       enableI18n: this.translationEnabled,
       // Batching config
       batchConfig: {

--- a/packages/next/src/config-dir/I18NConfiguration.ts
+++ b/packages/next/src/config-dir/I18NConfiguration.ts
@@ -358,14 +358,9 @@ export class I18NConfiguration {
    * @returns True if translation is required, otherwise false
    */
   requiresTranslation(locale: string): [boolean, boolean] {
-    if (!this.translationEnabled) {
-      return [false, false];
-    }
-
-    const i18nConfig = getI18nConfig();
     return [
-      i18nConfig.requiresTranslation(locale),
-      i18nConfig.requiresDialectTranslation(locale),
+      this._i18nCache.requiresTranslation(locale),
+      this._i18nCache.requiresDialectTranslation(locale),
     ];
   }
 

--- a/packages/next/src/config-dir/I18NConfiguration.ts
+++ b/packages/next/src/config-dir/I18NConfiguration.ts
@@ -19,7 +19,11 @@ import {
 } from '../utils/cookies';
 import { defaultLocaleHeaderName } from '../utils/headers';
 import type { CustomMapping } from '@generaltranslation/format/types';
-import { I18nCache, initializeI18nConfig } from 'gt-i18n/internal';
+import {
+  getI18nConfig,
+  I18nCache,
+  initializeI18nConfig,
+} from 'gt-i18n/internal';
 import type { LookupOptions } from 'gt-i18n/internal/types';
 import { loadTranslations } from './loadTranslation';
 
@@ -253,7 +257,7 @@ export class I18NConfiguration {
       localeCookieName,
       resetLocaleCookieName,
     } = this;
-    const customMapping = this._i18nCache.getCustomMapping();
+    const customMapping = getI18nConfig().getCustomMapping();
     const _versionId = this._i18nCache.getVersionId();
     return {
       projectId,
@@ -287,7 +291,7 @@ export class I18NConfiguration {
    * @returns {string} A BCP-47 locale tag
    */
   getDefaultLocale(): string {
-    return this._i18nCache.getDefaultLocale();
+    return getI18nConfig().getDefaultLocale();
   }
 
   /**
@@ -295,7 +299,7 @@ export class I18NConfiguration {
    * @returns {string[]} A list of BCP-47 locale tags, or undefined if none were provided
    */
   getLocales(): string[] {
-    return this._i18nCache.getLocales();
+    return getI18nConfig().getLocales();
   }
 
   /**
@@ -354,9 +358,10 @@ export class I18NConfiguration {
    * @returns True if translation is required, otherwise false
    */
   requiresTranslation(locale: string): [boolean, boolean] {
+    const i18nConfig = getI18nConfig();
     return [
-      this._i18nCache.requiresTranslation(locale),
-      this._i18nCache.requiresDialectTranslation(locale),
+      i18nConfig.requiresTranslation(locale),
+      i18nConfig.requiresDialectTranslation(locale),
     ];
   }
 

--- a/packages/next/src/config-dir/I18NConfiguration.ts
+++ b/packages/next/src/config-dir/I18NConfiguration.ts
@@ -358,9 +358,13 @@ export class I18NConfiguration {
    * @returns True if translation is required, otherwise false
    */
   requiresTranslation(locale: string): [boolean, boolean] {
+    const i18nConfig = getI18nConfig();
+    const translationRequired =
+      this.isTranslationEnabled() && i18nConfig.requiresTranslation(locale);
     return [
-      this._i18nCache.requiresTranslation(locale),
-      this._i18nCache.requiresDialectTranslation(locale),
+      translationRequired,
+      translationRequired &&
+        i18nConfig.isSameLanguage(i18nConfig.getDefaultLocale(), locale),
     ];
   }
 

--- a/packages/next/src/config-dir/I18NConfiguration.ts
+++ b/packages/next/src/config-dir/I18NConfiguration.ts
@@ -358,6 +358,10 @@ export class I18NConfiguration {
    * @returns True if translation is required, otherwise false
    */
   requiresTranslation(locale: string): [boolean, boolean] {
+    if (!this.translationEnabled) {
+      return [false, false];
+    }
+
     const i18nConfig = getI18nConfig();
     return [
       i18nConfig.requiresTranslation(locale),

--- a/packages/next/src/config-dir/__tests__/I18NConfiguration.test.ts
+++ b/packages/next/src/config-dir/__tests__/I18NConfiguration.test.ts
@@ -17,10 +17,8 @@ vi.mock('gt-i18n/internal', () => ({
     getDefaultLocale: () => mockLocaleConfig.defaultLocale,
     getLocales: () => mockLocaleConfig.locales,
     getCustomMapping: () => mockLocaleConfig.customMapping,
-    requiresTranslation: () =>
-      mockLocaleConfig.enableI18n && mockLocaleConfig.translationRequired,
+    requiresTranslation: () => mockLocaleConfig.translationRequired,
     requiresDialectTranslation: () =>
-      mockLocaleConfig.enableI18n &&
       mockLocaleConfig.translationRequired &&
       mockLocaleConfig.dialectTranslationRequired,
   }),

--- a/packages/next/src/config-dir/__tests__/I18NConfiguration.test.ts
+++ b/packages/next/src/config-dir/__tests__/I18NConfiguration.test.ts
@@ -18,6 +18,7 @@ vi.mock('gt-i18n/internal', () => ({
     getLocales: () => mockLocaleConfig.locales,
     getCustomMapping: () => mockLocaleConfig.customMapping,
     requiresTranslation: () => mockLocaleConfig.translationRequired,
+    isSameLanguage: () => mockLocaleConfig.dialectTranslationRequired,
     requiresDialectTranslation: () =>
       mockLocaleConfig.translationRequired &&
       mockLocaleConfig.dialectTranslationRequired,

--- a/packages/next/src/config-dir/__tests__/I18NConfiguration.test.ts
+++ b/packages/next/src/config-dir/__tests__/I18NConfiguration.test.ts
@@ -13,6 +13,17 @@ const mockLocaleConfig = vi.hoisted(() => ({
 }));
 
 vi.mock('gt-i18n/internal', () => ({
+  getI18nConfig: () => ({
+    getDefaultLocale: () => mockLocaleConfig.defaultLocale,
+    getLocales: () => mockLocaleConfig.locales,
+    getCustomMapping: () => mockLocaleConfig.customMapping,
+    requiresTranslation: () =>
+      mockLocaleConfig.enableI18n && mockLocaleConfig.translationRequired,
+    requiresDialectTranslation: () =>
+      mockLocaleConfig.enableI18n &&
+      mockLocaleConfig.translationRequired &&
+      mockLocaleConfig.dialectTranslationRequired,
+  }),
   initializeI18nConfig: (params: {
     defaultLocale?: string;
     locales?: string[];

--- a/packages/node/src/async-i18n-cache/AsyncConditionStore.ts
+++ b/packages/node/src/async-i18n-cache/AsyncConditionStore.ts
@@ -3,7 +3,7 @@ import type {
   LocaleResolverConfig,
   ScopedConditionStore,
 } from 'gt-i18n/internal/types';
-import { getI18nCache } from 'gt-i18n/internal';
+import { getI18nConfig } from 'gt-i18n/internal';
 
 type Store = {
   locale: string;
@@ -39,10 +39,7 @@ export class AsyncConditionStore implements ScopedConditionStore {
    * TODO: should this be a static function
    * */
   run<T>(locale: string, callback: () => T): T {
-    return this.store.run(
-      { locale: getI18nCache().determineLocale(locale) },
-      callback
-    );
+    return this.store.run({ locale: resolveLocale(locale) }, callback);
   }
 
   getLocale(): string {
@@ -50,11 +47,11 @@ export class AsyncConditionStore implements ScopedConditionStore {
     if (!store) {
       if (process.env.NODE_ENV === 'production') {
         console.warn(OUTSIDE_SCOPE_MESSAGE);
-        return getI18nCache().determineLocale();
+        return resolveLocale();
       }
       throw new Error(OUTSIDE_SCOPE_MESSAGE);
     }
-    return getI18nCache().determineLocale(store.locale);
+    return resolveLocale(store.locale);
   }
 
   /**
@@ -71,4 +68,9 @@ export class AsyncConditionStore implements ScopedConditionStore {
     }
     return store.enableI18n ?? true;
   }
+}
+
+function resolveLocale(locale?: string): string {
+  const i18nConfig = getI18nConfig();
+  return i18nConfig.determineLocale(locale) || i18nConfig.getDefaultLocale();
 }

--- a/packages/node/src/async-i18n-cache/__tests__/AsyncConditionStore.test.ts
+++ b/packages/node/src/async-i18n-cache/__tests__/AsyncConditionStore.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { I18nCache, setI18nCache } from 'gt-i18n/internal';
+import { I18nCache, initializeI18nConfig, setI18nCache } from 'gt-i18n/internal';
 import { AsyncConditionStore } from '../AsyncConditionStore';
 
 describe('AsyncConditionStore', () => {
@@ -10,6 +10,10 @@ describe('AsyncConditionStore', () => {
   });
 
   function setTestCache() {
+    initializeI18nConfig({
+      defaultLocale: 'en',
+      locales: ['en', 'fr'],
+    });
     setI18nCache(
       new I18nCache({
         defaultLocale: 'en',

--- a/packages/node/src/async-i18n-cache/__tests__/AsyncConditionStore.test.ts
+++ b/packages/node/src/async-i18n-cache/__tests__/AsyncConditionStore.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { I18nCache, initializeI18nConfig, setI18nCache } from 'gt-i18n/internal';
+import {
+  I18nCache,
+  initializeI18nConfig,
+  setI18nCache,
+} from 'gt-i18n/internal';
 import { AsyncConditionStore } from '../AsyncConditionStore';
 
 describe('AsyncConditionStore', () => {

--- a/packages/react-core/src/deprecated/provider/__tests__/i18n-store.test.ts
+++ b/packages/react-core/src/deprecated/provider/__tests__/i18n-store.test.ts
@@ -1,10 +1,19 @@
 import { describe, expect, it, vi } from 'vitest';
-import { I18nManager, WritableConditionStore } from 'gt-i18n/internal';
+import {
+  I18nManager,
+  initializeI18nConfig,
+  WritableConditionStore,
+} from 'gt-i18n/internal';
 import { setReadonlyConditionStore as setConditionStore } from '../../../condition-store/singleton-operations';
 import { setReactI18nCache } from '../../../i18n-cache/singleton-operations';
 import { I18nStore } from '../../../i18n-store/I18nStore';
 
 function createManager() {
+  initializeI18nConfig({
+    defaultLocale: 'en',
+    locales: ['en', 'fr', 'es'],
+  });
+
   return new I18nManager({
     defaultLocale: 'en',
     locales: ['en', 'fr', 'es'],

--- a/packages/react/src/condition-store/BrowserConditionStore.ts
+++ b/packages/react/src/condition-store/BrowserConditionStore.ts
@@ -1,10 +1,8 @@
-import {
-  getReactI18nCache,
-  WritableConditionStoreParams,
-} from '@generaltranslation/react-core/context';
+import { WritableConditionStoreParams } from '@generaltranslation/react-core/context';
 import { getCookieValue, setCookieValue } from './cookies';
 import { readBrowserLocale } from './readBrowserLocale';
 import { GetEnableI18n, GetLocale } from '../i18n-cache/types';
+import { getI18nConfig } from 'gt-i18n/internal';
 import {
   LocaleCandidates,
   WritableConditionStoreInterface,
@@ -49,7 +47,7 @@ export class BrowserConditionStore implements WritableConditionStoreInterface {
     this.enableI18nCookieName = config.enableI18nCookieName;
     setCookieValue({
       cookieName: this.localeCookieName,
-      value: getReactI18nCache().determineLocale(config.locale),
+      value: resolveLocale(config.locale),
     });
   }
 
@@ -83,7 +81,7 @@ export class BrowserConditionStore implements WritableConditionStoreInterface {
   updateLocale = (locale: LocaleCandidates): void => {
     setCookieValue({
       cookieName: this.localeCookieName,
-      value: getReactI18nCache().determineLocale(locale),
+      value: resolveLocale(locale),
     });
   };
 
@@ -114,5 +112,12 @@ export class BrowserConditionStore implements WritableConditionStoreInterface {
 function getBrowserLocale(cookieName: string, getLocale?: GetLocale): string {
   const candidates = readBrowserLocale(cookieName);
   if (getLocale) candidates.push(getLocale());
-  return getReactI18nCache().determineLocale(candidates);
+  return resolveLocale(candidates);
+}
+
+function resolveLocale(candidates?: LocaleCandidates): string {
+  const i18nConfig = getI18nConfig();
+  return (
+    i18nConfig.determineLocale(candidates) || i18nConfig.getDefaultLocale()
+  );
 }

--- a/packages/react/src/condition-store/createBrowserConditionStore.ts
+++ b/packages/react/src/condition-store/createBrowserConditionStore.ts
@@ -1,5 +1,5 @@
-import { getReactI18nCache } from '@generaltranslation/react-core/context';
 import type { LocaleCandidates } from 'gt-i18n/internal';
+import { getI18nConfig } from 'gt-i18n/internal';
 import {
   BrowserConditionStore,
   BrowserConditionStoreParams,
@@ -66,7 +66,14 @@ function determineLocale({
   candidates.push(...readBrowserLocale(localeCookieName));
   if (locale) candidates.push(...locale);
   if (getLocale) candidates.push(getLocale());
-  return getReactI18nCache().determineLocale(candidates);
+  return resolveLocale(candidates);
+}
+
+function resolveLocale(candidates?: LocaleCandidates): string {
+  const i18nConfig = getI18nConfig();
+  return (
+    i18nConfig.determineLocale(candidates) || i18nConfig.getDefaultLocale()
+  );
 }
 
 function determineEnableI18n({

--- a/packages/react/src/deprecated/i18n-context/browser-i18n-manager/__tests__/BrowserI18nManager.test.ts
+++ b/packages/react/src/deprecated/i18n-context/browser-i18n-manager/__tests__/BrowserI18nManager.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { initializeI18nConfig } from 'gt-i18n/internal';
 import { BrowserI18nManager } from '../BrowserI18nManager';
 
 describe('BrowserI18nManager', () => {
@@ -14,6 +15,10 @@ describe('BrowserI18nManager', () => {
     };
     vi.stubGlobal('document', { documentElement });
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    initializeI18nConfig({
+      defaultLocale: 'en-US',
+      locales: ['en-US'],
+    });
     const manager = new BrowserI18nManager({
       defaultLocale: 'en-US',
       locales: ['en-US'],

--- a/packages/react/src/deprecated/i18n-context/browser-i18n-manager/utils/__tests__/determineLocale.test.ts
+++ b/packages/react/src/deprecated/i18n-context/browser-i18n-manager/utils/__tests__/determineLocale.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { initializeI18nConfig } from 'gt-i18n/internal';
 import { getLocale } from '../../../functions/locale-operations';
 import { initializeGT } from '../../../setup/initializeGT';
 import { determineLocale } from '../determineLocale';
@@ -6,6 +7,16 @@ import { determineLocale } from '../determineLocale';
 describe('determineLocale', () => {
   it('resolves custom locale aliases returned by getLocale', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    initializeI18nConfig({
+      defaultLocale: 'en',
+      locales: ['en', 'fr'],
+      customMapping: {
+        'brand-french': {
+          code: 'fr',
+          name: 'Brand French',
+        },
+      },
+    });
 
     expect(
       determineLocale({
@@ -26,6 +37,10 @@ describe('determineLocale', () => {
   });
 
   it('preserves default locale dialects through browser setup', () => {
+    initializeI18nConfig({
+      defaultLocale: 'pt-BR',
+      locales: ['pt', 'fr'],
+    });
     initializeGT({
       defaultLocale: 'pt-BR',
       locales: ['pt', 'fr'],

--- a/packages/react/src/i18n-cache/BrowserI18nCache.ts
+++ b/packages/react/src/i18n-cache/BrowserI18nCache.ts
@@ -2,7 +2,7 @@ import type {
   I18nCacheConstructorParams,
   TranslationsLoader,
 } from 'gt-i18n/internal/types';
-import { I18nCache } from 'gt-i18n/internal';
+import { getI18nConfig, I18nCache } from 'gt-i18n/internal';
 import type { HtmlTagOptions } from './types';
 import type { Translation } from 'gt-i18n/types';
 import { DEFAULT_HTML_TAG_OPTIONS } from './constants';
@@ -116,17 +116,17 @@ export class BrowserI18nCache extends I18nCache<Translation> {
   ): void {
     // Get parameters
     const htmlLocale = htmlTagOptions?.lang || locale;
-    const gtInstance = this.getGTClass();
-    const canonicalLocale = gtInstance.resolveCanonicalLocale(htmlLocale);
+    const i18nConfig = getI18nConfig();
+    const canonicalLocale = i18nConfig.resolveCanonicalLocale(htmlLocale);
 
     // Validate parameters
-    if (!gtInstance.isValidLocale(canonicalLocale)) {
+    if (!i18nConfig.isValidLocale(canonicalLocale)) {
       console.warn(createInvalidLocaleWarning(htmlLocale));
       return;
     }
 
     const localeDirection =
-      htmlTagOptions?.dir || gtInstance.getLocaleDirection(canonicalLocale);
+      htmlTagOptions?.dir || i18nConfig.getLocaleDirection(canonicalLocale);
 
     // Merge options
     const mergedHtmlTagOptions = {


### PR DESCRIPTION
## Summary

- Remove `defaultLocale`, `locales`, and `customMapping` from `I18nCache` constructor/config ownership.
- Remove `LocaleConfig` ownership from `I18nCache` and delegate cache locale operations to `I18nConfig`.
- Update `BrowserI18nCache` HTML locale helpers to use `I18nConfig`.
- Keep condition stores and non-cache consumers unchanged for later PRs.

## Stack

1. Previous: introduce `I18nConfig`.
2. Previous: initialize `I18nConfig` alongside existing setup.
3. This PR: move `I18nCache` locale ownership to `I18nConfig`.
4. Next: move condition stores to `I18nConfig`.

## Verification

- `pnpm --filter gt-i18n build`
- `pnpm --filter gt-react build`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1493"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782433976&installation_id=127936663&pr_number=1493&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1493&signature=c1f13f360644ead3bda03edf5030c639fbcde4aa82bcb7b90fc5c42e8fbe8e6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR completes step 3 of a multi-PR refactor by moving locale configuration ownership (`defaultLocale`, `locales`, `customMapping`) out of `I18nCache` and into the `I18nConfig` singleton. `I18nCache` now delegates all locale operations to `getI18nConfig()`, `BrowserI18nCache` HTML helpers switch from `GT`-instance locale calls to `I18nConfig`, and `AsyncConditionStore`/`BrowserConditionStore` replace `getI18nCache().determineLocale()` with `getI18nConfig().determineLocale()`.

- `I18nCacheConstructorParams` and `I18nCacheConfig` drop `defaultLocale`, `locales`, and `customMapping`; tests are updated to call `initializeI18nConfig()` before constructing `I18nCache`.
- `getI18nCache()` now throws instead of silently creating a fallback cache, enforcing the invariant that callers must initialize the singleton explicitly.
- All locale-resolution helpers (`determineLocale`, `requiresTranslation`, `requiresDialectTranslation`, `sanitizeLocale`) on `I18nCache` are marked `@deprecated` in preparation for removal in a later PR.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the refactor is logically consistent and the initialization invariant (I18nConfig before I18nCache) is enforced by the new throw in getI18nCache(). One test file still passes omitted constructor fields that TypeScript will reject at compile time.

The AsyncConditionStore test still passes `defaultLocale` and `locales` directly to `new I18nCache({...})`, fields now excluded from `I18nCacheConstructorParams` via the `Omit`. TypeScript's excess-property check on an object literal passed directly to a typed constructor will flag this as a compile error in the `gt-node` package build, which is outside the PR's stated verification scope (`gt-i18n` and `gt-react` only).

packages/node/src/async-i18n-cache/__tests__/AsyncConditionStore.test.ts — the I18nCache constructor call still passes defaultLocale and locales that were removed from the type.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/i18n/src/i18n-cache/I18nCache.ts | Locale ownership removed from I18nCache; all locale operations now delegate to getI18nConfig(). Minor redundancy in requiresTranslation passing defaultLocale/locales it just fetched from the same singleton. |
| packages/i18n/src/i18n-cache/singleton-operations.ts | Fallback cache path removed; getI18nCache() now throws instead of silently constructing a default cache, enforcing the invariant that I18nCache must be explicitly initialized. |
| packages/i18n/src/i18n-cache/types.ts | Omits defaultLocale, locales, and customMapping from I18nCacheConstructorParams and I18nCacheConfig correctly; locale config is now fully owned by I18nConfig. |
| packages/next/src/config-dir/I18NConfiguration.ts | requiresTranslation now correctly guards with isTranslationEnabled() before consulting i18nConfig; getDefaultLocale/getLocales/getCustomMapping delegated to getI18nConfig(). |
| packages/node/src/async-i18n-cache/__tests__/AsyncConditionStore.test.ts | Adds initializeI18nConfig before constructing I18nCache, but the I18nCache constructor call still passes defaultLocale and locales which are now Omit'd from I18nCacheConstructorParams — will produce a TypeScript excess-property error at compile time. |
| packages/react/src/i18n-cache/BrowserI18nCache.ts | updateHtmlTag replaced GT instance locale helpers (resolveCanonicalLocale, isValidLocale, getLocaleDirection) with equivalent calls on getI18nConfig(); functionally equivalent since both come from the same LocaleConfig base. |
| packages/i18n/src/i18n-cache/translations-manager/LocalesCache.ts | Removed defaultLocale constructor param; now fetches it from getI18nConfig() at construction time to seed the dictionary cache for the default locale. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant I18NConfiguration
    participant I18nCache
    participant I18nConfig

    Note over Caller,I18nConfig: Initialization
    Caller->>I18NConfiguration: new I18NConfiguration(params)
    I18NConfiguration->>I18nConfig: "initializeI18nConfig({defaultLocale, locales, customMapping})"
    I18NConfiguration->>I18nCache: "new I18nCache({apiKey, enableI18n, ...})"
    I18nCache->>I18nConfig: getI18nConfig().getDefaultLocale()
    I18nCache->>I18nConfig: getI18nConfig().getCustomMapping()

    Note over Caller,I18nConfig: Runtime Locale Resolution
    Caller->>I18NConfiguration: requiresTranslation(locale)
    I18NConfiguration->>I18NConfiguration: isTranslationEnabled()
    I18NConfiguration->>I18nConfig: getI18nConfig().requiresTranslation(locale)
    I18nConfig-->>I18NConfiguration: boolean
    I18NConfiguration->>I18nConfig: getI18nConfig().isSameLanguage(defaultLocale, locale)
    I18nConfig-->>I18NConfiguration: boolean
    I18NConfiguration-->>Caller: [translationRequired, dialectRequired]

    Note over Caller,I18nConfig: Browser/Node locale resolution
    Caller->>BrowserConditionStore: resolveLocale(candidates)
    BrowserConditionStore->>I18nConfig: getI18nConfig().determineLocale(candidates)
    I18nConfig-->>BrowserConditionStore: locale or undefined
    BrowserConditionStore->>I18nConfig: getI18nConfig().getDefaultLocale() (fallback)
    BrowserConditionStore-->>Caller: resolved locale
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `packages/i18n/src/i18n-cache/singleton-operations.ts`, line 20-26 ([link](https://github.com/generaltranslation/gt/blob/4b6670aa182c9671a907fecfa0c2eb471b24770e/packages/i18n/src/i18n-cache/singleton-operations.ts#L20-L26)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Fallback `I18nCache` construction now throws instead of degrading gracefully**

   `getI18nConfig()` throws `Error: I18nConfig was not initialized` when `initializeI18nConfig` hasn't been called yet. `new I18nCache({})` invokes `getI18nConfig()` in its constructor (line 92 of `I18nCache.ts`), so this fallback path — which is intentionally reached *before* `initializeGT()` runs — will now throw an unhandled exception instead of returning a cache using `libraryDefaultLocale`. The preceding `logger.warn(...)` message ("Falling back to the default locale…") is now misleading, as execution never reaches a usable cache.

   The fix is to ensure `initializeI18nConfig` is called with `libraryDefaultLocale` defaults before `new I18nCache({})` in this path, so the warning holds true at runtime.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/i18n/src/i18n-cache/singleton-operations.ts
   Line: 20-26

   Comment:
   **Fallback `I18nCache` construction now throws instead of degrading gracefully**

   `getI18nConfig()` throws `Error: I18nConfig was not initialized` when `initializeI18nConfig` hasn't been called yet. `new I18nCache({})` invokes `getI18nConfig()` in its constructor (line 92 of `I18nCache.ts`), so this fallback path — which is intentionally reached *before* `initializeGT()` runs — will now throw an unhandled exception instead of returning a cache using `libraryDefaultLocale`. The preceding `logger.warn(...)` message ("Falling back to the default locale…") is now misleading, as execution never reaches a usable cache.

   The fix is to ensure `initializeI18nConfig` is called with `libraryDefaultLocale` defaults before `new I18nCache({})` in this path, so the warning holds true at runtime.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fi18n%2Fsrc%2Fi18n-cache%2Fsingleton-operations.ts%0ALine%3A%2020-26%0A%0AComment%3A%0A**Fallback%20%60I18nCache%60%20construction%20now%20throws%20instead%20of%20degrading%20gracefully**%0A%0A%60getI18nConfig%28%29%60%20throws%20%60Error%3A%20I18nConfig%20was%20not%20initialized%60%20when%20%60initializeI18nConfig%60%20hasn't%20been%20called%20yet.%20%60new%20I18nCache%28%7B%7D%29%60%20invokes%20%60getI18nConfig%28%29%60%20in%20its%20constructor%20%28line%2092%20of%20%60I18nCache.ts%60%29%2C%20so%20this%20fallback%20path%20%E2%80%94%20which%20is%20intentionally%20reached%20*before*%20%60initializeGT%28%29%60%20runs%20%E2%80%94%20will%20now%20throw%20an%20unhandled%20exception%20instead%20of%20returning%20a%20cache%20using%20%60libraryDefaultLocale%60.%20The%20preceding%20%60logger.warn%28...%29%60%20message%20%28%22Falling%20back%20to%20the%20default%20locale%E2%80%A6%22%29%20is%20now%20misleading%2C%20as%20execution%20never%20reaches%20a%20usable%20cache.%0A%0AThe%20fix%20is%20to%20ensure%20%60initializeI18nConfig%60%20is%20called%20with%20%60libraryDefaultLocale%60%20defaults%20before%20%60new%20I18nCache%28%7B%7D%29%60%20in%20this%20path%2C%20so%20the%20warning%20holds%20true%20at%20runtime.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=generaltranslation%2Fgt&pr=1493&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fodysseus%2Fuse-i18n-config-in-cache%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fodysseus%2Fuse-i18n-config-in-cache%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fi18n%2Fsrc%2Fi18n-cache%2Fsingleton-operations.ts%0ALine%3A%2020-26%0A%0AComment%3A%0A**Fallback%20%60I18nCache%60%20construction%20now%20throws%20instead%20of%20degrading%20gracefully**%0A%0A%60getI18nConfig%28%29%60%20throws%20%60Error%3A%20I18nConfig%20was%20not%20initialized%60%20when%20%60initializeI18nConfig%60%20hasn't%20been%20called%20yet.%20%60new%20I18nCache%28%7B%7D%29%60%20invokes%20%60getI18nConfig%28%29%60%20in%20its%20constructor%20%28line%2092%20of%20%60I18nCache.ts%60%29%2C%20so%20this%20fallback%20path%20%E2%80%94%20which%20is%20intentionally%20reached%20*before*%20%60initializeGT%28%29%60%20runs%20%E2%80%94%20will%20now%20throw%20an%20unhandled%20exception%20instead%20of%20returning%20a%20cache%20using%20%60libraryDefaultLocale%60.%20The%20preceding%20%60logger.warn%28...%29%60%20message%20%28%22Falling%20back%20to%20the%20default%20locale%E2%80%A6%22%29%20is%20now%20misleading%2C%20as%20execution%20never%20reaches%20a%20usable%20cache.%0A%0AThe%20fix%20is%20to%20ensure%20%60initializeI18nConfig%60%20is%20called%20with%20%60libraryDefaultLocale%60%20defaults%20before%20%60new%20I18nCache%28%7B%7D%29%60%20in%20this%20path%2C%20so%20the%20warning%20holds%20true%20at%20runtime.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

2. `packages/node/src/async-i18n-cache/__tests__/AsyncConditionStore.test.ts`, line 17-22 ([link](https://github.com/generaltranslation/gt/blob/6cd873c38778c30053b71d17bca9ba504f7c34c2/packages/node/src/async-i18n-cache/__tests__/AsyncConditionStore.test.ts#L17-L22)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> `defaultLocale` and `locales` were removed from `I18nCacheConstructorParams` by this PR (via `Omit<GTConfig, 'cacheExpiryTime' | keyof I18nConfigParams>`), but the `new I18nCache({...})` call here still passes them as object-literal properties. TypeScript's excess-property check on an object literal passed directly to a typed constructor parameter will flag this as a compilation error. The `gt-node` package is not in the PR's verification list, so the failure was silently missed.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/node/src/async-i18n-cache/__tests__/AsyncConditionStore.test.ts
   Line: 17-22

   Comment:
   `defaultLocale` and `locales` were removed from `I18nCacheConstructorParams` by this PR (via `Omit<GTConfig, 'cacheExpiryTime' | keyof I18nConfigParams>`), but the `new I18nCache({...})` call here still passes them as object-literal properties. TypeScript's excess-property check on an object literal passed directly to a typed constructor parameter will flag this as a compilation error. The `gt-node` package is not in the PR's verification list, so the failure was silently missed.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fnode%2Fsrc%2Fasync-i18n-cache%2F__tests__%2FAsyncConditionStore.test.ts%0ALine%3A%2017-22%0A%0AComment%3A%0A%60defaultLocale%60%20and%20%60locales%60%20were%20removed%20from%20%60I18nCacheConstructorParams%60%20by%20this%20PR%20%28via%20%60Omit%3CGTConfig%2C%20'cacheExpiryTime'%20%7C%20keyof%20I18nConfigParams%3E%60%29%2C%20but%20the%20%60new%20I18nCache%28%7B...%7D%29%60%20call%20here%20still%20passes%20them%20as%20object-literal%20properties.%20TypeScript's%20excess-property%20check%20on%20an%20object%20literal%20passed%20directly%20to%20a%20typed%20constructor%20parameter%20will%20flag%20this%20as%20a%20compilation%20error.%20The%20%60gt-node%60%20package%20is%20not%20in%20the%20PR's%20verification%20list%2C%20so%20the%20failure%20was%20silently%20missed.%0A%0A%60%60%60suggestion%0A%20%20%20%20setI18nCache%28new%20I18nCache%28%7B%7D%29%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=generaltranslation%2Fgt&pr=1493&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fodysseus%2Fuse-i18n-config-in-cache%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fodysseus%2Fuse-i18n-config-in-cache%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fnode%2Fsrc%2Fasync-i18n-cache%2F__tests__%2FAsyncConditionStore.test.ts%0ALine%3A%2017-22%0A%0AComment%3A%0A%60defaultLocale%60%20and%20%60locales%60%20were%20removed%20from%20%60I18nCacheConstructorParams%60%20by%20this%20PR%20%28via%20%60Omit%3CGTConfig%2C%20'cacheExpiryTime'%20%7C%20keyof%20I18nConfigParams%3E%60%29%2C%20but%20the%20%60new%20I18nCache%28%7B...%7D%29%60%20call%20here%20still%20passes%20them%20as%20object-literal%20properties.%20TypeScript's%20excess-property%20check%20on%20an%20object%20literal%20passed%20directly%20to%20a%20typed%20constructor%20parameter%20will%20flag%20this%20as%20a%20compilation%20error.%20The%20%60gt-node%60%20package%20is%20not%20in%20the%20PR's%20verification%20list%2C%20so%20the%20failure%20was%20silently%20missed.%0A%0A%60%60%60suggestion%0A%20%20%20%20setI18nCache%28new%20I18nCache%28%7B%7D%29%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fi18n%2Fsrc%2Fi18n-cache%2FI18nCache.ts%3A640-646%0A**Redundant%20round-trip%20through%20I18nConfig%20in%20%60requiresTranslation%60**%0A%0A%60this.getDefaultLocale%28%29%60%20delegates%20to%20%60getI18nConfig%28%29.getDefaultLocale%28%29%60%20and%20%60this.getLocales%28%29%60%20delegates%20to%20%60getI18nConfig%28%29.getLocales%28%29%60%2C%20so%20the%20values%20are%20immediately%20fetched%20from%20the%20singleton%20and%20passed%20straight%20back%20into%20the%20same%20singleton's%20%60requiresTranslation%60%20call.%20Since%20%60I18nConfig%60%20%28via%20%60LocaleConfig%60%29%20already%20holds%20%60defaultLocale%60%20and%20%60locales%60%20as%20instance%20state%2C%20the%20two%20intermediate%20variables%20are%20unnecessary.%20%60I18NConfiguration.requiresTranslation%60%20already%20calls%20%60i18nConfig.requiresTranslation%28locale%29%60%20with%20a%20single%20argument%20with%20no%20issue%2C%20confirming%20the%20two-arg%20form%20is%20redundant%20here.%0A%0A&repo=generaltranslation%2Fgt&pr=1493&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fodysseus%2Fuse-i18n-config-in-cache%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fodysseus%2Fuse-i18n-config-in-cache%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fi18n%2Fsrc%2Fi18n-cache%2FI18nCache.ts%3A640-646%0A**Redundant%20round-trip%20through%20I18nConfig%20in%20%60requiresTranslation%60**%0A%0A%60this.getDefaultLocale%28%29%60%20delegates%20to%20%60getI18nConfig%28%29.getDefaultLocale%28%29%60%20and%20%60this.getLocales%28%29%60%20delegates%20to%20%60getI18nConfig%28%29.getLocales%28%29%60%2C%20so%20the%20values%20are%20immediately%20fetched%20from%20the%20singleton%20and%20passed%20straight%20back%20into%20the%20same%20singleton's%20%60requiresTranslation%60%20call.%20Since%20%60I18nConfig%60%20%28via%20%60LocaleConfig%60%29%20already%20holds%20%60defaultLocale%60%20and%20%60locales%60%20as%20instance%20state%2C%20the%20two%20intermediate%20variables%20are%20unnecessary.%20%60I18NConfiguration.requiresTranslation%60%20already%20calls%20%60i18nConfig.requiresTranslation%28locale%29%60%20with%20a%20single%20argument%20with%20no%20issue%2C%20confirming%20the%20two-arg%20form%20is%20redundant%20here.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/i18n/src/i18n-cache/I18nCache.ts:640-646
**Redundant round-trip through I18nConfig in `requiresTranslation`**

`this.getDefaultLocale()` delegates to `getI18nConfig().getDefaultLocale()` and `this.getLocales()` delegates to `getI18nConfig().getLocales()`, so the values are immediately fetched from the singleton and passed straight back into the same singleton's `requiresTranslation` call. Since `I18nConfig` (via `LocaleConfig`) already holds `defaultLocale` and `locales` as instance state, the two intermediate variables are unnecessary. `I18NConfiguration.requiresTranslation` already calls `i18nConfig.requiresTranslation(locale)` with a single argument with no issue, confirming the two-arg form is redundant here.


`````

</details>

<sub>Reviews (8): Last reviewed commit: ["fix: preserve next locale checks"](https://github.com/generaltranslation/gt/commit/0e2d889cf53e0a31425b85fee43a0abcf74e7683) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34071951)</sub>

<!-- /greptile_comment -->