### PR TITLE
feat(i18n): add singleton default string format

### DIFF
--- a/.changeset/singleton-string-format.md
+++ b/.changeset/singleton-string-format.md
@@ -1,0 +1,8 @@
+---
+'@generaltranslation/format': minor
+'gt-i18n': minor
+'@generaltranslation/react-core': minor
+'gt-next': minor
+---
+
+Add a singleton default string format that can be set with `globalThis.__GT_DEFAULT_STRING_FORMAT__`.

--- a/packages/format/src/core.ts
+++ b/packages/format/src/core.ts
@@ -11,6 +11,7 @@ import {
 } from './formatting/format';
 import { intlCache } from './cache/IntlCache';
 import type { CutoffFormatOptions } from './formatting/custom-formats/CutoffFormat/types';
+import { getDefaultStringFormat } from './formatting/defaultStringFormat';
 import { _determineLocale } from './locales/determineLocale';
 import { _getLocaleDirection } from './locales/getLocaleDirection';
 import { _getLocaleEmoji } from './locales/getLocaleEmoji';
@@ -126,8 +127,9 @@ export function formatCutoff(
  * });
  */
 export function formatMessage(message: string, options?: MessageFormatOptions) {
-  if (options?.dataFormat === 'STRING') return message;
-  if (options?.dataFormat === 'I18NEXT') {
+  const dataFormat = options?.dataFormat ?? getDefaultStringFormat();
+  if (dataFormat === 'STRING') return message;
+  if (dataFormat === 'I18NEXT') {
     return _formatMessageI18next(
       message,
       options?.locales,

--- a/packages/format/src/formatting/__tests__/format.test.ts
+++ b/packages/format/src/formatting/__tests__/format.test.ts
@@ -1,8 +1,16 @@
-import { describe, it, expect } from 'vitest';
+import { afterEach, describe, it, expect } from 'vitest';
 import { formatMessage } from '../../core';
 import { _formatListToParts } from '../format';
 
 describe('formatMessage i18next', () => {
+  afterEach(() => {
+    delete (
+      globalThis as typeof globalThis & {
+        __GT_DEFAULT_STRING_FORMAT__?: unknown;
+      }
+    ).__GT_DEFAULT_STRING_FORMAT__;
+  });
+
   it('interpolates i18next variables', () => {
     expect(
       formatMessage('Hello {{ name }}', {
@@ -59,6 +67,18 @@ describe('formatMessage i18next', () => {
         dataFormat: 'I18NEXT',
       })
     ).toBe('Hello {{name}}');
+  });
+
+  it('uses the global default string format when dataFormat is omitted', () => {
+    (
+      globalThis as typeof globalThis & {
+        __GT_DEFAULT_STRING_FORMAT__?: unknown;
+      }
+    ).__GT_DEFAULT_STRING_FORMAT__ = 'I18NEXT';
+
+    expect(
+      formatMessage('Hello {{name}}', { variables: { name: 'Ada' } })
+    ).toBe('Hello Ada');
   });
 });
 

--- a/packages/format/src/formatting/defaultStringFormat.ts
+++ b/packages/format/src/formatting/defaultStringFormat.ts
@@ -1,0 +1,18 @@
+import type { StringFormat } from '../types-dir/jsx/content';
+
+const DEFAULT_STRING_FORMAT_GLOBAL = '__GT_DEFAULT_STRING_FORMAT__';
+
+type GlobalWithDefaultStringFormat = typeof globalThis & {
+  [DEFAULT_STRING_FORMAT_GLOBAL]?: unknown;
+};
+
+export function isStringFormat(value: unknown): value is StringFormat {
+  return value === 'ICU' || value === 'I18NEXT' || value === 'STRING';
+}
+
+export function getDefaultStringFormat(): StringFormat {
+  const value = (globalThis as GlobalWithDefaultStringFormat)[
+    DEFAULT_STRING_FORMAT_GLOBAL
+  ];
+  return isStringFormat(value) ? value : 'ICU';
+}

--- a/packages/format/src/internal.ts
+++ b/packages/format/src/internal.ts
@@ -1,4 +1,8 @@
 import { intlCache } from './cache/IntlCache';
+export {
+  getDefaultStringFormat,
+  isStringFormat,
+} from './formatting/defaultStringFormat';
 
 export function getCachedPluralRules(
   locales?: Intl.LocalesArgument

--- a/packages/i18n/src/i18n-manager/translations-manager/utils/dictionary-helpers.ts
+++ b/packages/i18n/src/i18n-manager/translations-manager/utils/dictionary-helpers.ts
@@ -9,6 +9,8 @@ import type {
   DictionaryLookupOptions,
   DictionaryOptions,
 } from '../../../translation-functions/types/options';
+import type { StringFormat } from '@generaltranslation/format/types';
+import { getDefaultStringFormat } from '@generaltranslation/format/internal';
 
 function getDictionaryPath(id: DictionaryPath): string[] {
   const path = id ? id.split('.') : [];
@@ -110,12 +112,13 @@ export function getDictionaryValue(value: DictionaryEntry): DictionaryValue {
 }
 
 export function resolveDictionaryLookupOptions(
-  options: DictionaryEntry['options']
+  options: DictionaryEntry['options'],
+  defaultFormat: StringFormat = getDefaultStringFormat()
 ): DictionaryLookupOptions {
   const { $format, context, ...rest } = options;
   return {
     ...rest,
-    $format: isStringFormat($format) ? $format : 'ICU',
+    $format: isStringFormat($format) ? $format : defaultFormat,
     ...(rest.$context === undefined &&
       typeof context === 'string' && { $context: context }),
   };

--- a/packages/i18n/src/translation-functions/__tests__/t.test.ts
+++ b/packages/i18n/src/translation-functions/__tests__/t.test.ts
@@ -11,6 +11,11 @@ import { t } from '../t';
 describe('t', () => {
   afterEach(() => {
     setConditionStore({ getLocale: () => 'en' });
+    delete (
+      globalThis as typeof globalThis & {
+        __GT_DEFAULT_STRING_FORMAT__?: unknown;
+      }
+    ).__GT_DEFAULT_STRING_FORMAT__;
   });
 
   it('works without an explicit locale', () => {
@@ -39,6 +44,29 @@ describe('t', () => {
 
     setI18nManager(manager);
     setConditionStore(conditionStore);
+    await manager.loadTranslations('fr');
+
+    expect(t(message, { name: 'Alice' })).toBe('Bonjour Alice !');
+  });
+
+  it('uses the global default string format when $format is omitted', async () => {
+    const message = 'Hello {{name}}!';
+    const translatedMessage = 'Bonjour {{name}} !';
+    (
+      globalThis as typeof globalThis & {
+        __GT_DEFAULT_STRING_FORMAT__?: unknown;
+      }
+    ).__GT_DEFAULT_STRING_FORMAT__ = 'I18NEXT';
+    const manager = new I18nManager({
+      defaultLocale: 'en',
+      locales: ['en', 'fr'],
+      loadTranslations: vi.fn().mockResolvedValue({
+        [hashMessage(message, { $format: 'I18NEXT' })]: translatedMessage,
+      }),
+    });
+
+    setI18nManager(manager);
+    setConditionStore({ getLocale: () => 'fr' });
     await manager.loadTranslations('fr');
 
     expect(t(message, { name: 'Alice' })).toBe('Bonjour Alice !');

--- a/packages/i18n/src/translation-functions/internal/__tests__/helpers.test.ts
+++ b/packages/i18n/src/translation-functions/internal/__tests__/helpers.test.ts
@@ -57,6 +57,7 @@ describe('translation helpers', () => {
         .fn()
         .mockResolvedValue('Bonjour {name} !'),
       getDefaultLocale: vi.fn().mockReturnValue('en'),
+      getDefaultStringFormat: vi.fn().mockReturnValue('STRING'),
     };
     vi.mocked(getI18nManager).mockReturnValue(
       mockManager as unknown as ReturnType<typeof getI18nManager>
@@ -78,6 +79,7 @@ describe('translation helpers', () => {
       getLocale: vi.fn().mockReturnValue('fr'),
       lookupTranslation: vi.fn().mockReturnValue(undefined),
       getDefaultLocale: vi.fn().mockReturnValue('en'),
+      getDefaultStringFormat: vi.fn().mockReturnValue('STRING'),
     };
     vi.mocked(getI18nManager).mockReturnValue(
       mockManager as unknown as ReturnType<typeof getI18nManager>

--- a/packages/i18n/src/translation-functions/internal/__tests__/resolveTranslationSync.test.ts
+++ b/packages/i18n/src/translation-functions/internal/__tests__/resolveTranslationSync.test.ts
@@ -17,6 +17,7 @@ describe('resolveTranslationSync', () => {
       getLocale: vi.fn().mockReturnValue('fr'),
       lookupTranslation: vi.fn().mockReturnValue('Bonjour {name} !'),
       getDefaultLocale: vi.fn().mockReturnValue('en'),
+      getDefaultStringFormat: vi.fn().mockReturnValue('ICU'),
     };
     vi.mocked(getI18nManager).mockReturnValue(
       mockManager as unknown as ReturnType<typeof getI18nManager>
@@ -43,6 +44,7 @@ describe('resolveTranslationSync', () => {
     const mockManager = {
       getLocale: vi.fn().mockReturnValue('fr'),
       lookupTranslation: vi.fn().mockReturnValue(undefined),
+      getDefaultStringFormat: vi.fn().mockReturnValue('ICU'),
     };
     vi.mocked(getI18nManager).mockReturnValue(
       mockManager as unknown as ReturnType<typeof getI18nManager>
@@ -62,6 +64,7 @@ describe('resolveTranslationSync', () => {
       getLocale: vi.fn().mockReturnValue('fr'),
       lookupTranslation: vi.fn().mockReturnValue('Translated'),
       getDefaultLocale: vi.fn().mockReturnValue('en'),
+      getDefaultStringFormat: vi.fn().mockReturnValue('ICU'),
     };
     vi.mocked(getI18nManager).mockReturnValue(
       mockManager as unknown as ReturnType<typeof getI18nManager>
@@ -96,6 +99,7 @@ describe('resolveTranslationSync', () => {
       getLocale: vi.fn().mockReturnValue('fr'),
       lookupTranslation: vi.fn().mockReturnValue('Translated'),
       getDefaultLocale: vi.fn().mockReturnValue('en'),
+      getDefaultStringFormat: vi.fn().mockReturnValue('ICU'),
     };
     vi.mocked(getI18nManager).mockReturnValue(
       mockManager as unknown as ReturnType<typeof getI18nManager>

--- a/packages/i18n/src/translation-functions/internal/getGT.ts
+++ b/packages/i18n/src/translation-functions/internal/getGT.ts
@@ -7,6 +7,7 @@ import { GTFunctionType } from '../types/functions';
 import { interpolateMessage } from '../utils/interpolation/interpolateMessage';
 import { createLookupOptions } from './helpers';
 import type { StringFormat } from '@generaltranslation/format/types';
+import { getDefaultStringFormat } from '@generaltranslation/format/internal';
 
 /**
  * Returns the gt function that registers a string at build time and resolves its translation at runtime.
@@ -44,10 +45,11 @@ export async function getGT(): Promise<GTFunctionType> {
     options: InlineTranslationOptions = {}
   ) => {
     const targetLocale = options.$locale ?? locale;
+    const defaultStringFormat = getDefaultStringFormat();
     const lookupOptions = createLookupOptions<StringFormat>(
       targetLocale,
       options,
-      'ICU'
+      defaultStringFormat
     );
 
     // Lookup translation

--- a/packages/i18n/src/translation-functions/internal/helpers.ts
+++ b/packages/i18n/src/translation-functions/internal/helpers.ts
@@ -1,6 +1,7 @@
 import { getI18nManager } from '../../i18n-manager/singleton-operations';
 import { NormalizedLookupOptions, ResolutionOptions } from '../types/options';
 import { interpolateMessage } from '../utils/interpolation/interpolateMessage';
+import { getDefaultStringFormat } from '@generaltranslation/format/internal';
 import type {
   DataFormat,
   JsxChildren,
@@ -72,7 +73,11 @@ export function resolveStringContent(
   options: ResolutionOptions<StringFormat> = {}
 ): StringContent | undefined {
   const i18nManager = getI18nManager();
-  const lookupOptions = createLookupOptions(locale, options, 'STRING');
+  const lookupOptions = createLookupOptions(
+    locale,
+    options,
+    getDefaultStringLookupFormat()
+  );
   const translation = i18nManager.lookupTranslation(
     lookupOptions.$locale,
     content,
@@ -96,7 +101,11 @@ export function resolveStringContentWithFallback(
   options: ResolutionOptions<StringFormat> = {}
 ): StringContent {
   const i18nManager = getI18nManager();
-  const lookupOptions = createLookupOptions(locale, options, 'STRING');
+  const lookupOptions = createLookupOptions(
+    locale,
+    options,
+    getDefaultStringLookupFormat()
+  );
   const translation = i18nManager.lookupTranslation(
     lookupOptions.$locale,
     content,
@@ -121,7 +130,11 @@ export async function resolveStringContentWithRuntimeFallback(
   options: ResolutionOptions<StringFormat> = {}
 ): Promise<StringContent> {
   const i18nManager = getI18nManager();
-  const lookupOptions = createLookupOptions(locale, options, 'STRING');
+  const lookupOptions = createLookupOptions(
+    locale,
+    options,
+    getDefaultStringLookupFormat()
+  );
   const translation = await i18nManager.lookupTranslationWithFallback(
     lookupOptions.$locale,
     content,
@@ -147,4 +160,9 @@ export function createLookupOptions<T extends DataFormat>(
     $format: (options.$format ?? defaultFormat) as T,
     $locale: locale,
   };
+}
+
+function getDefaultStringLookupFormat(): StringFormat {
+  const defaultStringFormat = getDefaultStringFormat();
+  return defaultStringFormat === 'ICU' ? 'STRING' : defaultStringFormat;
 }

--- a/packages/i18n/src/translation-functions/internal/sync-translation-resolution.ts
+++ b/packages/i18n/src/translation-functions/internal/sync-translation-resolution.ts
@@ -3,6 +3,7 @@ import {
   resolveStringContent,
   resolveStringContentWithFallback,
 } from './helpers';
+import { getDefaultStringFormat } from '@generaltranslation/format/internal';
 
 /**
  * Synchronously resolve a translation for a given message and options
@@ -16,7 +17,10 @@ export function resolveTranslationSync(
   message: string,
   options: InlineTranslationOptions = {}
 ) {
-  return resolveStringContent(locale, message, { $format: 'ICU', ...options });
+  return resolveStringContent(locale, message, {
+    ...options,
+    $format: options.$format ?? getDefaultStringFormat(),
+  });
 }
 
 /**
@@ -32,7 +36,7 @@ export function resolveTranslationSyncWithFallback(
   options: InlineTranslationOptions = {}
 ) {
   return resolveStringContentWithFallback(locale, message, {
-    $format: 'ICU',
     ...options,
+    $format: options.$format ?? getDefaultStringFormat(),
   });
 }

--- a/packages/i18n/src/translation-functions/internal/tx.ts
+++ b/packages/i18n/src/translation-functions/internal/tx.ts
@@ -2,9 +2,7 @@ import { RuntimeTranslationOptions } from '../types/options';
 import type { StringFormat } from '@generaltranslation/format/types';
 import { getDefaultStringFormat } from '@generaltranslation/format/internal';
 import { resolveStringContentWithRuntimeFallback } from './helpers';
-import {
-  getCurrentLocale,
-} from '../../i18n-manager/singleton-operations';
+import { getCurrentLocale } from '../../i18n-manager/singleton-operations';
 
 type RuntimeTranslationOptionsWithFormat = Omit<
   RuntimeTranslationOptions,

--- a/packages/i18n/src/translation-functions/internal/tx.ts
+++ b/packages/i18n/src/translation-functions/internal/tx.ts
@@ -1,7 +1,10 @@
 import { RuntimeTranslationOptions } from '../types/options';
 import type { StringFormat } from '@generaltranslation/format/types';
+import { getDefaultStringFormat } from '@generaltranslation/format/internal';
 import { resolveStringContentWithRuntimeFallback } from './helpers';
-import { getCurrentLocale } from '../../i18n-manager/singleton-operations';
+import {
+  getCurrentLocale,
+} from '../../i18n-manager/singleton-operations';
 
 type RuntimeTranslationOptionsWithFormat = Omit<
   RuntimeTranslationOptions,
@@ -30,8 +33,11 @@ export async function tx(
 ): Promise<string> {
   const locale =
     typeof options.$locale === 'string' ? options.$locale : getCurrentLocale();
+  const defaultStringFormat = getDefaultStringFormat();
   return resolveStringContentWithRuntimeFallback(locale, content, {
-    $format: 'STRING',
     ...options,
+    $format:
+      options.$format ??
+      (defaultStringFormat === 'ICU' ? 'STRING' : defaultStringFormat),
   });
 }

--- a/packages/i18n/src/translation-functions/msg/msg.ts
+++ b/packages/i18n/src/translation-functions/msg/msg.ts
@@ -3,6 +3,7 @@ import type {
   InlineTranslationOptions,
 } from '../types/options';
 import { formatMessage } from '@generaltranslation/format';
+import { getDefaultStringFormat } from '@generaltranslation/format/internal';
 import {
   encode,
   libraryDefaultLocale,
@@ -75,6 +76,7 @@ export function msg(
 
   // Extract variables
   const variables = extractVariables(options);
+  const dataFormat = options.$format ?? getDefaultStringFormat();
 
   // Interpolate string
   let interpolatedString: string = message;
@@ -85,7 +87,7 @@ export function msg(
         ...variables,
         [VAR_IDENTIFIER]: 'other',
       },
-      dataFormat: options.$format ?? 'ICU',
+      dataFormat,
     });
   } catch {
     logger.warn(createInterpolationFailureMessage(message));
@@ -97,7 +99,7 @@ export function msg(
   const $_hash =
     options.$_hash ||
     hashMessage(message, {
-      $format: 'ICU',
+      $format: dataFormat,
       ...options,
     });
 

--- a/packages/i18n/src/translation-functions/t.ts
+++ b/packages/i18n/src/translation-functions/t.ts
@@ -1,6 +1,7 @@
 import { resolveStringContentWithFallback } from './internal/helpers';
 import { InlineTranslationOptions } from './types/options';
 import { getCurrentLocale } from '../i18n-manager/singleton-operations';
+import { getDefaultStringFormat } from '@generaltranslation/format/internal';
 
 /**
  * Translate a message
@@ -11,7 +12,7 @@ import { getCurrentLocale } from '../i18n-manager/singleton-operations';
 export function t(message: string, options: InlineTranslationOptions = {}) {
   const locale = options.$locale ?? getCurrentLocale();
   return resolveStringContentWithFallback(locale, message, {
-    $format: 'ICU',
     ...options,
+    $format: options.$format ?? getDefaultStringFormat(),
   });
 }

--- a/packages/next/src/server-dir/buildtime/__tests__/getTranslations.test.ts
+++ b/packages/next/src/server-dir/buildtime/__tests__/getTranslations.test.ts
@@ -232,6 +232,7 @@ describe('getTranslations', () => {
       expect(mockFormatMessage).toHaveBeenCalledWith(mockEntry, {
         locales: ['en'],
         variables: { [VAR_IDENTIFIER]: 'other' },
+        dataFormat: 'ICU',
       });
     });
 
@@ -252,6 +253,7 @@ describe('getTranslations', () => {
       expect(mockFormatMessage).toHaveBeenCalledWith(mockEntry, {
         locales: ['en'],
         variables: { name: 'John', [VAR_IDENTIFIER]: 'other' },
+        dataFormat: 'ICU',
       });
     });
   });
@@ -376,6 +378,7 @@ describe('getTranslations', () => {
         variables: {
           [VAR_IDENTIFIER]: 'other',
         },
+        dataFormat: 'ICU',
       });
     });
 

--- a/packages/next/src/server-dir/buildtime/getTranslationFunction.ts
+++ b/packages/next/src/server-dir/buildtime/getTranslationFunction.ts
@@ -25,6 +25,10 @@ import type {
   FormatVariables,
   StringFormat,
 } from '@generaltranslation/format/types';
+import {
+  getDefaultStringFormat,
+  isStringFormat,
+} from '@generaltranslation/format/internal';
 import { use } from '../../utils/use';
 
 type RenderFn = (msg: string, locales: string[], fallback?: string) => string;
@@ -160,6 +164,7 @@ async function createTranslator(_messages?: _Messages): Promise<Translator> {
       ...variables
     } = options;
     const formatVariables = variables as FormatVariables;
+    const resolvedFormat = format ?? getDefaultStringFormat();
 
     const renderMessage: RenderFn = (msg, locales, fallback) => {
       return renderMessageHelper({
@@ -169,17 +174,17 @@ async function createTranslator(_messages?: _Messages): Promise<Translator> {
         id,
         fallback,
         maxChars,
-        format,
+        format: resolvedFormat,
       });
     };
 
     const calculateHash = () =>
       hashSource({
-        source: indexVars(message),
+        source: resolvedFormat === 'ICU' ? indexVars(message) : message,
         ...(context && { context }),
         ...(maxChars != null && { maxChars: Math.abs(maxChars) }),
         ...(id && { id }),
-        dataFormat: format || 'ICU',
+        dataFormat: resolvedFormat,
       });
 
     return {
@@ -375,7 +380,8 @@ async function createTranslator(_messages?: _Messages): Promise<Translator> {
     const context = typeof $context === 'string' ? $context : undefined;
     const id = typeof $id === 'string' ? $id : undefined;
     const maxChars = typeof $maxChars === 'number' ? $maxChars : undefined;
-    const format = typeof $format === 'string' ? $format : undefined;
+    const format = isStringFormat($format) ? $format : undefined;
+    const resolvedFormat = format ?? getDefaultStringFormat();
     const formatVariables = decodedVariables as FormatVariables;
 
     const renderMessage: RenderFn = (msg, locales, fallback) => {
@@ -385,7 +391,7 @@ async function createTranslator(_messages?: _Messages): Promise<Translator> {
         variables: formatVariables,
         fallback,
         maxChars,
-        format,
+        format: resolvedFormat,
       });
     };
 

--- a/packages/next/src/server-dir/buildtime/getTranslationFunction.ts
+++ b/packages/next/src/server-dir/buildtime/getTranslationFunction.ts
@@ -56,6 +56,7 @@ type InitResult = {
   maxChars?: number;
   _hash?: string;
   variables: FormatVariables;
+  dataFormat: StringFormat;
   calculateHash: () => string;
   renderMessage: RenderFn;
 };
@@ -138,6 +139,7 @@ async function createTranslator(_messages?: _Messages): Promise<Translator> {
           variables,
           id,
           maxChars,
+          format,
         });
       }
 
@@ -193,6 +195,7 @@ async function createTranslator(_messages?: _Messages): Promise<Translator> {
       maxChars,
       _hash,
       variables: formatVariables,
+      dataFormat: resolvedFormat,
       calculateHash,
       renderMessage,
     };
@@ -223,19 +226,21 @@ async function createTranslator(_messages?: _Messages): Promise<Translator> {
     maxChars?: number;
     id?: string;
     hash: string;
+    dataFormat: StringFormat;
     renderMessage: RenderFn;
   }) {
-    const { source, context, maxChars, id, hash, renderMessage } = args;
+    const { source, context, maxChars, id, hash, dataFormat, renderMessage } =
+      args;
     try {
       I18NConfig.translate({
-        source: indexVars(source),
+        source: dataFormat === 'ICU' ? indexVars(source) : source,
         targetLocale: locale,
         options: {
           ...(context && { $context: context }),
           ...(maxChars != null && { $maxChars: maxChars }),
           ...(id && { $id: id }),
           $_hash: hash,
-          $format: 'ICU',
+          $format: dataFormat,
         },
       }).then((result) => {
         // eslint-disable-next-line no-console
@@ -273,7 +278,7 @@ async function createTranslator(_messages?: _Messages): Promise<Translator> {
       const init = initializeGT(message, options);
       if (!init) return;
 
-      const { id, context, maxChars, _hash, calculateHash } = init;
+      const { id, context, maxChars, _hash, dataFormat, calculateHash } = init;
       const { translationEntry, hash } = getTranslationData(
         calculateHash,
         id,
@@ -283,14 +288,14 @@ async function createTranslator(_messages?: _Messages): Promise<Translator> {
 
       try {
         preloadedTranslations![hash] = (await I18NConfig.translate({
-          source: indexVars(message),
+          source: dataFormat === 'ICU' ? indexVars(message) : message,
           targetLocale: locale,
           options: {
             ...(context && { $context: context }),
             ...(maxChars != null && { $maxChars: maxChars }),
             ...(id && { $id: id }),
             $_hash: hash,
-            $format: 'ICU',
+            $format: dataFormat,
           },
         })) as string;
       } catch (error) {
@@ -305,7 +310,15 @@ async function createTranslator(_messages?: _Messages): Promise<Translator> {
   const gt = (message: string, options: GTStringOptions = {}): string => {
     const init = initializeGT(message, options);
     if (!init) return '';
-    const { id, context, maxChars, _hash, calculateHash, renderMessage } = init;
+    const {
+      id,
+      context,
+      maxChars,
+      _hash,
+      dataFormat,
+      calculateHash,
+      renderMessage,
+    } = init;
 
     // Early: no translation needed
     if (!translationRequired) return renderMessage(message, [defaultLocale]);
@@ -344,6 +357,7 @@ async function createTranslator(_messages?: _Messages): Promise<Translator> {
       maxChars,
       id,
       hash,
+      dataFormat,
       renderMessage,
     });
     return renderMessage(message, [defaultLocale]);
@@ -448,6 +462,7 @@ async function createTranslator(_messages?: _Messages): Promise<Translator> {
       maxChars,
       id,
       hash: $_hash,
+      dataFormat: resolvedFormat,
       renderMessage,
     });
 

--- a/packages/next/src/server-dir/buildtime/getTranslations.tsx
+++ b/packages/next/src/server-dir/buildtime/getTranslations.tsx
@@ -45,6 +45,7 @@ import type {
   FormatVariables,
   StringFormat,
 } from '@generaltranslation/format/types';
+import { getDefaultStringFormat } from '@generaltranslation/format/internal';
 
 /**
  * Returns the dictionary access function t(), which is used to translate an item from the dictionary.
@@ -143,6 +144,7 @@ export async function getTranslations(id?: string): Promise<
     // Extract format from options
     const { $format: format, ...variableOptions } =
       options as DictionaryTranslationOptions & { $format?: StringFormat };
+    const dataFormat = format ?? getDefaultStringFormat();
     const maxChars =
       metadata?.$maxChars ??
       (typeof options.$maxChars === 'number' ? options.$maxChars : undefined);
@@ -166,7 +168,7 @@ export async function getTranslations(id?: string): Promise<
               ...declaredVars,
               [VAR_IDENTIFIER]: 'other',
             },
-            dataFormat: format,
+            dataFormat,
           }
         );
         const cutoffMessage = gt.formatCutoff(formattedMessage, {
@@ -245,13 +247,13 @@ export async function getTranslations(id?: string): Promise<
     const getHash = () => {
       if (metadata?.$_hash) return metadata.$_hash;
       const hash = hashSource({
-        source: indexVars(entry),
+        source: dataFormat === 'ICU' ? indexVars(entry) : entry,
         ...(metadata?.$context && { context: metadata.$context }),
         ...(metadata?.$maxChars != null && {
           maxChars: Math.abs(metadata.$maxChars),
         }),
         id,
-        dataFormat: 'ICU',
+        dataFormat,
       });
       // Inject hash if not there yet
       metadata = { ...metadata, $_hash: hash };

--- a/packages/next/src/server-dir/runtime/tx.ts
+++ b/packages/next/src/server-dir/runtime/tx.ts
@@ -12,6 +12,7 @@ import type {
   FormatVariables,
   StringFormat,
 } from '@generaltranslation/format/types';
+import { getDefaultStringFormat } from '@generaltranslation/format/internal';
 
 type TxOptions = FormatVariables & {
   $locale?: string;
@@ -109,13 +110,13 @@ export async function tx(
 
   // ----- CALCULATE HASH ----- //
 
+  const dataFormat = format ?? getDefaultStringFormat();
   const hash = hashSource({
-    source: format === 'ICU' ? indexVars(message) : message,
+    source: dataFormat === 'ICU' ? indexVars(message) : message,
     ...(context && { context }),
     ...(maxChars != null && { maxChars: Math.abs(maxChars) }),
-    dataFormat: format || 'ICU',
+    dataFormat,
   });
-  const dataFormat = format || 'ICU';
   const source = dataFormat === 'ICU' ? indexVars(message) : message;
   const lookupOptions = {
     ...formatVariables,

--- a/packages/next/src/server-dir/runtime/tx.ts
+++ b/packages/next/src/server-dir/runtime/tx.ts
@@ -80,6 +80,7 @@ export async function tx(
   const defaultLocale = I18NConfig.getDefaultLocale();
   const [translationRequired] = I18NConfig.requiresTranslation(locale);
   const gt = I18NConfig.getGTClass();
+  const dataFormat = format ?? getDefaultStringFormat();
 
   // ----- DEFINE RENDER FUNCTION ----- //
 
@@ -94,7 +95,7 @@ export async function tx(
           ...declaredVars,
           [VAR_IDENTIFIER]: 'other',
         },
-        dataFormat: format,
+        dataFormat,
       }
     );
     const cutoffMessage = gt.formatCutoff(formattedMessage, {
@@ -110,7 +111,6 @@ export async function tx(
 
   // ----- CALCULATE HASH ----- //
 
-  const dataFormat = format ?? getDefaultStringFormat();
   const hash = hashSource({
     source: dataFormat === 'ICU' ? indexVars(message) : message,
     ...(context && { context }),

--- a/packages/react-core/src/dictionaries/injectHashes.ts
+++ b/packages/react-core/src/dictionaries/injectHashes.ts
@@ -4,6 +4,7 @@ import { Dictionary } from '../types-dir/types';
 import getEntryAndMetadata from './getEntryAndMetadata';
 import { set } from './indexDict';
 import { indexVars } from 'generaltranslation/internal';
+import { getDefaultStringFormat } from '@generaltranslation/format/internal';
 
 /**
  * @description Given a dictionary, adds hashes to all dictionary entries
@@ -22,14 +23,15 @@ export function injectHashes(
       let { entry, metadata } = getEntryAndMetadata(value);
       if (!metadata?.$_hash) {
         metadata ||= {};
+        const dataFormat = metadata.$format ?? getDefaultStringFormat();
         metadata.$_hash = hashSource({
-          source: indexVars(entry),
+          source: dataFormat === 'ICU' ? indexVars(entry) : entry,
           ...(metadata?.$context && { context: metadata.$context }),
           ...(metadata?.$maxChars != null && {
             maxChars: Math.abs(metadata.$maxChars),
           }),
           id: wholeId,
-          dataFormat: 'ICU',
+          dataFormat,
         });
         set(dictionary, key, [entry, metadata]);
         updateDictionary = true;

--- a/packages/react-core/src/provider/hooks/translation/useCreateInternalUseGTFunction.ts
+++ b/packages/react-core/src/provider/hooks/translation/useCreateInternalUseGTFunction.ts
@@ -6,6 +6,7 @@ import {
   _Message,
 } from '../../../types-dir/types';
 import type { StringFormat } from '@generaltranslation/format/types';
+import { getDefaultStringFormat } from '@generaltranslation/format/internal';
 import { TranslateIcuCallback } from '../../../types-dir/runtime';
 import { GT } from 'generaltranslation';
 import {
@@ -152,6 +153,7 @@ export default function useCreateInternalUseGTFunction({
     } = options;
     const format =
       typeof rawFormat === 'string' ? (rawFormat as StringFormat) : undefined;
+    const resolvedFormat = format ?? getDefaultStringFormat();
 
     // Update renderContent to use actual variables
     const renderMessage = (
@@ -173,11 +175,11 @@ export default function useCreateInternalUseGTFunction({
     // Calculate hash
     const calculateHash = () =>
       hashSource({
-        source: indexVars(message),
+        source: resolvedFormat === 'ICU' ? indexVars(message) : message,
         ...(context && { context }),
         ...(maxChars != null && { maxChars: Math.abs(maxChars) }),
         ...(id && { id }),
-        dataFormat: format || 'ICU',
+        dataFormat: resolvedFormat,
       });
 
     return {

--- a/packages/react-core/src/provider/hooks/translation/useCreateInternalUseTranslationsFunction.ts
+++ b/packages/react-core/src/provider/hooks/translation/useCreateInternalUseTranslationsFunction.ts
@@ -25,6 +25,7 @@ import {
   condenseVars,
 } from 'generaltranslation/internal';
 import type { StringFormat } from '@generaltranslation/format/types';
+import { getDefaultStringFormat } from '@generaltranslation/format/internal';
 
 export default function useCreateInternalUseTranslationsFunction(
   gt: GT,
@@ -72,6 +73,7 @@ export default function useCreateInternalUseTranslationsFunction(
       // Extract format from options
       const { $format: format, ...variableOptions } =
         options as DictionaryTranslationOptions & { $format?: StringFormat };
+      const dataFormat = format ?? getDefaultStringFormat();
       const maxChars =
         metadata?.$maxChars ??
         (typeof options.$maxChars === 'number' ? options.$maxChars : undefined);
@@ -157,13 +159,13 @@ export default function useCreateInternalUseTranslationsFunction(
       let hash = '';
       const getHash = () =>
         hashSource({
-          source: indexVars(entry),
+          source: dataFormat === 'ICU' ? indexVars(entry) : entry,
           ...(metadata?.$context && { context: metadata.$context }),
           ...(metadata?.$maxChars != null && {
             maxChars: Math.abs(metadata.$maxChars),
           }),
           id,
-          dataFormat: 'ICU',
+          dataFormat,
         });
       if (!translationEntry) {
         hash = getHash();


### PR DESCRIPTION
## Summary
- stacked on #1602
- add a globalThis-backed default string format helper
- use the singleton default when string calls omit $format across i18n, React Core hashing, and Next paths
- add changeset for affected packages

## Testing
- pnpm --filter @generaltranslation/format test
- pnpm --filter @generaltranslation/format build
- pnpm --filter gt-i18n test
- pnpm --filter @generaltranslation/react-core test
- pnpm --filter gt-next build