### PR TITLE
fix(cli): hash cooked template literals

### DIFF
--- a/.changeset/cooked-template-literals.md
+++ b/.changeset/cooked-template-literals.md
@@ -1,0 +1,5 @@
+---
+"gt": patch
+---
+
+Hash cooked static template literal values during CLI extraction.

--- a/packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/__tests__/processTranslationCall.test.ts
+++ b/packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/__tests__/processTranslationCall.test.ts
@@ -94,19 +94,6 @@ describe('processTranslationCall - array support', () => {
     expect(output.errors).toHaveLength(0);
   });
 
-  it('should extract cooked template literals without expressions', () => {
-    const output = runProcessTranslationCall(
-      't(`Line one.\\n\\nLine two\\tTabbed`, { $format: "STRING" })'
-    );
-
-    expect(output.updates).toHaveLength(1);
-    expect(output.updates[0]).toMatchObject({
-      dataFormat: 'STRING',
-      source: 'Line one.\n\nLine two\tTabbed',
-    });
-    expect(output.errors).toHaveLength(0);
-  });
-
   it('should handle mixed string literals and template literals', () => {
     const output = runProcessTranslationCall('t(["hello", `world`])');
 
@@ -220,6 +207,21 @@ describe('processTranslationCall - array support', () => {
     expect(output.updates).toHaveLength(1);
     expect(output.updates[0]).toMatchObject({ source: 'hello' });
     expect(output.errors.length).toBeGreaterThan(0);
+  });
+});
+
+describe('processTranslationCall - template literal support', () => {
+  it('should extract cooked template literals without expressions', () => {
+    const output = runProcessTranslationCall(
+      't(`Line one.\\n\\nLine two\\tTabbed`, { $format: "STRING" })'
+    );
+
+    expect(output.updates).toHaveLength(1);
+    expect(output.updates[0]).toMatchObject({
+      dataFormat: 'STRING',
+      source: 'Line one.\n\nLine two\tTabbed',
+    });
+    expect(output.errors).toHaveLength(0);
   });
 });
 

--- a/packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/__tests__/processTranslationCall.test.ts
+++ b/packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/__tests__/processTranslationCall.test.ts
@@ -94,6 +94,19 @@ describe('processTranslationCall - array support', () => {
     expect(output.errors).toHaveLength(0);
   });
 
+  it('should extract cooked template literals without expressions', () => {
+    const output = runProcessTranslationCall(
+      't(`Line one.\\n\\nLine two\\tTabbed`, { $format: "STRING" })'
+    );
+
+    expect(output.updates).toHaveLength(1);
+    expect(output.updates[0]).toMatchObject({
+      dataFormat: 'STRING',
+      source: 'Line one.\n\nLine two\tTabbed',
+    });
+    expect(output.errors).toHaveLength(0);
+  });
+
   it('should handle mixed string literals and template literals', () => {
     const output = runProcessTranslationCall('t(["hello", `world`])');
 

--- a/packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/handleLiteralTranslationCall.ts
+++ b/packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/handleLiteralTranslationCall.ts
@@ -33,7 +33,9 @@ export function handleLiteralTranslationCall({
 }): void {
   // ignore dynamic content flag is triggered, check strings are valid ICU
   const source =
-    arg.type === 'StringLiteral' ? arg.value : arg.quasis[0].value.raw;
+    arg.type === 'StringLiteral'
+      ? arg.value
+      : (arg.quasis[0].value.cooked ?? arg.quasis[0].value.raw);
 
   // Validate is ICU — skip for non-ICU formats
   if (


### PR DESCRIPTION
## Summary
- Extract no-expression template literals from CLI inline calls using the cooked value so escape sequences match runtime hashing
- Add a regression test for newline and tab escapes
- Add a patch changeset for `gt`

## Tests
- pnpm --filter gt... build
- pnpm exec vitest run --config=./vitest.config.ts src/react/jsx/utils/stringParsing/processTranslationCall/__tests__/processTranslationCall.test.ts (from packages/cli)
- pnpm --filter gt typecheck
- pnpm exec oxfmt --check packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/handleLiteralTranslationCall.ts packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/__tests__/processTranslationCall.test.ts
- pnpm exec oxlint packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/handleLiteralTranslationCall.ts packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/__tests__/processTranslationCall.test.ts
- pnpm --filter gt test

## Changeset
- Added `.changeset/cooked-template-literals.md`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1534"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782924752&installation_id=127936663&pr_number=1534&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1534&signature=aaa69aed907c3e21e6585814db0f3777a44a32544d98be56706636d119bd76ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where template literals containing escape sequences (e.g. `\n`, `\t`) were hashed using their raw source text instead of their interpreted (cooked) value, causing a mismatch between the CLI-generated hash and the runtime hash.

- **Core fix** (`handleLiteralTranslationCall.ts`): replaces `arg.quasis[0].value.raw` with `arg.quasis[0].value.cooked ?? arg.quasis[0].value.raw`, so escape sequences are interpreted the same way JavaScript does at runtime. The `raw` fallback correctly handles the rare case where `cooked` is `null` (illegal escape sequences in tagged template positions).
- **Regression test**: a new `describe('processTranslationCall - template literal support')` block verifies that `` `Line one.\n\nLine two\tTabbed` `` is extracted as the cooked string with actual newline and tab characters.
- **Changeset**: a `patch` entry for the `gt` package documents the fix.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a one-line targeted fix in a well-tested extraction utility with no side effects on other code paths.

The fix correctly aligns CLI extraction with runtime JavaScript semantics by preferring the cooked template value. The fallback to `raw` when `cooked` is `null` is sound. The new regression test directly covers the escape-sequence mismatch scenario, and existing tests continue to exercise string literals and expression-free template literals.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/handleLiteralTranslationCall.ts | Switches template literal extraction from `.raw` to `.cooked` (with `.raw` fallback) so escape sequences like `\n` and `\t` produce the same string as the runtime, fixing hash mismatches. |
| packages/cli/src/react/jsx/utils/stringParsing/processTranslationCall/__tests__/processTranslationCall.test.ts | Adds a new `describe` block for template literal support with a regression test covering `\n` and `\t` escape sequences; test correctly asserts the cooked (interpreted) values. |
| .changeset/cooked-template-literals.md | Patch changeset entry for the `gt` package documenting the template literal hashing fix. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[handleLiteralTranslationCall] --> B{StringLiteral?}
    B -- Yes --> C[source = arg.value]
    B -- No TemplateLiteral --> D{cooked != null?}
    D -- Yes --> E[source = cooked value]
    D -- No fallback --> F[source = raw value]
    C --> G[ICU validation then push update]
    E --> G
    F --> G
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test(cli): move template literal coverag..."](https://github.com/generaltranslation/gt/commit/522dd26a269c5c55135dd6e01c78a302610b74db) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34949928)</sub>

<!-- /greptile_comment -->