### PR TITLE
fix: refetch composite content

### DIFF
--- a/.changeset/breezy-zoos-remain.md
+++ b/.changeset/breezy-zoos-remain.md
@@ -1,0 +1,5 @@
+---
+"gt": patch
+---
+
+Refetch composite content

--- a/packages/cli/src/api/__tests__/downloadFileBatch.test.ts
+++ b/packages/cli/src/api/__tests__/downloadFileBatch.test.ts
@@ -9,6 +9,7 @@ import {
   FileFormat,
 } from 'generaltranslation/types';
 import { createMockSettings } from '../__mocks__/settings.js';
+import { readLockfile } from '../../fs/config/downloadedVersions.js';
 import type { FileStatusTracker } from '../../workflow/PollJobsStep.js';
 
 // Mock dependencies
@@ -16,22 +17,38 @@ vi.mock('../../utils/gt.js', () => ({
   gt: {
     downloadFileBatch: vi.fn(),
     resolveAliasLocale: vi.fn((locale) => locale), // Return locale as-is for testing
+    resolveCanonicalLocale: vi.fn((locale) => locale),
   },
 }));
 
 vi.mock('fs', () => ({
   existsSync: vi.fn(),
   mkdirSync: vi.fn(),
+  readFileSync: vi.fn(),
   promises: {
     writeFile: vi.fn(),
   },
 }));
 
-vi.mock('path', () => ({
-  default: {
-    dirname: vi.fn(),
-  },
-  dirname: vi.fn(),
+vi.mock('path', () => {
+  // Shared instances so default and named imports resolve to the same mocks
+  const dirname = vi.fn();
+  const relative = vi.fn();
+  return {
+    default: { dirname, relative },
+    dirname,
+    relative,
+  };
+});
+
+vi.mock('../../fs/config/downloadedVersions.js', () => ({
+  readLockfile: vi.fn(() => ({
+    data: { entries: [] },
+    entryMap: new Map(),
+    originalV1: false,
+  })),
+  writeLockfile: vi.fn(),
+  findOrCreateEntry: vi.fn(() => ({ translations: {} })),
 }));
 
 vi.mock('../../console/logger.js', () => ({
@@ -483,6 +500,7 @@ describe('downloadFileBatch', () => {
           branchId: 'branch-1',
           fileId: 'file-1',
           versionId: 'version-1',
+          locale: 'en',
           fileFormat: 'JSON' as FileFormat,
           data: 'content1',
           fileName: 'file1.json',
@@ -512,5 +530,110 @@ describe('downloadFileBatch', () => {
     expect(logger.error).toHaveBeenCalled();
     expect(result.successful).toHaveLength(0);
     expect(result.failed).toHaveLength(1);
+  });
+
+  it('always merges composite schema files from fresh data, even when the lockfile is up to date', async () => {
+    // Composite files (e.g. Mintlify docs.json) merge translations into the
+    // source file itself, so outputPath always exists and the lockfile check
+    // cannot tell whether derived split outputs ({locale}/docs.json) are still
+    // on disk. The up-to-date skip must be bypassed for them — otherwise a run
+    // that cleared the locale dirs never regenerates the locale nav files.
+    const sourceDocsJson = JSON.stringify({
+      navigation: {
+        languages: [{ language: 'en', tabs: [{ tab: 'Guides' }] }],
+      },
+    });
+    const translatedPayload = JSON.stringify({
+      '/navigation/languages': { '/0': { '/tabs/0/tab': 'Guías' } },
+    });
+
+    const files: BatchedFiles = [
+      {
+        branchId: 'branch-1',
+        fileId: 'file-1',
+        versionId: 'version-1',
+        outputPath: 'docs.json',
+        inputPath: 'docs.json',
+        locale: 'es',
+      },
+    ];
+    const fileTracker = createMockFileTracker(files);
+
+    vi.mocked(gt.downloadFileBatch).mockResolvedValue({
+      files: [
+        {
+          id: 'translation-1',
+          branchId: 'branch-1',
+          fileId: 'file-1',
+          versionId: 'version-1',
+          locale: 'es',
+          fileFormat: 'JSON' as FileFormat,
+          data: translatedPayload,
+          fileName: 'docs.json',
+          metadata: {},
+        },
+      ],
+      count: 1,
+    });
+
+    // Lockfile says this exact version+locale was already downloaded, and the
+    // output file exists — the conditions that previously triggered the skip
+    vi.mocked(readLockfile).mockReturnValue({
+      data: { entries: [] },
+      entryMap: new Map([
+        [
+          'file-1',
+          {
+            versionId: 'version-1',
+            fileName: 'docs.json',
+            translations: {
+              es: {
+                updatedAt: '2026-01-01T00:00:00.000Z',
+                fileName: 'docs.json',
+              },
+            },
+          },
+        ],
+      ]),
+      originalV1: false,
+    } as any);
+
+    setupFileSystemMocks({ dirExists: true });
+    vi.mocked(fs.readFileSync).mockReturnValue(sourceDocsJson);
+    vi.mocked(path.relative).mockReturnValue('docs.json');
+
+    const result = await downloadFileBatch(
+      fileTracker,
+      files,
+      createMockSettings({
+        locales: ['en', 'es'],
+        options: {
+          jsonSchema: {
+            'docs.json': {
+              composite: {
+                '$.navigation.languages': {
+                  type: 'array',
+                  key: '$.language',
+                  include: ['$..tab'],
+                },
+              },
+            },
+          },
+        },
+      } as any)
+    );
+
+    // Fresh data must be merged and written — not skipped
+    expect(result.skipped).toHaveLength(0);
+    expect(result.successful).toHaveLength(1);
+    const writeCall = vi
+      .mocked(fs.promises.writeFile)
+      .mock.calls.find((c) => c[0] === 'docs.json');
+    expect(writeCall).toBeDefined();
+    const written = JSON.parse(writeCall![1] as string);
+    const esEntry = written.navigation.languages.find(
+      (l: any) => l.language === 'es'
+    );
+    expect(esEntry.tabs[0].tab).toBe('Guías');
   });
 });

--- a/packages/cli/src/api/downloadFileBatch.ts
+++ b/packages/cli/src/api/downloadFileBatch.ts
@@ -226,7 +226,21 @@ export async function downloadFileBatch(
             : undefined;
         const fileExists = fs.existsSync(outputPath);
 
-        if (!forceDownload && fileExists && downloadedTranslation) {
+        // Composite schema files merge translations into the source file itself,
+        // so outputPath always exists and the lock can't tell whether derived
+        // split outputs (e.g. {locale}/docs.json) are still on disk. Always
+        // merge fresh API data so derived files are regenerated every run;
+        // local edits to translated output are preserved via `gt save-local`.
+        const isInPlaceComposite = options.options?.jsonSchema
+          ? !!validateJsonSchema(options.options, inputPath)?.composite
+          : false;
+
+        if (
+          !forceDownload &&
+          fileExists &&
+          downloadedTranslation &&
+          !isInPlaceComposite
+        ) {
           // For schema-based files, re-merge with current source in case
           // non-translatable fields changed (skip the API download, not the merge)
           try {
@@ -277,8 +291,12 @@ export async function downloadFileBatch(
               // even when the API download was skipped
               recordRemerged(outputPath);
             }
-          } catch {
-            // If re-merge fails, still count as skipped — not worth failing the download
+          } catch (error) {
+            // If re-merge fails, still count as skipped — not worth failing
+            // the download, but surface it so missing output is diagnosable
+            logger.warn(
+              `Failed to re-merge existing translation for ${outputPath} (${locale}): ${error}`
+            );
           }
           result.skipped.push(requestedFile);
           continue;

--- a/packages/cli/src/utils/__tests__/splitMintlifyLanguageRefs.test.ts
+++ b/packages/cli/src/utils/__tests__/splitMintlifyLanguageRefs.test.ts
@@ -752,6 +752,41 @@ describe('splitMintlifyLanguageRefs', () => {
     });
   });
 
+  it('never writes self-referential stubs for entries left in $ref form', async () => {
+    // If the merge step did not run (e.g. translations were cached), docs.json
+    // on disk still has its source-form locale entries: { language, $ref }.
+    // Splitting those would write { "$ref": "./es/docs.json" } INTO
+    // es/docs.json — a circular ref that overwrites the real nav file.
+    const sourceFormDocsJson = {
+      navigation: {
+        languages: [
+          { language: 'en', tabs: [{ tab: 'Guides', groups: [] }] },
+          { language: 'es', $ref: './es/docs.json' },
+        ],
+      },
+    };
+
+    mockRead.mockImplementation((p) => {
+      if (path.resolve(p as string) === path.resolve('/project/docs.json'))
+        return JSON.stringify(sourceFormDocsJson);
+      throw new Error('ENOENT');
+    });
+
+    mockRefMap = new Map();
+
+    await splitMintlifyLanguageRefs(makeSettings());
+
+    // No locale file written — the es entry was never inlined this run
+    expect(getWritten('/project/es/docs.json')).toBeUndefined();
+
+    // The es entry is left untouched in docs.json
+    const docsResult = getWritten('/project/docs.json') as any;
+    expect(docsResult.navigation.languages[1]).toEqual({
+      language: 'es',
+      $ref: './es/docs.json',
+    });
+  });
+
   it('does not clobber a top-level $ref file that was left un-inlined (e.g. redirects)', async () => {
     // mergeJson only re-inlines the composite path (navigation.languages); other
     // refs like `redirects` stay collapsed as { $ref } in the written docs.json.

--- a/packages/cli/src/utils/splitMintlifyLanguageRefs.ts
+++ b/packages/cli/src/utils/splitMintlifyLanguageRefs.ts
@@ -294,6 +294,15 @@ function processSplitEntries(
 
     if (!isJsonContainer(entry) || Array.isArray(entry)) continue;
     const { [keyPropertyName]: _, ...contentWithoutKey } = entry;
+
+    // If the entry still carries a top-level $ref, it was never inlined this
+    // run (e.g. the merge step didn't process this file). There is no content
+    // to extract — writing would produce a self-referential stub that
+    // overwrites or shadows the real ref file. Leave the entry untouched.
+    if (typeof contentWithoutKey.$ref === 'string') {
+      continue;
+    }
+
     const entryFilePath = path.resolve(
       entryBaseDir,
       path.join(keyValue, navFileName)


### PR DESCRIPTION
<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1586"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783733038&installation_id=127936663&pr_number=1586&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1586&signature=59ed6c31792bcaf482c0507bcf1400e46fea71627b4aa3799cd7477beef5fb30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where Mintlify composite schema files (e.g. `docs.json`) were incorrectly skipped during `gt pull` when the lockfile showed the version was already downloaded, preventing derived locale navigation files from being regenerated after a clean locale directory.

- **`downloadFileBatch.ts`**: Adds an `isInPlaceComposite` check so composite files always fall through to the fresh-merge path, bypassing the lockfile skip; also surfaces re-merge failures via `logger.warn` instead of swallowing them silently.
- **`splitMintlifyLanguageRefs.ts`**: Adds a defensive guard that skips writing a locale ref file when its corresponding language entry is still in `$ref` form (i.e. the merge step did not inline it), preventing a self-referential stub from overwriting the real ref file.
- Both changes are covered by new, targeted test cases that assert correct end-to-end behavior for each failure mode.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the fix is narrowly scoped to composite schema files and is well covered by the new integration test.

The core logic change — the `isInPlaceComposite` bypass — relies on `validateJsonSchema` returning a truthy `composite` field when given `inputPath`. If `inputPath` is in a different form than the keys stored in `options.options.jsonSchema` (e.g. absolute vs. relative), the check silently returns `false` and the composite file is skipped again, reproducing the original bug. The `splitMintlifyLanguageRefs.ts` guard is straightforward and low-risk. Tests cover the new scenarios well, but do not exercise the path-normalization edge case.

packages/cli/src/api/downloadFileBatch.ts — the `isInPlaceComposite` check at line 234.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/api/downloadFileBatch.ts | Adds `isInPlaceComposite` bypass to skip-on-lockfile-hit logic so composite schema files are always re-merged from fresh API data; also improves catch-block logging with `logger.warn`. |
| packages/cli/src/utils/splitMintlifyLanguageRefs.ts | Adds a defense-in-depth guard: if a non-default language entry still has a top-level `$ref` after key removal, skip writing the stub file to prevent a self-referential circular reference from overwriting the real ref file. |
| packages/cli/src/api/__tests__/downloadFileBatch.test.ts | Adds test coverage for the composite-file bypass: mocks a locked version+locale, verifies the skip is not taken, and asserts the translated nav entry is merged and written correctly. |
| packages/cli/src/utils/__tests__/splitMintlifyLanguageRefs.test.ts | Adds a test verifying that entries left in `$ref` form (merge step did not run) are skipped without writing a self-referential stub to the locale directory. |
| .changeset/breezy-zoos-remain.md | Patch changeset entry for the composite content re-fetch fix; correct package name and version bump type. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[downloadFileBatch called] --> B[Batch API download]
    B --> C{For each downloaded file}
    C --> D[Check lockfile entry & fileExists]
    D --> E{isInPlaceComposite?}
    E -- Yes --> G[Merge fresh API data with source file]
    E -- No --> F{forceDownload=false & fileExists & downloadedTranslation?}
    F -- Yes --> SKIP[Re-merge existing content / result.skipped]
    F -- No --> G
    G --> H[Write merged output]
    H --> I[result.successful / Update lockfile]
    H --> J[splitMintlifyLanguageRefs runs]
    J --> K{Entry still has top-level $ref?}
    K -- Yes: was never inlined --> L[Skip: leave entry untouched]
    K -- No: fully inlined --> M[Write locale ref file e.g. es/docs.json]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fcli%2Fsrc%2Fapi%2FdownloadFileBatch.ts%3A234-236%0A**%60inputPath%60%20must%20exactly%20match%20the%20jsonSchema%20config%20key**%0A%0A%60validateJsonSchema%60%20is%20given%20%60inputPath%60%20%28which%20comes%20from%20%60fileProperties.fileName%60%29%20to%20look%20up%20the%20JSON%20schema%20config.%20If%20the%20config%20key%20is%20stored%20as%20%60'docs.json'%60%20but%20the%20resolved%20%60inputPath%60%20is%20an%20absolute%20path%20like%20%60'%2Fproject%2Fdocs.json'%60%2C%20the%20lookup%20will%20return%20%60null%60%2C%20%60isInPlaceComposite%60%20will%20be%20%60false%60%2C%20and%20composite%20files%20will%20silently%20fall%20back%20to%20the%20skipped%20path%20%E2%80%94%20reproducing%20the%20original%20bug%20without%20any%20error.%20Any%20path%20normalization%20difference%20between%20config-time%20and%20runtime%20would%20trigger%20this.%20It's%20worth%20verifying%20that%20%60validateJsonSchema%60%20handles%20both%20relative%20and%20absolute%20forms%20consistently%2C%20or%20that%20%60inputPath%60%20is%20always%20in%20the%20same%20form%20as%20the%20keys%20in%20%60options.options.jsonSchema%60.%0A%0A&repo=generaltranslation%2Fgt&pr=1586&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22f%2Frefetch-composites%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22f%2Frefetch-composites%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fcli%2Fsrc%2Fapi%2FdownloadFileBatch.ts%3A234-236%0A**%60inputPath%60%20must%20exactly%20match%20the%20jsonSchema%20config%20key**%0A%0A%60validateJsonSchema%60%20is%20given%20%60inputPath%60%20%28which%20comes%20from%20%60fileProperties.fileName%60%29%20to%20look%20up%20the%20JSON%20schema%20config.%20If%20the%20config%20key%20is%20stored%20as%20%60'docs.json'%60%20but%20the%20resolved%20%60inputPath%60%20is%20an%20absolute%20path%20like%20%60'%2Fproject%2Fdocs.json'%60%2C%20the%20lookup%20will%20return%20%60null%60%2C%20%60isInPlaceComposite%60%20will%20be%20%60false%60%2C%20and%20composite%20files%20will%20silently%20fall%20back%20to%20the%20skipped%20path%20%E2%80%94%20reproducing%20the%20original%20bug%20without%20any%20error.%20Any%20path%20normalization%20difference%20between%20config-time%20and%20runtime%20would%20trigger%20this.%20It's%20worth%20verifying%20that%20%60validateJsonSchema%60%20handles%20both%20relative%20and%20absolute%20forms%20consistently%2C%20or%20that%20%60inputPath%60%20is%20always%20in%20the%20same%20form%20as%20the%20keys%20in%20%60options.options.jsonSchema%60.%0A%0A&repo=generaltranslation%2Fgt&pr=1586&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/cli/src/api/downloadFileBatch.ts:234-236
**`inputPath` must exactly match the jsonSchema config key**

`validateJsonSchema` is given `inputPath` (which comes from `fileProperties.fileName`) to look up the JSON schema config. If the config key is stored as `'docs.json'` but the resolved `inputPath` is an absolute path like `'/project/docs.json'`, the lookup will return `null`, `isInPlaceComposite` will be `false`, and composite files will silently fall back to the skipped path — reproducing the original bug without any error. Any path normalization difference between config-time and runtime would trigger this. It's worth verifying that `validateJsonSchema` handles both relative and absolute forms consistently, or that `inputPath` is always in the same form as the keys in `options.options.jsonSchema`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: refetch composite content"](https://github.com/generaltranslation/gt/commit/1a231387f4884558366876b23bd0da6b0b18724d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36874268)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->