### PR TITLE
feat(next): resolve enableI18n from static config

### DIFF
--- a/packages/i18n/src/i18n-config/I18nConfig.ts
+++ b/packages/i18n/src/i18n-config/I18nConfig.ts
@@ -14,6 +14,7 @@ export type I18nConfigParams = Pick<
   | 'defaultLocale'
   | 'locales'
   | 'customMapping'
+  | 'enableI18n'
   | 'projectId'
   | 'devApiKey'
   | 'apiKey'
@@ -29,6 +30,7 @@ export type LocaleCandidates = string | string[] | undefined;
 
 export class I18nConfig extends LocaleConfig {
   private runtimeConfig: RuntimeConfig;
+  private enableI18n: boolean;
 
   constructor(params: I18nConfigParams = {}) {
     super(getLocaleConfigParams(params));
@@ -38,10 +40,19 @@ export class I18nConfig extends LocaleConfig {
       apiKey: params.apiKey,
       runtimeUrl: params.runtimeUrl,
     };
+    this.enableI18n = params.enableI18n ?? true;
   }
 
   getDefaultLocale(): string {
     return this.defaultLocale;
+  }
+
+  /**
+   * Whether the i18n runtime is enabled. When false, locale detection and
+   * translation are bypassed and content renders in the default locale.
+   */
+  getEnableI18n(): boolean {
+    return this.enableI18n;
   }
 
   getLocales(): string[] {

--- a/packages/i18n/src/i18n-config/__tests__/I18nConfig.test.ts
+++ b/packages/i18n/src/i18n-config/__tests__/I18nConfig.test.ts
@@ -20,6 +20,19 @@ describe('I18nConfig', () => {
     expect(config.getLocales()).toEqual(['fr']);
   });
 
+  it('enables i18n by default', () => {
+    expect(new I18nConfig({ defaultLocale: 'en' }).getEnableI18n()).toBe(true);
+  });
+
+  it('honors an explicit enableI18n flag', () => {
+    expect(
+      new I18nConfig({ defaultLocale: 'en', enableI18n: false }).getEnableI18n()
+    ).toBe(false);
+    expect(
+      new I18nConfig({ defaultLocale: 'en', enableI18n: true }).getEnableI18n()
+    ).toBe(true);
+  });
+
   it('skips locale validation when GT services are disabled', () => {
     const config = new I18nConfig({
       defaultLocale: 'invalid-locale',

--- a/packages/next/src/config-dir/props/defaultWithGTConfigProps.ts
+++ b/packages/next/src/config-dir/props/defaultWithGTConfigProps.ts
@@ -22,6 +22,7 @@ type DefaultGTConfigProps = {
   runtimeUrl: string;
   cacheUrl: string;
   defaultLocale: string;
+  enableI18n: boolean;
   getLocale: () => Promise<string>;
   locales: string[];
   maxConcurrentRequests: number;
@@ -51,6 +52,7 @@ export const defaultWithGTConfigProps: DefaultGTConfigProps = {
   runtimeUrl: defaultRuntimeApiUrl,
   cacheUrl: defaultCacheUrl,
   defaultLocale: libraryDefaultLocale,
+  enableI18n: true,
   getLocale: async () => libraryDefaultLocale,
   locales: [] as string[],
   maxConcurrentRequests: 100,

--- a/packages/next/src/config-dir/props/withGTConfigProps.ts
+++ b/packages/next/src/config-dir/props/withGTConfigProps.ts
@@ -55,6 +55,9 @@ export type withGTConfigProps = {
   locales?: string[];
   defaultLocale?: string;
   ignoreBrowserLocales?: boolean;
+  // Master i18n switch. When false, locale detection and translation are
+  // bypassed and content renders in the default locale. Default: true.
+  enableI18n?: boolean;
   // Rendering
   renderSettings?: {
     method: RenderMethod;

--- a/packages/next/src/request/__tests__/getEnableI18n.test.ts
+++ b/packages/next/src/request/__tests__/getEnableI18n.test.ts
@@ -1,0 +1,20 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { initializeI18nConfig } from 'gt-i18n/internal';
+import { getEnableI18n } from '../getEnableI18n';
+
+describe('getEnableI18n', () => {
+  afterEach(() => {
+    // Reset the shared config singleton between cases.
+    initializeI18nConfig({ defaultLocale: 'en' });
+  });
+
+  it('resolves true by default (config omits enableI18n)', async () => {
+    initializeI18nConfig({ defaultLocale: 'en' });
+    await expect(getEnableI18n()).resolves.toBe(true);
+  });
+
+  it('resolves false when config disables i18n', async () => {
+    initializeI18nConfig({ defaultLocale: 'en', enableI18n: false });
+    await expect(getEnableI18n()).resolves.toBe(false);
+  });
+});

--- a/packages/next/src/request/getEnableI18n.ts
+++ b/packages/next/src/request/getEnableI18n.ts
@@ -1,8 +1,11 @@
+import { getI18nConfig } from 'gt-i18n/internal';
 import { use } from '../utils/use';
 
 export async function getEnableI18n(): Promise<boolean> {
-  // TODO: read this from a request condition store once gt-next sets one up.
-  return true;
+  // Resolved statically from config (default true) so consuming routes are not
+  // opted out of static rendering. A per-request dynamic override can be
+  // layered in front of this later if a runtime-toggle use case arises.
+  return getI18nConfig().getEnableI18n();
 }
 
 export function useEnableI18n(): boolean {


### PR DESCRIPTION
## What

`enableI18n` is the master on/off switch for the i18n runtime (default `true`): when `false`, content renders in the default locale without translation.

On gt-next it was hard-stubbed:

```ts
export async function getEnableI18n(): Promise<boolean> {
  // TODO: read this from a request condition store once gt-next sets one up.
  return true;
}
```

This wires it to **static config** instead:

- `I18nConfig` now carries an `enableI18n` flag (default `true`) exposed via `getEnableI18n()`.
- gt-next's `getEnableI18n()` reads `getI18nConfig().getEnableI18n()`.
- `withGTConfig({ enableI18n: false })` is the public knob (explicit `true` default added to `defaultWithGTConfigProps`).

## Why static config (not a cookie / request store)

`enableI18n` was historically config-sourced (`config?.enableI18n ?? true`); the browser cookie path exists only as the async-toggle hydration exception. Reading a cookie/header in `getEnableI18n` would force consuming routes into **dynamic rendering**, which is disqualifying under the Cache Components direction. The switch is a build-time constant in the common case, so it's resolved synchronously from config — `getEnableI18n` pulls in no `next/headers`/`cookies`, keeping routes statically renderable. The existing `withGTConfig` → `JSON.stringify(mergedConfig)` → env → `initializeI18nConfig` pipeline already passed the value through; the only thing dropping it was the `I18nConfigParams` `Pick`.

A per-request **dynamic override** (an `AsyncLocalStorage`-backed store), and full provider-level disabling (skipping translation loading + collapsing locale detection), are intentionally out of scope here — this PR is the static-config gate on the `RscT` render.

## Tests

- `I18nConfig`: defaults to `true`; honors an explicit flag.
- gt-next `getEnableI18n`: resolves `true` by default, `false` when config disables i18n.
- Full workspace build green; gt-i18n + gt-next suites green; oxlint/oxfmt clean.

## Runtime verification

Verified end-to-end in `examples/next-ssg` (SSG, non-default locales, local translations) with `withGTConfig({ enableI18n: false })`: the `/es` route's rendered `<h1>` is the **English source**, not the Spanish translation — even though the Spanish translation is present in the page's translation payload. This confirms the gate flows `config → getEnableI18n() → RscT (shouldTranslate=false) → source render`.

The complementary `enableI18n: true` translate path could not be exercised in that app due to a **separate, pre-existing** gap (independent of this PR): gt-next never initializes the `react-core` `getReactI18nCache()` singleton that `RscT` reads, so the translate path throws `I18nCache was not initialized`. That belongs to the in-flight cache/provider-runtime work (e.g. #1532). The `createContext`-in-RSC build break that previously blocked all Next test-app builds is fixed in the stacked PR #1561.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires `enableI18n` — previously hard-stubbed to `true` — to the static `I18nConfig` singleton, so `withGTConfig({ enableI18n: false })` actually gates the RSC translation path without forcing dynamic rendering.

- `I18nConfig` gains a private `enableI18n` field (defaulting to `true` via nullish coalescing) and a `getEnableI18n()` accessor; `enableI18n` is now included in `I18nConfigParams`'s `Pick<GTConfig, …>` so the value survives the existing `withGTConfig → JSON.stringify → env → initializeI18nConfig` pipeline.
- gt-next's `getEnableI18n()` replaces the hardcoded `return true` with `getI18nConfig().getEnableI18n()`, and `enableI18n: true` is added to `defaultWithGTConfigProps` so the merge always produces a typed boolean.
- Both layers ship matching unit tests covering the default-`true` and explicit-`false` paths.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a targeted, minimal wiring of an existing config value through a well-tested singleton pipeline.

The change is small and strictly additive: it adds one field to an internal Pick type, stores it in a class, exposes a getter, reads it from config in one function, and adds a default. The existing withGTConfig → env → initializeI18nConfig pipeline already carried the value; only the I18nConfigParams Pick was dropping it. Both layers are covered by new unit tests, and the PR description documents a successful end-to-end verification in examples/next-ssg.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/i18n/src/i18n-config/I18nConfig.ts | Adds `enableI18n` to `I18nConfigParams` Pick and stores/exposes it on the class; default of `true` via `??` is correct and matches GTConfig. |
| packages/next/src/request/getEnableI18n.ts | Replaces hard-coded `return true` with `getI18nConfig().getEnableI18n()`; async signature preserved for forward-compatibility; `use` import is still consumed by `useEnableI18n()`. |
| packages/next/src/config-dir/props/defaultWithGTConfigProps.ts | Adds `enableI18n: true` to both the `DefaultGTConfigProps` type and the constant, ensuring the merge in `getI18NConfig()` always resolves a typed boolean. |
| packages/next/src/config-dir/props/withGTConfigProps.ts | Exposes `enableI18n?: boolean` to the public `withGTConfigProps` API surface with an explanatory comment; no issues. |
| packages/i18n/src/i18n-config/__tests__/I18nConfig.test.ts | New tests cover default-true and explicit true/false paths; straightforward and correct. |
| packages/next/src/request/__tests__/getEnableI18n.test.ts | Tests initialize the singleton before each assertion and reset in `afterEach`; covers both the default and disabled paths cleanly. |
| .changeset/enable-i18n-static-config.md | Changeset correctly marks both `gt-i18n` and `gt-next` as minor bumps and describes the behavioral change accurately. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["withGTConfig({ enableI18n: false })"] --> B["JSON.stringify(mergedConfig)\n_GENERALTRANSLATION_I18N_CONFIG_PARAMS env var"]
    B --> C["getI18NConfig()\nreads env var, merges with defaultWithGTConfigProps"]
    C --> D["initializeI18nConfig(configParams)\ncreates I18nConfig with enableI18n stored"]
    D --> E["I18nConfig singleton\n.enableI18n = false"]
    E --> F["getEnableI18n()\ngetI18nConfig().getEnableI18n()"]
    F --> G["RscT: shouldTranslate = false\nrenders source content"]

    H["withGTConfig() omits enableI18n"] --> I["defaultWithGTConfigProps.enableI18n = true"]
    I --> D
```
</details>

<sub>Reviews (2): Last reviewed commit: ["feat(next): resolve enableI18n from stat..."](https://github.com/generaltranslation/gt/commit/592a76e6a66167c6360edf9ca78c688417279103) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35971772)</sub>

<!-- /greptile_comment -->