### PR TITLE
ci: add benchmark workflow timeout

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -22,6 +22,7 @@ env:
 jobs:
   benchmark:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -22,7 +22,7 @@ env:
 jobs:
   benchmark:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Add a 10-minute timeout to the benchmark workflow job so CI cannot run indefinitely.
- Based on the latest 30 successful `main` benchmark workflow runs: 19 actually ran benchmarks, and the slowest successful benchmark job took 4m31s. Rounding that up and adding 5 minutes gives a 10-minute timeout.

## Testing
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1539"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782940768&installation_id=127936663&pr_number=1539&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1539&signature=1959fe7f9037e29d06ee1ab9759d0174b7e84e3343bfe60801bef329d9e4e5a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a 30-minute job-level timeout to the benchmark workflow so that runaway benchmark runs can no longer block CI indefinitely.

- A single `timeout-minutes: 30` line is added to the `benchmark` job, covering all steps from checkout through result storage.
- The workflow includes Rust toolchain installation, a WASM build (`wasm32-wasip1` target), full `pnpm build`, and Playwright E2E benchmarks — workloads that on a cold runner can collectively approach the 30-minute limit.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The change is safe to merge — it closes an obvious gap by preventing indefinitely hanging benchmark jobs.

The 30-minute timeout is a conservative choice for a workflow that chains Rust toolchain setup, WASM compilation, a full package build, and Playwright E2E benchmarks in sequence. On a cold runner this sequence can realistically run close to the limit, meaning the timeout could occasionally kill a legitimate run rather than only catching true hangs.

benchmark.yml — the chosen timeout value warrants a follow-up once real runner durations are measured.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/benchmark.yml | Adds timeout-minutes: 30 to the benchmark job to prevent indefinitely hanging CI runs; the 30-minute budget may be tight given Rust toolchain setup and WASM compilation are included in the same job. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Trigger: PR / dispatch / workflow_dispatch] --> B[Checkout code]
    B --> C{Should benchmarks run?}
    C -- No --> Z[Job ends early]
    C -- Yes --> D[Install pnpm + Node 24 + Rust toolchain]
    D --> E[pnpm install]
    E --> F[Install Playwright Chromium]
    F --> G[pnpm build — includes WASM compilation]
    G --> H[Run unit benchmarks]
    H --> I[Run E2E benchmarks via Playwright]
    I --> J[Transform results]
    J --> K[Store & compare via benchmark-action]
    K --> L[Job complete]
    style A fill:#4a90d9,color:#fff
    style Z fill:#aaa,color:#fff
    style L fill:#27ae60,color:#fff
    subgraph "⏱ 30-minute job timeout"
        B
        C
        D
        E
        F
        G
        H
        I
        J
        K
    end
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fbenchmark.yml%3A25%0A**Timeout%20may%20be%20too%20tight%20for%20cold%20runners**%0A%0AThe%2030-minute%20budget%20covers%20Rust%20toolchain%20download%2C%20%60wasm32-wasip1%60%20target%20compilation%2C%20%60pnpm%20install%60%2C%20a%20full%20%60pnpm%20build%60%20%28which%20includes%20the%20WASM%20build%20step%29%2C%20and%20Playwright%20E2E%20benchmarks%20%E2%80%94%20all%20in%20sequence.%20On%20a%20cold%20GitHub-hosted%20runner%20with%20no%20Rust%20cache%2C%20toolchain%20setup%20and%20WASM%20compilation%20alone%20can%20consume%2015%E2%80%9320%20minutes%2C%20leaving%20very%20little%20headroom%20for%20the%20build%20and%20benchmark%20steps.%20A%20timeout%20that%20is%20too%20short%20will%20silently%20kill%20valid%20benchmark%20runs%20rather%20than%20only%20catching%20true%20hangs.%20Consider%20raising%20to%2045%E2%80%9360%20minutes%2C%20or%20splitting%20setup%20steps%20with%20per-step%20%60timeout-minutes%60%20once%20you%20have%20measured%20typical%20run%20durations.%0A%0A&repo=generaltranslation%2Fgt&pr=1539&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fci%2Fbenchmark-timeout%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fci%2Fbenchmark-timeout%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fbenchmark.yml%3A25%0A**Timeout%20may%20be%20too%20tight%20for%20cold%20runners**%0A%0AThe%2030-minute%20budget%20covers%20Rust%20toolchain%20download%2C%20%60wasm32-wasip1%60%20target%20compilation%2C%20%60pnpm%20install%60%2C%20a%20full%20%60pnpm%20build%60%20%28which%20includes%20the%20WASM%20build%20step%29%2C%20and%20Playwright%20E2E%20benchmarks%20%E2%80%94%20all%20in%20sequence.%20On%20a%20cold%20GitHub-hosted%20runner%20with%20no%20Rust%20cache%2C%20toolchain%20setup%20and%20WASM%20compilation%20alone%20can%20consume%2015%E2%80%9320%20minutes%2C%20leaving%20very%20little%20headroom%20for%20the%20build%20and%20benchmark%20steps.%20A%20timeout%20that%20is%20too%20short%20will%20silently%20kill%20valid%20benchmark%20runs%20rather%20than%20only%20catching%20true%20hangs.%20Consider%20raising%20to%2045%E2%80%9360%20minutes%2C%20or%20splitting%20setup%20steps%20with%20per-step%20%60timeout-minutes%60%20once%20you%20have%20measured%20typical%20run%20durations.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/workflows/benchmark.yml:25
**Timeout may be too tight for cold runners**

The 30-minute budget covers Rust toolchain download, `wasm32-wasip1` target compilation, `pnpm install`, a full `pnpm build` (which includes the WASM build step), and Playwright E2E benchmarks — all in sequence. On a cold GitHub-hosted runner with no Rust cache, toolchain setup and WASM compilation alone can consume 15–20 minutes, leaving very little headroom for the build and benchmark steps. A timeout that is too short will silently kill valid benchmark runs rather than only catching true hangs. Consider raising to 45–60 minutes, or splitting setup steps with per-step `timeout-minutes` once you have measured typical run durations.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: add benchmark workflow timeout"](https://github.com/generaltranslation/gt/commit/f987d196ebb81e773bf3354713b6ac612989700c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35008526)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->