### PR TITLE
feat(3): resolve gt-react/context to an RSC-safe implementation under react-server

### DIFF
--- a/packages/next/src/server-dir/buildtime/T.tsx
+++ b/packages/next/src/server-dir/buildtime/T.tsx
@@ -1,5 +1,5 @@
 import { getRequestConditions } from '../../request/getRequestConditions';
-import { RscT } from 'gt-react/context';
+import { T as RscT } from 'gt-react/context';
 import type { ReactNode } from 'react';
 
 type TProps = {
@@ -17,9 +17,8 @@ type TProps = {
  * Build-time translation component that renders its children in the user's given locale.
  */
 export async function T(props: TProps): Promise<ReactNode> {
-  const { _locale: locale, _enableI18n: enableI18n } =
-    await getRequestConditions();
-  return RscT({ ...props, locale, enableI18n });
+  const conditions = await getRequestConditions();
+  return RscT({ ...props, ...conditions });
 }
 
 /** @internal _gtt - The GT transformation for the component. */

--- a/packages/next/src/server-dir/buildtime/__tests__/T.test.tsx
+++ b/packages/next/src/server-dir/buildtime/__tests__/T.test.tsx
@@ -10,7 +10,7 @@ vi.mock('../../../request/getRequestConditions', () => ({
 }));
 
 vi.mock('gt-react/context', () => ({
-  RscT: mockRscT,
+  T: mockRscT,
 }));
 
 describe('buildtime T', () => {
@@ -30,8 +30,8 @@ describe('buildtime T', () => {
     expect(mockRscT).toHaveBeenCalledWith({
       children: 'Hello',
       id: 'greeting',
-      locale: 'fr',
-      enableI18n: false,
+      _locale: 'fr',
+      _enableI18n: false,
     });
     expect(T._gtt).toBe('translate-server');
   });

--- a/packages/react-core/src/components/translation/T.tsx
+++ b/packages/react-core/src/components/translation/T.tsx
@@ -9,37 +9,38 @@ import {
   type JsxTranslationOptions,
 } from '../../utils/translation/prepareT';
 
+type TProps = {
+  children: ReactNode;
+  _locale?: string;
+  _enableI18n?: boolean;
+} & JsxTranslationOptions;
+
+type ResolvedTProps = TProps & {
+  _locale: string;
+  _enableI18n: boolean;
+};
+
 // ===== Component ===== //
 
 /**
  * External-store version of the `<T>` component.
  */
-function T(
-  props: {
-    children: ReactNode;
-  } & JsxTranslationOptions
-): ReactNode {
+function T(props: TProps): ReactNode {
   return useComputeT(props);
 }
 
-function GtInternalTranslateJsx(
-  props: {
-    children: ReactNode;
-  } & JsxTranslationOptions
-): ReactNode {
+function GtInternalTranslateJsx(props: TProps): ReactNode {
   return useComputeT(props);
 }
 
 async function RscT({
   children: sourceChildren,
-  locale,
-  enableI18n,
+  _locale,
+  _enableI18n,
   ...params
-}: {
-  children: ReactNode;
-  locale: string;
-  enableI18n: boolean;
-} & JsxTranslationOptions): Promise<ReactNode> {
+}: ResolvedTProps): Promise<ReactNode> {
+  const locale = _locale;
+  const enableI18n = _enableI18n;
   const defaultLocale = getI18nConfig().getDefaultLocale();
   const shouldTranslate =
     enableI18n && getI18nConfig().requiresTranslation(locale);
@@ -83,16 +84,17 @@ GtInternalTranslateJsx._gtt = 'translate-client-automatic';
 RscT._gtt = 'translate-server';
 
 export { GtInternalTranslateJsx, RscT, T };
+export type { ResolvedTProps, TProps };
 
 /**
  * Render logic
  */
 function useComputeT({
   children: sourceChildren,
+  _locale,
+  _enableI18n,
   ...params
-}: {
-  children: ReactNode;
-} & JsxTranslationOptions): ReactNode {
+}: TProps): ReactNode {
   // Prepare our source children for rendering
   const {
     defaultLocale,
@@ -105,6 +107,8 @@ function useComputeT({
   } = usePrepareT({
     sourceChildren,
     params,
+    _locale,
+    _enableI18n,
   });
 
   // Lookup translation in cache

--- a/packages/react-core/src/components/translation/__tests__/T.test.tsx
+++ b/packages/react-core/src/components/translation/__tests__/T.test.tsx
@@ -27,7 +27,7 @@ describe('RscT', () => {
     getLookupTranslation.mockResolvedValue(lookupTranslation);
 
     await expect(
-      RscT({ children: 'Hello', locale: 'fr', enableI18n: true })
+      RscT({ children: 'Hello', _locale: 'fr', _enableI18n: true })
     ).resolves.toBe('Bonjour');
 
     expect(getLookupTranslation).toHaveBeenCalledWith('fr');
@@ -42,7 +42,7 @@ describe('RscT', () => {
 
   it('renders source without loading translations for the default locale', async () => {
     await expect(
-      RscT({ children: 'Hello', locale: 'en', enableI18n: true })
+      RscT({ children: 'Hello', _locale: 'en', _enableI18n: true })
     ).resolves.toBe('Hello');
 
     expect(getLookupTranslation).not.toHaveBeenCalled();
@@ -50,7 +50,7 @@ describe('RscT', () => {
 
   it('renders source without loading translations when i18n is disabled', async () => {
     await expect(
-      RscT({ children: 'Hello', locale: 'fr', enableI18n: false })
+      RscT({ children: 'Hello', _locale: 'fr', _enableI18n: false })
     ).resolves.toBe('Hello');
 
     expect(getLookupTranslation).not.toHaveBeenCalled();

--- a/packages/react-core/src/utils/translation/prepareT.ts
+++ b/packages/react-core/src/utils/translation/prepareT.ts
@@ -3,7 +3,7 @@ import addGTIdentifier from '../internal/addGTIdentifier';
 import { removeInjectedT } from '../internal/removeInjectedT';
 import writeChildrenAsObjects from '../internal/writeChildrenAsObjects';
 import { useEnableI18n, useLocale } from '../../hooks/condition-store';
-import { useShouldTranslate } from '../../hooks/utils';
+import { getI18nConfig } from 'gt-i18n/internal';
 import type { JsxTranslationOptions as JsxTranslationOptionsWithSugar } from 'gt-i18n/types';
 import type { JsxChildren } from 'generaltranslation/types';
 import type { ReactNode } from 'react';
@@ -29,19 +29,26 @@ type PreparedT = {
 function usePrepareT({
   sourceChildren,
   params,
+  _locale,
+  _enableI18n,
 }: {
   sourceChildren: ReactNode;
   params: JsxTranslationOptions;
+  _locale?: string;
+  _enableI18n?: boolean;
 }): PreparedT & {
   defaultLocale: string;
   locale: string;
   enableI18n: boolean;
   shouldTranslate: boolean;
 } {
-  const locale = useLocale();
-  const enableI18n = useEnableI18n();
+  const contextLocale = useLocale();
+  const contextEnableI18n = useEnableI18n();
   const defaultLocale = useDefaultLocale();
-  const shouldTranslate = useShouldTranslate();
+  const locale = _locale ?? contextLocale;
+  const enableI18n = _enableI18n ?? contextEnableI18n;
+  const shouldTranslate =
+    enableI18n && getI18nConfig().requiresTranslation(locale);
   const prepared = useMemo(
     () =>
       prepareT({

--- a/packages/react/src/__tests__/context-rsc.test.ts
+++ b/packages/react/src/__tests__/context-rsc.test.ts
@@ -18,8 +18,8 @@ describe('gt-react/context react-server surface', () => {
     expect(mod.Num).toBeTypeOf('function');
     expect(mod.Plural).toBeTypeOf('function');
     expect(mod.RelativeTime).toBeTypeOf('function');
-    expect(mod.RscT).toBeTypeOf('function');
-    expect(mod.T).toBe(mod.RscT);
+    expect(mod.RscT).toBeUndefined();
+    expect(mod.T).toBeTypeOf('function');
     expect(mod.Var).toBeTypeOf('function');
     expect(mod.getFormatLocales).toBeTypeOf('function');
     expect(mod.getPluralBranch).toBeTypeOf('function');

--- a/packages/react/src/components/LocaleSelector.tsx
+++ b/packages/react/src/components/LocaleSelector.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type React from 'react';
 import { InternalLocaleSelector } from '@generaltranslation/react-core/context';
 import { CustomMapping } from 'generaltranslation/types';
 import { useLocaleSelector } from './useLocaleSelector';
@@ -13,12 +13,7 @@ import { useLocaleSelector } from './useLocaleSelector';
 export function LocaleSelector({
   locales: _locales,
   ...props
-}: {
-  locales?: string[];
-  customNames?: { [key: string]: string };
-  customMapping?: CustomMapping;
-  [key: string]: any;
-}): React.JSX.Element | null {
+}: LocaleSelectorProps): React.JSX.Element | null {
   // Get locale selector properties
   const { locale, locales, getLocaleProperties, setLocale } =
     useLocaleSelector(_locales);
@@ -33,3 +28,10 @@ export function LocaleSelector({
     />
   );
 }
+
+export type LocaleSelectorProps = {
+  locales?: string[];
+  customNames?: { [key: string]: string };
+  customMapping?: CustomMapping;
+  [key: string]: any;
+};

--- a/packages/react/src/context.client.ts
+++ b/packages/react/src/context.client.ts
@@ -1,7 +1,5 @@
 'use client';
 
-import type { RscT as CoreRscT } from '@generaltranslation/react-core/context';
-
 export { initializeGTSPA } from './setup/initializeGTSPA';
 export { useLocaleSelector } from './components/useLocaleSelector';
 export { useSetLocale, useSetEnableI18n } from './hooks/conditions-store';
@@ -10,13 +8,6 @@ export {
   defaultLocaleCookieName,
   defaultRegionCookieName,
 } from './cookie-names';
-
-export const RscT: typeof CoreRscT = Object.assign(
-  () => {
-    throw new Error('gt-react: RscT cannot be used in a client environment.');
-  },
-  { _gtt: 'translate-server' as const }
-);
 
 // ===== Components ===== //
 export { LocaleSelector } from './components/LocaleSelector';

--- a/packages/react/src/context.rsc.ts
+++ b/packages/react/src/context.rsc.ts
@@ -18,7 +18,6 @@ export {
   Num,
   Plural,
   RelativeTime,
-  RscT,
   T,
   Var,
 } from '@generaltranslation/react-core/components-rsc';

--- a/packages/react/src/context.server.ts
+++ b/packages/react/src/context.server.ts
@@ -23,7 +23,6 @@ export {
   Plural,
   Derive,
   GtInternalTranslateJsx,
-  RscT,
   T,
   Currency,
   DateTime,

--- a/packages/react/src/context.types.ts
+++ b/packages/react/src/context.types.ts
@@ -28,7 +28,6 @@ export {
   Plural,
   Derive,
   GtInternalTranslateJsx,
-  RscT,
   T,
   Currency,
   DateTime,


### PR DESCRIPTION
## Summary

PR 3 of the RSC-safe context entrypoint stack (stacked on #1574). Users should only ever import `gt-react/context` and have runtime-specific behavior handled automatically — including in React Server Component runtimes. This PR makes the `react-server` export condition resolve `gt-react/context` to a new RSC-safe implementation, `src/context.rsc.tsx`:

```
gt-react/context
├─ react-server → dist/context.rsc.*     (new: RSC-safe implementation)
├─ browser      → dist/context.client.*  (unchanged)
└─ default      → dist/context.server.*  (unchanged, now marked 'use client')
```

`gt-react/context-rsc` is unchanged and remains the explicit internal interface (consumed by gt-next, and the building blocks `context.rsc` is composed from).

## What gt-react/context provides under react-server

Mirrors the `context.server` export surface exactly (enforced by a parity test):

- **Pure functions** (`msg`, `t`, `decode*`, `derive`, `declareVar`, fallbacks, `getTranslationsSnapshot`, cache accessors, `initializeGT`) — the real implementations; `msg()` just works in a server component.
- **Components** (`Plural`, `Currency`, `DateTime`, `Num`, `RelativeTime`; `Branch`/`Derive`/`Var` are already pure) — the RSC implementations, resolving conditions from the read-only condition store singleton when not passed explicitly (the same providerless fallback the hook implementations use).
- **Read-only hooks** (`useLocale`, `useEnableI18n`, `useDefaultLocale`, `useLocales`, `useCustomMapping`, `useFormatLocales`) — singleton-backed plain functions; they work in RSC.
- **Client components** (`GTProvider`, `LocaleSelector`, client `<T>`/`GtInternalTranslateJsx`) — async wrappers over a **lazy** dynamic import of the `'use client'` `context.server` entrypoint. RSC bundlers turn the rendered components into client references; the laziness means merely importing `gt-react/context` under react-server never evaluates client code (verified with `node --conditions=react-server`, where react has no `createContext`). A small rolldown plugin keeps that import external so the directive survives bundling.
- **Impossible-in-RSC APIs** (`useGT`/`useMessages`/`useTranslations` — they need `useSyncExternalStore` — plus `useSetLocale`/`useLocaleSelector`/SPA setup) — throw with actionable messages, mirroring the existing throwing `RscT` stub in `context.client`.

`context.server.ts` also gains the `'use client'` directive (it is the client-capable runtime; the directive replaces a no-op bare `'server-only'` string), which is what makes the lazy boundary work and converts any stray react-server import of it from a silent `createContext` leak into a well-defined boundary.

Supporting changes: pure `getShouldTranslate` extracted to a hook-free module (it was `t()`'s one transitive hook-module import); react-core `context-rsc` additionally exports the server-safe functions (`t`, `getTranslationsSnapshot`, cache/condition-store accessors, `internalInitializeGTSRA`) and component prop types.

## Known limitations (flagged)

- `<T>` under react-server currently renders through the client boundary (client-side translation). A later PR in this stack makes the `RscT` import graph fully RSC-safe and will serve server-side translation from this entrypoint; until then `RscT` throws here.
- `RegionSelector` has no non-deprecated implementation in gt-react; gt-next re-exports it via its own client boundary in the migration PR.

## Testing

- Leak test: importing `context.rsc` with `createContext` poisoned and client modules forbidden succeeds; `useGT()` throws the intended message.
- Parity test: `context.rsc` and `context.server` export-name sets are identical.
- Package test: `node --conditions=react-server` resolves `gt-react/context` to the RSC implementation (`msg` callable, components present, `useGT` throws); `'use client'` directive asserted in `dist/client.*`, `dist/context.client.*`, `dist/context.server.*`.
- `pnpm turbo test --filter @generaltranslation/react-core --filter gt-react`, typechecks for both packages.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR (3rd in the RSC-safe context stack) renames the internal `RscT`/`locale`/`enableI18n` prop surface to underscore-prefixed `_locale`/`_enableI18n` across `react-core` and `gt-next`, removes `RscT` as a named public export (it now lives only as the `T` alias in `components-rsc`), and teaches `usePrepareT` to accept explicit override props — removing the transitive `useShouldTranslate` hook dependency that blocked RSC use.

- **Prop rename throughout the stack**: `RscT`'s parameters `locale`/`enableI18n` become `_locale`/`_enableI18n`; `getRequestConditions()` is updated to match, so `gt-next`'s `buildtime/T` can now spread the conditions object directly onto the call.
- **`usePrepareT` hook decoupled from `useShouldTranslate`**: Replaced with an inline `getI18nConfig().requiresTranslation(locale)` call, which is pure and RSC-safe; the hook-based `T` (client) still calls `useLocale`/`useEnableI18n` but now overrides them when explicit props are present.
- **`RscT` retired from public API**: `context.rsc`, `context.server`, `context.types`, and `context.client` all drop their `RscT` export; downstream consumers (`gt-next/buildtime/T`) are migrated to `T as RscT`.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all changed code paths are covered by updated tests, the prop renames are applied consistently across the monorepo, and the hook-decoupling in usePrepareT mirrors the existing RscT logic exactly.

The prop renaming is applied uniformly across react-core, gt-next, and all gt-react context entrypoints. The removal of useShouldTranslate in favour of a direct getI18nConfig() call is behaviorally identical and tested. The RscT retirement from the public API is a clean breaking removal with all callsites migrated.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react-core/src/components/translation/T.tsx | Renames RscT props from locale/enableI18n to _locale/_enableI18n, exports TProps/ResolvedTProps, and makes T/GtInternalTranslateJsx accept optional override props — clean, consistent refactor. |
| packages/react-core/src/utils/translation/prepareT.ts | Removes useShouldTranslate hook import; replaces it with direct getI18nConfig().requiresTranslation() call; adds _locale/_enableI18n override path — correct and hook-free. |
| packages/next/src/server-dir/buildtime/T.tsx | Migrates from { RscT } to { T as RscT } import, spreads full conditions object; getRequestConditions now returns _locale/_enableI18n matching the updated interface. |
| packages/react/src/context.rsc.ts | Removes RscT from exports; T (which aliases RscT in components-rsc) remains the sole translation component export. |
| packages/react/src/components/LocaleSelector.tsx | Switches to type-only React import (safe with the automatic JSX transform), extracts LocaleSelectorProps as a named export for downstream use. |

</details>

</details>

<sub>Reviews (4): Last reviewed commit: ["fix: align rsc t condition props"](https://github.com/generaltranslation/gt/commit/c1b9364fe67a9d9ecd52ea73d14558cd450fc290) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36535018)</sub>

<!-- /greptile_comment -->