### PR TITLE
refactor: remove i18n cache runtime flags

### DIFF
--- a/packages/i18n/src/i18n-cache/I18nCache.ts
+++ b/packages/i18n/src/i18n-cache/I18nCache.ts
@@ -214,7 +214,7 @@ class I18nCache<
       !!this.config.devApiKey &&
       !!this.config.projectId &&
       this.isRuntimeUrlEnabled() &&
-      this.config.environment === 'development'
+      getRuntimeEnvironment() === 'development'
     );
   }
 
@@ -631,7 +631,7 @@ class I18nCache<
       throw error;
     }
 
-    switch (this.config.environment) {
+    switch (getRuntimeEnvironment()) {
       case 'development':
         throw error;
       case 'production':
@@ -764,8 +764,6 @@ function standardizeConfig<TranslationValue extends Translation>(
   config: I18nCacheConstructorParams<TranslationValue>
 ) {
   return {
-    environment: config.environment || getRuntimeEnvironment(),
-    enableI18n: config.enableI18n !== undefined ? config.enableI18n : true,
     projectId: config.projectId,
     devApiKey: config.devApiKey,
     apiKey: config.apiKey,

--- a/packages/i18n/src/i18n-cache/__tests__/I18nCache.handleError.test.ts
+++ b/packages/i18n/src/i18n-cache/__tests__/I18nCache.handleError.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { I18nCache } from '../I18nCache';
 import { initializeI18nConfig } from '../../i18n-config/singleton-operations';
 
@@ -16,9 +16,14 @@ describe('I18nCache.handleError', () => {
     vi.clearAllMocks();
   });
 
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it('throws in development mode when error occurs', async () => {
+    vi.stubEnv('NODE_ENV', 'development');
+
     const cache = new I18nCache({
-      environment: 'development',
       loadTranslations: vi.fn().mockRejectedValue(new Error('Load failed')),
     });
 
@@ -26,8 +31,9 @@ describe('I18nCache.handleError', () => {
   });
 
   it('logs and returns fallback in production mode', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+
     const cache = new I18nCache({
-      environment: 'production',
       loadTranslations: vi.fn().mockRejectedValue(new Error('Load failed')),
     });
 

--- a/packages/i18n/src/i18n-cache/__tests__/I18nCache.test.ts
+++ b/packages/i18n/src/i18n-cache/__tests__/I18nCache.test.ts
@@ -54,6 +54,7 @@ describe('I18nCache', () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    vi.unstubAllEnvs();
   });
 
   // ===== REGRESSION TESTS ===== //
@@ -86,10 +87,11 @@ describe('I18nCache', () => {
   });
 
   it('enables dev hot reload with dev credentials, a project id, and development environment', () => {
+    vi.stubEnv('NODE_ENV', 'development');
+
     const cache = createCache({
       devApiKey: 'dev-key',
       projectId: 'project-id',
-      environment: 'development',
     });
 
     expect(cache.isDevHotReloadEnabled()).toBe(true);
@@ -98,36 +100,38 @@ describe('I18nCache', () => {
   it.each([
     {
       name: 'missing dev API key',
+      environment: 'development',
       config: {
         projectId: 'project-id',
-        environment: 'development',
       },
     },
     {
       name: 'missing project id',
+      environment: 'development',
       config: {
         devApiKey: 'dev-key',
-        environment: 'development',
       },
     },
     {
       name: 'disabled runtime URL',
+      environment: 'development',
       config: {
         devApiKey: 'dev-key',
         projectId: 'project-id',
         runtimeUrl: null,
-        environment: 'development',
       },
     },
     {
       name: 'production environment',
+      environment: 'production',
       config: {
         devApiKey: 'dev-key',
         projectId: 'project-id',
-        environment: 'production',
       },
     },
-  ])('disables dev hot reload for $name', ({ config }) => {
+  ])('disables dev hot reload for $name', ({ config, environment }) => {
+    vi.stubEnv('NODE_ENV', environment);
+
     const cache = createCache(config);
 
     expect(cache.isDevHotReloadEnabled()).toBe(false);
@@ -410,9 +414,8 @@ describe('I18nCache', () => {
     expect(cache.lookupDictionary('en', 'missing')).toBeUndefined();
   });
 
-  it('lookupDictionary() returns undefined when source leaf is missing and i18n is disabled', () => {
+  it('lookupDictionary() returns undefined when source leaf is missing and translation is required', () => {
     const cache = createCache({
-      enableI18n: false,
       dictionary: {
         greeting: 'Hello',
       },
@@ -1190,6 +1193,8 @@ describe('I18nCache', () => {
   });
 
   it('lookupDictionaryWithFallback() rejects when runtime translation is not a string', async () => {
+    vi.stubEnv('NODE_ENV', 'development');
+
     const source = 'Hello';
     const sourceOptions: LookupOptions = { $format: 'ICU' };
     const sourceHash = hashMessage(source, sourceOptions);
@@ -1197,7 +1202,6 @@ describe('I18nCache', () => {
       dictionary: {
         greeting: source,
       },
-      environment: 'development',
       runtimeTranslation: {},
     });
 

--- a/packages/i18n/src/i18n-cache/__tests__/resolveTranslationSync.test.ts
+++ b/packages/i18n/src/i18n-cache/__tests__/resolveTranslationSync.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { I18nCache } from '../I18nCache';
 import { hashMessage } from '../../utils/hashMessage';
 import { initializeI18nConfig } from '../../i18n-config/singleton-operations';
@@ -10,6 +10,10 @@ describe('I18nCache.resolveTranslationSync', () => {
       locales: ['en', 'fr'],
     });
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it('should return undefined when no translations loaded for locale', () => {
@@ -25,9 +29,10 @@ describe('I18nCache.resolveTranslationSync', () => {
   });
 
   it('does not throw without options in development', () => {
+    vi.stubEnv('NODE_ENV', 'development');
+
     const cache = new I18nCache({
       loadTranslations: vi.fn(),
-      environment: 'development',
     });
 
     const options = { $format: 'ICU' as const };

--- a/packages/i18n/src/i18n-cache/types.ts
+++ b/packages/i18n/src/i18n-cache/types.ts
@@ -33,7 +33,11 @@ export type I18nCacheConstructorParams<
 > = DictionaryConfig &
   Omit<
     GTConfig,
-    'cacheExpiryTime' | 'defaultLocale' | 'locales' | 'customMapping'
+    | 'cacheExpiryTime'
+    | 'defaultLocale'
+    | 'locales'
+    | 'customMapping'
+    | 'enableI18n'
   > & {
     /**
      * Locale cache TTL in milliseconds. Undefined uses the default TTL, null
@@ -41,7 +45,6 @@ export type I18nCacheConstructorParams<
      */
     cacheExpiryTime?: number | null;
     loadTranslations?: TranslationsLoader;
-    environment?: 'development' | 'production';
     batchConfig?: TranslationBatchConfig;
     runtimeTranslation?: RuntimeTranslationConfig;
     // Cache lifecycle hooks
@@ -53,14 +56,6 @@ export type I18nCacheConstructorParams<
  * I18nCache class configuration
  */
 export type I18nCacheConfig = {
-  environment: 'development' | 'production';
-  /**
-   * @deprecated
-   * Perhaps we can keep this around, but more for
-   * doing an initial load, but it may get overwritten
-   * so like a "initialEnableI18n" flag?
-   */
-  enableI18n: boolean;
   projectId?: string;
   devApiKey?: string;
   apiKey?: string;

--- a/packages/next/src/config-dir/I18NConfiguration.ts
+++ b/packages/next/src/config-dir/I18NConfiguration.ts
@@ -186,7 +186,6 @@ export class I18NConfiguration {
       devApiKey,
       projectId,
       runtimeUrl,
-      enableI18n: this.translationEnabled,
       // Batching config
       batchConfig: {
         maxConcurrentRequests,
@@ -213,8 +212,6 @@ export class I18NConfiguration {
       cacheExpiryTime:
         loadTranslationsType === 'remote' ? (cacheExpiryTime ?? null) : null,
       _versionId,
-      environment:
-        process.env.NODE_ENV === 'development' ? 'development' : 'production',
       ...(shouldLoadTranslations && {
         loadTranslations: async (locale: string) =>
           (await loadTranslations({


### PR DESCRIPTION
## Summary
- remove environment and enableI18n from i18nCache config/types
- use getRuntimeEnvironment() inside i18nCache for runtime-sensitive behavior
- stop passing i18n enablement/environment into i18nCache from Next config

## Testing
- pnpm --filter gt-i18n test
- pnpm --filter gt-i18n typecheck
- pnpm --filter @generaltranslation/react-core typecheck
- pnpm --filter gt-react typecheck
- pnpm --filter gt-next typecheck
- pnpm format
- pnpm lint

Note: gt-node typecheck is currently blocked by existing AsyncConditionStore type errors unrelated to this change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1512"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782520989&installation_id=127936663&pr_number=1512&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1512&signature=85b1e8084f5ac8bc78d0eb9d16192fec47069425392417ea422c4af80ea3a159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the `environment` and `enableI18n` fields from `I18nCache`'s constructor params and internal config, instead calling `getRuntimeEnvironment()` directly inside the methods that need environment-sensitive behavior (`isDevHotReloadEnabled` and `handleError`). The corresponding `environment` prop is also dropped from the `I18NConfiguration` → `I18nCache` construction path in `gt-next`.

- **`environment` → dynamic lookup**: `standardizeConfig` previously froze the environment at construction time; now `getRuntimeEnvironment()` is called inline at each call site.
- **`enableI18n` removed**: The field was stored in `I18nCacheConfig` but was never read anywhere in the class body — confirmed dead config.
- **Tests updated**: All env-sensitive tests now use `vi.stubEnv('NODE_ENV', ...)` with `afterEach(() => vi.unstubAllEnvs())` teardown.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — focused cleanup with no logic gaps and well-updated tests.

The refactor correctly replaces a construction-time environment snapshot with per-call reads from getRuntimeEnvironment(). Since process.env.NODE_ENV is effectively static in all supported runtimes, the behavioral change is invisible in production. The previously stored enableI18n field was confirmed dead code — never read inside I18nCache — so its removal carries no risk.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/i18n/src/i18n-cache/I18nCache.ts | Replaces frozen this.config.environment with live getRuntimeEnvironment() calls in isDevHotReloadEnabled and handleError; removes environment/enableI18n from standardizeConfig. |
| packages/i18n/src/i18n-cache/types.ts | Drops environment from I18nCacheConstructorParams and I18nCacheConfig; adds enableI18n to the Omit list so it can't be passed to the constructor. |
| packages/next/src/config-dir/I18NConfiguration.ts | Removes enableI18n and environment from the I18nCache constructor call; no behavioral change since those fields were unused by the cache. |
| packages/i18n/src/i18n-cache/__tests__/I18nCache.handleError.test.ts | Replaces constructor environment param with vi.stubEnv per test; adds afterEach vi.unstubAllEnvs for isolation. |
| packages/i18n/src/i18n-cache/__tests__/I18nCache.test.ts | Updates env-sensitive tests to stub NODE_ENV; moves environment from config to a top-level it.each datum; renames the enableI18n: false test to better reflect its actual assertion. |
| packages/i18n/src/i18n-cache/__tests__/resolveTranslationSync.test.ts | Replaces constructor environment: development with vi.stubEnv; adds afterEach teardown — clean and consistent with the other test files. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant I18nCache
    participant getRuntimeEnvironment

    Note over I18nCache: Before this PR
    Caller->>I18nCache: "new I18nCache({ environment: 'development' })"
    I18nCache->>I18nCache: standardizeConfig() freezes environment in this.config
    Caller->>I18nCache: isDevHotReloadEnabled()
    I18nCache->>I18nCache: reads this.config.environment

    Note over I18nCache: After this PR
    Caller->>I18nCache: "new I18nCache({})"
    I18nCache->>I18nCache: standardizeConfig() — no environment field
    Caller->>I18nCache: isDevHotReloadEnabled()
    I18nCache->>getRuntimeEnvironment: getRuntimeEnvironment()
    getRuntimeEnvironment-->>I18nCache: "'development' | 'production'"
    Caller->>I18nCache: handleError(err)
    I18nCache->>getRuntimeEnvironment: getRuntimeEnvironment()
    getRuntimeEnvironment-->>I18nCache: "'development' | 'production'"
```
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: remove i18n cache runtime flag..."](https://github.com/generaltranslation/gt/commit/47042b5ffce6889e4284eb42206c49bdb7333227) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34277587)</sub>

<!-- /greptile_comment -->