### PR TITLE
refactor: rename gt context providers

### DIFF
--- a/packages/react/src/context.client.ts
+++ b/packages/react/src/context.client.ts
@@ -1,6 +1,6 @@
 'use client';
 
-export { CSRGTProvider as GTProvider } from './provider/CSRGTProvider';
+export { BrowserGTProvider as GTProvider } from './provider/BrowserGTProvider';
 export { initializeGTSPA } from './setup/initializeGTSPA';
 export { LocaleSelector } from './components/LocaleSelector';
 export { useLocaleSelector } from './components/useLocaleSelector';

--- a/packages/react/src/context.server.ts
+++ b/packages/react/src/context.server.ts
@@ -1,6 +1,6 @@
 'server-only';
 
-export { SSRGTProvider as GTProvider } from './provider/SSRGTProvider';
+export { ServerGTProvider as GTProvider } from './provider/ServerGTProvider';
 export { initializeGTSPA } from './setup/initializeGTSPA';
 export { LocaleSelector } from './components/LocaleSelector';
 export { useLocaleSelector } from './components/useLocaleSelector';

--- a/packages/react/src/context.types.ts
+++ b/packages/react/src/context.types.ts
@@ -1,9 +1,9 @@
-import { CSRGTProvider } from './provider/CSRGTProvider';
+import { BrowserGTProvider } from './provider/BrowserGTProvider';
 
 /**
  * Wrap GTProvider around the content that you want to translate
  */
-export const GTProvider: typeof CSRGTProvider = () => {
+export const GTProvider: typeof BrowserGTProvider = () => {
   throw new Error(
     'gt-react: You have imported a function from the dedicated types entrypoint. If you are seeing this error, it means something has gone wrong.'
   );

--- a/packages/react/src/provider/BrowserGTProvider.tsx
+++ b/packages/react/src/provider/BrowserGTProvider.tsx
@@ -7,7 +7,7 @@ import { createOrUpdateBrowserConditionStore } from '../condition-store/createBr
  * GTProvider because needs to syncrhonize any incoming
  * server-side translations
  */
-export function CSRGTProvider(props: SharedGTProviderProps) {
+export function BrowserGTProvider(props: SharedGTProviderProps) {
   // TODO: if a specific translation entry changes, but not the locale, this does not trigger a re-render
   // TODO: optimize by skipping updateTranslations() if client is responsible for reloading translations
   // (eg reloadLocale === undefined), see getI18nStore().updateLocale() in InternalGTProvider

--- a/packages/react/src/provider/ServerGTProvider.tsx
+++ b/packages/react/src/provider/ServerGTProvider.tsx
@@ -12,7 +12,7 @@ import { InternalGTProvider } from '@generaltranslation/react-core/context';
  *
  * TODO: find some way to enforce this is only imported on the server
  */
-export function SSRGTProvider(props: SharedGTProviderProps) {
+export function ServerGTProvider(props: SharedGTProviderProps) {
   // The condition store may already be created at the module level
   if (!isReadonlyConditionStoreInitialized()) {
     const conditionStore = new ReadonlyConditionStore(props);


### PR DESCRIPTION
Renames the context provider implementations from CSR/SSR naming to Browser/Server naming and updates the corresponding entrypoint imports.\n\nNo changeset.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1498"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782439476&installation_id=127936663&pr_number=1498&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1498&signature=cbf283ec86685a0d6e673967498e01e1e9ede229c9525ed954963597ed259ae7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR renames the internal React context provider implementations from CSR/SSR terminology to Browser/Server terminology, updating file names, function names, and their import sites accordingly. The public-facing `GTProvider` export alias is unchanged, so there is no breaking change for consumers.

- `CSRGTProvider.tsx` → `BrowserGTProvider.tsx` and `SSRGTProvider.tsx` → `ServerGTProvider.tsx`, with matching function renames inside each file.
- `context.client.ts`, `context.server.ts`, and `context.types.ts` all updated to import from the new file names; a repo-wide search confirms no stale references to the old names remain.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Pure rename refactor with no logic changes; public exports are unaffected and no stale references remain in the codebase.

All five changed files are consistent — files and functions are renamed together, every import site is updated, and a repo-wide grep confirms no remaining references to the old CSRGTProvider/SSRGTProvider names. The public GTProvider alias exposed to consumers is unchanged.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react/src/provider/BrowserGTProvider.tsx | Renamed from CSRGTProvider.tsx; function renamed from CSRGTProvider to BrowserGTProvider. No logic changes. |
| packages/react/src/provider/ServerGTProvider.tsx | Renamed from SSRGTProvider.tsx; function renamed from SSRGTProvider to ServerGTProvider. No logic changes. |
| packages/react/src/context.client.ts | Import updated to reference BrowserGTProvider from the renamed file. Public export alias GTProvider unchanged. |
| packages/react/src/context.server.ts | Import updated to reference ServerGTProvider from the renamed file. Public export alias GTProvider unchanged. |
| packages/react/src/context.types.ts | Type reference updated from CSRGTProvider to BrowserGTProvider; stub GTProvider type remains correct. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[context.client.ts<br/>'use client'] -->|exports GTProvider| B[BrowserGTProvider<br/>formerly CSRGTProvider]
    C[context.server.ts<br/>'server-only'] -->|exports GTProvider| D[ServerGTProvider<br/>formerly SSRGTProvider]
    E[context.types.ts<br/>types entrypoint] -->|typeof BrowserGTProvider| F[GTProvider stub<br/>throws at runtime]
    B --> G[InternalGTProvider<br/>react-core]
    D --> G
```
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: rename gt context providers"](https://github.com/generaltranslation/gt/commit/d260f10d14010db631055abfed2907ca196747de) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34080963)</sub>

<!-- /greptile_comment -->