### PR TITLE
fix(react-core): create GT context lazily for RSC compatibility

### DIFF
--- a/packages/react-core/src/context/InternalGTProvider.tsx
+++ b/packages/react-core/src/context/InternalGTProvider.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, type ReactNode } from 'react';
 import { I18nStore } from '../i18n-store/I18nStore';
 import type { Dictionary, Translation } from 'gt-i18n/types';
 import type { Locale, Hash } from 'gt-i18n/internal/types';
-import { GTContext } from './context';
+import { getGTContext } from './context';
 import type { ReadonlyConditionStore } from 'gt-i18n/internal';
 import type {
   OnMissingDictionaryEntry,
@@ -71,7 +71,6 @@ export function InternalGTProvider({
     i18nStore.updateDictionaries(dictionaries ?? {});
   }, [translations, dictionaries, i18nStore]);
 
-  //
-
+  const GTContext = getGTContext();
   return <GTContext.Provider value={value}>{children}</GTContext.Provider>;
 }

--- a/packages/react-core/src/context/context.ts
+++ b/packages/react-core/src/context/context.ts
@@ -5,7 +5,7 @@ import {
   ReadonlyConditionStoreInterface,
 } from 'gt-i18n/internal/types';
 import { Translation } from 'gt-i18n/types';
-import { createContext, useContext } from 'react';
+import { createContext, useContext, type Context } from 'react';
 import { I18nStore } from '../i18n-store/I18nStore';
 import { getRenderStrategy } from '../setup/globals';
 import type {
@@ -41,10 +41,22 @@ export type GTContextType = {
   onMissingDictionaryObj?: OnMissingDictionaryObj;
 };
 
-export const GTContext = createContext<GTContextType | undefined>(undefined);
+let gtContext: Context<GTContextType | undefined> | undefined;
+
+/**
+ * Lazily create the GT context.
+ *
+ * `createContext` is unavailable in the React Server Components runtime, and
+ * gt-next pulls this module into the RSC graph (via RscT), so it must not be
+ * called at module load. Server components never read the context (they
+ * consume snapshots), so it is only ever created on the client/SSR path.
+ */
+export function getGTContext(): Context<GTContextType | undefined> {
+  return (gtContext ??= createContext<GTContextType | undefined>(undefined));
+}
 
 export function useGTContext(): GTContextType | undefined {
-  const context = useContext(GTContext);
+  const context = useContext(getGTContext());
   if (context || getRenderStrategy() === 'SPA') {
     return context;
   }


### PR DESCRIPTION
Stacked on #1560.

## Problem

Every Next test app (`tests/apps/next/*`) failed to build on `odysseus` — both webpack and turbopack — with:

```
TypeError: (0 , s.createContext) is not a function
```

during Next's "collect page data" phase (RSC/server graph evaluation), on every route.

## Root cause

`packages/react-core/src/context/context.ts` ran `createContext(...)` at **module top-level**:

```ts
export const GTContext = createContext<GTContextType | undefined>(undefined);
```

gt-next's server `<T>` imports `RscT` from `gt-react/context` → `context.server` → the bundled `@generaltranslation/react-core/context` barrel, which includes this module. Under the `react-server` condition React does not export `createContext`, so evaluating the barrel in the RSC graph throws.

## Fix

Create the context lazily, on first use:

```ts
let gtContext;
export function getGTContext() {
  return (gtContext ??= createContext<GTContextType | undefined>(undefined));
}
```

`useGTContext()` and `InternalGTProvider` go through `getGTContext()`. Server components never read the context (they consume snapshots), so `createContext` now only runs on the client/SSR path and never at module load in the RSC graph. The lazy value is memoized, so the Provider and consumers share one stable context instance.

## Verification

- `tests/apps/next/general-cases` now builds and generates all 17 pages — **webpack and turbopack** (previously every route threw).
- Unit tests green: react-core 316, gt-react 25, gt-next 219; full workspace build 21/21; oxlint/oxfmt clean.

## Notes

- Blast radius is contained: the only top-level `createContext` in the non-deprecated tree was this one; the `GTContext` exported from react-core's legacy `.` entry is a different (deprecated) context and is unaffected.
- This unblocks the deferred runtime render check from #1560.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1561"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783300140&installation_id=127936663&pr_number=1561&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1561&signature=362de538bc597b5a558960ed89fbc030814dfc34fe1d0e5d676834669dc9cdb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This patch fixes a `TypeError: createContext is not a function` crash that broke every Next.js test app build when the RSC graph evaluated the `react-core` context module. The fix defers `createContext` from module load time to first call via a lazy `getGTContext()` getter that memoizes with `??=`.

- **`context.ts`**: Replaces the top-level `export const GTContext = createContext(...)` with a module-level `let gtContext` variable and an exported `getGTContext()` function that initializes it on first call. `useGTContext()` is updated to call `getGTContext()` internally, keeping its public API unchanged.
- **`InternalGTProvider.tsx`**: Calls `getGTContext()` inside the component body (client/SSR path only) instead of importing the bare context object; also removes a stray blank comment.
- **Scope confirmed safe**: All non-deprecated callers go through `useGTContext()` or `getGTContext()`, and the deprecated `GTContext` re-exported from `src/index.ts` is a separate object in `deprecated/provider/GTContext.ts` — untouched by this change.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is minimal, well-scoped, and directly addresses a build-breaking regression without altering any public APIs.

The lazy `getGTContext()` getter is idempotent (the `??=` assignment guarantees a single stable context instance shared by both the Provider and all consumers), deprecated paths are untouched, and all non-deprecated callers already go through `useGTContext()` or the component render path where `createContext` is guaranteed to be available.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react-core/src/context/context.ts | Replaces module-level `createContext(...)` with a lazy `getGTContext()` getter that memoizes via `??=`; `useGTContext()` unchanged in behavior |
| packages/react-core/src/context/InternalGTProvider.tsx | Switches from direct `GTContext` import to `getGTContext()` called inside the component body; also removes a stray blank comment |
| .changeset/rsc-lazy-gt-context.md | Changeset entry correctly marks this as a patch for `@generaltranslation/react-core` with a clear description of the root cause and fix |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(react-core): create GT context lazil..."](https://github.com/generaltranslation/gt/commit/9b66137e72ddc07ad89368da543773082dad32de) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35972143)</sub>

<!-- /greptile_comment -->