### PR TITLE
refactor: track runtime gt lookups

### DIFF
--- a/packages/react-core/src/hooks/useGT.ts
+++ b/packages/react-core/src/hooks/useGT.ts
@@ -9,7 +9,7 @@ import type { GTFunctionType, InlineTranslationOptions } from 'gt-i18n/types';
 import type { StringFormat } from '@generaltranslation/format/types';
 import { useDefaultLocale } from './i18n-config';
 import { getI18nConfig } from 'gt-i18n/internal';
-import { useLookupResolver } from '../i18n-store/lookup-adapter/useLookupResolver';
+import { useTrackedTranslationResolver } from '../i18n-store/lookup-adapter/useTrackedTranslationResolver';
 
 const EMPTY_TRANSLATE_LOOKUPS: TranslateLookup<string>[] = [];
 
@@ -23,7 +23,7 @@ export function useGT(_messages?: Message[]): GTFunctionType {
   const locale = useLocale();
   const defaultLocale = useDefaultLocale();
   const shouldTranslate = useShouldTranslate();
-  const lookupResolver = useLookupResolver();
+  const translationResolver = useTrackedTranslationResolver();
   const devHotReloadEnabled = getI18nConfig().isDevHotReloadEnabled();
 
   // Compiler optimization: pre-fetch translations
@@ -57,10 +57,11 @@ export function useGT(_messages?: Message[]): GTFunctionType {
         message,
         options: lookupOptions,
       };
-      const translation = lookupResolver.resolveTranslation(lookup);
+      translationResolver.track(lookup);
+      const translation = translationResolver.resolve(lookup);
 
       if (translation == null && devHotReloadEnabled) {
-        lookupResolver.handleMissingTranslation(lookup);
+        translationResolver.handleMissing(lookup);
       }
 
       return interpolateMessage({
@@ -74,8 +75,8 @@ export function useGT(_messages?: Message[]): GTFunctionType {
       defaultLocale,
       devHotReloadEnabled,
       locale,
-      lookupResolver,
       shouldTranslate,
+      translationResolver,
     ]
   );
 }

--- a/packages/react-core/src/i18n-store/I18nStore.ts
+++ b/packages/react-core/src/i18n-store/I18nStore.ts
@@ -7,6 +7,7 @@ import type {
   DictionaryLookup,
   DictionaryObjectSnapshot,
   StoreListener,
+  TranslateEventListener,
   TranslateLookup,
   TranslateManySnapshot,
   TranslateSnapshot,
@@ -26,7 +27,6 @@ import {
   ReactI18nCacheParams,
 } from '../i18n-cache/ReactI18nCache';
 
-type TranslateStoreListener = (lookup: TranslateLookup) => void;
 type DictionaryStoreListener = (event: DictionaryLookup) => void;
 
 export type I18nStoreParams = ReactI18nCacheParams;
@@ -47,7 +47,7 @@ export class I18nStore {
 
   // ----- Listener Sets ----- //
 
-  private translateListeners = new Set<TranslateStoreListener>();
+  private translateListeners = new Set<TranslateEventListener>();
   private translateManySnapshotCache = new WeakMap<
     readonly TranslateLookup[],
     TranslateManySnapshot
@@ -122,12 +122,18 @@ export class I18nStore {
     listener: StoreListener
   ): Unsubscribe => {
     const lookupKey = getTranslateListenerKey(lookup);
-    const wrappedListener: TranslateStoreListener = (lookup) => {
+    const wrappedListener: TranslateEventListener = (lookup) => {
       if (getTranslateListenerKey(lookup) === lookupKey) {
         listener();
       }
     };
     return subscribeToSet(this.translateListeners, wrappedListener);
+  };
+
+  subscribeToTranslationEvents = (
+    listener: TranslateEventListener
+  ): Unsubscribe => {
+    return subscribeToSet(this.translateListeners, listener);
   };
 
   subscribeToTranslateMany = <T extends Translation>(

--- a/packages/react-core/src/i18n-store/lookup-adapter/LookupAdapter.ts
+++ b/packages/react-core/src/i18n-store/lookup-adapter/LookupAdapter.ts
@@ -7,6 +7,7 @@ import type {
   DictionaryLookup,
   DictionaryObjectSnapshot,
   StoreListener,
+  TranslateEventListener,
   TranslateLookup,
   TranslateManySnapshot,
   TranslateSnapshot,
@@ -26,6 +27,10 @@ export type LookupAdapter = {
   subscribeToTranslate: <T extends Translation>(
     lookup: TranslateLookup<T>,
     listener: StoreListener
+  ) => Unsubscribe;
+
+  subscribeToTranslationEvents: (
+    listener: TranslateEventListener
   ) => Unsubscribe;
 
   /**

--- a/packages/react-core/src/i18n-store/lookup-adapter/factories.ts
+++ b/packages/react-core/src/i18n-store/lookup-adapter/factories.ts
@@ -3,6 +3,7 @@ import { getI18nStore } from '../singleton-operations';
 import type {
   DictionaryLookup,
   StoreListener,
+  TranslateEventListener,
   TranslateLookup,
   TranslateManySnapshot,
   Unsubscribe,
@@ -22,6 +23,7 @@ export function createSPALookupAdapter(): LookupAdapter {
   return {
     mode: 'SPA',
     subscribeToTranslate,
+    subscribeToTranslationEvents,
     getStoreTranslation: (lookup) => {
       return getI18nStore().getTranslateSnapshot(lookup);
     },
@@ -96,6 +98,12 @@ export function createSRALookupAdapter(context: GTContextType): LookupAdapter {
         return noopSubscribe();
       }
       return i18nStore.subscribeToTranslate(lookup, listener);
+    },
+    subscribeToTranslationEvents: (listener) => {
+      if (!getI18nConfig().isDevHotReloadEnabled()) {
+        return noopSubscribe();
+      }
+      return i18nStore.subscribeToTranslationEvents(listener);
     },
     getStoreTranslation: (lookup) => {
       if (!getI18nConfig().isDevHotReloadEnabled()) {
@@ -218,6 +226,12 @@ function subscribeToTranslate<T extends Translation>(
   listener: StoreListener
 ): Unsubscribe {
   return getI18nStore().subscribeToTranslate(lookup, listener);
+}
+
+function subscribeToTranslationEvents(
+  listener: TranslateEventListener
+): Unsubscribe {
+  return getI18nStore().subscribeToTranslationEvents(listener);
 }
 
 function subscribeToTranslateMany<T extends Translation>(

--- a/packages/react-core/src/i18n-store/lookup-adapter/useTrackedTranslationResolver.ts
+++ b/packages/react-core/src/i18n-store/lookup-adapter/useTrackedTranslationResolver.ts
@@ -1,0 +1,59 @@
+import { useCallback, useMemo, useRef, useSyncExternalStore } from 'react';
+import { getTranslateListenerKey } from 'gt-i18n/internal';
+import type { Translation } from 'gt-i18n/types';
+import type { TranslateLookup, TranslateSnapshot } from '../storeTypes';
+import { useLookupAdapter } from './useLookupAdapter';
+
+export type TrackedTranslationResolver = {
+  track: <T extends Translation>(lookup: TranslateLookup<T>) => void;
+  resolve: <T extends Translation>(
+    lookup: TranslateLookup<T>
+  ) => TranslateSnapshot<T>;
+  handleMissing: <T extends Translation>(lookup: TranslateLookup<T>) => void;
+};
+
+export function useTrackedTranslationResolver(): TrackedTranslationResolver {
+  const adapter = useLookupAdapter();
+  /**
+   * Track lookups per hook instance without updating React state during render.
+   * The version ref is only an invalidation counter for useSyncExternalStore.
+   */
+  const trackedKeysRef = useRef(new Set<string>());
+  const versionRef = useRef(0);
+
+  const getSnapshot = useCallback(() => {
+    return versionRef.current;
+  }, []);
+
+  useSyncExternalStore(
+    useCallback(
+      (listener) => {
+        return adapter.subscribeToTranslationEvents((lookup) => {
+          const key = getTranslateListenerKey(lookup);
+          if (!trackedKeysRef.current.has(key)) return;
+          versionRef.current++;
+          listener();
+        });
+      },
+      [adapter]
+    ),
+    getSnapshot,
+    getSnapshot
+  );
+
+  return useMemo(
+    () => ({
+      track: (lookup) => {
+        trackedKeysRef.current.add(getTranslateListenerKey(lookup));
+      },
+      resolve: (lookup) => {
+        const storeTranslation = adapter.getStoreTranslation(lookup);
+        return adapter.resolveTranslation(lookup, storeTranslation);
+      },
+      handleMissing: (lookup) => {
+        adapter.handleMissingTranslation?.(lookup);
+      },
+    }),
+    [adapter]
+  );
+}

--- a/packages/react-core/src/i18n-store/storeTypes.ts
+++ b/packages/react-core/src/i18n-store/storeTypes.ts
@@ -9,6 +9,7 @@ import type {
 
 export type Unsubscribe = () => void;
 export type StoreListener = () => void;
+export type TranslateEventListener = (lookup: TranslateLookup) => void;
 
 // ----- Lookups ----- //
 


### PR DESCRIPTION
Split out from #1541. Full split ledger and verification notes are in branch `e/odysseus/pr-stack-split-plan` at `.codex/pr-stack-split-plan.md`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1547"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782960513&installation_id=127936663&pr_number=1547&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1547&signature=d08b15acf309c94e0c98af387d62437783c57a9b3407da2a68946a3bd57176ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors `useGT` to replace per-key store subscriptions with a single broadcast subscription that filters events against a component-local set of tracked keys. A new `useTrackedTranslationResolver` hook manages the tracking via `useSyncExternalStore` and an integer version counter, aiming to reduce subscription overhead per `gt()` call.

- **`useTrackedTranslationResolver`** subscribes to all `TranslateEventListener` events via the adapter and filters by `trackedKeysRef`, incrementing a version counter to trigger React re-renders only for relevant key updates.
- **`I18nStore`** gains a public `subscribeToTranslationEvents` that exposes the full listener set, and `factories.ts` wires it into both SPA (always active, events only emitted in dev) and SRA (gated on `isDevHotReloadEnabled`) adapters.
- **`storeTypes.ts`** centralises the `TranslateEventListener` type that was previously a local alias inside `I18nStore.ts`.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the refactor is well-scoped, the useSyncExternalStore pattern is correctly applied, and the SPA/SRA adapter asymmetry in subscription gating is intentional and harmless.

The new broadcast-then-filter subscription model is a sound replacement for per-key subscriptions. The version counter approach with useSyncExternalStore is idiomatic, hydration-safe (both client and server snapshots start at 0), and Concurrent-Mode safe. Translation events only fire during dev hot-reload, so the unconditional SPA subscription is inert in production. No data loss, no incorrect re-render paths, no new error surfaces identified.

useTrackedTranslationResolver.ts is the core of the change and worth a close read, specifically around the append-only trackedKeysRef set (a concern already raised in a prior review thread).
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react-core/src/i18n-store/lookup-adapter/useTrackedTranslationResolver.ts | New hook that replaces per-key subscriptions with a single broadcast subscription, filtering events by a ref-tracked key set. Uses useSyncExternalStore with an integer version counter for re-render triggering. The trackedKeysRef set is append-only across the component's lifetime. |
| packages/react-core/src/hooks/useGT.ts | Updated to use useTrackedTranslationResolver; gt() callback now calls track() before resolve(), and method names renamed. Dependency array updated. Logic is otherwise unchanged. |
| packages/react-core/src/i18n-store/I18nStore.ts | Added subscribeToTranslationEvents that exposes the full translateListeners set to callers (no key filter), replacing the local TranslateStoreListener type alias with the shared TranslateEventListener. |
| packages/react-core/src/i18n-store/lookup-adapter/factories.ts | Wired subscribeToTranslationEvents into both SPA and SRA adapters. SRA adapter correctly gates on isDevHotReloadEnabled; SPA does not gate (consistent with existing subscribeToTranslate behavior). |
| packages/react-core/src/i18n-store/lookup-adapter/LookupAdapter.ts | Interface extended with subscribeToTranslationEvents; clean, minimal change. |
| packages/react-core/src/i18n-store/storeTypes.ts | Added TranslateEventListener type, consolidating what was previously a local type alias in I18nStore.ts. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Component as Component (useGT)
    participant Resolver as useTrackedTranslationResolver
    participant Adapter as LookupAdapter
    participant Store as I18nStore
    participant Cache as ReactI18nCache

    Note over Component,Cache: Mount / Initial Render
    Component->>Resolver: useTrackedTranslationResolver()
    Resolver->>Adapter: adapter.subscribeToTranslationEvents(cb)
    Adapter->>Store: subscribeToTranslationEvents(cb)
    Store-->>Adapter: unsubscribe fn
    Adapter-->>Resolver: unsubscribe fn (via useSyncExternalStore)

    Note over Component,Cache: gt("Hello, {name}!") called during render
    Component->>Resolver: track(lookup) → trackedKeysRef.add(key)
    Component->>Resolver: resolve(lookup)
    Resolver->>Adapter: getStoreTranslation + resolveTranslation
    Adapter->>Store: getTranslateSnapshot
    Store-->>Adapter: "translation | undefined"
    Adapter-->>Resolver: resolved translation
    Resolver-->>Component: translation

    Note over Component,Cache: Dev hot-reload: translation updated
    Cache-->>Store: update cache entry
    Store->>Store: emitTranslateEvent(lookup)
    Store->>Resolver: broadcast to all TranslateEventListeners
    Resolver->>Resolver: key in trackedKeysRef? YES → versionRef++, listener()
    Resolver-->>Component: useSyncExternalStore detects snapshot change → re-render
```
</details>

<sub>Reviews (2): Last reviewed commit: ["refactor: track runtime gt lookups"](https://github.com/generaltranslation/gt/commit/464e147f284c91461f033d148b7997eb5567fe20) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35055056)</sub>

<!-- /greptile_comment -->