### PR TITLE
F/mintlify ref sibling fix

### DIFF
--- a/.changeset/clear-garlics-tan.md
+++ b/.changeset/clear-garlics-tan.md
@@ -1,0 +1,5 @@
+---
+"gt": patch
+---
+
+Handle Mintlify `$ref` siblings, add omit to composite JSONs

--- a/packages/cli/src/config/optionPresets.ts
+++ b/packages/cli/src/config/optionPresets.ts
@@ -30,7 +30,10 @@ export function generatePreset(
                 '$..item',
                 '$..anchor',
                 '$..dropdown',
+                '$..product',
+                '$..description',
               ],
+              omitProperties: ['default'],
               transform: {
                 '$..pages[*]': {
                   match: '^{locale}/(.*)$',
@@ -71,7 +74,10 @@ export function generatePreset(
                 '$..item',
                 '$..anchor',
                 '$..dropdown',
+                '$..product',
+                '$..description',
               ],
+              omitProperties: ['default'],
               transform: {
                 '$..pages[*]': {
                   match: '^/?(.*)$',

--- a/packages/cli/src/formats/json/__tests__/mergeJson.test.ts
+++ b/packages/cli/src/formats/json/__tests__/mergeJson.test.ts
@@ -286,6 +286,64 @@ describe('mergeJson', () => {
       expect(frenchItem.desc).toBe('Nouvelle Description');
     });
 
+    it('should omit configured properties from generated locale entries', () => {
+      // Mintlify language entries support `default: true` on the default
+      // language; cloning it into every locale would declare multiple defaults
+      const originalContent = JSON.stringify({
+        navigation: {
+          languages: [
+            {
+              language: 'en',
+              default: true,
+              hidden: false,
+              tabs: [{ tab: 'Guides' }],
+            },
+          ],
+        },
+      });
+
+      const targets = [
+        {
+          translatedContent: JSON.stringify({
+            '/navigation/languages': {
+              '/0': { '/tabs/0/tab': 'Guías' },
+            },
+          }),
+          targetLocale: 'es',
+        },
+      ];
+
+      const result = mergeJson(
+        originalContent,
+        'docs.json',
+        {
+          jsonSchema: {
+            '**/*.json': {
+              composite: {
+                '$.navigation.languages': {
+                  type: 'array',
+                  include: ['$..tab'],
+                  key: '$.language',
+                  omitProperties: ['default'],
+                },
+              },
+            },
+          },
+        },
+        targets,
+        'en'
+      );
+
+      const parsed = JSON.parse(result[0]);
+      const en = parsed.navigation.languages.find(hasLanguage('en'));
+      expect(en.default).toBe(true);
+
+      const es = parsed.navigation.languages.find(hasLanguage('es'));
+      expect(es.default).toBeUndefined();
+      expect(es.hidden).toBe(false); // only listed properties are omitted
+      expect(es.tabs[0].tab).toBe('Guías');
+    });
+
     it('should overwrite existing target locale item when available', () => {
       const originalContent = JSON.stringify({
         items: [

--- a/packages/cli/src/formats/json/mergeJson.ts
+++ b/packages/cli/src/formats/json/mergeJson.ts
@@ -240,6 +240,7 @@ export function mergeJson(
             defaultLocaleKeyPointer,
             targetLocaleKeyProperty
           );
+          omitProperties(mutatedSourceItem, sourceObjectOptions.omitProperties);
           for (const [
             translatedKeyJsonPointer,
             translatedValue,
@@ -367,6 +368,7 @@ export function mergeJson(
         // If the target locale has a matching source item, use it to mutate the source item
         // Otherwise, fallback to the default locale source item
         const mutateSourceItem = structuredClone(defaultLocaleSourceItem);
+        omitProperties(mutateSourceItem, sourceObjectOptions.omitProperties);
 
         // 3. Merge the target items with the source item (if there are transformations to perform)
         const mergedItems: Record<string, JSONValue> = {
@@ -528,6 +530,21 @@ function sortByLocaleOrder(
   }
 
   return items;
+}
+
+/**
+ * Remove top-level properties from a generated non-default-locale entry
+ * (e.g. Mintlify's `default: true` flag, which is only valid on one entry)
+ */
+function omitProperties(
+  item: JSONValue,
+  properties: string[] | undefined
+): void {
+  if (!properties?.length) return;
+  if (!item || typeof item !== 'object' || Array.isArray(item)) return;
+  for (const property of properties) {
+    delete (item as JSONObject)[property];
+  }
 }
 
 /**

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -385,6 +385,11 @@ export type SourceObjectOptions = {
   // for example, helpful for handling urls with locale-specific paths
   transform?: TransformOptions;
 
+  // optional list of top-level properties to remove from generated
+  // non-default-locale entries (e.g. Mintlify's `default: true` flag on the
+  // default language entry, which must not be cloned into other locales)
+  omitProperties?: string[];
+
   // optional sorting behavior for array sourceObjects. When set to 'locale',
   // the array will be ordered to match the locales array provided to mergeJson
   // When set to 'localesAlphabetical', the default locale will be placed first

--- a/packages/cli/src/utils/__tests__/resolveMintlifyRefs.test.ts
+++ b/packages/cli/src/utils/__tests__/resolveMintlifyRefs.test.ts
@@ -130,7 +130,10 @@ describe('resolveMintlifyRefs', () => {
       },
     };
 
-    const { resolved } = resolveMintlifyRefs(json, '/project/docs.json');
+    const { resolved, refMap } = resolveMintlifyRefs(
+      json,
+      '/project/docs.json'
+    );
 
     expect(resolved).toEqual({
       appearance: {
@@ -138,6 +141,8 @@ describe('resolveMintlifyRefs', () => {
         strict: true, // sibling overrides ref content
       },
     });
+    // Siblings are recorded so the split step can restore them next to the $ref
+    expect(refMap.get('/appearance')!.siblings).toEqual({ strict: true });
   });
 
   it('drops sibling keys when $ref resolves to a non-object', () => {

--- a/packages/cli/src/utils/__tests__/splitMintlifyLanguageRefs.test.ts
+++ b/packages/cli/src/utils/__tests__/splitMintlifyLanguageRefs.test.ts
@@ -613,6 +613,145 @@ describe('splitMintlifyLanguageRefs', () => {
     });
   });
 
+  it('preserves sibling keys next to restored $refs (Mintlify products nav)', async () => {
+    // Source docs.json had entries where the label lives ONLY next to the $ref:
+    //   { "product": "Home", "$ref": "./products/home.json" }
+    // Resolution folds the label into the inlined subtree (Mintlify sibling
+    // merge); the splitter must lift it back next to the $ref instead of
+    // dropping it (en) or burying it in the written locale ref file (es).
+    const mergedDocsJson = {
+      navigation: {
+        languages: [
+          {
+            language: 'en',
+            products: [
+              {
+                description: 'Home docs',
+                tabs: [{ tab: 'Start', groups: [] }],
+                product: 'Home',
+              },
+            ],
+          },
+          {
+            language: 'es',
+            products: [
+              {
+                description: 'Home docs (es)',
+                tabs: [{ tab: 'Inicio', groups: [] }],
+                product: 'Inicio',
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    mockRead.mockImplementation((p) => {
+      if (path.resolve(p as string) === path.resolve('/project/docs.json'))
+        return JSON.stringify(mergedDocsJson);
+      throw new Error('ENOENT');
+    });
+
+    mockRefMap = new Map([
+      [
+        '/navigation/languages/0/products/0',
+        {
+          sourceFile: path.resolve('/project/products/home.json'),
+          refPath: './products/home.json',
+          containingDir: path.resolve('/project'),
+          originalContent: {
+            description: 'Home docs',
+            tabs: [{ tab: 'Start', groups: [] }],
+          },
+          siblings: { product: 'Home' },
+        },
+      ],
+    ]);
+
+    await splitMintlifyLanguageRefs(makeSettings());
+
+    const docsResult = getWritten('/project/docs.json') as any;
+
+    // en: label restored next to the $ref; the English source file untouched
+    expect(docsResult.navigation.languages[0].products[0]).toEqual({
+      product: 'Home',
+      $ref: './products/home.json',
+    });
+    expect(getWritten('/project/products/home.json')).toBeUndefined();
+
+    // es: translated label lifted next to the $ref in the extracted entry,
+    // and excluded from the written locale ref file (mirrors source topology)
+    expect(docsResult.navigation.languages[1]).toEqual({
+      language: 'es',
+      $ref: './es/docs.json',
+    });
+    const esDocs = getWritten('/project/es/docs.json') as any;
+    expect(esDocs.products[0]).toEqual({
+      product: 'Inicio',
+      $ref: './products/home.json',
+    });
+    const esHome = getWritten('/project/es/products/home.json') as any;
+    expect(esHome).toEqual({
+      description: 'Home docs (es)',
+      tabs: [{ tab: 'Inicio', groups: [] }],
+    });
+  });
+
+  it('keeps a sibling key in the locale ref file when the referenced file also defines it', async () => {
+    // Sibling precedence case: the key exists in BOTH the ref file and as a
+    // $ref sibling. It must stay in both places to preserve the source
+    // topology and Mintlify's sibling-overrides-file semantics.
+    const mergedDocsJson = {
+      navigation: {
+        languages: [
+          {
+            language: 'en',
+            products: [{ description: 'Home docs', product: 'Home' }],
+          },
+          {
+            language: 'es',
+            products: [{ description: 'Home docs (es)', product: 'Inicio' }],
+          },
+        ],
+      },
+    };
+
+    mockRead.mockImplementation((p) => {
+      if (path.resolve(p as string) === path.resolve('/project/docs.json'))
+        return JSON.stringify(mergedDocsJson);
+      throw new Error('ENOENT');
+    });
+
+    mockRefMap = new Map([
+      [
+        '/navigation/languages/0/products/0',
+        {
+          sourceFile: path.resolve('/project/products/home.json'),
+          refPath: './products/home.json',
+          containingDir: path.resolve('/project'),
+          originalContent: { description: 'Home docs', product: 'Home (file)' },
+          siblings: { product: 'Home' },
+        },
+      ],
+    ]);
+
+    await splitMintlifyLanguageRefs(makeSettings());
+
+    const docsResult = getWritten('/project/docs.json') as any;
+    expect(docsResult.navigation.languages[0].products[0]).toEqual({
+      product: 'Home',
+      $ref: './products/home.json',
+    });
+
+    const esHome = getWritten('/project/es/products/home.json') as any;
+    expect(esHome.product).toBe('Inicio');
+    const esDocs = getWritten('/project/es/docs.json') as any;
+    expect(esDocs.products[0]).toEqual({
+      product: 'Inicio',
+      $ref: './products/home.json',
+    });
+  });
+
   it('does not clobber a top-level $ref file that was left un-inlined (e.g. redirects)', async () => {
     // mergeJson only re-inlines the composite path (navigation.languages); other
     // refs like `redirects` stay collapsed as { $ref } in the written docs.json.

--- a/packages/cli/src/utils/resolveMintlifyRefs.ts
+++ b/packages/cli/src/utils/resolveMintlifyRefs.ts
@@ -9,6 +9,7 @@ export type RefMapEntry = {
   refPath: string;
   containingDir: string;
   originalContent: unknown;
+  siblings?: Record<string, unknown>;
 };
 
 export type RefMap = Map<string, RefMapEntry>;
@@ -133,12 +134,15 @@ function resolveRef(
     return rest;
   }
 
+  const { $ref: _, ...siblings } = obj;
+
   // Record provenance before recursive resolution
   refMap.set(pointer, {
     sourceFile: resolvedFilePath,
     refPath,
     containingDir: baseDir,
     originalContent: parsed,
+    siblings,
   });
 
   // Recursively resolve nested $ref in the referenced file
@@ -155,8 +159,6 @@ function resolveRef(
   );
 
   // Apply Mintlify merge rules
-  const { $ref: _, ...siblings } = obj;
-
   if (
     resolvedContent !== null &&
     typeof resolvedContent === 'object' &&

--- a/packages/cli/src/utils/splitMintlifyLanguageRefs.ts
+++ b/packages/cli/src/utils/splitMintlifyLanguageRefs.ts
@@ -402,7 +402,11 @@ function restoreTopLevelRefs(
  */
 function extractRefSiblings(
   subtree: unknown,
-  ref: { siblings?: Record<string, unknown>; originalContent?: unknown }
+  ref: {
+    siblings?: Record<string, unknown>;
+    originalContent?: unknown;
+    refPath?: string;
+  }
 ): { siblings: Record<string, unknown>; content: unknown } {
   const originalSiblings = ref.siblings ?? {};
   const siblingKeys = Object.keys(originalSiblings);
@@ -425,6 +429,13 @@ function extractRefSiblings(
         delete content[key];
       }
     } else {
+      // Object resolutions always merge siblings into the subtree, so this
+      // only fires if that invariant breaks upstream. Restoring the source
+      // value keeps the output schema-valid, but it skips translation — warn
+      // so the regression is visible.
+      logger.warn(
+        `Sibling key "${key}" missing from translated content for $ref ${ref.refPath ?? '(unknown)'}; restoring source value`
+      );
       siblings[key] = originalSiblings[key];
     }
   }

--- a/packages/cli/src/utils/splitMintlifyLanguageRefs.ts
+++ b/packages/cli/src/utils/splitMintlifyLanguageRefs.ts
@@ -224,6 +224,7 @@ function processSplitEntries(
         const defaultEntry = entries[defaultIndex];
         for (const ref of internalRefs) {
           setAtPointer(defaultEntry, ref.relativePointer, {
+            ...ref.siblings,
             $ref: ref.refPath,
           });
         }
@@ -257,9 +258,14 @@ function processSplitEntries(
           const relToBaseDir = path.relative(entryBaseDir, originalAbsPath);
           const localeRelPath = path.join(keyValue, relToBaseDir);
           const outputPath = path.resolve(entryBaseDir, localeRelPath);
-          writeJsonFile(outputPath, subtree);
 
-          setAtPointer(entry, ref.relativePointer, { $ref: ref.refPath });
+          const { siblings, content } = extractRefSiblings(subtree, ref);
+          writeJsonFile(outputPath, content);
+
+          setAtPointer(entry, ref.relativePointer, {
+            ...siblings,
+            $ref: ref.refPath,
+          });
         }
       }
 
@@ -303,7 +309,10 @@ function processSplitEntries(
   // When the default entry was itself a $ref, restore it to that single $ref;
   // its source file is the untouched English source already on disk.
   if (defaultEntryRef) {
-    entries[defaultIndex] = { $ref: defaultEntryRef.refPath };
+    entries[defaultIndex] = {
+      ...defaultEntryRef.siblings,
+      $ref: defaultEntryRef.refPath,
+    };
   }
 
   logger.info(`Split keyed entries into ref files`);
@@ -376,9 +385,50 @@ function restoreTopLevelRefs(
       continue;
     }
 
-    writeJsonFile(entry.sourceFile, subtree);
-    setAtPointer(fileJson, pointer, { $ref: entry.refPath });
+    const { siblings, content } = extractRefSiblings(subtree, entry);
+    writeJsonFile(entry.sourceFile, content);
+    setAtPointer(fileJson, pointer, { ...siblings, $ref: entry.refPath });
   }
+}
+
+/**
+ * Mintlify merges keys placed next to a `$ref` on top of the referenced file's
+ * content, so ref resolution folds them into the inlined subtree. When
+ * restoring the `$ref`, lift those keys back out: they stay next to the `$ref`
+ * (with their possibly translated values) and are dropped from the content
+ * written to the ref file — unless the referenced file also defined the key,
+ * in which case it stays in both, preserving the source topology and
+ * Mintlify's sibling-precedence semantics.
+ */
+function extractRefSiblings(
+  subtree: unknown,
+  ref: { siblings?: Record<string, unknown>; originalContent?: unknown }
+): { siblings: Record<string, unknown>; content: unknown } {
+  const originalSiblings = ref.siblings ?? {};
+  const siblingKeys = Object.keys(originalSiblings);
+  if (siblingKeys.length === 0) {
+    return { siblings: {}, content: subtree };
+  }
+  if (!isJsonContainer(subtree) || Array.isArray(subtree)) {
+    // Non-object content cannot carry merged siblings; restore the originals
+    return { siblings: { ...originalSiblings }, content: subtree };
+  }
+  const content = { ...subtree };
+  const siblings: Record<string, unknown> = {};
+  const original = ref.originalContent;
+  const originalContentHasKey = (key: string) =>
+    isJsonContainer(original) && !Array.isArray(original) && key in original;
+  for (const key of siblingKeys) {
+    if (key in content) {
+      siblings[key] = content[key];
+      if (!originalContentHasKey(key)) {
+        delete content[key];
+      }
+    } else {
+      siblings[key] = originalSiblings[key];
+    }
+  }
+  return { siblings, content };
 }
 
 /**
@@ -388,11 +438,19 @@ function restoreTopLevelRefs(
 function collectInternalRefs(
   refMap: RefMap,
   entryPointerPrefix: string
-): { relativePointer: string; refPath: string; resolvedDir: string }[] {
+): {
+  relativePointer: string;
+  refPath: string;
+  resolvedDir: string;
+  siblings?: Record<string, unknown>;
+  originalContent?: unknown;
+}[] {
   const refs: {
     relativePointer: string;
     refPath: string;
     resolvedDir: string;
+    siblings?: Record<string, unknown>;
+    originalContent?: unknown;
   }[] = [];
 
   for (const [pointer, entry] of refMap.entries()) {
@@ -401,6 +459,8 @@ function collectInternalRefs(
       relativePointer: pointer.slice(entryPointerPrefix.length),
       refPath: entry.refPath,
       resolvedDir: entry.containingDir,
+      siblings: entry.siblings,
+      originalContent: entry.originalContent,
     });
   }
 


### PR DESCRIPTION
<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783706716&installation_id=127936663&pr_number=1582&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1582&signature=20e3ac2d03081fc81e58e58c04ec135522d591dc1215fc2906a3bda89da6334d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two related Mintlify `$ref` handling issues in the CLI: sibling keys placed next to a `$ref` (e.g. `{ "product": "Home", "$ref": "..." }`) are now correctly lifted back out when restoring refs after translation, and a new `omitProperties` feature prevents locale-specific flags like `default: true` from being cloned into non-default locale entries.

- **Sibling key restoration** (`resolveMintlifyRefs.ts`, `splitMintlifyLanguageRefs.ts`): Sibling data is now recorded in the refMap at resolution time. A new `extractRefSiblings` helper correctly lifts translated sibling values back next to the restored `$ref`, removing them from the written ref-file content unless the original file also defined them (where both copies are preserved to honour Mintlify's sibling-precedence semantics).
- **`omitProperties` support** (`mergeJson.ts`, `types/index.ts`, `optionPresets.ts`): A new `omitProperties?: string[]` field on `SourceObjectOptions` lets callers strip top-level properties from generated non-default-locale entries; the Mintlify presets use it to drop `default: true` and the include lists are extended with `$..product` and `$..description`.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all changes are additive and well-tested with no modifications to existing logic paths for documents that don't use Mintlify sibling keys.

The sibling extraction move in resolveMintlifyRefs is functionally identical; the new extractRefSiblings helper has two dedicated tests covering the common and precedence edge cases; omitProperties is isolated to cloned non-default locale items and never touches the source entry.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/utils/splitMintlifyLanguageRefs.ts | New extractRefSiblings helper lifts translated sibling values back next to the restored $ref in three call sites; collectInternalRefs now propagates siblings/originalContent downstream; logger.warn added for the unreachable fallback path. |
| packages/cli/src/utils/resolveMintlifyRefs.ts | Sibling extraction moved earlier so siblings are stored in the refMap entry before recursive resolution; behaviour is functionally identical for the merge step. |
| packages/cli/src/formats/json/mergeJson.ts | Adds omitProperties helper called on both composite-array merge paths to strip configured top-level keys from generated non-default locale entries. |
| packages/cli/src/config/optionPresets.ts | Adds $..product and $..description to the include list and sets omitProperties: ['default'] for both Mintlify preset configurations. |
| packages/cli/src/types/index.ts | Adds optional omitProperties?: string[] field to SourceObjectOptions with clear JSDoc explaining the Mintlify use-case. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: review"](https://github.com/generaltranslation/gt/commit/b89712c66db4f9081e11ee516352b7bb371abdfb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36777415)</sub>

<!-- /greptile_comment -->