### PR TITLE
feat: gt-remark text node jsx plugin

### DIFF
--- a/.changeset/swift-rules-speak.md
+++ b/.changeset/swift-rules-speak.md
@@ -1,0 +1,5 @@
+---
+"gt-remark": patch
+---
+
+Adding escape plugin for MDX JSX text nodes

--- a/packages/remark/README.md
+++ b/packages/remark/README.md
@@ -41,9 +41,11 @@ JSX text nodes, use the named MDX JSX text plugin before stringifying:
 
 ```ts
 import { escapeMarkdownInMdxJsxTextNodes } from 'gt-remark';
+import remarkMdx from 'remark-mdx';
 
 const file = await unified()
   .use(remarkParse)
+  .use(remarkMdx)
   .use(escapeMarkdownInMdxJsxTextNodes)
   .use(remarkStringify)
   .process('<p>*literal translated text*</p>');

--- a/packages/remark/README.md
+++ b/packages/remark/README.md
@@ -36,4 +36,17 @@ const file = await unified()
   .process('Hello & <world>');
 ```
 
+For translated MDX that may contain literal markdown-control characters inside
+JSX text nodes, use the named MDX JSX text plugin before stringifying:
+
+```ts
+import { escapeMarkdownInMdxJsxTextNodes } from 'gt-remark';
+
+const file = await unified()
+  .use(remarkParse)
+  .use(escapeMarkdownInMdxJsxTextNodes)
+  .use(remarkStringify)
+  .process('<p>*literal translated text*</p>');
+```
+
 See the [full documentation](https://generaltranslation.com/docs) for guides and API reference.

--- a/packages/remark/src/__tests__/index.test.ts
+++ b/packages/remark/src/__tests__/index.test.ts
@@ -2,8 +2,19 @@ import { describe, it, expect } from 'vitest';
 import { unified } from 'unified';
 import remarkParse from 'remark-parse';
 import remarkStringify from 'remark-stringify';
-import { escapeHtmlInTextNodes, remarkGfmCustom } from '../index';
+import {
+  escapeHtmlInTextNodes,
+  escapeMarkdownInMdxJsxText,
+  escapeMarkdownInMdxJsxTextNodes,
+  remarkGfmCustom,
+} from '../index';
 import type { Root, Text, Paragraph, Code, InlineCode } from 'mdast';
+
+type TestTreeNode = {
+  type?: string;
+  value?: unknown;
+  children?: TestTreeNode[];
+};
 
 describe('escapeHtmlInTextNodes', () => {
   const createTextNode = (value: string): Text => ({
@@ -504,6 +515,67 @@ describe('escapeHtmlInTextNodes', () => {
       const result = processAst(tree);
       expect(result).toContain('&lt;placeholder&gt; &amp; &quot;special&quot;');
     });
+  });
+});
+
+describe('escapeMarkdownInMdxJsxTextNodes', () => {
+  const processAst = (tree: Root) => {
+    const pluginProcessor = unified().use(escapeMarkdownInMdxJsxTextNodes);
+    return pluginProcessor.runSync(tree) as unknown as TestTreeNode;
+  };
+
+  it('escapes markdown-control characters inside MDX JSX text nodes', () => {
+    const tree = {
+      type: 'root',
+      children: [
+        {
+          type: 'mdxJsxFlowElement',
+          name: 'p',
+          attributes: [],
+          children: [
+            {
+              type: 'text',
+              value: '*literal* _value_ {name} `tick` & raw',
+            },
+          ],
+        },
+      ],
+    } as unknown as Root;
+
+    const result = processAst(tree);
+
+    expect(result.children?.[0]?.children?.[0]?.value).toBe(
+      '&#42;literal&#42; &#95;value&#95; &#123;name&#125; &#96;tick&#96; &amp; raw'
+    );
+  });
+
+  it('does not escape markdown syntax outside MDX JSX nodes', () => {
+    const tree = {
+      type: 'root',
+      children: [
+        {
+          type: 'paragraph',
+          children: [
+            {
+              type: 'text',
+              value: '*literal* _value_ {name} `tick` & raw',
+            },
+          ],
+        },
+      ],
+    } as unknown as Root;
+
+    const result = processAst(tree);
+
+    expect(result.children?.[0]?.children?.[0]?.value).toBe(
+      '*literal* _value_ {name} `tick` & raw'
+    );
+  });
+
+  it('does not double escape existing entities', () => {
+    expect(escapeMarkdownInMdxJsxText('Already &#42; &amp; *')).toBe(
+      'Already &#42; &amp; &#42;'
+    );
   });
 });
 

--- a/packages/remark/src/__tests__/index.test.ts
+++ b/packages/remark/src/__tests__/index.test.ts
@@ -535,7 +535,7 @@ describe('escapeMarkdownInMdxJsxTextNodes', () => {
           children: [
             {
               type: 'text',
-              value: '*literal* _value_ {name} `tick` & raw',
+              value: '*literal* _value_ [label] {name} `tick` & raw',
             },
           ],
         },
@@ -545,7 +545,7 @@ describe('escapeMarkdownInMdxJsxTextNodes', () => {
     const result = processAst(tree);
 
     expect(result.children?.[0]?.children?.[0]?.value).toBe(
-      '&#42;literal&#42; &#95;value&#95; &#123;name&#125; &#96;tick&#96; &amp; raw'
+      '&#42;literal&#42; &#95;value&#95; &#91;label&#93; &#123;name&#125; &#96;tick&#96; &amp; raw'
     );
   });
 
@@ -573,8 +573,8 @@ describe('escapeMarkdownInMdxJsxTextNodes', () => {
   });
 
   it('does not double escape existing entities', () => {
-    expect(escapeMarkdownInMdxJsxText('Already &#42; &amp; *')).toBe(
-      'Already &#42; &amp; &#42;'
+    expect(escapeMarkdownInMdxJsxText('Already &#42; &#91; &amp; * [')).toBe(
+      'Already &#42; &#91; &amp; &#42; &#91;'
     );
   });
 });

--- a/packages/remark/src/index.ts
+++ b/packages/remark/src/index.ts
@@ -1,4 +1,8 @@
 export { default as escapeHtmlInTextNodes } from './plugins/escapeHtmlInTextNodes.js';
+export {
+  default as escapeMarkdownInMdxJsxTextNodes,
+  escapeMarkdownInMdxJsxText,
+} from './plugins/escapeMarkdownInMdxJsxTextNodes.js';
 export { default as remarkGfmCustom } from './plugins/remarkGfmCustom.js';
 export { default as normalizeCJKCharacters } from './plugins/normalizeCJKCharacters.js';
 

--- a/packages/remark/src/plugins/escapeMarkdownInMdxJsxTextNodes.ts
+++ b/packages/remark/src/plugins/escapeMarkdownInMdxJsxTextNodes.ts
@@ -19,6 +19,8 @@ export function escapeMarkdownInMdxJsxText(value: string): string {
     .replace(AMP_NOT_ENTITY, '&amp;')
     .replace(/\*/g, '&#42;')
     .replace(/_/g, '&#95;')
+    .replace(/\[/g, '&#91;')
+    .replace(/\]/g, '&#93;')
     .replace(/\{/g, '&#123;')
     .replace(/\}/g, '&#125;')
     .replace(/`/g, '&#96;');
@@ -28,10 +30,10 @@ export function escapeMarkdownInMdxJsxText(value: string): string {
  * Escape markdown-control characters in text nodes inside MDX JSX elements.
  *
  * Markdown syntax inside JSX text is parsed differently from normal markdown;
- * a translated literal `*`, `_`, `{`, `}`, or backtick can create invalid MDX
- * or change rendered text. Normal markdown outside JSX is intentionally left
- * alone so emphasis, strong text, and inline code continue to serialize as
- * markdown syntax.
+ * a translated literal `*`, `_`, `[`, `]`, `{`, `}`, or backtick can create
+ * invalid MDX or change rendered text. Normal markdown outside JSX is
+ * intentionally left alone so emphasis, strong text, and inline code continue
+ * to serialize as markdown syntax.
  */
 const escapeMarkdownInMdxJsxTextNodes: Plugin<[], Root> = function () {
   return function (tree: Root) {

--- a/packages/remark/src/plugins/escapeMarkdownInMdxJsxTextNodes.ts
+++ b/packages/remark/src/plugins/escapeMarkdownInMdxJsxTextNodes.ts
@@ -1,0 +1,55 @@
+import type { Root } from 'mdast';
+import type { Plugin } from 'unified';
+
+type MdxTreeNode = {
+  type?: string;
+  value?: unknown;
+  children?: MdxTreeNode[];
+};
+
+// & that is NOT already an entity: &word;  &#123;  &#x1A2B;
+const AMP_NOT_ENTITY = /&(?![a-zA-Z][a-zA-Z0-9]*;|#\d+;|#x[0-9A-Fa-f]+;)/g;
+
+function isMdxJsxNode(node: MdxTreeNode): boolean {
+  return node.type === 'mdxJsxFlowElement' || node.type === 'mdxJsxTextElement';
+}
+
+export function escapeMarkdownInMdxJsxText(value: string): string {
+  return value
+    .replace(AMP_NOT_ENTITY, '&amp;')
+    .replace(/\*/g, '&#42;')
+    .replace(/_/g, '&#95;')
+    .replace(/\{/g, '&#123;')
+    .replace(/\}/g, '&#125;')
+    .replace(/`/g, '&#96;');
+}
+
+/**
+ * Escape markdown-control characters in text nodes inside MDX JSX elements.
+ *
+ * Markdown syntax inside JSX text is parsed differently from normal markdown;
+ * a translated literal `*`, `_`, `{`, `}`, or backtick can create invalid MDX
+ * or change rendered text. Normal markdown outside JSX is intentionally left
+ * alone so emphasis, strong text, and inline code continue to serialize as
+ * markdown syntax.
+ */
+const escapeMarkdownInMdxJsxTextNodes: Plugin<[], Root> = function () {
+  return function (tree: Root) {
+    const visit = (node: MdxTreeNode, insideMdxJsx: boolean) => {
+      if (
+        insideMdxJsx &&
+        node.type === 'text' &&
+        typeof node.value === 'string'
+      ) {
+        node.value = escapeMarkdownInMdxJsxText(node.value);
+      }
+
+      const childInsideMdxJsx = insideMdxJsx || isMdxJsxNode(node);
+      node.children?.forEach((child) => visit(child, childInsideMdxJsx));
+    };
+
+    visit(tree as MdxTreeNode, false);
+  };
+};
+
+export default escapeMarkdownInMdxJsxTextNodes;


### PR DESCRIPTION
<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1583"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783715441&installation_id=127936663&pr_number=1583&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1583&signature=b98c2454deb7cde81106c6e02618482890a57279c475c8eb12f77814207b2371"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces `escapeMarkdownInMdxJsxTextNodes`, a new remark plugin that escapes markdown-control characters (`*`, `_`, `{`, `}`, `` ` ``, `&`) inside text nodes that are children of MDX JSX elements, preventing translated literals from being misinterpreted as markup. The plugin is idempotent — it uses a negative lookahead regex to skip already-escaped HTML entities — and only targets MDX JSX node types, leaving normal markdown outside JSX untouched.

- New `escapeMarkdownInMdxJsxTextNodes` plugin added to `packages/remark`, exported from the package index alongside the helper `escapeMarkdownInMdxJsxText`.
- Tests cover escaping inside MDX JSX nodes, no-op behavior outside MDX JSX, and idempotency for pre-existing entities.
- README documentation example is missing `remark-mdx` in the pipeline, so the sample code would silently produce no escaping.

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The plugin implementation itself is correct and safe to merge, but the README example ships broken documentation that will mislead users into thinking the plugin has no effect.

The plugin logic, entity-skipping regex, and AST traversal are all correct. However, the README usage example omits remark-mdx from the pipeline — without it remarkParse never emits MDX JSX nodes, so the example silently does nothing. There is also a gap where [ and ] characters inside JSX text are not escaped, which can produce unintended links from translated text.

packages/remark/README.md needs remark-mdx added to the example pipeline; packages/remark/src/plugins/escapeMarkdownInMdxJsxTextNodes.ts warrants a second look for [ and ] escaping coverage.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/remark/src/plugins/escapeMarkdownInMdxJsxTextNodes.ts | New remark plugin that escapes markdown-control characters (*,_,{,},`,&) in text nodes inside MDX JSX elements; logic is sound and idempotent, but [ and ] are not escaped, leaving a gap for unintended link formation. |
| packages/remark/README.md | Adds usage example for the new plugin, but the pipeline shown omits remark-mdx, meaning the example silently does nothing as remarkParse won't produce the MDX JSX AST nodes the plugin targets. |
| packages/remark/src/__tests__/index.test.ts | Adds test coverage for the new plugin: escaping inside MDX JSX nodes, no-op outside MDX JSX nodes, and idempotency for pre-existing entities; all cases look correct. |
| packages/remark/src/index.ts | Exports both the plugin (default) and the helper function escapeMarkdownInMdxJsxText from the new module; straightforward re-export. |
| .changeset/swift-rules-speak.md | Patch-level changeset entry for gt-remark; appropriate versioning for an additive feature. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[unified pipeline input] --> B[remarkParse + remarkMdx]
    B --> C{AST node type?}
    C -- mdxJsxFlowElement or mdxJsxTextElement --> D[Set insideMdxJsx = true]
    C -- other node --> E[Pass through, recurse with insideMdxJsx=false]
    D --> F{Child node type = text?}
    F -- yes --> G[escapeMarkdownInMdxJsxText]
    G --> G1[Escape amp, asterisk, underscore, braces, backtick]
    G1 --> G2[Skip already-escaped HTML entities]
    G2 --> H[Escaped text node]
    F -- no --> I[Recurse into children with insideMdxJsx=true]
    H --> K[remarkStringify output]
    I --> K
    E --> K
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fremark%2FREADME.md%3A39-49%0A**README%20example%20silently%20no-ops%20without%20remark-mdx**%0A%0AThe%20example%20pipeline%20uses%20only%20%60remarkParse%60%20%2B%20%60escapeMarkdownInMdxJsxTextNodes%60%20%2B%20%60remarkStringify%60.%20%60remarkParse%60%20does%20not%20understand%20MDX%20syntax%2C%20so%20%60%3Cp%3E*literal%20translated%20text*%3C%2Fp%3E%60%20is%20parsed%20as%20an%20HTML%20raw%20node%2C%20**not**%20as%20%60mdxJsxFlowElement%60%20%2F%20%60mdxJsxTextElement%60.%20The%20plugin%20walks%20the%20tree%20looking%20for%20those%20node%20types%20and%20finds%20none%20%E2%80%94%20the%20%60*%60%20characters%20pass%20through%20unescaped.%20A%20reader%20copying%20this%20example%20will%20see%20no%20escaping%20and%20conclude%20the%20plugin%20doesn't%20work.%0A%0AThe%20pipeline%20needs%20%60remark-mdx%60%20%28e.g.%20%60import%20remarkMdx%20from%20'remark-mdx'%60%29%20added%20with%20%60.use%28remarkMdx%29%60%20so%20the%20parser%20actually%20emits%20MDX%20JSX%20nodes%20that%20the%20plugin%20can%20visit.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fremark%2Fsrc%2Fplugins%2FescapeMarkdownInMdxJsxTextNodes.ts%3A17-25%0A**%60%5B%60%20and%20%60%5D%60%20not%20escaped%20%E2%80%94%20translated%20text%20can%20form%20unintended%20links**%0A%0AInside%20MDX%20JSX%20children%20the%20content%20is%20still%20parsed%20as%20inline%20Markdown%2C%20so%20translated%20text%20containing%20%60%5Bclick%20here%5D%28url%29%60%20or%20even%20a%20bare%20%60%5Bbracketed%20phrase%5D%60%20will%20be%20interpreted%20as%20a%20link%20or%20link%20reference%20rather%20than%20rendered%20literally.%20The%20plugin%20currently%20escapes%20%60*%60%2C%20%60_%60%2C%20%60%60%20%60%20%60%60%2C%20%60%7B%60%2C%20%60%7D%60%2C%20and%20%60%26%60%2C%20but%20omits%20%60%5B%60%20%28and%20correspondingly%20%60%5D%60%29.%20Adding%20%60.replace%28%2F%5C%5B%2Fg%2C%20'%26%2391%3B'%29%60%20and%20%60.replace%28%2F%5C%5D%2Fg%2C%20'%26%2393%3B'%29%60%20would%20close%20this%20gap.%0A%0A&repo=generaltranslation%2Fgt&pr=1583&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22f%2Fgt-remark-jsx-text%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22f%2Fgt-remark-jsx-text%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fremark%2FREADME.md%3A39-49%0A**README%20example%20silently%20no-ops%20without%20remark-mdx**%0A%0AThe%20example%20pipeline%20uses%20only%20%60remarkParse%60%20%2B%20%60escapeMarkdownInMdxJsxTextNodes%60%20%2B%20%60remarkStringify%60.%20%60remarkParse%60%20does%20not%20understand%20MDX%20syntax%2C%20so%20%60%3Cp%3E*literal%20translated%20text*%3C%2Fp%3E%60%20is%20parsed%20as%20an%20HTML%20raw%20node%2C%20**not**%20as%20%60mdxJsxFlowElement%60%20%2F%20%60mdxJsxTextElement%60.%20The%20plugin%20walks%20the%20tree%20looking%20for%20those%20node%20types%20and%20finds%20none%20%E2%80%94%20the%20%60*%60%20characters%20pass%20through%20unescaped.%20A%20reader%20copying%20this%20example%20will%20see%20no%20escaping%20and%20conclude%20the%20plugin%20doesn't%20work.%0A%0AThe%20pipeline%20needs%20%60remark-mdx%60%20%28e.g.%20%60import%20remarkMdx%20from%20'remark-mdx'%60%29%20added%20with%20%60.use%28remarkMdx%29%60%20so%20the%20parser%20actually%20emits%20MDX%20JSX%20nodes%20that%20the%20plugin%20can%20visit.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fremark%2Fsrc%2Fplugins%2FescapeMarkdownInMdxJsxTextNodes.ts%3A17-25%0A**%60%5B%60%20and%20%60%5D%60%20not%20escaped%20%E2%80%94%20translated%20text%20can%20form%20unintended%20links**%0A%0AInside%20MDX%20JSX%20children%20the%20content%20is%20still%20parsed%20as%20inline%20Markdown%2C%20so%20translated%20text%20containing%20%60%5Bclick%20here%5D%28url%29%60%20or%20even%20a%20bare%20%60%5Bbracketed%20phrase%5D%60%20will%20be%20interpreted%20as%20a%20link%20or%20link%20reference%20rather%20than%20rendered%20literally.%20The%20plugin%20currently%20escapes%20%60*%60%2C%20%60_%60%2C%20%60%60%20%60%20%60%60%2C%20%60%7B%60%2C%20%60%7D%60%2C%20and%20%60%26%60%2C%20but%20omits%20%60%5B%60%20%28and%20correspondingly%20%60%5D%60%29.%20Adding%20%60.replace%28%2F%5C%5B%2Fg%2C%20'%26%2391%3B'%29%60%20and%20%60.replace%28%2F%5C%5D%2Fg%2C%20'%26%2393%3B'%29%60%20would%20close%20this%20gap.%0A%0A&repo=generaltranslation%2Fgt&pr=1583&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/remark/README.md:39-49
**README example silently no-ops without remark-mdx**

The example pipeline uses only `remarkParse` + `escapeMarkdownInMdxJsxTextNodes` + `remarkStringify`. `remarkParse` does not understand MDX syntax, so `<p>*literal translated text*</p>` is parsed as an HTML raw node, **not** as `mdxJsxFlowElement` / `mdxJsxTextElement`. The plugin walks the tree looking for those node types and finds none — the `*` characters pass through unescaped. A reader copying this example will see no escaping and conclude the plugin doesn't work.

The pipeline needs `remark-mdx` (e.g. `import remarkMdx from 'remark-mdx'`) added with `.use(remarkMdx)` so the parser actually emits MDX JSX nodes that the plugin can visit.

### Issue 2 of 2
packages/remark/src/plugins/escapeMarkdownInMdxJsxTextNodes.ts:17-25
**`[` and `]` not escaped — translated text can form unintended links**

Inside MDX JSX children the content is still parsed as inline Markdown, so translated text containing `[click here](url)` or even a bare `[bracketed phrase]` will be interpreted as a link or link reference rather than rendered literally. The plugin currently escapes `*`, `_`, `` ` ``, `{`, `}`, and `&`, but omits `[` (and correspondingly `]`). Adding `.replace(/\[/g, '&#91;')` and `.replace(/\]/g, '&#93;')` would close this gap.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: gt-remark text node jsx plugin"](https://github.com/generaltranslation/gt/commit/9e057ea334d793f4a3b5726c996b7535c5855171) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36814432)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->