### PR TITLE
refactor: read condition store locales from i18n config

### DIFF
--- a/packages/i18n/src/condition-store/ReadonlyConditionStore.ts
+++ b/packages/i18n/src/condition-store/ReadonlyConditionStore.ts
@@ -1,45 +1,18 @@
-import { CustomMapping } from 'generaltranslation/types';
-import type {
-  LocaleResolverConfig,
-  ReadonlyConditionStoreInterface as ReadonlyConditionStoreContract,
-} from '../i18n-cache/types';
-import { createLocaleResolver, type LocaleCandidates } from './localeResolver';
+import type { ReadonlyConditionStoreInterface as ReadonlyConditionStoreContract } from '../i18n-cache/types';
+import { getI18nConfig } from '../i18n-config/singleton-operations';
+import type { LocaleCandidates } from './localeResolver';
 
 export type ReadonlyConditionStoreParams = {
-  /**
-   * @deprecated - this will be moved to a locale config cache
-   */
-  defaultLocale?: string;
-  /**
-   * @deprecated - this will be moved to a locale config cache
-   */
-  locales?: string[];
-  /**
-   * @deprecated - this will be moved to a locale config cache
-   */
-  customMapping?: CustomMapping;
   locale: LocaleCandidates;
   enableI18n?: boolean;
 };
 
 export class ReadonlyConditionStore implements ReadonlyConditionStoreContract {
-  /**
-   * @deprecated use I18nConfig instead
-   */
-  protected readonly resolveLocale: (candidates?: LocaleCandidates) => string;
   protected locale: string;
   protected enableI18n: boolean;
 
-  constructor({
-    locale,
-    enableI18n = true,
-    ...localeConfig
-  }: ReadonlyConditionStoreParams) {
-    /**
-     * TODO: change this to I18nConfig once condition stores are migrated.
-     */
-    this.resolveLocale = createLocaleResolver(localeConfig);
-    this.locale = this.resolveLocale(locale);
+  constructor({ locale, enableI18n = true }: ReadonlyConditionStoreParams) {
+    this.locale = resolveLocale(locale);
     this.enableI18n = enableI18n;
   }
 
@@ -56,4 +29,11 @@ export class ReadonlyConditionStore implements ReadonlyConditionStoreContract {
   setLocale = (locale: LocaleCandidates): void => {};
 
   setEnableI18n = (enableI18n: boolean): void => {};
+}
+
+function resolveLocale(candidates?: LocaleCandidates): string {
+  const i18nConfig = getI18nConfig();
+  return (
+    i18nConfig.determineLocale(candidates) || i18nConfig.getDefaultLocale()
+  );
 }

--- a/packages/i18n/src/condition-store/WritableConditionStore.ts
+++ b/packages/i18n/src/condition-store/WritableConditionStore.ts
@@ -1,5 +1,6 @@
 import type { LocaleCandidates } from '../i18n-cache';
 import type { WritableConditionStoreInterface } from '../i18n-cache/types';
+import { getI18nConfig } from '../i18n-config/singleton-operations';
 import {
   ReadonlyConditionStore,
   type ReadonlyConditionStoreParams,
@@ -12,7 +13,7 @@ export class WritableConditionStore
   implements WritableConditionStoreInterface
 {
   setLocale = (locale: LocaleCandidates): void => {
-    this.locale = this.resolveLocale(locale);
+    this.locale = getI18nConfig().resolveSupportedLocale(locale);
   };
 
   setEnableI18n = (enableI18n: boolean): void => {

--- a/packages/next/src/config-dir/__tests__/I18NConfiguration.test.ts
+++ b/packages/next/src/config-dir/__tests__/I18NConfiguration.test.ts
@@ -17,9 +17,11 @@ vi.mock('gt-i18n/internal', () => ({
     getDefaultLocale: () => mockLocaleConfig.defaultLocale,
     getLocales: () => mockLocaleConfig.locales,
     getCustomMapping: () => mockLocaleConfig.customMapping,
-    requiresTranslation: () => mockLocaleConfig.translationRequired,
+    requiresTranslation: () =>
+      mockLocaleConfig.enableI18n && mockLocaleConfig.translationRequired,
     isSameLanguage: () => mockLocaleConfig.dialectTranslationRequired,
     requiresDialectTranslation: () =>
+      mockLocaleConfig.enableI18n &&
       mockLocaleConfig.translationRequired &&
       mockLocaleConfig.dialectTranslationRequired,
   }),

--- a/packages/node/src/async-i18n-cache/AsyncConditionStore.ts
+++ b/packages/node/src/async-i18n-cache/AsyncConditionStore.ts
@@ -1,8 +1,5 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
-import type {
-  LocaleResolverConfig,
-  ScopedConditionStore,
-} from 'gt-i18n/internal/types';
+import type { ScopedConditionStore } from 'gt-i18n/internal/types';
 import { getI18nConfig } from 'gt-i18n/internal';
 
 type Store = {
@@ -16,7 +13,7 @@ const OUTSIDE_SCOPE_MESSAGE =
 const ENABLE_I18N_MESSAGE =
   'AsyncConditionStore: getEnableI18n() called outside of a withGT() scope.';
 
-type AsyncConditionStoreConstructorParams = LocaleResolverConfig & {
+type AsyncConditionStoreConstructorParams = {
   store?: AsyncLocalStorage<Store>;
 };
 
@@ -26,12 +23,7 @@ type AsyncConditionStoreConstructorParams = LocaleResolverConfig & {
 export class AsyncConditionStore implements ScopedConditionStore {
   private store: AsyncLocalStorage<Store>;
 
-  constructor({
-    defaultLocale,
-    locales,
-    customMapping,
-    store,
-  }: AsyncConditionStoreConstructorParams = {}) {
+  constructor({ store }: AsyncConditionStoreConstructorParams = {}) {
     this.store = store ?? new AsyncLocalStorage();
   }
 

--- a/packages/node/src/setup/initializeGT.ts
+++ b/packages/node/src/setup/initializeGT.ts
@@ -16,11 +16,7 @@ export function initializeGT(params: InitializeGTParams): void {
   initializeI18nConfig(params);
 
   const i18nCache = new I18nCache<string>(params);
-  const conditionStore = new AsyncConditionStore({
-    defaultLocale: i18nCache.getDefaultLocale(),
-    locales: i18nCache.getLocales(),
-    customMapping: i18nCache.getCustomMapping(),
-  });
+  const conditionStore = new AsyncConditionStore();
 
   setI18nCache(i18nCache);
   setAsyncConditionStore(conditionStore);

--- a/packages/react-core/src/condition-store/singleton-operations.ts
+++ b/packages/react-core/src/condition-store/singleton-operations.ts
@@ -60,7 +60,6 @@ function getReadonlyConditionStoreWithFallback(): ReadonlyConditionStoreInterfac
     // Fallback to default configuration (important: do not set globally)
     return new ReadonlyConditionStore({
       locale: libraryDefaultLocale,
-      locales: [libraryDefaultLocale],
     });
   }
 }

--- a/packages/react-core/src/condition-store/singleton-operations.ts
+++ b/packages/react-core/src/condition-store/singleton-operations.ts
@@ -6,7 +6,6 @@ import {
 import {
   createConditionStoreSingleton,
   getRuntimeEnvironment,
-  ReadonlyConditionStore,
 } from 'gt-i18n/internal';
 import type { ReadonlyConditionStoreInterface } from 'gt-i18n/internal/types';
 import { getRenderStrategy } from '../setup/globals';
@@ -58,9 +57,12 @@ function getReadonlyConditionStoreWithFallback(): ReadonlyConditionStoreInterfac
     }
 
     // Fallback to default configuration (important: do not set globally)
-    return new ReadonlyConditionStore({
-      locale: libraryDefaultLocale,
-    });
+    return {
+      getLocale: () => libraryDefaultLocale,
+      getEnableI18n: () => true,
+      setLocale: () => {},
+      setEnableI18n: () => {},
+    };
   }
 }
 

--- a/packages/react/src/condition-store/BrowserConditionStore.ts
+++ b/packages/react/src/condition-store/BrowserConditionStore.ts
@@ -16,8 +16,6 @@ export type ReloadType = (state: SerializedBrowserConditionStoreState) => void;
 
 /**
  * The configuration for the BrowserConditionStore
- * @param {string[]} locales - The accepted locales
- * @param {CustomMapping} [customMapping] - The custom mapping
  * @param {GetLocale} getLocale - The function to get the locale
  * @param {string} [localeCookieName=defaultLocaleCookieName] - The name of the locale cookie to check
  */

--- a/packages/react/src/provider/CSRGTProvider.tsx
+++ b/packages/react/src/provider/CSRGTProvider.tsx
@@ -1,7 +1,4 @@
-import {
-  getReactI18nCache,
-  InternalGTProvider,
-} from '@generaltranslation/react-core/context';
+import { InternalGTProvider } from '@generaltranslation/react-core/context';
 import type { SharedGTProviderProps } from './SharedGTProviderProps';
 import { createOrUpdateBrowserConditionStore } from '../condition-store/createBrowserConditionStore';
 
@@ -10,21 +7,11 @@ import { createOrUpdateBrowserConditionStore } from '../condition-store/createBr
  * GTProvider because needs to syncrhonize any incoming
  * server-side translations
  */
-export function CSRGTProvider({
-  defaultLocale = getReactI18nCache().getDefaultLocale(),
-  locales = getReactI18nCache().getLocales(),
-  customMapping = getReactI18nCache().getCustomMapping(),
-  ...props
-}: SharedGTProviderProps) {
+export function CSRGTProvider(props: SharedGTProviderProps) {
   // TODO: if a specific translation entry changes, but not the locale, this does not trigger a re-render
   // TODO: optimize by skipping updateTranslations() if client is responsible for reloading translations
   // (eg reloadLocale === undefined), see getI18nStore().updateLocale() in InternalGTProvider
-  createOrUpdateBrowserConditionStore({
-    defaultLocale,
-    locales,
-    customMapping,
-    ...props,
-  });
+  createOrUpdateBrowserConditionStore(props);
 
   return <InternalGTProvider {...props} />;
 }

--- a/packages/react/src/provider/SSRGTProvider.tsx
+++ b/packages/react/src/provider/SSRGTProvider.tsx
@@ -4,10 +4,7 @@ import {
   setReadonlyConditionStore,
 } from '../condition-store/singleton-operations';
 import type { SharedGTProviderProps } from './SharedGTProviderProps';
-import {
-  getReactI18nCache,
-  InternalGTProvider,
-} from '@generaltranslation/react-core/context';
+import { InternalGTProvider } from '@generaltranslation/react-core/context';
 
 /**
  * For the server side GTProvider, we don't need to synchronize translations
@@ -15,20 +12,10 @@ import {
  *
  * TODO: find some way to enforce this is only imported on the server
  */
-export function SSRGTProvider({
-  defaultLocale = getReactI18nCache().getDefaultLocale(),
-  locales = getReactI18nCache().getLocales(),
-  customMapping = getReactI18nCache().getCustomMapping(),
-  ...props
-}: SharedGTProviderProps) {
+export function SSRGTProvider(props: SharedGTProviderProps) {
   // The condition store may already be created at the module level
   if (!isReadonlyConditionStoreInitialized()) {
-    const conditionStore = new ReadonlyConditionStore({
-      defaultLocale,
-      locales,
-      customMapping,
-      ...props,
-    });
+    const conditionStore = new ReadonlyConditionStore(props);
     setReadonlyConditionStore(conditionStore);
   }
   return <InternalGTProvider {...props} />;

--- a/packages/react/src/provider/SharedGTProviderProps.ts
+++ b/packages/react/src/provider/SharedGTProviderProps.ts
@@ -1,12 +1,11 @@
 import type { InternalGTProviderProps } from '@generaltranslation/react-core/context';
-import type { LocaleCandidates } from 'gt-i18n/internal/types';
+import type { ReadonlyConditionStoreParams } from 'gt-i18n/internal/types';
 
 /**
  * We force the user to pass translations so they can be synchronously accessed
  *
  * - {@link InternalGTProviderProps} - requires translations and dictionaries
- * - locale - request/browser locale candidates
+ * - {@link ReadonlyConditionStoreParams} - requires locale
  */
-export type SharedGTProviderProps = InternalGTProviderProps & {
-  locale: LocaleCandidates;
-};
+export type SharedGTProviderProps = InternalGTProviderProps &
+  ReadonlyConditionStoreParams;

--- a/packages/react/src/provider/SharedGTProviderProps.ts
+++ b/packages/react/src/provider/SharedGTProviderProps.ts
@@ -1,11 +1,12 @@
 import type { InternalGTProviderProps } from '@generaltranslation/react-core/context';
-import type { ReadonlyConditionStoreParams } from 'gt-i18n/internal/types';
+import type { LocaleCandidates } from 'gt-i18n/internal/types';
 
 /**
  * We force the user to pass translations so they can be synchronously accessed
  *
  * - {@link InternalGTProviderProps} - requires translations and dictionaries
- * - {@link ReadonlyConditionStoreParams} - requires locale
+ * - locale - request/browser locale candidates
  */
-export type SharedGTProviderProps = InternalGTProviderProps &
-  ReadonlyConditionStoreParams;
+export type SharedGTProviderProps = InternalGTProviderProps & {
+  locale: LocaleCandidates;
+};

--- a/packages/tanstack-start/src/provider/GTProvider.tsx
+++ b/packages/tanstack-start/src/provider/GTProvider.tsx
@@ -32,9 +32,6 @@ export function GTProvider(props: GTProviderProps): React.ReactNode {
   return (
     <GTReactProvider
       ssr={isSSREnabled()}
-      defaultLocale={i18nCache.getDefaultLocale()}
-      locales={i18nCache.getLocales()}
-      customMapping={i18nCache.getCustomMapping()}
       enableI18n={i18nCache.isTranslationEnabled()}
       loadTranslations={(locale: string) => i18nCache.loadTranslations(locale)}
       _versionId={i18nCache.getVersionId()}


### PR DESCRIPTION
## Summary

- Remove locale config ownership from readonly, writable, browser, and async condition stores.
- Resolve condition store locale candidates through `I18nConfig`.
- Stop React/TanStack provider wiring from forwarding locale config into condition stores.

## Stack

1. Previous: introduce and initialize `I18nConfig`.
2. Previous: move `I18nCache` locale ownership to `I18nConfig`.
3. This PR: move condition stores to `I18nConfig`.
4. Next: replace remaining cache locale consumers.

## Verification

- `pnpm --filter gt-i18n build`
- `pnpm --filter gt-react build`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1494"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782433985&installation_id=127936663&pr_number=1494&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1494&signature=925d32d10020f6b4aad99951ab6491efe45f6de66aea25273457fc7b6e9452d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR completes step 3 of a refactoring stack by moving locale-candidate resolution out of all condition stores (`ReadonlyConditionStore`, `WritableConditionStore`, `AsyncConditionStore`, `BrowserConditionStore`) and centralizing it in `I18nConfig`. Providers (SSR, CSR, TanStack) are simplified by dropping the explicit forwarding of `defaultLocale`, `locales`, and `customMapping` into the stores, which now call `getI18nConfig()` directly.

- All four condition-store classes now delegate to `getI18nConfig().determineLocale()` / `resolveSupportedLocale()`, and the locale-resolver fields and constructor params are removed from each.
- The production fallback in `react-core/singleton-operations.ts` was fixed from the previous review: it now returns a plain object literal instead of constructing `ReadonlyConditionStore`, so the graceful-degradation path no longer depends on `I18nConfig` being initialized.
- Provider components (`SSRGTProvider`, `CSRGTProvider`, TanStack `GTProvider`) are each 10–15 lines shorter with the locale-config forwarding eliminated.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; all condition stores correctly delegate to I18nConfig which is always initialized before the stores are constructed.

The refactoring is mechanically consistent: I18nConfig is initialized first in every setup path (initializeGT, I18NConfiguration constructor, React providers), so the new getI18nConfig() calls inside condition-store constructors and setLocale will always find an initialized singleton. The previously-flagged fallback issue is properly resolved by returning a plain literal instead of constructing ReadonlyConditionStore. The only finding is an imprecise test mock that does not cause test failures and does not affect runtime behavior.

packages/next/src/config-dir/__tests__/I18NConfiguration.test.ts — the getI18nConfig() mock behavior diverges slightly from the real LocaleConfig implementation in ways that are harmless today but could mislead future test authors.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/i18n/src/condition-store/ReadonlyConditionStore.ts | Removes self-contained locale resolver; delegates to getI18nConfig().determineLocale() in a module-level resolveLocale() helper. Locale params stripped from constructor as planned. |
| packages/i18n/src/condition-store/WritableConditionStore.ts | setLocale now calls getI18nConfig().resolveSupportedLocale() instead of the old self-contained resolver; consistent with the constructor's resolveLocale helper. |
| packages/react-core/src/condition-store/singleton-operations.ts | Production fallback now returns a plain object literal instead of constructing ReadonlyConditionStore, eliminating the previously-flagged dependency on getI18nConfig() in the error-recovery path. |
| packages/react/src/condition-store/BrowserConditionStore.ts | Locale params removed from BrowserConditionStoreParams; resolveLocale now delegates to getI18nConfig(). JSDoc updated to remove stale param docs. |
| packages/react/src/provider/SSRGTProvider.tsx | No longer pulls defaultLocale/locales/customMapping from the React i18n cache; passes props directly to ReadonlyConditionStore, whose constructor now delegates to I18nConfig. |
| packages/react/src/provider/CSRGTProvider.tsx | Simplified: no longer extracts locale config defaults from getReactI18nCache(); passes props straight to createOrUpdateBrowserConditionStore. |
| packages/node/src/async-i18n-cache/AsyncConditionStore.ts | Constructor simplified: locale params removed; resolveLocale now calls getI18nConfig() directly instead of holding a local resolver instance. |
| packages/node/src/setup/initializeGT.ts | AsyncConditionStore construction simplified from 4 locale params to zero; correct because I18nConfig is initialized just before it and provides locale resolution. |
| packages/next/src/config-dir/__tests__/I18NConfiguration.test.ts | Mock for getI18nConfig().requiresTranslation() now adds an enableI18n guard not present in the real I18nConfig implementation; and the requiresDialectTranslation mock change is never exercised by any test in this file. |
| packages/tanstack-start/src/provider/GTProvider.tsx | Three locale-config props removed from GTReactProvider spread; locale resolution is now fully owned by I18nConfig inside the condition stores. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Provider as SSR/CSR/TanStack Provider
    participant Store as ConditionStore
    participant I18nConfig as I18nConfig singleton
    participant LocaleConfig as LocaleConfig

    Note over Provider,I18nConfig: Before this PR — locale config forwarded explicitly
    Provider->>Store: "new Store({ locale, defaultLocale, locales, customMapping })"
    Store->>Store: "createLocaleResolver({ defaultLocale, locales, customMapping })"
    Store->>Store: this.resolveLocale(locale)

    Note over Provider,I18nConfig: After this PR — stores delegate to I18nConfig singleton
    Provider->>Store: "new Store({ locale })"
    Store->>I18nConfig: getI18nConfig()
    I18nConfig->>LocaleConfig: determineLocale(candidates)
    LocaleConfig-->>Store: resolved locale string
    Store-->>Provider: locale set

    Note over Provider,I18nConfig: Production fallback (no store initialized)
    Provider->>Store: getReadonlyConditionStoreWithFallback()
    Store-->>Provider: plain object literal, no I18nConfig dependency
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/react/src/condition-store/BrowserConditionStore.ts`, line 17-23 ([link](https://github.com/generaltranslation/gt/blob/687ade41fba0e41e585515f3a0f2127d611ddfbb/packages/react/src/condition-store/BrowserConditionStore.ts#L17-L23)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The JSDoc for `BrowserConditionStoreParams` still documents `@param {string[]} locales` and `@param {CustomMapping} [customMapping]`, but those fields were removed from `WritableConditionStoreParams` in this PR. Any reader relying on the JSDoc to understand the accepted config will be misled.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/react/src/condition-store/BrowserConditionStore.ts
   Line: 17-23

   Comment:
   The JSDoc for `BrowserConditionStoreParams` still documents `@param {string[]} locales` and `@param {CustomMapping} [customMapping]`, but those fields were removed from `WritableConditionStoreParams` in this PR. Any reader relying on the JSDoc to understand the accepted config will be misled.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Freact%2Fsrc%2Fcondition-store%2FBrowserConditionStore.ts%0ALine%3A%2017-23%0A%0AComment%3A%0AThe%20JSDoc%20for%20%60BrowserConditionStoreParams%60%20still%20documents%20%60%40param%20%7Bstring%5B%5D%7D%20locales%60%20and%20%60%40param%20%7BCustomMapping%7D%20%5BcustomMapping%5D%60%2C%20but%20those%20fields%20were%20removed%20from%20%60WritableConditionStoreParams%60%20in%20this%20PR.%20Any%20reader%20relying%20on%20the%20JSDoc%20to%20understand%20the%20accepted%20config%20will%20be%20misled.%0A%0A%60%60%60suggestion%0A%2F**%0A%20*%20The%20configuration%20for%20the%20BrowserConditionStore%0A%20*%20%40param%20%7BGetLocale%7D%20getLocale%20-%20The%20function%20to%20get%20the%20locale%0A%20*%20%40param%20%7Bstring%7D%20%5BlocaleCookieName%3DdefaultLocaleCookieName%5D%20-%20The%20name%20of%20the%20locale%20cookie%20to%20check%0A%20*%2F%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=generaltranslation%2Fgt&pr=1494&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fodysseus%2Fuse-i18n-config-in-condition-stores%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fodysseus%2Fuse-i18n-config-in-condition-stores%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Freact%2Fsrc%2Fcondition-store%2FBrowserConditionStore.ts%0ALine%3A%2017-23%0A%0AComment%3A%0AThe%20JSDoc%20for%20%60BrowserConditionStoreParams%60%20still%20documents%20%60%40param%20%7Bstring%5B%5D%7D%20locales%60%20and%20%60%40param%20%7BCustomMapping%7D%20%5BcustomMapping%5D%60%2C%20but%20those%20fields%20were%20removed%20from%20%60WritableConditionStoreParams%60%20in%20this%20PR.%20Any%20reader%20relying%20on%20the%20JSDoc%20to%20understand%20the%20accepted%20config%20will%20be%20misled.%0A%0A%60%60%60suggestion%0A%2F**%0A%20*%20The%20configuration%20for%20the%20BrowserConditionStore%0A%20*%20%40param%20%7BGetLocale%7D%20getLocale%20-%20The%20function%20to%20get%20the%20locale%0A%20*%20%40param%20%7Bstring%7D%20%5BlocaleCookieName%3DdefaultLocaleCookieName%5D%20-%20The%20name%20of%20the%20locale%20cookie%20to%20check%0A%20*%2F%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fnext%2Fsrc%2Fconfig-dir%2F__tests__%2FI18NConfiguration.test.ts%3A20-26%0A**Mock%20adds%20enableI18n%20guard%20absent%20from%20the%20real%20implementation**%0A%0AThe%20%60getI18nConfig%28%29%60%20mock%20for%20%60requiresTranslation%60%20now%20checks%20%60mockLocaleConfig.enableI18n%60%2C%20but%20the%20real%20%60LocaleConfig.requiresTranslation%28%29%60%20never%20reads%20%60enableI18n%60%20%E2%80%94%20that%20guard%20lives%20in%20%60I18NConfiguration.requiresTranslation%28%29%60%20via%20%60this.isTranslationEnabled%28%29%60.%20Similarly%2C%20the%20%60requiresDialectTranslation%60%20mock%20change%20adds%20the%20same%20guard%2C%20yet%20no%20test%20in%20this%20file%20calls%20any%20path%20that%20exercises%20%60getI18nConfig%28%29.requiresDialectTranslation%28%29%60%2C%20making%20that%20change%20dead%20code%20in%20the%20mock.%20The%20existing%20test%20cases%20still%20pass%20because%20%60isTranslationEnabled%28%29%60%20short-circuits%20the%20call%20before%20the%20mock%20is%20reached.%20Future%20tests%20that%20set%20%60enableI18n%20%3D%20false%60%20directly%20on%20the%20mock%20object%20while%20keeping%20%60isTranslationEnabled%28%29%20%3D%20true%60%20will%20see%20different%20results%20from%20the%20real%20implementation.%0A%0A&repo=generaltranslation%2Fgt&pr=1494&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fodysseus%2Fuse-i18n-config-in-condition-stores%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fodysseus%2Fuse-i18n-config-in-condition-stores%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fnext%2Fsrc%2Fconfig-dir%2F__tests__%2FI18NConfiguration.test.ts%3A20-26%0A**Mock%20adds%20enableI18n%20guard%20absent%20from%20the%20real%20implementation**%0A%0AThe%20%60getI18nConfig%28%29%60%20mock%20for%20%60requiresTranslation%60%20now%20checks%20%60mockLocaleConfig.enableI18n%60%2C%20but%20the%20real%20%60LocaleConfig.requiresTranslation%28%29%60%20never%20reads%20%60enableI18n%60%20%E2%80%94%20that%20guard%20lives%20in%20%60I18NConfiguration.requiresTranslation%28%29%60%20via%20%60this.isTranslationEnabled%28%29%60.%20Similarly%2C%20the%20%60requiresDialectTranslation%60%20mock%20change%20adds%20the%20same%20guard%2C%20yet%20no%20test%20in%20this%20file%20calls%20any%20path%20that%20exercises%20%60getI18nConfig%28%29.requiresDialectTranslation%28%29%60%2C%20making%20that%20change%20dead%20code%20in%20the%20mock.%20The%20existing%20test%20cases%20still%20pass%20because%20%60isTranslationEnabled%28%29%60%20short-circuits%20the%20call%20before%20the%20mock%20is%20reached.%20Future%20tests%20that%20set%20%60enableI18n%20%3D%20false%60%20directly%20on%20the%20mock%20object%20while%20keeping%20%60isTranslationEnabled%28%29%20%3D%20true%60%20will%20see%20different%20results%20from%20the%20real%20implementation.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/next/src/config-dir/__tests__/I18NConfiguration.test.ts:20-26
**Mock adds enableI18n guard absent from the real implementation**

The `getI18nConfig()` mock for `requiresTranslation` now checks `mockLocaleConfig.enableI18n`, but the real `LocaleConfig.requiresTranslation()` never reads `enableI18n` — that guard lives in `I18NConfiguration.requiresTranslation()` via `this.isTranslationEnabled()`. Similarly, the `requiresDialectTranslation` mock change adds the same guard, yet no test in this file calls any path that exercises `getI18nConfig().requiresDialectTranslation()`, making that change dead code in the mock. The existing test cases still pass because `isTranslationEnabled()` short-circuits the call before the mock is reached. Future tests that set `enableI18n = false` directly on the mock object while keeping `isTranslationEnabled() = true` will see different results from the real implementation.


`````

</details>

<sub>Reviews (7): Last reviewed commit: ["fix: use condition store params in share..."](https://github.com/generaltranslation/gt/commit/f3efc40f59f372abf64127f729286cb20e344e5d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34071973)</sub>

<!-- /greptile_comment -->