### PR TITLE
feat: backtick escaping

### DIFF
--- a/.changeset/olive-pots-sniff.md
+++ b/.changeset/olive-pots-sniff.md
@@ -1,0 +1,5 @@
+---
+"gt-remark": patch
+---
+
+Add backtick escaping

--- a/packages/remark/src/__tests__/index.test.ts
+++ b/packages/remark/src/__tests__/index.test.ts
@@ -184,6 +184,59 @@ describe('escapeHtmlInTextNodes', () => {
     });
   });
 
+  describe('backtick (`) escaping', () => {
+    it('should escape a standalone literal backtick in text', () => {
+      const tree: Root = {
+        type: 'root',
+        children: [
+          createParagraph([
+            createTextNode('use backticks (`) and plus (+) characters'),
+          ]),
+        ],
+      };
+      const result = processAst(tree);
+      expect(result).toContain('use backticks (&#96;) and plus (+) characters');
+      expect(result).not.toContain('(`)');
+    });
+
+    it('should not escape backticks inside code spans', () => {
+      const tree: Root = {
+        type: 'root',
+        children: [
+          createParagraph([
+            createTextNode('inject the '),
+            createInlineCode('<script>'),
+            createTextNode(' tag'),
+          ]),
+        ],
+      };
+      const result = processAst(tree);
+      // The inlineCode delimiters (real backticks) must survive untouched.
+      expect(result).toContain('`<script>`');
+    });
+
+    it('should leave a text node with no bare backtick that could re-open a span', () => {
+      // Regression: a literal backtick in prose used to survive the roundtrip
+      // bare, re-pairing inline-code delimiters and shoving protected content
+      // (e.g. <script>) out of its code span -> "Expected a closing tag".
+      const tree: Root = {
+        type: 'root',
+        children: [
+          createParagraph([
+            createTextNode('use backticks (`) to inject the '),
+            createInlineCode('<script>'),
+            createTextNode(' tag'),
+          ]),
+        ],
+      };
+      const result = processAst(tree);
+      // Exactly two bare backticks remain: the inlineCode delimiters. The
+      // literal prose backtick is now the &#96; entity.
+      expect((result.match(/`/g) || []).length).toBe(2);
+      expect(result).toContain('(&#96;)');
+    });
+  });
+
   describe('combined character escaping', () => {
     it('should escape all HTML characters together', () => {
       const tree: Root = {

--- a/packages/remark/src/plugins/escapeHtmlInTextNodes.ts
+++ b/packages/remark/src/plugins/escapeHtmlInTextNodes.ts
@@ -7,7 +7,7 @@ import { IGNORE_ALWAYS, IGNORE_HEADINGS } from './shared.js';
 const AMP_NOT_ENTITY = /&(?![a-zA-Z][a-zA-Z0-9]*;|#\d+;|#x[0-9A-Fa-f]+;)/g;
 
 /**
- * Escape HTML-sensitive characters ('{', '}', `&`, `<`, `>`, `"`, `'`) in text nodes,
+ * Escape HTML-sensitive characters ('{', '}', `&`, `<`, `>`, `"`, `'`, '`') in text nodes,
  * leaving code, math, MDX expressions, and front-matter untouched.
  * Ensures literals render safely without altering already-escaped entities.
  */
@@ -22,6 +22,7 @@ const escapeHtmlInTextNodes: Plugin<[], Root> = function () {
         [/>/g, '&gt;'],
         [/"/g, '&quot;'],
         [/'/g, '&#39;'],
+        [/`/g, '&#96;'],
       ],
       { ignore: IGNORE_ALWAYS }
     );


### PR DESCRIPTION
<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1526"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782620466&installation_id=127936663&pr_number=1526&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1526&signature=94501ae91da8f8e392ef53b87eba9e3d504fbfef9455f633899bad90b4eee7ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds backtick (`` ` ``) escaping to the `escapeHtmlInTextNodes` remark plugin, converting literal backticks in text nodes to the HTML entity `&#96;`. This prevents bare backticks in prose from accidentally pairing with backtick delimiters that wrap `inlineCode` nodes during stringification, which could shift protected content (e.g., `<script>` tags) out of their code spans.

- A single replacement entry `[/\`/g, '&#96;']` is added to the first `findAndReplace` call, consistently placed alongside `<`, `>`, `\"`, and `'` — all using the same `{ ignore: IGNORE_ALWAYS }` guard that excludes `code` and `inlineCode` nodes.
- Three focused tests are added: standalone backtick escaping, verifying `inlineCode` delimiters are untouched, and a regression test confirming only the two stringifier-generated backticks remain after a mixed prose-plus-inline-code node tree is processed.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This is a small, well-targeted addition that matches the established escaping pattern in the plugin; the change is safe to merge.

The new backtick replacement is placed in the correct findAndReplace pass, guarded by the same IGNORE_ALWAYS list that protects inlineCode and code nodes. The AMP_NOT_ENTITY pattern runs before the backtick pattern so the ampersand in the produced &#96; entity is never re-processed. Three new tests cover the standalone case, the inlineCode delimiter preservation case, and the key regression scenario. No existing behavior is altered.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/remark/src/plugins/escapeHtmlInTextNodes.ts | Adds backtick-to-&#96; replacement in the first findAndReplace pass; correctly placed before the separate curly-brace pass and correctly guarded by IGNORE_ALWAYS so inlineCode and code nodes are untouched. |
| packages/remark/src/__tests__/index.test.ts | Adds three new test cases under a dedicated 'backtick escaping' describe block that cover the standalone case, the inlineCode delimiter preservation case, and the regression scenario. |
| .changeset/olive-pots-sniff.md | Patch-level changeset entry for gt-remark; correctly categorized as a patch. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[AST text node] --> B{Node type in IGNORE_ALWAYS?}
    B -- yes --- C[Skip - leave untouched]
    B -- no --> D[findAndReplace pass 1]
    D --> E[Escape amp, lt, gt, quot, apos]
    E --> H[Escape backtick to numeric entity - NEW]
    H --> I[findAndReplace pass 2]
    I --> J[Escape curly braces and underscore - headings skipped]
    J --> K[Safe text node output]
    K --> L[remarkStringify wraps inlineCode nodes with backtick delimiters]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat: backtick escaping"](https://github.com/generaltranslation/gt/commit/ab488d5fe7313d2c2ea1ae0308e75e86de8f18cb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34513943)</sub>

<!-- /greptile_comment -->