### PR TITLE
refactor: replace cache locale consumers

### DIFF
--- a/packages/i18n/src/condition-store/WritableConditionStore.ts
+++ b/packages/i18n/src/condition-store/WritableConditionStore.ts
@@ -13,7 +13,9 @@ export class WritableConditionStore
   implements WritableConditionStoreInterface
 {
   setLocale = (locale: LocaleCandidates): void => {
-    this.locale = getI18nConfig().resolveSupportedLocale(locale);
+    const i18nConfig = getI18nConfig();
+    this.locale =
+      i18nConfig.determineLocale(locale) || i18nConfig.getDefaultLocale();
   };
 
   setEnableI18n = (enableI18n: boolean): void => {

--- a/packages/i18n/src/helpers/locale.ts
+++ b/packages/i18n/src/helpers/locale.ts
@@ -1,5 +1,6 @@
 import { getWritableConditionStore } from '../condition-store/singleton-operations';
 import { getI18nCache } from '../i18n-cache/singleton-operations';
+import { getI18nConfig } from '../i18n-config/singleton-operations';
 
 /**
  * Get the current locale
@@ -22,8 +23,7 @@ export function getLocale() {
  * console.log(locales); // ['en-US', 'es-ES']
  */
 export function getLocales() {
-  const i18nCache = getI18nCache();
-  return i18nCache.getLocales();
+  return getI18nConfig().getLocales();
 }
 
 /**
@@ -35,8 +35,7 @@ export function getLocales() {
  * console.log(defaultLocale); // 'en-US'
  */
 export function getDefaultLocale() {
-  const i18nCache = getI18nCache();
-  return i18nCache.getDefaultLocale();
+  return getI18nConfig().getDefaultLocale();
 }
 
 /**

--- a/packages/i18n/src/i18n-cache/I18nCache.ts
+++ b/packages/i18n/src/i18n-cache/I18nCache.ts
@@ -165,30 +165,6 @@ class I18nCache<
   // ========== Getters and Setters ========== //
 
   /**
-   * Get the default locale
-   * @deprecated use I18nConfig instead
-   */
-  getDefaultLocale(): string {
-    return getI18nConfig().getDefaultLocale();
-  }
-
-  /**
-   * Get the locales
-   * @deprecated use I18nConfig instead
-   */
-  getLocales(): string[] {
-    return getI18nConfig().getLocales();
-  }
-
-  /**
-   * Get the custom locale mapping
-   * @deprecated use I18nConfig instead
-   */
-  getCustomMapping() {
-    return getI18nConfig().getCustomMapping();
-  }
-
-  /**
    * Get the version ID
    */
   getVersionId(): string | undefined {
@@ -631,38 +607,13 @@ class I18nCache<
 
   // ========== Metadata ========== //
 
-  /**
-   * Returns true if translation is required
-   * @param {string} locale - The user's locale
-   * @returns {boolean} True if translation is required, otherwise false
-   * @deprecated use I18nConfig instead
-   */
-  requiresTranslation(locale: string): boolean {
-    const defaultLocale = this.getDefaultLocale();
-    const locales = this.getLocales();
+  private requiresTranslation(locale: string): boolean {
     return (
       this.isTranslationEnabled() &&
-      getI18nConfig().requiresTranslation(locale, defaultLocale, locales)
+      getI18nConfig().requiresTranslation(locale)
     );
   }
 
-  /**
-   * Returns true if dialect translation is required
-   * @param {string} locale - The user's locale
-   * @returns {boolean} True if dialect translation is required, otherwise false
-   * @deprecated use I18nConfig instead
-   */
-  requiresDialectTranslation(locale: string): boolean {
-    const defaultLocale = this.getDefaultLocale();
-    return (
-      this.requiresTranslation(locale) &&
-      getI18nConfig().isSameLanguage(defaultLocale, locale)
-    );
-  }
-
-  /**
-   * @deprecated use I18nConfig instead
-   */
   public sanitizeLocale(locale: string): string | undefined {
     try {
       return this._resolveLocale(locale);

--- a/packages/i18n/src/i18n-cache/I18nCache.ts
+++ b/packages/i18n/src/i18n-cache/I18nCache.ts
@@ -165,6 +165,30 @@ class I18nCache<
   // ========== Getters and Setters ========== //
 
   /**
+   * Get the default locale
+   * @deprecated use I18nConfig instead
+   */
+  getDefaultLocale(): string {
+    return getI18nConfig().getDefaultLocale();
+  }
+
+  /**
+   * Get the locales
+   * @deprecated use I18nConfig instead
+   */
+  getLocales(): string[] {
+    return getI18nConfig().getLocales();
+  }
+
+  /**
+   * Get the custom locale mapping
+   * @deprecated use I18nConfig instead
+   */
+  getCustomMapping() {
+    return getI18nConfig().getCustomMapping();
+  }
+
+  /**
    * Get the version ID
    */
   getVersionId(): string | undefined {

--- a/packages/i18n/src/i18n-cache/I18nCache.ts
+++ b/packages/i18n/src/i18n-cache/I18nCache.ts
@@ -609,8 +609,7 @@ class I18nCache<
 
   private requiresTranslation(locale: string): boolean {
     return (
-      this.isTranslationEnabled() &&
-      getI18nConfig().requiresTranslation(locale)
+      this.isTranslationEnabled() && getI18nConfig().requiresTranslation(locale)
     );
   }
 

--- a/packages/i18n/src/i18n-cache/__tests__/I18nCache.test.ts
+++ b/packages/i18n/src/i18n-cache/__tests__/I18nCache.test.ts
@@ -1167,9 +1167,6 @@ describe('I18nCache', () => {
         }),
       });
 
-      expect(cache.requiresTranslation('en-GB')).toBe(true);
-      expect(cache.requiresDialectTranslation('en-GB')).toBe(true);
-
       const translations = await cache.loadTranslations(testCase.locale);
 
       expect(loadTranslations).toHaveBeenCalledTimes(1);
@@ -1309,7 +1306,7 @@ describe('I18nCache', () => {
     );
   });
 
-  it('resolves custom aliases for locale metadata operations', () => {
+  it('resolves custom aliases for GT instances', () => {
     const cache = createCache({
       customMapping: {
         'brand-french': {
@@ -1319,8 +1316,6 @@ describe('I18nCache', () => {
       },
     });
 
-    expect(cache.requiresTranslation('brand-french')).toBe(true);
-    expect(cache.requiresDialectTranslation('en-US')).toBe(false);
     expect(() => cache.getGTClass('brand-french')).not.toThrow();
   });
 
@@ -1385,8 +1380,6 @@ describe('I18nCache', () => {
     await expect(cache.getLookupTranslation('fr')).resolves.toEqual(
       expect.any(Function)
     );
-    expect(cache.requiresTranslation('fr')).toBe(true);
-    expect(cache.requiresDialectTranslation('fr')).toBe(false);
     expect(() => cache.getGTClass('fr')).not.toThrow();
   });
 

--- a/packages/i18n/src/translation-functions/internal/__tests__/helpers.test.ts
+++ b/packages/i18n/src/translation-functions/internal/__tests__/helpers.test.ts
@@ -4,6 +4,7 @@ import {
   resolveStringContentWithFallback,
   resolveStringContentWithRuntimeFallback,
 } from '../helpers';
+import { initializeI18nConfig } from '../../../i18n-config/singleton-operations';
 import { getI18nCache } from '../../../i18n-cache/singleton-operations';
 import { interpolateMessage } from '../../utils/interpolation/interpolateMessage';
 
@@ -13,6 +14,7 @@ vi.mock('../../utils/interpolation/interpolateMessage');
 describe('translation helpers', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    initializeI18nConfig({ defaultLocale: 'en' });
     vi.mocked(interpolateMessage).mockReturnValue('interpolated-result');
   });
 
@@ -56,7 +58,6 @@ describe('translation helpers', () => {
       lookupTranslationWithFallback: vi
         .fn()
         .mockResolvedValue('Bonjour {name} !'),
-      getDefaultLocale: vi.fn().mockReturnValue('en'),
     };
     vi.mocked(getI18nCache).mockReturnValue(
       mockCache as unknown as ReturnType<typeof getI18nCache>
@@ -77,7 +78,6 @@ describe('translation helpers', () => {
     const mockCache = {
       getLocale: vi.fn().mockReturnValue('fr'),
       lookupTranslation: vi.fn().mockReturnValue(undefined),
-      getDefaultLocale: vi.fn().mockReturnValue('en'),
     };
     vi.mocked(getI18nCache).mockReturnValue(
       mockCache as unknown as ReturnType<typeof getI18nCache>

--- a/packages/i18n/src/translation-functions/internal/__tests__/resolveTranslationSync.test.ts
+++ b/packages/i18n/src/translation-functions/internal/__tests__/resolveTranslationSync.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { resolveTranslationSync } from '../sync-translation-resolution';
+import { initializeI18nConfig } from '../../../i18n-config/singleton-operations';
 import { getI18nCache } from '../../../i18n-cache/singleton-operations';
 import { interpolateMessage } from '../../utils/interpolation/interpolateMessage';
 
@@ -9,6 +10,7 @@ vi.mock('../../utils/interpolation/interpolateMessage');
 describe('resolveTranslationSync', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    initializeI18nConfig({ defaultLocale: 'en' });
     vi.mocked(interpolateMessage).mockReturnValue('interpolated-result');
   });
 
@@ -16,7 +18,6 @@ describe('resolveTranslationSync', () => {
     const mockCache = {
       getLocale: vi.fn().mockReturnValue('fr'),
       lookupTranslation: vi.fn().mockReturnValue('Bonjour {name} !'),
-      getDefaultLocale: vi.fn().mockReturnValue('en'),
     };
     vi.mocked(getI18nCache).mockReturnValue(
       mockCache as unknown as ReturnType<typeof getI18nCache>
@@ -61,7 +62,6 @@ describe('resolveTranslationSync', () => {
     const mockCache = {
       getLocale: vi.fn().mockReturnValue('fr'),
       lookupTranslation: vi.fn().mockReturnValue('Translated'),
-      getDefaultLocale: vi.fn().mockReturnValue('en'),
     };
     vi.mocked(getI18nCache).mockReturnValue(
       mockCache as unknown as ReturnType<typeof getI18nCache>
@@ -95,7 +95,6 @@ describe('resolveTranslationSync', () => {
     const mockCache = {
       getLocale: vi.fn().mockReturnValue('fr'),
       lookupTranslation: vi.fn().mockReturnValue('Translated'),
-      getDefaultLocale: vi.fn().mockReturnValue('en'),
     };
     vi.mocked(getI18nCache).mockReturnValue(
       mockCache as unknown as ReturnType<typeof getI18nCache>

--- a/packages/i18n/src/translation-functions/internal/getGT.ts
+++ b/packages/i18n/src/translation-functions/internal/getGT.ts
@@ -1,4 +1,5 @@
 import { getI18nCache } from '../../i18n-cache/singleton-operations';
+import { getI18nConfig } from '../../i18n-config/singleton-operations';
 import { InlineTranslationOptions } from '../types/options';
 import { GTFunctionType } from '../types/functions';
 import { interpolateMessage } from '../utils/interpolation/interpolateMessage';
@@ -19,7 +20,7 @@ export async function getGT(): Promise<GTFunctionType> {
   const i18nCache = getI18nCache();
   const locale = getLocale();
   await i18nCache.loadTranslations(locale);
-  const sourceLocale = i18nCache.getDefaultLocale();
+  const sourceLocale = getI18nConfig().getDefaultLocale();
 
   /**
    * Registers a message at build time and resolves its translation at runtime.

--- a/packages/i18n/src/translation-functions/internal/getTranslations.ts
+++ b/packages/i18n/src/translation-functions/internal/getTranslations.ts
@@ -1,4 +1,5 @@
 import { getI18nCache } from '../../i18n-cache/singleton-operations';
+import { getI18nConfig } from '../../i18n-config/singleton-operations';
 import { DictionaryTranslationOptions } from '../types/options';
 import { TFunctionType } from '../types/functions';
 import { renderDictionaryEntry } from './renderDictionaryEntry';
@@ -23,7 +24,7 @@ export async function getTranslations(): Promise<TFunctionType> {
     i18nCache.loadDictionary(locale),
     i18nCache.loadTranslations(locale),
   ]);
-  const sourceLocale = i18nCache.getDefaultLocale();
+  const sourceLocale = getI18nConfig().getDefaultLocale();
 
   /**
    * Dictionary resolution

--- a/packages/i18n/src/translation-functions/internal/helpers.ts
+++ b/packages/i18n/src/translation-functions/internal/helpers.ts
@@ -1,4 +1,5 @@
 import { getI18nCache } from '../../i18n-cache/singleton-operations';
+import { getI18nConfig } from '../../i18n-config/singleton-operations';
 import { NormalizedLookupOptions, ResolutionOptions } from '../types/options';
 import { interpolateMessage } from '../utils/interpolation/interpolateMessage';
 import type {
@@ -83,7 +84,7 @@ export function resolveStringContent(
     source: content,
     target: translation,
     options: lookupOptions,
-    sourceLocale: i18nCache.getDefaultLocale(),
+    sourceLocale: getI18nConfig().getDefaultLocale(),
   });
 }
 
@@ -106,7 +107,7 @@ export function resolveStringContentWithFallback(
     source: content,
     target: translation,
     options: lookupOptions,
-    sourceLocale: i18nCache.getDefaultLocale(),
+    sourceLocale: getI18nConfig().getDefaultLocale(),
   });
 }
 
@@ -131,7 +132,7 @@ export async function resolveStringContentWithRuntimeFallback(
     source: content,
     target: translation,
     options: lookupOptions,
-    sourceLocale: i18nCache.getDefaultLocale(),
+    sourceLocale: getI18nConfig().getDefaultLocale(),
   });
 }
 /**

--- a/packages/next/src/config-dir/I18NConfiguration.ts
+++ b/packages/next/src/config-dir/I18NConfiguration.ts
@@ -164,7 +164,11 @@ export class I18NConfiguration {
     // Translation and dictionary managers
     const shouldLoadTranslations = loadTranslationsType !== 'disabled';
     const runtimeTranslationTimeout = this.renderSettings.timeout;
-    initializeI18nConfig({ defaultLocale, locales, customMapping });
+    initializeI18nConfig({
+      defaultLocale,
+      locales,
+      customMapping,
+    });
     this._i18nCache = new I18nCache<TranslatedChildren>({
       apiKey,
       devApiKey,
@@ -358,9 +362,12 @@ export class I18NConfiguration {
    * @returns True if translation is required, otherwise false
    */
   requiresTranslation(locale: string): [boolean, boolean] {
+    if (!this.translationEnabled) {
+      return [false, false];
+    }
+
     const i18nConfig = getI18nConfig();
-    const translationRequired =
-      this.isTranslationEnabled() && i18nConfig.requiresTranslation(locale);
+    const translationRequired = i18nConfig.requiresTranslation(locale);
     return [
       translationRequired,
       translationRequired &&

--- a/packages/node/src/helpers/getRequestLocale.ts
+++ b/packages/node/src/helpers/getRequestLocale.ts
@@ -54,16 +54,14 @@ function parseAcceptLanguage(header: string): string[] {
 export function getRequestLocale(request: RequestLike): string {
   // Setup
   const i18nConfig = getI18nConfig();
-  const defaultLocale = i18nConfig.getDefaultLocale();
 
   // Get the accept-language header
   const acceptLanguage = request.headers['accept-language'];
   const headerValue = Array.isArray(acceptLanguage)
     ? acceptLanguage[0]
     : acceptLanguage;
-  if (!headerValue) return defaultLocale;
 
   // Parse the accept-language header
-  const preferredLocales = parseAcceptLanguage(headerValue);
+  const preferredLocales = headerValue ? parseAcceptLanguage(headerValue) : [];
   return i18nConfig.resolveSupportedLocale(preferredLocales);
 }

--- a/packages/node/src/helpers/getRequestLocale.ts
+++ b/packages/node/src/helpers/getRequestLocale.ts
@@ -63,5 +63,8 @@ export function getRequestLocale(request: RequestLike): string {
 
   // Parse the accept-language header
   const preferredLocales = headerValue ? parseAcceptLanguage(headerValue) : [];
-  return i18nConfig.resolveSupportedLocale(preferredLocales);
+  return (
+    i18nConfig.determineLocale(preferredLocales) ||
+    i18nConfig.getDefaultLocale()
+  );
 }

--- a/packages/node/src/helpers/getRequestLocale.ts
+++ b/packages/node/src/helpers/getRequestLocale.ts
@@ -1,4 +1,4 @@
-import { getI18nCache } from 'gt-i18n/internal';
+import { getI18nConfig } from 'gt-i18n/internal';
 
 /**
  * A request object like interface
@@ -53,9 +53,8 @@ function parseAcceptLanguage(header: string): string[] {
  */
 export function getRequestLocale(request: RequestLike): string {
   // Setup
-  const i18nCache = getI18nCache<string>();
-  const defaultLocale = i18nCache.getDefaultLocale();
-  const gtInstance = i18nCache.getGTClass();
+  const i18nConfig = getI18nConfig();
+  const defaultLocale = i18nConfig.getDefaultLocale();
 
   // Get the accept-language header
   const acceptLanguage = request.headers['accept-language'];
@@ -66,5 +65,5 @@ export function getRequestLocale(request: RequestLike): string {
 
   // Parse the accept-language header
   const preferredLocales = parseAcceptLanguage(headerValue);
-  return gtInstance.determineLocale(preferredLocales) || defaultLocale;
+  return i18nConfig.resolveSupportedLocale(preferredLocales);
 }

--- a/packages/react-core/src/functions/translation/t.ts
+++ b/packages/react-core/src/functions/translation/t.ts
@@ -1,6 +1,7 @@
 import {
   createLookupOptions,
   getRuntimeEnvironment,
+  getI18nConfig,
   interpolateMessage,
 } from 'gt-i18n/internal';
 import type {
@@ -59,7 +60,7 @@ export function resolveStringContent(
   options: ResolutionOptions<StringFormat> = {}
 ): StringContent {
   const i18nCache = getReactI18nCache();
-  const defaultLocale = i18nCache.getDefaultLocale();
+  const defaultLocale = getI18nConfig().getDefaultLocale();
   if (!getShouldTranslate()) {
     return interpolateMessage({
       options,

--- a/packages/react-core/src/hooks/__tests__/utils.test.ts
+++ b/packages/react-core/src/hooks/__tests__/utils.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest';
+import { initializeI18nConfig } from 'gt-i18n/internal';
 import { setReadonlyConditionStore } from '../../condition-store/singleton-operations';
-import type { ReactI18nCache } from '../../i18n-cache/ReactI18nCache';
-import { setReactI18nCache } from '../../i18n-cache/singleton-operations';
 import { getShouldTranslate } from '../utils';
 
 function setup({
@@ -15,11 +14,11 @@ function setup({
   locales?: string[];
   customMapping?: Record<string, { code: string; name: string }>;
 }) {
-  setReactI18nCache({
-    getDefaultLocale: () => 'en',
-    getLocales: () => locales,
-    getCustomMapping: () => customMapping,
-  } as ReactI18nCache);
+  initializeI18nConfig({
+    defaultLocale: 'en',
+    locales,
+    customMapping,
+  });
   setReadonlyConditionStore({
     getLocale: () => locale,
     getEnableI18n: () => enableI18n,

--- a/packages/react-core/src/hooks/utils.ts
+++ b/packages/react-core/src/hooks/utils.ts
@@ -2,7 +2,7 @@ import { useDefaultLocale } from './external-store-hooks';
 import { useLocale } from './condition-store';
 import { requiresTranslation } from 'generaltranslation/core';
 import { getReadonlyConditionStoreWithFallback } from '../condition-store/singleton-operations';
-import { getReactI18nCache } from '../i18n-cache/singleton-operations';
+import { getI18nConfig } from 'gt-i18n/internal';
 
 export function useFormatLocales(localesProp: string[] = []): string[] {
   const locale = useLocale();
@@ -22,13 +22,13 @@ export function useShouldTranslate(): boolean {
  */
 export function getShouldTranslate(): boolean {
   const conditionStore = getReadonlyConditionStoreWithFallback();
-  const i18nCache = getReactI18nCache();
+  const i18nConfig = getI18nConfig();
 
   const enableI18n = conditionStore.getEnableI18n();
   const locale = conditionStore.getLocale();
-  const defaultLocale = i18nCache.getDefaultLocale();
-  const locales = i18nCache.getLocales();
-  const customMapping = i18nCache.getCustomMapping();
+  const defaultLocale = i18nConfig.getDefaultLocale();
+  const locales = i18nConfig.getLocales();
+  const customMapping = i18nConfig.getCustomMapping();
   return (
     enableI18n &&
     requiresTranslation(defaultLocale, locale, [...locales], customMapping)

--- a/packages/react-core/src/i18n-store/I18nStore.ts
+++ b/packages/react-core/src/i18n-store/I18nStore.ts
@@ -18,6 +18,7 @@ import type { Translation } from 'gt-i18n/types';
 import { getReactI18nCache } from '../i18n-cache/singleton-operations';
 import { RuntimeTranslationScope } from './RuntimeTranslationScope';
 import { RuntimeDictionaryScope } from './RuntimeDictionaryScope';
+import { getI18nConfig } from 'gt-i18n/internal';
 
 type EntryCacheEvent = {
   locale: string;
@@ -138,15 +139,15 @@ export class I18nStore {
   // ===== Manager Config Snapshots ===== //
 
   getDefaultLocaleSnapshot = (): string => {
-    return getReactI18nCache().getDefaultLocale();
+    return getI18nConfig().getDefaultLocale();
   };
 
   getLocalesSnapshot = (): readonly string[] => {
-    return getReactI18nCache().getLocales();
+    return getI18nConfig().getLocales();
   };
 
   getCustomMappingSnapshot = (): CustomMapping => {
-    return getReactI18nCache().getCustomMapping();
+    return getI18nConfig().getCustomMapping();
   };
 
   // ===== I18nCache Snapshots ===== //


### PR DESCRIPTION
## Summary

- Replace remaining non-deprecated internal reads of locale config from `i18nCache` with `I18nConfig`.
- Update translation helpers, React Core hooks/store, Node request locale handling, and Next configuration locale access.
- Keep public helper exports as wrappers while moving their implementation to `I18nConfig`.

## Stack

1. Previous: introduce and initialize `I18nConfig`.
2. Previous: migrate cache and condition-store locale ownership.
3. This PR: replace remaining cache locale consumers.
4. Next: consolidate locale helper internals onto `I18nConfig`.

## Verification

- `pnpm --filter gt-i18n build`
- `pnpm --filter gt-react build`
- `pnpm --filter gt-next typecheck` currently fails on existing unresolved `@generaltranslation/next-internal`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1495"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782433991&installation_id=127936663&pr_number=1495&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1495&signature=90ce0d2b19fbd263555f25ebbfe1f24c222ee38af87b1e2b51917ed1b0631da2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces internal reads of locale configuration from `I18nCache` with the new `I18nConfig` singleton across translation helpers, React Core hooks/store, Node request locale handling, and Next configuration. The public `getLocales()` and `getDefaultLocale()` helper wrappers are preserved but now delegate to `I18nConfig` instead of `I18nCache`.

- `WritableConditionStore.setLocale` migrates from `resolveSupportedLocale` to `determineLocale(locale) || getDefaultLocale()`, and several `I18nCache` methods (`requiresTranslation`, `requiresDialectTranslation`, `getDefaultLocale`, `getLocales`) are depublicized or removed from the cache's external surface.
- `I18NConfiguration.requiresTranslation` gains an early-return guard on `translationEnabled`, then delegates to `I18nConfig.requiresTranslation`, matching the old guarded logic.
- Test suites are updated to call `initializeI18nConfig` in `beforeEach` instead of mocking cache methods directly.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all locale reads are redirected to the already-initialized I18nConfig singleton with no behavioural regressions.

Every changed call site maps cleanly onto an equivalent I18nConfig method. The determineLocale(locale) || getDefaultLocale() replacement for resolveSupportedLocale, the early-return guard in I18NConfiguration.requiresTranslation, and the empty-array fallback path in getRequestLocale all preserve prior semantics. I18nConfig is seeded with the same defaultLocale, locales, and customMapping values the cache previously held, so results are consistent across callers.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/i18n/src/condition-store/WritableConditionStore.ts | Replaces resolveSupportedLocale with determineLocale(locale) || getDefaultLocale() — a deliberate API migration with equivalent semantics. |
| packages/i18n/src/helpers/locale.ts | Public getLocales() and getDefaultLocale() wrappers redirected from I18nCache to I18nConfig; no logic change. |
| packages/i18n/src/i18n-cache/I18nCache.ts | requiresTranslation made private and simplified; requiresDialectTranslation removed. Internal getI18nConfig().requiresTranslation(locale) call uses the config singleton which holds the same defaultLocale/locales that were previously passed explicitly. |
| packages/next/src/config-dir/I18NConfiguration.ts | Early-return guard on translationEnabled replaces the inline boolean AND; logic is equivalent. initializeI18nConfig call reformatted for readability only. |
| packages/node/src/helpers/getRequestLocale.ts | Migrates from getI18nCache to getI18nConfig; empty-header path now passes [] to determineLocale, which returns undefined and falls through to getDefaultLocale() — equivalent to the old early return. |
| packages/react-core/src/functions/translation/t.ts | defaultLocale in resolveStringContent now sourced from I18nConfig instead of ReactI18nCache; the cache reference remains for other operations. |
| packages/react-core/src/hooks/utils.ts | getShouldTranslate reads defaultLocale, locales, and customMapping from I18nConfig instead of ReactI18nCache; functional behaviour unchanged. |
| packages/react-core/src/i18n-store/I18nStore.ts | Three snapshot methods (getDefaultLocaleSnapshot, getLocalesSnapshot, getCustomMappingSnapshot) migrated to I18nConfig; no logic change. |
| packages/i18n/src/translation-functions/internal/helpers.ts | Three sourceLocale reads migrated from i18nCache.getDefaultLocale() to getI18nConfig().getDefaultLocale(); correct and consistent with the rest of the PR. |
| packages/i18n/src/i18n-cache/__tests__/I18nCache.test.ts | Removes now-private requiresTranslation/requiresDialectTranslation assertions; remaining test coverage is appropriate. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Locale Request] --> B{Source}
    B -->|React hooks / store| C[getShouldTranslate / I18nStore snapshots]
    B -->|Node HTTP request| D[getRequestLocale]
    B -->|Translation functions| E[getGT / getTranslations / helpers.ts / t.ts]
    B -->|Next config| F[I18NConfiguration.requiresTranslation]
    B -->|Condition store| G[WritableConditionStore.setLocale]

    C --> H[getI18nConfig]
    D --> H
    E --> H
    F --> I{translationEnabled?}
    I -->|No| J[return false, false]
    I -->|Yes| H
    G --> H

    H --> K[I18nConfig / LocaleConfig]
    K --> L[getDefaultLocale]
    K --> M[getLocales]
    K --> N[getCustomMapping]
    K --> O[requiresTranslation]
    K --> P[determineLocale]
```
</details>

<sub>Reviews (6): Last reviewed commit: ["fix: preserve cache locale compatibility"](https://github.com/generaltranslation/gt/commit/44f64704cd4feaa677378e5174a075781857f4e0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34071987)</sub>

<!-- /greptile_comment -->