### PR TITLE
refactor: consolidate gt context helper

### DIFF
--- a/packages/react-core/src/hooks/useDefaultLocale.ts
+++ b/packages/react-core/src/hooks/useDefaultLocale.ts
@@ -1,4 +1,4 @@
-import useGTContext from '../provider/GTContext';
+import { useGTContext } from '../provider/GTContext';
 
 /**
  * Retrieves the application's default locale from the `<GTProvider>` context.

--- a/packages/react-core/src/hooks/useGTClass.ts
+++ b/packages/react-core/src/hooks/useGTClass.ts
@@ -1,5 +1,5 @@
 import type { LocaleProperties } from '@generaltranslation/format/types';
-import useGTContext from '../provider/GTContext';
+import { useGTContext } from '../provider/GTContext';
 
 /**
  * Returns the configured GT class instance.

--- a/packages/react-core/src/hooks/useLocale.ts
+++ b/packages/react-core/src/hooks/useLocale.ts
@@ -1,4 +1,4 @@
-import useGTContext from '../provider/GTContext';
+import { useGTContext } from '../provider/GTContext';
 
 /**
  * Retrieves the user's locale from the `<GTProvider>` context.

--- a/packages/react-core/src/hooks/useLocaleDirection.ts
+++ b/packages/react-core/src/hooks/useLocaleDirection.ts
@@ -1,4 +1,4 @@
-import useGTContext from '../provider/GTContext';
+import { useGTContext } from '../provider/GTContext';
 
 /**
  * Retrieves the text direction ('ltr' or 'rtl') for the current or specified locale from the `<GTProvider>` context.

--- a/packages/react-core/src/hooks/useLocaleSelector.ts
+++ b/packages/react-core/src/hooks/useLocaleSelector.ts
@@ -1,5 +1,5 @@
 import { useCallback, useMemo } from 'react';
-import useGTContext from '../provider/GTContext';
+import { useGTContext } from '../provider/GTContext';
 
 /**
  *

--- a/packages/react-core/src/hooks/useLocales.ts
+++ b/packages/react-core/src/hooks/useLocales.ts
@@ -1,4 +1,4 @@
-import useGTContext from '../provider/GTContext';
+import { useGTContext } from '../provider/GTContext';
 
 /**
  * Retrieves the user's list of supported locales from the `<GTProvider>` context.

--- a/packages/react-core/src/hooks/useRegion.ts
+++ b/packages/react-core/src/hooks/useRegion.ts
@@ -1,4 +1,4 @@
-import useGTContext from '../provider/GTContext';
+import { useGTContext } from '../provider/GTContext';
 
 /**
  * A React hook that retrieves the user's currently selected region from the `<GTProvider>` context.

--- a/packages/react-core/src/hooks/useRegionSelector.ts
+++ b/packages/react-core/src/hooks/useRegionSelector.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import useGTContext from '../provider/GTContext';
+import { useGTContext } from '../provider/GTContext';
 import { getLocaleProperties } from '@generaltranslation/format';
 
 type RegionData = {

--- a/packages/react-core/src/hooks/useSetLocale.ts
+++ b/packages/react-core/src/hooks/useSetLocale.ts
@@ -1,4 +1,4 @@
-import useGTContext from '../provider/GTContext';
+import { useGTContext } from '../provider/GTContext';
 
 /**
  * Sets the user's locale in the `<GTProvider>` context.

--- a/packages/react-core/src/hooks/useVersionId.ts
+++ b/packages/react-core/src/hooks/useVersionId.ts
@@ -1,4 +1,4 @@
-import useGTContext from '../provider/GTContext';
+import { useGTContext } from '../provider/GTContext';
 
 /**
  * Retrieves the version ID from the `<GTProvider>` context.

--- a/packages/react-core/src/provider/GTContext.ts
+++ b/packages/react-core/src/provider/GTContext.ts
@@ -3,7 +3,7 @@ import { GTContextType } from '../types-dir/context';
 
 export const GTContext = createContext<GTContextType | undefined>(undefined);
 
-export default function useGTContext(
+export function useGTContext(
   errorString = 'useGTContext() must be used within a <GTProvider>!'
 ): GTContextType {
   const context = useContext(GTContext);

--- a/packages/react-core/src/translation/T.tsx
+++ b/packages/react-core/src/translation/T.tsx
@@ -1,7 +1,7 @@
 import React, { Suspense } from 'react';
 import renderDefaultChildren from '../rendering/renderDefaultChildren';
 import { addGTIdentifier, writeChildrenAsObjects } from '../internal';
-import useGTContext from '../provider/GTContext';
+import { useGTContext } from '../provider/GTContext';
 import renderTranslatedChildren from '../rendering/renderTranslatedChildren';
 import { useMemo } from 'react';
 import renderVariable from '../rendering/renderVariable';

--- a/packages/react-core/src/translation/hooks/useGT.tsx
+++ b/packages/react-core/src/translation/hooks/useGT.tsx
@@ -1,4 +1,4 @@
-import useGTContext from '../../provider/GTContext';
+import { useGTContext } from '../../provider/GTContext';
 import { _Messages, Translations } from '../../types-dir/types';
 import { useable } from '../../promises/dangerouslyUsable';
 import { useCallback } from 'react';

--- a/packages/react-core/src/translation/hooks/useMessages.ts
+++ b/packages/react-core/src/translation/hooks/useMessages.ts
@@ -1,4 +1,4 @@
-import useGTContext from '../../provider/GTContext';
+import { useGTContext } from '../../provider/GTContext';
 import { _Messages, Translations } from '../../types-dir/types';
 import { useable } from '../../promises/dangerouslyUsable';
 import { MFunctionType } from '../../types-dir/types';

--- a/packages/react-core/src/translation/hooks/useTranslations.tsx
+++ b/packages/react-core/src/translation/hooks/useTranslations.tsx
@@ -1,4 +1,4 @@
-import useGTContext from '../../provider/GTContext';
+import { useGTContext } from '../../provider/GTContext';
 
 /**
  * Gets the dictionary access function `t` provided by `<GTProvider>`.


### PR DESCRIPTION
## Summary
- Convert the internal `useGTContext` helper from a default export to a named export alongside `GTContext`.
- Update internal React Core imports to use the named helper.

## Testing
- `pnpm --filter @generaltranslation/react-core... build`
- `pnpm --filter @generaltranslation/react-core typecheck`
- `pnpm --filter @generaltranslation/react-core test`
- `pnpm exec oxlint packages/react-core/src`
- `pnpm exec oxfmt --check packages/react-core/src/provider/GTContext.ts packages/react-core/src/hooks/useDefaultLocale.ts packages/react-core/src/hooks/useGTClass.ts packages/react-core/src/hooks/useLocale.ts packages/react-core/src/hooks/useLocaleDirection.ts packages/react-core/src/hooks/useLocaleSelector.ts packages/react-core/src/hooks/useLocales.ts packages/react-core/src/hooks/useRegion.ts packages/react-core/src/hooks/useRegionSelector.ts packages/react-core/src/hooks/useSetLocale.ts packages/react-core/src/hooks/useVersionId.ts packages/react-core/src/translation/T.tsx packages/react-core/src/translation/hooks/useGT.tsx packages/react-core/src/translation/hooks/useMessages.ts packages/react-core/src/translation/hooks/useTranslations.tsx`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1540"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782941726&installation_id=127936663&pr_number=1540&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1540&signature=c21949e472843a1d2c8a77c17cad4432508fb483ddaa6964223b4b150ecad350"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR converts the internal `useGTContext` helper from a default export to a named export and updates all 15 call sites across `react-core` to use the named import syntax. There are no public API changes — `useGTContext` is not re-exported from `index.ts`.

- `GTContext.ts`: `export default function useGTContext` → `export function useGTContext`
- All 14 consumer files (hooks and translation components): `import useGTContext from ...` → `import { useGTContext } from ...`

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — purely a mechanical rename of an internal export, with no public API changes.

Every consumer of `useGTContext` within the package is updated consistently, and the function itself is not re-exported from `index.ts`, so no downstream packages are affected. The function body, signature, and runtime behavior are identical before and after the change.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react-core/src/provider/GTContext.ts | Changed useGTContext from a default export to a named export; GTContext context object and function logic are unchanged. |
| packages/react-core/src/hooks/useDefaultLocale.ts | Updated import to use named useGTContext; no functional changes. |
| packages/react-core/src/translation/T.tsx | Updated import to use named useGTContext; no functional changes. |
| packages/react-core/src/translation/hooks/useGT.tsx | Updated import to use named useGTContext; no functional changes. |
| packages/react-core/src/translation/hooks/useMessages.ts | Updated import to use named useGTContext; no functional changes. |
| packages/react-core/src/translation/hooks/useTranslations.tsx | Updated import to use named useGTContext; no functional changes. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[GTContext.ts] -->|export function useGTContext| B[Named Export]
    B --> C[useDefaultLocale.ts]
    B --> D[useGTClass.ts]
    B --> E[useLocale.ts]
    B --> F[useLocaleDirection.ts]
    B --> G[useLocaleSelector.ts]
    B --> H[useLocales.ts]
    B --> I[useRegion.ts]
    B --> J[useRegionSelector.ts]
    B --> K[useSetLocale.ts]
    B --> L[useVersionId.ts]
    B --> M[T.tsx]
    B --> N[useGT.tsx]
    B --> O[useMessages.ts]
    B --> P[useTranslations.tsx]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: consolidate gt context helper"](https://github.com/generaltranslation/gt/commit/8ba4db0fe16426874461a30878bf996cad1ac789) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35011699)</sub>

<!-- /greptile_comment -->