### PR TITLE
refactor(i18n): store gtServicesEnabled on global object

### DIFF
--- a/packages/i18n/src/i18n-cache/I18nCache.ts
+++ b/packages/i18n/src/i18n-cache/I18nCache.ts
@@ -29,6 +29,7 @@ import { TRANSLATIONS_CACHE_MISS_EVENT_NAME } from './event-subscription/types';
 import type { I18nEvents } from './event-subscription/types';
 import { getRuntimeEnvironment } from '../utils/getRuntimeEnvironment';
 import { getI18nConfig } from '../i18n-config/singleton-operations';
+import { setupGTServicesEnabled } from '../setup/globals';
 import type { CustomMapping } from '@generaltranslation/format/types';
 
 /**
@@ -84,6 +85,8 @@ class I18nCache<
    */
   constructor(params: I18nCacheConstructorParams<TranslationValue>) {
     super();
+
+    setupGTServicesEnabled(params);
 
     // Validation
     publishValidationResults(validateConfig(params), 'I18nCache: ');

--- a/packages/i18n/src/i18n-cache/utils/getGTServicesEnabled.ts
+++ b/packages/i18n/src/i18n-cache/utils/getGTServicesEnabled.ts
@@ -1,26 +1,6 @@
-import {
-  getLoadTranslationsType,
-  LoadTranslationsType,
-} from './getLoadTranslationsType';
-import {
-  getTranslationApiType,
-  TranslationApiType,
-} from './getTranslationApiType';
-
-/**
- * Returns true if GT services are enabled
- * @param config - The configuration
- * @returns True if GT services are enabled
- */
-export function getGTServicesEnabled(config: {
-  projectId?: string;
-  devApiKey?: string;
-  apiKey?: string;
-  cacheUrl?: string | null;
-  runtimeUrl?: string | null;
-}): boolean {
-  return (
-    getLoadTranslationsType(config) === LoadTranslationsType.GT_REMOTE ||
-    getTranslationApiType(config) === TranslationApiType.GT
-  );
-}
+export { evaluateGTServicesEnabled } from '../../setup/evaluateGTServicesEnabled';
+export {
+  getGTServicesEnabled,
+  setupGTServicesEnabled,
+} from '../../setup/globals';
+export type { GTServicesSetupParams } from '../../setup/types';

--- a/packages/i18n/src/i18n-cache/validation/config-validation/__tests__/validateLocales.test.ts
+++ b/packages/i18n/src/i18n-cache/validation/config-validation/__tests__/validateLocales.test.ts
@@ -1,12 +1,20 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { setupGTServicesEnabled } from '../../../utils/getGTServicesEnabled';
 import { validateLocales } from '../validateLocales';
 
 describe('validateLocales', () => {
+  beforeEach(() => {
+    setupGTServicesEnabled({});
+  });
+
   it('validates invalid locale when GT services enabled', () => {
+    setupGTServicesEnabled({
+      projectId: 'test-project',
+      cacheUrl: undefined,
+    });
+
     const result = validateLocales({
       defaultLocale: 'invalid-locale',
-      projectId: 'test-project',
-      cacheUrl: undefined, // GT_REMOTE enabled
     });
     expect(result).toHaveLength(1);
     expect(result[0].type).toBe('error');
@@ -14,11 +22,14 @@ describe('validateLocales', () => {
   });
 
   it('validates multiple locales when GT services enabled', () => {
+    setupGTServicesEnabled({
+      projectId: 'test-project',
+      runtimeUrl: undefined,
+    });
+
     const result = validateLocales({
       locales: ['en', 'invalid-locale'],
       defaultLocale: 'en',
-      projectId: 'test-project',
-      runtimeUrl: undefined, // GT enabled
     });
     expect(result).toHaveLength(1);
     expect(result[0].type).toBe('error');
@@ -26,10 +37,13 @@ describe('validateLocales', () => {
   });
 
   it('skips validation when GT services disabled', () => {
-    const result = validateLocales({
-      defaultLocale: 'invalid-locale',
+    setupGTServicesEnabled({
       cacheUrl: null,
       runtimeUrl: null,
+    });
+
+    const result = validateLocales({
+      defaultLocale: 'invalid-locale',
     });
     expect(result).toHaveLength(0);
   });

--- a/packages/i18n/src/i18n-cache/validation/config-validation/validateLocales.ts
+++ b/packages/i18n/src/i18n-cache/validation/config-validation/validateLocales.ts
@@ -12,17 +12,12 @@ import type { CustomMapping } from '@generaltranslation/format/types';
  * Only apply if using GT services
  */
 export function validateLocales(params: {
-  projectId?: string;
-  devApiKey?: string;
-  apiKey?: string;
   defaultLocale?: string;
   locales?: string[];
   customMapping?: CustomMapping;
-  cacheUrl?: string | null;
-  runtimeUrl?: string | null;
 }): ValidationResult[] {
   const results: ValidationResult[] = [];
-  if (!getGTServicesEnabled(params)) {
+  if (!getGTServicesEnabled()) {
     return results;
   }
   const { defaultLocale, locales, customMapping } = params;

--- a/packages/i18n/src/i18n-config/singleton-operations.ts
+++ b/packages/i18n/src/i18n-config/singleton-operations.ts
@@ -1,4 +1,8 @@
+import { setupGTServicesEnabled } from '../setup/globals';
+import type { GTServicesSetupParams } from '../setup/types';
 import { I18nConfig, type I18nConfigParams } from './I18nConfig';
+
+export type I18nConfigInitializeParams = I18nConfigParams & GTServicesSetupParams;
 
 let i18nConfig: I18nConfig | undefined = undefined;
 
@@ -16,8 +20,9 @@ export function setI18nConfig(nextI18nConfig: I18nConfig): void {
 }
 
 export function initializeI18nConfig(
-  params: I18nConfigParams = {}
+  params: I18nConfigInitializeParams = {}
 ): I18nConfig {
+  setupGTServicesEnabled(params);
   const nextI18nConfig = new I18nConfig(params);
   setI18nConfig(nextI18nConfig);
   return nextI18nConfig;

--- a/packages/i18n/src/internal.ts
+++ b/packages/i18n/src/internal.ts
@@ -30,6 +30,12 @@ export {
   isI18nConfigInitialized,
   setI18nConfig,
 } from './i18n-config/singleton-operations';
+export type { I18nConfigInitializeParams } from './i18n-config/singleton-operations';
+export {
+  getGTServicesEnabled,
+  setupGTServicesEnabled,
+} from './setup/globals';
+export type { GTServicesSetupParams } from './setup/types';
 export { I18nConfig } from './i18n-config/I18nConfig';
 export type { I18nConfigParams } from './i18n-config/I18nConfig';
 /** @deprecated use getI18nCache instead */

--- a/packages/i18n/src/setup/__tests__/globals.test.ts
+++ b/packages/i18n/src/setup/__tests__/globals.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getGTServicesEnabled,
+  setupGTServicesEnabled,
+} from '../globals';
+
+describe('gtServicesEnabled globals', () => {
+  it('throws before initialization', () => {
+    delete globalThis.__generaltranslation?.gtServicesEnabled;
+
+    expect(() => getGTServicesEnabled()).toThrow(
+      'Cannot read gtServicesEnabled. GT has not been initialized.'
+    );
+  });
+
+  it('stores the evaluated gt services flag', () => {
+    setupGTServicesEnabled({
+      projectId: 'test-project',
+      cacheUrl: undefined,
+    });
+    expect(getGTServicesEnabled()).toBe(true);
+
+    setupGTServicesEnabled({
+      cacheUrl: null,
+      runtimeUrl: null,
+    });
+    expect(getGTServicesEnabled()).toBe(false);
+  });
+});

--- a/packages/i18n/src/setup/evaluateGTServicesEnabled.ts
+++ b/packages/i18n/src/setup/evaluateGTServicesEnabled.ts
@@ -1,0 +1,21 @@
+import {
+  getLoadTranslationsType,
+  LoadTranslationsType,
+} from '../i18n-cache/utils/getLoadTranslationsType';
+import {
+  getTranslationApiType,
+  TranslationApiType,
+} from '../i18n-cache/utils/getTranslationApiType';
+import type { GTServicesSetupParams } from './types';
+
+/**
+ * Returns true if GT services are enabled for the given configuration.
+ */
+export function evaluateGTServicesEnabled(
+  config: GTServicesSetupParams
+): boolean {
+  return (
+    getLoadTranslationsType(config) === LoadTranslationsType.GT_REMOTE ||
+    getTranslationApiType(config) === TranslationApiType.GT
+  );
+}

--- a/packages/i18n/src/setup/globals.ts
+++ b/packages/i18n/src/setup/globals.ts
@@ -1,0 +1,30 @@
+import { evaluateGTServicesEnabled } from './evaluateGTServicesEnabled';
+import type { GTServicesSetupParams } from './types';
+
+declare global {
+  var __generaltranslation: {
+    renderStrategy?: 'SPA' | 'server-render';
+    gtServicesEnabled?: boolean;
+  };
+}
+
+const globalState = (globalThis.__generaltranslation ??= {});
+
+/**
+ * Evaluate whether GT services are enabled and persist the result on the global object.
+ */
+export function setupGTServicesEnabled(config: GTServicesSetupParams): void {
+  globalState.gtServicesEnabled = evaluateGTServicesEnabled(config);
+}
+
+/**
+ * Returns true if GT services are enabled.
+ */
+export function getGTServicesEnabled(): boolean {
+  if (globalState.gtServicesEnabled === undefined) {
+    throw new Error(
+      'Cannot read gtServicesEnabled. GT has not been initialized.'
+    );
+  }
+  return globalState.gtServicesEnabled;
+}

--- a/packages/i18n/src/setup/types.ts
+++ b/packages/i18n/src/setup/types.ts
@@ -1,0 +1,10 @@
+/**
+ * Configuration fields used to determine whether GT cloud services are enabled.
+ */
+export type GTServicesSetupParams = {
+  projectId?: string;
+  devApiKey?: string;
+  apiKey?: string;
+  cacheUrl?: string | null;
+  runtimeUrl?: string | null;
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Store `gtServicesEnabled` on `globalThis.__generaltranslation`, following the same pattern as `renderStrategy` in react-core.

- Add `setupGTServicesEnabled` / `getGTServicesEnabled` in `packages/i18n/src/setup`
- Call setup from `initializeI18nConfig` and `I18nCache` construction
- Simplify `validateLocales` to read the global flag instead of accepting GT credential fields

Base: `e/odysseus/cleanup-i18n-store-dead-code`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-df0f4bde-1ed1-49ca-96ab-0fcfb3262d0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-df0f4bde-1ed1-49ca-96ab-0fcfb3262d0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1501"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782492721&installation_id=127936663&pr_number=1501&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1501&signature=979f920dda60b1373a8ef83f49a7a77b70bcb941e4fd29a6ca680dc5a26f90ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->