### PR TITLE
feat: add react native locale store getter

### DIFF
--- a/.changeset/twelve-donuts-invite.md
+++ b/.changeset/twelve-donuts-invite.md
@@ -1,0 +1,5 @@
+---
+'gt-react-native': minor
+---
+
+Add getLocaleFromNativeStore for reading the persisted locale imperatively.

--- a/packages/react-native/src/index.tsx
+++ b/packages/react-native/src/index.tsx
@@ -1,4 +1,5 @@
 import { GTProvider } from './provider/GTProvider';
+import { getLocaleFromNativeStore } from './utils/nativeStore';
 
 import {
   T,
@@ -61,6 +62,7 @@ export {
   useLocaleProperties,
   useLocaleDirection,
   useVersionId,
+  getLocaleFromNativeStore,
   type DictionaryTranslationOptions,
   type InlineTranslationOptions,
   type RuntimeTranslationOptions,

--- a/packages/react-native/src/provider/hooks/locale/useDetermineLocale.ts
+++ b/packages/react-native/src/provider/hooks/locale/useDetermineLocale.ts
@@ -4,6 +4,7 @@ import {
   determineLocale,
   resolveAliasLocale,
 } from '@generaltranslation/format';
+import { defaultLocaleCookieName } from '@generaltranslation/react-core/internal';
 import { libraryDefaultLocale } from 'generaltranslation/internal';
 import type { CustomMapping } from '@generaltranslation/format/types';
 import type {
@@ -19,7 +20,7 @@ export function useDetermineLocale({
   locale: _locale = '',
   defaultLocale = libraryDefaultLocale,
   locales = [],
-  localeCookieName = 'generaltranslation.locale',
+  localeCookieName = defaultLocaleCookieName,
   ssr = false, // not relevant
   customMapping,
   enableI18n,

--- a/packages/react-native/src/utils/nativeStore.ts
+++ b/packages/react-native/src/utils/nativeStore.ts
@@ -1,10 +1,24 @@
+import { defaultLocaleCookieName } from '@generaltranslation/react-core/internal';
 import { Platform } from 'react-native';
 import GtReactNative from '../NativeGtReactNative';
 import { ssrUnsupportedWarning } from '../errors-dir/warnings';
 
 /**
- * Native store interface, used to replace cookie behavior from gt-react
+ * Get the locale from the native store.
+ *
+ * This reads persisted native storage directly, so it can temporarily be out of
+ * sync with React state while a locale change is in progress.
+ *
+ * If GTProvider uses a custom localeCookieName, pass that same value as the key.
+ *
+ * @param key - The key to get the locale from
+ * @returns The locale from the native store
  */
+export function getLocaleFromNativeStore(
+  key = defaultLocaleCookieName
+): string | null {
+  return nativeStoreGet(key);
+}
 
 /**
  * Get a value from the native store


### PR DESCRIPTION
## Summary
- Add `getLocaleFromNativeStore()` to `gt-react-native` for imperative persisted locale reads.
- Allow an optional native store key, defaulting to `generaltranslation.locale`.
- Add a minor changeset.

## Verification
- `pnpm --filter gt-react-native... build`
- `pnpm --filter gt-react-native typecheck`
- `pnpm --filter gt-react-native test`
- `pnpm exec oxfmt --check packages/react-native/src/index.tsx packages/react-native/src/utils/nativeStore.ts .changeset/twelve-donuts-invite.md`
- `pnpm exec oxlint packages/react-native/src/index.tsx packages/react-native/src/utils/nativeStore.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `getLocaleFromNativeStore()` to `gt-react-native`, providing an imperative, synchronous way to read the persisted locale from native storage without requiring React context. It also replaces the hardcoded `'generaltranslation.locale'` default key in `useDetermineLocale` with the shared `defaultLocaleCookieName` constant to eliminate duplication.

- **`nativeStore.ts`**: New `getLocaleFromNativeStore(key?)` function that delegates to the existing synchronous `nativeStoreGet`, with JSDoc noting the out-of-sync caveat and the requirement to pass a matching key when `GTProvider` uses a custom `localeCookieName`.
- **`useDetermineLocale.ts`**: Swaps the hardcoded default string for the imported `defaultLocaleCookieName` constant, keeping both callsites in sync automatically.
- **`index.tsx`**: Exports the new function as part of the public API.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the new function is a thin, synchronous wrapper over the already-established nativeStoreGet with no behaviour change to existing paths.

The change adds a single exported function that delegates entirely to the pre-existing nativeStoreGet, and replaces one hardcoded string with a shared constant. Both paths have been in production; nothing in the new code introduces a new failure mode. Previous review feedback about the custom-key caveat and the stray comment has been addressed in this revision.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react-native/src/utils/nativeStore.ts | Adds getLocaleFromNativeStore(), a thin synchronous wrapper over the existing nativeStoreGet with a defaulted key constant and clear JSDoc; no issues found. |
| packages/react-native/src/provider/hooks/locale/useDetermineLocale.ts | Replaces hardcoded 'generaltranslation.locale' default with the shared defaultLocaleCookieName constant, eliminating a potential drift between the hook and the new getter. |
| packages/react-native/src/index.tsx | Imports and re-exports getLocaleFromNativeStore in the correct position among other utilities; no issues found. |
| .changeset/twelve-donuts-invite.md | Correctly marks the change as a minor bump for gt-react-native with an appropriate description. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller as Caller (imperative)
    participant Getter as getLocaleFromNativeStore(key?)
    participant StoreGet as nativeStoreGet(key)
    participant Web as localStorage (web)
    participant Native as GtReactNative.nativeStoreGet (native)

    Caller->>Getter: call with optional key
    Getter->>StoreGet: delegate with defaultLocaleCookieName or custom key
    alt "Platform.OS === 'web'"
        StoreGet->>Web: localStorage.getItem(key)
        Web-->>StoreGet: "string | null"
    else native (iOS / Android)
        StoreGet->>Native: nativeStoreGet(key)
        Native-->>StoreGet: "string | null"
    end
    StoreGet-->>Getter: "string | null"
    Getter-->>Caller: "string | null"
```
</details>

<sub>Reviews (2): Last reviewed commit: ["feat: add react native locale store gett..."](https://github.com/generaltranslation/gt/commit/e3ff5bc63e336a0c623af8ba2db12a7fe3ee102b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34963241)</sub>

<!-- /greptile_comment -->