### PR TITLE
refactor: move dev hot reload check to i18n config

### DIFF
--- a/packages/i18n/src/i18n-cache/I18nCache.ts
+++ b/packages/i18n/src/i18n-cache/I18nCache.ts
@@ -27,8 +27,8 @@ import { EventEmitter } from './event-subscription/EventEmitter';
 import { subscribeLifecycleCallbacks } from './lifecycle-hooks/subscribeLifecycleCallbacks';
 import { TRANSLATIONS_CACHE_MISS_EVENT_NAME } from './event-subscription/types';
 import type { I18nEvents } from './event-subscription/types';
-import { getRuntimeEnvironment } from '../utils/getRuntimeEnvironment';
 import { getI18nConfig } from '../i18n-config/singleton-operations';
+import { getRuntimeEnvironment } from '../utils/getRuntimeEnvironment';
 
 /**
  * Default translation timeout in milliseconds for a runtime translation request
@@ -203,18 +203,6 @@ class I18nCache<
   getGTClass(locale?: string): GT {
     return this.getGTClassClean(
       locale ? this._resolveLocale(locale) : undefined
-    );
-  }
-
-  /**
-   * Returns true when development hot reload runtime translation requests can run.
-   */
-  isDevHotReloadEnabled(): boolean {
-    return (
-      !!this.config.devApiKey &&
-      !!this.config.projectId &&
-      this.isRuntimeUrlEnabled() &&
-      getRuntimeEnvironment() === 'development'
     );
   }
 
@@ -697,10 +685,6 @@ class I18nCache<
         this._resolveCacheLocale(options.$locale) ??
         this._resolveLocale(options.$locale),
     };
-  }
-
-  private isRuntimeUrlEnabled(): boolean {
-    return this.config.runtimeUrl !== null && this.config.runtimeUrl !== '';
   }
 
   private async lookupTranslationWithFallbackResolved<

--- a/packages/i18n/src/i18n-cache/__tests__/I18nCache.test.ts
+++ b/packages/i18n/src/i18n-cache/__tests__/I18nCache.test.ts
@@ -86,57 +86,6 @@ describe('I18nCache', () => {
     expect(result).toBe(translatedString);
   });
 
-  it('enables dev hot reload with dev credentials, a project id, and development environment', () => {
-    vi.stubEnv('NODE_ENV', 'development');
-
-    const cache = createCache({
-      devApiKey: 'dev-key',
-      projectId: 'project-id',
-    });
-
-    expect(cache.isDevHotReloadEnabled()).toBe(true);
-  });
-
-  it.each([
-    {
-      name: 'missing dev API key',
-      environment: 'development',
-      config: {
-        projectId: 'project-id',
-      },
-    },
-    {
-      name: 'missing project id',
-      environment: 'development',
-      config: {
-        devApiKey: 'dev-key',
-      },
-    },
-    {
-      name: 'disabled runtime URL',
-      environment: 'development',
-      config: {
-        devApiKey: 'dev-key',
-        projectId: 'project-id',
-        runtimeUrl: null,
-      },
-    },
-    {
-      name: 'production environment',
-      environment: 'production',
-      config: {
-        devApiKey: 'dev-key',
-        projectId: 'project-id',
-      },
-    },
-  ])('disables dev hot reload for $name', ({ config, environment }) => {
-    vi.stubEnv('NODE_ENV', environment);
-
-    const cache = createCache(config);
-
-    expect(cache.isDevHotReloadEnabled()).toBe(false);
-  });
-
   // ===== NEW BEHAVIOR TESTS ===== //
 
   it('loadTranslations() returns Record<Hash, Translation>', async () => {

--- a/packages/i18n/src/i18n-config/I18nConfig.ts
+++ b/packages/i18n/src/i18n-config/I18nConfig.ts
@@ -5,18 +5,29 @@ import {
 import type { CustomMapping } from '@generaltranslation/format/types';
 import { libraryDefaultLocale } from 'generaltranslation/internal';
 import { validateI18nConfigParams } from './validation';
+import { getRuntimeEnvironment } from '../utils/getRuntimeEnvironment';
 
 export type I18nConfigParams = {
   defaultLocale?: string;
   locales?: string[];
   customMapping?: CustomMapping;
+  projectId?: string;
+  devApiKey?: string;
+  runtimeUrl?: string | null;
 };
 
 export type LocaleCandidates = string | string[] | undefined;
 
 export class I18nConfig extends LocaleConfig {
+  private projectId?: string;
+  private devApiKey?: string;
+  private runtimeUrl?: string | null;
+
   constructor(params: I18nConfigParams = {}) {
     super(getLocaleConfigParams(params));
+    this.projectId = params.projectId;
+    this.devApiKey = params.devApiKey;
+    this.runtimeUrl = params.runtimeUrl;
   }
 
   getDefaultLocale(): string {
@@ -76,6 +87,19 @@ export class I18nConfig extends LocaleConfig {
     return (
       this.requiresTranslation(locale) &&
       this.isSameLanguage(this.getDefaultLocale(), locale)
+    );
+  }
+
+  /**
+   * Returns true when development hot reload runtime translation requests can run.
+   */
+  isDevHotReloadEnabled(): boolean {
+    return (
+      !!this.devApiKey &&
+      !!this.projectId &&
+      this.runtimeUrl !== null &&
+      this.runtimeUrl !== '' &&
+      getRuntimeEnvironment() === 'development'
     );
   }
 

--- a/packages/i18n/src/i18n-config/__tests__/I18nConfig.test.ts
+++ b/packages/i18n/src/i18n-config/__tests__/I18nConfig.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { setupGTServicesEnabled } from '../../globals/getGTServicesEnabled';
 import { I18nConfig } from '../I18nConfig';
 
@@ -8,6 +8,10 @@ describe('I18nConfig', () => {
       cacheUrl: null,
       runtimeUrl: null,
     });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it('defaults locales to the resolved default locale', () => {
@@ -95,5 +99,54 @@ describe('I18nConfig', () => {
         },
       })
     ).toBe('fr');
+  });
+
+  it('enables dev hot reload with dev credentials, a project id, and development environment', () => {
+    vi.stubEnv('NODE_ENV', 'development');
+
+    const config = new I18nConfig({
+      devApiKey: 'dev-key',
+      projectId: 'project-id',
+    });
+
+    expect(config.isDevHotReloadEnabled()).toBe(true);
+  });
+
+  it.each([
+    {
+      name: 'missing dev API key',
+      environment: 'development',
+      config: {
+        projectId: 'project-id',
+      },
+    },
+    {
+      name: 'missing project id',
+      environment: 'development',
+      config: {
+        devApiKey: 'dev-key',
+      },
+    },
+    {
+      name: 'disabled runtime URL',
+      environment: 'development',
+      config: {
+        devApiKey: 'dev-key',
+        projectId: 'project-id',
+        runtimeUrl: null,
+      },
+    },
+    {
+      name: 'production environment',
+      environment: 'production',
+      config: {
+        devApiKey: 'dev-key',
+        projectId: 'project-id',
+      },
+    },
+  ])('disables dev hot reload for $name', ({ config, environment }) => {
+    vi.stubEnv('NODE_ENV', environment);
+
+    expect(new I18nConfig(config).isDevHotReloadEnabled()).toBe(false);
   });
 });

--- a/packages/react-core/src/hooks/external-store.ts
+++ b/packages/react-core/src/hooks/external-store.ts
@@ -11,7 +11,7 @@ import type {
 import { getI18nStore } from '../i18n-store/singleton-operations';
 import type { RuntimeTranslationScope } from '../i18n-store/RuntimeTranslationScope';
 import type { RuntimeDictionaryScope } from '../i18n-store/RuntimeDictionaryScope';
-import { getReactI18nCache } from '../i18n-cache/singleton-operations';
+import { getI18nConfig } from 'gt-i18n/internal';
 
 /**
  * @internal
@@ -25,7 +25,7 @@ export function useTranslate<T extends Translation>(
     () => store.getTranslateSnapshot(lookup),
     () => store.getTranslateSnapshot(lookup)
   );
-  if (translation == null && getReactI18nCache().isDevHotReloadEnabled()) {
+  if (translation == null && getI18nConfig().isDevHotReloadEnabled()) {
     store.translate(lookup);
   }
   return translation;
@@ -43,7 +43,7 @@ export function useTranslateMany<T extends Translation>(
     () => store.getTranslateManySnapshot(lookups),
     () => store.getTranslateManySnapshot(lookups)
   );
-  const devHotReloadEnabled = getReactI18nCache().isDevHotReloadEnabled();
+  const devHotReloadEnabled = getI18nConfig().isDevHotReloadEnabled();
   translations.forEach((translation, index) => {
     if (translation == null && devHotReloadEnabled) {
       store.translate(lookups[index]);
@@ -64,7 +64,7 @@ export function useDictionaryEntry(
     () => store.getDictionaryEntrySnapshot(lookup),
     () => store.getDictionaryEntrySnapshot(lookup)
   );
-  if (dictionaryEntry == null && getReactI18nCache().isDevHotReloadEnabled()) {
+  if (dictionaryEntry == null && getI18nConfig().isDevHotReloadEnabled()) {
     store.translateDictionaryEntry(lookup);
   }
   return dictionaryEntry;
@@ -82,7 +82,7 @@ export function useDictionaryObject(
     () => store.getDictionaryObjectSnapshot(lookup),
     () => store.getDictionaryObjectSnapshot(lookup)
   );
-  if (dictionaryObject == null && getReactI18nCache().isDevHotReloadEnabled()) {
+  if (dictionaryObject == null && getI18nConfig().isDevHotReloadEnabled()) {
     store.translateDictionaryObject(lookup);
   }
   return dictionaryObject;

--- a/packages/react-core/src/hooks/useGT.ts
+++ b/packages/react-core/src/hooks/useGT.ts
@@ -26,7 +26,7 @@ export function useGT(_messages?: Message[]): GTFunctionType {
   const defaultLocale = getI18nConfig().getDefaultLocale();
   const shouldTranslate = getShouldTranslate();
   const scope = useRuntimeTranslationScope();
-  const devHotReloadEnabled = getReactI18nCache().isDevHotReloadEnabled();
+  const devHotReloadEnabled = getI18nConfig().isDevHotReloadEnabled();
 
   // Compiler optimization: pre-fetch translations
   useSubscribeToExtractedMessages(

--- a/packages/react-core/src/hooks/useTranslations.ts
+++ b/packages/react-core/src/hooks/useTranslations.ts
@@ -23,12 +23,13 @@ import type {
 
 export function useTranslations(id?: string): UseTranslationsFunction {
   const locale = useLocale();
-  const defaultLocale = getI18nConfig().getDefaultLocale();
+  const i18nConfig = getI18nConfig();
+  const defaultLocale = i18nConfig.getDefaultLocale();
   const shouldTranslate = getShouldTranslate();
   const scope = useRuntimeDictionaryScope();
   const gt = useGT();
   const rootId = id ?? '';
-  const devHotReloadEnabled = getReactI18nCache().isDevHotReloadEnabled();
+  const devHotReloadEnabled = i18nConfig.isDevHotReloadEnabled();
 
   useDictionaryObject({ locale: defaultLocale, id: rootId });
   useDictionaryObject({ locale, id: rootId });

--- a/packages/react-core/src/i18n-store/RuntimeDictionaryScope.ts
+++ b/packages/react-core/src/i18n-store/RuntimeDictionaryScope.ts
@@ -1,7 +1,6 @@
 import { getI18nStore } from './singleton-operations';
 import type { DictionaryLookup, Unsubscribe } from './storeTypes';
-import { getDictionaryListenerKey } from 'gt-i18n/internal';
-import { getReactI18nCache } from '../i18n-cache/singleton-operations';
+import { getDictionaryListenerKey, getI18nConfig } from 'gt-i18n/internal';
 
 /**
  * Tracks dictionary lookups discovered by useTranslations callbacks.
@@ -13,7 +12,7 @@ export class RuntimeDictionaryScope {
   private pendingObjects = new Map<string, Unsubscribe>();
 
   translateEntry(lookup: DictionaryLookup) {
-    if (!getReactI18nCache().isDevHotReloadEnabled()) return;
+    if (!getI18nConfig().isDevHotReloadEnabled()) return;
 
     const key = getDictionaryListenerKey(lookup);
     if (this.pendingEntries.has(key)) return;
@@ -27,7 +26,7 @@ export class RuntimeDictionaryScope {
   }
 
   translateObject(lookup: DictionaryLookup) {
-    if (!getReactI18nCache().isDevHotReloadEnabled()) return;
+    if (!getI18nConfig().isDevHotReloadEnabled()) return;
 
     const key = getDictionaryListenerKey(lookup);
     if (this.pendingObjects.has(key)) return;

--- a/packages/react-core/src/i18n-store/RuntimeTranslationScope.ts
+++ b/packages/react-core/src/i18n-store/RuntimeTranslationScope.ts
@@ -1,7 +1,6 @@
 import { getI18nStore } from './singleton-operations';
 import type { TranslateLookup, Unsubscribe } from './storeTypes';
-import { getTranslateListenerKey } from 'gt-i18n/internal';
-import { getReactI18nCache } from '../i18n-cache/singleton-operations';
+import { getI18nConfig, getTranslateListenerKey } from 'gt-i18n/internal';
 
 /**
  * Owned by I18nStore, this should not be imported to any other files
@@ -12,7 +11,7 @@ export class RuntimeTranslationScope {
   private pendingKeys = new Map<string, Unsubscribe>();
 
   translate(lookup: TranslateLookup) {
-    if (!getReactI18nCache().isDevHotReloadEnabled()) return;
+    if (!getI18nConfig().isDevHotReloadEnabled()) return;
 
     const key = getTranslateListenerKey(lookup);
     if (this.pendingKeys.has(key)) return;

--- a/packages/react/src/i18n-cache/BrowserI18nCache.ts
+++ b/packages/react/src/i18n-cache/BrowserI18nCache.ts
@@ -33,7 +33,10 @@ export class BrowserI18nCache extends I18nCache<Translation> {
     // Must be initialized before super()
     const { htmlTagOptions, ...managerConfig } = config;
     const localStorageCaches: Record<string, LocalStorageTranslationCache> = {};
-    const devHotReloadEnabled = isDevHotReloadEnabled(config);
+    // TODO: this only works when you've defined a custom loadTranslations function
+    // meaning CDN users will not have access to this feature
+    const devHotReloadEnabled =
+      getI18nConfig().isDevHotReloadEnabled() && !!config.loadTranslations;
     const loadTranslations = devHotReloadEnabled
       ? wrapLoaderWithLocalStorage(
           config.loadTranslations!,
@@ -168,22 +171,6 @@ function wrapLoaderWithLocalStorage(
     });
     return localStorageCaches[locale].getInternalCache();
   };
-}
-
-/**
- * Determines if dev hot reload is enabled (any flag)
- * @param config - The configuration
- * @returns True if dev hot reload is enabled, false otherwise
- */
-function isDevHotReloadEnabled(config: BrowserI18nCacheParams) {
-  // TODO: this only works when you've defined a custom loadTranslations function
-  // meaning CDN users will not have access to this feature
-  return !!(
-    import.meta.env?.DEV &&
-    config.loadTranslations &&
-    config.projectId &&
-    config.devApiKey
-  );
 }
 
 const createInvalidLocaleWarning = (locale: string) =>


### PR DESCRIPTION
## Summary
- Move dev hot reload eligibility from I18nCache to I18nConfig
- Update React runtime callers to read the config singleton
- Move hot reload eligibility tests from I18nCache to I18nConfig

## Tests
- pnpm --filter gt-i18n test
- pnpm --filter @generaltranslation/react-core test
- pnpm --filter gt-react test
- pnpm --filter gt-i18n build
- pnpm lint
- pnpm format

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1533"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782690980&installation_id=127936663&pr_number=1533&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1533&signature=29d65dec6eb8404ee68449a5cccdf11e5fe048ef9043d001f942f51dad91b44a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves the `isDevHotReloadEnabled()` eligibility check out of `I18nCache` and into `I18nConfig`, then updates all React runtime callers to read from the `I18nConfig` singleton instead of the cache. Tests are migrated accordingly, with a welcome `afterEach(() => vi.unstubAllEnvs())` cleanup that was missing in the old suite.

- `I18nConfig` gains `projectId`, `devApiKey`, and `runtimeUrl` fields alongside a new `isDevHotReloadEnabled()` method whose logic matches the removed `I18nCache` implementation.
- All `react-core` hooks (`useGT`, `useTranslations`, `external-store`, `RuntimeTranslationScope`, `RuntimeDictionaryScope`) are updated to call `getI18nConfig().isDevHotReloadEnabled()` instead of `getReactI18nCache().isDevHotReloadEnabled()`.
- `BrowserI18nCache` replaces its local Vite-specific helper with the shared `I18nConfig` method, which silently introduces a `runtimeUrl !== null` requirement that the old browser-only helper did not have.

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to merge for the common case, but the BrowserI18nCache change alters existing behaviour for anyone who explicitly sets runtimeUrl: null while providing a custom loadTranslations.

The refactor is mechanically clean across nine of the ten changed files. The one concern is in BrowserI18nCache: the old local helper did not gate browser dev hot reload on runtimeUrl at all, but the replacement call through I18nConfig.isDevHotReloadEnabled() does. A developer who opts out of runtime translation (runtimeUrl: null) while still supplying a custom loadTranslations will silently lose browser hot reload with no warning or error to explain the change.

packages/react/src/i18n-cache/BrowserI18nCache.ts deserves a second look to confirm whether the runtimeUrl guard should apply to the loadTranslations-based hot reload path.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/i18n/src/i18n-config/I18nConfig.ts | Adds projectId, devApiKey, runtimeUrl fields and isDevHotReloadEnabled() method; logic matches old I18nCache method but undefined runtimeUrl now passes the check (correct behavior). |
| packages/react/src/i18n-cache/BrowserI18nCache.ts | Replaces local isDevHotReloadEnabled helper with getI18nConfig().isDevHotReloadEnabled(); silently adds a runtimeUrl check that the old helper did not have, breaking browser dev hot reload for users who set runtimeUrl: null with a custom loadTranslations. |
| packages/i18n/src/i18n-cache/I18nCache.ts | Removes isDevHotReloadEnabled() and isRuntimeUrlEnabled() methods; logic moved to I18nConfig. Clean removal. |
| packages/i18n/src/i18n-config/__tests__/I18nConfig.test.ts | Adds afterEach vi.unstubAllEnvs() cleanup (missing in old I18nCache tests) and migrates all isDevHotReloadEnabled tests. Coverage is complete. |
| packages/react-core/src/hooks/external-store.ts | Swaps getReactI18nCache().isDevHotReloadEnabled() for getI18nConfig().isDevHotReloadEnabled() in all four hook functions. Straightforward mechanical change. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["initializeGTSPA(config)"] --> B["initializeI18nConfig(config)"]
    B --> C["new BrowserI18nCache(config)"]
    C --> D["getI18nConfig().isDevHotReloadEnabled()"]
    D --> E{devApiKey AND projectId?}
    E -- No --> F["return false"]
    E -- Yes --> G{runtimeUrl not null or empty?}
    G -- No --> F
    G -- Yes --> H{getRuntimeEnvironment == development?}
    H -- No --> F
    H -- Yes --> I["return true"]
    I --> J{loadTranslations provided?}
    J -- Yes --> K["wrapLoaderWithLocalStorage + subscribe cache-miss"]
    J -- No --> L["use config.loadTranslations as-is"]
    M["React hooks: useGT, useTranslations, external-store"] --> N["getI18nConfig().isDevHotReloadEnabled()"]
    N --> E
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Freact%2Fsrc%2Fi18n-cache%2FBrowserI18nCache.ts%3A38-39%0A**Unintended%20runtimeUrl%20requirement%20added%20to%20browser%20dev%20hot%20reload**%0A%0AThe%20old%20local%20helper%20did%20not%20check%20%60runtimeUrl%60%20at%20all%20%E2%80%94%20it%20only%20required%20%60import.meta.env%3F.DEV%60%2C%20%60loadTranslations%60%2C%20%60projectId%60%2C%20and%20%60devApiKey%60.%20By%20delegating%20to%20%60getI18nConfig%28%29.isDevHotReloadEnabled%28%29%60%2C%20this%20now%20also%20requires%20%60runtimeUrl%20!%3D%3D%20null%20%26%26%20runtimeUrl%20!%3D%3D%20''%60.%20A%20user%20who%20explicitly%20sets%20%60runtimeUrl%3A%20null%60%20to%20opt%20out%20of%20runtime%20translation%20%28e.g.%20to%20reduce%20API%20costs%29%20but%20still%20provides%20a%20custom%20%60loadTranslations%60%20will%20silently%20have%20browser%20dev%20hot%20reload%20disabled%20with%20no%20diagnostic%20message%20explaining%20why.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fi18n%2Fsrc%2Fi18n-config%2FI18nConfig.ts%3A96-104%0A**%60runtimeUrl%20%3D%3D%3D%20undefined%60%20silently%20enables%20the%20runtime-URL%20gate**%0A%0AWhen%20%60runtimeUrl%60%20is%20not%20provided%20at%20all%20%28the%20common%20case%29%2C%20%60this.runtimeUrl%60%20is%20%60undefined%60.%20The%20checks%20%60undefined%20!%3D%3D%20null%60%20and%20%60undefined%20!%3D%3D%20''%60%20both%20pass%2C%20so%20the%20method%20behaves%20as%20if%20a%20runtime%20URL%20is%20configured.%20This%20matches%20the%20old%20%60isRuntimeUrlEnabled%28%29%60%20logic%20and%20is%20probably%20intentional%2C%20but%20it%20means%20callers%20cannot%20distinguish%20%22user%20explicitly%20left%20runtimeUrl%20at%20its%20default%22%20from%20%22user%20intentionally%20left%20it%20unconfigured.%22%20Consider%20documenting%20this%20assumption%20or%20using%20a%20default%20value%20%28e.g.%20the%20production%20API%20URL%29%20so%20the%20check%20is%20explicit.%0A%0A&repo=generaltranslation%2Fgt&pr=1533&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fodysseus%2Fmove-hot-reload-to-config%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fodysseus%2Fmove-hot-reload-to-config%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Freact%2Fsrc%2Fi18n-cache%2FBrowserI18nCache.ts%3A38-39%0A**Unintended%20runtimeUrl%20requirement%20added%20to%20browser%20dev%20hot%20reload**%0A%0AThe%20old%20local%20helper%20did%20not%20check%20%60runtimeUrl%60%20at%20all%20%E2%80%94%20it%20only%20required%20%60import.meta.env%3F.DEV%60%2C%20%60loadTranslations%60%2C%20%60projectId%60%2C%20and%20%60devApiKey%60.%20By%20delegating%20to%20%60getI18nConfig%28%29.isDevHotReloadEnabled%28%29%60%2C%20this%20now%20also%20requires%20%60runtimeUrl%20!%3D%3D%20null%20%26%26%20runtimeUrl%20!%3D%3D%20''%60.%20A%20user%20who%20explicitly%20sets%20%60runtimeUrl%3A%20null%60%20to%20opt%20out%20of%20runtime%20translation%20%28e.g.%20to%20reduce%20API%20costs%29%20but%20still%20provides%20a%20custom%20%60loadTranslations%60%20will%20silently%20have%20browser%20dev%20hot%20reload%20disabled%20with%20no%20diagnostic%20message%20explaining%20why.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fi18n%2Fsrc%2Fi18n-config%2FI18nConfig.ts%3A96-104%0A**%60runtimeUrl%20%3D%3D%3D%20undefined%60%20silently%20enables%20the%20runtime-URL%20gate**%0A%0AWhen%20%60runtimeUrl%60%20is%20not%20provided%20at%20all%20%28the%20common%20case%29%2C%20%60this.runtimeUrl%60%20is%20%60undefined%60.%20The%20checks%20%60undefined%20!%3D%3D%20null%60%20and%20%60undefined%20!%3D%3D%20''%60%20both%20pass%2C%20so%20the%20method%20behaves%20as%20if%20a%20runtime%20URL%20is%20configured.%20This%20matches%20the%20old%20%60isRuntimeUrlEnabled%28%29%60%20logic%20and%20is%20probably%20intentional%2C%20but%20it%20means%20callers%20cannot%20distinguish%20%22user%20explicitly%20left%20runtimeUrl%20at%20its%20default%22%20from%20%22user%20intentionally%20left%20it%20unconfigured.%22%20Consider%20documenting%20this%20assumption%20or%20using%20a%20default%20value%20%28e.g.%20the%20production%20API%20URL%29%20so%20the%20check%20is%20explicit.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/react/src/i18n-cache/BrowserI18nCache.ts:38-39
**Unintended runtimeUrl requirement added to browser dev hot reload**

The old local helper did not check `runtimeUrl` at all — it only required `import.meta.env?.DEV`, `loadTranslations`, `projectId`, and `devApiKey`. By delegating to `getI18nConfig().isDevHotReloadEnabled()`, this now also requires `runtimeUrl !== null && runtimeUrl !== ''`. A user who explicitly sets `runtimeUrl: null` to opt out of runtime translation (e.g. to reduce API costs) but still provides a custom `loadTranslations` will silently have browser dev hot reload disabled with no diagnostic message explaining why.

### Issue 2 of 2
packages/i18n/src/i18n-config/I18nConfig.ts:96-104
**`runtimeUrl === undefined` silently enables the runtime-URL gate**

When `runtimeUrl` is not provided at all (the common case), `this.runtimeUrl` is `undefined`. The checks `undefined !== null` and `undefined !== ''` both pass, so the method behaves as if a runtime URL is configured. This matches the old `isRuntimeUrlEnabled()` logic and is probably intentional, but it means callers cannot distinguish "user explicitly left runtimeUrl at its default" from "user intentionally left it unconfigured." Consider documenting this assumption or using a default value (e.g. the production API URL) so the check is explicit.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: move dev hot reload check to i..."](https://github.com/generaltranslation/gt/commit/32f5055714c91864dab2647fa3597ddc418bbeb6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34678051)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->