### PR TITLE
chore: add escaping of terminal backslashes

### DIFF
--- a/.changeset/breezy-sides-unite.md
+++ b/.changeset/breezy-sides-unite.md
@@ -1,0 +1,5 @@
+---
+"gt-remark": patch
+---
+
+Escaping terminal backslashes

--- a/packages/remark/src/__tests__/index.test.ts
+++ b/packages/remark/src/__tests__/index.test.ts
@@ -237,6 +237,38 @@ describe('escapeHtmlInTextNodes', () => {
     });
   });
 
+  describe('backslash (\\) escaping', () => {
+    it('should escape terminal backslashes in text nodes', () => {
+      const tree: Root = {
+        type: 'root',
+        children: [createParagraph([createTextNode('Ctrl+\\')])],
+      };
+      const result = processAst(tree);
+      expect(result).toContain('Ctrl+&#92;');
+      expect(result).not.toContain('Ctrl+\\');
+    });
+
+    it('should escape line-ending backslashes in text nodes', () => {
+      const tree: Root = {
+        type: 'root',
+        children: [createParagraph([createTextNode('Ctrl+\\\nShift+\\')])],
+      };
+      const result = processAst(tree);
+      expect(result).toContain('Ctrl+&#92;');
+      expect(result).toContain('Shift+&#92;');
+    });
+
+    it('should not escape non-terminal backslashes in text nodes', () => {
+      const tree: Root = {
+        type: 'root',
+        children: [createParagraph([createTextNode('C:\\Users\\name')])],
+      };
+      const result = processAst(tree);
+      expect(result).toContain('C:\\Users\\name');
+      expect(result).not.toContain('C:&#92;Users&#92;name');
+    });
+  });
+
   describe('combined character escaping', () => {
     it('should escape all HTML characters together', () => {
       const tree: Root = {

--- a/packages/remark/src/plugins/escapeHtmlInTextNodes.ts
+++ b/packages/remark/src/plugins/escapeHtmlInTextNodes.ts
@@ -5,9 +5,11 @@ import { IGNORE_ALWAYS, IGNORE_HEADINGS } from './shared.js';
 
 // & that is NOT already an entity: &word;  &#123;  &#x1A2B;
 const AMP_NOT_ENTITY = /&(?![a-zA-Z][a-zA-Z0-9]*;|#\d+;|#x[0-9A-Fa-f]+;)/g;
+const LINE_ENDING_BACKSLASHES = /\\+(?=\n|$)/g;
 
 /**
- * Escape HTML-sensitive characters ('{', '}', `&`, `<`, `>`, `"`, `'`, '`') in text nodes,
+ * Escape HTML-sensitive characters ('{', '}', `&`, `<`, `>`, `"`, `'`, '`') and
+ * line-ending backslashes in text nodes,
  * leaving code, math, MDX expressions, and front-matter untouched.
  * Ensures literals render safely without altering already-escaped entities.
  */
@@ -23,6 +25,10 @@ const escapeHtmlInTextNodes: Plugin<[], Root> = function () {
         [/"/g, '&quot;'],
         [/'/g, '&#39;'],
         [/`/g, '&#96;'],
+        [
+          LINE_ENDING_BACKSLASHES,
+          (match: string) => match.replace(/\\/g, '&#92;'),
+        ],
       ],
       { ignore: IGNORE_ALWAYS }
     );


### PR DESCRIPTION
<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1563"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783485398&installation_id=127936663&pr_number=1563&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1563&signature=f311226e9a71a3483aaa52c5647d9c44853da9bc6e0ba9bd6169453a8ebf8bb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds escaping of terminal (line-ending) backslashes in MDX text nodes, converting `\` at end-of-string or before a newline to `&#92;` to prevent the remark/MDX pipeline from treating them as hard line breaks.

- Introduces the `LINE_ENDING_BACKSLASHES = /\\+(?=
|$)/g` regex and a replacement function appended at the end of the existing `findAndReplace` pairs in `escapeHtmlInTextNodes.ts`.
- Covers three test cases: a single terminal backslash, backslashes ending each segment of a multi-line text node, and non-terminal backslashes (e.g., `C:\\Users\
ame`) that must be left unchanged.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is small and self-contained, touching only the text-node escaping pipeline with no side effects on code, math, MDX expressions, or headings.

The regex correctly targets only backslashes that are immediately before a newline or end-of-string. The replacement function is correct and the existing pattern of placing AMP_NOT_ENTITY first ensures the & in the inserted entity is not double-escaped. Tests cover the three meaningful cases and the changeset is correctly scoped to a patch.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/remark/src/plugins/escapeHtmlInTextNodes.ts | Adds LINE_ENDING_BACKSLASHES regex and replacement to escape terminal/line-ending backslashes as &#92; in text nodes, preventing MDX from treating them as hard line breaks |
| packages/remark/src/__tests__/index.test.ts | Adds three tests for backslash escaping: terminal backslash, mid-string newline-separated backslashes, and non-terminal backslashes that should be left alone |
| .changeset/breezy-sides-unite.md | Changeset entry marking gt-remark as a patch bump for the terminal backslash escaping fix |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Text Node Value] --> B[Pass 1: Escape bare ampersands to &amp;]
    B --> C[Passes 2-6: Escape lt gt quot apos backtick]
    C --> D{Pass 7: LINE_ENDING_BACKSLASHES}
    D -->|backslash before newline or end of string| E[Replace each backslash with entity 92]
    D -->|backslash in middle of string| F[Leave unchanged]
    E --> G[Escaped Text Node written back to AST]
    F --> G
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: add escaping of terminal backslas..."](https://github.com/generaltranslation/gt/commit/9b334a47dc659f549e7d694168fed7b3960e3436) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36140940)</sub>

<!-- /greptile_comment -->