### PR TITLE
refactor(1): extract format locales helper

### DIFF
--- a/packages/react-core/src/components/branches/Plural.tsx
+++ b/packages/react-core/src/components/branches/Plural.tsx
@@ -1,6 +1,7 @@
 import getPluralBranch from '../../utils/plurals/getPluralBranch';
 import type { ReactNode } from 'react';
-import { useFormatLocales } from '../../hooks/utils';
+import { useEnableI18n, useLocale } from '../../hooks/condition-store';
+import { getFormatLocales } from '../../hooks/utils';
 
 type PluralProps = {
   children?: ReactNode;
@@ -17,7 +18,9 @@ function GtInternalPlural({
   locales: localesProp = [],
   ...branches
 }: PluralProps): ReactNode {
-  const locales = useFormatLocales(localesProp);
+  const locale = useLocale();
+  const enableI18n = useEnableI18n();
+  const locales = getFormatLocales({ locale, enableI18n, localesProp });
   if (typeof n !== 'number') {
     return children;
   }

--- a/packages/react-core/src/components/variables/Currency.tsx
+++ b/packages/react-core/src/components/variables/Currency.tsx
@@ -1,5 +1,6 @@
 import { getReactI18nCache } from '../../i18n-cache/singleton-operations';
-import { useFormatLocales } from '../../hooks/utils';
+import { useEnableI18n, useLocale } from '../../hooks/condition-store';
+import { getFormatLocales } from '../../hooks/utils';
 
 type CurrencyProps = {
   children: number | string | null | undefined;
@@ -17,7 +18,9 @@ function GtInternalCurrency({
   options = {},
   locales: localesProp = [],
 }: CurrencyProps): string | null {
-  const locales = useFormatLocales(localesProp);
+  const locale = useLocale();
+  const enableI18n = useEnableI18n();
+  const locales = getFormatLocales({ locale, enableI18n, localesProp });
   const gt = getReactI18nCache().getGTClass();
   if (children == null) return null;
   const parsedNumber =

--- a/packages/react-core/src/components/variables/DateTime.tsx
+++ b/packages/react-core/src/components/variables/DateTime.tsx
@@ -1,5 +1,6 @@
 import { getReactI18nCache } from '../../i18n-cache/singleton-operations';
-import { useFormatLocales } from '../../hooks/utils';
+import { useEnableI18n, useLocale } from '../../hooks/condition-store';
+import { getFormatLocales } from '../../hooks/utils';
 
 type DateTimeProps = {
   children: Date | null | undefined;
@@ -15,7 +16,9 @@ function GtInternalDateTime({
   options = {},
   locales: localesProp = [],
 }: DateTimeProps): string | null {
-  const locales = useFormatLocales(localesProp);
+  const locale = useLocale();
+  const enableI18n = useEnableI18n();
+  const locales = getFormatLocales({ locale, enableI18n, localesProp });
   // TODO: theres a world in which we don't need the i18n cache, if user passes their own params
   const gt = getReactI18nCache().getGTClass();
   if (children == null) return null;

--- a/packages/react-core/src/components/variables/Num.tsx
+++ b/packages/react-core/src/components/variables/Num.tsx
@@ -1,5 +1,6 @@
 import { getReactI18nCache } from '../../i18n-cache/singleton-operations';
-import { useFormatLocales } from '../../hooks/utils';
+import { useEnableI18n, useLocale } from '../../hooks/condition-store';
+import { getFormatLocales } from '../../hooks/utils';
 
 type NumProps = {
   children: number | string | null | undefined;
@@ -15,7 +16,9 @@ function GtInternalNum({
   options = {},
   locales: localesProp = [],
 }: NumProps): string | null {
-  const locales = useFormatLocales(localesProp);
+  const locale = useLocale();
+  const enableI18n = useEnableI18n();
+  const locales = getFormatLocales({ locale, enableI18n, localesProp });
   const gt = getReactI18nCache().getGTClass();
   if (children == null) return null;
   const parsedNumber =

--- a/packages/react-core/src/components/variables/RelativeTime.tsx
+++ b/packages/react-core/src/components/variables/RelativeTime.tsx
@@ -1,5 +1,6 @@
 import { getReactI18nCache } from '../../i18n-cache/singleton-operations';
-import { useFormatLocales } from '../../hooks/utils';
+import { useEnableI18n, useLocale } from '../../hooks/condition-store';
+import { getFormatLocales } from '../../hooks/utils';
 
 type RelativeTimeProps = {
   date?: Date | null | undefined;
@@ -23,7 +24,9 @@ function GtInternalRelativeTime({
   locales: localesProp = [],
   options = {},
 }: RelativeTimeProps): string | null {
-  const locales = useFormatLocales(localesProp);
+  const locale = useLocale();
+  const enableI18n = useEnableI18n();
+  const locales = getFormatLocales({ locale, enableI18n, localesProp });
   const gt = getReactI18nCache().getGTClass();
   const resolvedDate = date ?? children;
 

--- a/packages/react-core/src/context.ts
+++ b/packages/react-core/src/context.ts
@@ -19,7 +19,7 @@ export {
 export { useGT } from './hooks/useGT';
 export { useMessages } from './hooks/useMessages';
 export { useTranslations } from './hooks/useTranslations';
-export { useFormatLocales } from './hooks/utils';
+export { getFormatLocales, useFormatLocales } from './hooks/utils';
 
 // ===== Functions ===== //
 export { getTranslationsSnapshot } from './functions/helpers/getTranslationsSnapshot';

--- a/packages/react-core/src/hooks/__tests__/utils.test.ts
+++ b/packages/react-core/src/hooks/__tests__/utils.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { initializeI18nConfig } from 'gt-i18n/internal';
 import { setReadonlyConditionStore } from '../../condition-store/singleton-operations';
-import { getShouldTranslate } from '../utils';
+import { getFormatLocales, getShouldTranslate } from '../utils';
 
 function setup({
   locale,
@@ -57,5 +57,43 @@ describe('getShouldTranslate', () => {
     setup({ locale: 'fr', enableI18n: false });
 
     expect(getShouldTranslate()).toBe(false);
+  });
+});
+
+describe('getFormatLocales', () => {
+  it('uses an explicit locale when translation is required', () => {
+    setup({ locale: 'en' });
+
+    expect(
+      getFormatLocales({
+        locale: 'fr',
+        enableI18n: true,
+        localesProp: ['fr-CA'],
+      })
+    ).toEqual(['fr-CA', 'fr', 'en']);
+  });
+
+  it('returns only the default locale when explicit locale does not require translation', () => {
+    setup({ locale: 'de', locales: ['en', 'fr', 'de'] });
+
+    expect(
+      getFormatLocales({
+        locale: 'en',
+        enableI18n: true,
+        localesProp: ['fr-CA'],
+      })
+    ).toEqual(['en']);
+  });
+
+  it('returns only the default locale when translation is disabled', () => {
+    setup({ locale: 'fr', enableI18n: false });
+
+    expect(
+      getFormatLocales({
+        locale: 'fr',
+        enableI18n: false,
+        localesProp: ['fr-CA'],
+      })
+    ).toEqual(['en']);
   });
 });

--- a/packages/react-core/src/hooks/utils.ts
+++ b/packages/react-core/src/hooks/utils.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { useLocale } from './condition-store';
+import { useEnableI18n, useLocale } from './condition-store';
 import { getReadonlyConditionStoreWithFallback } from '../condition-store/singleton-operations';
 import { getI18nConfig } from 'gt-i18n/internal';
 
@@ -9,15 +9,33 @@ export function useFormatLocales(
   localesProp: string[] = EMPTY_LOCALES_PROP
 ): string[] {
   const locale = useLocale();
-  const defaultLocale = getI18nConfig().getDefaultLocale();
-  const shouldTranslate = getShouldTranslate();
+  const enableI18n = useEnableI18n();
   return useMemo(
     () =>
-      shouldTranslate
-        ? [...localesProp, locale, defaultLocale]
-        : [defaultLocale],
-    [defaultLocale, locale, localesProp, shouldTranslate]
+      getFormatLocales({
+        locale,
+        enableI18n,
+        localesProp,
+      }),
+    [locale, enableI18n, localesProp]
   );
+}
+
+export function getFormatLocales({
+  locale,
+  enableI18n,
+  localesProp = EMPTY_LOCALES_PROP,
+}: {
+  locale: string;
+  enableI18n: boolean;
+  localesProp?: string[];
+}): string[] {
+  const defaultLocale = getI18nConfig().getDefaultLocale();
+  const shouldTranslate =
+    enableI18n && getI18nConfig().requiresTranslation(locale);
+  return shouldTranslate
+    ? [...localesProp, locale, defaultLocale]
+    : [defaultLocale];
 }
 
 export function useShouldTranslate(): boolean {

--- a/packages/react/src/context.client.ts
+++ b/packages/react/src/context.client.ts
@@ -28,6 +28,7 @@ export {
   useDefaultLocale,
   useEnableI18n,
   useLocales,
+  getFormatLocales,
   useFormatLocales,
   useGT,
   useMessages,

--- a/packages/react/src/context.server.ts
+++ b/packages/react/src/context.server.ts
@@ -28,6 +28,7 @@ export {
   useDefaultLocale,
   useEnableI18n,
   useLocales,
+  getFormatLocales,
   useFormatLocales,
   useGT,
   useMessages,

--- a/packages/react/src/context.types.ts
+++ b/packages/react/src/context.types.ts
@@ -39,6 +39,7 @@ export {
   useDefaultLocale,
   useEnableI18n,
   useLocales,
+  getFormatLocales,
   useFormatLocales,
   useGT,
   useMessages,


### PR DESCRIPTION
## Summary
- extract getFormatLocales as the shared locale-list helper
- update react-core variable and plural components to call getFormatLocales directly
- keep useFormatLocales as a thin wrapper for context compatibility

## Tests
- pnpm --filter @generaltranslation/react-core exec vitest run src/hooks/__tests__/utils.test.ts
- pnpm --filter @generaltranslation/react-core typecheck
- pnpm exec oxlint packages/react-core/src/hooks/utils.ts packages/react-core/src/hooks/__tests__/utils.test.ts packages/react-core/src/components/variables/Num.tsx packages/react-core/src/components/variables/Currency.tsx packages/react-core/src/components/variables/DateTime.tsx packages/react-core/src/components/variables/RelativeTime.tsx packages/react-core/src/components/branches/Plural.tsx packages/react-core/src/context.ts packages/react/src/context.server.ts packages/react/src/context.client.ts packages/react/src/context.types.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1521"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782527784&installation_id=127936663&pr_number=1521&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1521&signature=8add3cdd3a232603a95dbb03ffacf9f73793021f5297b3b6f10d9d0ee4b553cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors the locale-list logic by extracting `getFormatLocales` as a standalone pure function, allowing both hook-based (React) and non-hook (server/SSR) callers to share the same logic without duplicating the `enableI18n && requiresTranslation` guard.

- **`getFormatLocales`** is extracted from `useFormatLocales`, takes explicit `{ locale, enableI18n, localesProp }` params, and is exported from all three context barrels.
- **`useFormatLocales`** becomes a thin `useMemo` wrapper that reads `useLocale()` / `useEnableI18n()` and delegates to `getFormatLocales` — preserving backward compatibility.
- **Five components** (Num, Currency, DateTime, RelativeTime, Plural) are updated to call hooks directly and pass values to `getFormatLocales`; tests cover all key branches including `enableI18n=false`.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the refactoring is mechanically straightforward, the enableI18n guard is correctly preserved in getFormatLocales, and the enableI18n=false branch is now explicitly tested.

The extraction is a clean lift-and-shift: getFormatLocales replicates the exact enableI18n && requiresTranslation(locale) logic that getShouldTranslate already used, the five updated components each read and pass both locale and enableI18n explicitly, and the new tests confirm all three branches.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react-core/src/hooks/utils.ts | Extracts getFormatLocales as a pure function with explicit locale, enableI18n, localesProp params; useFormatLocales becomes a thin useMemo wrapper with the enableI18n guard correctly applied. |
| packages/react-core/src/hooks/__tests__/utils.test.ts | Adds three getFormatLocales tests covering: translation required, default locale (no translation), and enableI18n=false — all key branches exercised. |
| packages/react-core/src/components/branches/Plural.tsx | Switched from useFormatLocales to direct useLocale + useEnableI18n hooks feeding getFormatLocales. |
| packages/react-core/src/components/variables/Num.tsx | Replaced useFormatLocales with direct hook reads + getFormatLocales. |
| packages/react-core/src/context.ts | Adds getFormatLocales to the public re-export list alongside useFormatLocales. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/ody..."](https://github.com/generaltranslation/gt/commit/b161af7df5c8b54d5e8781907847560395b6a38f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34289575)</sub>

<!-- /greptile_comment -->