### PR TITLE
refactor: simplify i18n config hooks

### DIFF
--- a/packages/react-core/src/components/translation/T.tsx
+++ b/packages/react-core/src/components/translation/T.tsx
@@ -6,8 +6,8 @@ import renderDefaultChildren from '../../utils/rendering/renderDefaultChildren';
 import renderTranslatedChildren from '../../utils/rendering/renderTranslatedChildren';
 import { renderVariable } from '../../utils/rendering/renderVariable';
 import { useLocale } from '../../hooks/condition-store';
-import { useDefaultLocale } from '../../hooks/i18n-config';
 import { useTranslate } from '../../hooks/external-store';
+import { getI18nConfig } from 'gt-i18n/internal';
 import type { JsxTranslationOptions as JsxTranslationOptionsWithSugar } from 'gt-i18n/types';
 import type { JsxChildren } from 'generaltranslation/types';
 import type { TaggedChildren } from '../../utils/types';
@@ -103,7 +103,7 @@ function usePrepSourceRender({
   shouldTranslate: boolean;
 } {
   const locale = useLocale();
-  const defaultLocale = useDefaultLocale();
+  const defaultLocale = getI18nConfig().getDefaultLocale();
   const shouldTranslate = useShouldTranslate();
   const taggedSourceChildren = useMemo(
     () => addGTIdentifier(removeInjectedT(sourceChildren)),

--- a/packages/react-core/src/components/translation/T.tsx
+++ b/packages/react-core/src/components/translation/T.tsx
@@ -6,10 +6,8 @@ import renderDefaultChildren from '../../utils/rendering/renderDefaultChildren';
 import renderTranslatedChildren from '../../utils/rendering/renderTranslatedChildren';
 import { renderVariable } from '../../utils/rendering/renderVariable';
 import { useLocale } from '../../hooks/condition-store';
-import {
-  useDefaultLocale,
-  useTranslate,
-} from '../../hooks/external-store-hooks';
+import { useDefaultLocale } from '../../hooks/i18n-config';
+import { useTranslate } from '../../hooks/external-store';
 import type { JsxTranslationOptions as JsxTranslationOptionsWithSugar } from 'gt-i18n/types';
 import type { JsxChildren } from 'generaltranslation/types';
 import type { TaggedChildren } from '../../utils/types';

--- a/packages/react-core/src/components/translation/T.tsx
+++ b/packages/react-core/src/components/translation/T.tsx
@@ -12,7 +12,7 @@ import type { JsxTranslationOptions as JsxTranslationOptionsWithSugar } from 'gt
 import type { JsxChildren } from 'generaltranslation/types';
 import type { TaggedChildren } from '../../utils/types';
 import type { ReactNode } from 'react';
-import { useShouldTranslate } from '../../hooks/utils';
+import { getShouldTranslate } from '../../hooks/utils';
 
 // ===== Component ===== //
 
@@ -104,7 +104,7 @@ function usePrepSourceRender({
 } {
   const locale = useLocale();
   const defaultLocale = getI18nConfig().getDefaultLocale();
-  const shouldTranslate = useShouldTranslate();
+  const shouldTranslate = getShouldTranslate();
   const taggedSourceChildren = useMemo(
     () => addGTIdentifier(removeInjectedT(sourceChildren)),
     [sourceChildren]

--- a/packages/react-core/src/context.ts
+++ b/packages/react-core/src/context.ts
@@ -15,7 +15,7 @@ export {
   useCustomMapping,
   useDefaultLocale,
   useLocales,
-} from './hooks/external-store-hooks';
+} from './hooks/i18n-config';
 export { useGT } from './hooks/useGT';
 export { useMessages } from './hooks/useMessages';
 export { useTranslations } from './hooks/useTranslations';

--- a/packages/react-core/src/hooks/external-store.ts
+++ b/packages/react-core/src/hooks/external-store.ts
@@ -8,7 +8,6 @@ import type {
   DictionaryEntrySnapshot,
   DictionaryObjectSnapshot,
 } from '../i18n-store/storeTypes';
-import type { CustomMapping } from 'generaltranslation/types';
 import { getI18nStore } from '../i18n-store/singleton-operations';
 import type { RuntimeTranslationScope } from '../i18n-store/RuntimeTranslationScope';
 import type { RuntimeDictionaryScope } from '../i18n-store/RuntimeDictionaryScope';
@@ -87,33 +86,6 @@ export function useDictionaryObject(
     store.translateDictionaryObject(lookup);
   }
   return dictionaryObject;
-}
-
-export function useCustomMapping(): CustomMapping {
-  const store = getI18nStore();
-  return useSyncExternalStore(
-    store.subscribeToCustomMapping,
-    store.getCustomMappingSnapshot,
-    store.getCustomMappingSnapshot
-  );
-}
-
-export function useDefaultLocale(): string {
-  const store = getI18nStore();
-  return useSyncExternalStore(
-    store.subscribeToDefaultLocale,
-    store.getDefaultLocaleSnapshot,
-    store.getDefaultLocaleSnapshot
-  );
-}
-
-export function useLocales(): readonly string[] {
-  const store = getI18nStore();
-  return useSyncExternalStore(
-    store.subscribeToLocales,
-    store.getLocalesSnapshot,
-    store.getLocalesSnapshot
-  );
 }
 
 /**

--- a/packages/react-core/src/hooks/i18n-config.ts
+++ b/packages/react-core/src/hooks/i18n-config.ts
@@ -7,9 +7,9 @@ export function useCustomMapping(): CustomMapping {
 }
 
 export function useDefaultLocale(): string {
-  return getI18nConfig().getDefaultLocale();
+  return useMemo(() => getI18nConfig().getDefaultLocale(), []);
 }
 
 export function useLocales(): readonly string[] {
-  return getI18nConfig().getLocales();
+  return useMemo(() => getI18nConfig().getLocales(), []);
 }

--- a/packages/react-core/src/hooks/i18n-config.ts
+++ b/packages/react-core/src/hooks/i18n-config.ts
@@ -1,0 +1,15 @@
+import { useMemo } from 'react';
+import { getI18nConfig } from 'gt-i18n/internal';
+import type { CustomMapping } from 'generaltranslation/types';
+
+export function useCustomMapping(): CustomMapping {
+  return useMemo(() => getI18nConfig().getCustomMapping(), []);
+}
+
+export function useDefaultLocale(): string {
+  return getI18nConfig().getDefaultLocale();
+}
+
+export function useLocales(): readonly string[] {
+  return getI18nConfig().getLocales();
+}

--- a/packages/react-core/src/hooks/useGT.ts
+++ b/packages/react-core/src/hooks/useGT.ts
@@ -7,7 +7,7 @@ import {
 import type { InlineTranslationOptionsFields } from 'gt-i18n/internal/types';
 import { useRuntimeTranslationScope, useTranslateMany } from './external-store';
 import { useLocale } from './condition-store';
-import { useShouldTranslate } from './utils';
+import { getShouldTranslate } from './utils';
 import { getReactI18nCache } from '../i18n-cache/singleton-operations';
 import type { TranslateLookup } from '../i18n-store/storeTypes';
 import type { GTFunctionType, InlineTranslationOptions } from 'gt-i18n/types';
@@ -24,7 +24,7 @@ type Message = InlineTranslationOptionsFields & {
 export function useGT(_messages?: Message[]): GTFunctionType {
   const locale = useLocale();
   const defaultLocale = getI18nConfig().getDefaultLocale();
-  const shouldTranslate = useShouldTranslate();
+  const shouldTranslate = getShouldTranslate();
   const scope = useRuntimeTranslationScope();
   const devHotReloadEnabled = getReactI18nCache().isDevHotReloadEnabled();
 

--- a/packages/react-core/src/hooks/useGT.ts
+++ b/packages/react-core/src/hooks/useGT.ts
@@ -1,15 +1,17 @@
 import { useCallback, useMemo } from 'react';
-import { createLookupOptions } from 'gt-i18n/internal';
+import {
+  createLookupOptions,
+  getI18nConfig,
+  interpolateMessage,
+} from 'gt-i18n/internal';
 import type { InlineTranslationOptionsFields } from 'gt-i18n/internal/types';
 import { useRuntimeTranslationScope, useTranslateMany } from './external-store';
-import { useDefaultLocale } from './i18n-config';
 import { useLocale } from './condition-store';
 import { useShouldTranslate } from './utils';
 import { getReactI18nCache } from '../i18n-cache/singleton-operations';
 import type { TranslateLookup } from '../i18n-store/storeTypes';
 import type { GTFunctionType, InlineTranslationOptions } from 'gt-i18n/types';
 import type { StringFormat } from '@generaltranslation/format/types';
-import { interpolateMessage } from 'gt-i18n/internal';
 
 const EMPTY_TRANSLATE_LOOKUPS: TranslateLookup<string>[] = [];
 
@@ -21,7 +23,7 @@ type Message = InlineTranslationOptionsFields & {
 
 export function useGT(_messages?: Message[]): GTFunctionType {
   const locale = useLocale();
-  const defaultLocale = useDefaultLocale();
+  const defaultLocale = getI18nConfig().getDefaultLocale();
   const shouldTranslate = useShouldTranslate();
   const scope = useRuntimeTranslationScope();
   const devHotReloadEnabled = getReactI18nCache().isDevHotReloadEnabled();

--- a/packages/react-core/src/hooks/useGT.ts
+++ b/packages/react-core/src/hooks/useGT.ts
@@ -1,11 +1,8 @@
 import { useCallback, useMemo } from 'react';
 import { createLookupOptions } from 'gt-i18n/internal';
 import type { InlineTranslationOptionsFields } from 'gt-i18n/internal/types';
-import {
-  useDefaultLocale,
-  useRuntimeTranslationScope,
-  useTranslateMany,
-} from './external-store-hooks';
+import { useRuntimeTranslationScope, useTranslateMany } from './external-store';
+import { useDefaultLocale } from './i18n-config';
 import { useLocale } from './condition-store';
 import { useShouldTranslate } from './utils';
 import { getReactI18nCache } from '../i18n-cache/singleton-operations';

--- a/packages/react-core/src/hooks/useInternalLocaleSelector.ts
+++ b/packages/react-core/src/hooks/useInternalLocaleSelector.ts
@@ -1,12 +1,13 @@
 import { useCallback, useMemo } from 'react';
-import { useCustomMapping, useLocales } from './i18n-config';
 import { useLocale } from './condition-store';
 import { getLocaleProperties } from 'generaltranslation';
+import { getI18nConfig } from 'gt-i18n/internal';
 
 export function useInternalLocaleSelector(locales?: string[]) {
   // Retrieve the locale, locales, and setLocale function
-  const contextLocales = useLocales();
-  const customMapping = useCustomMapping();
+  const i18nConfig = getI18nConfig();
+  const contextLocales = i18nConfig.getLocales();
+  const customMapping = i18nConfig.getCustomMapping();
   const locale = useLocale();
 
   // sort

--- a/packages/react-core/src/hooks/useInternalLocaleSelector.ts
+++ b/packages/react-core/src/hooks/useInternalLocaleSelector.ts
@@ -1,12 +1,12 @@
 import { useCallback, useMemo } from 'react';
+import { useCustomMapping, useLocales } from './i18n-config';
 import { useLocale } from './condition-store';
 import { getLocaleProperties } from 'generaltranslation';
-import { getI18nConfig } from 'gt-i18n/internal';
 
 export function useInternalLocaleSelector(locales?: string[]) {
   // Retrieve the locale, locales, and setLocale function
-  const contextLocales = useMemo(() => getI18nConfig().getLocales(), []);
-  const customMapping = useMemo(() => getI18nConfig().getCustomMapping(), []);
+  const contextLocales = useLocales();
+  const customMapping = useCustomMapping();
   const locale = useLocale();
 
   // sort

--- a/packages/react-core/src/hooks/useInternalLocaleSelector.ts
+++ b/packages/react-core/src/hooks/useInternalLocaleSelector.ts
@@ -5,9 +5,8 @@ import { getI18nConfig } from 'gt-i18n/internal';
 
 export function useInternalLocaleSelector(locales?: string[]) {
   // Retrieve the locale, locales, and setLocale function
-  const i18nConfig = getI18nConfig();
-  const contextLocales = i18nConfig.getLocales();
-  const customMapping = i18nConfig.getCustomMapping();
+  const contextLocales = useMemo(() => getI18nConfig().getLocales(), []);
+  const customMapping = useMemo(() => getI18nConfig().getCustomMapping(), []);
   const locale = useLocale();
 
   // sort

--- a/packages/react-core/src/hooks/useInternalLocaleSelector.ts
+++ b/packages/react-core/src/hooks/useInternalLocaleSelector.ts
@@ -1,5 +1,5 @@
 import { useCallback, useMemo } from 'react';
-import { useCustomMapping, useLocales } from './external-store-hooks';
+import { useCustomMapping, useLocales } from './i18n-config';
 import { useLocale } from './condition-store';
 import { getLocaleProperties } from 'generaltranslation';
 

--- a/packages/react-core/src/hooks/useTranslations.ts
+++ b/packages/react-core/src/hooks/useTranslations.ts
@@ -11,7 +11,7 @@ import {
   useRuntimeDictionaryScope,
 } from './external-store';
 import { useLocale } from './condition-store';
-import { useShouldTranslate } from './utils';
+import { getShouldTranslate } from './utils';
 import { getReactI18nCache } from '../i18n-cache/singleton-operations';
 import { useGT } from './useGT';
 import type {
@@ -24,7 +24,7 @@ import type {
 export function useTranslations(id?: string): UseTranslationsFunction {
   const locale = useLocale();
   const defaultLocale = getI18nConfig().getDefaultLocale();
-  const shouldTranslate = useShouldTranslate();
+  const shouldTranslate = getShouldTranslate();
   const scope = useRuntimeDictionaryScope();
   const gt = useGT();
   const rootId = id ?? '';

--- a/packages/react-core/src/hooks/useTranslations.ts
+++ b/packages/react-core/src/hooks/useTranslations.ts
@@ -6,10 +6,10 @@ import {
   resolveDictionaryLookupOptions,
 } from 'gt-i18n/internal';
 import {
-  useDefaultLocale,
   useDictionaryObject,
   useRuntimeDictionaryScope,
-} from './external-store-hooks';
+} from './external-store';
+import { useDefaultLocale } from './i18n-config';
 import { useLocale } from './condition-store';
 import { useShouldTranslate } from './utils';
 import { getReactI18nCache } from '../i18n-cache/singleton-operations';

--- a/packages/react-core/src/hooks/useTranslations.ts
+++ b/packages/react-core/src/hooks/useTranslations.ts
@@ -1,6 +1,7 @@
 import { useCallback, useMemo } from 'react';
 import {
   extractVariables,
+  getI18nConfig,
   renderDictionaryEntry,
   renderDictionaryObject,
   resolveDictionaryLookupOptions,
@@ -9,7 +10,6 @@ import {
   useDictionaryObject,
   useRuntimeDictionaryScope,
 } from './external-store';
-import { useDefaultLocale } from './i18n-config';
 import { useLocale } from './condition-store';
 import { useShouldTranslate } from './utils';
 import { getReactI18nCache } from '../i18n-cache/singleton-operations';
@@ -23,7 +23,7 @@ import type {
 
 export function useTranslations(id?: string): UseTranslationsFunction {
   const locale = useLocale();
-  const defaultLocale = useDefaultLocale();
+  const defaultLocale = getI18nConfig().getDefaultLocale();
   const shouldTranslate = useShouldTranslate();
   const scope = useRuntimeDictionaryScope();
   const gt = useGT();

--- a/packages/react-core/src/hooks/utils.ts
+++ b/packages/react-core/src/hooks/utils.ts
@@ -5,7 +5,7 @@ import { getI18nConfig } from 'gt-i18n/internal';
 export function useFormatLocales(localesProp: string[] = []): string[] {
   const locale = useLocale();
   const defaultLocale = getI18nConfig().getDefaultLocale();
-  const shouldTranslate = useShouldTranslate();
+  const shouldTranslate = getShouldTranslate();
   return shouldTranslate
     ? [...localesProp, locale, defaultLocale]
     : [defaultLocale];

--- a/packages/react-core/src/hooks/utils.ts
+++ b/packages/react-core/src/hooks/utils.ts
@@ -1,11 +1,10 @@
-import { useDefaultLocale } from './i18n-config';
 import { useLocale } from './condition-store';
 import { getReadonlyConditionStoreWithFallback } from '../condition-store/singleton-operations';
 import { getI18nConfig } from 'gt-i18n/internal';
 
 export function useFormatLocales(localesProp: string[] = []): string[] {
   const locale = useLocale();
-  const defaultLocale = useDefaultLocale();
+  const defaultLocale = getI18nConfig().getDefaultLocale();
   const shouldTranslate = useShouldTranslate();
   return shouldTranslate
     ? [...localesProp, locale, defaultLocale]

--- a/packages/react-core/src/hooks/utils.ts
+++ b/packages/react-core/src/hooks/utils.ts
@@ -1,14 +1,23 @@
+import { useMemo } from 'react';
 import { useLocale } from './condition-store';
 import { getReadonlyConditionStoreWithFallback } from '../condition-store/singleton-operations';
 import { getI18nConfig } from 'gt-i18n/internal';
 
-export function useFormatLocales(localesProp: string[] = []): string[] {
+const EMPTY_LOCALES_PROP: string[] = [];
+
+export function useFormatLocales(
+  localesProp: string[] = EMPTY_LOCALES_PROP
+): string[] {
   const locale = useLocale();
   const defaultLocale = getI18nConfig().getDefaultLocale();
   const shouldTranslate = getShouldTranslate();
-  return shouldTranslate
-    ? [...localesProp, locale, defaultLocale]
-    : [defaultLocale];
+  return useMemo(
+    () =>
+      shouldTranslate
+        ? [...localesProp, locale, defaultLocale]
+        : [defaultLocale],
+    [defaultLocale, locale, localesProp, shouldTranslate]
+  );
 }
 
 export function useShouldTranslate(): boolean {

--- a/packages/react-core/src/hooks/utils.ts
+++ b/packages/react-core/src/hooks/utils.ts
@@ -1,4 +1,4 @@
-import { useDefaultLocale } from './external-store-hooks';
+import { useDefaultLocale } from './i18n-config';
 import { useLocale } from './condition-store';
 import { getReadonlyConditionStoreWithFallback } from '../condition-store/singleton-operations';
 import { getI18nConfig } from 'gt-i18n/internal';

--- a/packages/react-core/src/i18n-store/I18nStore.ts
+++ b/packages/react-core/src/i18n-store/I18nStore.ts
@@ -2,7 +2,6 @@ import {
   getDictionaryListenerKey,
   getTranslateListenerKey,
 } from 'gt-i18n/internal';
-import type { CustomMapping } from 'generaltranslation/types';
 import type {
   DictionaryEntrySnapshot,
   DictionaryLookup,
@@ -17,7 +16,6 @@ import type { Translation } from 'gt-i18n/types';
 import { getReactI18nCache } from '../i18n-cache/singleton-operations';
 import { RuntimeTranslationScope } from './RuntimeTranslationScope';
 import { RuntimeDictionaryScope } from './RuntimeDictionaryScope';
-import { getI18nConfig } from 'gt-i18n/internal';
 import {
   dictionaryEntryEventMatchesLookup,
   dictionaryObjectEventMatchesLookup,
@@ -30,17 +28,14 @@ type DictionaryStoreListener = (event: DictionaryLookup) => void;
 export type I18nStoreParams = {};
 
 /**
- * A subscription wrapper around the I18nCache and the ConditionStore
+ * A subscription wrapper around the I18nCache.
  *
- * It is assumed that the I18nCache and the ConditionStore are already initialized.
- * It is assumed that the locale and translations are already sync accessible.
+ * It is assumed that the I18nCache is already initialized.
+ * It is assumed that translations are already sync accessible.
  */
 export class I18nStore {
   // ===== Listener Sets ===== //
 
-  private defaultLocaleListeners = new Set<StoreListener>();
-  private localesListeners = new Set<StoreListener>();
-  private customMappingListeners = new Set<StoreListener>();
   private translateListeners = new Set<TranslateStoreListener>();
   private translateManySnapshotCache = new WeakMap<
     readonly TranslateLookup[],
@@ -59,20 +54,6 @@ export class I18nStore {
       throw new Error('Failed to initialize I18nStore. Reason: ' + error);
     }
   }
-
-  // ===== Manager Config Subscriptions ===== //
-
-  subscribeToDefaultLocale = (listener: StoreListener): Unsubscribe => {
-    return subscribeToSet(this.defaultLocaleListeners, listener);
-  };
-
-  subscribeToLocales = (listener: StoreListener): Unsubscribe => {
-    return subscribeToSet(this.localesListeners, listener);
-  };
-
-  subscribeToCustomMapping = (listener: StoreListener): Unsubscribe => {
-    return subscribeToSet(this.customMappingListeners, listener);
-  };
 
   // ===== I18nCache Subscriptions ===== //
 
@@ -126,20 +107,6 @@ export class I18nStore {
     };
     return subscribeToSet(this.dictionaryObjectListeners, wrappedListener);
   }
-
-  // ===== Manager Config Snapshots ===== //
-
-  getDefaultLocaleSnapshot = (): string => {
-    return getI18nConfig().getDefaultLocale();
-  };
-
-  getLocalesSnapshot = (): readonly string[] => {
-    return getI18nConfig().getLocales();
-  };
-
-  getCustomMappingSnapshot = (): CustomMapping => {
-    return getI18nConfig().getCustomMapping();
-  };
 
   // ===== I18nCache Snapshots ===== //
 


### PR DESCRIPTION
## Summary
- move readonly i18n config hooks into hooks/i18n-config.ts
- keep customMapping stable with useMemo and remove config subscriptions from I18nStore
- rename external-store-hooks.ts to external-store.ts

## Tests
- pnpm --filter @generaltranslation/react-core typecheck
- pnpm --filter @generaltranslation/react-core test
- pnpm exec oxfmt --check packages/react-core/src/components/translation/T.tsx packages/react-core/src/context.ts packages/react-core/src/hooks/external-store.ts packages/react-core/src/hooks/i18n-config.ts packages/react-core/src/hooks/useGT.ts packages/react-core/src/hooks/useInternalLocaleSelector.ts packages/react-core/src/hooks/useTranslations.ts packages/react-core/src/hooks/utils.ts packages/react-core/src/i18n-store/I18nStore.ts
- pnpm exec oxlint packages/react-core/src/components/translation/T.tsx packages/react-core/src/context.ts packages/react-core/src/hooks/external-store.ts packages/react-core/src/hooks/i18n-config.ts packages/react-core/src/hooks/useGT.ts packages/react-core/src/hooks/useInternalLocaleSelector.ts packages/react-core/src/hooks/useTranslations.ts packages/react-core/src/hooks/utils.ts packages/react-core/src/i18n-store/I18nStore.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1511"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782520582&installation_id=127936663&pr_number=1511&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1511&signature=8e1c32f3696afb8f994a972528a62b75ea86a053d7f36ec70fcb88be5902401d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This refactor simplifies how read-only i18n config values are consumed across `react-core` by replacing `useSyncExternalStore`-based subscriptions with direct `getI18nConfig()` calls (wrapped in `useMemo(fn, [])` for the public hook API), reflecting the invariant that config is immutable after initialization.

- **New `hooks/i18n-config.ts`** consolidates `useDefaultLocale`, `useLocales`, and `useCustomMapping` as `useMemo`-stabilized hooks; the corresponding subscription methods are removed from `I18nStore`, and `external-store-hooks.ts` is renamed to `external-store.ts`.
- **Internal callers** (`useGT`, `useTranslations`, `T.tsx`) bypass the hook wrappers entirely and call `getI18nConfig()` directly, with `getShouldTranslate()` extracted as a plain helper function alongside a now-unused `useShouldTranslate` wrapper in `utils.ts`.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change correctly models config as immutable after initialization, and all internal callers have been updated consistently.

The refactor is internally consistent: config values (defaultLocale, locales, customMapping) are now read directly from the singleton without subscriptions, which is correct given they never change after init. String and boolean primitives used in useCallback/useMemo dependency arrays remain correctly comparable by value. The rename of external-store-hooks.ts is complete with no stale imports remaining in the repo.

packages/react-core/src/hooks/utils.ts — the now-unused useShouldTranslate wrapper is worth cleaning up.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react-core/src/hooks/i18n-config.ts | New file consolidating read-only i18n config hooks; correctly uses useMemo(fn, []) for reference stability since config is immutable after init. |
| packages/react-core/src/hooks/external-store.ts | Renamed from external-store-hooks.ts; removed useSyncExternalStore-based config hooks now handled in i18n-config.ts. |
| packages/react-core/src/hooks/utils.ts | Extracted getShouldTranslate() as a plain function; useShouldTranslate() is now a hollow wrapper that is never called anywhere in the codebase — dead code. |
| packages/react-core/src/i18n-store/I18nStore.ts | Removed config subscription methods and snapshot getters; simplification is safe since config is treated as immutable after init. |
| packages/react-core/src/hooks/useGT.ts | Switched to direct getI18nConfig().getDefaultLocale() and getShouldTranslate() calls; string primitive deps remain correct. |
| packages/react-core/src/hooks/useTranslations.ts | Same pattern as useGT.ts — config access inlined directly; defaultLocale as string dep in useCallback is correct. |
| packages/react-core/src/components/translation/T.tsx | Switched to direct getI18nConfig() and getShouldTranslate() calls in render; no reactivity concern since shouldTranslate is re-read on every render. |
| packages/react-core/src/context.ts | Import source updated for useCustomMapping, useDefaultLocale, useLocales — now from i18n-config.ts. |
| packages/react-core/src/hooks/useInternalLocaleSelector.ts | Import path change only — now sources useCustomMapping and useLocales from i18n-config.ts; no logic changes. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Before ["Before (external-store-hooks.ts)"]
        USS1[useSyncExternalStore] --> UDL1[useDefaultLocale]
        USS2[useSyncExternalStore] --> UL1[useLocales]
        USS3[useSyncExternalStore] --> UCM1[useCustomMapping]
        I18nStore["I18nStore\nsubscribeToDefaultLocale\nsubscribeToLocales\nsubscribeToCustomMapping"] --> USS1 & USS2 & USS3
    end

    subgraph After ["After (i18n-config.ts + external-store.ts)"]
        getI18nConfig["getI18nConfig() singleton"] --> MemoUDL["useDefaultLocale\nuseMemo(fn, [])"]
        getI18nConfig --> MemoUL["useLocales\nuseMemo(fn, [])"]
        getI18nConfig --> MemoUCM["useCustomMapping\nuseMemo(fn, [])"]
        getI18nConfig --> DirectRead["direct read in\nuseGT / useTranslations / T.tsx"]
    end

    subgraph Utils ["utils.ts"]
        GST["getShouldTranslate()\n(plain function)"] --> UST["useShouldTranslate()\n(wrapper — dead code)"]
    end
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Freact-core%2Fsrc%2Fhooks%2Futils.ts%3A23-25%0A%60useShouldTranslate%60%20is%20now%20dead%20code%20%E2%80%94%20all%20internal%20callers%20switched%20to%20%60getShouldTranslate%28%29%60%20in%20this%20PR%2C%20and%20%60useShouldTranslate%60%20is%20not%20re-exported%20from%20%60context.ts%60.%20A%20repo-wide%20search%20confirms%20it%20is%20defined%20only%20here%20and%20called%20nowhere.%20The%20wrapper%20can%20be%20removed.%0A%0A%60%60%60suggestion%0A%2F%2F%20useShouldTranslate%20removed%20%E2%80%94%20use%20getShouldTranslate%28%29%20directly%0A%60%60%60%0A%0A&repo=generaltranslation%2Fgt&pr=1511&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fodysseus%2Fi18n-config-hooks%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fodysseus%2Fi18n-config-hooks%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Freact-core%2Fsrc%2Fhooks%2Futils.ts%3A23-25%0A%60useShouldTranslate%60%20is%20now%20dead%20code%20%E2%80%94%20all%20internal%20callers%20switched%20to%20%60getShouldTranslate%28%29%60%20in%20this%20PR%2C%20and%20%60useShouldTranslate%60%20is%20not%20re-exported%20from%20%60context.ts%60.%20A%20repo-wide%20search%20confirms%20it%20is%20defined%20only%20here%20and%20called%20nowhere.%20The%20wrapper%20can%20be%20removed.%0A%0A%60%60%60suggestion%0A%2F%2F%20useShouldTranslate%20removed%20%E2%80%94%20use%20getShouldTranslate%28%29%20directly%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/react-core/src/hooks/utils.ts:23-25
`useShouldTranslate` is now dead code — all internal callers switched to `getShouldTranslate()` in this PR, and `useShouldTranslate` is not re-exported from `context.ts`. A repo-wide search confirms it is defined only here and called nowhere. The wrapper can be removed.

```suggestion
// useShouldTranslate removed — use getShouldTranslate() directly
```

`````

</details>

<sub>Reviews (6): Last reviewed commit: ["refactor: reuse memoized i18n config hoo..."](https://github.com/generaltranslation/gt/commit/b87b2e6074e3412bf1c3971cd42fca1a170dac57) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34276893)</sub>

<!-- /greptile_comment -->