### PR TITLE
feat(i18n): support i18next string interpolation

### DIFF
--- a/.changeset/i18next-string-format.md
+++ b/.changeset/i18next-string-format.md
@@ -1,0 +1,6 @@
+---
+'@generaltranslation/format': minor
+'gt-i18n': minor
+---
+
+Add i18next string interpolation and formatting support for strings marked as I18NEXT format.

--- a/packages/format/package.json
+++ b/packages/format/package.json
@@ -51,6 +51,7 @@
     "definition": "dist/index.d.cts"
   },
   "dependencies": {
+    "i18next": "^25.10.10",
     "intl-messageformat": "^10.7.16"
   },
   "exports": {

--- a/packages/format/src/core.ts
+++ b/packages/format/src/core.ts
@@ -4,6 +4,7 @@ import {
   _formatList,
   _formatListToParts,
   _formatMessageICU,
+  _formatMessageI18next,
   _formatNum,
   _formatRelativeTime,
   _selectRelativeTimeUnit,
@@ -126,6 +127,13 @@ export function formatCutoff(
  */
 export function formatMessage(message: string, options?: MessageFormatOptions) {
   if (options?.dataFormat === 'STRING') return message;
+  if (options?.dataFormat === 'I18NEXT') {
+    return _formatMessageI18next(
+      message,
+      options?.locales,
+      options?.variables as Record<string, unknown> | undefined
+    );
+  }
   return _formatMessageICU(message, options?.locales, options?.variables);
 }
 

--- a/packages/format/src/formatting/__tests__/format.test.ts
+++ b/packages/format/src/formatting/__tests__/format.test.ts
@@ -1,5 +1,66 @@
 import { describe, it, expect } from 'vitest';
+import { formatMessage } from '../../core';
 import { _formatListToParts } from '../format';
+
+describe('formatMessage i18next', () => {
+  it('interpolates i18next variables', () => {
+    expect(
+      formatMessage('Hello {{ name }}', {
+        dataFormat: 'I18NEXT',
+        variables: { name: 'Ada' },
+      })
+    ).toBe('Hello Ada');
+  });
+
+  it('formats i18next numbers with inline options', () => {
+    expect(
+      formatMessage('Value {{ count, number(minimumFractionDigits: 2) }}', {
+        dataFormat: 'I18NEXT',
+        locales: 'en',
+        variables: { count: 12 },
+      })
+    ).toBe('Value 12.00');
+  });
+
+  it('formats i18next currency shorthand', () => {
+    expect(
+      formatMessage('Total {{ amount, currency(USD) }}', {
+        dataFormat: 'I18NEXT',
+        locales: 'en-US',
+        variables: { amount: 1234.5 },
+      })
+    ).toBe('Total $1,234.50');
+  });
+
+  it('formats i18next dates with per-value format params', () => {
+    expect(
+      formatMessage('On {{ date, datetime }}', {
+        dataFormat: 'I18NEXT',
+        locales: 'en-US',
+        variables: {
+          date: new Date(Date.UTC(2012, 11, 20, 3, 0, 0)),
+          formatParams: {
+            date: {
+              timeZone: 'UTC',
+              weekday: 'long',
+              year: 'numeric',
+              month: 'long',
+              day: 'numeric',
+            },
+          },
+        } as Record<string, unknown>,
+      })
+    ).toBe('On Thursday, December 20, 2012');
+  });
+
+  it('leaves missing i18next variables unchanged', () => {
+    expect(
+      formatMessage('Hello {{name}}', {
+        dataFormat: 'I18NEXT',
+      })
+    ).toBe('Hello {{name}}');
+  });
+});
 
 describe('_formatListToParts', () => {
   it('should format empty array', () => {

--- a/packages/format/src/formatting/format.ts
+++ b/packages/format/src/formatting/format.ts
@@ -2,12 +2,26 @@ import { FormatVariables } from '../types';
 import { intlCache } from '../cache/IntlCache';
 import { libraryDefaultLocale } from '../settings/settings';
 import { IntlMessageFormat } from 'intl-messageformat';
+import { createInstance } from 'i18next';
 
 type FormatParams<Value, Options> = {
   value: Value;
   locales?: string | string[];
   options?: Options;
 };
+
+const i18nextFormatter = createInstance();
+const i18nextMessageKey = '__gt_message__';
+
+i18nextFormatter.init({
+  lng: libraryDefaultLocale,
+  fallbackLng: false,
+  initImmediate: false,
+  showSupportNotice: false,
+  interpolation: {
+    escapeValue: false,
+  },
+});
 
 /**
  * Formats a message according to the specified locales and options.
@@ -28,6 +42,29 @@ export function _formatMessageICU(
 ): string {
   const messageFormat = new IntlMessageFormat(message, locales);
   return messageFormat.format(variables)?.toString() ?? '';
+}
+
+/**
+ * Formats a message using i18next-style interpolation.
+ *
+ * Supports the default `{{value}}` syntax and i18next's built-in Intl-backed
+ * formatters, e.g. `{{value, number}}` and `{{value, currency(USD)}}`.
+ *
+ * @internal
+ */
+export function _formatMessageI18next(
+  message: string,
+  locales: string | string[] = libraryDefaultLocale,
+  variables: Record<string, unknown> = {}
+): string {
+  const formattedMessage = i18nextFormatter.t(i18nextMessageKey, {
+    ...variables,
+    lng: Array.isArray(locales) ? locales[0] : locales,
+    defaultValue: message,
+  });
+  return typeof formattedMessage === 'string'
+    ? formattedMessage
+    : String(formattedMessage ?? '');
 }
 
 /**

--- a/packages/format/src/types.ts
+++ b/packages/format/src/types.ts
@@ -44,7 +44,4 @@ export type {
   VariableType,
 };
 
-export type FormatVariables = Record<
-  string,
-  string | number | boolean | null | undefined | Date
->;
+export type FormatVariables = Record<string, unknown>;

--- a/packages/i18n/src/translation-functions/msg/__tests__/msg.test.ts
+++ b/packages/i18n/src/translation-functions/msg/__tests__/msg.test.ts
@@ -31,6 +31,15 @@ describe('msg function integration', () => {
     const decoded = decodeMsg(result);
     expect(decoded).toBe('5 items');
   });
+
+  it('should format i18next messages', () => {
+    const result = msg('Hello {{name}}', {
+      $format: 'I18NEXT',
+      name: 'World',
+    });
+    const decoded = decodeMsg(result);
+    expect(decoded).toBe('Hello World');
+  });
 });
 
 describe('msg function integration with variables', () => {

--- a/packages/i18n/src/translation-functions/msg/msg.ts
+++ b/packages/i18n/src/translation-functions/msg/msg.ts
@@ -85,6 +85,7 @@ export function msg(
         ...variables,
         [VAR_IDENTIFIER]: 'other',
       },
+      dataFormat: options.$format ?? 'ICU',
     });
   } catch {
     logger.warn(createInterpolationFailureMessage(message));

--- a/packages/i18n/src/translation-functions/utils/formatMessage.ts
+++ b/packages/i18n/src/translation-functions/utils/formatMessage.ts
@@ -12,7 +12,7 @@ import { formatMessage as _formatMessage } from '@generaltranslation/format';
  */
 export function formatMessage(
   encodedMsg: string,
-  variables: Record<string, string>,
+  variables: Record<string, unknown>,
   locales?: string | string[],
   dataFormat?: StringFormat
 ): string {

--- a/packages/i18n/src/translation-functions/utils/interpolation/__tests__/interpolateMessage.test.ts
+++ b/packages/i18n/src/translation-functions/utils/interpolation/__tests__/interpolateMessage.test.ts
@@ -16,4 +16,33 @@ describe('interpolateMessage', () => {
       })
     ).toBe('Value 1,234.5');
   });
+
+  it('interpolates i18next translations', () => {
+    expect(
+      interpolateMessage({
+        source: 'Hello {{name}}',
+        target: 'Bonjour {{name}}',
+        options: {
+          $format: 'I18NEXT',
+          $locale: 'fr',
+          name: 'Ada',
+        },
+      })
+    ).toBe('Bonjour Ada');
+  });
+
+  it('formats missing i18next translation fallback with the source locale', () => {
+    expect(
+      interpolateMessage({
+        source: 'Value {{n, number}}',
+        target: undefined,
+        options: {
+          $format: 'I18NEXT',
+          $locale: 'fr',
+          n: 1234.5,
+        },
+        sourceLocale: 'en',
+      })
+    ).toBe('Value 1,234.5');
+  });
 });

--- a/packages/i18n/src/translation-functions/utils/interpolation/interpolateStringMessage.ts
+++ b/packages/i18n/src/translation-functions/utils/interpolation/interpolateStringMessage.ts
@@ -1,4 +1,6 @@
 import { formatCutoff } from '@generaltranslation/format';
+import { extractVariables } from '../../../utils/extractVariables';
+import { formatMessage } from '../formatMessage';
 import { InlineTranslationOptions } from '../../types/options';
 
 /**
@@ -8,7 +10,17 @@ export function interpolateStringMessage(
   encodedMsg: string,
   options: InlineTranslationOptions
 ): string {
-  const cutoffMessage = formatCutoff(encodedMsg, {
+  const message =
+    options.$format === 'I18NEXT'
+      ? formatMessage(
+          encodedMsg,
+          extractVariables(options),
+          options.$locale ?? options.$_locales,
+          options.$format
+        )
+      : encodedMsg;
+
+  const cutoffMessage = formatCutoff(message, {
     locales: options.$locale ?? options.$_locales,
     maxChars: options.$maxChars,
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -864,6 +864,9 @@ importers:
 
   packages/format:
     dependencies:
+      i18next:
+        specifier: ^25.10.10
+        version: 25.10.10(typescript@5.9.3)
       intl-messageformat:
         specifier: ^10.7.16
         version: 10.7.16


### PR DESCRIPTION
## Summary
- add i18next-backed interpolation and formatting for strings marked as I18NEXT
- consume i18next directly from @generaltranslation/format instead of manually parsing i18next formatting syntax
- route gt-i18n I18NEXT strings through the shared formatter
- add changeset for @generaltranslation/format and gt-i18n

## Testing
- pnpm --filter @generaltranslation/format build
- pnpm --filter @generaltranslation/format test
- pnpm --filter gt-i18n test
- pnpm build

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds i18next-style string interpolation and Intl-backed formatting (`number`, `currency`, `datetime`, `relativetime`) to `@generaltranslation/format`, then wires the new `I18NEXT` data format through `gt-i18n`'s `msg()` and string-interpolation path.

- **`packages/format`**: Introduces a module-level i18next singleton (no resources, key-less lookup, `defaultValue` carries the template) plus `_formatMessageI18next` which delegates interpolation and Intl formatting entirely to i18next `t()`. `FormatVariables` is widened from a union to `Record<string, unknown>` to accommodate `Date` objects and nested `formatParams`.
- **`packages/i18n`**: `msg()` now passes `dataFormat` to `formatMessage`; `interpolateStringMessage` gains an `I18NEXT` branch that calls `formatMessage` before handing off to `formatCutoff`; both `formatMessage` wrapper and tests updated to match the widened type.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; all interpolation logic delegates to a well-tested i18next singleton, and the new I18NEXT branch integrates cleanly alongside the existing ICU path.

The changes are additive and well-scoped. The core routing, variable extraction, and cutoff logic are unchanged. The i18next singleton is initialised once at module load with no side effects that could affect other call paths, and the per-call lng override is the correct way to vary locale without mutating shared state. All findings are non-blocking.

packages/format/src/formatting/format.ts — the variable-spread ordering means lng and defaultValue are reserved names that cannot be used as template placeholders; worth a comment in the public API docs.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/format/src/formatting/format.ts | Introduces module-level i18next singleton and _formatMessageI18next; user variables spread into t() options can silently collide with reserved i18next option keys (lng, defaultValue). |
| packages/format/src/core.ts | Routes I18NEXT dataFormat to _formatMessageI18next; change is minimal and correct. |
| packages/format/src/types.ts | Widens FormatVariables from a union type to Record<string, unknown> to support complex i18next values like Date objects and nested formatParams. |
| packages/i18n/src/translation-functions/msg/msg.ts | Passes dataFormat to formatMessage; VAR_IDENTIFIER sentinel is still injected for I18NEXT format (noted in prior review). |
| packages/i18n/src/translation-functions/utils/interpolation/interpolateStringMessage.ts | Routes I18NEXT through formatMessage before cutoff; no fallback-to-source on interpolation failure unlike interpolateIcuMessage. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["msg(message, { $format: 'I18NEXT', ...vars })"] --> B["formatMessage (core.ts)\ndataFormat = 'I18NEXT'"]
    B --> C["_formatMessageI18next\n(format.ts)"]
    C --> D["i18nextFormatter.t(__gt_message__, {\n  ...variables,\n  lng: locale,\n  defaultValue: message\n})"]
    D --> E["i18next interpolates\n{{ var }} syntax +\nIntl formatters"]
    E --> F["interpolated string"]

    G["interpolateMessage\n(router)"] --> H{{"$format?"}}
    H -- I18NEXT --> I["interpolateStringMessage"]
    H -- ICU --> J["interpolateIcuMessage\n(+ fallback-to-source)"]
    H -- STRING --> I
    I --> K{{"$format === 'I18NEXT'?"}}
    K -- yes --> L["formatMessage → _formatMessageI18next"]
    K -- no --> M["pass-through"]
    L --> N["formatCutoff"]
    M --> N
    N --> O["final string"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["msg(message, { $format: 'I18NEXT', ...vars })"] --> B["formatMessage (core.ts)\ndataFormat = 'I18NEXT'"]
    B --> C["_formatMessageI18next\n(format.ts)"]
    C --> D["i18nextFormatter.t(__gt_message__, {\n  ...variables,\n  lng: locale,\n  defaultValue: message\n})"]
    D --> E["i18next interpolates\n{{ var }} syntax +\nIntl formatters"]
    E --> F["interpolated string"]

    G["interpolateMessage\n(router)"] --> H{{"$format?"}}
    H -- I18NEXT --> I["interpolateStringMessage"]
    H -- ICU --> J["interpolateIcuMessage\n(+ fallback-to-source)"]
    H -- STRING --> I
    I --> K{{"$format === 'I18NEXT'?"}}
    K -- yes --> L["formatMessage → _formatMessageI18next"]
    K -- no --> M["pass-through"]
    L --> N["formatCutoff"]
    M --> N
    N --> O["final string"]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["feat(i18n): support i18next string inter..."](https://github.com/generaltranslation/gt/commit/bbd68bdd849e3c4b96a32caaca0e17ff2cd23481) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37938146)</sub>

<!-- /greptile_comment -->