### PR TITLE
refactor(2): extend i18n config with runtime values

### DIFF
--- a/packages/i18n/src/i18n-config/I18nConfig.ts
+++ b/packages/i18n/src/i18n-config/I18nConfig.ts
@@ -10,13 +10,28 @@ export type I18nConfigParams = {
   defaultLocale?: string;
   locales?: string[];
   customMapping?: CustomMapping;
+  projectId?: string;
+  devApiKey?: string;
+  runtimeUrl?: string | null;
+  cacheUrl?: string | null;
+  loadTranslationsType?: 'remote' | 'custom' | 'disabled';
+  loadDictionaryEnabled?: boolean;
 };
 
 export type LocaleCandidates = string | string[] | undefined;
 
 export class I18nConfig extends LocaleConfig {
+  private projectId?: string;
+  private devApiKey?: string;
+  private runtimeUrl?: string | null;
+  private translationEnabled: boolean;
+
   constructor(params: I18nConfigParams = {}) {
     super(getLocaleConfigParams(params));
+    this.projectId = params.projectId;
+    this.devApiKey = params.devApiKey;
+    this.runtimeUrl = params.runtimeUrl;
+    this.translationEnabled = getTranslationEnabled(params);
   }
 
   getDefaultLocale(): string {
@@ -29,6 +44,22 @@ export class I18nConfig extends LocaleConfig {
 
   getCustomMapping(): CustomMapping {
     return this.customMapping || {};
+  }
+
+  getProjectId(): string | undefined {
+    return this.projectId;
+  }
+
+  getDevApiKey(): string | undefined {
+    return this.devApiKey;
+  }
+
+  getRuntimeUrl(): string | null | undefined {
+    return this.runtimeUrl;
+  }
+
+  getTranslationEnabled(): boolean {
+    return this.translationEnabled;
   }
 
   determineLocale(
@@ -140,5 +171,18 @@ function hasI18nConfigParams(config: I18nConfigParams): boolean {
     config.defaultLocale !== undefined ||
     config.locales !== undefined ||
     config.customMapping !== undefined
+  );
+}
+
+function getTranslationEnabled({
+  loadTranslationsType,
+  projectId,
+  cacheUrl,
+  loadDictionaryEnabled,
+}: I18nConfigParams): boolean {
+  return !!(
+    loadTranslationsType === 'custom' ||
+    (loadTranslationsType === 'remote' && projectId && cacheUrl) ||
+    loadDictionaryEnabled
   );
 }

--- a/packages/i18n/src/i18n-config/__tests__/I18nConfig.test.ts
+++ b/packages/i18n/src/i18n-config/__tests__/I18nConfig.test.ts
@@ -96,4 +96,19 @@ describe('I18nConfig', () => {
       })
     ).toBe('fr');
   });
+
+  it('stores runtime config values', () => {
+    const config = new I18nConfig({
+      projectId: 'project-id',
+      devApiKey: 'gt-dev-key',
+      runtimeUrl: 'https://runtime.example.com',
+      cacheUrl: 'https://cache.example.com',
+      loadTranslationsType: 'remote',
+    });
+
+    expect(config.getProjectId()).toBe('project-id');
+    expect(config.getDevApiKey()).toBe('gt-dev-key');
+    expect(config.getRuntimeUrl()).toBe('https://runtime.example.com');
+    expect(config.getTranslationEnabled()).toBe(true);
+  });
 });

--- a/packages/next/src/config-dir/I18NConfiguration.ts
+++ b/packages/next/src/config-dir/I18NConfiguration.ts
@@ -61,14 +61,9 @@ type RuntimeTranslationParams = {
 
 export class I18NConfiguration extends I18nCache<TranslatedChildren> {
   // Feature flags
-  translationEnabled: boolean;
   developmentApiEnabled: boolean;
   productionApiEnabled: boolean;
   dictionaryEnabled: boolean;
-  // Cloud integration
-  projectId?: string;
-  devApiKey?: string;
-  runtimeUrl: string | undefined;
   // Rendering
   renderSettings: {
     method: RenderMethod;
@@ -92,7 +87,7 @@ export class I18NConfiguration extends I18nCache<TranslatedChildren> {
     cacheUrl,
     cacheExpiryTime,
     loadTranslationsType,
-    loadDictionaryEnabled,
+    loadDictionaryEnabled: _loadDictionaryEnabled,
     // Locale info
     defaultLocale,
     locales: _locales,
@@ -117,31 +112,8 @@ export class I18NConfiguration extends I18nCache<TranslatedChildren> {
   }: I18NConfigurationParams) {
     void _dictionary;
     void _customMapping;
+    void _loadDictionaryEnabled;
     void _locales;
-
-    // Enables locale-based translation lookups through I18nCache. Runtime API
-    // availability is tracked separately by developmentApiEnabled/productionApiEnabled.
-    const translationEnabled = !!(
-      (
-        loadTranslationsType === 'custom' || // load local translation
-        (loadTranslationsType === 'remote' &&
-          projectId && // projectId required because it's part of the GET request
-          cacheUrl) ||
-        loadDictionaryEnabled
-      ) // load local dictionary
-    );
-
-    // runtime translation enabled
-    const runtimeApiEnabled = !!(runtimeUrl ===
-    defaultWithGTConfigProps.runtimeUrl
-      ? projectId
-      : runtimeUrl);
-    const developmentApiEnabled = !!(
-      runtimeApiEnabled &&
-      devApiKey &&
-      process.env.NODE_ENV === 'development'
-    );
-    const productionApiEnabled = !!(runtimeApiEnabled && apiKey);
 
     // ----- SETUP ----- //
 
@@ -211,12 +183,18 @@ export class I18NConfiguration extends I18nCache<TranslatedChildren> {
 
     // ----- CLOUD INTEGRATION ----- //
 
-    this.devApiKey = devApiKey;
-    this.projectId = projectId;
-    this.runtimeUrl = runtimeUrl;
-    this.translationEnabled = translationEnabled;
-    this.developmentApiEnabled = developmentApiEnabled;
-    this.productionApiEnabled = productionApiEnabled;
+    const i18nConfig = getI18nConfig();
+    const i18nConfigRuntimeUrl = i18nConfig.getRuntimeUrl();
+    const runtimeApiEnabled = !!(i18nConfigRuntimeUrl ===
+    defaultWithGTConfigProps.runtimeUrl
+      ? i18nConfig.getProjectId()
+      : i18nConfigRuntimeUrl);
+    this.developmentApiEnabled = !!(
+      runtimeApiEnabled &&
+      i18nConfig.getDevApiKey() &&
+      process.env.NODE_ENV === 'development'
+    );
+    this.productionApiEnabled = !!(runtimeApiEnabled && apiKey);
     this.dictionaryEnabled = _usingPlugin;
     this.renderSettings = renderSettingsWithDefaults;
     this._dictionaryManager = dictionaryManager;
@@ -248,6 +226,22 @@ export class I18NConfiguration extends I18nCache<TranslatedChildren> {
     timeout?: number;
   } {
     return this.renderSettings;
+  }
+
+  get projectId(): string | undefined {
+    return getI18nConfig().getProjectId();
+  }
+
+  get devApiKey(): string | undefined {
+    return getI18nConfig().getDevApiKey();
+  }
+
+  get runtimeUrl(): string | undefined {
+    return getI18nConfig().getRuntimeUrl() ?? undefined;
+  }
+
+  get translationEnabled(): boolean {
+    return getI18nConfig().getTranslationEnabled();
   }
 
   /**

--- a/packages/next/src/config-dir/__tests__/I18NConfiguration.test.ts
+++ b/packages/next/src/config-dir/__tests__/I18NConfiguration.test.ts
@@ -10,6 +10,10 @@ const mockLocaleConfig = vi.hoisted(() => ({
   defaultLocale: 'en',
   locales: ['en', 'fr'],
   customMapping: {},
+  projectId: undefined as string | undefined,
+  devApiKey: undefined as string | undefined,
+  runtimeUrl: undefined as string | undefined,
+  translationEnabled: true,
   translationRequired: true,
   dialectTranslationRequired: false,
   enableI18n: true,
@@ -20,6 +24,10 @@ vi.mock('gt-i18n/internal', () => ({
     getDefaultLocale: () => mockLocaleConfig.defaultLocale,
     getLocales: () => mockLocaleConfig.locales,
     getCustomMapping: () => mockLocaleConfig.customMapping,
+    getProjectId: () => mockLocaleConfig.projectId,
+    getDevApiKey: () => mockLocaleConfig.devApiKey,
+    getRuntimeUrl: () => mockLocaleConfig.runtimeUrl,
+    getTranslationEnabled: () => mockLocaleConfig.translationEnabled,
     requiresTranslation: () =>
       mockLocaleConfig.enableI18n && mockLocaleConfig.translationRequired,
     isSameLanguage: () => mockLocaleConfig.dialectTranslationRequired,
@@ -32,12 +40,28 @@ vi.mock('gt-i18n/internal', () => ({
     defaultLocale?: string;
     locales?: string[];
     customMapping?: Record<string, unknown>;
+    projectId?: string;
+    devApiKey?: string;
+    runtimeUrl?: string;
+    loadTranslationsType?: 'remote' | 'custom' | 'disabled';
+    cacheUrl?: string | null;
+    loadDictionaryEnabled?: boolean;
   }) => {
     mockLocaleConfig.defaultLocale =
       params.defaultLocale ?? mockLocaleConfig.defaultLocale;
     mockLocaleConfig.locales = params.locales ?? mockLocaleConfig.locales;
     mockLocaleConfig.customMapping =
       params.customMapping ?? mockLocaleConfig.customMapping;
+    mockLocaleConfig.projectId = params.projectId;
+    mockLocaleConfig.devApiKey = params.devApiKey;
+    mockLocaleConfig.runtimeUrl = params.runtimeUrl;
+    mockLocaleConfig.translationEnabled = !!(
+      params.loadTranslationsType === 'custom' ||
+      (params.loadTranslationsType === 'remote' &&
+        params.projectId &&
+        params.cacheUrl) ||
+      params.loadDictionaryEnabled
+    );
   },
   setupGTServicesEnabled: vi.fn(),
   I18nCache: class {
@@ -154,6 +178,10 @@ describe('I18NConfiguration', () => {
     mockLocaleConfig.defaultLocale = 'en';
     mockLocaleConfig.locales = ['en', 'fr'];
     mockLocaleConfig.customMapping = {};
+    mockLocaleConfig.projectId = undefined;
+    mockLocaleConfig.devApiKey = undefined;
+    mockLocaleConfig.runtimeUrl = undefined;
+    mockLocaleConfig.translationEnabled = true;
     mockLocaleConfig.translationRequired = true;
     mockLocaleConfig.dialectTranslationRequired = false;
     mockLocaleConfig.enableI18n = true;
@@ -290,6 +318,25 @@ describe('I18NConfiguration', () => {
         customMapping,
       })
     );
+  });
+
+  it('reads client runtime config from gt-i18n config accessors', () => {
+    const config = createConfig();
+
+    mockLocaleConfig.projectId = 'config-project-id';
+    mockLocaleConfig.devApiKey = 'gt-dev-config';
+    mockLocaleConfig.runtimeUrl = 'https://runtime.example.com';
+    mockLocaleConfig.translationEnabled = false;
+
+    expect(config.getClientSideConfig()).toEqual(
+      expect.objectContaining({
+        projectId: 'config-project-id',
+        devApiKey: 'gt-dev-config',
+        runtimeUrl: 'https://runtime.example.com',
+        translationEnabled: false,
+      })
+    );
+    expect(config.isTranslationEnabled()).toBe(false);
   });
 
   it('initializes locale metadata from environment-backed config params', () => {

--- a/packages/next/src/dictionary/__tests__/getDictionary.test.ts
+++ b/packages/next/src/dictionary/__tests__/getDictionary.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockUpdateDictionaries = vi.hoisted(() => vi.fn());
+const mockLoadDictionary = vi.hoisted(() => vi.fn());
+const mockLookupDictionaryObj = vi.hoisted(() => vi.fn());
+
+vi.mock('../../config-dir/getI18NConfig', () => ({
+  getI18NConfig: () => ({
+    getDefaultLocale: () => 'en',
+    updateDictionaries: mockUpdateDictionaries,
+    loadDictionary: mockLoadDictionary,
+    lookupDictionaryObj: mockLookupDictionaryObj,
+  }),
+}));
+
+describe('getDictionary', () => {
+  beforeEach(async () => {
+    mockUpdateDictionaries.mockReset();
+    mockLoadDictionary.mockReset();
+    mockLookupDictionaryObj.mockReset();
+    mockLoadDictionary.mockResolvedValue({ greeting: 'Hello' });
+    mockLookupDictionaryObj.mockReturnValue(undefined);
+
+    const { _setDictionary } = await import('../getDictionary');
+    _setDictionary({});
+    mockUpdateDictionaries.mockClear();
+  });
+
+  it('syncs set dictionaries into i18n cache', async () => {
+    const { _setDictionary } = await import('../getDictionary');
+    const dictionary = { greeting: 'Hello' };
+
+    _setDictionary(dictionary);
+
+    expect(mockUpdateDictionaries).toHaveBeenCalledWith({
+      en: dictionary,
+    });
+  });
+
+  it('reads cached dictionary entries before falling back to the singleton', async () => {
+    mockLookupDictionaryObj.mockReturnValue('Bonjour');
+    const { _setDictionary, getDictionaryEntry } =
+      await import('../getDictionary');
+
+    _setDictionary({ greeting: 'Hello' });
+
+    expect(getDictionaryEntry('greeting')).toBe('Bonjour');
+  });
+
+  it('returns dictionaries through the i18n cache', async () => {
+    const { _setDictionary, getDictionary } = await import('../getDictionary');
+    _setDictionary({ greeting: 'Hello' });
+
+    await expect(getDictionary()).resolves.toEqual({ greeting: 'Hello' });
+    expect(mockLoadDictionary).toHaveBeenCalledWith('en');
+  });
+});

--- a/packages/next/src/dictionary/getDictionary.ts
+++ b/packages/next/src/dictionary/getDictionary.ts
@@ -7,12 +7,13 @@ import { customLoadDictionaryWarning } from '../errors/createErrors';
 import { resolveDictionaryLoader } from '../resolvers/resolveDictionaryLoader';
 import { defaultWithGTConfigProps } from '../config-dir/props/defaultWithGTConfigProps';
 import { getLocaleProperties } from '@generaltranslation/format';
+import { getI18NConfig } from '../config-dir/getI18NConfig';
 
 export let internalDictionary: Dictionary | undefined = undefined;
 
 export async function getDictionary(): Promise<Dictionary | undefined> {
   // Singleton pattern
-  if (internalDictionary !== undefined) return internalDictionary;
+  if (internalDictionary !== undefined) return getCachedDictionary();
 
   // Get dictionary file type
   const dictionaryFileType =
@@ -28,7 +29,10 @@ export async function getDictionary(): Promise<Dictionary | undefined> {
   } catch {
     // No bundled dictionary module was generated.
   }
-  if (internalDictionary) return internalDictionary;
+  if (internalDictionary) {
+    syncDictionaryCache(internalDictionary);
+    return getCachedDictionary();
+  }
 
   // Second, check for custom dictionary loader
   const customLoadDictionary = resolveDictionaryLoader(); // must be user defined bc compiler reasons
@@ -65,16 +69,45 @@ export async function getDictionary(): Promise<Dictionary | undefined> {
     internalDictionary = {};
   }
 
-  return internalDictionary;
+  syncDictionaryCache(internalDictionary);
+  return getCachedDictionary();
 }
 
 export function getDictionaryEntry(
   id: string
 ): Dictionary | DictionaryEntry | undefined {
+  const cachedEntry = getCachedDictionaryEntry(id);
+  if (cachedEntry !== undefined) return cachedEntry;
   if (!internalDictionary) return undefined;
   return getEntry(internalDictionary, id);
 }
 
 export function _setDictionary(dictionary: Dictionary) {
   internalDictionary = dictionary;
+  syncDictionaryCache(dictionary);
+}
+
+function getDefaultLocale() {
+  return getI18NConfig().getDefaultLocale();
+}
+
+function syncDictionaryCache(dictionary: Dictionary) {
+  getI18NConfig().updateDictionaries({
+    [getDefaultLocale()]: dictionary,
+  });
+}
+
+async function getCachedDictionary(): Promise<Dictionary> {
+  return (await getI18NConfig().loadDictionary(
+    getDefaultLocale()
+  )) as Dictionary;
+}
+
+function getCachedDictionaryEntry(
+  id: string
+): Dictionary | DictionaryEntry | undefined {
+  return getI18NConfig().lookupDictionaryObj(getDefaultLocale(), id) as
+    | Dictionary
+    | DictionaryEntry
+    | undefined;
 }


### PR DESCRIPTION
## Summary
- Extend `packages/i18n/src/i18n-config/I18nConfig.ts` with runtime config values for project ID, dev API key, runtime URL, and translation-enabled state.
- Have `I18NConfiguration` read those values from `getI18nConfig()` instead of storing duplicate instance fields.
- Integrate `gt-next` source dictionary loading with the inherited `I18nCache` dictionary cache by seeding `updateDictionaries()` and reading entries through cache lookups.
- Keep Next-specific render settings and API/dictionary enabled flags local to `I18NConfiguration`.

## Testing
- `PATH=/opt/homebrew/bin:/usr/bin:/bin:$PATH pnpm exec vitest run packages/next/src/dictionary/__tests__/getDictionary.test.ts packages/i18n/src/i18n-config/__tests__/I18nConfig.test.ts packages/next/src/config-dir/__tests__/I18NConfiguration.test.ts packages/next/src/config-dir/__tests__/I18NConfiguration.integration.test.ts packages/next/src/server-dir/buildtime/__tests__/getTranslations.test.ts`
- `PATH=/opt/homebrew/bin:/usr/bin:/bin:$PATH pnpm exec oxfmt --check packages/next/src/dictionary/getDictionary.ts packages/next/src/dictionary/__tests__/getDictionary.test.ts packages/i18n/src/i18n-config/I18nConfig.ts packages/i18n/src/i18n-config/__tests__/I18nConfig.test.ts packages/next/src/config-dir/I18NConfiguration.ts packages/next/src/config-dir/__tests__/I18NConfiguration.test.ts`
- `PATH=/opt/homebrew/bin:/usr/bin:/bin:$PATH pnpm exec oxlint packages/next/src/dictionary/getDictionary.ts packages/next/src/dictionary/__tests__/getDictionary.test.ts packages/i18n/src/i18n-config/I18nConfig.ts packages/next/src/config-dir/I18NConfiguration.ts`
