### PR TITLE
fix: restore ci builds on rust stable

### DIFF
--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -10,6 +10,8 @@ permissions:
 
 env:
   CI: true
+  # size-limit-action checks out and builds the base branch for comparison.
+  RUSTFLAGS: '-C link-arg=--allow-undefined'
 
 jobs:
   size:

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -12,6 +12,7 @@ env:
   CI: true
   # size-limit-action checks out and builds the base branch for comparison.
   RUSTFLAGS: '-C link-arg=--allow-undefined'
+  TURBO_ENV_MODE: loose
 
 jobs:
   size:

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -32,7 +32,7 @@
     "build": "pnpm run build:swc-plugin && pnpm run transpile",
     "build:clean": "rm -rf ./swc-plugin/target && sh ../../scripts/clean.sh && pnpm run build",
     "build:release": "pnpm run build:clean",
-    "build:swc-plugin": "cargo build --release --target wasm32-wasip1 --manifest-path ./swc-plugin/Cargo.toml && node scripts/copy-wasm.js",
+    "build:swc-plugin": "cd swc-plugin && cargo build --release --target wasm32-wasip1 && cd .. && node scripts/copy-wasm.js",
     "build:no-swc-plugin": "pnpm run transpile",
     "release": "pnpm run build:clean && pnpm publish",
     "release:alpha": "pnpm run build:clean && pnpm publish --tag alpha",

--- a/packages/next/swc-plugin/.cargo/config.toml
+++ b/packages/next/swc-plugin/.cargo/config.toml
@@ -13,3 +13,6 @@ build-darwin-x64 = "build --target x86_64-apple-darwin --release"
 build-darwin-arm64 = "build --target aarch64-apple-darwin --release"
 build-win32-x64 = "build --target x86_64-pc-windows-msvc --release"
 build-win32-arm64 = "build --target aarch64-pc-windows-msvc --release"
+
+[target.wasm32-wasip1]
+rustflags = ["-C", "link-arg=--allow-undefined"]

--- a/tests/apps/cli-test-app/next.config.ts
+++ b/tests/apps/cli-test-app/next.config.ts
@@ -1,7 +1,10 @@
 import type { NextConfig } from 'next';
+import { getTurbopackRoot } from '../next/turbopackRoot';
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  turbopack: {
+    root: getTurbopackRoot(import.meta.url),
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- allow undefined SWC host imports when linking the gt-next WASI plugin on current Rust stable
- run the SWC plugin Cargo build from the plugin directory so Cargo reads its .cargo/config.toml
- set turbopack.root in the CLI test app so Next 16 can resolve the workspace root in CI

## Testing
- RUSTUP_TOOLCHAIN=1.96.0 pnpm exec turbo build --force --filter=generaltranslation --filter=gt-i18n --filter='@generaltranslation/react-core' --filter=gt-react --filter=gt-tanstack-start --filter=gt-next
- RUSTUP_TOOLCHAIN=1.96.0 pnpm exec turbo build --force --filter='...[origin/main]' --filter='!gt-next-middleware-e2e' --filter='!./examples/*'
- pnpm exec oxfmt --check packages/next/package.json tests/apps/cli-test-app/next.config.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1524"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782606171&installation_id=127936663&pr_number=1524&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1524&signature=cde3b56e460bceccbb7f61b78a58da42556181e660beb4b16eddbac7efeeec02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores CI builds on Rust stable by wiring the `--allow-undefined` linker flag so the SWC WASM plugin can reference undefined SWC host imports that are now absent on the current stable toolchain.

- **`.cargo/config.toml`**: Scopes `rustflags = ["-C", "link-arg=--allow-undefined"]` to the `[target.wasm32-wasip1]` section (correct, targeted fix). The `build:swc-plugin` script is updated from `--manifest-path` to `cd swc-plugin` so Cargo actually finds this config file at build time.
- **`size-limit.yml`**: Adds a global `RUSTFLAGS` env var and `TURBO_ENV_MODE: loose` so that the size-limit-action (which builds both branches independently) also picks up the flag regardless of its working directory.
- **`cli-test-app/next.config.ts`**: Sets `turbopack.root` via `getTurbopackRoot(import.meta.url)` to resolve the pnpm workspace root for Next 16 in CI.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all changes are CI/build configuration fixes with no impact on runtime library behaviour.

The changes are narrowly scoped: a Cargo config addition, a build script working-directory fix, a workflow env var, and a Next.js config update in a test app. None of these touch production code paths. The --allow-undefined flag is correctly scoped to the WASM target in config.toml; the global RUSTFLAGS in the workflow is a pragmatic safeguard for a WASM-only CI job.

No files require special attention. The only minor asymmetry is that test:rust in package.json still uses --manifest-path, but this does not affect current test targets.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/size-limit.yml | Adds global RUSTFLAGS='-C link-arg=--allow-undefined' and TURBO_ENV_MODE=loose to enable WASM builds on Rust stable in the size-limit CI workflow. |
| packages/next/package.json | Switches build:swc-plugin from --manifest-path to cd swc-plugin so Cargo reads the .cargo/config.toml placed in the plugin directory. |
| packages/next/swc-plugin/.cargo/config.toml | Adds a [target.wasm32-wasip1] section with rustflags = ["-C", "link-arg=--allow-undefined"] to allow undefined SWC host imports on Rust stable. |
| tests/apps/cli-test-app/next.config.ts | Sets turbopack.root via getTurbopackRoot so Next 16 can resolve the pnpm workspace root in CI. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[pnpm run build] --> B[build:swc-plugin]
    B --> C["cd swc-plugin\n(cwd = swc-plugin/)"]
    C --> D["Cargo reads\n.cargo/config.toml\n[target.wasm32-wasip1]\nrustflags = --allow-undefined"]
    D --> E["cargo build --release\n--target wasm32-wasip1"]
    E --> F["cd ..\nnode scripts/copy-wasm.js"]
    F --> G[transpile]

    H["size-limit CI\n(size-limit-action)"] --> I["env RUSTFLAGS=\n'-C link-arg=--allow-undefined'\nTURBO_ENV_MODE=loose"]
    I --> J[pnpm run build]
    J --> B

    K[cli-test-app] --> L["next.config.ts\nturbopack.root =\ngetTurbopackRoot(import.meta.url)"]
    L --> M["Common ancestor of\napp dir + next pkg dir\n→ workspace root"]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Fsize-limit.yml%3A13-15%0AThe%20%60RUSTFLAGS%60%20env%20var%20is%20set%20globally%20for%20the%20whole%20workflow%2C%20not%20scoped%20to%20the%20%60wasm32-wasip1%60%20target.%20If%20any%20transitive%20native%20Rust%20build%20is%20ever%20triggered%20in%20this%20workflow%20%28e.g.%2C%20a%20proc-macro%2C%20a%20build%20script%2C%20or%20a%20future%20package%20added%20to%20the%20size-limit%20set%29%2C%20%60--allow-undefined%60%20would%20be%20silently%20passed%20to%20the%20native%20linker.%20While%20this%20is%20harmless%20in%20the%20current%20workflow%20%28only%20WASM%20is%20built%29%2C%20the%20%60.cargo%2Fconfig.toml%60%20approach%20used%20elsewhere%20in%20this%20PR%20already%20scopes%20the%20flag%20correctly%20via%20%60%5Btarget.wasm32-wasip1%5D%60.%20Relying%20solely%20on%20the%20config.toml%20and%20dropping%20the%20global%20env%20var%20would%20be%20safer%20long-term%20%E2%80%94%20though%20the%20current%20state%20is%20not%20broken%20for%20the%20WASM-only%20workflow.%0A%0A%60%60%60suggestion%0A%20%20%23%20size-limit-action%20checks%20out%20and%20builds%20the%20base%20branch%20for%20comparison.%0A%20%20%23%20RUSTFLAGS%20is%20set%20globally%20here%20because%20size-limit-action%20may%20invoke%20builds%0A%20%20%23%20from%20a%20directory%20other%20than%20swc-plugin%2C%20bypassing%20.cargo%2Fconfig.toml%20lookup.%0A%20%20RUSTFLAGS%3A%20'-C%20link-arg%3D--allow-undefined'%0A%20%20TURBO_ENV_MODE%3A%20loose%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fnext%2Fpackage.json%3A43%0A%60test%3Arust%60%20still%20uses%20%60--manifest-path%20.%2Fswc-plugin%2FCargo.toml%60%2C%20which%20means%20Cargo%20won't%20find%20%60swc-plugin%2F.cargo%2Fconfig.toml%60%20during%20test%20runs%20%28the%20same%20cwd-vs-manifest-path%20issue%20the%20%60build%3Aswc-plugin%60%20script%20just%20fixed%29.%20Tests%20don't%20target%20%60wasm32-wasip1%60%20today%2C%20so%20this%20is%20not%20currently%20broken%20%E2%80%94%20but%20if%20any%20future%20test%20ever%20targets%20WASM%2C%20it%20will%20silently%20miss%20the%20%60--allow-undefined%60%20rustflag.%20For%20consistency%20and%20future-proofing%20consider%20aligning%20this%20to%20%60cd%20swc-plugin%20%26%26%20cargo%20test%20%26%26%20cd%20..%60%20as%20well.%0A%0A&repo=generaltranslation%2Fgt&pr=1524&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22fix%2Fci-build-rust-stable%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fci-build-rust-stable%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Fsize-limit.yml%3A13-15%0AThe%20%60RUSTFLAGS%60%20env%20var%20is%20set%20globally%20for%20the%20whole%20workflow%2C%20not%20scoped%20to%20the%20%60wasm32-wasip1%60%20target.%20If%20any%20transitive%20native%20Rust%20build%20is%20ever%20triggered%20in%20this%20workflow%20%28e.g.%2C%20a%20proc-macro%2C%20a%20build%20script%2C%20or%20a%20future%20package%20added%20to%20the%20size-limit%20set%29%2C%20%60--allow-undefined%60%20would%20be%20silently%20passed%20to%20the%20native%20linker.%20While%20this%20is%20harmless%20in%20the%20current%20workflow%20%28only%20WASM%20is%20built%29%2C%20the%20%60.cargo%2Fconfig.toml%60%20approach%20used%20elsewhere%20in%20this%20PR%20already%20scopes%20the%20flag%20correctly%20via%20%60%5Btarget.wasm32-wasip1%5D%60.%20Relying%20solely%20on%20the%20config.toml%20and%20dropping%20the%20global%20env%20var%20would%20be%20safer%20long-term%20%E2%80%94%20though%20the%20current%20state%20is%20not%20broken%20for%20the%20WASM-only%20workflow.%0A%0A%60%60%60suggestion%0A%20%20%23%20size-limit-action%20checks%20out%20and%20builds%20the%20base%20branch%20for%20comparison.%0A%20%20%23%20RUSTFLAGS%20is%20set%20globally%20here%20because%20size-limit-action%20may%20invoke%20builds%0A%20%20%23%20from%20a%20directory%20other%20than%20swc-plugin%2C%20bypassing%20.cargo%2Fconfig.toml%20lookup.%0A%20%20RUSTFLAGS%3A%20'-C%20link-arg%3D--allow-undefined'%0A%20%20TURBO_ENV_MODE%3A%20loose%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fnext%2Fpackage.json%3A43%0A%60test%3Arust%60%20still%20uses%20%60--manifest-path%20.%2Fswc-plugin%2FCargo.toml%60%2C%20which%20means%20Cargo%20won't%20find%20%60swc-plugin%2F.cargo%2Fconfig.toml%60%20during%20test%20runs%20%28the%20same%20cwd-vs-manifest-path%20issue%20the%20%60build%3Aswc-plugin%60%20script%20just%20fixed%29.%20Tests%20don't%20target%20%60wasm32-wasip1%60%20today%2C%20so%20this%20is%20not%20currently%20broken%20%E2%80%94%20but%20if%20any%20future%20test%20ever%20targets%20WASM%2C%20it%20will%20silently%20miss%20the%20%60--allow-undefined%60%20rustflag.%20For%20consistency%20and%20future-proofing%20consider%20aligning%20this%20to%20%60cd%20swc-plugin%20%26%26%20cargo%20test%20%26%26%20cd%20..%60%20as%20well.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
.github/workflows/size-limit.yml:13-15
The `RUSTFLAGS` env var is set globally for the whole workflow, not scoped to the `wasm32-wasip1` target. If any transitive native Rust build is ever triggered in this workflow (e.g., a proc-macro, a build script, or a future package added to the size-limit set), `--allow-undefined` would be silently passed to the native linker. While this is harmless in the current workflow (only WASM is built), the `.cargo/config.toml` approach used elsewhere in this PR already scopes the flag correctly via `[target.wasm32-wasip1]`. Relying solely on the config.toml and dropping the global env var would be safer long-term — though the current state is not broken for the WASM-only workflow.

```suggestion
  # size-limit-action checks out and builds the base branch for comparison.
  # RUSTFLAGS is set globally here because size-limit-action may invoke builds
  # from a directory other than swc-plugin, bypassing .cargo/config.toml lookup.
  RUSTFLAGS: '-C link-arg=--allow-undefined'
  TURBO_ENV_MODE: loose
```

### Issue 2 of 2
packages/next/package.json:43
`test:rust` still uses `--manifest-path ./swc-plugin/Cargo.toml`, which means Cargo won't find `swc-plugin/.cargo/config.toml` during test runs (the same cwd-vs-manifest-path issue the `build:swc-plugin` script just fixed). Tests don't target `wasm32-wasip1` today, so this is not currently broken — but if any future test ever targets WASM, it will silently miss the `--allow-undefined` rustflag. For consistency and future-proofing consider aligning this to `cd swc-plugin && cargo test && cd ..` as well.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: pass linker env through turbo in si..."](https://github.com/generaltranslation/gt/commit/ac394f807a06a84f041cf2ca089f88ca9e7f5485) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34490745)</sub>

<!-- /greptile_comment -->