### PR TITLE
refactor: consolidate locale helpers on i18n config

### DIFF
--- a/packages/i18n/src/condition-store/ReadonlyConditionStore.ts
+++ b/packages/i18n/src/condition-store/ReadonlyConditionStore.ts
@@ -1,6 +1,6 @@
 import type { ReadonlyConditionStoreInterface as ReadonlyConditionStoreContract } from '../i18n-cache/types';
+import type { LocaleCandidates } from '../i18n-config/I18nConfig';
 import { getI18nConfig } from '../i18n-config/singleton-operations';
-import type { LocaleCandidates } from './localeResolver';
 
 export type ReadonlyConditionStoreParams = {
   locale: LocaleCandidates;

--- a/packages/i18n/src/condition-store/WritableConditionStore.ts
+++ b/packages/i18n/src/condition-store/WritableConditionStore.ts
@@ -1,5 +1,5 @@
-import type { LocaleCandidates } from '../i18n-cache';
 import type { WritableConditionStoreInterface } from '../i18n-cache/types';
+import type { LocaleCandidates } from '../i18n-config/I18nConfig';
 import { getI18nConfig } from '../i18n-config/singleton-operations';
 import {
   ReadonlyConditionStore,

--- a/packages/i18n/src/condition-store/__tests__/localeResolver.test.ts
+++ b/packages/i18n/src/condition-store/__tests__/localeResolver.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { initializeI18nConfig } from '../../i18n-config/singleton-operations';
 import {
   createLocaleResolver,
   determineSupportedLocale,
@@ -13,6 +14,10 @@ const customMapping = {
 };
 
 describe('localeResolver', () => {
+  beforeEach(() => {
+    initializeI18nConfig();
+  });
+
   it('resolves custom aliases to supported canonical locales', () => {
     expect(
       determineSupportedLocale('brand-french', {

--- a/packages/i18n/src/condition-store/__tests__/localeResolver.test.ts
+++ b/packages/i18n/src/condition-store/__tests__/localeResolver.test.ts
@@ -47,6 +47,30 @@ describe('localeResolver', () => {
     ).toBe('en');
   });
 
+  it('does not treat undefined config fields as explicit overrides', () => {
+    initializeI18nConfig({
+      defaultLocale: 'en',
+      locales: ['en', 'fr'],
+    });
+
+    expect(
+      determineSupportedLocale('fr', {
+        defaultLocale: undefined,
+        locales: undefined,
+        customMapping: undefined,
+      })
+    ).toBe('fr');
+  });
+
+  it('does not add the default locale to explicit override locales', () => {
+    expect(
+      determineSupportedLocale('en', {
+        defaultLocale: 'en',
+        locales: ['fr', 'de'],
+      })
+    ).toBeUndefined();
+  });
+
   it('creates reusable locale resolvers', () => {
     const resolveLocale = createLocaleResolver({
       defaultLocale: 'en',

--- a/packages/i18n/src/condition-store/localeResolver.ts
+++ b/packages/i18n/src/condition-store/localeResolver.ts
@@ -1,5 +1,4 @@
 import {
-  I18nConfig,
   type I18nConfigParams,
   type LocaleCandidates,
 } from '../i18n-config/I18nConfig';
@@ -14,7 +13,7 @@ export function determineSupportedLocale(
   candidates: LocaleCandidates,
   config: I18nConfigParams = {}
 ): string | undefined {
-  return getLocaleResolverConfig(config).determineSupportedLocale(candidates);
+  return getI18nConfig().determineSupportedLocale(candidates, config);
 }
 
 /**
@@ -24,26 +23,10 @@ export function resolveSupportedLocale(
   candidates: LocaleCandidates,
   config: I18nConfigParams = {}
 ): string {
-  return getLocaleResolverConfig(config).resolveSupportedLocale(candidates);
+  return getI18nConfig().resolveSupportedLocale(candidates, config);
 }
 
 export function createLocaleResolver(config: I18nConfigParams = {}) {
-  const i18nConfig = getLocaleResolverConfig(config);
   return (candidates?: LocaleCandidates): string =>
-    i18nConfig.resolveSupportedLocale(candidates);
-}
-
-function getLocaleResolverConfig(config: I18nConfigParams): I18nConfig {
-  if (hasLocaleResolverConfigParams(config)) {
-    return new I18nConfig(config);
-  }
-  return getI18nConfig();
-}
-
-function hasLocaleResolverConfigParams(config: I18nConfigParams): boolean {
-  return (
-    'defaultLocale' in config ||
-    'locales' in config ||
-    'customMapping' in config
-  );
+    getI18nConfig().resolveSupportedLocale(candidates, config);
 }

--- a/packages/i18n/src/condition-store/localeResolver.ts
+++ b/packages/i18n/src/condition-store/localeResolver.ts
@@ -1,52 +1,20 @@
-import { LocaleConfig } from '@generaltranslation/format';
-import { libraryDefaultLocale } from 'generaltranslation/internal';
-import type { LocaleResolverConfig } from '../i18n-cache/types';
+import {
+  I18nConfig,
+  type I18nConfigParams,
+  type LocaleCandidates,
+} from '../i18n-config/I18nConfig';
+import { getI18nConfig } from '../i18n-config/singleton-operations';
 
-export type LocaleCandidates = string | string[] | undefined;
-
-function normalizeConditionStoreConfig({
-  defaultLocale,
-  locales,
-  customMapping,
-}: LocaleResolverConfig = {}) {
-  const fallbackLocale = defaultLocale || libraryDefaultLocale;
-  return {
-    defaultLocale: fallbackLocale,
-    locales: locales?.length ? locales : [fallbackLocale],
-    customMapping,
-  };
-}
-
-type NormalizedConditionStoreConfig = ReturnType<
-  typeof normalizeConditionStoreConfig
->;
+export type { LocaleCandidates } from '../i18n-config/I18nConfig';
 
 /**
  * Return the best supported locale for the candidates, or undefined when none match.
  */
 export function determineSupportedLocale(
   candidates: LocaleCandidates,
-  config: LocaleResolverConfig = {}
+  config: I18nConfigParams = {}
 ): string | undefined {
-  return determineSupportedLocaleWithConfig(
-    candidates,
-    normalizeConditionStoreConfig(config)
-  );
-}
-
-function determineSupportedLocaleWithConfig(
-  candidates: LocaleCandidates,
-  config: NormalizedConditionStoreConfig
-): string | undefined {
-  if (
-    candidates == null ||
-    (Array.isArray(candidates) && candidates.length === 0)
-  ) {
-    return undefined;
-  }
-
-  const localeConfig = new LocaleConfig(config);
-  return localeConfig.determineLocale(candidates) || undefined;
+  return getLocaleResolverConfig(config).determineSupportedLocale(candidates);
 }
 
 /**
@@ -54,18 +22,28 @@ function determineSupportedLocaleWithConfig(
  */
 export function resolveSupportedLocale(
   candidates: LocaleCandidates,
-  config: LocaleResolverConfig = {}
+  config: I18nConfigParams = {}
 ): string {
-  const normalizedConfig = normalizeConditionStoreConfig(config);
-  return (
-    determineSupportedLocaleWithConfig(candidates, normalizedConfig) ||
-    normalizedConfig.defaultLocale
-  );
+  return getLocaleResolverConfig(config).resolveSupportedLocale(candidates);
 }
 
-export function createLocaleResolver(config: LocaleResolverConfig = {}) {
-  const normalizedConfig = normalizeConditionStoreConfig(config);
+export function createLocaleResolver(config: I18nConfigParams = {}) {
+  const i18nConfig = getLocaleResolverConfig(config);
   return (candidates?: LocaleCandidates): string =>
-    determineSupportedLocaleWithConfig(candidates, normalizedConfig) ||
-    normalizedConfig.defaultLocale;
+    i18nConfig.resolveSupportedLocale(candidates);
+}
+
+function getLocaleResolverConfig(config: I18nConfigParams): I18nConfig {
+  if (hasLocaleResolverConfigParams(config)) {
+    return new I18nConfig(config);
+  }
+  return getI18nConfig();
+}
+
+function hasLocaleResolverConfigParams(config: I18nConfigParams): boolean {
+  return (
+    'defaultLocale' in config ||
+    'locales' in config ||
+    'customMapping' in config
+  );
 }

--- a/packages/i18n/src/helpers/locale.ts
+++ b/packages/i18n/src/helpers/locale.ts
@@ -1,5 +1,4 @@
 import { getWritableConditionStore } from '../condition-store/singleton-operations';
-import { getI18nCache } from '../i18n-cache/singleton-operations';
 import { getI18nConfig } from '../i18n-config/singleton-operations';
 
 /**
@@ -50,7 +49,5 @@ export function getDefaultLocale() {
  * const localeProperties = getLocaleProperties('en-US');
  */
 export function getLocaleProperties(locale = getLocale()) {
-  const i18nCache = getI18nCache();
-  const gtInstance = i18nCache.getGTClass();
-  return gtInstance.getLocaleProperties(locale);
+  return getI18nConfig().getLocaleProperties(locale);
 }

--- a/packages/i18n/src/i18n-cache/I18nCache.ts
+++ b/packages/i18n/src/i18n-cache/I18nCache.ts
@@ -658,8 +658,7 @@ class I18nCache<
 
   private requiresTranslation(locale: string): boolean {
     return (
-      this.isTranslationEnabled() &&
-      getI18nConfig().requiresTranslation(locale)
+      this.isTranslationEnabled() && getI18nConfig().requiresTranslation(locale)
     );
   }
 

--- a/packages/i18n/src/i18n-cache/I18nCache.ts
+++ b/packages/i18n/src/i18n-cache/I18nCache.ts
@@ -29,7 +29,6 @@ import { TRANSLATIONS_CACHE_MISS_EVENT_NAME } from './event-subscription/types';
 import type { I18nEvents } from './event-subscription/types';
 import { getRuntimeEnvironment } from '../utils/getRuntimeEnvironment';
 import { getI18nConfig } from '../i18n-config/singleton-operations';
-import type { CustomMapping } from '@generaltranslation/format/types';
 
 /**
  * Default translation timeout in milliseconds for a runtime translation request
@@ -194,30 +193,6 @@ class I18nCache<
    */
   getVersionId(): string | undefined {
     return this.config._versionId;
-  }
-
-  /**
-   * Get the default locale.
-   * @deprecated use getI18nConfig().getDefaultLocale() instead
-   */
-  getDefaultLocale(): string {
-    return getI18nConfig().getDefaultLocale();
-  }
-
-  /**
-   * Get the supported locales.
-   * @deprecated use getI18nConfig().getLocales() instead
-   */
-  getLocales(): string[] {
-    return getI18nConfig().getLocales();
-  }
-
-  /**
-   * Get the custom locale mapping.
-   * @deprecated use getI18nConfig().getCustomMapping() instead
-   */
-  getCustomMapping(): CustomMapping {
-    return getI18nConfig().getCustomMapping();
   }
 
   /**

--- a/packages/i18n/src/i18n-cache/I18nCache.ts
+++ b/packages/i18n/src/i18n-cache/I18nCache.ts
@@ -29,6 +29,7 @@ import { TRANSLATIONS_CACHE_MISS_EVENT_NAME } from './event-subscription/types';
 import type { I18nEvents } from './event-subscription/types';
 import { getRuntimeEnvironment } from '../utils/getRuntimeEnvironment';
 import { getI18nConfig } from '../i18n-config/singleton-operations';
+import type { CustomMapping } from '@generaltranslation/format/types';
 
 /**
  * Default translation timeout in milliseconds for a runtime translation request
@@ -193,6 +194,30 @@ class I18nCache<
    */
   getVersionId(): string | undefined {
     return this.config._versionId;
+  }
+
+  /**
+   * Get the default locale.
+   * @deprecated use getI18nConfig().getDefaultLocale() instead
+   */
+  getDefaultLocale(): string {
+    return getI18nConfig().getDefaultLocale();
+  }
+
+  /**
+   * Get the supported locales.
+   * @deprecated use getI18nConfig().getLocales() instead
+   */
+  getLocales(): string[] {
+    return getI18nConfig().getLocales();
+  }
+
+  /**
+   * Get the custom locale mapping.
+   * @deprecated use getI18nConfig().getCustomMapping() instead
+   */
+  getCustomMapping(): CustomMapping {
+    return getI18nConfig().getCustomMapping();
   }
 
   /**

--- a/packages/i18n/src/i18n-cache/I18nCache.ts
+++ b/packages/i18n/src/i18n-cache/I18nCache.ts
@@ -633,7 +633,8 @@ class I18nCache<
 
   private requiresTranslation(locale: string): boolean {
     return (
-      this.isTranslationEnabled() && getI18nConfig().requiresTranslation(locale)
+      this.isTranslationEnabled() &&
+      getI18nConfig().requiresTranslation(locale)
     );
   }
 

--- a/packages/i18n/src/i18n-cache/index.ts
+++ b/packages/i18n/src/i18n-cache/index.ts
@@ -9,7 +9,7 @@ export {
   determineSupportedLocale,
   resolveSupportedLocale,
 } from '../condition-store/localeResolver';
-export type { LocaleCandidates } from '../condition-store/localeResolver';
+export type { LocaleCandidates } from '../i18n-config/I18nConfig';
 
 // Events
 export {

--- a/packages/i18n/src/i18n-config/I18nConfig.ts
+++ b/packages/i18n/src/i18n-config/I18nConfig.ts
@@ -78,7 +78,7 @@ export class I18nConfig extends LocaleConfig {
     if (!config || !hasI18nConfigParams(config)) {
       return this;
     }
-    return new LocaleConfig(getLocaleConfigParams(config));
+    return new LocaleConfig(getLocaleResolverConfigParams(config));
   }
 
   private determineSupportedLocaleWithConfig(
@@ -114,6 +114,18 @@ function getLocaleConfigParams(
   return {
     defaultLocale,
     locales: Array.from(new Set([defaultLocale, ...locales])),
+    customMapping: customMapping || {},
+  };
+}
+
+function getLocaleResolverConfigParams({
+  defaultLocale = libraryDefaultLocale,
+  locales,
+  customMapping,
+}: I18nConfigParams = {}): LocaleConfigConstructorParams {
+  return {
+    defaultLocale,
+    locales: locales?.length ? locales : [defaultLocale],
     customMapping: customMapping || {},
   };
 }

--- a/packages/i18n/src/i18n-config/I18nConfig.ts
+++ b/packages/i18n/src/i18n-config/I18nConfig.ts
@@ -1,4 +1,7 @@
-import { LocaleConfig } from '@generaltranslation/format';
+import {
+  LocaleConfig,
+  type LocaleConfigConstructorParams,
+} from '@generaltranslation/format';
 import type { CustomMapping } from '@generaltranslation/format/types';
 import { libraryDefaultLocale } from 'generaltranslation/internal';
 import { validateI18nConfigParams } from './validation';
@@ -18,24 +21,7 @@ export type LocaleCandidates = string | string[] | undefined;
 
 export class I18nConfig extends LocaleConfig {
   constructor(params: I18nConfigParams = {}) {
-    const {
-      defaultLocale = libraryDefaultLocale,
-      locales = [defaultLocale],
-      customMapping,
-    } = params;
-
-    validateI18nConfigParams({
-      ...params,
-      defaultLocale,
-      locales,
-      customMapping,
-    });
-
-    super({
-      defaultLocale,
-      locales: Array.from(new Set([defaultLocale, ...locales])),
-      customMapping: customMapping || {},
-    });
+    super(getLocaleConfigParams(params));
   }
 
   getDefaultLocale(): string {
@@ -49,4 +35,93 @@ export class I18nConfig extends LocaleConfig {
   getCustomMapping(): CustomMapping {
     return this.customMapping || {};
   }
+
+  determineSupportedLocale(
+    candidates: LocaleCandidates,
+    config?: I18nConfigParams
+  ): string | undefined {
+    return this.determineSupportedLocaleWithConfig(
+      candidates,
+      this.getLocaleConfig(config)
+    );
+  }
+
+  resolveSupportedLocale(
+    candidates?: LocaleCandidates,
+    config?: I18nConfigParams
+  ): string {
+    const localeConfig = this.getLocaleConfig(config);
+    return (
+      this.determineSupportedLocaleWithConfig(candidates, localeConfig) ||
+      localeConfig.defaultLocale
+    );
+  }
+
+  resolveLocale(locale: string): string {
+    const resolvedLocale = this.determineSupportedLocale(locale);
+    if (!this.isValidLocale(locale) || !resolvedLocale) {
+      throw new Error(
+        `Locale "${locale}" is not valid. Use a valid BCP 47 locale code or add a custom mapping.`
+      );
+    }
+    return resolvedLocale;
+  }
+
+  requiresDialectTranslation(locale: string): boolean {
+    return (
+      this.requiresTranslation(locale) &&
+      this.isSameLanguage(this.getDefaultLocale(), locale)
+    );
+  }
+
+  private getLocaleConfig(config?: I18nConfigParams): LocaleConfig {
+    if (!config || !hasI18nConfigParams(config)) {
+      return this;
+    }
+    return new LocaleConfig(getLocaleConfigParams(config));
+  }
+
+  private determineSupportedLocaleWithConfig(
+    candidates: LocaleCandidates,
+    localeConfig: LocaleConfig
+  ): string | undefined {
+    if (
+      candidates == null ||
+      (Array.isArray(candidates) && candidates.length === 0)
+    ) {
+      return undefined;
+    }
+    return localeConfig.determineLocale(candidates);
+  }
+}
+
+function getLocaleConfigParams(
+  params: I18nConfigParams = {}
+): LocaleConfigConstructorParams {
+  const {
+    defaultLocale = libraryDefaultLocale,
+    locales = [defaultLocale],
+    customMapping,
+  } = params;
+
+  validateI18nConfigParams({
+    ...params,
+    defaultLocale,
+    locales,
+    customMapping,
+  });
+
+  return {
+    defaultLocale,
+    locales: Array.from(new Set([defaultLocale, ...locales])),
+    customMapping: customMapping || {},
+  };
+}
+
+function hasI18nConfigParams(config: I18nConfigParams): boolean {
+  return (
+    config.defaultLocale !== undefined ||
+    config.locales !== undefined ||
+    config.customMapping !== undefined
+  );
 }

--- a/packages/i18n/src/i18n-config/I18nConfig.ts
+++ b/packages/i18n/src/i18n-config/I18nConfig.ts
@@ -14,6 +14,8 @@ export type I18nConfigParams = {
   runtimeUrl?: string | null;
 };
 
+export type LocaleCandidates = string | string[] | undefined;
+
 export class I18nConfig extends LocaleConfig {
   constructor(params: I18nConfigParams = {}) {
     const {

--- a/packages/i18n/src/i18n-config/__tests__/I18nConfig.test.ts
+++ b/packages/i18n/src/i18n-config/__tests__/I18nConfig.test.ts
@@ -60,4 +60,34 @@ describe('I18nConfig', () => {
 
     errorSpy.mockRestore();
   });
+
+  it('treats an empty string locale candidate as unsupported', () => {
+    const config = new I18nConfig({
+      defaultLocale: 'en',
+      locales: ['en', 'fr'],
+    });
+
+    expect(config.determineSupportedLocale('')).toBeUndefined();
+    expect(config.resolveSupportedLocale('')).toBe('en');
+  });
+
+  it('supports one-off locale config overrides', () => {
+    const config = new I18nConfig({
+      defaultLocale: 'en',
+      locales: ['en'],
+    });
+
+    expect(
+      config.determineSupportedLocale('brand-french', {
+        defaultLocale: 'en',
+        locales: ['en', 'fr'],
+        customMapping: {
+          'brand-french': {
+            code: 'fr',
+            name: 'Brand French',
+          },
+        },
+      })
+    ).toBe('fr');
+  });
 });

--- a/packages/i18n/src/internal-types.ts
+++ b/packages/i18n/src/internal-types.ts
@@ -17,7 +17,7 @@ export type { I18nConfigParams } from './i18n-config/I18nConfig';
 export type { I18nCacheConstructorParams as I18nManagerConstructorParams } from './i18n-cache/types';
 /** @deprecated use I18nCacheConfig instead */
 export type { I18nCacheConfig as I18nManagerConfig } from './i18n-cache/types';
-export type { LocaleCandidates } from './condition-store/localeResolver';
+export type { LocaleCandidates } from './i18n-config/I18nConfig';
 export type {
   DictionaryValue,
   DictionaryEntry,

--- a/packages/next/src/config-dir/I18NConfiguration.ts
+++ b/packages/next/src/config-dir/I18NConfiguration.ts
@@ -370,8 +370,7 @@ export class I18NConfiguration {
     const translationRequired = i18nConfig.requiresTranslation(locale);
     return [
       translationRequired,
-      translationRequired &&
-        i18nConfig.isSameLanguage(i18nConfig.getDefaultLocale(), locale),
+      translationRequired && i18nConfig.requiresDialectTranslation(locale),
     ];
   }
 

--- a/packages/react-core/src/hooks/utils.ts
+++ b/packages/react-core/src/hooks/utils.ts
@@ -1,6 +1,5 @@
 import { useDefaultLocale } from './external-store-hooks';
 import { useLocale } from './condition-store';
-import { requiresTranslation } from 'generaltranslation/core';
 import { getReadonlyConditionStoreWithFallback } from '../condition-store/singleton-operations';
 import { getI18nConfig } from 'gt-i18n/internal';
 
@@ -26,11 +25,5 @@ export function getShouldTranslate(): boolean {
 
   const enableI18n = conditionStore.getEnableI18n();
   const locale = conditionStore.getLocale();
-  const defaultLocale = i18nConfig.getDefaultLocale();
-  const locales = i18nConfig.getLocales();
-  const customMapping = i18nConfig.getCustomMapping();
-  return (
-    enableI18n &&
-    requiresTranslation(defaultLocale, locale, [...locales], customMapping)
-  );
+  return enableI18n && i18nConfig.requiresTranslation(locale);
 }

--- a/packages/react/src/deprecated/i18n-context/browser-i18n-manager/utils/__tests__/determineLocale.test.ts
+++ b/packages/react/src/deprecated/i18n-context/browser-i18n-manager/utils/__tests__/determineLocale.test.ts
@@ -1,10 +1,14 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { initializeI18nConfig } from 'gt-i18n/internal';
 import { getLocale } from '../../../functions/locale-operations';
 import { initializeGT } from '../../../setup/initializeGT';
 import { determineLocale } from '../determineLocale';
 
 describe('determineLocale', () => {
+  beforeEach(() => {
+    initializeI18nConfig();
+  });
+
   it('resolves custom locale aliases returned by getLocale', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     initializeI18nConfig({

--- a/packages/tanstack-start/src/functions/__tests__/determineLocale.test.ts
+++ b/packages/tanstack-start/src/functions/__tests__/determineLocale.test.ts
@@ -20,6 +20,7 @@ vi.mock('@tanstack/react-start/server', () => ({
 }));
 
 import { determineLocale } from '../determineLocale';
+import { initializeI18nConfig } from 'gt-i18n/internal';
 
 const localeConfig = {
   defaultLocale: 'en',
@@ -55,6 +56,7 @@ function restoreGlobalProperty(
 
 describe('determineLocale', () => {
   beforeEach(() => {
+    initializeI18nConfig(localeConfig);
     mockCookie.mockReset();
     mockRequestHeader.mockReset();
     process.env._GENERALTRANSLATION_IGNORE_BROWSER_LOCALES = 'false';

--- a/packages/tanstack-start/src/functions/determineLocale.ts
+++ b/packages/tanstack-start/src/functions/determineLocale.ts
@@ -1,7 +1,7 @@
 import { defaultLocaleCookieName } from 'gt-react/context';
 import { createIsomorphicFn } from '@tanstack/react-start';
 import { getRequestHeader, getCookie } from '@tanstack/react-start/server';
-import { I18nConfig } from 'gt-i18n/internal';
+import { getI18nConfig } from 'gt-i18n/internal';
 import type { I18nConfigParams } from 'gt-i18n/internal/types';
 
 /**
@@ -47,11 +47,11 @@ function determineLocaleServer({
     );
   }
 
-  return new I18nConfig({
+  return getI18nConfig().resolveSupportedLocale(candidates, {
     defaultLocale,
     locales,
     customMapping,
-  }).resolveSupportedLocale(candidates);
+  });
 }
 
 /**
@@ -81,9 +81,9 @@ function determineLocaleClient({
     );
   }
 
-  return new I18nConfig({
+  return getI18nConfig().resolveSupportedLocale(candidates, {
     defaultLocale,
     locales,
     customMapping,
-  }).resolveSupportedLocale(candidates);
+  });
 }

--- a/packages/tanstack-start/src/functions/determineLocale.ts
+++ b/packages/tanstack-start/src/functions/determineLocale.ts
@@ -1,8 +1,8 @@
 import { defaultLocaleCookieName } from 'gt-react/context';
 import { createIsomorphicFn } from '@tanstack/react-start';
 import { getRequestHeader, getCookie } from '@tanstack/react-start/server';
-import { resolveSupportedLocale } from 'gt-i18n/internal';
-import type { LocaleResolverConfig } from 'gt-i18n/internal/types';
+import { I18nConfig } from 'gt-i18n/internal';
+import type { I18nConfigParams } from 'gt-i18n/internal/types';
 
 /**
  * Determines the locale isomorphicly.
@@ -21,7 +21,7 @@ function determineLocaleServer({
   defaultLocale,
   locales,
   customMapping,
-}: LocaleResolverConfig) {
+}: I18nConfigParams) {
   const candidates: string[] = [];
 
   // (1) Check cookie
@@ -47,11 +47,11 @@ function determineLocaleServer({
     );
   }
 
-  return resolveSupportedLocale(candidates, {
+  return new I18nConfig({
     defaultLocale,
     locales,
     customMapping,
-  });
+  }).resolveSupportedLocale(candidates);
 }
 
 /**
@@ -61,7 +61,7 @@ function determineLocaleClient({
   defaultLocale,
   locales,
   customMapping,
-}: LocaleResolverConfig) {
+}: I18nConfigParams) {
   const candidates: string[] = [];
 
   // (1) Check cookie
@@ -81,9 +81,9 @@ function determineLocaleClient({
     );
   }
 
-  return resolveSupportedLocale(candidates, {
+  return new I18nConfig({
     defaultLocale,
     locales,
     customMapping,
-  });
+  }).resolveSupportedLocale(candidates);
 }


### PR DESCRIPTION
## Summary

- Delegate `condition-store/localeResolver` helper logic to `I18nConfig`.
- Move `getLocaleProperties()` implementation to `I18nConfig` while keeping the public helper wrapper.
- Update TanStack Start locale determination to use `I18nConfig` directly instead of the floating resolver helper.

## Stack

1. Previous: introduce, initialize, and migrate locale ownership to `I18nConfig`.
2. Previous: replace remaining cache locale consumers.
3. This PR: consolidate locale helper internals onto `I18nConfig`.

## Verification

- `pnpm --filter gt-i18n build`
- `pnpm --filter gt-i18n test`
- `pnpm --filter gt-react build`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1496"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782433999&installation_id=127936663&pr_number=1496&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1496&signature=239df3422dc1d13e9bf341034e9dac8b38f0b2c132a37a6325964ec7f1f28f9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR consolidates locale-resolution logic from the standalone `localeResolver` helpers and `I18nCache` onto `I18nConfig`, making `I18nConfig` the single authority for determining, resolving, and validating locales. Two previously-flagged behavioral regressions (undefined-field override detection and auto-inclusion of `defaultLocale` in explicit override lists) have been corrected with proper `hasI18nConfigParams` checks and the `getLocaleResolverConfigParams` path.

- **`I18nConfig` gains `determineSupportedLocale`, `resolveSupportedLocale`, `resolveLocale`, and `requiresDialectTranslation`** — `localeResolver.ts` becomes a thin delegation layer over the singleton.
- **`getLocaleProperties` and `getShouldTranslate`** drop their `I18nCache`/`generaltranslation/core` intermediaries and call `I18nConfig` directly; semantics are unchanged.
- **TanStack Start `determineLocale`** switches from the standalone `resolveSupportedLocale` helper to `getI18nConfig().resolveSupportedLocale`, with test fixtures updated to initialize the singleton in `beforeEach`.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The refactoring is purely structural — behavior is preserved across all call sites — and the two regressions called out in earlier review rounds are addressed with regression tests.

All changed call sites delegate to the same underlying LocaleConfig logic they used before, just through I18nConfig as the intermediary. The two behavioral edge-cases previously flagged are now guarded and covered by tests. The only open items are a slightly misleading error message in resolveLocale and a per-call LocaleConfig allocation in createLocaleResolver — neither affects correctness.

The new resolveLocale method in packages/i18n/src/i18n-config/I18nConfig.ts has a mixed error condition whose message is inaccurate for valid-BCP-47-but-unsupported locales; worth a second look before the method gets wider usage.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/i18n/src/i18n-config/I18nConfig.ts | New methods added: `determineSupportedLocale`, `resolveSupportedLocale`, `resolveLocale`, `requiresDialectTranslation`. Constructor extraction to `getLocaleConfigParams` is clean. The `resolveLocale` error condition (`!isValidLocale || !resolvedLocale`) produces a misleading message when a valid BCP 47 locale is simply not in the supported list. |
| packages/i18n/src/condition-store/localeResolver.ts | Significantly simplified; now delegates entirely to `getI18nConfig()`. The `createLocaleResolver` closure no longer pre-computes a `LocaleConfig`; it re-evaluates the singleton and constructs a new `LocaleConfig` on each invocation when explicit params are given. |
| packages/tanstack-start/src/functions/determineLocale.ts | Replaced `resolveSupportedLocale` standalone call with `getI18nConfig().resolveSupportedLocale`. Behavior is equivalent: explicit params are passed through and `hasI18nConfigParams` ensures undefined fields don't create a spurious override. Type updated from `LocaleResolverConfig` to `I18nConfigParams`. |
| packages/i18n/src/helpers/locale.ts | Removed `i18nCache.getGTClass()` intermediary; `getLocaleProperties` now delegates directly to `getI18nConfig().getLocaleProperties(locale)`. Cleaner and equivalent. |
| packages/react-core/src/hooks/utils.ts | Simplified `getShouldTranslate` to call `i18nConfig.requiresTranslation(locale)` directly, removing the manual extraction of `defaultLocale`/`locales`/`customMapping`. `LocaleConfig.requiresTranslation` uses the same fields internally, so behavior is identical. |
| packages/next/src/config-dir/I18NConfiguration.ts | Inline `requiresTranslation && isSameLanguage` replaced by `requiresDialectTranslation`. Semantically identical, reduces duplication. |
| packages/i18n/src/condition-store/__tests__/localeResolver.test.ts | Added `beforeEach(() => initializeI18nConfig())` to reset the singleton between tests. Two regression tests added: one for undefined-valued fields not triggering override detection, one for explicit locales not auto-including `defaultLocale`. |
| packages/tanstack-start/src/functions/__tests__/determineLocale.test.ts | Added `initializeI18nConfig(localeConfig)` in `beforeEach` so that the singleton is ready before each test, which is now required since `determineLocale` calls `getI18nConfig()`. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[determineSupportedLocale / resolveSupportedLocale / createLocaleResolver] --> B[getI18nConfig singleton]
    B --> C{hasI18nConfigParams?}
    C -- No override --> D[Use singleton LocaleConfig as-is]
    C -- Explicit params --> E[getLocaleResolverConfigParams\nlocales kept as-is\nno defaultLocale prepend]
    E --> F[new LocaleConfig override]
    D --> G[determineSupportedLocaleWithConfig]
    F --> G
    G --> H{candidates null/empty?}
    H -- Yes --> I[return undefined]
    H -- No --> J[LocaleConfig.determineLocale]
    J --> K{match found?}
    K -- Yes --> L[return matched locale]
    K -- No / resolveSupportedLocale --> M[return localeConfig.defaultLocale]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fi18n%2Fsrc%2Fi18n-config%2FI18nConfig.ts%3A60-68%0A**Misleading%20error%20message%20when%20locale%20is%20valid%20BCP%2047%20but%20unsupported**%0A%0AThe%20guard%20condition%20is%20%60!this.isValidLocale%28locale%29%20%7C%7C%20!resolvedLocale%60.%20Because%20%60isValidLocale%60%20only%20validates%20BCP%2047%20format%20%28after%20resolving%20custom%20mapping%20aliases%29%2C%20a%20locale%20that%20IS%20a%20valid%20BCP%2047%20code%20but%20is%20simply%20absent%20from%20the%20configured%20%60locales%60%20array%20will%20hit%20the%20%60!resolvedLocale%60%20branch%20and%20throw%20%22Locale%20X%20is%20not%20valid.%22%20A%20developer%20debugging%20why%20%60'de'%60%20fails%20when%20the%20app%20only%20supports%20%60%5B'en'%2C%20'fr'%5D%60%20would%20receive%20a%20misleading%20error%20suggesting%20the%20code%20itself%20is%20invalid%20%E2%80%94%20the%20real%20cause%20is%20that%20it's%20missing%20from%20%60locales%60.%20The%20hint%20%22Use%20a%20valid%20BCP%2047%20locale%20code%20or%20add%20a%20custom%20mapping%22%20is%20also%20unhelpful%20in%20that%20case%20%28adding%20a%20custom%20mapping%20for%20'de'%20would%20not%20help%3B%20adding%20it%20to%20%60locales%60%20would%29.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fi18n%2Fsrc%2Fcondition-store%2FlocaleResolver.ts%3A29-32%0A**%60createLocaleResolver%60%20now%20allocates%20a%20new%20%60LocaleConfig%60%20on%20every%20invocation**%0A%0APreviously%2C%20the%20config%20was%20normalized%20once%20when%20%60createLocaleResolver%60%20was%20called%2C%20and%20the%20returned%20closure%20reused%20that%20single%20%60NormalizedConditionStoreConfig%60.%20With%20the%20delegation%20to%20%60getI18nConfig%28%29.resolveSupportedLocale%28candidates%2C%20config%29%60%2C%20every%20call%20to%20the%20returned%20resolver%20triggers%20%60getLocaleConfig%28config%29%60%20%E2%86%92%20%60new%20LocaleConfig%28getLocaleResolverConfigParams%28config%29%29%60%20%28when%20explicit%20params%20are%20provided%29.%20For%20resolvers%20that%20are%20called%20frequently%20in%20a%20hot%20path%20%28e.g.%2C%20per-request%20locale%20resolution%29%2C%20this%20creates%20a%20new%20%60LocaleConfig%60%20object%20on%20each%20invocation%20rather%20than%20once%20at%20setup%20time.%0A%0A&repo=generaltranslation%2Fgt&pr=1496&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fodysseus%2Fconsolidate-i18n-config-locale-helpers%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fodysseus%2Fconsolidate-i18n-config-locale-helpers%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fi18n%2Fsrc%2Fi18n-config%2FI18nConfig.ts%3A60-68%0A**Misleading%20error%20message%20when%20locale%20is%20valid%20BCP%2047%20but%20unsupported**%0A%0AThe%20guard%20condition%20is%20%60!this.isValidLocale%28locale%29%20%7C%7C%20!resolvedLocale%60.%20Because%20%60isValidLocale%60%20only%20validates%20BCP%2047%20format%20%28after%20resolving%20custom%20mapping%20aliases%29%2C%20a%20locale%20that%20IS%20a%20valid%20BCP%2047%20code%20but%20is%20simply%20absent%20from%20the%20configured%20%60locales%60%20array%20will%20hit%20the%20%60!resolvedLocale%60%20branch%20and%20throw%20%22Locale%20X%20is%20not%20valid.%22%20A%20developer%20debugging%20why%20%60'de'%60%20fails%20when%20the%20app%20only%20supports%20%60%5B'en'%2C%20'fr'%5D%60%20would%20receive%20a%20misleading%20error%20suggesting%20the%20code%20itself%20is%20invalid%20%E2%80%94%20the%20real%20cause%20is%20that%20it's%20missing%20from%20%60locales%60.%20The%20hint%20%22Use%20a%20valid%20BCP%2047%20locale%20code%20or%20add%20a%20custom%20mapping%22%20is%20also%20unhelpful%20in%20that%20case%20%28adding%20a%20custom%20mapping%20for%20'de'%20would%20not%20help%3B%20adding%20it%20to%20%60locales%60%20would%29.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fi18n%2Fsrc%2Fcondition-store%2FlocaleResolver.ts%3A29-32%0A**%60createLocaleResolver%60%20now%20allocates%20a%20new%20%60LocaleConfig%60%20on%20every%20invocation**%0A%0APreviously%2C%20the%20config%20was%20normalized%20once%20when%20%60createLocaleResolver%60%20was%20called%2C%20and%20the%20returned%20closure%20reused%20that%20single%20%60NormalizedConditionStoreConfig%60.%20With%20the%20delegation%20to%20%60getI18nConfig%28%29.resolveSupportedLocale%28candidates%2C%20config%29%60%2C%20every%20call%20to%20the%20returned%20resolver%20triggers%20%60getLocaleConfig%28config%29%60%20%E2%86%92%20%60new%20LocaleConfig%28getLocaleResolverConfigParams%28config%29%29%60%20%28when%20explicit%20params%20are%20provided%29.%20For%20resolvers%20that%20are%20called%20frequently%20in%20a%20hot%20path%20%28e.g.%2C%20per-request%20locale%20resolution%29%2C%20this%20creates%20a%20new%20%60LocaleConfig%60%20object%20on%20each%20invocation%20rather%20than%20once%20at%20setup%20time.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/i18n/src/i18n-config/I18nConfig.ts:60-68
**Misleading error message when locale is valid BCP 47 but unsupported**

The guard condition is `!this.isValidLocale(locale) || !resolvedLocale`. Because `isValidLocale` only validates BCP 47 format (after resolving custom mapping aliases), a locale that IS a valid BCP 47 code but is simply absent from the configured `locales` array will hit the `!resolvedLocale` branch and throw "Locale X is not valid." A developer debugging why `'de'` fails when the app only supports `['en', 'fr']` would receive a misleading error suggesting the code itself is invalid — the real cause is that it's missing from `locales`. The hint "Use a valid BCP 47 locale code or add a custom mapping" is also unhelpful in that case (adding a custom mapping for 'de' would not help; adding it to `locales` would).

### Issue 2 of 2
packages/i18n/src/condition-store/localeResolver.ts:29-32
**`createLocaleResolver` now allocates a new `LocaleConfig` on every invocation**

Previously, the config was normalized once when `createLocaleResolver` was called, and the returned closure reused that single `NormalizedConditionStoreConfig`. With the delegation to `getI18nConfig().resolveSupportedLocale(candidates, config)`, every call to the returned resolver triggers `getLocaleConfig(config)` → `new LocaleConfig(getLocaleResolverConfigParams(config))` (when explicit params are provided). For resolvers that are called frequently in a hot path (e.g., per-request locale resolution), this creates a new `LocaleConfig` object on each invocation rather than once at setup time.

`````

</details>

<sub>Reviews (6): Last reviewed commit: ["fix: avoid duplicate cache locale getter..."](https://github.com/generaltranslation/gt/commit/ed56a3172ede6475ba5fc9bc6a7da6546ab9cb94) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34072003)</sub>

<!-- /greptile_comment -->