### PR TITLE
refactor: narrow gt services config types

### DIFF
--- a/packages/i18n/src/globals/__tests__/getGTServicesEnabled.test.ts
+++ b/packages/i18n/src/globals/__tests__/getGTServicesEnabled.test.ts
@@ -33,8 +33,4 @@ describe('getGTServicesEnabled', () => {
 
     expect(getGTServicesEnabled()).toBe(false);
   });
-
-  it('preserves config-based reads before consumers migrate to global reads', () => {
-    expect(getGTServicesEnabled({ projectId: 'test-project' })).toBe(true);
-  });
 });

--- a/packages/i18n/src/globals/getGTServicesEnabled.ts
+++ b/packages/i18n/src/globals/getGTServicesEnabled.ts
@@ -42,16 +42,9 @@ function resolveGTServicesEnabled(config: GTServicesEnabledParams): boolean {
 }
 
 /**
- * Returns true if GT services are enabled
- * @param config - The configuration
- * @returns True if GT services are enabled
+ * Returns true if GT services are enabled.
  */
-export function getGTServicesEnabled(
-  config?: GTServicesEnabledParams
-): boolean {
-  if (config) {
-    return resolveGTServicesEnabled(config);
-  }
+export function getGTServicesEnabled(): boolean {
   return getI18nGlobals().gtServicesEnabled ?? false;
 }
 

--- a/packages/i18n/src/i18n-cache/validation/config-validation/__tests__/validateLocales.test.ts
+++ b/packages/i18n/src/i18n-cache/validation/config-validation/__tests__/validateLocales.test.ts
@@ -1,12 +1,15 @@
 import { describe, it, expect } from 'vitest';
 import { validateLocales } from '../validateLocales';
+import { setupGTServicesEnabled } from '../../../../globals/getGTServicesEnabled';
 
 describe('validateLocales', () => {
   it('validates invalid locale when GT services enabled', () => {
-    const result = validateLocales({
-      defaultLocale: 'invalid-locale',
+    setupGTServicesEnabled({
       projectId: 'test-project',
       cacheUrl: undefined, // GT_REMOTE enabled
+    });
+    const result = validateLocales({
+      defaultLocale: 'invalid-locale',
     });
     expect(result).toHaveLength(1);
     expect(result[0].type).toBe('error');
@@ -14,11 +17,14 @@ describe('validateLocales', () => {
   });
 
   it('validates multiple locales when GT services enabled', () => {
+    setupGTServicesEnabled({
+      projectId: 'test-project',
+      devApiKey: 'test-key',
+      runtimeUrl: undefined, // GT enabled
+    });
     const result = validateLocales({
       locales: ['en', 'invalid-locale'],
       defaultLocale: 'en',
-      projectId: 'test-project',
-      runtimeUrl: undefined, // GT enabled
     });
     expect(result).toHaveLength(1);
     expect(result[0].type).toBe('error');
@@ -26,10 +32,12 @@ describe('validateLocales', () => {
   });
 
   it('skips validation when GT services disabled', () => {
-    const result = validateLocales({
-      defaultLocale: 'invalid-locale',
+    setupGTServicesEnabled({
       cacheUrl: null,
       runtimeUrl: null,
+    });
+    const result = validateLocales({
+      defaultLocale: 'invalid-locale',
     });
     expect(result).toHaveLength(0);
   });

--- a/packages/i18n/src/i18n-cache/validation/config-validation/validateLocales.ts
+++ b/packages/i18n/src/i18n-cache/validation/config-validation/validateLocales.ts
@@ -12,17 +12,12 @@ import type { CustomMapping } from '@generaltranslation/format/types';
  * Only apply if using GT services
  */
 export function validateLocales(params: {
-  projectId?: string;
-  devApiKey?: string;
-  apiKey?: string;
   defaultLocale?: string;
   locales?: string[];
   customMapping?: CustomMapping;
-  cacheUrl?: string | null;
-  runtimeUrl?: string | null;
 }): ValidationResult[] {
   const results: ValidationResult[] = [];
-  if (!getGTServicesEnabled(params)) {
+  if (!getGTServicesEnabled()) {
     return results;
   }
   const { defaultLocale, locales, customMapping } = params;

--- a/packages/i18n/src/i18n-cache/validation/validateConfig.ts
+++ b/packages/i18n/src/i18n-cache/validation/validateConfig.ts
@@ -2,7 +2,6 @@ import { ValidationResult } from './types';
 import { I18nCacheConstructorParams } from '../types';
 import { validateLoadTranslations } from './config-validation/validateLoadTranslations';
 import { validateTranslationApi } from './config-validation/validateTranslationApi';
-import { validateLocales } from './config-validation/validateLocales';
 import { validateDictionary } from './config-validation/validateDictionary';
 import type { Translation } from '../translations-manager/utils/types/translation-data';
 
@@ -18,7 +17,6 @@ export function validateConfig<TranslationValue extends Translation>(
 
   results.push(...validateLoadTranslations(config));
   results.push(...validateTranslationApi(config));
-  results.push(...validateLocales(config));
   results.push(...validateDictionary(config));
 
   return results;

--- a/packages/i18n/src/i18n-config/I18nConfig.ts
+++ b/packages/i18n/src/i18n-config/I18nConfig.ts
@@ -10,11 +10,6 @@ export type I18nConfigParams = {
   defaultLocale?: string;
   locales?: string[];
   customMapping?: CustomMapping;
-  projectId?: string;
-  devApiKey?: string;
-  apiKey?: string;
-  cacheUrl?: string | null;
-  runtimeUrl?: string | null;
 };
 
 export type LocaleCandidates = string | string[] | undefined;

--- a/packages/i18n/src/i18n-config/__tests__/I18nConfig.test.ts
+++ b/packages/i18n/src/i18n-config/__tests__/I18nConfig.test.ts
@@ -1,7 +1,15 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { setupGTServicesEnabled } from '../../globals/getGTServicesEnabled';
 import { I18nConfig } from '../I18nConfig';
 
 describe('I18nConfig', () => {
+  beforeEach(() => {
+    setupGTServicesEnabled({
+      cacheUrl: null,
+      runtimeUrl: null,
+    });
+  });
+
   it('defaults locales to the resolved default locale', () => {
     const config = new I18nConfig({ defaultLocale: 'fr' });
 
@@ -11,21 +19,19 @@ describe('I18nConfig', () => {
   it('skips locale validation when GT services are disabled', () => {
     const config = new I18nConfig({
       defaultLocale: 'invalid-locale',
-      cacheUrl: null,
-      runtimeUrl: null,
     });
 
     expect(config.getDefaultLocale()).toBe('invalid-locale');
   });
 
   it('validates configured locales when GT services are enabled', () => {
+    setupGTServicesEnabled({ projectId: 'test-project' });
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     expect(
       () =>
         new I18nConfig({
           defaultLocale: 'invalid-locale',
-          projectId: 'test-project',
         })
     ).toThrow('Invalid I18nConfig locale configuration');
     expect(errorSpy).toHaveBeenCalledWith(
@@ -36,13 +42,13 @@ describe('I18nConfig', () => {
   });
 
   it('validates custom mapping locales when GT services are enabled', () => {
+    setupGTServicesEnabled({ projectId: 'test-project' });
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     expect(
       () =>
         new I18nConfig({
           defaultLocale: 'en',
-          projectId: 'test-project',
           customMapping: {
             invalidStringMapping: 'invalid-locale',
             invalidObjectMapping: {

--- a/packages/i18n/src/i18n-config/validation.ts
+++ b/packages/i18n/src/i18n-config/validation.ts
@@ -1,14 +1,11 @@
 import { isValidLocale } from '@generaltranslation/format';
-import {
-  createDiagnosticMessage,
-  defaultCacheUrl,
-  defaultRuntimeApiUrl,
-} from 'generaltranslation/internal';
+import { createDiagnosticMessage } from 'generaltranslation/internal';
+import { getGTServicesEnabled } from '../globals/getGTServicesEnabled';
 import logger from '../logs/logger';
 import type { I18nConfigParams } from './I18nConfig';
 
 export function validateI18nConfigParams(params: I18nConfigParams): void {
-  if (!getGTServicesEnabled(params)) {
+  if (!getGTServicesEnabled()) {
     return;
   }
 
@@ -36,21 +33,6 @@ export function validateI18nConfigParams(params: I18nConfigParams): void {
       })
     );
   }
-}
-
-function getGTServicesEnabled({
-  projectId,
-  devApiKey,
-  apiKey,
-  cacheUrl,
-  runtimeUrl,
-}: I18nConfigParams): boolean {
-  return (
-    ((cacheUrl === undefined || cacheUrl === defaultCacheUrl) && !!projectId) ||
-    ((runtimeUrl === undefined || runtimeUrl === defaultRuntimeApiUrl) &&
-      !!projectId &&
-      !!(devApiKey || apiKey))
-  );
 }
 
 function getInvalidLocales({

--- a/packages/next/src/config-dir/I18NConfiguration.ts
+++ b/packages/next/src/config-dir/I18NConfiguration.ts
@@ -25,13 +25,16 @@ import {
   initializeI18nConfig,
   setupGTServicesEnabled,
 } from 'gt-i18n/internal';
-import type { LookupOptions } from 'gt-i18n/internal/types';
+import type {
+  GTServicesEnabledParams,
+  LookupOptions,
+} from 'gt-i18n/internal/types';
 import { loadTranslations } from './loadTranslation';
 
-type I18NConfigurationParams = {
-  apiKey?: string;
-  devApiKey?: string;
-  projectId?: string;
+type I18NConfigurationParams = Omit<
+  GTServicesEnabledParams,
+  'cacheUrl' | 'runtimeUrl'
+> & {
   runtimeUrl: string | undefined;
   cacheUrl: string | null;
   cacheExpiryTime?: number;

--- a/packages/node/src/setup/types.ts
+++ b/packages/node/src/setup/types.ts
@@ -1,7 +1,7 @@
 import type {
-  GTConfig,
-  TranslationsLoader,
-  DictionaryConfig,
+  GTServicesEnabledParams,
+  I18nCacheConstructorParams,
+  I18nConfigParams,
 } from 'gt-i18n/internal/types';
 
 /**
@@ -10,10 +10,9 @@ import type {
  * @param {string[]} params.locales - The locales to support
  * @param {object} params.loadTranslations - The custom translation loader to use
  */
-export type InitializeGTParams = DictionaryConfig &
-  GTConfig & {
-    loadTranslations?: TranslationsLoader;
-  };
+export type InitializeGTParams = I18nConfigParams &
+  GTServicesEnabledParams &
+  I18nCacheConstructorParams<string>;
 
 // Other Reexports
 export type { GTConfig, TranslationsLoader } from 'gt-i18n/internal/types';


### PR DESCRIPTION
## Summary
- switch locale validation to read GT services state from the i18n global
- keep I18nConfigParams locale-only and use GTServicesEnabledParams on initializer types
- remove temporary config-based getGTServicesEnabled reads

## Testing
- pnpm --filter gt-i18n test
- pnpm --filter gt-next typecheck
- pnpm --filter @generaltranslation/react-core typecheck
- pnpm exec oxfmt --check <changed files>
- pnpm exec oxlint <changed files>

Note: gt-i18n / gt-react / gt-node package typechecks still hit existing upstream condition-store LocaleCandidates errors outside this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1507"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782507971&installation_id=127936663&pr_number=1507&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1507&signature=651c16590f193984d8daa4fa06f527a9a46e39b50c17c075c7e62df88719e895"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR narrows the type surface of GT services configuration by splitting the previously mixed `I18nConfigParams` into locale-only and services-enabled concerns, and by making `getGTServicesEnabled` a pure global-state reader that requires `setupGTServicesEnabled` to be called first by initializers.

- **`getGTServicesEnabled` simplified**: the optional `config` parameter is removed; callers must set global state via `setupGTServicesEnabled` before locale validation runs, and `I18NConfiguration` (next) already does this in the right order.
- **`I18nConfigParams` narrowed**: GT-services fields (`projectId`, `devApiKey`, `apiKey`, `cacheUrl`, `runtimeUrl`) are removed from `I18nConfigParams` and from `validateLocales`'s signature; those fields now flow exclusively through `GTServicesEnabledParams`.
- **`validateLocales` removed from `validateConfig`**: locale validation now lives solely in the `I18nConfig` constructor via `validateI18nConfigParams`; the exported `validateLocales` function in `validateLocales.ts` is no longer called from any production code path (flagged in a prior review).

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the refactor is well-scoped and the initialization order (setupGTServicesEnabled before initializeI18nConfig) is correct in all touched call sites.

All changed files perform a straightforward narrowing of types and removal of a temporary config-read path. Locale validation logic itself is unchanged; only the source of the GT-services flag has moved from inline computation to a pre-initialized global. Tests have been updated to match and each test manages global state explicitly.

packages/i18n/src/i18n-cache/validation/config-validation/validateLocales.ts is now unreachable from production code — flagged in a prior review comment and worth cleaning up, but does not affect runtime behavior.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/i18n/src/globals/getGTServicesEnabled.ts | Removes the optional `config` param from `getGTServicesEnabled`, making it a pure global-state reader; callers must use `setupGTServicesEnabled` first. |
| packages/i18n/src/i18n-config/I18nConfig.ts | Strips GT-services fields from `I18nConfigParams`, making the type locale-only as intended. |
| packages/i18n/src/i18n-cache/validation/config-validation/validateLocales.ts | Narrows signature to locale-only params and delegates GT services check to the global; the function is no longer called from `validateConfig.ts`, leaving it as dead exported code (noted in a previous review comment). |
| packages/i18n/src/i18n-cache/validation/validateConfig.ts | Removes `validateLocales` call; locale validation now lives solely in the `I18nConfig` constructor path via `validateI18nConfigParams`. |
| packages/next/src/config-dir/I18NConfiguration.ts | Switches `I18NConfigurationParams` to extend `Omit<GTServicesEnabledParams, 'cacheUrl' | 'runtimeUrl'>` with explicit required fields; `setupGTServicesEnabled` is correctly called before `initializeI18nConfig`. |
| packages/node/src/setup/types.ts | Replaces the old ad-hoc type composition with `I18nConfigParams & GTServicesEnabledParams & I18nCacheConstructorParams<string>`; re-exports of `GTConfig` and `TranslationsLoader` are preserved for downstream compatibility. |
| packages/i18n/src/globals/__tests__/getGTServicesEnabled.test.ts | Removes the config-based read test that no longer applies after the parameter was dropped. |
| packages/i18n/src/i18n-cache/validation/config-validation/__tests__/validateLocales.test.ts | Each test now calls `setupGTServicesEnabled` before `validateLocales`; tests are deterministic as each sets its own global state before asserting. |
| packages/i18n/src/i18n-config/__tests__/I18nConfig.test.ts | Adds a `beforeEach` that disables GT services so each test starts from a clean global state; tests that need services enabled call `setupGTServicesEnabled` explicitly. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller as Initializer (next/node)
    participant SGE as setupGTServicesEnabled()
    participant Global as i18n Global State
    participant II18n as initializeI18nConfig()
    participant I18nCfg as I18nConfig constructor
    participant VAL as validateI18nConfigParams()
    participant GGE as getGTServicesEnabled()

    Caller->>SGE: "{ projectId, apiKey, devApiKey, runtimeUrl, cacheUrl }"
    SGE->>SGE: resolveGTServicesEnabled(config)
    SGE->>Global: "gtServicesEnabled = true/false"

    Caller->>II18n: "{ defaultLocale, locales, customMapping }"
    II18n->>I18nCfg: new I18nConfig(params)
    I18nCfg->>VAL: validateI18nConfigParams(params)
    VAL->>GGE: getGTServicesEnabled()
    GGE->>Global: read gtServicesEnabled
    Global-->>GGE: true/false
    GGE-->>VAL: boolean
    alt GT services enabled
        VAL->>VAL: validate locales (throw on invalid)
    else GT services disabled
        VAL-->>I18nCfg: return (skip validation)
    end
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/i18n/src/i18n-cache/validation/config-validation/validateLocales.ts`, line 14-43 ([link](https://github.com/generaltranslation/gt/blob/05b04321a6a0faafc10751476f15f97f75040446/packages/i18n/src/i18n-cache/validation/config-validation/validateLocales.ts#L14-L43)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`validateLocales` is now unreachable production code**

   After removing the `validateLocales(config)` call from `validateConfig.ts`, a grep across `packages/` shows this function is only referenced by its own test file — no production code path calls it. Locale validation is still covered by `validateI18nConfigParams` (called from the `I18nConfig` constructor), so there is no functional gap, but this exported function is now dead code and may cause confusion about where locale validation occurs.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/i18n/src/i18n-cache/validation/config-validation/validateLocales.ts
   Line: 14-43

   Comment:
   **`validateLocales` is now unreachable production code**

   After removing the `validateLocales(config)` call from `validateConfig.ts`, a grep across `packages/` shows this function is only referenced by its own test file — no production code path calls it. Locale validation is still covered by `validateI18nConfigParams` (called from the `I18nConfig` constructor), so there is no functional gap, but this exported function is now dead code and may cause confusion about where locale validation occurs.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fi18n%2Fsrc%2Fi18n-cache%2Fvalidation%2Fconfig-validation%2FvalidateLocales.ts%0ALine%3A%2014-43%0A%0AComment%3A%0A**%60validateLocales%60%20is%20now%20unreachable%20production%20code**%0A%0AAfter%20removing%20the%20%60validateLocales%28config%29%60%20call%20from%20%60validateConfig.ts%60%2C%20a%20grep%20across%20%60packages%2F%60%20shows%20this%20function%20is%20only%20referenced%20by%20its%20own%20test%20file%20%E2%80%94%20no%20production%20code%20path%20calls%20it.%20Locale%20validation%20is%20still%20covered%20by%20%60validateI18nConfigParams%60%20%28called%20from%20the%20%60I18nConfig%60%20constructor%29%2C%20so%20there%20is%20no%20functional%20gap%2C%20but%20this%20exported%20function%20is%20now%20dead%20code%20and%20may%20cause%20confusion%20about%20where%20locale%20validation%20occurs.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=generaltranslation%2Fgt&pr=1507&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fodysseus%2Fcleanup-gt-services-types%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fodysseus%2Fcleanup-gt-services-types%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fi18n%2Fsrc%2Fi18n-cache%2Fvalidation%2Fconfig-validation%2FvalidateLocales.ts%0ALine%3A%2014-43%0A%0AComment%3A%0A**%60validateLocales%60%20is%20now%20unreachable%20production%20code**%0A%0AAfter%20removing%20the%20%60validateLocales%28config%29%60%20call%20from%20%60validateConfig.ts%60%2C%20a%20grep%20across%20%60packages%2F%60%20shows%20this%20function%20is%20only%20referenced%20by%20its%20own%20test%20file%20%E2%80%94%20no%20production%20code%20path%20calls%20it.%20Locale%20validation%20is%20still%20covered%20by%20%60validateI18nConfigParams%60%20%28called%20from%20the%20%60I18nConfig%60%20constructor%29%2C%20so%20there%20is%20no%20functional%20gap%2C%20but%20this%20exported%20function%20is%20now%20dead%20code%20and%20may%20cause%20confusion%20about%20where%20locale%20validation%20occurs.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["refactor: narrow gt services config type..."](https://github.com/generaltranslation/gt/commit/92d056809db9b6bbdc14520ae09796a7d3df16fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34245210)</sub>

<!-- /greptile_comment -->