### PR TITLE
fix: preload registered msg calls in getMessages

### DIFF
--- a/packages/compiler/src/passes/__tests__/runtimeTranslatePass.test.ts
+++ b/packages/compiler/src/passes/__tests__/runtimeTranslatePass.test.ts
@@ -150,6 +150,25 @@ function getOptionValue(
   return undefined;
 }
 
+function getObjectValue(
+  object: t.ObjectExpression,
+  key: string
+): string | number | undefined {
+  for (const prop of object.properties) {
+    if (!t.isObjectProperty(prop)) continue;
+    const propKey = t.isStringLiteral(prop.key)
+      ? prop.key.value
+      : t.isIdentifier(prop.key)
+        ? prop.key.name
+        : undefined;
+    if (propKey === key) {
+      if (t.isStringLiteral(prop.value)) return prop.value.value;
+      if (t.isNumericLiteral(prop.value)) return prop.value.value;
+    }
+  }
+  return undefined;
+}
+
 /** Check if code contains a Promise.all call */
 function hasPromiseAll(code: string): boolean {
   return code.includes('Promise.all');
@@ -780,6 +799,51 @@ describe('runtimeTranslatePass', () => {
 
       expect(calls).toHaveLength(1);
       expect(getOptionValue(calls[0], '$_hash')).toBeUndefined();
+    });
+
+    it('injects registered msg() calls into getMessages()', () => {
+      const state = initializeState({}, 'test.tsx');
+      const ast = parser.parse(
+        `
+        import { getMessages, msg } from 'gt-next/server';
+        const greeting = msg("Hello", { $context: "nav" });
+        export async function Page() {
+          const m = await getMessages();
+          return m(greeting);
+        }
+      `,
+        {
+          sourceType: 'module',
+          plugins: ['jsx', 'typescript'],
+        }
+      );
+
+      traverse(ast, collectionPass(state));
+      traverse(ast, injectionPass(state));
+
+      let getMessagesCall: t.CallExpression | undefined;
+      traverse(ast, {
+        CallExpression(path) {
+          if (t.isIdentifier(path.node.callee, { name: 'getMessages' })) {
+            getMessagesCall = path.node;
+          }
+        },
+      });
+
+      expect(getMessagesCall).toBeDefined();
+      const messagesArg = getMessagesCall!.arguments[0];
+      expect(t.isArrayExpression(messagesArg)).toBe(true);
+      const firstMessage = (messagesArg as t.ArrayExpression).elements[0];
+      expect(t.isObjectExpression(firstMessage)).toBe(true);
+      expect(
+        getObjectValue(firstMessage as t.ObjectExpression, 'message')
+      ).toBe('Hello');
+      expect(
+        getObjectValue(firstMessage as t.ObjectExpression, '$context')
+      ).toBe('nav');
+      expect(
+        getObjectValue(firstMessage as t.ObjectExpression, '$_hash')
+      ).toBeDefined();
     });
 
     it('keeps useGT callback hash alignment when standalone t() appears first', () => {

--- a/packages/compiler/src/processing/collection/processCallExpression.ts
+++ b/packages/compiler/src/processing/collection/processCallExpression.ts
@@ -79,14 +79,20 @@ export function processCallExpression(
       canonicalName === GT_OTHER_FUNCTIONS.msg
     ) {
       // msg() is runtime-only content; it must not advance the injection counter.
-      handleStandaloneTranslation(callExprPath, state, { injectHash: false });
+      handleStandaloneTranslation(callExprPath, state, {
+        injectHash: false,
+        runtimeSource: 'msg',
+      });
     } else if (
       type === 'generaltranslation' &&
       canonicalName === GT_OTHER_FUNCTIONS.t
     ) {
       // Standalone t() receives an injected $_hash, so collection reserves a
       // matching counter slot for the injection pass.
-      handleStandaloneTranslation(callExprPath, state, { injectHash: true });
+      handleStandaloneTranslation(callExprPath, state, {
+        injectHash: true,
+        runtimeSource: 't',
+      });
     }
   };
 }
@@ -302,7 +308,10 @@ function handleReactInvocation(
 function handleStandaloneTranslation(
   callExprPath: NodePath<t.CallExpression>,
   state: TransformState,
-  { injectHash }: { injectHash: boolean }
+  {
+    injectHash,
+    runtimeSource,
+  }: { injectHash: boolean; runtimeSource: 'msg' | 't' }
 ) {
   // Reuse the same validation as useGT_callback (identical argument structure)
   const params = validateTranslationFunction(callExprPath, state);
@@ -325,5 +334,6 @@ function handleStandaloneTranslation(
     maxChars: params.maxChars,
     format: params.format,
     injectHash,
+    runtimeSource,
   });
 }

--- a/packages/compiler/src/state/StringCollector.ts
+++ b/packages/compiler/src/state/StringCollector.ts
@@ -21,6 +21,8 @@ export interface TranslationContent {
   maxChars?: number;
   /** Optional format from options: t("text", {$format: "STRING"}) → "STRING" */
   format?: string;
+  /** Runtime-only source function, when registered outside a callback */
+  runtimeSource?: 'msg' | 't';
 }
 
 /**
@@ -214,8 +216,15 @@ export class StringCollector {
   /**
    * Get all runtime-only translation entries
    */
-  getRuntimeOnlyContent(): TranslationContent[] {
-    return this.runtimeOnlyEntries;
+  getRuntimeOnlyContent(
+    runtimeSource?: TranslationContent['runtimeSource']
+  ): TranslationContent[] {
+    if (!runtimeSource) {
+      return this.runtimeOnlyEntries;
+    }
+    return this.runtimeOnlyEntries.filter(
+      (entry) => entry.runtimeSource === runtimeSource
+    );
   }
 
   /**

--- a/packages/compiler/src/transform/injection/injectCallbackDeclaratorFunctionParameters.ts
+++ b/packages/compiler/src/transform/injection/injectCallbackDeclaratorFunctionParameters.ts
@@ -7,6 +7,7 @@ import { GT_FUNCTIONS_WITH_CALLBACKS } from '../../utils/constants/gt/constants'
 import { extractIdentifiersFromLVal } from '../../utils/parsing/extractIdentifiersFromLVal';
 import { trackOverridingVariable } from '../tracking/trackOverridingVariable';
 import { createErrorLocation } from '../../utils/errors';
+import type { TranslationContent } from '../../state/StringCollector';
 
 /**
  * inject parameters into invocation of translation function
@@ -93,6 +94,10 @@ export function injectCallbackDeclaratorFunctionParameters(
     case GT_FUNCTIONS_WITH_CALLBACKS.getGT:
       injectUseGTParameters(expression, state, id);
       break;
+    case GT_FUNCTIONS_WITH_CALLBACKS.useMessages:
+    case GT_FUNCTIONS_WITH_CALLBACKS.getMessages:
+      injectUseMessagesParameters(expression, state);
+      break;
     default:
       return;
   }
@@ -117,43 +122,56 @@ function injectUseGTParameters(
   }
 
   // Inject the parameters into the call expression
-  expression.arguments = [
-    t.arrayExpression(
-      translationContent.map((content) =>
-        t.objectExpression([
-          t.objectProperty(t.identifier('hash'), t.stringLiteral(content.hash)),
-          t.objectProperty(
-            t.identifier('message'),
-            t.stringLiteral(content.message)
-          ),
-          ...(content.id
-            ? [
-                t.objectProperty(
-                  t.identifier('id'),
-                  t.stringLiteral(content.id)
-                ),
-              ]
-            : []),
-          ...(content.context
-            ? [
-                t.objectProperty(
-                  t.identifier('context'),
-                  t.stringLiteral(content.context)
-                ),
-              ]
-            : []),
-          ...(content.maxChars != null
-            ? [
-                t.objectProperty(
-                  t.identifier('maxChars'),
-                  t.numericLiteral(content.maxChars)
-                ),
-              ]
-            : []),
-        ])
-      )
-    ),
-  ];
+  expression.arguments = [buildMessagesArrayExpression(translationContent)];
+}
+
+/**
+ * Inject the registered msg() calls into useMessages/getMessages so server
+ * async boundaries can preload translations before m() renders them.
+ */
+function injectUseMessagesParameters(
+  expression: t.CallExpression,
+  state: TransformState
+) {
+  const translationContent = state.stringCollector.getRuntimeOnlyContent('msg');
+  if (!translationContent.length) {
+    return;
+  }
+
+  expression.arguments = [buildMessagesArrayExpression(translationContent)];
+}
+
+function buildMessagesArrayExpression(content: TranslationContent[]) {
+  return t.arrayExpression(
+    content.map((entry) =>
+      t.objectExpression([
+        t.objectProperty(
+          t.identifier('message'),
+          t.stringLiteral(entry.message)
+        ),
+        t.objectProperty(t.identifier('$_hash'), t.stringLiteral(entry.hash)),
+        ...(entry.id
+          ? [t.objectProperty(t.identifier('$id'), t.stringLiteral(entry.id))]
+          : []),
+        ...(entry.context
+          ? [
+              t.objectProperty(
+                t.identifier('$context'),
+                t.stringLiteral(entry.context)
+              ),
+            ]
+          : []),
+        ...(entry.maxChars != null
+          ? [
+              t.objectProperty(
+                t.identifier('$maxChars'),
+                t.numericLiteral(entry.maxChars)
+              ),
+            ]
+          : []),
+      ])
+    )
+  );
 }
 
 /**

--- a/packages/compiler/src/transform/registration/registerStandaloneTranslation.ts
+++ b/packages/compiler/src/transform/registration/registerStandaloneTranslation.ts
@@ -14,6 +14,7 @@ export function registerStandaloneTranslation({
   hash,
   format,
   injectHash,
+  runtimeSource,
 }: {
   state: TransformState;
   content: string;
@@ -23,6 +24,7 @@ export function registerStandaloneTranslation({
   hash?: string;
   format?: string;
   injectHash?: boolean;
+  runtimeSource?: 'msg' | 't';
 }): void {
   hash ??= hashSource({
     source: content,
@@ -39,6 +41,7 @@ export function registerStandaloneTranslation({
     context,
     maxChars,
     format,
+    runtimeSource,
   });
 
   // Runtime-only entries, including msg() and t`...`, stop here. Only


### PR DESCRIPTION
## Summary

- Track standalone `msg()` registrations separately from standalone `t()` runtime entries.
- Inject registered `msg()` content into empty `getMessages()` / `useMessages()` calls so awaited server boundaries can preload translations before `m()` renders them.
- Add a compiler regression test for the `msg()` + `await getMessages()` pattern.

## Tests

- `pnpm --filter @generaltranslation/format build`
- `pnpm --filter generaltranslation build`
- `pnpm --filter @generaltranslation/compiler test`
- `pnpm --filter @generaltranslation/compiler typecheck`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1592"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783822400&installation_id=127936663&pr_number=1592&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1592&signature=7e5a6ad3feaacb82f013f1ea175c9a5ccebe1debf6c767a671262837123a45d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enables the compiler to inject registered `msg()` content into empty `getMessages()`/`useMessages()` calls, so server async boundaries can preload translations before `m()` renders them. It also tracks `msg()` and `t()` standalone registrations separately via a new `runtimeSource` discriminant on `TranslationContent`.

- `processCallExpression` now tags standalone `msg()` entries with `runtimeSource: 'msg'` and standalone `t()` with `runtimeSource: 't'`, letting `getRuntimeOnlyContent('msg')` filter precisely.
- `injectCallbackDeclaratorFunctionParameters` gains a `useMessages`/`getMessages` case that calls the new `injectUseMessagesParameters`, which feeds the `msg()`-only slice of `runtimeOnlyEntries` through the refactored `buildMessagesArrayExpression` helper — a helper that is also used by the existing `injectUseGTParameters` path with updated `$`-prefixed key names (`$_hash`, `$id`, `$context`, `$maxChars`) matching the `_Message` type.
- A regression test covers the `msg()` + `await getMessages()` pattern end-to-end through the collection and injection passes.

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

- Safe to merge with the caveat that the shared `buildMessagesArrayExpression` helper quietly changes the injected object shape for the pre-existing `useGT`/`getGT` path — a change that is correct per the `_Message` type but is undocumented and untested by key-name assertions.
- The new `getMessages`/`useMessages` injection path is well-structured and the emitted key names (`$_hash`, `$id`, `$context`, `$maxChars`) correctly match the `_Message` type consumed by `createTranslator`. However, the refactoring also silently renames the keys injected into the existing `useGT`/`getGT` path. The old keys (`hash`, `id`, `context`, `maxChars`) did not match `_Message`, so the old preloading was effectively a no-op — the rename is actually a fix — but it is not called out in the PR description and no existing test asserts the emitted key names, meaning a future regression on this path would be invisible until runtime.
- packages/compiler/src/transform/injection/injectCallbackDeclaratorFunctionParameters.ts deserves a second look: the implicit key-name change for `useGT`/`getGT` through `buildMessagesArrayExpression` should be explicitly documented and covered by a test that inspects the emitted property names.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/compiler/src/transform/injection/injectCallbackDeclaratorFunctionParameters.ts | Adds `useMessages`/`getMessages` injection case and extracts shared `buildMessagesArrayExpression`; the refactoring silently renames injected property keys for the existing `useGT`/`getGT` path from `hash`/`id`/`context`/`maxChars` to `$_hash`/`$id`/`$context`/`$maxChars`. |
| packages/compiler/src/state/StringCollector.ts | Adds optional `runtimeSource` field to `TranslationContent` and allows `getRuntimeOnlyContent` to filter by it; clean, additive change with no side-effects on other paths. |
| packages/compiler/src/processing/collection/processCallExpression.ts | Passes `runtimeSource: 'msg'` or `runtimeSource: 't'` to `handleStandaloneTranslation` to distinguish the two standalone translation types; straightforward additive change. |
| packages/compiler/src/transform/registration/registerStandaloneTranslation.ts | Threads the new `runtimeSource` parameter through to `pushRuntimeOnlyContent`; minimal and correct. |
| packages/compiler/src/passes/__tests__/runtimeTranslatePass.test.ts | Adds regression test for `msg()` + `await getMessages()` pattern and a helper `getObjectValue`; covers `message`, `$context`, and `$_hash` but omits `$id` and `$maxChars` cases. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Source as Source File
    participant CollectionPass
    participant StringCollector
    participant InjectionPass
    participant RuntimeCode as getMessages/useMessages

    Source->>CollectionPass: "msg("Hello", { $context: "nav" })"
    CollectionPass->>StringCollector: "pushRuntimeOnlyContent({ message, hash, context, runtimeSource: 'msg' })"

    Source->>CollectionPass: "const m = await getMessages()"
    CollectionPass->>StringCollector: incrementCounter() [tracks getMessages variable]

    CollectionPass-->>InjectionPass: pass 2 begins

    InjectionPass->>StringCollector: getRuntimeOnlyContent('msg')
    StringCollector-->>InjectionPass: "[{ message, hash, context, runtimeSource: 'msg' }]"

    InjectionPass->>InjectionPass: buildMessagesArrayExpression(content)
    Note over InjectionPass: Emits { message, $_hash, $context, $id?, $maxChars? }

    InjectionPass->>RuntimeCode: "getMessages([{ message: "Hello", $_hash: "...", $context: "nav" }])"
    Note over RuntimeCode: Preloads translations before m() renders them
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fcompiler%2Fsrc%2Ftransform%2Finjection%2FinjectCallbackDeclaratorFunctionParameters.ts%3A144-175%0A**Silent%20property-name%20change%20for%20%60useGT%60%2F%60getGT%60%20injection**%0A%0A%60buildMessagesArrayExpression%60%20is%20now%20shared%20between%20the%20existing%20%60injectUseGTParameters%60%20path%20and%20the%20new%20%60injectUseMessagesParameters%60%20path%2C%20but%20it%20uses%20different%20key%20names%20than%20the%20code%20it%20replaced.%20The%20old%20%60injectUseGTParameters%60%20emitted%20%60hash%60%2C%20%60id%60%2C%20%60context%60%2C%20and%20%60maxChars%60%3B%20this%20shared%20helper%20emits%20%60%24_hash%60%2C%20%60%24id%60%2C%20%60%24context%60%2C%20and%20%60%24maxChars%60.%0A%0AThis%20change%20is%20architecturally%20correct%20%E2%80%94%20the%20%60_Message%60%20type%20and%20%60initializeGT%60%20both%20destructure%20the%20%60%24%60-prefixed%20names%20%E2%80%94%20meaning%20the%20old%20emitted%20keys%20were%20silently%20dead%20%28they%20would%20fall%20through%20to%20%60...variables%60%20as%20formatting%20variables%20rather%20than%20driving%20hash%20lookup%29.%20However%2C%20the%20PR%20description%20mentions%20only%20the%20%60getMessages%60%2F%60useMessages%60%20feature%20and%20doesn't%20call%20out%20that%20existing%20%60useGT%60%2F%60getGT%60%20preloading%20behaviour%20has%20changed.%20If%20any%20downstream%20consumer%20or%20integration%20test%20was%20relying%20on%20the%20old%20key%20names%20a%20regression%20would%20be%20invisible%20until%20runtime.%20Consider%20adding%20a%20note%20to%20the%20PR%20description%20and%20a%20dedicated%20assertion%20in%20the%20%60useGT%60%20injection%20tests%20that%20verifies%20the%20emitted%20key%20names%20match%20%60_Message%60.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fcompiler%2Fsrc%2Fpasses%2F__tests__%2FruntimeTranslatePass.test.ts%3A804-847%0A**Test%20coverage%20gaps%20for%20new%20injection%20path**%0A%0AThe%20new%20test%20verifies%20%60message%60%2C%20%60%24context%60%2C%20and%20%60%24_hash%60%20but%20does%20not%20exercise%20%60%24id%60%20or%20%60%24maxChars%60%20injection.%20Given%20that%20the%20%60_Message%60%20type%20explicitly%20includes%20both%20%28%60%24id%3F%60%20and%20%60%24maxChars%3F%60%29%2C%20and%20%60buildMessagesArrayExpression%60%20conditionally%20emits%20them%2C%20an%20untested%20code%20path%20exists%20where%20a%20%60msg%28%22text%22%2C%20%7B%20%24id%3A%20%22key%22%2C%20%24maxChars%3A%2050%20%7D%29%60%20call%20would%20produce%20an%20injected%20object%20that%20omits%20those%20fields%20silently%20%28if%20there%20were%20a%20conditional%20bug%29.%0A%0AA%20companion%20test%20asserting%20that%20%60%24id%60%20and%20%60%24maxChars%60%20appear%20in%20the%20injected%20object%20when%20present%20in%20the%20original%20%60msg%28%29%60%20call%20would%20close%20this%20gap.%0A%0A&repo=generaltranslation%2Fgt&pr=1592&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fodysseus%2Ftx-hmr-msg-registration%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fodysseus%2Ftx-hmr-msg-registration%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fcompiler%2Fsrc%2Ftransform%2Finjection%2FinjectCallbackDeclaratorFunctionParameters.ts%3A144-175%0A**Silent%20property-name%20change%20for%20%60useGT%60%2F%60getGT%60%20injection**%0A%0A%60buildMessagesArrayExpression%60%20is%20now%20shared%20between%20the%20existing%20%60injectUseGTParameters%60%20path%20and%20the%20new%20%60injectUseMessagesParameters%60%20path%2C%20but%20it%20uses%20different%20key%20names%20than%20the%20code%20it%20replaced.%20The%20old%20%60injectUseGTParameters%60%20emitted%20%60hash%60%2C%20%60id%60%2C%20%60context%60%2C%20and%20%60maxChars%60%3B%20this%20shared%20helper%20emits%20%60%24_hash%60%2C%20%60%24id%60%2C%20%60%24context%60%2C%20and%20%60%24maxChars%60.%0A%0AThis%20change%20is%20architecturally%20correct%20%E2%80%94%20the%20%60_Message%60%20type%20and%20%60initializeGT%60%20both%20destructure%20the%20%60%24%60-prefixed%20names%20%E2%80%94%20meaning%20the%20old%20emitted%20keys%20were%20silently%20dead%20%28they%20would%20fall%20through%20to%20%60...variables%60%20as%20formatting%20variables%20rather%20than%20driving%20hash%20lookup%29.%20However%2C%20the%20PR%20description%20mentions%20only%20the%20%60getMessages%60%2F%60useMessages%60%20feature%20and%20doesn't%20call%20out%20that%20existing%20%60useGT%60%2F%60getGT%60%20preloading%20behaviour%20has%20changed.%20If%20any%20downstream%20consumer%20or%20integration%20test%20was%20relying%20on%20the%20old%20key%20names%20a%20regression%20would%20be%20invisible%20until%20runtime.%20Consider%20adding%20a%20note%20to%20the%20PR%20description%20and%20a%20dedicated%20assertion%20in%20the%20%60useGT%60%20injection%20tests%20that%20verifies%20the%20emitted%20key%20names%20match%20%60_Message%60.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fcompiler%2Fsrc%2Fpasses%2F__tests__%2FruntimeTranslatePass.test.ts%3A804-847%0A**Test%20coverage%20gaps%20for%20new%20injection%20path**%0A%0AThe%20new%20test%20verifies%20%60message%60%2C%20%60%24context%60%2C%20and%20%60%24_hash%60%20but%20does%20not%20exercise%20%60%24id%60%20or%20%60%24maxChars%60%20injection.%20Given%20that%20the%20%60_Message%60%20type%20explicitly%20includes%20both%20%28%60%24id%3F%60%20and%20%60%24maxChars%3F%60%29%2C%20and%20%60buildMessagesArrayExpression%60%20conditionally%20emits%20them%2C%20an%20untested%20code%20path%20exists%20where%20a%20%60msg%28%22text%22%2C%20%7B%20%24id%3A%20%22key%22%2C%20%24maxChars%3A%2050%20%7D%29%60%20call%20would%20produce%20an%20injected%20object%20that%20omits%20those%20fields%20silently%20%28if%20there%20were%20a%20conditional%20bug%29.%0A%0AA%20companion%20test%20asserting%20that%20%60%24id%60%20and%20%60%24maxChars%60%20appear%20in%20the%20injected%20object%20when%20present%20in%20the%20original%20%60msg%28%29%60%20call%20would%20close%20this%20gap.%0A%0A&repo=generaltranslation%2Fgt&pr=1592&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/compiler/src/transform/injection/injectCallbackDeclaratorFunctionParameters.ts:144-175
**Silent property-name change for `useGT`/`getGT` injection**

`buildMessagesArrayExpression` is now shared between the existing `injectUseGTParameters` path and the new `injectUseMessagesParameters` path, but it uses different key names than the code it replaced. The old `injectUseGTParameters` emitted `hash`, `id`, `context`, and `maxChars`; this shared helper emits `$_hash`, `$id`, `$context`, and `$maxChars`.

This change is architecturally correct — the `_Message` type and `initializeGT` both destructure the `$`-prefixed names — meaning the old emitted keys were silently dead (they would fall through to `...variables` as formatting variables rather than driving hash lookup). However, the PR description mentions only the `getMessages`/`useMessages` feature and doesn't call out that existing `useGT`/`getGT` preloading behaviour has changed. If any downstream consumer or integration test was relying on the old key names a regression would be invisible until runtime. Consider adding a note to the PR description and a dedicated assertion in the `useGT` injection tests that verifies the emitted key names match `_Message`.

### Issue 2 of 2
packages/compiler/src/passes/__tests__/runtimeTranslatePass.test.ts:804-847
**Test coverage gaps for new injection path**

The new test verifies `message`, `$context`, and `$_hash` but does not exercise `$id` or `$maxChars` injection. Given that the `_Message` type explicitly includes both (`$id?` and `$maxChars?`), and `buildMessagesArrayExpression` conditionally emits them, an untested code path exists where a `msg("text", { $id: "key", $maxChars: 50 })` call would produce an injected object that omits those fields silently (if there were a conditional bug).

A companion test asserting that `$id` and `$maxChars` appear in the injected object when present in the original `msg()` call would close this gap.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: preload registered msg calls in get..."](https://github.com/generaltranslation/gt/commit/f65f605164b9fdb66d40b8de3d6b82add0c6556d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37137404)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->