### PR TITLE
refactor: remove locale getters from I18NConfiguration

### DIFF
--- a/packages/next/src/config-dir/I18NConfiguration.ts
+++ b/packages/next/src/config-dir/I18NConfiguration.ts
@@ -292,24 +292,6 @@ export class I18NConfiguration {
     return this._i18nCache.getGTClass();
   }
 
-  // ----- LOCALES ----- //
-
-  /**
-   * Gets the application's default locale
-   * @returns {string} A BCP-47 locale tag
-   */
-  getDefaultLocale(): string {
-    return getI18nConfig().getDefaultLocale();
-  }
-
-  /**
-   * Gets the list of approved locales for this app
-   * @returns {string[]} A list of BCP-47 locale tags, or undefined if none were provided
-   */
-  getLocales(): string[] {
-    return getI18nConfig().getLocales();
-  }
-
   /**
    * Gets the version ID for the current source
    * @returns {string | undefined} The version ID, if set

--- a/packages/next/src/config-dir/__tests__/I18NConfiguration.test.ts
+++ b/packages/next/src/config-dir/__tests__/I18NConfiguration.test.ts
@@ -239,7 +239,7 @@ describe('I18NConfiguration', () => {
     );
   });
 
-  it('exposes configured locale values and client custom mappings', () => {
+  it('exposes client custom mappings', () => {
     const customMapping = {
       'brand-french': {
         code: 'fr',
@@ -252,26 +252,11 @@ describe('I18NConfiguration', () => {
       customMapping,
     });
 
-    expect(config.getDefaultLocale()).toBe('en-US');
-    expect(config.getLocales()).toEqual(['en-US', 'fr', 'brand-french']);
     expect(config.getClientSideConfig()).toEqual(
       expect.objectContaining({
         customMapping,
       })
     );
-  });
-
-  it('reads locale values from gt-i18n config accessors', () => {
-    const config = createConfig({
-      defaultLocale: 'en',
-      locales: ['en', 'fr'],
-    });
-
-    mockLocaleConfig.defaultLocale = 'es';
-    mockLocaleConfig.locales = ['es', 'es-MX'];
-
-    expect(config.getDefaultLocale()).toBe('es');
-    expect(config.getLocales()).toEqual(['es', 'es-MX']);
   });
 
   it('reads client custom mappings from gt-i18n config accessors', () => {
@@ -310,8 +295,8 @@ describe('I18NConfiguration', () => {
 
     const config = getI18NConfig();
 
-    expect(config.getDefaultLocale()).toBe('en-US');
-    expect(config.getLocales()).toEqual(['en-US', 'es', 'brand-spanish']);
+    expect(mockLocaleConfig.defaultLocale).toBe('en-US');
+    expect(mockLocaleConfig.locales).toEqual(['en-US', 'es', 'brand-spanish']);
     expect(config.getClientSideConfig()).toEqual(
       expect.objectContaining({
         customMapping,
@@ -322,12 +307,12 @@ describe('I18NConfiguration', () => {
   it('initializes locale metadata in the default config fallback', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-    const config = getI18NConfig();
+    getI18NConfig();
 
-    expect(config.getDefaultLocale()).toBe(
+    expect(mockLocaleConfig.defaultLocale).toBe(
       defaultWithGTConfigProps.defaultLocale
     );
-    expect(config.getLocales()).toEqual([
+    expect(mockLocaleConfig.locales).toEqual([
       defaultWithGTConfigProps.defaultLocale,
     ]);
     warn.mockRestore();

--- a/packages/next/src/index.server.ts
+++ b/packages/next/src/index.server.ts
@@ -31,6 +31,7 @@ import type {
   RuntimeTranslationOptions,
 } from 'gt-react';
 import { GT } from 'generaltranslation';
+import { getI18nConfig } from 'gt-i18n/internal';
 import {
   useMessages,
   useGT,
@@ -47,11 +48,13 @@ export function useLocaleProperties(locale: string): LocaleProperties {
 }
 
 export function useLocales() {
-  return getI18NConfig().getLocales();
+  getI18NConfig(); // ensure the i18n config singleton is initialized
+  return getI18nConfig().getLocales();
 }
 
 export function useDefaultLocale() {
-  return getI18NConfig().getDefaultLocale();
+  getI18NConfig(); // ensure the i18n config singleton is initialized
+  return getI18nConfig().getDefaultLocale();
 }
 
 export function useVersionId() {

--- a/packages/next/src/provider/GTProvider.tsx
+++ b/packages/next/src/provider/GTProvider.tsx
@@ -1,6 +1,7 @@
 import { DictionaryEntry, mergeDictionaries } from 'gt-react/internal';
 import { isValidElement } from 'react';
 import { getI18NConfig } from '../config-dir/getI18NConfig';
+import { getI18nConfig } from 'gt-i18n/internal';
 import { getLocale } from '../request/getLocale';
 import { getDictionary, getDictionaryEntry } from '../dictionary/getDictionary';
 import { Dictionary, Translations } from 'gt-react/internal';
@@ -26,7 +27,7 @@ export async function GTProvider({
   // ---------- SETUP ---------- //
   const I18NConfig = getI18NConfig();
   const locale = _locale || (await getLocale());
-  const defaultLocale = I18NConfig.getDefaultLocale();
+  const defaultLocale = getI18nConfig().getDefaultLocale();
   const [translationRequired, dialectTranslationRequired] =
     I18NConfig.requiresTranslation(locale);
 
@@ -79,7 +80,7 @@ export async function GTProvider({
       dictionaryTranslations={dictionaryTranslations}
       translations={translations}
       locale={locale}
-      locales={I18NConfig.getLocales()}
+      locales={getI18nConfig().getLocales()}
       defaultLocale={defaultLocale}
       translationRequired={translationRequired}
       dialectTranslationRequired={dialectTranslationRequired}

--- a/packages/next/src/request/getLocale.ts
+++ b/packages/next/src/request/getLocale.ts
@@ -1,4 +1,5 @@
 import { getI18NConfig } from '../config-dir/getI18NConfig';
+import { getI18nConfig } from 'gt-i18n/internal';
 import { use } from '../utils/use';
 import { legacyGetLocaleFunction } from './utils/legacyGetLocaleFunction';
 import { getRequestFunction } from './utils/getRequestFunction';
@@ -31,12 +32,12 @@ export async function getLocale(): Promise<string> {
     getLocaleFunction = async () => {
       const requestLocale = await requestFunction();
       return gt.resolveAliasLocale(
-        requestLocale || I18NConfig.getDefaultLocale()
+        requestLocale || getI18nConfig().getDefaultLocale()
       );
     };
   } else {
     // Support legacy behavior
-    getLocaleFunction = legacyGetLocaleFunction(I18NConfig, gt);
+    getLocaleFunction = legacyGetLocaleFunction(gt);
   }
 
   return getLocaleFunction();

--- a/packages/next/src/request/headers/getNextLocale.ts
+++ b/packages/next/src/request/headers/getNextLocale.ts
@@ -1,5 +1,6 @@
 import { cookies, headers } from 'next/headers';
 import { getI18NConfig } from '../../config-dir/getI18NConfig';
+import { getI18nConfig } from 'gt-i18n/internal';
 import { noLocalesCouldBeDeterminedWarning } from '../../errors/ssg';
 import { RequestFunctionReturnType } from '../types';
 
@@ -16,8 +17,9 @@ export async function getNextLocale(): Promise<RequestFunctionReturnType> {
   const [headersList, cookieStore] = await Promise.all([headers(), cookies()]);
 
   const I18NConfig = getI18NConfig();
-  const defaultLocale = I18NConfig.getDefaultLocale();
-  const locales = I18NConfig.getLocales();
+  const i18nConfig = getI18nConfig();
+  const defaultLocale = i18nConfig.getDefaultLocale();
+  const locales = i18nConfig.getLocales();
 
   const preferredLocales: string[] = [];
 

--- a/packages/next/src/request/utils/legacyGetLocaleFunction.ts
+++ b/packages/next/src/request/utils/legacyGetLocaleFunction.ts
@@ -2,7 +2,7 @@ import { GT } from 'generaltranslation';
 import { RequestFunctionReturnType } from '../types';
 import { legacyGetRequestFunction } from './legacyGetRequestFunction';
 import { isSSR } from './isSSR';
-import { I18NConfiguration } from '../../config-dir/I18NConfiguration';
+import { getI18nConfig } from 'gt-i18n/internal';
 
 let getLocaleFunction: () => Promise<RequestFunctionReturnType>;
 let getStaticLocaleFunction: () => Promise<RequestFunctionReturnType>;
@@ -10,10 +10,7 @@ let getStaticLocaleFunction: () => Promise<RequestFunctionReturnType>;
 /**
  * @deprecated
  */
-export function legacyGetLocaleFunction(
-  I18NConfig: I18NConfiguration,
-  gt: GT
-): () => Promise<string> {
+export function legacyGetLocaleFunction(gt: GT): () => Promise<string> {
   // Construct getLocale function
   getLocaleFunction = legacyGetRequestFunction('getLocale', true);
   getStaticLocaleFunction = legacyGetRequestFunction('getLocale', false);
@@ -24,6 +21,6 @@ export function legacyGetLocaleFunction(
     const locale = isSSR()
       ? await getLocaleFunction()
       : await getStaticLocaleFunction();
-    return gt.resolveAliasLocale(locale || I18NConfig.getDefaultLocale());
+    return gt.resolveAliasLocale(locale || getI18nConfig().getDefaultLocale());
   };
 }

--- a/packages/next/src/server-dir/buildtime/__tests__/getTranslations.test.ts
+++ b/packages/next/src/server-dir/buildtime/__tests__/getTranslations.test.ts
@@ -47,7 +47,6 @@ type GetTranslations = (typeof import('../getTranslations'))['getTranslations'];
 type UseTranslations = (typeof import('../getTranslations'))['useTranslations'];
 type MockFunction = ReturnType<typeof vi.fn>;
 type MockI18NConfig = {
-  getDefaultLocale: MockFunction;
   requiresTranslation: MockFunction;
   getDictionaryTranslations: MockFunction;
   getCachedTranslations: MockFunction;
@@ -149,13 +148,16 @@ describe('getTranslations', () => {
     const module = await import('../getTranslations');
     getTranslations = module.getTranslations;
 
+    // Initialize the gt-i18n config singleton in the fresh module registry
+    const { initializeI18nConfig } = await import('gt-i18n/internal');
+    initializeI18nConfig({ defaultLocale: 'en', locales: ['en'] });
+
     consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     // Set environment variables for locale detection
     process.env._GENERALTRANSLATION_IGNORE_BROWSER_LOCALES = 'false';
 
     mockI18NConfig = {
-      getDefaultLocale: vi.fn(() => 'en'),
       requiresTranslation: vi.fn(() => [false]),
       getDictionaryTranslations: vi.fn(),
       getCachedTranslations: vi.fn(),

--- a/packages/next/src/server-dir/buildtime/getTranslationFunction.ts
+++ b/packages/next/src/server-dir/buildtime/getTranslationFunction.ts
@@ -1,6 +1,7 @@
 // getTranslationFunction.ts (refactored)
 
 import { getI18NConfig } from '../../config-dir/getI18NConfig';
+import { getI18nConfig } from 'gt-i18n/internal';
 import { getLocale } from '../../server';
 import { hashSource } from 'generaltranslation/id';
 import {
@@ -68,7 +69,7 @@ async function createTranslator(_messages?: _Messages): Promise<Translator> {
   // ---------- SET UP ---------- //
   const I18NConfig = getI18NConfig();
   const locale = await getLocale();
-  const defaultLocale = I18NConfig.getDefaultLocale();
+  const defaultLocale = getI18nConfig().getDefaultLocale();
   const [translationRequired] = I18NConfig.requiresTranslation(locale);
   const gtClass = I18NConfig.getGTClass();
 

--- a/packages/next/src/server-dir/buildtime/getTranslations.tsx
+++ b/packages/next/src/server-dir/buildtime/getTranslations.tsx
@@ -30,6 +30,7 @@ import {
   createTranslationLoadingWarning,
 } from '../../errors/createErrors';
 import { getI18NConfig } from '../../config-dir/getI18NConfig';
+import { getI18nConfig } from 'gt-i18n/internal';
 import { getLocale } from '../../request/getLocale';
 import { hashSource } from 'generaltranslation/id';
 import { use } from '../../utils/use';
@@ -80,7 +81,7 @@ export async function getTranslations(id?: string): Promise<
 
   const I18NConfig = getI18NConfig();
   const locale = await getLocale();
-  const defaultLocale = I18NConfig.getDefaultLocale();
+  const defaultLocale = getI18nConfig().getDefaultLocale();
   const [translationRequired] = I18NConfig.requiresTranslation(locale);
   const gt = I18NConfig.getGTClass();
 

--- a/packages/next/src/server-dir/runtime/_Tx.tsx
+++ b/packages/next/src/server-dir/runtime/_Tx.tsx
@@ -1,4 +1,5 @@
 import { getI18NConfig } from '../../config-dir/getI18NConfig';
+import { getI18nConfig } from 'gt-i18n/internal';
 import { getLocale } from '../../request/getLocale';
 import { Suspense } from 'react';
 import {
@@ -56,7 +57,7 @@ export async function Tx({
   const maxChars = $maxChars;
   const I18NConfig = getI18NConfig();
   locale ||= await getLocale();
-  const defaultLocale = I18NConfig.getDefaultLocale();
+  const defaultLocale = getI18nConfig().getDefaultLocale();
   const [translationRequired, dialectTranslationRequired] =
     I18NConfig.requiresTranslation(locale);
 

--- a/packages/next/src/server-dir/runtime/__tests__/tx.test.ts
+++ b/packages/next/src/server-dir/runtime/__tests__/tx.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { initializeI18nConfig } from 'gt-i18n/internal';
 import { tx } from '../tx';
 
 const { mockLookupTranslation, mockTranslate } = vi.hoisted(() => ({
@@ -6,9 +7,10 @@ const { mockLookupTranslation, mockTranslate } = vi.hoisted(() => ({
   mockTranslate: vi.fn(),
 }));
 
+initializeI18nConfig({ defaultLocale: 'en', locales: ['en', 'fr'] });
+
 vi.mock('../../../config-dir/getI18NConfig', () => ({
   getI18NConfig: () => ({
-    getDefaultLocale: () => 'en',
     requiresTranslation: () => [true, false],
     getGTClass: () => ({
       formatMessage: (message: string) => message,

--- a/packages/next/src/server-dir/runtime/tx.ts
+++ b/packages/next/src/server-dir/runtime/tx.ts
@@ -1,4 +1,5 @@
 import { getI18NConfig } from '../../config-dir/getI18NConfig';
+import { getI18nConfig } from 'gt-i18n/internal';
 import { getLocale } from '../../request/getLocale';
 import { createStringTranslationError } from '../../errors/createErrors';
 import { hashSource } from 'generaltranslation/id';
@@ -76,7 +77,7 @@ export async function tx(
 
   const I18NConfig = getI18NConfig();
   const locale = typeof $locale === 'string' ? $locale : await getLocale();
-  const defaultLocale = I18NConfig.getDefaultLocale();
+  const defaultLocale = getI18nConfig().getDefaultLocale();
   const [translationRequired] = I18NConfig.requiresTranslation(locale);
   const gt = I18NConfig.getGTClass();
 

--- a/packages/next/src/server.ts
+++ b/packages/next/src/server.ts
@@ -15,9 +15,11 @@ import {
   getMessages,
   getGT,
 } from './server-dir/buildtime/getTranslationFunction';
+import { getI18nConfig } from 'gt-i18n/internal';
 
 export function getDefaultLocale(): string {
-  return getI18NConfig().getDefaultLocale();
+  getI18NConfig(); // ensure the i18n config singleton is initialized
+  return getI18nConfig().getDefaultLocale();
 }
 
 export function getGTClass() {
@@ -29,7 +31,8 @@ export function getLocaleProperties(locale: string): LocaleProperties {
 }
 
 export function getLocales(): string[] {
-  return getI18NConfig().getLocales();
+  getI18NConfig(); // ensure the i18n config singleton is initialized
+  return getI18nConfig().getLocales();
 }
 
 export function getVersionId(): string | undefined {


### PR DESCRIPTION
## Description

Removes the `getDefaultLocale()` and `getLocales()` delegation methods from `I18NConfiguration` in `gt-next`. Call sites now read locale config directly from the `gt-i18n` `I18nConfig` singleton via `getI18nConfig()`.

- The public `getDefaultLocale`/`getLocales`/`useDefaultLocale`/`useLocales` exports keep a bare `getI18NConfig()` call first, since that is what lazily initializes the config singleton when these are the first gt-next APIs invoked.
- `legacyGetLocaleFunction` no longer needs the `I18NConfiguration` parameter, so it was dropped.
- Tests that relied on the removed methods now initialize or assert against the `gt-i18n` config directly.

## Testing

- `pnpm build`
- `pnpm --filter gt-next test` (216 JS + 295 Rust tests pass)
- `pnpm lint` / `pnpm format` (no new warnings)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1580"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783626298&installation_id=127936663&pr_number=1580&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1580&signature=3ead70417f2367368239d729c6f6fec67a2f1fb17eb20a63e97ef8b515b18cd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the `getDefaultLocale()` and `getLocales()` delegation methods from `I18NConfiguration` and updates all call sites to read locale config directly from the `gt-i18n` `I18nConfig` singleton via `getI18nConfig()`. Every call site that now uses `getI18nConfig()` is preceded by a `getI18NConfig()` call (which lazily initializes the `gt-i18n` singleton), so the initialization ordering contract is correctly preserved across all paths.

- **`server.ts` / `index.server.ts`**: Public exports explicitly guard with a bare `getI18NConfig()` call before delegating to `getI18nConfig()`.
- **Internal consumers** (`GTProvider`, `getNextLocale`, `getTranslationFunction`, `getTranslations`, `_Tx`, `tx`): Each already called `getI18NConfig()` in the same function body before reading from `getI18nConfig()`.
- **`legacyGetLocaleFunction`**: Drops the `I18NConfiguration` parameter; the returned closure safely defers its `getI18nConfig()` call until after `getLocale()` has already invoked `getI18NConfig()`.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the initialization ordering contract is preserved at every call site and all 511 passing tests confirm correctness.

The refactoring is mechanical and well-scoped: the two removed delegation methods were one-liners that forwarded directly to `getI18nConfig()`, and every updated call site still starts with a `getI18NConfig()` call that initializes the singleton before reading from it. The only note is that `initializeI18nConfig` in `tx.test.ts` is placed at module top level rather than inside `beforeEach`, which is a minor test hygiene concern but does not affect runtime correctness or current test results.

No files require special attention; `tx.test.ts` carries a minor test-isolation note but is otherwise correct.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/next/src/config-dir/I18NConfiguration.ts | Removes `getDefaultLocale()` and `getLocales()` delegation methods; remaining methods unchanged. |
| packages/next/src/server.ts | Public `getDefaultLocale`/`getLocales` now call `getI18NConfig()` for initialization then delegate to `getI18nConfig()` for the value; guard pattern is correct. |
| packages/next/src/index.server.ts | `useLocales`/`useDefaultLocale` mirror the same initialization-guard pattern applied in server.ts; consistent and correct. |
| packages/next/src/provider/GTProvider.tsx | `getI18NConfig()` is called first (initializing gt-i18n singleton), then `getI18nConfig()` is safely used for `defaultLocale` and `locales`. |
| packages/next/src/request/headers/getNextLocale.ts | Correctly reads `defaultLocale`/`locales` from `getI18nConfig()` after `getI18NConfig()` has initialized the singleton. |
| packages/next/src/request/utils/legacyGetLocaleFunction.ts | Drops `I18NConfiguration` parameter; deferred closure reads `getI18nConfig()` safely because `getLocale.ts` always calls `getI18NConfig()` first. |
| packages/next/src/server-dir/runtime/__tests__/tx.test.ts | `initializeI18nConfig` called at module top level rather than inside `beforeEach`; harmless today with one test, but fragile if the file grows. |
| packages/next/src/server-dir/buildtime/__tests__/getTranslations.test.ts | Correctly initializes `gt-i18n` config singleton inside `beforeEach` after module reset; `getDefaultLocale` mock removed from `MockI18NConfig`. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant server.ts
    participant getI18NConfig
    participant gt-i18n singleton

    Note over Caller,gt-i18n singleton: Public API entry (e.g. getDefaultLocale)
    Caller->>server.ts: getDefaultLocale()
    server.ts->>getI18NConfig: getI18NConfig() [initializes gt-i18n]
    getI18NConfig->>gt-i18n singleton: initializeI18nConfig(configParams)
    getI18NConfig-->>server.ts: I18NConfiguration instance
    server.ts->>gt-i18n singleton: getI18nConfig().getDefaultLocale()
    gt-i18n singleton-->>server.ts: "en-US"
    server.ts-->>Caller: "en-US"

    Note over Caller,gt-i18n singleton: Internal consumer (e.g. GTProvider)
    Caller->>server.ts: GTProvider()
    server.ts->>getI18NConfig: getI18NConfig() [already initialized]
    getI18NConfig-->>server.ts: I18NConfiguration (from globalThis cache)
    server.ts->>gt-i18n singleton: getI18nConfig().getDefaultLocale()
    gt-i18n singleton-->>server.ts: "en-US"
    server.ts->>gt-i18n singleton: getI18nConfig().getLocales()
    gt-i18n singleton-->>server.ts: ["en-US", "fr"]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fnext%2Fsrc%2Fserver-dir%2Fruntime%2F__tests__%2Ftx.test.ts%3A10-12%0A%60initializeI18nConfig%60%20is%20called%20at%20module%20initialization%20level%20rather%20than%20inside%20%60beforeEach%60.%20The%20singleton%20will%20hold%20stale%20state%20if%20additional%20tests%20with%20different%20locale%20requirements%20are%20added%20to%20this%20file%2C%20since%20re-initializing%20inside%20%60beforeEach%60%20is%20not%20possible%20without%20a%20module%20reset.%20The%20%60getTranslations.test.ts%60%20companion%20file%20already%20demonstrates%20the%20correct%20pattern%20of%20calling%20%60initializeI18nConfig%60%20inside%20%60beforeEach%60%20after%20a%20module%20reset.%0A%0A%60%60%60suggestion%0Avi.mock%28'..%2F..%2F..%2Fconfig-dir%2FgetI18NConfig'%2C%20%28%29%20%3D%3E%20%28%7B%0A%60%60%60%0A%0A&repo=generaltranslation%2Fgt&pr=1580&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fodysseus%2Fremove-config-locale-getters%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fodysseus%2Fremove-config-locale-getters%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fnext%2Fsrc%2Fserver-dir%2Fruntime%2F__tests__%2Ftx.test.ts%3A10-12%0A%60initializeI18nConfig%60%20is%20called%20at%20module%20initialization%20level%20rather%20than%20inside%20%60beforeEach%60.%20The%20singleton%20will%20hold%20stale%20state%20if%20additional%20tests%20with%20different%20locale%20requirements%20are%20added%20to%20this%20file%2C%20since%20re-initializing%20inside%20%60beforeEach%60%20is%20not%20possible%20without%20a%20module%20reset.%20The%20%60getTranslations.test.ts%60%20companion%20file%20already%20demonstrates%20the%20correct%20pattern%20of%20calling%20%60initializeI18nConfig%60%20inside%20%60beforeEach%60%20after%20a%20module%20reset.%0A%0A%60%60%60suggestion%0Avi.mock%28'..%2F..%2F..%2Fconfig-dir%2FgetI18NConfig'%2C%20%28%29%20%3D%3E%20%28%7B%0A%60%60%60%0A%0A&repo=generaltranslation%2Fgt&pr=1580&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/next/src/server-dir/runtime/__tests__/tx.test.ts:10-12
`initializeI18nConfig` is called at module initialization level rather than inside `beforeEach`. The singleton will hold stale state if additional tests with different locale requirements are added to this file, since re-initializing inside `beforeEach` is not possible without a module reset. The `getTranslations.test.ts` companion file already demonstrates the correct pattern of calling `initializeI18nConfig` inside `beforeEach` after a module reset.

```suggestion
vi.mock('../../../config-dir/getI18NConfig', () => ({
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: remove locale getters from I18..."](https://github.com/generaltranslation/gt/commit/57eae86c12bae76458fc73265abd2e438ccd616a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36539994)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->