### PR TITLE
refactor: initialize next locale config outside i18n configuration

### DIFF
--- a/packages/next/src/config-dir/I18NConfiguration.ts
+++ b/packages/next/src/config-dir/I18NConfiguration.ts
@@ -18,11 +18,9 @@ import {
   defaultResetLocaleCookieName,
 } from '../utils/cookies';
 import { defaultLocaleHeaderName } from '../utils/headers';
-import type { CustomMapping } from '@generaltranslation/format/types';
 import {
   getI18nConfig,
   I18nCache,
-  initializeI18nConfig,
   setupGTServicesEnabled,
 } from 'gt-i18n/internal';
 import type {
@@ -52,7 +50,6 @@ type I18NConfigurationParams = Omit<
   headersAndCookies: HeadersAndCookies;
   _usingPlugin: boolean;
   _versionId?: string;
-  customMapping?: CustomMapping | undefined;
   [key: string]: unknown;
 };
 
@@ -113,11 +110,14 @@ export class I18NConfiguration {
     // Internal
     _usingPlugin,
     headersAndCookies,
-    customMapping,
+    // Locale config is initialized by getI18NConfig; keep stripping this from
+    // runtime translation metadata while this facade accepts legacy params.
+    customMapping: _customMapping,
     // Other metadata
     ...metadata
   }: I18NConfigurationParams) {
     void _dictionary;
+    void _customMapping;
 
     // ----- CLOUD INTEGRATION ----- //
 
@@ -174,11 +174,6 @@ export class I18NConfiguration {
       projectId,
       runtimeUrl,
       cacheUrl: shouldLoadTranslations ? cacheUrl : null,
-    });
-    initializeI18nConfig({
-      defaultLocale,
-      locales,
-      customMapping,
     });
 
     this._i18nCache = new I18nCache<TranslatedChildren>({

--- a/packages/next/src/config-dir/__tests__/I18NConfiguration.integration.test.ts
+++ b/packages/next/src/config-dir/__tests__/I18NConfiguration.integration.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { GT } from 'generaltranslation';
 import { I18NConfiguration } from '../I18NConfiguration';
+import { initializeI18nConfig } from 'gt-i18n/internal';
 
 const mockLoadTranslations = vi.hoisted(() => vi.fn());
 
@@ -11,7 +12,7 @@ vi.mock('../loadTranslation', () => ({
 type ConfigParams = ConstructorParameters<typeof I18NConfiguration>[0];
 
 function createConfig(overrides: Partial<ConfigParams> = {}) {
-  return new I18NConfiguration({
+  const configParams = {
     runtimeUrl: undefined,
     cacheUrl: null,
     loadTranslationsType: 'custom',
@@ -27,7 +28,9 @@ function createConfig(overrides: Partial<ConfigParams> = {}) {
     headersAndCookies: {},
     _usingPlugin: false,
     ...overrides,
-  });
+  } as ConfigParams;
+  initializeI18nConfig(configParams);
+  return new I18NConfiguration(configParams);
 }
 
 describe('I18NConfiguration integration', () => {

--- a/packages/next/src/config-dir/__tests__/I18NConfiguration.test.ts
+++ b/packages/next/src/config-dir/__tests__/I18NConfiguration.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { I18NConfiguration } from '../I18NConfiguration';
+import { getI18NConfig } from '../getI18NConfig';
+import { defaultWithGTConfigProps } from '../props/defaultWithGTConfigProps';
 
 const mockI18nCacheParams = vi.hoisted(() => vi.fn());
 const mockLookupTranslationWithFallback = vi.hoisted(() => vi.fn());
@@ -104,6 +106,9 @@ vi.mock('gt-i18n/internal', () => ({
 }));
 
 type ConfigParams = ConstructorParameters<typeof I18NConfiguration>[0];
+type GlobalWithI18NConfig = typeof globalThis & {
+  _GENERALTRANSLATION_I18N_CONFIG_INSTANCE?: I18NConfiguration;
+};
 
 function createConfig(overrides: Partial<ConfigParams> = {}) {
   return new I18NConfiguration({
@@ -131,11 +136,18 @@ function expectCacheParams(expected: unknown) {
   );
 }
 
+function resetGlobalConfig() {
+  const globalObj = globalThis as GlobalWithI18NConfig;
+  delete globalObj._GENERALTRANSLATION_I18N_CONFIG_INSTANCE;
+}
+
 describe('I18NConfiguration', () => {
   beforeEach(() => {
+    resetGlobalConfig();
     mockI18nCacheParams.mockReset();
     mockLookupTranslationWithFallback.mockReset();
     mockLookupTranslationWithFallback.mockResolvedValue('translated');
+    vi.unstubAllEnvs();
     mockLocaleConfig.defaultLocale = 'en';
     mockLocaleConfig.locales = ['en', 'fr'];
     mockLocaleConfig.customMapping = {};
@@ -244,6 +256,78 @@ describe('I18NConfiguration', () => {
         customMapping,
       })
     );
+  });
+
+  it('reads locale values from gt-i18n config accessors', () => {
+    const config = createConfig({
+      defaultLocale: 'en',
+      locales: ['en', 'fr'],
+    });
+
+    mockLocaleConfig.defaultLocale = 'es';
+    mockLocaleConfig.locales = ['es', 'es-MX'];
+
+    expect(config.getDefaultLocale()).toBe('es');
+    expect(config.getLocales()).toEqual(['es', 'es-MX']);
+  });
+
+  it('reads client custom mappings from gt-i18n config accessors', () => {
+    const config = createConfig();
+    const customMapping = {
+      'brand-french': {
+        code: 'fr',
+        name: 'Brand French',
+      },
+    };
+
+    mockLocaleConfig.customMapping = customMapping;
+
+    expect(config.getClientSideConfig()).toEqual(
+      expect.objectContaining({
+        customMapping,
+      })
+    );
+  });
+
+  it('initializes locale metadata from environment-backed config params', () => {
+    const customMapping = {
+      'brand-spanish': {
+        code: 'es',
+        name: 'Brand Spanish',
+      },
+    };
+    vi.stubEnv(
+      '_GENERALTRANSLATION_I18N_CONFIG_PARAMS',
+      JSON.stringify({
+        defaultLocale: 'en-US',
+        locales: ['en-US', 'es', 'brand-spanish'],
+        customMapping,
+      })
+    );
+
+    const config = getI18NConfig();
+
+    expect(config.getDefaultLocale()).toBe('en-US');
+    expect(config.getLocales()).toEqual(['en-US', 'es', 'brand-spanish']);
+    expect(config.getClientSideConfig()).toEqual(
+      expect.objectContaining({
+        customMapping,
+      })
+    );
+  });
+
+  it('initializes locale metadata in the default config fallback', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const config = getI18NConfig();
+
+    expect(config.getDefaultLocale()).toBe(
+      defaultWithGTConfigProps.defaultLocale
+    );
+    expect(config.getLocales()).toEqual([
+      defaultWithGTConfigProps.defaultLocale,
+    ]);
+    warn.mockRestore();
   });
 
   it('checks translation and dialect requirements from locale config', () => {

--- a/packages/next/src/config-dir/__tests__/I18NConfiguration.test.ts
+++ b/packages/next/src/config-dir/__tests__/I18NConfiguration.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { I18NConfiguration } from '../I18NConfiguration';
 import { getI18NConfig } from '../getI18NConfig';
 import { defaultWithGTConfigProps } from '../props/defaultWithGTConfigProps';
+import { initializeI18nConfig } from 'gt-i18n/internal';
 
 const mockI18nCacheParams = vi.hoisted(() => vi.fn());
 const mockLookupTranslationWithFallback = vi.hoisted(() => vi.fn());
@@ -111,7 +112,7 @@ type GlobalWithI18NConfig = typeof globalThis & {
 };
 
 function createConfig(overrides: Partial<ConfigParams> = {}) {
-  return new I18NConfiguration({
+  const configParams = {
     runtimeUrl: undefined,
     cacheUrl: null,
     loadTranslationsType: 'custom',
@@ -127,7 +128,9 @@ function createConfig(overrides: Partial<ConfigParams> = {}) {
     headersAndCookies: {},
     _usingPlugin: false,
     ...overrides,
-  });
+  } as ConfigParams;
+  initializeI18nConfig(configParams);
+  return new I18NConfiguration(configParams);
 }
 
 function expectCacheParams(expected: unknown) {

--- a/packages/next/src/config-dir/getI18NConfig.ts
+++ b/packages/next/src/config-dir/getI18NConfig.ts
@@ -6,6 +6,7 @@ import {
   usingDefaultsWarning,
 } from '../errors/createErrors';
 import { getDefaultRenderSettings } from 'gt-react/internal';
+import { initializeI18nConfig } from 'gt-i18n/internal';
 
 type GlobalWithI18NConfig = typeof globalThis & {
   _GENERALTRANSLATION_I18N_CONFIG_INSTANCE?: I18NConfiguration;
@@ -21,10 +22,14 @@ export function getI18NConfig(): I18NConfiguration {
   // initGT: Get config from environment
   const I18NConfigParams = process.env._GENERALTRANSLATION_I18N_CONFIG_PARAMS;
   if (I18NConfigParams) {
-    globalObj._GENERALTRANSLATION_I18N_CONFIG_INSTANCE = new I18NConfiguration({
+    const configParams = {
       ...defaultWithGTConfigProps,
       ...JSON.parse(I18NConfigParams),
-    });
+    } as ConstructorParameters<typeof I18NConfiguration>[0];
+    initializeI18nConfig(configParams);
+    globalObj._GENERALTRANSLATION_I18N_CONFIG_INSTANCE = new I18NConfiguration(
+      configParams
+    );
   } else {
     console.warn(usingDefaultsWarning);
     // no initGT implies:
@@ -60,7 +65,7 @@ export function getI18NConfig(): I18NConfiguration {
     }
 
     // disable all translation
-    globalObj._GENERALTRANSLATION_I18N_CONFIG_INSTANCE = new I18NConfiguration({
+    const configParams = {
       ...defaultWithGTConfigProps,
       locales: [defaultLocale],
       renderSettings: getDefaultRenderSettings(process.env.NODE_ENV),
@@ -71,7 +76,11 @@ export function getI18NConfig(): I18NConfiguration {
       cacheUrl: null,
       loadTranslationsType: 'disabled',
       loadDictionaryEnabled: false,
-    });
+    } as ConstructorParameters<typeof I18NConfiguration>[0];
+    initializeI18nConfig(configParams);
+    globalObj._GENERALTRANSLATION_I18N_CONFIG_INSTANCE = new I18NConfiguration(
+      configParams
+    );
   }
 
   return globalObj._GENERALTRANSLATION_I18N_CONFIG_INSTANCE;


### PR DESCRIPTION
## Summary
- add regression coverage for Next i18n locale metadata initialization
- initialize gt-i18n locale config in getI18NConfig lazy branches before creating I18NConfiguration
- keep I18NConfiguration as a compatibility facade while removing its locale config initialization side effect

## Tests
- pnpm --filter gt-next test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1517"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782526826&installation_id=127936663&pr_number=1517&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1517&signature=f27697d1c2911663040852351c323f593a5435ae8ac813d4203565feb3cc7629"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves the `initializeI18nConfig` call out of the `I18NConfiguration` constructor and into the two lazy-branch paths of `getI18NConfig`, removing the constructor's locale-config side effect. Four tests are added to verify that locale metadata (`defaultLocale`, `locales`, `customMapping`) is correctly initialized through the new call sites and that the `gt-i18n` config accessors are the live source of truth at runtime.

- **`I18NConfiguration.ts`**: removes `initializeI18nConfig` import and call from the constructor; `customMapping` is now explicitly destructured-and-voided to keep it out of the `…metadata` spread.
- **`getI18NConfig.ts`**: both the env-var path and the default-fallback path now call `initializeI18nConfig(configParams)` before `new I18NConfiguration(configParams)`.
- **Test files**: both unit and integration test helpers updated to call `initializeI18nConfig` before constructing `I18NConfiguration`; new regression tests cover both `getI18NConfig` lazy branches.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The refactor is logically correct: `initializeI18nConfig` is called before `new I18NConfiguration` in every production code path, and the new tests verify both lazy-initialization branches. The only change worth a second look is the silent discarding of `customMapping` inside the constructor with no explanatory comment.

Both production paths in `getI18NConfig` always call `initializeI18nConfig` before constructing `I18NConfiguration`, so the `gt-i18n` singleton is guaranteed to be set before any locale accessor runs. The `customMapping` void is intentional and correct, but the absence of a comment leaves a subtle maintenance trap for future contributors who may not immediately understand why it is discarded at the constructor level rather than forwarded.

packages/next/src/config-dir/I18NConfiguration.ts — the `void _customMapping` line benefits from a comment explaining the expected call-site contract.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/next/src/config-dir/getI18NConfig.ts | Correctly adds `initializeI18nConfig(configParams)` before `new I18NConfiguration(configParams)` in both lazy-initialization branches; ordering is sound since `i18nConfig` singleton is set before the constructor reads from it. |
| packages/next/src/config-dir/I18NConfiguration.ts | Removes `initializeI18nConfig` side-effect from constructor; `customMapping` is destructured-and-voided intentionally to prevent it leaking into `...metadata`, but no comment explains why, which may confuse future maintainers. |
| packages/next/src/config-dir/__tests__/I18NConfiguration.test.ts | Unit test helper updated correctly; new tests cover env-var and default fallback branches of `getI18NConfig` and confirm live delegation to `gt-i18n` accessors. |
| packages/next/src/config-dir/__tests__/I18NConfiguration.integration.test.ts | Integration test helper updated to call `initializeI18nConfig` before constructing `I18NConfiguration`; existing test coverage remains intact. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant getI18NConfig
    participant initializeI18nConfig
    participant I18nConfig_singleton as I18nConfig (gt-i18n singleton)
    participant I18NConfiguration

    Caller->>getI18NConfig: getI18NConfig()
    getI18NConfig->>getI18NConfig: check global singleton
    alt singleton already set
        getI18NConfig-->>Caller: return existing instance
    else env var present
        getI18NConfig->>initializeI18nConfig: initializeI18nConfig(configParams)
        initializeI18nConfig->>I18nConfig_singleton: new I18nConfig(params)
        initializeI18nConfig->>I18nConfig_singleton: setI18nConfig(instance)
        getI18NConfig->>I18NConfiguration: new I18NConfiguration(configParams)
        I18NConfiguration->>I18nConfig_singleton: getI18nConfig() on locale accessor calls
        getI18NConfig-->>Caller: return instance
    else no env var (default fallback)
        getI18NConfig->>initializeI18nConfig: initializeI18nConfig(configParams)
        initializeI18nConfig->>I18nConfig_singleton: new I18nConfig(params)
        initializeI18nConfig->>I18nConfig_singleton: setI18nConfig(instance)
        getI18NConfig->>I18NConfiguration: new I18NConfiguration(configParams)
        I18NConfiguration->>I18nConfig_singleton: getI18nConfig() on locale accessor calls
        getI18NConfig-->>Caller: return instance
    end
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fnext%2Fsrc%2Fconfig-dir%2FI18NConfiguration.ts%3A115-120%0AThe%20%60customMapping%60%20parameter%20is%20now%20silently%20discarded%20inside%20the%20constructor%20%E2%80%94%20the%20caller%20is%20responsible%20for%20forwarding%20it%20to%20%60initializeI18nConfig%60%20before%20construction.%20Without%20a%20comment%20here%2C%20a%20future%20reader%20may%20think%20the%20%60void%60%20is%20a%20mistake%20or%20try%20to%20%22fix%22%20it%20by%20re-adding%20the%20forwarding%20call%20inside%20the%20constructor%2C%20reintroducing%20the%20side%20effect%20this%20PR%20removes.%20A%20brief%20inline%20note%20makes%20the%20intent%20clear.%0A%0A%60%60%60suggestion%0A%20%20%20%20customMapping%3A%20_customMapping%2C%0A%20%20%20%20%2F%2F%20Other%20metadata%0A%20%20%20%20...metadata%0A%20%20%7D%3A%20I18NConfigurationParams%29%20%7B%0A%20%20%20%20void%20_dictionary%3B%0A%20%20%20%20%2F%2F%20customMapping%20is%20intentionally%20not%20forwarded%20here%3B%20callers%20must%20invoke%0A%20%20%20%20%2F%2F%20initializeI18nConfig%28params%29%20before%20constructing%20I18NConfiguration%20so%0A%20%20%20%20%2F%2F%20that%20the%20gt-i18n%20singleton%20is%20populated%20before%20any%20locale%20accessors%20run.%0A%20%20%20%20void%20_customMapping%3B%0A%60%60%60%0A%0A&repo=generaltranslation%2Fgt&pr=1517&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fodysseus%2Fnext-i18n-config-init%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fodysseus%2Fnext-i18n-config-init%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fnext%2Fsrc%2Fconfig-dir%2FI18NConfiguration.ts%3A115-120%0AThe%20%60customMapping%60%20parameter%20is%20now%20silently%20discarded%20inside%20the%20constructor%20%E2%80%94%20the%20caller%20is%20responsible%20for%20forwarding%20it%20to%20%60initializeI18nConfig%60%20before%20construction.%20Without%20a%20comment%20here%2C%20a%20future%20reader%20may%20think%20the%20%60void%60%20is%20a%20mistake%20or%20try%20to%20%22fix%22%20it%20by%20re-adding%20the%20forwarding%20call%20inside%20the%20constructor%2C%20reintroducing%20the%20side%20effect%20this%20PR%20removes.%20A%20brief%20inline%20note%20makes%20the%20intent%20clear.%0A%0A%60%60%60suggestion%0A%20%20%20%20customMapping%3A%20_customMapping%2C%0A%20%20%20%20%2F%2F%20Other%20metadata%0A%20%20%20%20...metadata%0A%20%20%7D%3A%20I18NConfigurationParams%29%20%7B%0A%20%20%20%20void%20_dictionary%3B%0A%20%20%20%20%2F%2F%20customMapping%20is%20intentionally%20not%20forwarded%20here%3B%20callers%20must%20invoke%0A%20%20%20%20%2F%2F%20initializeI18nConfig%28params%29%20before%20constructing%20I18NConfiguration%20so%0A%20%20%20%20%2F%2F%20that%20the%20gt-i18n%20singleton%20is%20populated%20before%20any%20locale%20accessors%20run.%0A%20%20%20%20void%20_customMapping%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/next/src/config-dir/I18NConfiguration.ts:115-120
The `customMapping` parameter is now silently discarded inside the constructor — the caller is responsible for forwarding it to `initializeI18nConfig` before construction. Without a comment here, a future reader may think the `void` is a mistake or try to "fix" it by re-adding the forwarding call inside the constructor, reintroducing the side effect this PR removes. A brief inline note makes the intent clear.

```suggestion
    customMapping: _customMapping,
    // Other metadata
    ...metadata
  }: I18NConfigurationParams) {
    void _dictionary;
    // customMapping is intentionally not forwarded here; callers must invoke
    // initializeI18nConfig(params) before constructing I18NConfiguration so
    // that the gt-i18n singleton is populated before any locale accessors run.
    void _customMapping;
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: initialize next locale config ..."](https://github.com/generaltranslation/gt/commit/9d49eeb525e32ca439fa7a942040c5acb1654105) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34287819)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->