### PR TITLE
refactor: clean up i18n store helpers

### DIFF
--- a/packages/react-core/src/i18n-store/I18nStore.ts
+++ b/packages/react-core/src/i18n-store/I18nStore.ts
@@ -7,7 +7,6 @@ import type {
   DictionaryEntrySnapshot,
   DictionaryLookup,
   DictionaryObjectSnapshot,
-  ListenerSet,
   StoreListener,
   TranslateLookup,
   TranslateManySnapshot,
@@ -19,14 +18,14 @@ import { getReactI18nCache } from '../i18n-cache/singleton-operations';
 import { RuntimeTranslationScope } from './RuntimeTranslationScope';
 import { RuntimeDictionaryScope } from './RuntimeDictionaryScope';
 import { getI18nConfig } from 'gt-i18n/internal';
+import {
+  dictionaryEntryEventMatchesLookup,
+  dictionaryObjectEventMatchesLookup,
+} from './utils/dictionary-events';
+import { subscribeToSet } from './utils/subscriptions';
 
-type EntryCacheEvent = {
-  locale: string;
-  id: string;
-};
 type TranslateStoreListener = (lookup: TranslateLookup) => void;
-type DictionaryStoreEvent = EntryCacheEvent;
-type DictionaryStoreListener = (event: DictionaryStoreEvent) => void;
+type DictionaryStoreListener = (event: DictionaryLookup) => void;
 
 export type I18nStoreParams = {};
 
@@ -39,10 +38,9 @@ export type I18nStoreParams = {};
 export class I18nStore {
   // ===== Listener Sets ===== //
 
-  private defaultLocaleListeners: ListenerSet = new Set();
-  private localesListeners: ListenerSet = new Set();
-  private customMappingListeners: ListenerSet = new Set();
-  private enableI18nListeners: ListenerSet = new Set();
+  private defaultLocaleListeners = new Set<StoreListener>();
+  private localesListeners = new Set<StoreListener>();
+  private customMappingListeners = new Set<StoreListener>();
   private translateListeners = new Set<TranslateStoreListener>();
   private translateManySnapshotCache = new WeakMap<
     readonly TranslateLookup[],
@@ -50,7 +48,6 @@ export class I18nStore {
   >();
   private dictionaryEntryListeners = new Set<DictionaryStoreListener>();
   private dictionaryObjectListeners = new Set<DictionaryStoreListener>();
-  private localeListeners: ListenerSet = new Set();
 
   /**
    * I18nCache must be already initialized
@@ -66,15 +63,15 @@ export class I18nStore {
   // ===== Manager Config Subscriptions ===== //
 
   subscribeToDefaultLocale = (listener: StoreListener): Unsubscribe => {
-    return this.subscribeToStaticSet(this.defaultLocaleListeners, listener);
+    return subscribeToSet(this.defaultLocaleListeners, listener);
   };
 
   subscribeToLocales = (listener: StoreListener): Unsubscribe => {
-    return this.subscribeToStaticSet(this.localesListeners, listener);
+    return subscribeToSet(this.localesListeners, listener);
   };
 
   subscribeToCustomMapping = (listener: StoreListener): Unsubscribe => {
-    return this.subscribeToStaticSet(this.customMappingListeners, listener);
+    return subscribeToSet(this.customMappingListeners, listener);
   };
 
   // ===== I18nCache Subscriptions ===== //
@@ -89,7 +86,7 @@ export class I18nStore {
         listener();
       }
     };
-    return this.subscribeToTranslateSet(wrappedListener);
+    return subscribeToSet(this.translateListeners, wrappedListener);
   }
 
   subscribeToTranslateMany<T extends Translation>(
@@ -114,10 +111,7 @@ export class I18nStore {
         listener();
       }
     };
-    return this.subscribeToDictionarySet(
-      this.dictionaryEntryListeners,
-      wrappedListener
-    );
+    return subscribeToSet(this.dictionaryEntryListeners, wrappedListener);
   }
 
   subscribeToDictionaryObject(
@@ -130,10 +124,7 @@ export class I18nStore {
         listener();
       }
     };
-    return this.subscribeToDictionarySet(
-      this.dictionaryObjectListeners,
-      wrappedListener
-    );
+    return subscribeToSet(this.dictionaryObjectListeners, wrappedListener);
   }
 
   // ===== Manager Config Snapshots ===== //
@@ -244,75 +235,16 @@ export class I18nStore {
     return new RuntimeDictionaryScope();
   };
 
-  private subscribeToStaticSet(
-    listenerSet: ListenerSet,
-    listener: StoreListener
-  ): Unsubscribe {
-    listenerSet.add(listener);
-    return () => {
-      listenerSet.delete(listener);
-    };
-  }
-
-  private subscribeToTranslateSet(
-    listener: TranslateStoreListener
-  ): Unsubscribe {
-    this.translateListeners.add(listener);
-    return () => {
-      this.translateListeners.delete(listener);
-    };
-  }
-
-  private subscribeToDictionarySet(
-    listenerSet: Set<DictionaryStoreListener>,
-    listener: DictionaryStoreListener
-  ): Unsubscribe {
-    listenerSet.add(listener);
-    return () => {
-      listenerSet.delete(listener);
-    };
-  }
-
   // ===== Listener Utilities ===== //
 
   private emitTranslateEvent(event: TranslateLookup): void {
     this.translateListeners.forEach((listener) => listener(event));
   }
 
-  private emitDictionaryEvent(event: DictionaryStoreEvent): void {
+  private emitDictionaryEvent(event: DictionaryLookup): void {
     this.dictionaryEntryListeners.forEach((listener) => listener(event));
     this.dictionaryObjectListeners.forEach((listener) => {
       listener(event);
     });
   }
-}
-
-// ===== Lookup Keys ===== //
-
-function getDictionaryLookupFromKey(lookupKey: string): DictionaryLookup {
-  const separatorIndex = lookupKey.indexOf(':');
-  return {
-    locale: lookupKey.slice(0, separatorIndex),
-    id: lookupKey.slice(separatorIndex + 1),
-  };
-}
-
-// ===== Event Matching ===== //
-
-function dictionaryEntryEventMatchesLookup(
-  event: DictionaryStoreEvent,
-  lookupKey: string
-): boolean {
-  return getDictionaryListenerKey(event) === lookupKey;
-}
-
-function dictionaryObjectEventMatchesLookup(
-  event: DictionaryStoreEvent,
-  lookupKey: string
-): boolean {
-  const { locale, id } = getDictionaryLookupFromKey(lookupKey);
-  if (locale !== event.locale) {
-    return false;
-  }
-  return id === '' || event.id === id || event.id.startsWith(`${id}.`);
 }

--- a/packages/react-core/src/i18n-store/storeTypes.ts
+++ b/packages/react-core/src/i18n-store/storeTypes.ts
@@ -9,7 +9,6 @@ import type {
 
 export type Unsubscribe = () => void;
 export type StoreListener = () => void;
-export type ListenerSet = Set<StoreListener>;
 
 // ----- Lookups ----- //
 

--- a/packages/react-core/src/i18n-store/utils/dictionary-events.ts
+++ b/packages/react-core/src/i18n-store/utils/dictionary-events.ts
@@ -1,0 +1,28 @@
+import { getDictionaryListenerKey } from 'gt-i18n/internal';
+import type { DictionaryLookup } from '../storeTypes';
+
+function getDictionaryLookupFromKey(lookupKey: string): DictionaryLookup {
+  const separatorIndex = lookupKey.indexOf(':');
+  return {
+    locale: lookupKey.slice(0, separatorIndex),
+    id: lookupKey.slice(separatorIndex + 1),
+  };
+}
+
+export function dictionaryEntryEventMatchesLookup(
+  event: DictionaryLookup,
+  lookupKey: string
+): boolean {
+  return getDictionaryListenerKey(event) === lookupKey;
+}
+
+export function dictionaryObjectEventMatchesLookup(
+  event: DictionaryLookup,
+  lookupKey: string
+): boolean {
+  const { locale, id } = getDictionaryLookupFromKey(lookupKey);
+  if (locale !== event.locale) {
+    return false;
+  }
+  return id === '' || event.id === id || event.id.startsWith(`${id}.`);
+}

--- a/packages/react-core/src/i18n-store/utils/subscriptions.ts
+++ b/packages/react-core/src/i18n-store/utils/subscriptions.ts
@@ -1,0 +1,11 @@
+import type { Unsubscribe } from '../storeTypes';
+
+export function subscribeToSet<T>(
+  listenerSet: Set<T>,
+  listener: T
+): Unsubscribe {
+  listenerSet.add(listener);
+  return () => {
+    listenerSet.delete(listener);
+  };
+}


### PR DESCRIPTION
## Summary
- remove unused i18n store listener state and private subscription wrappers
- move dictionary event matching and shared subscription wiring into i18n-store utils

## Testing
- pnpm --filter @generaltranslation/react-core... build
- pnpm --filter @generaltranslation/react-core typecheck
- pnpm --filter @generaltranslation/react-core test
- pnpm exec oxlint packages/react-core/src/i18n-store
- pnpm exec oxfmt --check packages/react-core/src/i18n-store/I18nStore.ts packages/react-core/src/i18n-store/storeTypes.ts packages/react-core/src/i18n-store/utils/dictionary-events.ts packages/react-core/src/i18n-store/utils/subscriptions.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1499"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782440245&installation_id=127936663&pr_number=1499&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1499&signature=ea021e50271bf23fd1d2e81a6eeee4c80085c93a320d375ce28bf1b165aabf1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a pure refactoring of the `I18nStore` subscription layer with no behavioral changes. Dead private fields (`enableI18nListeners`, `localeListeners`) are removed, the `ListenerSet` type alias is dropped in favour of direct `Set<StoreListener>` usage, and reusable logic is extracted into two new utility modules.

- **`utils/subscriptions.ts`**: Extracts the three structurally identical private `subscribeToXxx` methods into a single generic `subscribeToSet<T>` helper.
- **`utils/dictionary-events.ts`**: Moves `getDictionaryLookupFromKey`, `dictionaryEntryEventMatchesLookup`, and `dictionaryObjectEventMatchesLookup` out of `I18nStore.ts`, and aligns the `DictionaryStoreListener` event type with the already-equivalent `DictionaryLookup` from `storeTypes.ts`.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all changes are structural refactoring with no logic modifications.

Every moved function is an exact copy of its original; the removed fields were provably unreachable (no subscribe or emit methods referenced them); and the type-alias consolidation (DictionaryStoreEvent → DictionaryLookup) is structurally identical. No behavioural path has changed.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react-core/src/i18n-store/I18nStore.ts | Removed dead listener sets (enableI18nListeners, localeListeners), replaced ListenerSet type alias with direct Set<StoreListener>, and delegated subscription/event-matching logic to new utility modules. |
| packages/react-core/src/i18n-store/storeTypes.ts | Removed the ListenerSet type alias; call sites now use Set<StoreListener> directly. |
| packages/react-core/src/i18n-store/utils/dictionary-events.ts | New file housing getDictionaryLookupFromKey, dictionaryEntryEventMatchesLookup, and dictionaryObjectEventMatchesLookup, migrated verbatim from I18nStore.ts. |
| packages/react-core/src/i18n-store/utils/subscriptions.ts | New generic subscribeToSet utility extracted from the three private subscription methods that previously lived in I18nStore. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C as Consumer
    participant S as I18nStore
    participant SS as subscriptions.ts
    participant DE as dictionary-events.ts
    participant Cache as I18nCache

    C->>S: subscribeToDictionaryEntry(lookup, listener)
    S->>SS: subscribeToSet(dictionaryEntryListeners, wrappedListener)
    SS-->>C: unsubscribe fn

    C->>S: subscribeToDictionaryObject(lookup, listener)
    S->>SS: subscribeToSet(dictionaryObjectListeners, wrappedListener)
    SS-->>C: unsubscribe fn

    Note over S,Cache: On runtime translate
    S->>Cache: lookupDictionaryWithFallback(locale, id)
    Cache-->>S: result
    S->>S: emitDictionaryEvent(DictionaryLookup)
    S->>DE: dictionaryEntryEventMatchesLookup(event, lookupKey)
    DE-->>S: boolean
    S->>DE: dictionaryObjectEventMatchesLookup(event, lookupKey)
    DE-->>S: boolean
    S->>C: listener() (if matched)
```
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: clean up i18n store helpers"](https://github.com/generaltranslation/gt/commit/1d767ad4eb7ae9bc1c731a48899021c9ee963566) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34082114)</sub>

<!-- /greptile_comment -->