### PR TITLE
fix: fall back to buffer for utf8 hashing

### DIFF
--- a/.changeset/soft-buckets-promise.md
+++ b/.changeset/soft-buckets-promise.md
@@ -1,0 +1,5 @@
+---
+"generaltranslation": patch
+---
+
+Fall back to Buffer for UTF-8 hashing when TextEncoder is unavailable in Node-backed test environments.

--- a/packages/core/src/backwards-compatability/oldHashJsxChildren.ts
+++ b/packages/core/src/backwards-compatability/oldHashJsxChildren.ts
@@ -3,7 +3,8 @@
 import { OldJsxChild, OldJsxChildren, OldVariableObject } from './oldTypes';
 import { stableStringify as stringify } from '../utils/stableStringify';
 import { sha256 } from '@noble/hashes/sha2.js';
-import { bytesToHex, utf8ToBytes } from '@noble/hashes/utils.js';
+import { bytesToHex } from '@noble/hashes/utils.js';
+import { encodeUtf8 } from '../utils/encodeUtf8';
 
 // ----- FUNCTIONS ----- //
 /**
@@ -13,7 +14,7 @@ import { bytesToHex, utf8ToBytes } from '@noble/hashes/utils.js';
  * @returns {string} The resulting hash as a hexadecimal string.
  */
 export function oldHashString(string: string): string {
-  return bytesToHex(sha256(utf8ToBytes(string)));
+  return bytesToHex(sha256(encodeUtf8(string)));
 }
 
 /**

--- a/packages/core/src/id/__tests__/hashSource.test.ts
+++ b/packages/core/src/id/__tests__/hashSource.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { hashString } from '../hashSource';
+
+const encodingGlobal = globalThis as typeof globalThis & {
+  TextEncoder?: typeof TextEncoder;
+};
+
+describe('hashString', () => {
+  const originalTextEncoder = encodingGlobal.TextEncoder;
+  const unicodeString = 'caf\u00e9 \u{1f680}';
+
+  afterEach(() => {
+    encodingGlobal.TextEncoder = originalTextEncoder;
+  });
+
+  it('hashes consistently when TextEncoder is available', () => {
+    expect(hashString('RSVP')).toBe('1dfe8a8e0cb2d1da');
+    expect(hashString(unicodeString)).toBe('22b8c9581c75829d');
+  });
+
+  it('falls back to Buffer when TextEncoder is unavailable', () => {
+    encodingGlobal.TextEncoder = undefined;
+
+    expect(hashString('RSVP')).toBe('1dfe8a8e0cb2d1da');
+    expect(hashString(unicodeString)).toBe('22b8c9581c75829d');
+  });
+});

--- a/packages/core/src/id/hashSource.ts
+++ b/packages/core/src/id/hashSource.ts
@@ -3,9 +3,10 @@
 import { JsxChild, JsxChildren, Variable } from '../types';
 import { stableStringify as stringify } from '../utils/stableStringify';
 import { sha256 } from '@noble/hashes/sha2.js';
-import { bytesToHex, utf8ToBytes } from '@noble/hashes/utils.js';
+import { bytesToHex } from '@noble/hashes/utils.js';
 import isVariable from '../utils/isVariable';
 import { HashMetadata } from './types';
+import { encodeUtf8 } from '../utils/encodeUtf8';
 
 // ----- FUNCTIONS ----- //
 /**
@@ -17,7 +18,7 @@ import { HashMetadata } from './types';
  * @returns {string} The resulting hash as a hexadecimal string.
  */
 export function hashString(string: string): string {
-  return bytesToHex(sha256(utf8ToBytes(string))).slice(0, 16);
+  return bytesToHex(sha256(encodeUtf8(string))).slice(0, 16);
 }
 
 /**

--- a/packages/core/src/utils/encodeUtf8.ts
+++ b/packages/core/src/utils/encodeUtf8.ts
@@ -1,0 +1,17 @@
+/**
+ * Encode a string as UTF-8 bytes.
+ *
+ * Some Node-backed test environments, like older Jest jsdom setups, expose
+ * Buffer but not global TextEncoder.
+ */
+export function encodeUtf8(string: string): Uint8Array {
+  if (typeof TextEncoder !== 'undefined') {
+    return new TextEncoder().encode(string);
+  }
+
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(string, 'utf8');
+  }
+
+  throw new Error('TextEncoder is required to encode strings as UTF-8.');
+}


### PR DESCRIPTION
## TL;DR

Adds a Buffer fallback for UTF-8 hashing when TextEncoder is unavailable in Node-backed test environments, such as older Jest jsdom setups.

## Changes

- Adds an internal encodeUtf8 helper that prefers TextEncoder and falls back to Buffer.
- Uses the helper in current and backwards-compatible SHA-256 hashing paths.
- Adds a regression test that removes global TextEncoder and verifies hash output remains stable.
- Adds a patch changeset for generaltranslation.

## Notes

- Verified with `pnpm --filter generaltranslation typecheck`.
- Verified with `pnpm --filter generaltranslation build`.
- Verified with `pnpm --filter generaltranslation test -- src/id/__tests__/hashSource.test.ts` (runs the full core test suite in this config).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1557"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783282957&installation_id=127936663&pr_number=1557&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1557&signature=0eb12fe213af725cc705d72bbe70b7b49d828e2bd9cddb5b74d392220ffa2462"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->