### PR TITLE
refactor(1): extend next i18n configuration from cache

### DIFF
--- a/packages/next/src/config-dir/I18NConfiguration.ts
+++ b/packages/next/src/config-dir/I18NConfiguration.ts
@@ -59,7 +59,7 @@ type RuntimeTranslationParams = {
   options: LookupOptions;
 };
 
-export class I18NConfiguration {
+export class I18NConfiguration extends I18nCache<TranslatedChildren> {
   // Feature flags
   translationEnabled: boolean;
   developmentApiEnabled: boolean;
@@ -75,7 +75,6 @@ export class I18NConfiguration {
     timeout?: number;
   };
   // Dictionaries
-  private _i18nCache: I18nCache<TranslatedChildren>;
   private _dictionaryManager: DictionaryManager | undefined;
   // Headers and cookies
   private localeHeaderName: string;
@@ -96,7 +95,7 @@ export class I18NConfiguration {
     loadDictionaryEnabled,
     // Locale info
     defaultLocale,
-    locales,
+    locales: _locales,
     // Render method
     renderSettings,
     // Dictionaries
@@ -118,39 +117,31 @@ export class I18NConfiguration {
   }: I18NConfigurationParams) {
     void _dictionary;
     void _customMapping;
-
-    // ----- CLOUD INTEGRATION ----- //
-
-    this.devApiKey = devApiKey;
-    this.projectId = projectId;
-    this.runtimeUrl = runtimeUrl;
+    void _locales;
 
     // Enables locale-based translation lookups through I18nCache. Runtime API
     // availability is tracked separately by developmentApiEnabled/productionApiEnabled.
-    this.translationEnabled = !!(
+    const translationEnabled = !!(
       (
         loadTranslationsType === 'custom' || // load local translation
         (loadTranslationsType === 'remote' &&
-          this.projectId && // projectId required because it's part of the GET request
+          projectId && // projectId required because it's part of the GET request
           cacheUrl) ||
         loadDictionaryEnabled
       ) // load local dictionary
     );
 
     // runtime translation enabled
-    const runtimeApiEnabled = !!(this.runtimeUrl ===
+    const runtimeApiEnabled = !!(runtimeUrl ===
     defaultWithGTConfigProps.runtimeUrl
-      ? this.projectId
-      : this.runtimeUrl);
-    this.developmentApiEnabled = !!(
+      ? projectId
+      : runtimeUrl);
+    const developmentApiEnabled = !!(
       runtimeApiEnabled &&
-      this.devApiKey &&
+      devApiKey &&
       process.env.NODE_ENV === 'development'
     );
-    this.productionApiEnabled = !!(runtimeApiEnabled && apiKey);
-
-    // dictionary enabled
-    this.dictionaryEnabled = _usingPlugin;
+    const productionApiEnabled = !!(runtimeApiEnabled && apiKey);
 
     // ----- SETUP ----- //
 
@@ -158,7 +149,7 @@ export class I18NConfiguration {
     const defaultRenderSettings = getDefaultRenderSettings(
       process.env.NODE_ENV
     );
-    this.renderSettings = {
+    const renderSettingsWithDefaults = {
       method: renderSettings?.method || defaultRenderSettings.method,
       ...((renderSettings?.timeout !== undefined ||
         defaultRenderSettings.timeout !== undefined) && {
@@ -167,7 +158,7 @@ export class I18NConfiguration {
     };
     // Translation and dictionary managers
     const shouldLoadTranslations = loadTranslationsType !== 'disabled';
-    const runtimeTranslationTimeout = this.renderSettings.timeout;
+    const runtimeTranslationTimeout = renderSettingsWithDefaults.timeout;
     setupGTServicesEnabled({
       apiKey,
       devApiKey,
@@ -176,7 +167,7 @@ export class I18NConfiguration {
       cacheUrl: shouldLoadTranslations ? cacheUrl : null,
     });
 
-    this._i18nCache = new I18nCache<TranslatedChildren>({
+    super({
       apiKey,
       devApiKey,
       projectId,
@@ -217,6 +208,17 @@ export class I18NConfiguration {
           })) || {},
       }),
     });
+
+    // ----- CLOUD INTEGRATION ----- //
+
+    this.devApiKey = devApiKey;
+    this.projectId = projectId;
+    this.runtimeUrl = runtimeUrl;
+    this.translationEnabled = translationEnabled;
+    this.developmentApiEnabled = developmentApiEnabled;
+    this.productionApiEnabled = productionApiEnabled;
+    this.dictionaryEnabled = _usingPlugin;
+    this.renderSettings = renderSettingsWithDefaults;
     this._dictionaryManager = dictionaryManager;
     // Headers and cookies
     this.localeHeaderName =
@@ -266,7 +268,7 @@ export class I18NConfiguration {
       resetLocaleCookieName,
     } = this;
     const customMapping = getI18nConfig().getCustomMapping();
-    const _versionId = this._i18nCache.getVersionId();
+    const _versionId = this.getVersionId();
     return {
       projectId,
       translationEnabled,
@@ -289,7 +291,7 @@ export class I18NConfiguration {
    * @returns {GT} The GT class instance
    */
   getGTClass(): GT {
-    return this._i18nCache.getGTClass();
+    return super.getGTClass();
   }
 
   // ----- LOCALES ----- //
@@ -315,7 +317,7 @@ export class I18NConfiguration {
    * @returns {string | undefined} The version ID, if set
    */
   getVersionId(): string | undefined {
-    return this._i18nCache.getVersionId();
+    return super.getVersionId();
   }
 
   // ----- COOKIES AND HEADERS ----- //
@@ -410,17 +412,32 @@ export class I18NConfiguration {
    * @returns A promise that resolves to the translations.
    */
   async getCachedTranslations(locale: string): Promise<Translations> {
-    return (await this._i18nCache.loadTranslations(locale)) as Translations;
+    return (await this.loadTranslations(locale)) as Translations;
   }
 
   // ----- RUNTIME TRANSLATION ----- //
 
-  lookupTranslation({
-    source,
-    targetLocale,
-    options,
-  }: RuntimeTranslationParams): TranslatedChildren | undefined {
-    return this._i18nCache.lookupTranslation(targetLocale, source, options);
+  lookupTranslation(
+    targetLocale: string,
+    source: TranslatedChildren,
+    options: LookupOptions
+  ): TranslatedChildren | undefined;
+  lookupTranslation(
+    params: RuntimeTranslationParams
+  ): TranslatedChildren | undefined;
+  lookupTranslation(
+    targetLocaleOrParams: string | RuntimeTranslationParams,
+    source?: TranslatedChildren,
+    options?: LookupOptions
+  ): TranslatedChildren | undefined {
+    if (typeof targetLocaleOrParams === 'string') {
+      return super.lookupTranslation(targetLocaleOrParams, source!, options!);
+    }
+    return super.lookupTranslation(
+      targetLocaleOrParams.targetLocale,
+      targetLocaleOrParams.source,
+      targetLocaleOrParams.options
+    );
   }
 
   async translate({
@@ -428,7 +445,7 @@ export class I18NConfiguration {
     targetLocale,
     options,
   }: RuntimeTranslationParams): Promise<TranslatedChildren> {
-    const translation = await this._i18nCache.lookupTranslationWithFallback(
+    const translation = await this.lookupTranslationWithFallback(
       targetLocale,
       source,
       options


### PR DESCRIPTION
## Summary
- Make `I18NConfiguration` extend `I18nCache<TranslatedChildren>` directly instead of storing a private cache instance.
- Route existing config helpers through inherited cache methods while preserving the object-shaped Next runtime lookup API.

## Testing
- `PATH=/opt/homebrew/bin:$PATH pnpm exec vitest run packages/next/src/config-dir/__tests__/I18NConfiguration.test.ts packages/next/src/config-dir/__tests__/I18NConfiguration.integration.test.ts`
- `PATH=/opt/homebrew/bin:$PATH pnpm exec oxfmt --check packages/next/src/config-dir/I18NConfiguration.ts`
- `PATH=/opt/homebrew/bin:$PATH pnpm exec oxlint packages/next/src/config-dir/I18NConfiguration.ts`

## Notes
- A clean `gt-next` package typecheck from this `odysseus` worktree currently reports unrelated baseline errors in `packages/next/src/server-dir/buildtime/getTranslationFunction.ts` and `packages/next/src/server-dir/variables/renderVariable.tsx`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1567"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783561355&installation_id=127936663&pr_number=1567&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1567&signature=6891e0ee0b3b8615f8b4cedfa5df0e20dd7d1b07582478bbb737efcfca5d26ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors `I18NConfiguration` to extend `I18nCache<TranslatedChildren>` directly instead of holding a private `_i18nCache` instance, eliminating the composition layer and routing all cache interactions through inheritance.

- All formerly delegated calls (`_i18nCache.loadTranslations`, `_i18nCache.lookupTranslation`, etc.) are replaced with direct `super` calls or inherited methods, and `lookupTranslation` gains a backward-compatible object-param overload so existing call sites in `tx.ts` continue to work.
- Initialization order is adjusted to compute feature-flag locals before `super()` and assign them to `this.*` immediately after, satisfying the JavaScript \"no `this` before `super()`\" rule.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The refactor is structurally sound and all call sites continue to work; the two style-level findings do not affect runtime behavior.

The composition-to-inheritance migration is implemented correctly: `super()` is called before any `this` access, feature-flag locals are computed beforehand and assigned immediately after, and the `lookupTranslation` object-param overload preserves the existing call site in `tx.ts`. The only issues are a pair of redundant `super`-only overrides that silently narrow the `getGTClass` signature, and non-null assertions that are valid under the overload contract but would silently pass `undefined` to the parent if the assertions were ever bypassed at runtime.

packages/next/src/config-dir/I18NConfiguration.ts — specifically the `getGTClass` signature narrowing and the non-null assertions in the `lookupTranslation` overload implementation.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/next/src/config-dir/I18NConfiguration.ts | Converts composition to inheritance; backward-compat overload added for lookupTranslation; two method overrides are redundant no-ops; non-null assertions in the overload implementation are technically safe but could be guarded more explicitly. |

</details>

</details>

<details><summary><h3>Class Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
classDiagram
    direction TB

    class EventEmitter~I18nEvents~ {
        +subscribe()
        +emit()
        +hasListeners()
    }

    class I18nCache~TranslationValue~ {
        #config: I18nCacheConfig
        -localesCache: LocalesCache
        +getGTClass(locale?: string) GT
        +getVersionId() string|undefined
        +loadTranslations(locale) Promise
        +lookupTranslation(locale, message, options) T|undefined
        +lookupTranslationWithFallback(locale, message, options) Promise~T~
    }

    class I18NConfiguration {
        +translationEnabled: boolean
        +developmentApiEnabled: boolean
        +productionApiEnabled: boolean
        +dictionaryEnabled: boolean
        +projectId?: string
        +devApiKey?: string
        +runtimeUrl: string|undefined
        +renderSettings: object
        -_dictionaryManager: DictionaryManager
        +getGTClass() GT
        +getVersionId() string|undefined
        +lookupTranslation(locale, source, options) overload1
        +lookupTranslation(params) overload2
        +getCachedTranslations(locale) Promise
        +translate(params) Promise
        +getClientSideConfig() object
    }

    EventEmitter <|-- I18nCache : extends
    I18nCache <|-- I18NConfiguration : extends (NEW)

    note for I18NConfiguration "Before: held private _i18nCache instance\nAfter: IS an I18nCache via inheritance"
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fnext%2Fsrc%2Fconfig-dir%2FI18NConfiguration.ts%3A428-435%0AThe%20non-null%20assertions%20%60source!%60%20and%20%60options!%60%20are%20sound%20given%20the%20TypeScript%20overload%20signatures%2C%20but%20the%20parent's%20%60resolveTranslationSync%60%20arrow%20property%20also%20dispatches%20here%20with%20the%203-arg%20form.%20A%20guarded%20fallback%20keeps%20the%20runtime%20safe%20if%20the%20overloads%20are%20ever%20relaxed%20or%20the%20method%20is%20called%20from%20a%20JavaScript%20context.%0A%0A%60%60%60suggestion%0A%20%20lookupTranslation%28%0A%20%20%20%20targetLocaleOrParams%3A%20string%20%7C%20RuntimeTranslationParams%2C%0A%20%20%20%20source%3F%3A%20TranslatedChildren%2C%0A%20%20%20%20options%3F%3A%20LookupOptions%0A%20%20%29%3A%20TranslatedChildren%20%7C%20undefined%20%7B%0A%20%20%20%20if%20%28typeof%20targetLocaleOrParams%20%3D%3D%3D%20'string'%29%20%7B%0A%20%20%20%20%20%20if%20%28source%20%3D%3D%3D%20undefined%20%7C%7C%20options%20%3D%3D%3D%20undefined%29%20%7B%0A%20%20%20%20%20%20%20%20throw%20new%20Error%28%0A%20%20%20%20%20%20%20%20%20%20'lookupTranslation%3A%20source%20and%20options%20are%20required%20when%20targetLocale%20is%20a%20string'%0A%20%20%20%20%20%20%20%20%29%3B%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20return%20super.lookupTranslation%28targetLocaleOrParams%2C%20source%2C%20options%29%3B%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fnext%2Fsrc%2Fconfig-dir%2FI18NConfiguration.ts%3A293-321%0A**Redundant%20%60super%60-only%20overrides**%0A%0ABoth%20%60getGTClass%28%29%60%20and%20%60getVersionId%28%29%60%20are%20overridden%20only%20to%20call%20%60super.xxx%28%29%60%2C%20which%20is%20exactly%20what%20inheritance%20already%20does.%20The%20overrides%20have%20no%20effect%20on%20behavior%20but%20do%20silently%20narrow%20the%20public%20API%3A%20the%20parent's%20%60getGTClass%28locale%3F%3A%20string%29%60%20accepts%20an%20optional%20locale%2C%20while%20the%20child's%20override%20drops%20that%20parameter%2C%20making%20%60config.getGTClass%28locale%29%60%20a%20TypeScript%20error%20on%20%60I18NConfiguration%60%20instances.%20If%20locale-bound%20GT%20instances%20are%20never%20needed%20here%20that%20narrowing%20is%20intentional%E2%80%94consider%20adding%20a%20brief%20comment%20explaining%20it%3B%20otherwise%20delete%20both%20overrides%20and%20inherit%20directly.%0A%0A&repo=generaltranslation%2Fgt&pr=1567&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fodysseus%2Fi18n-configuration-extends-cache%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fodysseus%2Fi18n-configuration-extends-cache%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fnext%2Fsrc%2Fconfig-dir%2FI18NConfiguration.ts%3A428-435%0AThe%20non-null%20assertions%20%60source!%60%20and%20%60options!%60%20are%20sound%20given%20the%20TypeScript%20overload%20signatures%2C%20but%20the%20parent's%20%60resolveTranslationSync%60%20arrow%20property%20also%20dispatches%20here%20with%20the%203-arg%20form.%20A%20guarded%20fallback%20keeps%20the%20runtime%20safe%20if%20the%20overloads%20are%20ever%20relaxed%20or%20the%20method%20is%20called%20from%20a%20JavaScript%20context.%0A%0A%60%60%60suggestion%0A%20%20lookupTranslation%28%0A%20%20%20%20targetLocaleOrParams%3A%20string%20%7C%20RuntimeTranslationParams%2C%0A%20%20%20%20source%3F%3A%20TranslatedChildren%2C%0A%20%20%20%20options%3F%3A%20LookupOptions%0A%20%20%29%3A%20TranslatedChildren%20%7C%20undefined%20%7B%0A%20%20%20%20if%20%28typeof%20targetLocaleOrParams%20%3D%3D%3D%20'string'%29%20%7B%0A%20%20%20%20%20%20if%20%28source%20%3D%3D%3D%20undefined%20%7C%7C%20options%20%3D%3D%3D%20undefined%29%20%7B%0A%20%20%20%20%20%20%20%20throw%20new%20Error%28%0A%20%20%20%20%20%20%20%20%20%20'lookupTranslation%3A%20source%20and%20options%20are%20required%20when%20targetLocale%20is%20a%20string'%0A%20%20%20%20%20%20%20%20%29%3B%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20return%20super.lookupTranslation%28targetLocaleOrParams%2C%20source%2C%20options%29%3B%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fnext%2Fsrc%2Fconfig-dir%2FI18NConfiguration.ts%3A293-321%0A**Redundant%20%60super%60-only%20overrides**%0A%0ABoth%20%60getGTClass%28%29%60%20and%20%60getVersionId%28%29%60%20are%20overridden%20only%20to%20call%20%60super.xxx%28%29%60%2C%20which%20is%20exactly%20what%20inheritance%20already%20does.%20The%20overrides%20have%20no%20effect%20on%20behavior%20but%20do%20silently%20narrow%20the%20public%20API%3A%20the%20parent's%20%60getGTClass%28locale%3F%3A%20string%29%60%20accepts%20an%20optional%20locale%2C%20while%20the%20child's%20override%20drops%20that%20parameter%2C%20making%20%60config.getGTClass%28locale%29%60%20a%20TypeScript%20error%20on%20%60I18NConfiguration%60%20instances.%20If%20locale-bound%20GT%20instances%20are%20never%20needed%20here%20that%20narrowing%20is%20intentional%E2%80%94consider%20adding%20a%20brief%20comment%20explaining%20it%3B%20otherwise%20delete%20both%20overrides%20and%20inherit%20directly.%0A%0A&repo=generaltranslation%2Fgt&pr=1567&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/next/src/config-dir/I18NConfiguration.ts:428-435
The non-null assertions `source!` and `options!` are sound given the TypeScript overload signatures, but the parent's `resolveTranslationSync` arrow property also dispatches here with the 3-arg form. A guarded fallback keeps the runtime safe if the overloads are ever relaxed or the method is called from a JavaScript context.

```suggestion
  lookupTranslation(
    targetLocaleOrParams: string | RuntimeTranslationParams,
    source?: TranslatedChildren,
    options?: LookupOptions
  ): TranslatedChildren | undefined {
    if (typeof targetLocaleOrParams === 'string') {
      if (source === undefined || options === undefined) {
        throw new Error(
          'lookupTranslation: source and options are required when targetLocale is a string'
        );
      }
      return super.lookupTranslation(targetLocaleOrParams, source, options);
    }
```

### Issue 2 of 2
packages/next/src/config-dir/I18NConfiguration.ts:293-321
**Redundant `super`-only overrides**

Both `getGTClass()` and `getVersionId()` are overridden only to call `super.xxx()`, which is exactly what inheritance already does. The overrides have no effect on behavior but do silently narrow the public API: the parent's `getGTClass(locale?: string)` accepts an optional locale, while the child's override drops that parameter, making `config.getGTClass(locale)` a TypeScript error on `I18NConfiguration` instances. If locale-bound GT instances are never needed here that narrowing is intentional—consider adding a brief comment explaining it; otherwise delete both overrides and inherit directly.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: extend i18n cache in next conf..."](https://github.com/generaltranslation/gt/commit/9703494e4257bc99a3c2f1662ec8ec615594197f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36359188)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->