### PR TITLE
refactor(1): thread renderVariable through the prepared-T render chain

### DIFF
--- a/packages/react-core/src/components/translation/T.tsx
+++ b/packages/react-core/src/components/translation/T.tsx
@@ -3,6 +3,7 @@ import { getI18nConfig } from 'gt-i18n/internal';
 import { useRef, type ReactNode } from 'react';
 import { getReactI18nCache } from '../../i18n-cache/singleton-operations';
 import { renderPreparedT } from '../../utils/rendering/renderPreparedT';
+import { renderVariable } from '../../utils/rendering/renderVariable';
 import {
   prepareT,
   usePrepareT,
@@ -57,6 +58,7 @@ async function RscT({
       defaultLocale,
       enableI18n,
       shouldTranslate,
+      renderVariable,
     });
   }
 
@@ -74,6 +76,7 @@ async function RscT({
     defaultLocale,
     enableI18n,
     shouldTranslate,
+    renderVariable,
   });
 }
 
@@ -133,6 +136,7 @@ function useComputeT({
     defaultLocale,
     enableI18n,
     shouldTranslate,
+    renderVariable,
   });
 
   // record previous result

--- a/packages/react-core/src/utils/rendering/__tests__/renderVariable.test.tsx
+++ b/packages/react-core/src/utils/rendering/__tests__/renderVariable.test.tsx
@@ -99,6 +99,7 @@ describe('renderVariable locale handling', () => {
       children: createNumberVariable(5),
       defaultLocale: 'en',
       enableI18n: false,
+      renderVariable,
     });
 
     expect(React.isValidElement(result)).toBe(true);
@@ -117,6 +118,7 @@ describe('renderVariable locale handling', () => {
       target: { k: 'count', v: 'n' },
       locales: ['fr', 'en'],
       enableI18n: true,
+      renderVariable,
     });
 
     expect(React.isValidElement(result)).toBe(true);

--- a/packages/react-core/src/utils/rendering/renderDefaultChildren.tsx
+++ b/packages/react-core/src/utils/rendering/renderDefaultChildren.tsx
@@ -1,21 +1,27 @@
-import React, { ReactNode } from 'react';
+import React, { type ReactNode } from 'react';
 import getVariableProps, {
   isVariableElementProps,
 } from '../variables/_getVariableProps';
 import { libraryDefaultLocale } from 'generaltranslation/internal';
-import { TaggedChild, TaggedChildren, TaggedElement } from '../types';
+import {
+  type RenderVariable,
+  TaggedChild,
+  TaggedChildren,
+  TaggedElement,
+} from '../types';
 import getGTTag from './getGTTag';
 import getPluralBranch from '../plurals/getPluralBranch';
-import { renderVariable } from './renderVariable';
 
 export default function renderDefaultChildren({
   children,
   defaultLocale = libraryDefaultLocale,
   enableI18n,
+  renderVariable,
 }: {
   children: TaggedChildren;
   defaultLocale: string;
   enableI18n: boolean;
+  renderVariable: RenderVariable;
 }): React.ReactNode {
   const handleSingleChildElement = (child: TaggedElement): ReactNode => {
     const generaltranslation = getGTTag(child);

--- a/packages/react-core/src/utils/rendering/renderPreparedT.tsx
+++ b/packages/react-core/src/utils/rendering/renderPreparedT.tsx
@@ -2,7 +2,11 @@ import renderDefaultChildren from './renderDefaultChildren';
 import renderTranslatedChildren from './renderTranslatedChildren';
 import type { JsxChildren } from 'generaltranslation/types';
 import type { ReactNode } from 'react';
-import type { TaggedChildren } from '../types';
+import type { RenderVariable, TaggedChildren } from '../types';
+
+const missingRenderVariable: RenderVariable = () => {
+  throw new Error('renderPreparedT requires a renderVariable implementation.');
+};
 
 function renderPreparedT({
   taggedSourceChildren,
@@ -11,6 +15,7 @@ function renderPreparedT({
   defaultLocale,
   enableI18n,
   shouldTranslate,
+  renderVariable,
 }: {
   taggedSourceChildren: TaggedChildren;
   targetJsxChildren: JsxChildren | null | undefined;
@@ -18,12 +23,15 @@ function renderPreparedT({
   defaultLocale: string;
   enableI18n: boolean;
   shouldTranslate: boolean;
+  renderVariable?: RenderVariable;
 }): ReactNode {
+  const resolvedRenderVariable = renderVariable ?? missingRenderVariable;
   if (!shouldTranslate || targetJsxChildren == null) {
     return renderSource({
       taggedSourceChildren,
       defaultLocale,
       enableI18n,
+      renderVariable: resolvedRenderVariable,
     });
   }
 
@@ -32,6 +40,7 @@ function renderPreparedT({
     targetJsxChildren,
     locales: [locale, defaultLocale],
     enableI18n,
+    renderVariable: resolvedRenderVariable,
   });
 }
 
@@ -39,15 +48,18 @@ function renderSource({
   taggedSourceChildren,
   defaultLocale,
   enableI18n,
+  renderVariable,
 }: {
   taggedSourceChildren: TaggedChildren;
   defaultLocale: string;
   enableI18n: boolean;
+  renderVariable: RenderVariable;
 }): ReactNode {
   return renderDefaultChildren({
     children: taggedSourceChildren,
     defaultLocale,
     enableI18n,
+    renderVariable,
   });
 }
 
@@ -56,17 +68,20 @@ function renderTarget({
   targetJsxChildren,
   locales,
   enableI18n,
+  renderVariable,
 }: {
   taggedSourceChildren: TaggedChildren;
   targetJsxChildren: JsxChildren;
   locales: string[];
   enableI18n: boolean;
+  renderVariable: RenderVariable;
 }): ReactNode {
   return renderTranslatedChildren({
     source: taggedSourceChildren,
     target: targetJsxChildren,
     locales,
     enableI18n,
+    renderVariable,
   });
 }
 

--- a/packages/react-core/src/utils/rendering/renderTranslatedChildren.tsx
+++ b/packages/react-core/src/utils/rendering/renderTranslatedChildren.tsx
@@ -1,5 +1,6 @@
-import React, { ReactNode } from 'react';
+import React, { type ReactNode } from 'react';
 import {
+  RenderVariable,
   TaggedChildren,
   TaggedElement,
   TranslatedChildren,
@@ -17,18 +18,19 @@ import {
   HtmlContentPropValuesRecord,
 } from '@generaltranslation/format/types';
 import getGTTag from './getGTTag';
-import { renderVariable } from './renderVariable';
 
 function renderTranslatedElement({
   sourceElement,
   targetElement,
   locales = [libraryDefaultLocale],
   enableI18n,
+  renderVariable,
 }: {
   sourceElement: TaggedElement;
   targetElement: TranslatedElement;
   locales: string[];
   enableI18n: boolean;
+  renderVariable: RenderVariable;
 }): React.ReactNode {
   // Get props and generaltranslation
   const { props: sourceProps } = sourceElement;
@@ -58,6 +60,7 @@ function renderTranslatedElement({
         children: sourceElement,
         defaultLocale: locales[0],
         enableI18n,
+        renderVariable,
       });
     }
     const sourceBranches = sourceGT.branches || {};
@@ -75,6 +78,7 @@ function renderTranslatedElement({
       target: targetBranch as TranslatedChildren,
       locales,
       enableI18n,
+      renderVariable,
     });
   }
 
@@ -98,6 +102,7 @@ function renderTranslatedElement({
       target: targetBranch as TranslatedChildren,
       locales,
       enableI18n,
+      renderVariable,
     });
   }
 
@@ -110,6 +115,7 @@ function renderTranslatedElement({
         target: targetElement.c,
         locales,
         enableI18n,
+        renderVariable,
       }) as TaggedChildren,
     });
   }
@@ -125,6 +131,7 @@ function renderTranslatedElement({
         target: targetElement.c,
         locales,
         enableI18n,
+        renderVariable,
       }) as TaggedChildren,
     });
   }
@@ -134,6 +141,7 @@ function renderTranslatedElement({
     children: sourceElement,
     defaultLocale: locales[0],
     enableI18n,
+    renderVariable,
   });
 }
 
@@ -142,11 +150,13 @@ export default function renderTranslatedChildren({
   target,
   locales = [libraryDefaultLocale],
   enableI18n,
+  renderVariable,
 }: {
   source: TaggedChildren;
   target: TranslatedChildren;
   locales: string[];
   enableI18n: boolean;
+  renderVariable: RenderVariable;
 }): ReactNode {
   // Most straightforward case, return a valid React node
   if ((target === null || typeof target === 'undefined') && source)
@@ -154,6 +164,7 @@ export default function renderTranslatedChildren({
       children: source,
       defaultLocale: locales[0],
       enableI18n,
+      renderVariable,
     });
   if (typeof target === 'string') return target;
 
@@ -248,6 +259,7 @@ export default function renderTranslatedChildren({
             targetElement: targetChild,
             locales,
             enableI18n,
+            renderVariable,
           })}
         </React.Fragment>
       );
@@ -267,6 +279,7 @@ export default function renderTranslatedChildren({
           targetElement: target as TranslatedElement,
           locales,
           enableI18n,
+          renderVariable,
         });
       }
 
@@ -291,5 +304,6 @@ export default function renderTranslatedChildren({
     children: source,
     defaultLocale: locales[0],
     enableI18n,
+    renderVariable,
   });
 }


### PR DESCRIPTION
## Summary

Base PR of a 2-PR stack. Makes `renderPreparedT` and the render chain (`renderDefaultChildren` / `renderTranslatedChildren`) take an explicit `renderVariable` callback instead of statically importing the default renderer.

This is a **behavior-preserving** refactor — the only callers (`T` / `RscT` in `react-core`) pass the existing default `renderVariable`, so rendered output is identical. It exists to be split out from the follow-up so the callback-threading is reviewable on its own.

### Why

The follow-up PR introduces a dedicated server (RSC) entrypoint that must render *without* React context. Statically importing the default `renderVariable` (which pulls in the context-based variable components, and transitively `createContext`) makes that impossible. Threading the renderer as a parameter lets the server path inject a context-free renderer.

## Stack

1. **this PR** — thread `renderVariable` through the render chain
2. #1566 — add the dedicated `react-core/context-server` entrypoint (stacked on this)

## Testing

- `pnpm --filter @generaltranslation/react-core typecheck` ✓
- `pnpm --filter @generaltranslation/react-core test` (316 passed) ✓

No changeset added (intentional).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1568"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783561800&installation_id=127936663&pr_number=1568&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1568&signature=c445f7e078df990a4770d60178aa949a569ac6838a9604680d0f8f82b29738c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR threads `renderVariable` as an explicit parameter through `renderPreparedT`, `renderDefaultChildren`, and `renderTranslatedChildren` instead of statically importing the default renderer — a pure structural refactor with no observable behavior change.

- **`renderPreparedT.tsx`**: accepts an optional `renderVariable` with a throwing sentinel fallback (`missingRenderVariable`) and passes it down to `renderSource` / `renderTarget`.
- **`renderDefaultChildren.tsx` / `renderTranslatedChildren.tsx`**: static `renderVariable` import removed; parameter threaded through every recursive call site.
- **`T.tsx`**: both `RscT` and `useComputeT` now import and forward the default `renderVariable`, keeping existing output identical.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the refactor is behavior-preserving and all callers already supply the required argument.

The change is a straightforward parameter-threading refactor with no logic modifications. Both active callers pass `renderVariable` explicitly, so the throwing sentinel in `renderPreparedT` is never reached in practice. The two minor issues — the optional type on a parameter that has no safe default, and the missing `type` keyword on the `RenderVariable` import in `renderTranslatedChildren.tsx` — are cosmetic and do not affect runtime behavior.

packages/react-core/src/utils/rendering/renderPreparedT.tsx — the optional signature for `renderVariable` is worth tightening before the follow-up PR adds new callers.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react-core/src/utils/rendering/renderPreparedT.tsx | Adds `renderVariable` as an optional parameter with a throwing sentinel fallback; all callers pass it, but making it optional introduces a mismatch between the type signature and the intended contract. |
| packages/react-core/src/utils/rendering/renderTranslatedChildren.tsx | Threads `renderVariable` through all recursive call sites; imports `RenderVariable` without the `type` keyword, inconsistent with `renderDefaultChildren.tsx`. |
| packages/react-core/src/utils/rendering/renderDefaultChildren.tsx | Correctly removes the static import of `renderVariable` and accepts it as a required parameter; uses `type RenderVariable` import appropriately. |
| packages/react-core/src/components/translation/T.tsx | Both `RscT` and `useComputeT` now import and forward the default `renderVariable`, preserving existing behavior. |
| packages/react-core/src/utils/rendering/__tests__/renderVariable.test.tsx | Two test calls updated to pass explicit `renderVariable`; existing direct `renderVariable` tests are unaffected and remain correct. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["T / RscT\n(T.tsx)"] -->|"renderVariable (explicit)"| B["renderPreparedT"]
    B -->|"shouldTranslate = false\nor no target"| C["renderSource"]
    B -->|"shouldTranslate = true\n+ target present"| D["renderTarget"]
    C -->|"renderVariable"| E["renderDefaultChildren"]
    D -->|"renderVariable"| F["renderTranslatedChildren"]
    E -->|"renderVariable"| G["renderVariable()\n↳ variable React node"]
    F -->|"renderVariable\n(recursive)"| G
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Freact-core%2Fsrc%2Futils%2Frendering%2FrenderPreparedT.tsx%3A23-26%0AThe%20%60renderVariable%60%20parameter%20is%20typed%20as%20optional%20%28%60renderVariable%3F%3A%20RenderVariable%60%29%2C%20but%20there%20is%20no%20safe%20default%20%E2%80%94%20the%20fallback%20immediately%20throws%20at%20render%20time%20whenever%20a%20variable%20node%20is%20encountered.%20Every%20current%20caller%20supplies%20the%20argument%2C%20so%20the%20optionality%20provides%20no%20real%20convenience%3B%20it%20only%20delays%20what%20would%20be%20a%20compile-time%20omission%20error%20to%20a%20runtime%20one.%20Marking%20it%20required%20gives%20the%20same%20guarantee%20at%20the%20type%20level.%0A%0A%60%60%60suggestion%0A%20%20defaultLocale%3A%20string%3B%0A%20%20enableI18n%3A%20boolean%3B%0A%20%20shouldTranslate%3A%20boolean%3B%0A%20%20renderVariable%3A%20RenderVariable%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Freact-core%2Fsrc%2Futils%2Frendering%2FrenderTranslatedChildren.tsx%3A2-6%0A%60RenderVariable%60%20is%20a%20type%20alias%20and%20is%20imported%20here%20without%20the%20%60type%60%20keyword.%20%60renderDefaultChildren.tsx%60%20consistently%20uses%20%60type%20RenderVariable%60%20in%20the%20same%20position.%20Under%20%60isolatedModules%60%20%28which%20TypeScript%20projects%20typically%20enable%29%2C%20re-exporting%20a%20type%20without%20the%20%60type%60%20modifier%20can%20cause%20transpile-time%20errors%3B%20using%20%60type%60%20also%20makes%20the%20intent%20clear%20and%20enables%20better%20tree-shaking.%0A%0A%60%60%60suggestion%0Aimport%20%7B%0A%20%20type%20RenderVariable%2C%0A%20%20TaggedChildren%2C%0A%20%20TaggedElement%2C%0A%20%20TranslatedChildren%2C%0A%60%60%60%0A%0A&repo=generaltranslation%2Fgt&pr=1568&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fodysseus%2Frender-variable-callback%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fodysseus%2Frender-variable-callback%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Freact-core%2Fsrc%2Futils%2Frendering%2FrenderPreparedT.tsx%3A23-26%0AThe%20%60renderVariable%60%20parameter%20is%20typed%20as%20optional%20%28%60renderVariable%3F%3A%20RenderVariable%60%29%2C%20but%20there%20is%20no%20safe%20default%20%E2%80%94%20the%20fallback%20immediately%20throws%20at%20render%20time%20whenever%20a%20variable%20node%20is%20encountered.%20Every%20current%20caller%20supplies%20the%20argument%2C%20so%20the%20optionality%20provides%20no%20real%20convenience%3B%20it%20only%20delays%20what%20would%20be%20a%20compile-time%20omission%20error%20to%20a%20runtime%20one.%20Marking%20it%20required%20gives%20the%20same%20guarantee%20at%20the%20type%20level.%0A%0A%60%60%60suggestion%0A%20%20defaultLocale%3A%20string%3B%0A%20%20enableI18n%3A%20boolean%3B%0A%20%20shouldTranslate%3A%20boolean%3B%0A%20%20renderVariable%3A%20RenderVariable%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Freact-core%2Fsrc%2Futils%2Frendering%2FrenderTranslatedChildren.tsx%3A2-6%0A%60RenderVariable%60%20is%20a%20type%20alias%20and%20is%20imported%20here%20without%20the%20%60type%60%20keyword.%20%60renderDefaultChildren.tsx%60%20consistently%20uses%20%60type%20RenderVariable%60%20in%20the%20same%20position.%20Under%20%60isolatedModules%60%20%28which%20TypeScript%20projects%20typically%20enable%29%2C%20re-exporting%20a%20type%20without%20the%20%60type%60%20modifier%20can%20cause%20transpile-time%20errors%3B%20using%20%60type%60%20also%20makes%20the%20intent%20clear%20and%20enables%20better%20tree-shaking.%0A%0A%60%60%60suggestion%0Aimport%20%7B%0A%20%20type%20RenderVariable%2C%0A%20%20TaggedChildren%2C%0A%20%20TaggedElement%2C%0A%20%20TranslatedChildren%2C%0A%60%60%60%0A%0A&repo=generaltranslation%2Fgt&pr=1568&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/react-core/src/utils/rendering/renderPreparedT.tsx:23-26
The `renderVariable` parameter is typed as optional (`renderVariable?: RenderVariable`), but there is no safe default — the fallback immediately throws at render time whenever a variable node is encountered. Every current caller supplies the argument, so the optionality provides no real convenience; it only delays what would be a compile-time omission error to a runtime one. Marking it required gives the same guarantee at the type level.

```suggestion
  defaultLocale: string;
  enableI18n: boolean;
  shouldTranslate: boolean;
  renderVariable: RenderVariable;
```

### Issue 2 of 2
packages/react-core/src/utils/rendering/renderTranslatedChildren.tsx:2-6
`RenderVariable` is a type alias and is imported here without the `type` keyword. `renderDefaultChildren.tsx` consistently uses `type RenderVariable` in the same position. Under `isolatedModules` (which TypeScript projects typically enable), re-exporting a type without the `type` modifier can cause transpile-time errors; using `type` also makes the intent clear and enables better tree-shaking.

```suggestion
import {
  type RenderVariable,
  TaggedChildren,
  TaggedElement,
  TranslatedChildren,
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: thread renderVariable through ..."](https://github.com/generaltranslation/gt/commit/59abf30e6de339af3b2a1098db7d18e182466d03) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36359912)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->