### PR TITLE
refactor(1): move context RSC components to react

### DIFF
--- a/packages/react-core/src/components/translation/T.tsx
+++ b/packages/react-core/src/components/translation/T.tsx
@@ -1,10 +1,8 @@
 import { useTranslate } from '../../hooks/external-store';
 import { getI18nConfig } from 'gt-i18n/internal';
 import { useRef, type ReactNode } from 'react';
-import { getReactI18nCache } from '../../i18n-cache/singleton-operations';
 import { renderPreparedT } from '../../utils/rendering/renderPreparedT';
 import {
-  prepareT,
   usePrepareT,
   type JsxTranslationOptions,
 } from '../../utils/translation/prepareT';
@@ -30,59 +28,11 @@ function GtInternalTranslateJsx(
   return useComputeT(props);
 }
 
-async function RscT({
-  children: sourceChildren,
-  locale,
-  enableI18n,
-  ...params
-}: {
-  children: ReactNode;
-  locale: string;
-  enableI18n: boolean;
-} & JsxTranslationOptions): Promise<ReactNode> {
-  const defaultLocale = getI18nConfig().getDefaultLocale();
-  const shouldTranslate =
-    enableI18n && getI18nConfig().requiresTranslation(locale);
-  const prepared = prepareT({
-    sourceChildren,
-    params,
-    locale,
-  });
-
-  if (!shouldTranslate) {
-    return renderPreparedT({
-      ...prepared,
-      targetJsxChildren: undefined,
-      locale,
-      defaultLocale,
-      enableI18n,
-      shouldTranslate,
-    });
-  }
-
-  const lookupTranslation =
-    await getReactI18nCache().getLookupTranslation(locale);
-  const targetJsxChildren = lookupTranslation(
-    prepared.sourceJsxChildren,
-    prepared.targetOptions
-  );
-
-  return renderPreparedT({
-    ...prepared,
-    targetJsxChildren,
-    locale,
-    defaultLocale,
-    enableI18n,
-    shouldTranslate,
-  });
-}
-
 /** @internal _gtt - The GT transformation for the component. */
 T._gtt = 'translate-client';
 GtInternalTranslateJsx._gtt = 'translate-client-automatic';
-RscT._gtt = 'translate-server';
 
-export { GtInternalTranslateJsx, RscT, T };
+export { GtInternalTranslateJsx, T };
 
 /**
  * Render logic

--- a/packages/react-core/src/context.ts
+++ b/packages/react-core/src/context.ts
@@ -2,7 +2,7 @@
 export { Branch } from './components/branches/Branch';
 export { Plural } from './components/branches/Plural';
 export { Derive } from './components/derivation/Derive';
-export { GtInternalTranslateJsx, RscT, T } from './components/translation/T';
+export { GtInternalTranslateJsx, T } from './components/translation/T';
 export { Currency } from './components/variables/Currency';
 export { DateTime } from './components/variables/DateTime';
 export { Num } from './components/variables/Num';
@@ -81,3 +81,22 @@ export type {
 } from './hooks/utils/missing-translation';
 export type { TranslateLookup } from './i18n-store/storeTypes';
 export type { DictionaryLookup } from './i18n-store/storeTypes';
+export { GtInternalBranch } from './components/branches/Branch';
+export { GtInternalPlural } from './components/branches/Plural';
+export { GtInternalDerive } from './components/derivation/Derive';
+export { GtInternalCurrency } from './components/variables/Currency';
+export { GtInternalDateTime } from './components/variables/DateTime';
+export { GtInternalNum } from './components/variables/Num';
+export { GtInternalRelativeTime } from './components/variables/RelativeTime';
+export { GtInternalVar } from './components/variables/Var';
+export { renderPreparedT } from './utils/rendering/renderPreparedT';
+export { prepareT, usePrepareT } from './utils/translation/prepareT';
+export type {
+  JsxTranslationOptions,
+  PreparedT,
+} from './utils/translation/prepareT';
+export type {
+  TaggedChildren,
+  RelativeTimeFormatOptions,
+  RenderVariable,
+} from './utils/types';

--- a/packages/react-core/src/utils/rendering/renderDefaultChildren.tsx
+++ b/packages/react-core/src/utils/rendering/renderDefaultChildren.tsx
@@ -3,19 +3,26 @@ import getVariableProps, {
   isVariableElementProps,
 } from '../variables/_getVariableProps';
 import { libraryDefaultLocale } from 'generaltranslation/internal';
-import { TaggedChild, TaggedChildren, TaggedElement } from '../types';
+import {
+  type RenderVariable,
+  TaggedChild,
+  TaggedChildren,
+  TaggedElement,
+} from '../types';
 import getGTTag from './getGTTag';
 import getPluralBranch from '../plurals/getPluralBranch';
-import { renderVariable } from './renderVariable';
+import { renderVariable as defaultRenderVariable } from './renderVariable';
 
 export default function renderDefaultChildren({
   children,
   defaultLocale = libraryDefaultLocale,
   enableI18n,
+  renderVariable = defaultRenderVariable,
 }: {
   children: TaggedChildren;
   defaultLocale: string;
   enableI18n: boolean;
+  renderVariable?: RenderVariable;
 }): React.ReactNode {
   const handleSingleChildElement = (child: TaggedElement): ReactNode => {
     const generaltranslation = getGTTag(child);

--- a/packages/react-core/src/utils/rendering/renderPreparedT.tsx
+++ b/packages/react-core/src/utils/rendering/renderPreparedT.tsx
@@ -1,8 +1,9 @@
 import renderDefaultChildren from './renderDefaultChildren';
 import renderTranslatedChildren from './renderTranslatedChildren';
+import { renderVariable as defaultRenderVariable } from './renderVariable';
 import type { JsxChildren } from 'generaltranslation/types';
 import type { ReactNode } from 'react';
-import type { TaggedChildren } from '../types';
+import type { RenderVariable, TaggedChildren } from '../types';
 
 function renderPreparedT({
   taggedSourceChildren,
@@ -11,6 +12,7 @@ function renderPreparedT({
   defaultLocale,
   enableI18n,
   shouldTranslate,
+  renderVariable = defaultRenderVariable,
 }: {
   taggedSourceChildren: TaggedChildren;
   targetJsxChildren: JsxChildren | null | undefined;
@@ -18,12 +20,14 @@ function renderPreparedT({
   defaultLocale: string;
   enableI18n: boolean;
   shouldTranslate: boolean;
+  renderVariable?: RenderVariable;
 }): ReactNode {
   if (!shouldTranslate || targetJsxChildren == null) {
     return renderSource({
       taggedSourceChildren,
       defaultLocale,
       enableI18n,
+      renderVariable,
     });
   }
 
@@ -32,6 +36,7 @@ function renderPreparedT({
     targetJsxChildren,
     locales: [locale, defaultLocale],
     enableI18n,
+    renderVariable,
   });
 }
 
@@ -39,15 +44,18 @@ function renderSource({
   taggedSourceChildren,
   defaultLocale,
   enableI18n,
+  renderVariable,
 }: {
   taggedSourceChildren: TaggedChildren;
   defaultLocale: string;
   enableI18n: boolean;
+  renderVariable: RenderVariable;
 }): ReactNode {
   return renderDefaultChildren({
     children: taggedSourceChildren,
     defaultLocale,
     enableI18n,
+    renderVariable,
   });
 }
 
@@ -56,17 +64,20 @@ function renderTarget({
   targetJsxChildren,
   locales,
   enableI18n,
+  renderVariable,
 }: {
   taggedSourceChildren: TaggedChildren;
   targetJsxChildren: JsxChildren;
   locales: string[];
   enableI18n: boolean;
+  renderVariable: RenderVariable;
 }): ReactNode {
   return renderTranslatedChildren({
     source: taggedSourceChildren,
     target: targetJsxChildren,
     locales,
     enableI18n,
+    renderVariable,
   });
 }
 

--- a/packages/react-core/src/utils/rendering/renderTranslatedChildren.tsx
+++ b/packages/react-core/src/utils/rendering/renderTranslatedChildren.tsx
@@ -1,5 +1,6 @@
 import React, { ReactNode } from 'react';
 import {
+  RenderVariable,
   TaggedChildren,
   TaggedElement,
   TranslatedChildren,
@@ -17,18 +18,20 @@ import {
   HtmlContentPropValuesRecord,
 } from '@generaltranslation/format/types';
 import getGTTag from './getGTTag';
-import { renderVariable } from './renderVariable';
+import { renderVariable as defaultRenderVariable } from './renderVariable';
 
 function renderTranslatedElement({
   sourceElement,
   targetElement,
   locales = [libraryDefaultLocale],
   enableI18n,
+  renderVariable,
 }: {
   sourceElement: TaggedElement;
   targetElement: TranslatedElement;
   locales: string[];
   enableI18n: boolean;
+  renderVariable: RenderVariable;
 }): React.ReactNode {
   // Get props and generaltranslation
   const { props: sourceProps } = sourceElement;
@@ -58,6 +61,7 @@ function renderTranslatedElement({
         children: sourceElement,
         defaultLocale: locales[0],
         enableI18n,
+        renderVariable,
       });
     }
     const sourceBranches = sourceGT.branches || {};
@@ -75,6 +79,7 @@ function renderTranslatedElement({
       target: targetBranch as TranslatedChildren,
       locales,
       enableI18n,
+      renderVariable,
     });
   }
 
@@ -98,6 +103,7 @@ function renderTranslatedElement({
       target: targetBranch as TranslatedChildren,
       locales,
       enableI18n,
+      renderVariable,
     });
   }
 
@@ -110,6 +116,7 @@ function renderTranslatedElement({
         target: targetElement.c,
         locales,
         enableI18n,
+        renderVariable,
       }) as TaggedChildren,
     });
   }
@@ -125,6 +132,7 @@ function renderTranslatedElement({
         target: targetElement.c,
         locales,
         enableI18n,
+        renderVariable,
       }) as TaggedChildren,
     });
   }
@@ -134,6 +142,7 @@ function renderTranslatedElement({
     children: sourceElement,
     defaultLocale: locales[0],
     enableI18n,
+    renderVariable,
   });
 }
 
@@ -142,11 +151,13 @@ export default function renderTranslatedChildren({
   target,
   locales = [libraryDefaultLocale],
   enableI18n,
+  renderVariable = defaultRenderVariable,
 }: {
   source: TaggedChildren;
   target: TranslatedChildren;
   locales: string[];
   enableI18n: boolean;
+  renderVariable?: RenderVariable;
 }): ReactNode {
   // Most straightforward case, return a valid React node
   if ((target === null || typeof target === 'undefined') && source)
@@ -154,6 +165,7 @@ export default function renderTranslatedChildren({
       children: source,
       defaultLocale: locales[0],
       enableI18n,
+      renderVariable,
     });
   if (typeof target === 'string') return target;
 
@@ -248,6 +260,7 @@ export default function renderTranslatedChildren({
             targetElement: targetChild,
             locales,
             enableI18n,
+            renderVariable,
           })}
         </React.Fragment>
       );
@@ -267,6 +280,7 @@ export default function renderTranslatedChildren({
           targetElement: target as TranslatedElement,
           locales,
           enableI18n,
+          renderVariable,
         });
       }
 
@@ -291,5 +305,6 @@ export default function renderTranslatedChildren({
     children: source,
     defaultLocale: locales[0],
     enableI18n,
+    renderVariable,
   });
 }

--- a/packages/react/src/components/branches/Branch.tsx
+++ b/packages/react/src/components/branches/Branch.tsx
@@ -1,0 +1,16 @@
+import { GtInternalBranch } from '@generaltranslation/react-core/context';
+
+type BranchProps = Parameters<typeof GtInternalBranch>[0];
+
+// ===== Component ===== //
+
+function RscBranch(props: BranchProps): React.JSX.Element {
+  return <GtInternalBranch {...props} />;
+}
+
+/** @internal _gtt - The GT transformation for the component. */
+RscBranch._gtt = 'branch';
+
+// ===== Exports ===== //
+
+export { RscBranch };

--- a/packages/react/src/components/branches/Plural.tsx
+++ b/packages/react/src/components/branches/Plural.tsx
@@ -1,0 +1,30 @@
+import {
+  getReadonlyConditionStoreWithFallback,
+  GtInternalPlural,
+} from '@generaltranslation/react-core/context';
+
+type PluralProps = Parameters<typeof GtInternalPlural>[0];
+
+// ===== Component ===== //
+
+function RscPlural({
+  _enableI18n,
+  _locale,
+  ...props
+}: PluralProps): React.JSX.Element {
+  const conditionStore = getReadonlyConditionStoreWithFallback();
+  return (
+    <GtInternalPlural
+      {...props}
+      _enableI18n={_enableI18n ?? conditionStore.getEnableI18n()}
+      _locale={_locale ?? conditionStore.getLocale()}
+    />
+  );
+}
+
+/** @internal _gtt - The GT transformation for the component. */
+RscPlural._gtt = 'plural';
+
+// ===== Exports ===== //
+
+export { RscPlural };

--- a/packages/react/src/components/derivation/Derive.tsx
+++ b/packages/react/src/components/derivation/Derive.tsx
@@ -1,0 +1,21 @@
+import { GtInternalDerive } from '@generaltranslation/react-core/context';
+import type { ReactNode } from 'react';
+
+type DeriveProps<T extends ReactNode> = Parameters<
+  typeof GtInternalDerive<T>
+>[0];
+
+// ===== Component ===== //
+
+function RscDerive<T extends ReactNode>(
+  props: DeriveProps<T>
+): React.JSX.Element {
+  return <GtInternalDerive {...props} />;
+}
+
+/** @internal _gtt - The GT transformation for the component. */
+RscDerive._gtt = 'derive';
+
+// ===== Exports ===== //
+
+export { RscDerive };

--- a/packages/react/src/components/translation/T.tsx
+++ b/packages/react/src/components/translation/T.tsx
@@ -1,0 +1,65 @@
+import {
+  getReactI18nCache,
+  prepareT,
+  renderPreparedT,
+  type JsxTranslationOptions,
+} from '@generaltranslation/react-core/context';
+import { getI18nConfig } from 'gt-i18n/internal';
+import type { ReactNode } from 'react';
+import { renderVariable } from '../../utils/rendering/renderVariable';
+
+// ===== Component ===== //
+
+async function RscT({
+  children: sourceChildren,
+  locale,
+  enableI18n,
+  ...params
+}: {
+  children: ReactNode;
+  locale: string;
+  enableI18n: boolean;
+} & JsxTranslationOptions): Promise<ReactNode> {
+  const defaultLocale = getI18nConfig().getDefaultLocale();
+  const shouldTranslate =
+    enableI18n && getI18nConfig().requiresTranslation(locale);
+  const prepared = prepareT({
+    sourceChildren,
+    params,
+    locale,
+  });
+
+  if (!shouldTranslate) {
+    return renderPreparedT({
+      ...prepared,
+      targetJsxChildren: undefined,
+      locale,
+      defaultLocale,
+      enableI18n,
+      shouldTranslate,
+      renderVariable,
+    });
+  }
+
+  const lookupTranslation =
+    await getReactI18nCache().getLookupTranslation(locale);
+  const targetJsxChildren = lookupTranslation(
+    prepared.sourceJsxChildren,
+    prepared.targetOptions
+  );
+
+  return renderPreparedT({
+    ...prepared,
+    targetJsxChildren,
+    locale,
+    defaultLocale,
+    enableI18n,
+    shouldTranslate,
+    renderVariable,
+  });
+}
+
+/** @internal _gtt - The GT transformation for the component. */
+RscT._gtt = 'translate-server';
+
+export { RscT };

--- a/packages/react/src/components/translation/__tests__/T.test.tsx
+++ b/packages/react/src/components/translation/__tests__/T.test.tsx
@@ -1,8 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { initializeI18nConfig } from 'gt-i18n/internal';
-import { setReactI18nCache } from '../../../i18n-cache/singleton-operations';
+import {
+  setReactI18nCache,
+  type ReactI18nCache,
+} from '@generaltranslation/react-core/context';
 import { RscT } from '../T';
-import type { ReactI18nCache } from '../../../i18n-cache/ReactI18nCache';
 
 const getLookupTranslation = vi.fn();
 

--- a/packages/react/src/components/variables/Currency.tsx
+++ b/packages/react/src/components/variables/Currency.tsx
@@ -1,0 +1,30 @@
+import {
+  getReadonlyConditionStoreWithFallback,
+  GtInternalCurrency,
+} from '@generaltranslation/react-core/context';
+
+type CurrencyProps = Parameters<typeof GtInternalCurrency>[0];
+
+// ===== Component ===== //
+
+function RscCurrency({
+  _enableI18n,
+  _locale,
+  ...props
+}: CurrencyProps): React.JSX.Element {
+  const conditionStore = getReadonlyConditionStoreWithFallback();
+  return (
+    <GtInternalCurrency
+      {...props}
+      _enableI18n={_enableI18n ?? conditionStore.getEnableI18n()}
+      _locale={_locale ?? conditionStore.getLocale()}
+    />
+  );
+}
+
+/** @internal _gtt - The GT transformation for the component. */
+RscCurrency._gtt = 'variable-currency';
+
+// ===== Exports ===== //
+
+export { RscCurrency };

--- a/packages/react/src/components/variables/DateTime.tsx
+++ b/packages/react/src/components/variables/DateTime.tsx
@@ -1,0 +1,30 @@
+import {
+  getReadonlyConditionStoreWithFallback,
+  GtInternalDateTime,
+} from '@generaltranslation/react-core/context';
+
+type DateTimeProps = Parameters<typeof GtInternalDateTime>[0];
+
+// ===== Component ===== //
+
+function RscDateTime({
+  _enableI18n,
+  _locale,
+  ...props
+}: DateTimeProps): React.JSX.Element {
+  const conditionStore = getReadonlyConditionStoreWithFallback();
+  return (
+    <GtInternalDateTime
+      {...props}
+      _enableI18n={_enableI18n ?? conditionStore.getEnableI18n()}
+      _locale={_locale ?? conditionStore.getLocale()}
+    />
+  );
+}
+
+/** @internal _gtt - The GT transformation for the component. */
+RscDateTime._gtt = 'variable-datetime';
+
+// ===== Exports ===== //
+
+export { RscDateTime };

--- a/packages/react/src/components/variables/Num.tsx
+++ b/packages/react/src/components/variables/Num.tsx
@@ -1,0 +1,30 @@
+import {
+  getReadonlyConditionStoreWithFallback,
+  GtInternalNum,
+} from '@generaltranslation/react-core/context';
+
+type NumProps = Parameters<typeof GtInternalNum>[0];
+
+// ===== Component ===== //
+
+function RscNum({
+  _enableI18n,
+  _locale,
+  ...props
+}: NumProps): React.JSX.Element {
+  const conditionStore = getReadonlyConditionStoreWithFallback();
+  return (
+    <GtInternalNum
+      {...props}
+      _enableI18n={_enableI18n ?? conditionStore.getEnableI18n()}
+      _locale={_locale ?? conditionStore.getLocale()}
+    />
+  );
+}
+
+/** @internal _gtt - The GT transformation for the component. */
+RscNum._gtt = 'variable-number';
+
+// ===== Exports ===== //
+
+export { RscNum };

--- a/packages/react/src/components/variables/RelativeTime.tsx
+++ b/packages/react/src/components/variables/RelativeTime.tsx
@@ -1,0 +1,30 @@
+import {
+  getReadonlyConditionStoreWithFallback,
+  GtInternalRelativeTime,
+} from '@generaltranslation/react-core/context';
+
+type RelativeTimeProps = Parameters<typeof GtInternalRelativeTime>[0];
+
+// ===== Component ===== //
+
+function RscRelativeTime({
+  _enableI18n,
+  _locale,
+  ...props
+}: RelativeTimeProps): React.JSX.Element {
+  const conditionStore = getReadonlyConditionStoreWithFallback();
+  return (
+    <GtInternalRelativeTime
+      {...props}
+      _enableI18n={_enableI18n ?? conditionStore.getEnableI18n()}
+      _locale={_locale ?? conditionStore.getLocale()}
+    />
+  );
+}
+
+/** @internal _gtt - The GT transformation for the component. */
+RscRelativeTime._gtt = 'variable-relative-time';
+
+// ===== Exports ===== //
+
+export { RscRelativeTime };

--- a/packages/react/src/components/variables/Var.tsx
+++ b/packages/react/src/components/variables/Var.tsx
@@ -1,0 +1,17 @@
+import { GtInternalVar } from '@generaltranslation/react-core/context';
+import type { ReactNode } from 'react';
+
+type VarProps<T extends ReactNode> = Parameters<typeof GtInternalVar<T>>[0];
+
+// ===== Component ===== //
+
+function RscVar<T extends ReactNode>(props: VarProps<T>): T {
+  return GtInternalVar(props);
+}
+
+/** @internal _gtt - The GT transformation for the component. */
+RscVar._gtt = 'variable-variable';
+
+// ===== Exports ===== //
+
+export { RscVar };

--- a/packages/react/src/context.client.ts
+++ b/packages/react/src/context.client.ts
@@ -1,7 +1,5 @@
 'use client';
 
-import type { RscT as CoreRscT } from '@generaltranslation/react-core/context';
-
 export { initializeGTSPA } from './setup/initializeGTSPA';
 export { useLocaleSelector } from './components/useLocaleSelector';
 export { useSetLocale, useSetEnableI18n } from './hooks/conditions-store';
@@ -11,12 +9,35 @@ export {
   defaultRegionCookieName,
 } from './cookie-names';
 
-export const RscT: typeof CoreRscT = Object.assign(
-  () => {
-    throw new Error('gt-react: RscT cannot be used in a client environment.');
-  },
-  { _gtt: 'translate-server' as const }
-);
+function createRscStub<T>(name: string, _gtt: string): T {
+  return Object.assign(
+    () => {
+      throw new Error(
+        `gt-react: ${name} cannot be used in a client environment.`
+      );
+    },
+    { _gtt }
+  ) as unknown as T;
+}
+
+export const RscBranch: typeof import('./components/branches/Branch').RscBranch =
+  createRscStub('RscBranch', 'branch');
+export const RscPlural: typeof import('./components/branches/Plural').RscPlural =
+  createRscStub('RscPlural', 'plural');
+export const RscDerive: typeof import('./components/derivation/Derive').RscDerive =
+  createRscStub('RscDerive', 'derive');
+export const RscT: typeof import('./components/translation/T').RscT =
+  createRscStub('RscT', 'translate-server');
+export const RscCurrency: typeof import('./components/variables/Currency').RscCurrency =
+  createRscStub('RscCurrency', 'variable-currency');
+export const RscDateTime: typeof import('./components/variables/DateTime').RscDateTime =
+  createRscStub('RscDateTime', 'variable-datetime');
+export const RscNum: typeof import('./components/variables/Num').RscNum =
+  createRscStub('RscNum', 'variable-number');
+export const RscRelativeTime: typeof import('./components/variables/RelativeTime').RscRelativeTime =
+  createRscStub('RscRelativeTime', 'variable-relative-time');
+export const RscVar: typeof import('./components/variables/Var').RscVar =
+  createRscStub('RscVar', 'variable-variable');
 
 // ===== Components ===== //
 export { LocaleSelector } from './components/LocaleSelector';

--- a/packages/react/src/context.server.ts
+++ b/packages/react/src/context.server.ts
@@ -8,6 +8,15 @@ export {
   defaultLocaleCookieName,
   defaultRegionCookieName,
 } from './cookie-names';
+export { RscBranch } from './components/branches/Branch';
+export { RscPlural } from './components/branches/Plural';
+export { RscDerive } from './components/derivation/Derive';
+export { RscT } from './components/translation/T';
+export { RscCurrency } from './components/variables/Currency';
+export { RscDateTime } from './components/variables/DateTime';
+export { RscNum } from './components/variables/Num';
+export { RscRelativeTime } from './components/variables/RelativeTime';
+export { RscVar } from './components/variables/Var';
 
 // ===== Components ===== //
 export { ServerGTProvider as GTProvider } from './provider/ServerGTProvider';
@@ -19,7 +28,6 @@ export {
   Plural,
   Derive,
   GtInternalTranslateJsx,
-  RscT,
   T,
   Currency,
   DateTime,

--- a/packages/react/src/context.types.ts
+++ b/packages/react/src/context.types.ts
@@ -19,6 +19,16 @@ export {
   defaultRegionCookieName,
 } from './cookie-names';
 
+export declare const RscBranch: typeof import('./components/branches/Branch').RscBranch;
+export declare const RscPlural: typeof import('./components/branches/Plural').RscPlural;
+export declare const RscDerive: typeof import('./components/derivation/Derive').RscDerive;
+export declare const RscT: typeof import('./components/translation/T').RscT;
+export declare const RscCurrency: typeof import('./components/variables/Currency').RscCurrency;
+export declare const RscDateTime: typeof import('./components/variables/DateTime').RscDateTime;
+export declare const RscNum: typeof import('./components/variables/Num').RscNum;
+export declare const RscRelativeTime: typeof import('./components/variables/RelativeTime').RscRelativeTime;
+export declare const RscVar: typeof import('./components/variables/Var').RscVar;
+
 /**
  * TODO: throw error if any of these functions are called
  */
@@ -28,7 +38,6 @@ export {
   Plural,
   Derive,
   GtInternalTranslateJsx,
-  RscT,
   T,
   Currency,
   DateTime,

--- a/packages/react/src/utils/rendering/renderVariable.tsx
+++ b/packages/react/src/utils/rendering/renderVariable.tsx
@@ -1,0 +1,108 @@
+import { RscCurrency } from '../../components/variables/Currency';
+import { RscDateTime } from '../../components/variables/DateTime';
+import { RscNum } from '../../components/variables/Num';
+import { RscRelativeTime } from '../../components/variables/RelativeTime';
+import { RscVar } from '../../components/variables/Var';
+import {
+  GtInternalCurrency,
+  GtInternalDateTime,
+  GtInternalNum,
+  GtInternalRelativeTime,
+  GtInternalVar,
+} from '@generaltranslation/react-core/context';
+import type {
+  RelativeTimeFormatOptions,
+  RenderVariable,
+} from '@generaltranslation/react-core/context';
+import { libraryDefaultLocale } from 'generaltranslation/internal';
+import type { ReactNode } from 'react';
+
+// ===== Renderer ===== //
+
+const renderVariable: RenderVariable = ({
+  variableType,
+  variableValue,
+  variableOptions,
+  locales,
+  enableI18n,
+  injectionType,
+}) => {
+  const locale = locales[0] ?? libraryDefaultLocale;
+  const internalProps = {
+    _locale: locale,
+    _enableI18n: enableI18n,
+  };
+
+  if (variableType === 'n') {
+    const Num = injectionType === 'automatic' ? RscNum : GtInternalNum;
+    const numOptions = variableOptions as Intl.NumberFormatOptions | undefined;
+    return (
+      <Num {...internalProps} options={numOptions}>
+        {variableValue as number | string | null | undefined}
+      </Num>
+    );
+  }
+  if (variableType === 'd') {
+    const DateTime =
+      injectionType === 'automatic' ? RscDateTime : GtInternalDateTime;
+    const dateTimeOptions = variableOptions as
+      | Intl.DateTimeFormatOptions
+      | undefined;
+    return (
+      <DateTime {...internalProps} options={dateTimeOptions}>
+        {variableValue as Date | null | undefined}
+      </DateTime>
+    );
+  }
+  if (variableType === 'c') {
+    const Currency =
+      injectionType === 'automatic' ? RscCurrency : GtInternalCurrency;
+    const currencyOptions = variableOptions as
+      | Intl.NumberFormatOptions
+      | undefined;
+    return (
+      <Currency {...internalProps} options={currencyOptions}>
+        {variableValue as number | string | null | undefined}
+      </Currency>
+    );
+  }
+  if (variableType === 'rt') {
+    const RelativeTime =
+      injectionType === 'automatic' ? RscRelativeTime : GtInternalRelativeTime;
+    const relativeTimeOptions = variableOptions as
+      | RelativeTimeFormatOptions
+      | undefined;
+    if (typeof variableValue === 'number' && relativeTimeOptions?.unit) {
+      return (
+        <RelativeTime
+          {...internalProps}
+          value={variableValue}
+          unit={relativeTimeOptions.unit}
+          baseDate={relativeTimeOptions?.baseDate}
+          options={relativeTimeOptions}
+        />
+      );
+    }
+    const dateValue =
+      variableValue instanceof Date
+        ? variableValue
+        : typeof variableValue === 'string' || typeof variableValue === 'number'
+          ? new Date(variableValue)
+          : undefined;
+    return (
+      <RelativeTime
+        {...internalProps}
+        date={dateValue && !isNaN(dateValue.getTime()) ? dateValue : undefined}
+        baseDate={relativeTimeOptions?.baseDate}
+        options={relativeTimeOptions}
+      />
+    );
+  }
+  const renderedValue = variableValue as ReactNode;
+  const Var = injectionType === 'automatic' ? GtInternalVar : RscVar;
+  return <Var {...internalProps}>{renderedValue}</Var>;
+};
+
+// ===== Exports ===== //
+
+export { renderVariable };


### PR DESCRIPTION
## Summary
- Add the RSC context implementations to `gt-react` under `Rsc*` names, including `RscT`, variable components, and branch/derive components.
- Keep normal component implementations and normal `/context` component exports in `react-core`; expose only the shared internals/helpers needed by the moved RSC implementations through `react-core/context`.
- Deduplicate the moved code by sharing `prepareT`/`renderPreparedT` from `react-core` and making the `gt-react` RSC variable/branch/derive files thin wrappers around core internals.
- Wire `gt-react/context.server` to export the real `Rsc*` implementations, `context.client` to export throwing `Rsc*` stubs, and `context.types` to expose the `Rsc*` type definitions.

## Testing
- `pnpm --filter gt-react... build`
- `pnpm --filter @generaltranslation/react-core typecheck`
- `pnpm --filter gt-react typecheck`
- `pnpm --filter @generaltranslation/react-core test`
- `pnpm --filter gt-react test`
- `pnpm format`
- `pnpm lint` (passes with existing warnings)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves the RSC (React Server Component) context implementations out of `react-core` and into `gt-react` under `Rsc*` names (`RscT`, `RscBranch`, `RscPlural`, `RscDerive`, and the five variable components). To support this, `renderPreparedT` and its entire rendering chain are parameterized with an optional `renderVariable` callback so that `gt-react` can inject its RSC-specific version.

- **`react-core` changes**: `RscT` is removed from `T.tsx` and from the public `context` entrypoint; `prepareT`, `renderPreparedT`, `GtInternal*` components, and associated types are newly exported so `gt-react` can build thin RSC wrappers around them.
- **`gt-react` additions**: New `Rsc*` components read `locale`/`enableI18n` from `getReadonlyConditionStoreWithFallback()` when not supplied by a parent, preventing accidental hook calls in server context. A dedicated `renderVariable.tsx` selects `Rsc*` wrappers for automatically-injected variables and `GtInternal*` for explicitly-placed ones.
- **Entry-point wiring**: `context.server.ts` exports the real `Rsc*` implementations; `context.client.ts` exports throwing stubs via a shared `createRscStub` factory; `context.types.ts` adds matching `declare const` entries.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the refactoring is structurally sound, all removed exports are replaced at their new locations, and the rendering chain produces identical output to the previous implementation.

The RscT logic, prepareT/renderPreparedT parameterization, and the conditionStore fallback pattern in the Rsc variable components all look correct. Every place that previously called React hooks inside GtInternal* components is guarded by the Rsc wrappers passing explicit _locale/_enableI18n props, and renderVariable always supplies those props anyway. The only inconsistency is the inverted Var selection branch which is functionally harmless today since RscVar delegates directly to GtInternalVar.

packages/react/src/utils/rendering/renderVariable.tsx — the Var branch selection is inverted compared to all other variable types, worth revisiting if RscVar gains any distinct server behaviour.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react/src/utils/rendering/renderVariable.tsx | New RSC-specific renderVariable that selects Rsc* wrappers for automatic injection and GtInternal* for explicit placement — but the Var case is inverted relative to every other type. |
| packages/react/src/components/translation/T.tsx | RscT moved from react-core into gt-react; now injects the RSC-specific renderVariable and correctly imports prepareT/renderPreparedT/getReactI18nCache from the updated react-core/context entrypoint. |
| packages/react-core/src/context.ts | Removes RscT export and adds new internal exports (GtInternal*, prepareT, renderPreparedT, type aliases) needed by the moved RSC implementations in gt-react. |
| packages/react-core/src/utils/rendering/renderPreparedT.tsx | renderPreparedT now accepts an optional renderVariable parameter (defaulting to the react-core implementation), threaded through renderSource and renderTarget to support custom RSC rendering. |
| packages/react/src/context.client.ts | Adds throwing stubs for all nine new Rsc* components using a shared createRscStub factory, correctly matching the _gtt tags of their server counterparts. |
| packages/react/src/context.server.ts | Exports the real Rsc* implementations from their new gt-react locations and removes the old RscT re-export from react-core. |
| packages/react/src/context.types.ts | Adds declare-const entries for all nine new Rsc* components using import-typeof, matching the server/client entrypoints. |
| packages/react/src/components/variables/Var.tsx | Thin RscVar wrapper that delegates directly to GtInternalVar; no conditionStore needed since Var is locale-independent. |
| packages/react/src/components/branches/Plural.tsx | RscPlural reads locale/enableI18n from conditionStore as fallback before delegating to GtInternalPlural, preventing hook calls in server context. |
| packages/react-core/src/components/translation/T.tsx | RscT implementation and its _gtt tag cleanly removed; only GtInternalTranslateJsx and T remain. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller as RSC Caller
    participant RscT as RscT (gt-react)
    participant prepareT as prepareT (react-core)
    participant cache as getReactI18nCache (react-core)
    participant renderPreparedT as renderPreparedT (react-core)
    participant renderVar as renderVariable (gt-react RSC)
    participant RscNum as RscNum / RscCurrency / …
    participant GtInternal as GtInternalNum / …

    Caller->>RscT: render(children, locale, enableI18n)
    RscT->>prepareT: prepareT(sourceChildren, params, locale)
    prepareT-->>RscT: PreparedT
    alt shouldTranslate
        RscT->>cache: getLookupTranslation(locale)
        cache-->>RscT: lookupTranslation fn
        RscT->>RscT: "targetJsxChildren = lookupTranslation(…)"
    end
    RscT->>renderPreparedT: renderPreparedT(prepared, renderVariable)
    renderPreparedT->>renderVar: renderVariable(variableType, injectionType, …)
    alt "injectionType === automatic"
        renderVar->>RscNum: RscNum _locale _enableI18n
        RscNum-->>renderVar: formatted string
    else
        renderVar->>GtInternal: GtInternalNum _locale _enableI18n
        GtInternal-->>renderVar: formatted string
    end
    renderVar-->>renderPreparedT: ReactNode
    renderPreparedT-->>RscT: ReactNode
    RscT-->>Caller: ReactNode
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Freact%2Fsrc%2Futils%2Frendering%2FrenderVariable.tsx%3A101-103%0AThe%20%60Var%60%20branch%20is%20inverted%20relative%20to%20every%20other%20variable%20type%20in%20this%20file.%20For%20%60n%60%2C%20%60d%60%2C%20%60c%60%2C%20and%20%60rt%60%2C%20%60injectionType%20%3D%3D%3D%20'automatic'%60%20selects%20the%20%60Rsc*%60%20wrapper%20and%20the%20non-automatic%20path%20selects%20%60GtInternal*%60.%20For%20%60Var%60%20the%20two%20are%20flipped%20%E2%80%94%20%60automatic%60%20lands%20on%20%60GtInternalVar%60%20and%20non-automatic%20lands%20on%20%60RscVar%60.%20Since%20%60RscVar%60%20is%20a%20thin%20delegate%20to%20%60GtInternalVar%60%20the%20output%20is%20identical%20today%2C%20but%20future%20changes%20to%20either%20path%20%28e.g.%20adding%20conditionStore%20reads%20to%20%60RscVar%60%29%20will%20have%20an%20inverted%20effect%20compared%20to%20every%20other%20variable%20type.%0A%0A%60%60%60suggestion%0A%20%20const%20renderedValue%20%3D%20variableValue%20as%20ReactNode%3B%0A%20%20const%20Var%20%3D%20injectionType%20%3D%3D%3D%20'automatic'%20%3F%20RscVar%20%3A%20GtInternalVar%3B%0A%20%20return%20%3CVar%20%7B...internalProps%7D%3E%7BrenderedValue%7D%3C%2FVar%3E%3B%0A%60%60%60%0A%0A&repo=generaltranslation%2Fgt&pr=1551&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fodysseus%2Fmove-rsc-implementations-to-react%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fodysseus%2Fmove-rsc-implementations-to-react%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Freact%2Fsrc%2Futils%2Frendering%2FrenderVariable.tsx%3A101-103%0AThe%20%60Var%60%20branch%20is%20inverted%20relative%20to%20every%20other%20variable%20type%20in%20this%20file.%20For%20%60n%60%2C%20%60d%60%2C%20%60c%60%2C%20and%20%60rt%60%2C%20%60injectionType%20%3D%3D%3D%20'automatic'%60%20selects%20the%20%60Rsc*%60%20wrapper%20and%20the%20non-automatic%20path%20selects%20%60GtInternal*%60.%20For%20%60Var%60%20the%20two%20are%20flipped%20%E2%80%94%20%60automatic%60%20lands%20on%20%60GtInternalVar%60%20and%20non-automatic%20lands%20on%20%60RscVar%60.%20Since%20%60RscVar%60%20is%20a%20thin%20delegate%20to%20%60GtInternalVar%60%20the%20output%20is%20identical%20today%2C%20but%20future%20changes%20to%20either%20path%20%28e.g.%20adding%20conditionStore%20reads%20to%20%60RscVar%60%29%20will%20have%20an%20inverted%20effect%20compared%20to%20every%20other%20variable%20type.%0A%0A%60%60%60suggestion%0A%20%20const%20renderedValue%20%3D%20variableValue%20as%20ReactNode%3B%0A%20%20const%20Var%20%3D%20injectionType%20%3D%3D%3D%20'automatic'%20%3F%20RscVar%20%3A%20GtInternalVar%3B%0A%20%20return%20%3CVar%20%7B...internalProps%7D%3E%7BrenderedValue%7D%3C%2FVar%3E%3B%0A%60%60%60%0A%0A&repo=generaltranslation%2Fgt&pr=1551&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/react/src/utils/rendering/renderVariable.tsx:101-103
The `Var` branch is inverted relative to every other variable type in this file. For `n`, `d`, `c`, and `rt`, `injectionType === 'automatic'` selects the `Rsc*` wrapper and the non-automatic path selects `GtInternal*`. For `Var` the two are flipped — `automatic` lands on `GtInternalVar` and non-automatic lands on `RscVar`. Since `RscVar` is a thin delegate to `GtInternalVar` the output is identical today, but future changes to either path (e.g. adding conditionStore reads to `RscVar`) will have an inverted effect compared to every other variable type.

```suggestion
  const renderedValue = variableValue as ReactNode;
  const Var = injectionType === 'automatic' ? RscVar : GtInternalVar;
  return <Var {...internalProps}>{renderedValue}</Var>;
```

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["refactor: move context rsc components to..."](https://github.com/generaltranslation/gt/commit/3b7069a27d88273d29d6d3ae027f05c33131d3d1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35757964)</sub>

<!-- /greptile_comment -->