### PR TITLE
refactor: export browser condition helpers

### DIFF
--- a/packages/react/src/condition-store/createBrowserConditionStore.ts
+++ b/packages/react/src/condition-store/createBrowserConditionStore.ts
@@ -57,7 +57,7 @@ export function createOrUpdateBrowserConditionStore(
   setBrowserConditionStore(conditionStore);
 }
 
-function determineLocale({
+export function determineLocale({
   localeCookieName = defaultLocaleCookieName,
   getLocale,
   locale,
@@ -76,7 +76,7 @@ function resolveLocale(candidates?: LocaleCandidates): string {
   );
 }
 
-function determineEnableI18n({
+export function determineEnableI18n({
   enableI18n,
   enableI18nCookieName = defaultEnableI18nCookieName,
   getEnableI18n,


### PR DESCRIPTION
Split out from #1541. Full split ledger and verification notes are in branch `e/odysseus/pr-stack-split-plan` at `.codex/pr-stack-split-plan.md`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1544"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782960509&installation_id=127936663&pr_number=1544&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1544&signature=fd7ba6f01ef34a74b13dc4afa3952caf22175d4ce5797f56e0504c9ce6ab8391"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR promotes `determineLocale` and `determineEnableI18n` from module-private to exported functions in `createBrowserConditionStore.ts`, with no logic changes. It is a preparatory step split from #1541 so those helpers can be imported directly by other modules.

- `determineLocale` — resolves the active locale by merging cookie state, config candidates, and a `getLocale` callback.
- `determineEnableI18n` — resolves the i18n-enabled flag by checking a cookie first, then falling back to a callback or config value.
- `resolveLocale` remains private (unexported), which is consistent with it being a pure internal utility called only by `determineLocale`.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the only change is adding `export` to two functions, with no logic modifications whatsoever.

Both functions already existed and were used internally. Adding `export` exposes them to other modules without altering their behavior. No new code paths, no new state, and the rest of the module is unchanged.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react/src/condition-store/createBrowserConditionStore.ts | Adds `export` to `determineLocale` and `determineEnableI18n`; no logic changes. These helpers are needed by a downstream PR (#1541) and the rest of the module is untouched. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[createOrUpdateBrowserConditionStore] --> B[determineLocale]
    A --> C[determineEnableI18n]

    B --> D[readBrowserLocale\ncookie]
    B --> E[locale candidates\nfrom config]
    B --> F[getLocale\ncallback]
    D & E & F --> G[resolveLocale\nprivate]
    G --> H[i18nConfig.determineLocale\nor defaultLocale]

    C --> I[getCookieValue\nenableI18n cookie]
    I -->|undefined| J[getEnableI18n?\nor enableI18n\nor true]
    I -->|present| K[parse 'true' string → boolean]

    style B fill:#d4edda,stroke:#28a745
    style C fill:#d4edda,stroke:#28a745
```
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: export browser condition helpe..."](https://github.com/generaltranslation/gt/commit/f081100f5610ae2301c457438b2a720311168c16) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35055040)</sub>

<!-- /greptile_comment -->