### PR TITLE
refactor: add next async condition store

### DIFF
--- a/packages/next/src/__tests__/rscComponentWrappers.test.tsx
+++ b/packages/next/src/__tests__/rscComponentWrappers.test.tsx
@@ -1,72 +1,79 @@
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { mockComponents, mockGetRequestConditions } = vi.hoisted(() => ({
+const {
+  mockComponents,
+  mockGetEnableI18n,
+  mockGetLocale,
+  mockSetReadonlyConditionStore,
+} = vi.hoisted(() => ({
   mockComponents: {
-    Branch: vi.fn(),
-    Currency: vi.fn(),
-    DateTime: vi.fn(),
-    Num: vi.fn(),
-    Plural: vi.fn(),
-    RelativeTime: vi.fn(),
-    Var: vi.fn(),
+    RscBranch: vi.fn((props) => React.createElement('div', props)),
+    RscCurrency: vi.fn((props) => React.createElement('div', props)),
+    RscDateTime: vi.fn((props) => React.createElement('div', props)),
+    RscNum: vi.fn((props) => React.createElement('div', props)),
+    RscPlural: vi.fn((props) => React.createElement('div', props)),
+    RscRelativeTime: vi.fn((props) => React.createElement('div', props)),
+    RscVar: vi.fn((props) => React.createElement('div', props)),
   },
-  mockGetRequestConditions: vi.fn(),
+  mockGetEnableI18n: vi.fn(),
+  mockGetLocale: vi.fn(),
+  mockSetReadonlyConditionStore: vi.fn(),
 }));
 
-vi.mock('../request/getRequestConditions', () => ({
-  getRequestConditions: mockGetRequestConditions,
+vi.mock('../request/getEnableI18n', () => ({
+  getEnableI18n: mockGetEnableI18n,
 }));
 
-vi.mock('gt-react/context', () => mockComponents);
+vi.mock('../request/getLocale', () => ({
+  getLocale: mockGetLocale,
+}));
+
+vi.mock('gt-react/context', () => ({
+  ...mockComponents,
+  setReadonlyConditionStore: mockSetReadonlyConditionStore,
+}));
 
 describe('rsc component wrappers', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGetRequestConditions.mockResolvedValue({
-      _locale: 'fr',
-      _enableI18n: false,
-    });
+    mockGetEnableI18n.mockResolvedValue(false);
+    mockGetLocale.mockResolvedValue('fr');
   });
 
   it.each([
-    ['Branch', () => import('../branches/Branch'), mockComponents.Branch],
+    ['Branch', () => import('../branches/Branch'), mockComponents.RscBranch],
     [
       'Currency',
       () => import('../variables/Currency'),
-      mockComponents.Currency,
+      mockComponents.RscCurrency,
     ],
     [
       'DateTime',
       () => import('../variables/DateTime'),
-      mockComponents.DateTime,
+      mockComponents.RscDateTime,
     ],
-    ['Num', () => import('../variables/Num'), mockComponents.Num],
-    ['Plural', () => import('../branches/Plural'), mockComponents.Plural],
+    ['Num', () => import('../variables/Num'), mockComponents.RscNum],
+    ['Plural', () => import('../branches/Plural'), mockComponents.RscPlural],
     [
       'RelativeTime',
       () => import('../variables/RelativeTime'),
-      mockComponents.RelativeTime,
+      mockComponents.RscRelativeTime,
     ],
-    ['Var', () => import('../variables/Var'), mockComponents.Var],
+    ['Var', () => import('../variables/Var'), mockComponents.RscVar],
   ])(
-    '%s passes request conditions to gt-react/context',
+    '%s renders through gt-react/context RSC implementation',
     async (componentName, loadComponent, coreComponent) => {
       const module = await loadComponent();
       const component = module[componentName];
 
       const element = await component({ children: 'value' });
 
-      expect(mockGetRequestConditions).toHaveBeenCalled();
+      expect(mockGetLocale).toHaveBeenCalled();
+      expect(mockGetEnableI18n).toHaveBeenCalled();
+      expect(coreComponent).toHaveBeenCalledWith({ children: 'value' });
       expect(React.isValidElement(element)).toBe(true);
-      expect(element).toMatchObject({
-        type: coreComponent,
-        props: {
-          children: 'value',
-          _locale: 'fr',
-          _enableI18n: false,
-        },
-      });
+      expect(element.props).toMatchObject({ children: 'value' });
     }
   );
 });

--- a/packages/next/src/branches/Branch.tsx
+++ b/packages/next/src/branches/Branch.tsx
@@ -1,12 +1,11 @@
-import { Branch as CoreBranch } from 'gt-react/context';
-import { getRequestConditions } from '../request/getRequestConditions';
+import { RscBranch } from 'gt-react/context';
+import { withRequestConditions } from '../request/asyncConditionStore';
 import type { ReactNode } from 'react';
 
-type BranchProps = Parameters<typeof CoreBranch>[0];
+type BranchProps = Parameters<typeof RscBranch>[0];
 
 export async function Branch(props: BranchProps): Promise<ReactNode> {
-  const conditions = await getRequestConditions();
-  return <CoreBranch {...props} {...conditions} />;
+  return withRequestConditions(() => RscBranch(props));
 }
 
 /** @internal _gtt - The GT transformation for the component. */

--- a/packages/next/src/branches/Plural.tsx
+++ b/packages/next/src/branches/Plural.tsx
@@ -1,12 +1,11 @@
-import { Plural as CorePlural } from 'gt-react/context';
-import { getRequestConditions } from '../request/getRequestConditions';
+import { RscPlural } from 'gt-react/context';
+import { withRequestConditions } from '../request/asyncConditionStore';
 import type { ReactNode } from 'react';
 
-type PluralProps = Parameters<typeof CorePlural>[0];
+type PluralProps = Parameters<typeof RscPlural>[0];
 
 export async function Plural(props: PluralProps): Promise<ReactNode> {
-  const conditions = await getRequestConditions();
-  return <CorePlural {...props} {...conditions} />;
+  return withRequestConditions(() => RscPlural(props));
 }
 
 /** @internal _gtt - The GT transformation for the component. */

--- a/packages/next/src/config-dir/I18NConfiguration.ts
+++ b/packages/next/src/config-dir/I18NConfiguration.ts
@@ -21,6 +21,7 @@ import { defaultLocaleHeaderName } from '../utils/headers';
 import {
   getI18nConfig,
   I18nCache,
+  setI18nCache,
   setupGTServicesEnabled,
 } from 'gt-i18n/internal';
 import type {
@@ -217,6 +218,7 @@ export class I18NConfiguration {
           })) || {},
       }),
     });
+    setI18nCache(this._i18nCache);
     this._dictionaryManager = dictionaryManager;
     // Headers and cookies
     this.localeHeaderName =

--- a/packages/next/src/config-dir/__tests__/I18NConfiguration.test.ts
+++ b/packages/next/src/config-dir/__tests__/I18NConfiguration.test.ts
@@ -39,6 +39,7 @@ vi.mock('gt-i18n/internal', () => ({
     mockLocaleConfig.customMapping =
       params.customMapping ?? mockLocaleConfig.customMapping;
   },
+  setI18nCache: vi.fn(),
   setupGTServicesEnabled: vi.fn(),
   I18nCache: class {
     constructor(params: {

--- a/packages/next/src/request/__tests__/asyncConditionStore.test.ts
+++ b/packages/next/src/request/__tests__/asyncConditionStore.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const { mockGetEnableI18n, mockGetLocale, mockSetReadonlyConditionStore } =
+  vi.hoisted(() => ({
+    mockGetEnableI18n: vi.fn(),
+    mockGetLocale: vi.fn(),
+    mockSetReadonlyConditionStore: vi.fn(),
+  }));
+
+vi.mock('../getEnableI18n', () => ({
+  getEnableI18n: mockGetEnableI18n,
+}));
+
+vi.mock('../getLocale', () => ({
+  getLocale: mockGetLocale,
+}));
+
+vi.mock('gt-react/context', () => ({
+  setReadonlyConditionStore: mockSetReadonlyConditionStore,
+}));
+
+describe('withRequestConditions', () => {
+  it('exposes async request conditions through a sync condition store', async () => {
+    mockGetLocale.mockResolvedValue('fr');
+    mockGetEnableI18n.mockResolvedValue(false);
+
+    const { withRequestConditions } = await import('../asyncConditionStore');
+    const result = await withRequestConditions((conditions) => {
+      const conditionStore = mockSetReadonlyConditionStore.mock.calls[0][0];
+
+      return {
+        conditions,
+        enableI18n: conditionStore.getEnableI18n(),
+        locale: conditionStore.getLocale(),
+      };
+    });
+
+    expect(result).toEqual({
+      conditions: { locale: 'fr', enableI18n: false },
+      enableI18n: false,
+      locale: 'fr',
+    });
+  });
+});

--- a/packages/next/src/request/asyncConditionStore.ts
+++ b/packages/next/src/request/asyncConditionStore.ts
@@ -1,0 +1,64 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { setReadonlyConditionStore } from 'gt-react/context';
+import type { ReadonlyConditionStoreInterface } from 'gt-i18n/internal/types';
+import { getEnableI18n } from './getEnableI18n';
+import { getLocale } from './getLocale';
+
+export type RequestConditions = {
+  locale: string;
+  enableI18n: boolean;
+};
+
+class NextAsyncConditionStore implements ReadonlyConditionStoreInterface {
+  private readonly store = new AsyncLocalStorage<RequestConditions>();
+
+  async run<T>(
+    callback: (conditions: RequestConditions) => T | Promise<T>
+  ): Promise<T> {
+    const conditions = await getRequestConditionValues();
+    return this.store.run(conditions, () => callback(conditions));
+  }
+
+  getLocale = (): string => {
+    return this.getStore().locale;
+  };
+
+  getEnableI18n = (): boolean => {
+    return this.getStore().enableI18n;
+  };
+
+  setLocale = (_locale: string): void => {};
+
+  setEnableI18n = (_enabled: boolean): void => {};
+
+  private getStore(): RequestConditions {
+    const store = this.store.getStore();
+    if (!store) {
+      throw new Error(
+        'NextAsyncConditionStore: request conditions are unavailable outside a gt-next request scope.'
+      );
+    }
+    return store;
+  }
+}
+
+const nextAsyncConditionStore = new NextAsyncConditionStore();
+let isNextConditionStoreRegistered = false;
+
+export async function getRequestConditionValues(): Promise<RequestConditions> {
+  const [locale, enableI18n] = await Promise.all([
+    getLocale(),
+    getEnableI18n(),
+  ]);
+  return { locale, enableI18n };
+}
+
+export async function withRequestConditions<T>(
+  callback: (conditions: RequestConditions) => T | Promise<T>
+): Promise<T> {
+  if (!isNextConditionStoreRegistered) {
+    setReadonlyConditionStore(nextAsyncConditionStore);
+    isNextConditionStoreRegistered = true;
+  }
+  return nextAsyncConditionStore.run(callback);
+}

--- a/packages/next/src/request/getRequestConditions.ts
+++ b/packages/next/src/request/getRequestConditions.ts
@@ -1,11 +1,7 @@
-import { getEnableI18n } from './getEnableI18n';
-import { getLocale } from './getLocale';
+import { getRequestConditionValues } from './asyncConditionStore';
 
 export async function getRequestConditions() {
-  const [locale, enableI18n] = await Promise.all([
-    getLocale(),
-    getEnableI18n(),
-  ]);
+  const { locale, enableI18n } = await getRequestConditionValues();
   return {
     _locale: locale,
     _enableI18n: enableI18n,

--- a/packages/next/src/server-dir/buildtime/T.tsx
+++ b/packages/next/src/server-dir/buildtime/T.tsx
@@ -1,6 +1,6 @@
-import { getRequestConditions } from '../../request/getRequestConditions';
 import { RscT } from 'gt-react/context';
 import type { ReactNode } from 'react';
+import { withRequestConditions } from '../../request/asyncConditionStore';
 
 type TProps = {
   children: ReactNode;
@@ -17,9 +17,9 @@ type TProps = {
  * Build-time translation component that renders its children in the user's given locale.
  */
 export async function T(props: TProps): Promise<ReactNode> {
-  const { _locale: locale, _enableI18n: enableI18n } =
-    await getRequestConditions();
-  return RscT({ ...props, locale, enableI18n });
+  return withRequestConditions(({ locale, enableI18n }) =>
+    RscT({ ...props, locale, enableI18n })
+  );
 }
 
 /** @internal _gtt - The GT transformation for the component. */

--- a/packages/next/src/server-dir/buildtime/__tests__/T.test.tsx
+++ b/packages/next/src/server-dir/buildtime/__tests__/T.test.tsx
@@ -1,24 +1,34 @@
 import { describe, expect, it, vi } from 'vitest';
 
-const { mockGetRequestConditions, mockRscT } = vi.hoisted(() => ({
-  mockGetRequestConditions: vi.fn(),
+const {
+  mockGetEnableI18n,
+  mockGetLocale,
+  mockRscT,
+  mockSetReadonlyConditionStore,
+} = vi.hoisted(() => ({
+  mockGetEnableI18n: vi.fn(),
+  mockGetLocale: vi.fn(),
   mockRscT: vi.fn(),
+  mockSetReadonlyConditionStore: vi.fn(),
 }));
 
-vi.mock('../../../request/getRequestConditions', () => ({
-  getRequestConditions: mockGetRequestConditions,
+vi.mock('../../../request/getEnableI18n', () => ({
+  getEnableI18n: mockGetEnableI18n,
+}));
+
+vi.mock('../../../request/getLocale', () => ({
+  getLocale: mockGetLocale,
 }));
 
 vi.mock('gt-react/context', () => ({
   RscT: mockRscT,
+  setReadonlyConditionStore: mockSetReadonlyConditionStore,
 }));
 
 describe('buildtime T', () => {
-  it('passes request conditions to RscT', async () => {
-    mockGetRequestConditions.mockResolvedValue({
-      _locale: 'fr',
-      _enableI18n: false,
-    });
+  it('renders RscT in a request condition scope', async () => {
+    mockGetLocale.mockResolvedValue('fr');
+    mockGetEnableI18n.mockResolvedValue(false);
     mockRscT.mockResolvedValue('Bonjour');
 
     const { T } = await import('../T');
@@ -26,7 +36,9 @@ describe('buildtime T', () => {
       'Bonjour'
     );
 
-    expect(mockGetRequestConditions).toHaveBeenCalled();
+    expect(mockGetLocale).toHaveBeenCalled();
+    expect(mockGetEnableI18n).toHaveBeenCalled();
+    expect(mockSetReadonlyConditionStore).toHaveBeenCalled();
     expect(mockRscT).toHaveBeenCalledWith({
       children: 'Hello',
       id: 'greeting',

--- a/packages/next/src/variables/Currency.tsx
+++ b/packages/next/src/variables/Currency.tsx
@@ -1,12 +1,11 @@
-import { Currency as CoreCurrency } from 'gt-react/context';
-import { getRequestConditions } from '../request/getRequestConditions';
+import { RscCurrency } from 'gt-react/context';
+import { withRequestConditions } from '../request/asyncConditionStore';
 import type { ReactNode } from 'react';
 
-type CurrencyProps = Parameters<typeof CoreCurrency>[0];
+type CurrencyProps = Parameters<typeof RscCurrency>[0];
 
 export async function Currency(props: CurrencyProps): Promise<ReactNode> {
-  const conditions = await getRequestConditions();
-  return <CoreCurrency {...props} {...conditions} />;
+  return withRequestConditions(() => RscCurrency(props));
 }
 
 /** @internal _gtt - The GT transformation for the component. */

--- a/packages/next/src/variables/DateTime.tsx
+++ b/packages/next/src/variables/DateTime.tsx
@@ -1,12 +1,11 @@
-import { DateTime as CoreDateTime } from 'gt-react/context';
-import { getRequestConditions } from '../request/getRequestConditions';
+import { RscDateTime } from 'gt-react/context';
+import { withRequestConditions } from '../request/asyncConditionStore';
 import type { ReactNode } from 'react';
 
-type DateTimeProps = Parameters<typeof CoreDateTime>[0];
+type DateTimeProps = Parameters<typeof RscDateTime>[0];
 
 export async function DateTime(props: DateTimeProps): Promise<ReactNode> {
-  const conditions = await getRequestConditions();
-  return <CoreDateTime {...props} {...conditions} />;
+  return withRequestConditions(() => RscDateTime(props));
 }
 
 /** @internal _gtt - The GT transformation for the component. */

--- a/packages/next/src/variables/Num.tsx
+++ b/packages/next/src/variables/Num.tsx
@@ -1,12 +1,11 @@
-import { Num as CoreNum } from 'gt-react/context';
-import { getRequestConditions } from '../request/getRequestConditions';
+import { RscNum } from 'gt-react/context';
+import { withRequestConditions } from '../request/asyncConditionStore';
 import type { ReactNode } from 'react';
 
-type NumProps = Parameters<typeof CoreNum>[0];
+type NumProps = Parameters<typeof RscNum>[0];
 
 export async function Num(props: NumProps): Promise<ReactNode> {
-  const conditions = await getRequestConditions();
-  return <CoreNum {...props} {...conditions} />;
+  return withRequestConditions(() => RscNum(props));
 }
 
 /** @internal _gtt - The GT transformation for the component. */

--- a/packages/next/src/variables/RelativeTime.tsx
+++ b/packages/next/src/variables/RelativeTime.tsx
@@ -1,14 +1,13 @@
-import { RelativeTime as CoreRelativeTime } from 'gt-react/context';
-import { getRequestConditions } from '../request/getRequestConditions';
+import { RscRelativeTime } from 'gt-react/context';
+import { withRequestConditions } from '../request/asyncConditionStore';
 import type { ReactNode } from 'react';
 
-type RelativeTimeProps = Parameters<typeof CoreRelativeTime>[0];
+type RelativeTimeProps = Parameters<typeof RscRelativeTime>[0];
 
 export async function RelativeTime(
   props: RelativeTimeProps
 ): Promise<ReactNode> {
-  const conditions = await getRequestConditions();
-  return <CoreRelativeTime {...props} {...conditions} />;
+  return withRequestConditions(() => RscRelativeTime(props));
 }
 
 /** @internal _gtt - The GT transformation for the component. */

--- a/packages/next/src/variables/Var.tsx
+++ b/packages/next/src/variables/Var.tsx
@@ -1,12 +1,11 @@
-import { Var as CoreVar } from 'gt-react/context';
-import { getRequestConditions } from '../request/getRequestConditions';
+import { RscVar } from 'gt-react/context';
+import { withRequestConditions } from '../request/asyncConditionStore';
 import type { ReactNode } from 'react';
 
-type VarProps = Parameters<typeof CoreVar>[0];
+type VarProps = Parameters<typeof RscVar>[0];
 
 export async function Var(props: VarProps): Promise<ReactNode> {
-  const conditions = await getRequestConditions();
-  return <CoreVar {...props} {...conditions} />;
+  return withRequestConditions(() => RscVar(props));
 }
 
 /** @internal _gtt - The GT transformation for the component. */

--- a/packages/react/src/context.client.ts
+++ b/packages/react/src/context.client.ts
@@ -78,6 +78,7 @@ export {
   getTranslationsSnapshot,
   getReactI18nCache,
   setReactI18nCache,
+  setReadonlyConditionStore,
   t,
   // ===== Setup ===== //
   internalInitializeGTSRA as initializeGT,

--- a/packages/react/src/context.server.ts
+++ b/packages/react/src/context.server.ts
@@ -57,6 +57,7 @@ export {
   getTranslationsSnapshot,
   getReactI18nCache,
   setReactI18nCache,
+  setReadonlyConditionStore,
   t,
   // ===== Setup ===== //
   internalInitializeGTSRA as initializeGT,

--- a/packages/react/src/context.types.ts
+++ b/packages/react/src/context.types.ts
@@ -70,4 +70,5 @@ export {
   internalInitializeGTSRA as initializeGT,
   getReactI18nCache,
   setReactI18nCache,
+  setReadonlyConditionStore,
 } from '@generaltranslation/react-core/context';


### PR DESCRIPTION
## Summary
- add a gt-next async condition store that resolves request locale/i18n state and exposes it through the shared sync condition-store contract
- route gt-next RSC wrappers through gt-react/context Rsc* implementations
- register gt-next's I18nCache with the shared gt-i18n cache singleton for moved RSC implementations

## Tests
- pnpm --filter gt-next typecheck
- pnpm --filter gt-next test:js
- pnpm --filter gt-next build:no-swc-plugin
- pnpm lint

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1571"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783565182&installation_id=127936663&pr_number=1571&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1571&signature=e3cd260a147ece9197b9050bd0329066c6170079032584f7c1717e18a93e4a1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a `NextAsyncConditionStore` backed by `AsyncLocalStorage` that resolves the per-request locale and `enableI18n` flag once and exposes them through the shared `ReadonlyConditionStoreInterface` contract. RSC component wrappers in `gt-next` are rerouted to call their `gt-react/context` `Rsc*` counterparts inside `withRequestConditions`, and `I18NConfiguration` now registers its `I18nCache` with the shared `gt-i18n` singleton.

- **`asyncConditionStore.ts`** — new module; registers `NextAsyncConditionStore` as the `ReadonlyConditionStore` singleton on first use and wraps each RSC render in an `AsyncLocalStorage` context populated by `getLocale()` + `getEnableI18n()`.
- **RSC wrappers** (`Branch`, `Plural`, `Currency`, `DateTime`, `Num`, `RelativeTime`, `Var`, `T`) — switched from direct prop-spreading of `_locale`/`_enableI18n` to delegating through `withRequestConditions`, letting `Rsc*` components read from the store internally.
- **`gt-react` context exports** — `setReadonlyConditionStore` added to `context.server.ts`, `context.client.ts`, and `context.types.ts` to surface the registration API.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the async condition store wiring is correct and the existing test suite covers the key registration and data-flow paths.

The core AsyncLocalStorage pattern is correctly implemented and the singleton registration is properly guarded. The only notable issue is that NextAsyncConditionStore.run unconditionally calls getLocale() + getEnableI18n() on every invocation, so nested RSC components (e.g. a T wrapping a Currency) each pay a redundant fetch cost rather than reusing the already-active context.

packages/next/src/request/asyncConditionStore.ts — the run method's unconditional getRequestConditionValues() call is worth revisiting for nested renders.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/next/src/request/asyncConditionStore.ts | New file: implements NextAsyncConditionStore using AsyncLocalStorage, correctly wires getLocale/getEnableI18n into the shared condition-store singleton; redundant condition fetches possible on nested RSC renders |
| packages/next/src/server-dir/buildtime/T.tsx | Routes through withRequestConditions, passes locale/enableI18n explicitly to RscT (correct, as RscT accepts them as props) |
| packages/next/src/config-dir/I18NConfiguration.ts | Registers the gt-next I18nCache with the shared gt-i18n singleton via setI18nCache at construction time |
| packages/react/src/context.server.ts | Adds setReadonlyConditionStore to the server context re-exports from react-core |
| packages/next/src/request/getRequestConditions.ts | Refactored to delegate to getRequestConditionValues; no longer called by any internal wrapper — effectively dead code within the package unless exported publicly |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant RSC as Next.js RSC render
    participant W as withRequestConditions
    participant ALS as AsyncLocalStorage
    participant GL as getLocale / getEnableI18n
    participant CS as NextAsyncConditionStore singleton
    participant Rsc as RscT / RscBranch / RscCurrency

    RSC->>W: call withRequestConditions(callback)
    W->>CS: setReadonlyConditionStore (once, lazy)
    W->>CS: run(callback)
    CS->>GL: getLocale() + getEnableI18n()
    GL-->>CS: "{ locale, enableI18n }"
    CS->>ALS: AsyncLocalStorage.run(conditions, callback)
    ALS->>Rsc: callback(conditions)
    Rsc->>CS: useLocale() / useEnableI18n()
    CS->>ALS: getStore()
    ALS-->>CS: "{ locale, enableI18n }"
    CS-->>Rsc: locale / enableI18n
    Rsc-->>RSC: rendered ReactNode
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fnext%2Fsrc%2Frequest%2FasyncConditionStore.ts%3A15-20%0A**Redundant%20%60getRequestConditionValues%28%29%60%20calls%20in%20nested%20RSC%20renders**%0A%0AWhen%20RSC%20components%20nest%20%28e.g.%20%60%3CT%3E%60%20containing%20%60%3CCurrency%3E%60%29%2C%20each%20wrapper%20calls%20%60withRequestConditions%60%2C%20which%20calls%20%60nextAsyncConditionStore.run%28callback%29%60.%20Because%20%60run%60%20unconditionally%20awaits%20%60getRequestConditionValues%28%29%60%20before%20entering%20the%20%60AsyncLocalStorage%60%20context%2C%20every%20level%20of%20nesting%20triggers%20a%20fresh%20%60getLocale%28%29%60%20%2B%20%60getEnableI18n%28%29%60%20round-trip%20%E2%80%94%20even%20though%20the%20values%20are%20already%20available%20in%20the%20surrounding%20context.%20Checking%20%60this.store.getStore%28%29%60%20first%20would%20skip%20re-fetching%20when%20a%20context%20is%20already%20active.%0A%0A&repo=generaltranslation%2Fgt&pr=1571&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fodysseus%2Fnext-async-condition-store%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fodysseus%2Fnext-async-condition-store%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fnext%2Fsrc%2Frequest%2FasyncConditionStore.ts%3A15-20%0A**Redundant%20%60getRequestConditionValues%28%29%60%20calls%20in%20nested%20RSC%20renders**%0A%0AWhen%20RSC%20components%20nest%20%28e.g.%20%60%3CT%3E%60%20containing%20%60%3CCurrency%3E%60%29%2C%20each%20wrapper%20calls%20%60withRequestConditions%60%2C%20which%20calls%20%60nextAsyncConditionStore.run%28callback%29%60.%20Because%20%60run%60%20unconditionally%20awaits%20%60getRequestConditionValues%28%29%60%20before%20entering%20the%20%60AsyncLocalStorage%60%20context%2C%20every%20level%20of%20nesting%20triggers%20a%20fresh%20%60getLocale%28%29%60%20%2B%20%60getEnableI18n%28%29%60%20round-trip%20%E2%80%94%20even%20though%20the%20values%20are%20already%20available%20in%20the%20surrounding%20context.%20Checking%20%60this.store.getStore%28%29%60%20first%20would%20skip%20re-fetching%20when%20a%20context%20is%20already%20active.%0A%0A&repo=generaltranslation%2Fgt&pr=1571&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/next/src/request/asyncConditionStore.ts:15-20
**Redundant `getRequestConditionValues()` calls in nested RSC renders**

When RSC components nest (e.g. `<T>` containing `<Currency>`), each wrapper calls `withRequestConditions`, which calls `nextAsyncConditionStore.run(callback)`. Because `run` unconditionally awaits `getRequestConditionValues()` before entering the `AsyncLocalStorage` context, every level of nesting triggers a fresh `getLocale()` + `getEnableI18n()` round-trip — even though the values are already available in the surrounding context. Checking `this.store.getStore()` first would skip re-fetching when a context is already active.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: add next async condition store"](https://github.com/generaltranslation/gt/commit/e381af9f7e1423aa47f48c1e3d09fc1e27f22c55) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36365425)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->