### PR TITLE
refactor: store gt services flag globally

### DIFF
--- a/packages/i18n/src/i18n-cache/I18nCache.ts
+++ b/packages/i18n/src/i18n-cache/I18nCache.ts
@@ -30,6 +30,7 @@ import type { I18nEvents } from './event-subscription/types';
 import { getRuntimeEnvironment } from '../utils/getRuntimeEnvironment';
 import { getI18nConfig } from '../i18n-config/singleton-operations';
 import type { CustomMapping } from '@generaltranslation/format/types';
+import { setupGTServicesEnabled } from './utils/getGTServicesEnabled';
 
 /**
  * Default translation timeout in milliseconds for a runtime translation request
@@ -84,6 +85,8 @@ class I18nCache<
    */
   constructor(params: I18nCacheConstructorParams<TranslationValue>) {
     super();
+
+    setupGTServicesEnabled(params);
 
     // Validation
     const validationResults = validateConfig(params);

--- a/packages/i18n/src/i18n-cache/utils/__tests__/getGTServicesEnabled.test.ts
+++ b/packages/i18n/src/i18n-cache/utils/__tests__/getGTServicesEnabled.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getGTServicesEnabled,
+  setGTServicesEnabled,
+  setupGTServicesEnabled,
+} from '../getGTServicesEnabled';
+
+describe('getGTServicesEnabled', () => {
+  it('stores true when GT remote translations are enabled', () => {
+    setupGTServicesEnabled({ projectId: 'test-project' });
+
+    expect(getGTServicesEnabled()).toBe(true);
+  });
+
+  it('stores true when the GT runtime API is enabled', () => {
+    setupGTServicesEnabled({
+      projectId: 'test-project',
+      devApiKey: 'test-key',
+      cacheUrl: null,
+    });
+
+    expect(getGTServicesEnabled()).toBe(true);
+  });
+
+  it('stores false when GT services are disabled', () => {
+    setupGTServicesEnabled({
+      cacheUrl: null,
+      runtimeUrl: null,
+    });
+
+    expect(getGTServicesEnabled()).toBe(false);
+  });
+
+  it('allows runtimes to hydrate a previously computed value', () => {
+    setGTServicesEnabled(true);
+
+    expect(getGTServicesEnabled()).toBe(true);
+  });
+});

--- a/packages/i18n/src/i18n-cache/utils/getGTServicesEnabled.ts
+++ b/packages/i18n/src/i18n-cache/utils/getGTServicesEnabled.ts
@@ -7,20 +7,55 @@ import {
   TranslationApiType,
 } from './getTranslationApiType';
 
-/**
- * Returns true if GT services are enabled
- * @param config - The configuration
- * @returns True if GT services are enabled
- */
-export function getGTServicesEnabled(config: {
+export type GTServicesEnabledParams = {
   projectId?: string;
   devApiKey?: string;
   apiKey?: string;
   cacheUrl?: string | null;
   runtimeUrl?: string | null;
-}): boolean {
-  return (
+};
+
+declare global {
+  var __generaltranslation_i18n:
+    | {
+        gtServicesEnabled: boolean | undefined;
+      }
+    | undefined;
+}
+
+function getI18nGlobals() {
+  globalThis.__generaltranslation_i18n ??= {
+    gtServicesEnabled: undefined,
+  };
+  return globalThis.__generaltranslation_i18n;
+}
+
+/**
+ * Sets whether GT services are enabled.
+ * Use this when the value has already been computed outside this runtime.
+ */
+export function setGTServicesEnabled(gtServicesEnabled: boolean): void {
+  getI18nGlobals().gtServicesEnabled = gtServicesEnabled;
+}
+
+/**
+ * Evaluates and stores whether GT services are enabled.
+ * @param config - The configuration
+ * @returns True if GT services are enabled
+ */
+export function setupGTServicesEnabled(
+  config: GTServicesEnabledParams = {}
+): boolean {
+  const gtServicesEnabled =
     getLoadTranslationsType(config) === LoadTranslationsType.GT_REMOTE ||
-    getTranslationApiType(config) === TranslationApiType.GT
-  );
+    getTranslationApiType(config) === TranslationApiType.GT;
+  setGTServicesEnabled(gtServicesEnabled);
+  return gtServicesEnabled;
+}
+
+/**
+ * Returns true if GT services are enabled.
+ */
+export function getGTServicesEnabled(): boolean {
+  return getI18nGlobals().gtServicesEnabled ?? false;
 }

--- a/packages/i18n/src/i18n-cache/validation/config-validation/__tests__/validateLocales.test.ts
+++ b/packages/i18n/src/i18n-cache/validation/config-validation/__tests__/validateLocales.test.ts
@@ -1,12 +1,15 @@
 import { describe, it, expect } from 'vitest';
 import { validateLocales } from '../validateLocales';
+import { setupGTServicesEnabled } from '../../../utils/getGTServicesEnabled';
 
 describe('validateLocales', () => {
   it('validates invalid locale when GT services enabled', () => {
-    const result = validateLocales({
-      defaultLocale: 'invalid-locale',
+    setupGTServicesEnabled({
       projectId: 'test-project',
       cacheUrl: undefined, // GT_REMOTE enabled
+    });
+    const result = validateLocales({
+      defaultLocale: 'invalid-locale',
     });
     expect(result).toHaveLength(1);
     expect(result[0].type).toBe('error');
@@ -14,11 +17,14 @@ describe('validateLocales', () => {
   });
 
   it('validates multiple locales when GT services enabled', () => {
+    setupGTServicesEnabled({
+      projectId: 'test-project',
+      devApiKey: 'test-key',
+      runtimeUrl: undefined, // GT enabled
+    });
     const result = validateLocales({
       locales: ['en', 'invalid-locale'],
       defaultLocale: 'en',
-      projectId: 'test-project',
-      runtimeUrl: undefined, // GT enabled
     });
     expect(result).toHaveLength(1);
     expect(result[0].type).toBe('error');
@@ -26,10 +32,12 @@ describe('validateLocales', () => {
   });
 
   it('skips validation when GT services disabled', () => {
-    const result = validateLocales({
-      defaultLocale: 'invalid-locale',
+    setupGTServicesEnabled({
       cacheUrl: null,
       runtimeUrl: null,
+    });
+    const result = validateLocales({
+      defaultLocale: 'invalid-locale',
     });
     expect(result).toHaveLength(0);
   });

--- a/packages/i18n/src/i18n-cache/validation/config-validation/validateLocales.ts
+++ b/packages/i18n/src/i18n-cache/validation/config-validation/validateLocales.ts
@@ -12,17 +12,13 @@ import type { CustomMapping } from '@generaltranslation/format/types';
  * Only apply if using GT services
  */
 export function validateLocales(params: {
-  projectId?: string;
-  devApiKey?: string;
-  apiKey?: string;
   defaultLocale?: string;
   locales?: string[];
   customMapping?: CustomMapping;
-  cacheUrl?: string | null;
-  runtimeUrl?: string | null;
+  [key: string]: unknown;
 }): ValidationResult[] {
   const results: ValidationResult[] = [];
-  if (!getGTServicesEnabled(params)) {
+  if (!getGTServicesEnabled()) {
     return results;
   }
   const { defaultLocale, locales, customMapping } = params;

--- a/packages/i18n/src/i18n-config/singleton-operations.ts
+++ b/packages/i18n/src/i18n-config/singleton-operations.ts
@@ -1,5 +1,9 @@
 import { createDiagnosticMessage } from 'generaltranslation/internal';
 import { I18nConfig, type I18nConfigParams } from './I18nConfig';
+import {
+  setupGTServicesEnabled,
+  type GTServicesEnabledParams,
+} from '../i18n-cache/utils/getGTServicesEnabled';
 
 let i18nConfig: I18nConfig | undefined = undefined;
 
@@ -17,6 +21,7 @@ export function setI18nConfig(nextI18nConfig: I18nConfig): void {
 export function initializeI18nConfig(
   params: I18nConfigParams = {}
 ): I18nConfig {
+  setupGTServicesEnabled(params as GTServicesEnabledParams);
   const nextI18nConfig = new I18nConfig(params);
   setI18nConfig(nextI18nConfig);
   return nextI18nConfig;

--- a/packages/i18n/src/internal-types.ts
+++ b/packages/i18n/src/internal-types.ts
@@ -29,6 +29,7 @@ export type {
 } from './i18n-cache/translations-manager/DictionaryCache';
 export type { ReadonlyConditionStoreParams } from './condition-store/ReadonlyConditionStore';
 export type { WritableConditionStoreParams } from './condition-store/WritableConditionStore';
+export type { GTServicesEnabledParams } from './i18n-cache/utils/getGTServicesEnabled';
 
 // Translation Options (Function types exported by /types)
 export type * from './translation-functions/types/options';

--- a/packages/i18n/src/internal.ts
+++ b/packages/i18n/src/internal.ts
@@ -20,6 +20,11 @@ export {
   getDictionaryValue,
   resolveDictionaryLookupOptions,
 } from './i18n-cache/translations-manager/utils/dictionary-helpers';
+export {
+  getGTServicesEnabled,
+  setGTServicesEnabled,
+  setupGTServicesEnabled,
+} from './i18n-cache/utils/getGTServicesEnabled';
 
 /** @deprecated use I18nCache instead */
 export { I18nCache as I18nManager } from './i18n-cache/I18nCache';

--- a/packages/next/src/provider/ClientProviderWrapper.tsx
+++ b/packages/next/src/provider/ClientProviderWrapper.tsx
@@ -6,6 +6,11 @@ import { useCallback, useEffect, useMemo } from 'react';
 import { standardizeLocale } from '@generaltranslation/format';
 import { GT } from 'generaltranslation';
 import { useRouter } from 'next/navigation';
+import { getGTServicesEnabled, setGTServicesEnabled } from 'gt-i18n/internal';
+
+setGTServicesEnabled(
+  process.env._GENERALTRANSLATION_GT_SERVICES_ENABLED === 'true'
+);
 
 function extractLocale(pathname: string, gt: GT): string | null {
   const matches = pathname.match(/^\/([^/]+)(?:\/|$)/);
@@ -23,7 +28,6 @@ export function ClientProviderWrapper(
     locale,
     locales,
     defaultLocale,
-    gtServicesEnabled,
     referrerLocaleCookieName,
     localeRoutingEnabledCookieName,
     devApiKey,
@@ -31,6 +35,7 @@ export function ClientProviderWrapper(
     runtimeUrl,
     customMapping,
   } = props;
+  const gtServicesEnabled = getGTServicesEnabled();
 
   /**
    * Reloads server components

--- a/packages/next/src/provider/GTProvider.tsx
+++ b/packages/next/src/provider/GTProvider.tsx
@@ -87,9 +87,6 @@ export async function GTProvider({
       environment={
         process.env.NODE_ENV as 'development' | 'production' | 'test'
       }
-      gtServicesEnabled={
-        process.env._GENERALTRANSLATION_GT_SERVICES_ENABLED === 'true'
-      }
       {...I18NConfig.getClientSideConfig()}
     >
       {children}

--- a/packages/react/src/deprecated/react-context/types/config.ts
+++ b/packages/react/src/deprecated/react-context/types/config.ts
@@ -33,7 +33,6 @@ export type ClientProviderProps = {
   projectId?: string;
   devApiKey?: string;
   runtimeUrl?: string | null;
-  gtServicesEnabled?: boolean;
   localeCookieName?: string;
   resetLocaleCookieName: string;
   regionCookieName?: string;


### PR DESCRIPTION
## Summary
- store GT services enabled state on an i18n-owned global
- initialize the flag from i18n setup paths and read it through a dedicated getter
- remove Next client prop plumbing for gtServicesEnabled

## Testing
- pnpm --filter gt-i18n test
- pnpm --filter gt-i18n typecheck
- pnpm --filter gt-next typecheck
- pnpm build
- pnpm exec oxfmt --check <changed files>
- pnpm exec oxlint <changed files>

Note: full pnpm format / pnpm lint hit an existing unrelated oxfmt issue in packages/node/src/async-i18n-cache/__tests__/AsyncConditionStore.test.ts.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1503"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782495333&installation_id=127936663&pr_number=1503&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1503&signature=d8c720a9dac0fcb34d750dfcc1f71f81857a0533d74e92a3d532873cd58cc69f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves the `gtServicesEnabled` flag from a React prop (computed in the server component and passed down) to a `globalThis`-backed singleton in `gt-i18n`, with a dedicated setup/get/set triad. The build-time constant inlined by `withGTConfig` is used to hydrate the global on the client side at module load time.

- `getGTServicesEnabled.ts` introduces `setupGTServicesEnabled`, `setGTServicesEnabled`, and `getGTServicesEnabled` backed by `globalThis.__generaltranslation_i18n`, replacing the previous pure-function form.
- `GTProvider.tsx` drops the `gtServicesEnabled` prop; `ClientProviderWrapper.tsx` reads the value from the new global instead, initialized by a module-level `setGTServicesEnabled` call.
- `validateLocales` is simplified to call `getGTServicesEnabled()` with no arguments, removing the config params it previously required.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the build-time constant is correctly exposed via withGTConfig and inlined in both bundles, making the removal of the React prop a clean substitution.

The core logic is sound. The main rough edges are missing beforeEach cleanup in the new test files and the overly broad index signature on validateLocales. Neither affects runtime behaviour today, but the test-isolation gap could mask future bugs in the global-state machinery.

The two new test files would benefit from an explicit global-state reset in beforeEach, and validateLocales.ts has a broadened index signature worth tightening.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/i18n/src/i18n-cache/utils/getGTServicesEnabled.ts | Core refactor: replaces pure function with a globalThis-backed singleton (setup/get/set triad); safe but has a ?? false fallback for uninitialized state and no enforced initialization order. |
| packages/next/src/provider/ClientProviderWrapper.tsx | Module-level setGTServicesEnabled replaces the removed gtServicesEnabled prop; env var is correctly exposed via withGTConfig's Next.js env block, so the value is inlined in both server and client bundles. |
| packages/i18n/src/i18n-config/singleton-operations.ts | initializeI18nConfig now calls setupGTServicesEnabled before constructing I18nConfig; the as GTServicesEnabledParams cast is safe since GTServicesEnabledParams is a subset of I18nConfigParams. |
| packages/i18n/src/i18n-cache/utils/__tests__/getGTServicesEnabled.test.ts | New test file covering the setup/get/set surface; tests mutate globalThis without a beforeEach reset, creating implicit ordering sensitivity. |
| packages/i18n/src/i18n-cache/validation/config-validation/__tests__/validateLocales.test.ts | Tests updated to call setupGTServicesEnabled before each validateLocales call; similarly lacks beforeEach reset of the global. |
| packages/i18n/src/i18n-cache/I18nCache.ts | setupGTServicesEnabled correctly added before publishValidationResults, ensuring the global is initialized before locale validation runs. |
| packages/next/src/provider/GTProvider.tsx | Removed gtServicesEnabled prop pass-through; clean removal with no missing dependencies. |
| packages/react/src/deprecated/react-context/types/config.ts | Removed gtServicesEnabled from ClientProviderProps; straightforward type cleanup matching the implementation change. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Build as withGTConfig (build)
    participant Init as initializeI18nConfig
    participant Cache as I18nCache constructor
    participant Global as globalThis.__generaltranslation_i18n
    participant CPW as ClientProviderWrapper (module load)
    participant Render as Component render

    Build->>Build: compute gtServicesEnabled from config
    Build->>Build: set env._GENERALTRANSLATION_GT_SERVICES_ENABLED

    Init->>Global: setupGTServicesEnabled(params)
    Note over Global: gtServicesEnabled = computed from config

    Cache->>Global: setupGTServicesEnabled(params)
    Note over Global: gtServicesEnabled = computed from I18nCache params

    CPW->>Global: "setGTServicesEnabled(env === 'true')"
    Note over CPW: runs once at module load on server and client
    Note over Global: gtServicesEnabled = env var value

    Render->>Global: getGTServicesEnabled()
    Global-->>Render: boolean (false if uninitialised)
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Apackages%2Fi18n%2Fsrc%2Fi18n-cache%2Futils%2F__tests__%2FgetGTServicesEnabled.test.ts%3A1-8%0ANo%20%60beforeEach%60%20resets%20%60globalThis.__generaltranslation_i18n%60%20between%20tests.%20Each%20test%20does%20call%20a%20setup%20function%20before%20asserting%2C%20so%20the%20current%20order%20is%20fine%2C%20but%20if%20tests%20are%20ever%20shuffled%20or%20a%20new%20test%20is%20inserted%20that%20reads%20the%20flag%20without%20setting%20it%20first%2C%20it%20will%20silently%20inherit%20the%20previous%20test's%20state.%20Adding%20a%20reset%20guard%20makes%20the%20suite%20order-independent.%0A%0A%60%60%60suggestion%0Aimport%20%7B%20beforeEach%2C%20describe%2C%20expect%2C%20it%20%7D%20from%20'vitest'%3B%0Aimport%20%7B%0A%20%20getGTServicesEnabled%2C%0A%20%20setGTServicesEnabled%2C%0A%20%20setupGTServicesEnabled%2C%0A%7D%20from%20'..%2FgetGTServicesEnabled'%3B%0A%0Adescribe%28'getGTServicesEnabled'%2C%20%28%29%20%3D%3E%20%7B%0A%20%20beforeEach%28%28%29%20%3D%3E%20%7B%0A%20%20%20%20globalThis.__generaltranslation_i18n%20%3D%20undefined%3B%0A%20%20%7D%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Apackages%2Fi18n%2Fsrc%2Fi18n-cache%2Fvalidation%2Fconfig-validation%2F__tests__%2FvalidateLocales.test.ts%3A1-5%0ASame%20global-state%20leakage%20risk%20as%20the%20%60getGTServicesEnabled%60%20tests%20%E2%80%94%20no%20%60beforeEach%60%20resets%20the%20shared%20%60globalThis.__generaltranslation_i18n%60.%20Since%20every%20test%20calls%20%60setupGTServicesEnabled%60%20before%20asserting%2C%20the%20current%20tests%20pass%20in%20order%2C%20but%20the%20absence%20of%20an%20explicit%20reset%20makes%20the%20suite%20fragile%20under%20reordering%20or%20future%20additions.%0A%0A%60%60%60suggestion%0Aimport%20%7B%20beforeEach%2C%20describe%2C%20it%2C%20expect%20%7D%20from%20'vitest'%3B%0Aimport%20%7B%20validateLocales%20%7D%20from%20'..%2FvalidateLocales'%3B%0Aimport%20%7B%20setupGTServicesEnabled%20%7D%20from%20'..%2F..%2F..%2Futils%2FgetGTServicesEnabled'%3B%0A%0Adescribe%28'validateLocales'%2C%20%28%29%20%3D%3E%20%7B%0A%20%20beforeEach%28%28%29%20%3D%3E%20%7B%0A%20%20%20%20globalThis.__generaltranslation_i18n%20%3D%20undefined%3B%0A%20%20%7D%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Apackages%2Fi18n%2Fsrc%2Fi18n-cache%2Fvalidation%2Fconfig-validation%2FvalidateLocales.ts%3A18%0AThis%20catch-all%20index%20signature%20widens%20the%20function's%20type%20contract%20beyond%20what%20is%20actually%20consumed.%20Since%20only%20%60defaultLocale%60%2C%20%60locales%60%2C%20and%20%60customMapping%60%20are%20read%2C%20the%20extra%20spread%20can%20be%20removed%20to%20keep%20callers%20constrained.%0A%0A&repo=generaltranslation%2Fgt&pr=1503&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fodysseus%2Fglobal-gt-services-enabled%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fodysseus%2Fglobal-gt-services-enabled%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Apackages%2Fi18n%2Fsrc%2Fi18n-cache%2Futils%2F__tests__%2FgetGTServicesEnabled.test.ts%3A1-8%0ANo%20%60beforeEach%60%20resets%20%60globalThis.__generaltranslation_i18n%60%20between%20tests.%20Each%20test%20does%20call%20a%20setup%20function%20before%20asserting%2C%20so%20the%20current%20order%20is%20fine%2C%20but%20if%20tests%20are%20ever%20shuffled%20or%20a%20new%20test%20is%20inserted%20that%20reads%20the%20flag%20without%20setting%20it%20first%2C%20it%20will%20silently%20inherit%20the%20previous%20test's%20state.%20Adding%20a%20reset%20guard%20makes%20the%20suite%20order-independent.%0A%0A%60%60%60suggestion%0Aimport%20%7B%20beforeEach%2C%20describe%2C%20expect%2C%20it%20%7D%20from%20'vitest'%3B%0Aimport%20%7B%0A%20%20getGTServicesEnabled%2C%0A%20%20setGTServicesEnabled%2C%0A%20%20setupGTServicesEnabled%2C%0A%7D%20from%20'..%2FgetGTServicesEnabled'%3B%0A%0Adescribe%28'getGTServicesEnabled'%2C%20%28%29%20%3D%3E%20%7B%0A%20%20beforeEach%28%28%29%20%3D%3E%20%7B%0A%20%20%20%20globalThis.__generaltranslation_i18n%20%3D%20undefined%3B%0A%20%20%7D%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Apackages%2Fi18n%2Fsrc%2Fi18n-cache%2Fvalidation%2Fconfig-validation%2F__tests__%2FvalidateLocales.test.ts%3A1-5%0ASame%20global-state%20leakage%20risk%20as%20the%20%60getGTServicesEnabled%60%20tests%20%E2%80%94%20no%20%60beforeEach%60%20resets%20the%20shared%20%60globalThis.__generaltranslation_i18n%60.%20Since%20every%20test%20calls%20%60setupGTServicesEnabled%60%20before%20asserting%2C%20the%20current%20tests%20pass%20in%20order%2C%20but%20the%20absence%20of%20an%20explicit%20reset%20makes%20the%20suite%20fragile%20under%20reordering%20or%20future%20additions.%0A%0A%60%60%60suggestion%0Aimport%20%7B%20beforeEach%2C%20describe%2C%20it%2C%20expect%20%7D%20from%20'vitest'%3B%0Aimport%20%7B%20validateLocales%20%7D%20from%20'..%2FvalidateLocales'%3B%0Aimport%20%7B%20setupGTServicesEnabled%20%7D%20from%20'..%2F..%2F..%2Futils%2FgetGTServicesEnabled'%3B%0A%0Adescribe%28'validateLocales'%2C%20%28%29%20%3D%3E%20%7B%0A%20%20beforeEach%28%28%29%20%3D%3E%20%7B%0A%20%20%20%20globalThis.__generaltranslation_i18n%20%3D%20undefined%3B%0A%20%20%7D%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Apackages%2Fi18n%2Fsrc%2Fi18n-cache%2Fvalidation%2Fconfig-validation%2FvalidateLocales.ts%3A18%0AThis%20catch-all%20index%20signature%20widens%20the%20function's%20type%20contract%20beyond%20what%20is%20actually%20consumed.%20Since%20only%20%60defaultLocale%60%2C%20%60locales%60%2C%20and%20%60customMapping%60%20are%20read%2C%20the%20extra%20spread%20can%20be%20removed%20to%20keep%20callers%20constrained.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
packages/i18n/src/i18n-cache/utils/__tests__/getGTServicesEnabled.test.ts:1-8
No `beforeEach` resets `globalThis.__generaltranslation_i18n` between tests. Each test does call a setup function before asserting, so the current order is fine, but if tests are ever shuffled or a new test is inserted that reads the flag without setting it first, it will silently inherit the previous test's state. Adding a reset guard makes the suite order-independent.

```suggestion
import { beforeEach, describe, expect, it } from 'vitest';
import {
  getGTServicesEnabled,
  setGTServicesEnabled,
  setupGTServicesEnabled,
} from '../getGTServicesEnabled';

describe('getGTServicesEnabled', () => {
  beforeEach(() => {
    globalThis.__generaltranslation_i18n = undefined;
  });
```

### Issue 2 of 3
packages/i18n/src/i18n-cache/validation/config-validation/__tests__/validateLocales.test.ts:1-5
Same global-state leakage risk as the `getGTServicesEnabled` tests — no `beforeEach` resets the shared `globalThis.__generaltranslation_i18n`. Since every test calls `setupGTServicesEnabled` before asserting, the current tests pass in order, but the absence of an explicit reset makes the suite fragile under reordering or future additions.

```suggestion
import { beforeEach, describe, it, expect } from 'vitest';
import { validateLocales } from '../validateLocales';
import { setupGTServicesEnabled } from '../../../utils/getGTServicesEnabled';

describe('validateLocales', () => {
  beforeEach(() => {
    globalThis.__generaltranslation_i18n = undefined;
  });
```

### Issue 3 of 3
packages/i18n/src/i18n-cache/validation/config-validation/validateLocales.ts:18
This catch-all index signature widens the function's type contract beyond what is actually consumed. Since only `defaultLocale`, `locales`, and `customMapping` are read, the extra spread can be removed to keep callers constrained.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: store gt services flag globall..."](https://github.com/generaltranslation/gt/commit/ad9716cbb2c9480d2adcca12a61c03e1c15bd2a0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34202500)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->