### PR TITLE
fix: remove default setup locales

### DIFF
--- a/.changeset/remove-default-setup-locales.md
+++ b/.changeset/remove-default-setup-locales.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+Remove default target locales from the setup prompt.

--- a/packages/cli/src/setup/userInput.ts
+++ b/packages/cli/src/setup/userInput.ts
@@ -14,7 +14,6 @@ export async function getDesiredLocales(): Promise<{
   // Ask for the locales
   const locales = await promptLocaleList({
     message: 'Which languages would you like to translate your project into?',
-    defaultValue: ['es', 'fr', 'de', 'ja', 'zh'],
   });
   return { defaultLocale, locales };
 }


### PR DESCRIPTION
## Summary
- Remove the preselected target locales from the CLI setup locale prompt.
- Add a patch changeset for the CLI package.

## Tests
- pnpm build
- pnpm --filter gt test
- pnpm --filter gt typecheck

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1502"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782495247&installation_id=127936663&pr_number=1502&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1502&signature=d0ffaa7ae2c0a0c467307ef2e50e8e2305e8176b6dd719651bceb39dfe3ccfeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes the pre-populated default locale list (`es`, `fr`, `de`, `ja`, `zh`) from the CLI setup prompt so users start with a blank field and choose their own target locales.

- `packages/cli/src/setup/userInput.ts`: Drops `defaultValue` from the `promptLocaleList` call; both the ink and clack prompt paths already handle `undefined` defaults gracefully, so no behavioral issues arise.
- `.changeset/remove-default-setup-locales.md`: Adds a patch changeset correctly scoped to the `gt` package.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a one-line removal of hardcoded defaults, and both prompt paths handle a missing default gracefully.

The only change is dropping a pre-filled locale list from a CLI prompt. The underlying `promptLocaleList` function already accepts an optional `defaultValue` and handles `undefined` correctly in both the ink and clack code paths. No logic, validation, or data flow is altered.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/setup/userInput.ts | Removes the hardcoded `defaultValue: ['es', 'fr', 'de', 'ja', 'zh']` from the locale list prompt, leaving the field blank for users to fill in. Both code paths in `promptLocaleList` (ink and clack) handle an absent `defaultValue` gracefully. |
| .changeset/remove-default-setup-locales.md | Adds a patch-level changeset for the `gt` package describing the removal of default locales from the setup prompt. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant CLI as CLI (getDesiredLocales)
    participant Prompt as promptLocaleList

    User->>CLI: runs gt setup
    CLI->>Prompt: "promptLocale({ defaultValue: libraryDefaultLocale })"
    Prompt-->>User: "What is the default locale?" [pre-filled]
    User->>Prompt: confirms/changes default locale
    Prompt-->>CLI: defaultLocale

    CLI->>Prompt: "promptLocaleList({ message }) [no defaultValue]"
    Note over Prompt: Previously showed es fr de ja zh
    Note over Prompt: Now shows empty field
    Prompt-->>User: "Which languages to translate into?" [blank]
    User->>Prompt: enters desired locales
    Prompt-->>CLI: locales[]
    CLI-->>User: setup continues
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: remove default setup locales"](https://github.com/generaltranslation/gt/commit/14bb7d792e93b93187dd3655a70c2650ac472091) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34202209)</sub>

<!-- /greptile_comment -->