### PR TITLE
fix: update gt-node async condition store types

### DIFF
--- a/packages/node/src/async-i18n-cache/AsyncConditionStore.ts
+++ b/packages/node/src/async-i18n-cache/AsyncConditionStore.ts
@@ -1,5 +1,5 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
-import type { ScopedConditionStore } from 'gt-i18n/internal/types';
+import type { ScopedConditionStoreInterface } from 'gt-i18n/internal/types';
 import { getI18nConfig } from 'gt-i18n/internal';
 
 type Store = {
@@ -20,7 +20,7 @@ type AsyncConditionStoreConstructorParams = {
 /**
  * Condition store implementation that uses AsyncLocalStorage.
  */
-export class AsyncConditionStore implements ScopedConditionStore {
+export class AsyncConditionStore implements ScopedConditionStoreInterface {
   private store: AsyncLocalStorage<Store>;
 
   constructor({ store }: AsyncConditionStoreConstructorParams = {}) {
@@ -60,6 +60,10 @@ export class AsyncConditionStore implements ScopedConditionStore {
     }
     return store.enableI18n ?? true;
   }
+
+  setLocale = (_locale: string): void => {};
+
+  setEnableI18n = (_enableI18n: boolean): void => {};
 }
 
 function resolveLocale(locale?: string): string {


### PR DESCRIPTION
## Summary
- update gt-node's AsyncConditionStore to implement the current scoped condition store interface
- add required no-op condition setters for the readonly store contract

## Tests
- pnpm --filter gt-node typecheck
- pnpm --filter gt-node build
- pnpm --filter gt-node test
- pnpm exec oxlint packages/node
- pnpm exec oxfmt --check packages/node/src/async-i18n-cache/AsyncConditionStore.ts
- pnpm turbo typecheck --filter=gt-node
- pnpm turbo build --filter=gt-node

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1513"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782522408&installation_id=127936663&pr_number=1513&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1513&signature=944660ac0dd8d1a88d5a923ec766c6598780df3c194cc569c5f6de5e8c1855ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates `AsyncConditionStore` in `gt-node` to implement the renamed interface `ScopedConditionStoreInterface` (previously `ScopedConditionStore`) and adds the two no-op setter methods (`setLocale`, `setEnableI18n`) required by the `ReadonlyConditionStoreInterface` base contract.

- Updates the type import from `ScopedConditionStore` to `ScopedConditionStoreInterface` and adjusts the `implements` clause accordingly.
- Adds no-op `setLocale` and `setEnableI18n` arrow-function class fields to satisfy the readonly store contract and prevent runtime errors when the hooks are destructured in SSR contexts (e.g., `const setLocale = useSetLocale(); setLocale('es-ES')`).

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a minimal, targeted type alignment with no logic changes.

The two added methods are deliberate no-ops that match the intent documented in the interface itself (prevent errors when setters are destructured in SSR). The type rename is a straightforward 1-for-1 swap. No runtime behaviour changes.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/node/src/async-i18n-cache/AsyncConditionStore.ts | Type import updated to ScopedConditionStoreInterface; no-op setLocale and setEnableI18n arrow-function fields added to satisfy the ReadonlyConditionStoreInterface contract. Change is minimal and correct. |

</details>

</details>

<details><summary><h3>Class Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
classDiagram
    class ReadonlyConditionStoreInterface {
        <<interface>>
        +getLocale() string
        +getEnableI18n() boolean
        +setLocale(locale: string) void
        +setEnableI18n(enabled: boolean) void
    }

    class ScopedConditionStoreInterface {
        <<interface>>
        +run~T~(locale: string, callback: ()=>T) T
    }

    class AsyncConditionStore {
        -store: AsyncLocalStorage~Store~
        +run~T~(locale: string, callback: ()=>T) T
        +getLocale() string
        +getEnableI18n() boolean
        +setLocale(_locale: string) void
        +setEnableI18n(_enableI18n: boolean) void
    }

    ReadonlyConditionStoreInterface <|-- ScopedConditionStoreInterface
    ScopedConditionStoreInterface <|.. AsyncConditionStore : implements
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: update gt-node async condition stor..."](https://github.com/generaltranslation/gt/commit/78bc2a7ed43f805a260139d62e156444cb03fd09) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34280224)</sub>

<!-- /greptile_comment -->