### PR TITLE
refactor: relax dictionary cache config

### DIFF
--- a/packages/i18n/src/i18n-cache/I18nCache.ts
+++ b/packages/i18n/src/i18n-cache/I18nCache.ts
@@ -101,6 +101,7 @@ class I18nCache<
         _branchId: params._branchId,
       },
     }) as SafeTranslationsLoader<TranslationValue>;
+    // TODO: somewhere enforce that if you have a loadDictionary, you must have a dictionary
     const loadDictionary = params.loadDictionary ?? (() => Promise.resolve({}));
     const runtimeTranslationTimeout =
       this.config.runtimeTranslation?.timeout ?? DEFAULT_TRANSLATION_TIMEOUT;

--- a/packages/i18n/src/i18n-cache/types.ts
+++ b/packages/i18n/src/i18n-cache/types.ts
@@ -10,15 +10,10 @@ import type {
   DictionaryLoader,
 } from './translations-manager/DictionaryCache';
 
-export type DictionaryConfig =
-  | {
-      dictionary: Dictionary;
-      loadDictionary?: DictionaryLoader;
-    }
-  | {
-      dictionary?: Dictionary;
-      loadDictionary?: undefined;
-    };
+export type DictionaryConfig = {
+  dictionary?: Dictionary;
+  loadDictionary?: DictionaryLoader;
+};
 
 type RuntimeTranslationConfig = {
   timeout?: number;


### PR DESCRIPTION
Split out from #1541. Full split ledger and verification notes are in branch `e/odysseus/pr-stack-split-plan` at `.codex/pr-stack-split-plan.md`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1543"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782960508&installation_id=127936663&pr_number=1543&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1543&signature=d20bf7f64eb1e86ec719c2dfdd7e63f5109f538b2463c822d25320b079b79e46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR relaxes the `DictionaryConfig` type by replacing a discriminated union (which required `dictionary` whenever `loadDictionary` was set) with a flat type where both fields are independently optional. A TODO comment in `I18nCache.ts` acknowledges that the previously compile-time-enforced co-constraint now needs to be applied somewhere else.

- **`types.ts`**: `DictionaryConfig` collapses from two union branches into `{ dictionary?: Dictionary; loadDictionary?: DictionaryLoader }`, allowing all field combinations including `loadDictionary`-without-`dictionary`.
- **`I18nCache.ts`**: A single TODO comment is added noting that the `loadDictionary` ↔ `dictionary` pairing constraint must be enforced downstream; no runtime guard is introduced in this PR.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The core logic is unchanged; the only risk is that callers can now pass `loadDictionary` without `dictionary` and get silently broken dictionary behaviour in production — a gap the author explicitly notes as a TODO.

Removing the discriminated union leaves `loadDictionary`-without-`dictionary` as a valid combination at the call site, but it produces empty source dictionaries and silent runtime errors in production. No existing callers are broken by this change, but the missing guard means a future misconfiguration will be hard to diagnose.

Both changed files are small; the main thing worth a second look is whether `validateConfig` in `I18nCache.ts` (called at construction) already catches the `loadDictionary`-without-`dictionary` case, which would reduce the risk considerably.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/i18n/src/i18n-cache/types.ts | DictionaryConfig simplified from a discriminated union to a flat optional-fields type, removing compile-time enforcement that loadDictionary requires dictionary to be present. |
| packages/i18n/src/i18n-cache/I18nCache.ts | Added a TODO comment acknowledging that the loadDictionary+dictionary co-constraint is now unenforced; otherwise unchanged logic. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Caller constructs I18nCache(params)"] --> B{DictionaryConfig\nfields provided?}

    B -->|"dictionary only"| C["LocalesCache seeded\nwith static dictionary"]
    B -->|"both dictionary + loadDictionary"| D["LocalesCache seeded\nwith static dictionary;\nloadDictionary used for\nlocale-specific lookups"]
    B -->|"neither"| E["loadDictionary defaults\nto () => Promise.resolve({});\nall lookups return empty"]
    B -->|"loadDictionary only\n(NOW ALLOWED — previously blocked)"| F["LocalesCache gets\ndictionary: undefined;\ndefault-locale DictionaryCache\nstarts empty"]

    F --> G["getSourceDictionaryEntry(id)\nthrows DictionarySourceNotFoundError\nfor every key"]
    G --> H{"Runtime env?"}
    H -->|"production"| I["Error silently logged;\ndictionary lookups silently broken"]
    H -->|"development"| J["Error thrown"]

    style F fill:#ffe0e0
    style G fill:#ffe0e0
    style I fill:#ffe0e0
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fi18n%2Fsrc%2Fi18n-cache%2FI18nCache.ts%3A104-105%0A**Unenforced%20co-constraint%20between%20%60loadDictionary%60%20and%20%60dictionary%60**%0A%0AThe%20previous%20discriminated%20union%20in%20%60DictionaryConfig%60%20statically%20guaranteed%20that%20%60loadDictionary%60%20could%20only%20be%20supplied%20together%20with%20a%20%60dictionary%60.%20That%20compile-time%20guard%20is%20now%20gone%2C%20and%20the%20TODO%20indicates%20no%20runtime%20replacement%20exists%20yet%20either.%20If%20a%20caller%20passes%20%60loadDictionary%60%20without%20%60dictionary%60%2C%20the%20default-locale%20%60DictionaryCache%60%20initialises%20with%20%60undefined%60%2Fempty%20content%2C%20so%20every%20call%20to%20%60getSourceDictionaryEntry%60%20will%20throw%20%60DictionarySourceNotFoundError%60%20for%20any%20key%20%E2%80%94%20silently%20swallowed%20in%20production%20but%20producing%20broken%20dictionary%20lookups.%20Until%20the%20enforcement%20is%20added%2C%20callers%20have%20no%20signal%20%28compile-time%20or%20runtime%29%20that%20this%20combination%20is%20unsupported.%0A%0A&repo=generaltranslation%2Fgt&pr=1543&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fodysseus%2Frelax-dictionary-cache-config%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fodysseus%2Frelax-dictionary-cache-config%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fi18n%2Fsrc%2Fi18n-cache%2FI18nCache.ts%3A104-105%0A**Unenforced%20co-constraint%20between%20%60loadDictionary%60%20and%20%60dictionary%60**%0A%0AThe%20previous%20discriminated%20union%20in%20%60DictionaryConfig%60%20statically%20guaranteed%20that%20%60loadDictionary%60%20could%20only%20be%20supplied%20together%20with%20a%20%60dictionary%60.%20That%20compile-time%20guard%20is%20now%20gone%2C%20and%20the%20TODO%20indicates%20no%20runtime%20replacement%20exists%20yet%20either.%20If%20a%20caller%20passes%20%60loadDictionary%60%20without%20%60dictionary%60%2C%20the%20default-locale%20%60DictionaryCache%60%20initialises%20with%20%60undefined%60%2Fempty%20content%2C%20so%20every%20call%20to%20%60getSourceDictionaryEntry%60%20will%20throw%20%60DictionarySourceNotFoundError%60%20for%20any%20key%20%E2%80%94%20silently%20swallowed%20in%20production%20but%20producing%20broken%20dictionary%20lookups.%20Until%20the%20enforcement%20is%20added%2C%20callers%20have%20no%20signal%20%28compile-time%20or%20runtime%29%20that%20this%20combination%20is%20unsupported.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/i18n/src/i18n-cache/I18nCache.ts:104-105
**Unenforced co-constraint between `loadDictionary` and `dictionary`**

The previous discriminated union in `DictionaryConfig` statically guaranteed that `loadDictionary` could only be supplied together with a `dictionary`. That compile-time guard is now gone, and the TODO indicates no runtime replacement exists yet either. If a caller passes `loadDictionary` without `dictionary`, the default-locale `DictionaryCache` initialises with `undefined`/empty content, so every call to `getSourceDictionaryEntry` will throw `DictionarySourceNotFoundError` for any key — silently swallowed in production but producing broken dictionary lookups. Until the enforcement is added, callers have no signal (compile-time or runtime) that this combination is unsupported.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: relax dictionary cache config"](https://github.com/generaltranslation/gt/commit/1858b98527c1c422466367a223c6ef8d1f2f529c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35055036)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->