### PR TITLE
test: add i18n config refactor regressions

### DIFF
--- a/packages/i18n/src/translation-functions/__tests__/t.test.ts
+++ b/packages/i18n/src/translation-functions/__tests__/t.test.ts
@@ -2,7 +2,12 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { I18nCache } from '../../i18n-cache/I18nCache';
 import { setI18nCache } from '../../i18n-cache/singleton-operations';
 import { setWritableConditionStore } from '../../condition-store/singleton-operations';
-import { getLocale, getLocaleProperties } from '../../helpers/locale';
+import {
+  getDefaultLocale,
+  getLocale,
+  getLocaleProperties,
+  getLocales,
+} from '../../helpers/locale';
 import { hashMessage } from '../../utils/hashMessage';
 import { t } from '../t';
 
@@ -108,5 +113,28 @@ describe('t', () => {
     );
 
     expect(getLocaleProperties('de-DE').code).toBe('de-DE');
+  });
+
+  it('exposes configured locale helper values', () => {
+    setI18nCache(
+      new I18nCache({
+        defaultLocale: 'en-US',
+        locales: ['en-US', 'fr', 'brand-french'],
+        customMapping: {
+          'brand-french': {
+            code: 'fr',
+            name: 'Brand French',
+          },
+        },
+        loadTranslations: vi.fn(),
+      })
+    );
+
+    expect(getDefaultLocale()).toBe('en-US');
+    expect(getLocales()).toEqual(['en-US', 'fr', 'brand-french']);
+    expect(getLocaleProperties('brand-french')).toMatchObject({
+      code: 'fr',
+      name: 'Brand French',
+    });
   });
 });

--- a/packages/next/src/config-dir/__tests__/I18NConfiguration.test.ts
+++ b/packages/next/src/config-dir/__tests__/I18NConfiguration.test.ts
@@ -3,11 +3,49 @@ import { I18NConfiguration } from '../I18NConfiguration';
 
 const mockI18nCacheParams = vi.hoisted(() => vi.fn());
 const mockLookupTranslationWithFallback = vi.hoisted(() => vi.fn());
+const mockLocaleConfig = vi.hoisted(() => ({
+  defaultLocale: 'en',
+  locales: ['en', 'fr'],
+  customMapping: {},
+  translationRequired: true,
+  dialectTranslationRequired: false,
+  enableI18n: true,
+}));
 
 vi.mock('gt-i18n/internal', () => ({
+  getI18nConfig: () => ({
+    getDefaultLocale: () => mockLocaleConfig.defaultLocale,
+    getLocales: () => mockLocaleConfig.locales,
+    getCustomMapping: () => mockLocaleConfig.customMapping,
+    requiresTranslation: () => mockLocaleConfig.translationRequired,
+    requiresDialectTranslation: () =>
+      mockLocaleConfig.dialectTranslationRequired,
+  }),
+  initializeI18nConfig: (params: {
+    defaultLocale?: string;
+    locales?: string[];
+    customMapping?: Record<string, unknown>;
+  }) => {
+    mockLocaleConfig.defaultLocale =
+      params.defaultLocale ?? mockLocaleConfig.defaultLocale;
+    mockLocaleConfig.locales = params.locales ?? mockLocaleConfig.locales;
+    mockLocaleConfig.customMapping =
+      params.customMapping ?? mockLocaleConfig.customMapping;
+  },
   I18nCache: class {
-    constructor(params: unknown) {
+    constructor(params: {
+      defaultLocale?: string;
+      locales?: string[];
+      customMapping?: Record<string, unknown>;
+      enableI18n?: boolean;
+    }) {
       mockI18nCacheParams(params);
+      mockLocaleConfig.defaultLocale =
+        params.defaultLocale ?? mockLocaleConfig.defaultLocale;
+      mockLocaleConfig.locales = params.locales ?? mockLocaleConfig.locales;
+      mockLocaleConfig.customMapping =
+        params.customMapping ?? mockLocaleConfig.customMapping;
+      mockLocaleConfig.enableI18n = params.enableI18n ?? true;
     }
 
     getGTClass() {
@@ -16,12 +54,34 @@ vi.mock('gt-i18n/internal', () => ({
       };
     }
 
+    getDefaultLocale() {
+      return mockLocaleConfig.defaultLocale;
+    }
+
+    getLocales() {
+      return mockLocaleConfig.locales;
+    }
+
+    getCustomMapping() {
+      return mockLocaleConfig.customMapping;
+    }
+
+    getVersionId() {
+      return undefined;
+    }
+
     requiresTranslation() {
-      return true;
+      return (
+        mockLocaleConfig.enableI18n && mockLocaleConfig.translationRequired
+      );
     }
 
     requiresDialectTranslation() {
-      return false;
+      return (
+        mockLocaleConfig.enableI18n &&
+        mockLocaleConfig.translationRequired &&
+        mockLocaleConfig.dialectTranslationRequired
+      );
     }
 
     async loadTranslations() {
@@ -71,6 +131,12 @@ describe('I18NConfiguration', () => {
     mockI18nCacheParams.mockReset();
     mockLookupTranslationWithFallback.mockReset();
     mockLookupTranslationWithFallback.mockResolvedValue('translated');
+    mockLocaleConfig.defaultLocale = 'en';
+    mockLocaleConfig.locales = ['en', 'fr'];
+    mockLocaleConfig.customMapping = {};
+    mockLocaleConfig.translationRequired = true;
+    mockLocaleConfig.dialectTranslationRequired = false;
+    mockLocaleConfig.enableI18n = true;
   });
 
   it.each<[string, Partial<ConfigParams>, number | null]>([
@@ -151,5 +217,48 @@ describe('I18NConfiguration', () => {
         $maxChars: 12,
       }
     );
+  });
+
+  it('exposes configured locale values and client custom mappings', () => {
+    const customMapping = {
+      'brand-french': {
+        code: 'fr',
+        name: 'Brand French',
+      },
+    };
+    const config = createConfig({
+      defaultLocale: 'en-US',
+      locales: ['en-US', 'fr', 'brand-french'],
+      customMapping,
+    });
+
+    expect(config.getDefaultLocale()).toBe('en-US');
+    expect(config.getLocales()).toEqual(['en-US', 'fr', 'brand-french']);
+    expect(config.getClientSideConfig()).toEqual(
+      expect.objectContaining({
+        customMapping,
+      })
+    );
+  });
+
+  it('checks translation and dialect requirements from locale config', () => {
+    mockLocaleConfig.translationRequired = true;
+    mockLocaleConfig.dialectTranslationRequired = true;
+
+    const config = createConfig();
+
+    expect(config.requiresTranslation('en-GB')).toEqual([true, true]);
+  });
+
+  it('does not require translation when translation loading is disabled', () => {
+    mockLocaleConfig.translationRequired = true;
+    mockLocaleConfig.dialectTranslationRequired = true;
+
+    const config = createConfig({
+      loadTranslationsType: 'disabled',
+      loadDictionaryEnabled: false,
+    });
+
+    expect(config.requiresTranslation('fr')).toEqual([false, false]);
   });
 });

--- a/packages/next/src/config-dir/__tests__/I18NConfiguration.test.ts
+++ b/packages/next/src/config-dir/__tests__/I18NConfiguration.test.ts
@@ -13,25 +13,6 @@ const mockLocaleConfig = vi.hoisted(() => ({
 }));
 
 vi.mock('gt-i18n/internal', () => ({
-  getI18nConfig: () => ({
-    getDefaultLocale: () => mockLocaleConfig.defaultLocale,
-    getLocales: () => mockLocaleConfig.locales,
-    getCustomMapping: () => mockLocaleConfig.customMapping,
-    requiresTranslation: () => mockLocaleConfig.translationRequired,
-    requiresDialectTranslation: () =>
-      mockLocaleConfig.dialectTranslationRequired,
-  }),
-  initializeI18nConfig: (params: {
-    defaultLocale?: string;
-    locales?: string[];
-    customMapping?: Record<string, unknown>;
-  }) => {
-    mockLocaleConfig.defaultLocale =
-      params.defaultLocale ?? mockLocaleConfig.defaultLocale;
-    mockLocaleConfig.locales = params.locales ?? mockLocaleConfig.locales;
-    mockLocaleConfig.customMapping =
-      params.customMapping ?? mockLocaleConfig.customMapping;
-  },
   I18nCache: class {
     constructor(params: {
       defaultLocale?: string;

--- a/packages/node/src/helpers/__tests__/getLocale.test.ts
+++ b/packages/node/src/helpers/__tests__/getLocale.test.ts
@@ -51,4 +51,21 @@ describe('getLocale', () => {
     const result = getRequestLocale(request);
     expect(['en-US', 'es', 'fr', 'ja']).toContain(result);
   });
+
+  it('resolves custom mapped request locales', () => {
+    initializeGT({
+      defaultLocale: 'en-US',
+      locales: ['en-US', 'fr', 'brand-french'],
+      customMapping: {
+        'brand-french': {
+          code: 'fr',
+          name: 'Brand French',
+        },
+      },
+    });
+
+    const request = { headers: { 'accept-language': 'brand-french' } };
+
+    expect(getRequestLocale(request)).toBe('fr');
+  });
 });

--- a/packages/react-core/src/hooks/__tests__/utils.test.ts
+++ b/packages/react-core/src/hooks/__tests__/utils.test.ts
@@ -1,23 +1,25 @@
-import { describe, expect, it, vi } from 'vitest';
-import { I18nCache } from 'gt-i18n/internal';
+import { describe, expect, it } from 'vitest';
 import { setReadonlyConditionStore } from '../../condition-store/singleton-operations';
+import type { ReactI18nCache } from '../../i18n-cache/ReactI18nCache';
 import { setReactI18nCache } from '../../i18n-cache/singleton-operations';
 import { getShouldTranslate } from '../utils';
 
 function setup({
   locale,
   enableI18n = true,
+  locales = ['en', 'fr'],
+  customMapping = {},
 }: {
   locale: string;
   enableI18n?: boolean;
+  locales?: string[];
+  customMapping?: Record<string, { code: string; name: string }>;
 }) {
-  setReactI18nCache(
-    new I18nCache({
-      defaultLocale: 'en',
-      locales: ['en', 'fr'],
-      loadTranslations: vi.fn(),
-    })
-  );
+  setReactI18nCache({
+    getDefaultLocale: () => 'en',
+    getLocales: () => locales,
+    getCustomMapping: () => customMapping,
+  } as ReactI18nCache);
   setReadonlyConditionStore({
     getLocale: () => locale,
     getEnableI18n: () => enableI18n,
@@ -33,6 +35,21 @@ describe('getShouldTranslate', () => {
 
   it('returns true for supported non-default locales', () => {
     setup({ locale: 'fr' });
+
+    expect(getShouldTranslate()).toBe(true);
+  });
+
+  it('returns true for custom mapped non-default locales', () => {
+    setup({
+      locale: 'brand-french',
+      locales: ['en', 'fr', 'brand-french'],
+      customMapping: {
+        'brand-french': {
+          code: 'fr',
+          name: 'Brand French',
+        },
+      },
+    });
 
     expect(getShouldTranslate()).toBe(true);
   });

--- a/packages/react-core/src/hooks/__tests__/utils.test.ts
+++ b/packages/react-core/src/hooks/__tests__/utils.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest';
+import { I18nCache } from 'gt-i18n/internal';
+import { setReadonlyConditionStore } from '../../condition-store/singleton-operations';
+import { setReactI18nCache } from '../../i18n-cache/singleton-operations';
+import { getShouldTranslate } from '../utils';
+
+function setup({
+  locale,
+  enableI18n = true,
+}: {
+  locale: string;
+  enableI18n?: boolean;
+}) {
+  setReactI18nCache(
+    new I18nCache({
+      defaultLocale: 'en',
+      locales: ['en', 'fr'],
+      loadTranslations: vi.fn(),
+    })
+  );
+  setReadonlyConditionStore({
+    getLocale: () => locale,
+    getEnableI18n: () => enableI18n,
+  });
+}
+
+describe('getShouldTranslate', () => {
+  it('returns false for the default locale', () => {
+    setup({ locale: 'en' });
+
+    expect(getShouldTranslate()).toBe(false);
+  });
+
+  it('returns true for supported non-default locales', () => {
+    setup({ locale: 'fr' });
+
+    expect(getShouldTranslate()).toBe(true);
+  });
+
+  it('returns false when i18n is disabled', () => {
+    setup({ locale: 'fr', enableI18n: false });
+
+    expect(getShouldTranslate()).toBe(false);
+  });
+});

--- a/packages/tanstack-start/src/functions/__tests__/determineLocale.test.ts
+++ b/packages/tanstack-start/src/functions/__tests__/determineLocale.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockRequestHeader = vi.hoisted(() => vi.fn());
+const mockCookie = vi.hoisted(() => vi.fn());
+
+vi.mock('@tanstack/react-start', () => ({
+  createIsomorphicFn: () => ({
+    server: (serverFn: unknown) => ({
+      client: (clientFn: unknown) => ({
+        client: clientFn,
+        server: serverFn,
+      }),
+    }),
+  }),
+}));
+
+vi.mock('@tanstack/react-start/server', () => ({
+  getCookie: (...args: unknown[]) => mockCookie(...args),
+  getRequestHeader: (...args: unknown[]) => mockRequestHeader(...args),
+}));
+
+import { determineLocale } from '../determineLocale';
+
+const localeConfig = {
+  defaultLocale: 'en',
+  locales: ['en', 'fr', 'es', 'brand-french'],
+  customMapping: {
+    'brand-french': {
+      code: 'fr',
+      name: 'Brand French',
+    },
+  },
+};
+
+describe('determineLocale', () => {
+  beforeEach(() => {
+    mockCookie.mockReset();
+    mockRequestHeader.mockReset();
+    process.env._GENERALTRANSLATION_IGNORE_BROWSER_LOCALES = 'false';
+  });
+
+  it('uses the server cookie before Accept-Language', () => {
+    mockCookie.mockReturnValue('brand-french');
+    mockRequestHeader.mockReturnValue('es,en;q=0.8');
+
+    expect(
+      (
+        determineLocale as unknown as {
+          server: (config: typeof localeConfig) => string;
+        }
+      ).server(localeConfig)
+    ).toBe('fr');
+  });
+
+  it('falls back to the server Accept-Language header', () => {
+    mockCookie.mockReturnValue(undefined);
+    mockRequestHeader.mockReturnValue('es,en;q=0.8');
+
+    expect(
+      (
+        determineLocale as unknown as {
+          server: (config: typeof localeConfig) => string;
+        }
+      ).server(localeConfig)
+    ).toBe('es');
+  });
+
+  it('uses client cookies before navigator language', () => {
+    Object.defineProperty(globalThis, 'document', {
+      configurable: true,
+      value: {
+        cookie: 'generaltranslation.locale=brand-french',
+      },
+    });
+    Object.defineProperty(globalThis, 'navigator', {
+      configurable: true,
+      value: {
+        language: 'es',
+      },
+    });
+
+    expect(
+      (
+        determineLocale as unknown as {
+          client: (config: typeof localeConfig) => string;
+        }
+      ).client(localeConfig)
+    ).toBe('fr');
+  });
+});

--- a/packages/tanstack-start/src/functions/__tests__/determineLocale.test.ts
+++ b/packages/tanstack-start/src/functions/__tests__/determineLocale.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockRequestHeader = vi.hoisted(() => vi.fn());
 const mockCookie = vi.hoisted(() => vi.fn());
@@ -32,11 +32,37 @@ const localeConfig = {
   },
 };
 
+const originalDocumentDescriptor = Object.getOwnPropertyDescriptor(
+  globalThis,
+  'document'
+);
+const originalNavigatorDescriptor = Object.getOwnPropertyDescriptor(
+  globalThis,
+  'navigator'
+);
+
+function restoreGlobalProperty(
+  property: 'document' | 'navigator',
+  descriptor: PropertyDescriptor | undefined
+) {
+  if (descriptor) {
+    Object.defineProperty(globalThis, property, descriptor);
+    return;
+  }
+
+  Reflect.deleteProperty(globalThis, property);
+}
+
 describe('determineLocale', () => {
   beforeEach(() => {
     mockCookie.mockReset();
     mockRequestHeader.mockReset();
     process.env._GENERALTRANSLATION_IGNORE_BROWSER_LOCALES = 'false';
+  });
+
+  afterEach(() => {
+    restoreGlobalProperty('document', originalDocumentDescriptor);
+    restoreGlobalProperty('navigator', originalNavigatorDescriptor);
   });
 
   it('uses the server cookie before Accept-Language', () => {


### PR DESCRIPTION
## Summary
- add regression coverage for locale helper access before the i18n config refactor stack
- cover custom locale mapping behavior in gt-i18n, gt-node, gt-next, react-core, and gt-tanstack-start
- keep this PR test-only so the following refactor PRs can prove behavior stays unchanged

## Testing
- pnpm --filter gt-i18n test -- src/translation-functions/__tests__/t.test.ts
- pnpm --filter gt-node test -- src/helpers/__tests__/getLocale.test.ts
- pnpm --filter gt-next test:js -- src/config-dir/__tests__/I18NConfiguration.test.ts
- pnpm --filter @generaltranslation/supported-locales build
- pnpm --filter @generaltranslation/react-core test -- src/hooks/__tests__/utils.test.ts
- pnpm --filter gt-tanstack-start test -- src/functions/__tests__/determineLocale.test.ts
- pnpm exec oxfmt --check packages/i18n/src/translation-functions/__tests__/t.test.ts packages/node/src/helpers/__tests__/getLocale.test.ts packages/next/src/config-dir/__tests__/I18NConfiguration.test.ts packages/react-core/src/hooks/__tests__/utils.test.ts packages/tanstack-start/src/functions/__tests__/determineLocale.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1497"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782435964&installation_id=127936663&pr_number=1497&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1497&signature=b751dc796f85473645eacaeabf5bfe0042ce24e35e519ae52497f55250ca11d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This is a test-only PR that adds regression coverage for locale helper access and custom locale mapping behaviour across five packages before the upcoming i18n config refactor. All changed files are test files; no production code is modified.

- **`gt-i18n` / `gt-node`**: New tests verify that `getDefaultLocale`, `getLocales`, and `getLocaleProperties` / `getRequestLocale` all honour a `brand-french → fr` custom mapping after the respective singletons are initialised.
- **`gt-next`**: The `I18nCache` mock is extended with `getDefaultLocale`, `getLocales`, `getCustomMapping`, and `getVersionId`, and the `requiresTranslation`/`requiresDialectTranslation` stubs are updated to reflect `enableI18n`; three new tests exercise locale exposure, translation requirements, and the disabled-translation path.
- **`react-core` / `gt-tanstack-start`**: New test files cover `getShouldTranslate` (including the previously-missing custom-mapped locale path) and the server/client paths of `determineLocale`; the tanstack test correctly captures and restores `document`/`navigator` descriptors in `afterEach`, addressing the global-pollution concern from the prior review round.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Test-only PR with no production code changes; all new tests pass the same custom-mapping scenario across five packages and are safe to merge.

Every changed file is a test file. The new tests are well-isolated: singletons are reset in beforeEach, mutated globals are restored in afterEach, and the I18nCache mock is deterministic. No production logic is touched, so there is no regression risk from this PR itself.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/i18n/src/translation-functions/__tests__/t.test.ts | Adds a regression test verifying that getDefaultLocale, getLocales, and getLocaleProperties all reflect the custom mapping when an I18nCache is seeded with brand-french; straightforward and self-contained. |
| packages/next/src/config-dir/__tests__/I18NConfiguration.test.ts | Enhances the I18nCache mock with getDefaultLocale, getLocales, getCustomMapping, getVersionId, and updated requiresTranslation/requiresDialectTranslation stubs; adds three new tests covering locale exposure, translation requirement, and disabled-translation path. beforeEach properly resets all mockLocaleConfig fields. |
| packages/node/src/helpers/__tests__/getLocale.test.ts | Adds a regression test that re-initialises GT with a brand-french custom mapping and asserts getRequestLocale resolves it to fr; interacts safely with the existing beforeEach because each test resets the singleton via initializeGT. |
| packages/react-core/src/hooks/__tests__/utils.test.ts | New file with four getShouldTranslate tests including a custom-mapped locale case (brand-french → fr), which was flagged as missing in a previous review round; all four paths are now covered. |
| packages/tanstack-start/src/functions/__tests__/determineLocale.test.ts | New file testing server and client paths of determineLocale; correctly captures original document/navigator descriptors at module level and restores them in afterEach, addressing the global-pollution concern raised in the previous review. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Custom Mapping Config\nbrand-french → fr] --> B{Package}
    B --> C[gt-i18n\nt.test.ts]
    B --> D[gt-node\ngetLocale.test.ts]
    B --> E[gt-next\nI18NConfiguration.test.ts]
    B --> F[react-core\nutils.test.ts]
    B --> G[gt-tanstack-start\ndetermineLocale.test.ts]
    C --> C1[getDefaultLocale\ngetLocales\ngetLocaleProperties]
    D --> D1[getRequestLocale\nAccept-Language header]
    E --> E1[getDefaultLocale\ngetLocales\ngetClientSideConfig\nrequiresTranslation]
    F --> F1[getShouldTranslate\nenableI18n flag]
    G --> G1[determineLocale.server\ncookie → brand-french → fr]
    G --> G2[determineLocale.client\ndocument.cookie → brand-french → fr]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["test: address i18n config regression rev..."](https://github.com/generaltranslation/gt/commit/adc5f3c46f177ae95d53dbcac6859cab8736364a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34075297)</sub>

<!-- /greptile_comment -->