### PR TITLE
fix: stabilize benchmark playwright install

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -88,11 +88,6 @@ jobs:
         if: steps.should-run.outputs.run == 'true'
         run: pnpm install
 
-      - name: Install Playwright browsers
-        if: steps.should-run.outputs.run == 'true'
-        working-directory: tests/apps/next/middleware
-        run: npx playwright install chromium
-
       # --- Resolve version ---
 
       - name: Read gt-next version

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -6,7 +6,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 env:
   CI: true
@@ -28,7 +27,11 @@ jobs:
         with:
           targets: wasm32-wasip1
 
-      - uses: andresz1/size-limit-action@94bc357df29c36c8f8d50ea497c3e225c3c95d1d # v1.8.0
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          package_manager: pnpm
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build packages
+        run: pnpm exec turbo build --filter=generaltranslation --filter=gt-i18n --filter='@generaltranslation/react-core' --filter=gt-react --filter=gt-tanstack-start --filter=gt-next
+
+      - name: Check bundle sizes
+        run: pnpm size

--- a/tests/apps/next/middleware/benchmarks/playwright.config.ts
+++ b/tests/apps/next/middleware/benchmarks/playwright.config.ts
@@ -2,13 +2,16 @@ import { defineConfig, devices } from '@playwright/test';
 
 const PORT = process.env.CI ? 3456 : 3000;
 process.env.PORT = PORT.toString();
+const chromium = process.env.CI
+  ? { ...devices['Desktop Chrome'], channel: 'chrome' as const }
+  : devices['Desktop Chrome'];
 
 export default defineConfig({
   testDir: '.',
   testMatch: 'e2e-performance.spec.ts',
   fullyParallel: false,
   timeout: 30_000,
-  projects: [{ name: 'chromium', use: devices['Desktop Chrome'] }],
+  projects: [{ name: 'chromium', use: chromium }],
   webServer: {
     command: `PORT=${PORT} pnpm start`,
     port: PORT,

--- a/tests/apps/next/middleware/package.json
+++ b/tests/apps/next/middleware/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "test:e2e": "node runPlaywright.mjs",
-    "test:e2e:install": "npx playwright install chromium",
+    "test:e2e:install": "pnpm exec playwright install chromium-headless-shell",
     "bench": "pnpm bench:e2e",
     "bench:e2e": "node runBenchE2E.mjs",
     "lint": "oxlint --config ../../../../examples/.oxlintrc.next.json .",

--- a/tests/apps/next/middleware/runBenchE2E.mjs
+++ b/tests/apps/next/middleware/runBenchE2E.mjs
@@ -121,9 +121,8 @@ try {
   });
 
   logSection('Running e2e benchmarks');
-  execFileSync(
-    'npx',
-    ['playwright', 'test', '--config=benchmarks/playwright.config.ts'],
+  runPnpm(
+    ['exec', 'playwright', 'test', '--config=benchmarks/playwright.config.ts'],
     {
       cwd: __dirname,
       stdio: 'inherit',


### PR DESCRIPTION
## Summary
- remove the benchmark CI Playwright browser download that was stalling during Chromium install/extract
- run benchmark E2E tests against the GitHub runner's system Chrome channel in CI
- run Playwright through pnpm exec so scripts use the workspace-installed binary
- replace the duplicate size-limit action with the same explicit install/build/size commands used by CI

## Verification
- pnpm exec oxfmt --check .github/workflows/benchmark.yml .github/workflows/size-limit.yml tests/apps/next/middleware/package.json tests/apps/next/middleware/runBenchE2E.mjs tests/apps/next/middleware/benchmarks/playwright.config.ts
- pnpm --filter gt-next-middleware-e2e typecheck
- pnpm --dir tests/apps/next/middleware exec playwright --version
- pnpm exec turbo build --filter=generaltranslation --filter=gt-i18n --filter='@generaltranslation/react-core' --filter=gt-react --filter=gt-tanstack-start --filter=gt-next
- pnpm size
- GitHub Actions: Benchmarks / benchmark passed on run 26545837356

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR stabilizes the benchmark CI by removing the stalling Playwright Chromium download and instead pointing CI at the GitHub runner's pre-installed system Chrome via `channel: 'chrome'`. It also standardises the Playwright invocation to use the workspace binary via `pnpm exec`, and replaces the `andresz1/size-limit-action` with explicit install/build/check steps (dropping the automatic PR size-comparison comment as a result).

- **benchmark.yml**: Drops the `npx playwright install chromium` step that was stalling on extract; `playwright.config.ts` now conditionally sets `channel: 'chrome'` in CI so Playwright uses the runner's system Chrome without any download.
- **size-limit.yml**: Replaces the third-party action with manual `pnpm install` → `pnpm exec turbo build` → `pnpm size` steps; removes the `pull-requests: write` permission since no PR comment is posted.
- **runBenchE2E.mjs**: Switches from `npx playwright` to `pnpm exec playwright` so the workspace-pinned Playwright binary is always used.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — changes are scoped to CI workflow configuration and a benchmark test helper script with no impact on production code.

All changes touch only CI workflows and benchmark tooling. The core fix (using system Chrome instead of downloading Chromium) is well-supported on GitHub's ubuntu-latest runners, and the channel: 'chrome' conditional is properly gated on process.env.CI. The size-limit workflow refactor is a straightforward replacement that preserves the enforcement semantics while dropping the PR comment feature intentionally.

No files require special attention for CI correctness. tests/apps/next/middleware/package.json has a minor local-dev UX gap (chromium-headless-shell installed but full chromium needed for local bench:e2e).
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/benchmark.yml | Removed stalling `npx playwright install chromium` step; CI now relies on system Chrome via the playwright.config.ts channel setting |
| .github/workflows/size-limit.yml | Replaced third-party `andresz1/size-limit-action` with explicit install/build/check steps; removes `pull-requests: write` permission and PR comment comparison output as a side effect |
| tests/apps/next/middleware/benchmarks/playwright.config.ts | CI now uses system Chrome channel (`channel: 'chrome'`) to avoid Chromium download; local runs continue to use the default `devices['Desktop Chrome']` config |
| tests/apps/next/middleware/package.json | Changed `test:e2e:install` from `npx playwright install chromium` to `pnpm exec playwright install chromium-headless-shell`; introduces a browser type mismatch for local bench:e2e runs |
| tests/apps/next/middleware/runBenchE2E.mjs | Switched Playwright invocation from `npx playwright` to `pnpm exec playwright` to use workspace-installed binary |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[benchmark.yml trigger] --> B{should-run?}
    B -- No --> Z[Skip all steps]
    B -- Yes --> C[pnpm install]
    C --> D[Build packages]
    D --> E[Run unit benchmarks]
    E --> F[node runBenchE2E.mjs]
    F --> G[pnpm exec playwright test
--config=benchmarks/playwright.config.ts]

    G --> H{CI env?}
    H -- Yes --> I[channel: chrome
use system Chrome
no browser download]
    H -- No --> J[devices Desktop Chrome
needs local Chromium]

    I --> K[Collect results]
    J --> K
    K --> L[Transform & store results]

    subgraph size-limit.yml
        M[PR trigger] --> N[pnpm install]
        N --> O[pnpm exec turbo build]
        O --> P[pnpm size
fail on limit breach]
    end
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atests%2Fapps%2Fnext%2Fmiddleware%2Fpackage.json%3A10%0A**Browser%20type%20mismatch%20for%20local%20bench%3Ae2e%20runs**%0A%0A%60test%3Ae2e%3Ainstall%60%20now%20installs%20%60chromium-headless-shell%60%2C%20but%20this%20script%20is%20used%20for%20the%20regular%20test%3Ae2e%20flow.%20When%20running%20%60bench%3Ae2e%60%20locally%20%28%60process.env.CI%60%20unset%29%2C%20%60benchmarks%2Fplaywright.config.ts%60%20selects%20%60devices%5B'Desktop%20Chrome'%5D%60%20without%20a%20%60channel%60%2C%20which%20requires%20the%20full%20%60chromium%60%20binary%20%E2%80%94%20not%20%60chromium-headless-shell%60.%20A%20developer%20who%20has%20only%20run%20%60test%3Ae2e%3Ainstall%60%20will%20hit%20a%20%22browser%20not%20found%22%20error%20on%20local%20benchmark%20runs.%20Consider%20adding%20a%20%60bench%3Ae2e%3Ainstall%60%20script%20%28e.g.%20%60pnpm%20exec%20playwright%20install%20chromium%60%29%20or%20updating%20the%20local%20branch%20of%20the%20playwright%20config%20to%20use%20%60chromium-headless-shell%60%20as%20well.%0A%0A&repo=generaltranslation%2Fgt&pr=1509&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fodysseus%2Ffix-benchmark-playwright-install%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fodysseus%2Ffix-benchmark-playwright-install%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atests%2Fapps%2Fnext%2Fmiddleware%2Fpackage.json%3A10%0A**Browser%20type%20mismatch%20for%20local%20bench%3Ae2e%20runs**%0A%0A%60test%3Ae2e%3Ainstall%60%20now%20installs%20%60chromium-headless-shell%60%2C%20but%20this%20script%20is%20used%20for%20the%20regular%20test%3Ae2e%20flow.%20When%20running%20%60bench%3Ae2e%60%20locally%20%28%60process.env.CI%60%20unset%29%2C%20%60benchmarks%2Fplaywright.config.ts%60%20selects%20%60devices%5B'Desktop%20Chrome'%5D%60%20without%20a%20%60channel%60%2C%20which%20requires%20the%20full%20%60chromium%60%20binary%20%E2%80%94%20not%20%60chromium-headless-shell%60.%20A%20developer%20who%20has%20only%20run%20%60test%3Ae2e%3Ainstall%60%20will%20hit%20a%20%22browser%20not%20found%22%20error%20on%20local%20benchmark%20runs.%20Consider%20adding%20a%20%60bench%3Ae2e%3Ainstall%60%20script%20%28e.g.%20%60pnpm%20exec%20playwright%20install%20chromium%60%29%20or%20updating%20the%20local%20branch%20of%20the%20playwright%20config%20to%20use%20%60chromium-headless-shell%60%20as%20well.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
tests/apps/next/middleware/package.json:10
**Browser type mismatch for local bench:e2e runs**

`test:e2e:install` now installs `chromium-headless-shell`, but this script is used for the regular test:e2e flow. When running `bench:e2e` locally (`process.env.CI` unset), `benchmarks/playwright.config.ts` selects `devices['Desktop Chrome']` without a `channel`, which requires the full `chromium` binary — not `chromium-headless-shell`. A developer who has only run `test:e2e:install` will hit a "browser not found" error on local benchmark runs. Consider adding a `bench:e2e:install` script (e.g. `pnpm exec playwright install chromium`) or updating the local branch of the playwright config to use `chromium-headless-shell` as well.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: stabilize benchmark playwright inst..."](https://github.com/generaltranslation/gt/commit/b914033d967fedcd167274a18eb5f24bd7c5af71) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34271091)</sub>

<!-- /greptile_comment -->