### PR TITLE
feat(i18n): add config default string format

### DIFF
--- a/.changeset/config-string-format.md
+++ b/.changeset/config-string-format.md
@@ -1,0 +1,6 @@
+---
+'gt-i18n': minor
+'gt-next': minor
+---
+
+Add a `defaultStringFormat` configuration option for string calls that omit `$format`.

--- a/packages/i18n/src/config/types.ts
+++ b/packages/i18n/src/config/types.ts
@@ -1,4 +1,7 @@
-import type { CustomMapping } from '@generaltranslation/format/types';
+import type {
+  CustomMapping,
+  StringFormat,
+} from '@generaltranslation/format/types';
 
 /**
  * TODO: this is a react-only type, we need to move this
@@ -29,6 +32,10 @@ export type GTConfig = {
   locales?: string[];
   customMapping?: CustomMapping;
   enableI18n?: boolean;
+  /**
+   * Default string interpolation format when a string call omits `$format`.
+   */
+  defaultStringFormat?: StringFormat;
 
   // remote config
   projectId?: string;

--- a/packages/i18n/src/i18n-manager/I18nManager.ts
+++ b/packages/i18n/src/i18n-manager/I18nManager.ts
@@ -6,7 +6,10 @@ import { Translation } from './translations-manager/utils/types/translation-data
 import { libraryDefaultLocale } from 'generaltranslation/internal';
 import { GT } from 'generaltranslation';
 import { LocaleConfig, standardizeLocale } from '@generaltranslation/format';
-import type { CustomMapping } from '@generaltranslation/format/types';
+import type {
+  CustomMapping,
+  StringFormat,
+} from '@generaltranslation/format/types';
 import { LookupOptions } from '../translation-functions/types/options';
 import { getGTServicesEnabled } from './utils/getGTServicesEnabled';
 import {
@@ -207,6 +210,13 @@ class I18nManager<
   }
 
   /**
+   * Get the default string format for calls that omit $format.
+   */
+  getDefaultStringFormat() {
+    return this.config.defaultStringFormat;
+  }
+
+  /**
    * Get a gt class instance
    * @param locale - The locale to bind to the GT instance. When omitted, the GT instance is locale agnostic.
    * TODO: keep a cache to avoid creating new instances unnecessarily
@@ -397,7 +407,10 @@ class I18nManager<
     const translation = await this.lookupTranslationWithFallbackResolved(
       locale,
       sourceEntry.entry as TranslationValue,
-      resolveDictionaryLookupOptions(sourceEntry.options)
+      resolveDictionaryLookupOptions(
+        sourceEntry.options,
+        this.config.defaultStringFormat
+      )
     );
     if (typeof translation !== 'string') {
       throw new Error(
@@ -782,6 +795,9 @@ function standardizeConfig<TranslationValue extends Translation>(
     batchConfig: config.batchConfig,
     runtimeTranslation: config.runtimeTranslation,
     _versionId: config._versionId,
+    defaultStringFormat: isStringFormat(config.defaultStringFormat)
+      ? config.defaultStringFormat
+      : 'ICU',
     ...(gtServicesEnabled
       ? standardizeLocales(dedupedLocales)
       : dedupedLocales),
@@ -848,6 +864,10 @@ function standardizeLocales(config: {
     locales,
     customMapping,
   };
+}
+
+function isStringFormat(value: unknown): value is StringFormat {
+  return value === 'ICU' || value === 'I18NEXT' || value === 'STRING';
 }
 
 /**

--- a/packages/i18n/src/i18n-manager/translations-manager/utils/dictionary-helpers.ts
+++ b/packages/i18n/src/i18n-manager/translations-manager/utils/dictionary-helpers.ts
@@ -9,6 +9,7 @@ import type {
   DictionaryLookupOptions,
   DictionaryOptions,
 } from '../../../translation-functions/types/options';
+import type { StringFormat } from '@generaltranslation/format/types';
 
 function getDictionaryPath(id: DictionaryPath): string[] {
   const path = id ? id.split('.') : [];
@@ -110,12 +111,13 @@ export function getDictionaryValue(value: DictionaryEntry): DictionaryValue {
 }
 
 export function resolveDictionaryLookupOptions(
-  options: DictionaryEntry['options']
+  options: DictionaryEntry['options'],
+  defaultFormat: StringFormat = 'ICU'
 ): DictionaryLookupOptions {
   const { $format, context, ...rest } = options;
   return {
     ...rest,
-    $format: isStringFormat($format) ? $format : 'ICU',
+    $format: isStringFormat($format) ? $format : defaultFormat,
     ...(rest.$context === undefined &&
       typeof context === 'string' && { $context: context }),
   };

--- a/packages/i18n/src/i18n-manager/types.ts
+++ b/packages/i18n/src/i18n-manager/types.ts
@@ -1,5 +1,8 @@
 import type { RuntimeTranslateManyOptions } from 'generaltranslation/internal';
-import type { CustomMapping } from '@generaltranslation/format/types';
+import type {
+  CustomMapping,
+  StringFormat,
+} from '@generaltranslation/format/types';
 import type { GTConfig } from '../config/types';
 import type { TranslationsLoader } from './translations-manager/translations-loaders/types';
 import type { Translation } from './translations-manager/utils/types/translation-data';
@@ -55,6 +58,7 @@ export type I18nManagerConfig = {
   locales: string[];
   customMapping: CustomMapping;
   enableI18n: boolean;
+  defaultStringFormat: StringFormat;
   projectId?: string;
   devApiKey?: string;
   apiKey?: string;

--- a/packages/i18n/src/translation-functions/__tests__/t.test.ts
+++ b/packages/i18n/src/translation-functions/__tests__/t.test.ts
@@ -44,6 +44,25 @@ describe('t', () => {
     expect(t(message, { name: 'Alice' })).toBe('Bonjour Alice !');
   });
 
+  it('uses the configured default string format when $format is omitted', async () => {
+    const message = 'Hello {{name}}!';
+    const translatedMessage = 'Bonjour {{name}} !';
+    const manager = new I18nManager({
+      defaultLocale: 'en',
+      defaultStringFormat: 'I18NEXT',
+      locales: ['en', 'fr'],
+      loadTranslations: vi.fn().mockResolvedValue({
+        [hashMessage(message, { $format: 'I18NEXT' })]: translatedMessage,
+      }),
+    });
+
+    setI18nManager(manager);
+    setConditionStore({ getLocale: () => 'fr' });
+    await manager.loadTranslations('fr');
+
+    expect(t(message, { name: 'Alice' })).toBe('Bonjour Alice !');
+  });
+
   it('allows an explicit $locale to override the current locale', async () => {
     const message = 'Hello {name}!';
     const manager = new I18nManager({

--- a/packages/i18n/src/translation-functions/internal/__tests__/helpers.test.ts
+++ b/packages/i18n/src/translation-functions/internal/__tests__/helpers.test.ts
@@ -57,6 +57,7 @@ describe('translation helpers', () => {
         .fn()
         .mockResolvedValue('Bonjour {name} !'),
       getDefaultLocale: vi.fn().mockReturnValue('en'),
+      getDefaultStringFormat: vi.fn().mockReturnValue('STRING'),
     };
     vi.mocked(getI18nManager).mockReturnValue(
       mockManager as unknown as ReturnType<typeof getI18nManager>
@@ -78,6 +79,7 @@ describe('translation helpers', () => {
       getLocale: vi.fn().mockReturnValue('fr'),
       lookupTranslation: vi.fn().mockReturnValue(undefined),
       getDefaultLocale: vi.fn().mockReturnValue('en'),
+      getDefaultStringFormat: vi.fn().mockReturnValue('STRING'),
     };
     vi.mocked(getI18nManager).mockReturnValue(
       mockManager as unknown as ReturnType<typeof getI18nManager>

--- a/packages/i18n/src/translation-functions/internal/__tests__/resolveTranslationSync.test.ts
+++ b/packages/i18n/src/translation-functions/internal/__tests__/resolveTranslationSync.test.ts
@@ -17,6 +17,7 @@ describe('resolveTranslationSync', () => {
       getLocale: vi.fn().mockReturnValue('fr'),
       lookupTranslation: vi.fn().mockReturnValue('Bonjour {name} !'),
       getDefaultLocale: vi.fn().mockReturnValue('en'),
+      getDefaultStringFormat: vi.fn().mockReturnValue('ICU'),
     };
     vi.mocked(getI18nManager).mockReturnValue(
       mockManager as unknown as ReturnType<typeof getI18nManager>
@@ -43,6 +44,7 @@ describe('resolveTranslationSync', () => {
     const mockManager = {
       getLocale: vi.fn().mockReturnValue('fr'),
       lookupTranslation: vi.fn().mockReturnValue(undefined),
+      getDefaultStringFormat: vi.fn().mockReturnValue('ICU'),
     };
     vi.mocked(getI18nManager).mockReturnValue(
       mockManager as unknown as ReturnType<typeof getI18nManager>
@@ -62,6 +64,7 @@ describe('resolveTranslationSync', () => {
       getLocale: vi.fn().mockReturnValue('fr'),
       lookupTranslation: vi.fn().mockReturnValue('Translated'),
       getDefaultLocale: vi.fn().mockReturnValue('en'),
+      getDefaultStringFormat: vi.fn().mockReturnValue('ICU'),
     };
     vi.mocked(getI18nManager).mockReturnValue(
       mockManager as unknown as ReturnType<typeof getI18nManager>
@@ -96,6 +99,7 @@ describe('resolveTranslationSync', () => {
       getLocale: vi.fn().mockReturnValue('fr'),
       lookupTranslation: vi.fn().mockReturnValue('Translated'),
       getDefaultLocale: vi.fn().mockReturnValue('en'),
+      getDefaultStringFormat: vi.fn().mockReturnValue('ICU'),
     };
     vi.mocked(getI18nManager).mockReturnValue(
       mockManager as unknown as ReturnType<typeof getI18nManager>

--- a/packages/i18n/src/translation-functions/internal/getGT.ts
+++ b/packages/i18n/src/translation-functions/internal/getGT.ts
@@ -47,7 +47,7 @@ export async function getGT(): Promise<GTFunctionType> {
     const lookupOptions = createLookupOptions<StringFormat>(
       targetLocale,
       options,
-      'ICU'
+      i18nManager.getDefaultStringFormat()
     );
 
     // Lookup translation

--- a/packages/i18n/src/translation-functions/internal/helpers.ts
+++ b/packages/i18n/src/translation-functions/internal/helpers.ts
@@ -72,7 +72,11 @@ export function resolveStringContent(
   options: ResolutionOptions<StringFormat> = {}
 ): StringContent | undefined {
   const i18nManager = getI18nManager();
-  const lookupOptions = createLookupOptions(locale, options, 'STRING');
+  const lookupOptions = createLookupOptions(
+    locale,
+    options,
+    i18nManager.getDefaultStringFormat()
+  );
   const translation = i18nManager.lookupTranslation(
     lookupOptions.$locale,
     content,
@@ -96,7 +100,11 @@ export function resolveStringContentWithFallback(
   options: ResolutionOptions<StringFormat> = {}
 ): StringContent {
   const i18nManager = getI18nManager();
-  const lookupOptions = createLookupOptions(locale, options, 'STRING');
+  const lookupOptions = createLookupOptions(
+    locale,
+    options,
+    i18nManager.getDefaultStringFormat()
+  );
   const translation = i18nManager.lookupTranslation(
     lookupOptions.$locale,
     content,
@@ -121,7 +129,11 @@ export async function resolveStringContentWithRuntimeFallback(
   options: ResolutionOptions<StringFormat> = {}
 ): Promise<StringContent> {
   const i18nManager = getI18nManager();
-  const lookupOptions = createLookupOptions(locale, options, 'STRING');
+  const lookupOptions = createLookupOptions(
+    locale,
+    options,
+    i18nManager.getDefaultStringFormat()
+  );
   const translation = await i18nManager.lookupTranslationWithFallback(
     lookupOptions.$locale,
     content,

--- a/packages/i18n/src/translation-functions/internal/sync-translation-resolution.ts
+++ b/packages/i18n/src/translation-functions/internal/sync-translation-resolution.ts
@@ -16,7 +16,7 @@ export function resolveTranslationSync(
   message: string,
   options: InlineTranslationOptions = {}
 ) {
-  return resolveStringContent(locale, message, { $format: 'ICU', ...options });
+  return resolveStringContent(locale, message, options);
 }
 
 /**
@@ -31,8 +31,5 @@ export function resolveTranslationSyncWithFallback(
   message: string,
   options: InlineTranslationOptions = {}
 ) {
-  return resolveStringContentWithFallback(locale, message, {
-    $format: 'ICU',
-    ...options,
-  });
+  return resolveStringContentWithFallback(locale, message, options);
 }

--- a/packages/i18n/src/translation-functions/internal/tx.ts
+++ b/packages/i18n/src/translation-functions/internal/tx.ts
@@ -1,7 +1,10 @@
 import { RuntimeTranslationOptions } from '../types/options';
 import type { StringFormat } from '@generaltranslation/format/types';
 import { resolveStringContentWithRuntimeFallback } from './helpers';
-import { getCurrentLocale } from '../../i18n-manager/singleton-operations';
+import {
+  getCurrentLocale,
+  getI18nManager,
+} from '../../i18n-manager/singleton-operations';
 
 type RuntimeTranslationOptionsWithFormat = Omit<
   RuntimeTranslationOptions,
@@ -30,8 +33,11 @@ export async function tx(
 ): Promise<string> {
   const locale =
     typeof options.$locale === 'string' ? options.$locale : getCurrentLocale();
+  const defaultStringFormat = getI18nManager().getDefaultStringFormat();
   return resolveStringContentWithRuntimeFallback(locale, content, {
-    $format: 'STRING',
     ...options,
+    $format:
+      options.$format ??
+      (defaultStringFormat === 'ICU' ? 'STRING' : defaultStringFormat),
   });
 }

--- a/packages/i18n/src/translation-functions/t.ts
+++ b/packages/i18n/src/translation-functions/t.ts
@@ -10,8 +10,5 @@ import { getCurrentLocale } from '../i18n-manager/singleton-operations';
  */
 export function t(message: string, options: InlineTranslationOptions = {}) {
   const locale = options.$locale ?? getCurrentLocale();
-  return resolveStringContentWithFallback(locale, message, {
-    $format: 'ICU',
-    ...options,
-  });
+  return resolveStringContentWithFallback(locale, message, options);
 }

--- a/packages/next/src/config-dir/I18NConfiguration.ts
+++ b/packages/next/src/config-dir/I18NConfiguration.ts
@@ -19,6 +19,7 @@ import {
 } from '../utils/cookies';
 import { defaultLocaleHeaderName } from '../utils/headers';
 import type { CustomMapping } from '@generaltranslation/format/types';
+import type { StringFormat } from '@generaltranslation/format/types';
 import { I18nManager } from 'gt-i18n/internal';
 import type { LookupOptions } from 'gt-i18n/internal/types';
 import { loadTranslations } from './loadTranslation';
@@ -45,6 +46,7 @@ type I18NConfigurationParams = {
   _usingPlugin: boolean;
   _versionId?: string;
   customMapping?: CustomMapping | undefined;
+  defaultStringFormat?: StringFormat;
   [key: string]: unknown;
 };
 
@@ -106,6 +108,7 @@ export class I18NConfiguration {
     _usingPlugin,
     headersAndCookies,
     customMapping,
+    defaultStringFormat,
     // Other metadata
     ...metadata
   }: I18NConfigurationParams) {
@@ -170,6 +173,7 @@ export class I18NConfiguration {
       locales,
       // Custom mapping
       customMapping,
+      defaultStringFormat,
       enableI18n: this.translationEnabled,
       // Batching config
       batchConfig: {
@@ -292,6 +296,13 @@ export class I18NConfiguration {
    */
   getDefaultLocale(): string {
     return this._i18nManager.getDefaultLocale();
+  }
+
+  /**
+   * Gets the default string format for string calls that omit $format
+   */
+  getDefaultStringFormat(): StringFormat {
+    return this._i18nManager.getDefaultStringFormat();
   }
 
   /**

--- a/packages/next/src/server-dir/buildtime/__tests__/getTranslations.test.ts
+++ b/packages/next/src/server-dir/buildtime/__tests__/getTranslations.test.ts
@@ -232,6 +232,7 @@ describe('getTranslations', () => {
       expect(mockFormatMessage).toHaveBeenCalledWith(mockEntry, {
         locales: ['en'],
         variables: { [VAR_IDENTIFIER]: 'other' },
+        dataFormat: 'ICU',
       });
     });
 
@@ -252,6 +253,7 @@ describe('getTranslations', () => {
       expect(mockFormatMessage).toHaveBeenCalledWith(mockEntry, {
         locales: ['en'],
         variables: { name: 'John', [VAR_IDENTIFIER]: 'other' },
+        dataFormat: 'ICU',
       });
     });
   });
@@ -376,6 +378,7 @@ describe('getTranslations', () => {
         variables: {
           [VAR_IDENTIFIER]: 'other',
         },
+        dataFormat: 'ICU',
       });
     });
 

--- a/packages/next/src/server-dir/buildtime/getTranslationFunction.ts
+++ b/packages/next/src/server-dir/buildtime/getTranslationFunction.ts
@@ -36,6 +36,10 @@ type GTStringOptions = InlineTranslationOptions & {
   $_hash?: string;
 };
 
+function isStringFormat(value: unknown): value is StringFormat {
+  return value === 'ICU' || value === 'I18NEXT' || value === 'STRING';
+}
+
 type RenderMessageParams = {
   message: string;
   variables: FormatVariables | undefined;
@@ -160,6 +164,7 @@ async function createTranslator(_messages?: _Messages): Promise<Translator> {
       ...variables
     } = options;
     const formatVariables = variables as FormatVariables;
+    const resolvedFormat = format ?? I18NConfig.getDefaultStringFormat();
 
     const renderMessage: RenderFn = (msg, locales, fallback) => {
       return renderMessageHelper({
@@ -169,17 +174,17 @@ async function createTranslator(_messages?: _Messages): Promise<Translator> {
         id,
         fallback,
         maxChars,
-        format,
+        format: resolvedFormat,
       });
     };
 
     const calculateHash = () =>
       hashSource({
-        source: indexVars(message),
+        source: resolvedFormat === 'ICU' ? indexVars(message) : message,
         ...(context && { context }),
         ...(maxChars != null && { maxChars: Math.abs(maxChars) }),
         ...(id && { id }),
-        dataFormat: format || 'ICU',
+        dataFormat: resolvedFormat,
       });
 
     return {
@@ -375,7 +380,8 @@ async function createTranslator(_messages?: _Messages): Promise<Translator> {
     const context = typeof $context === 'string' ? $context : undefined;
     const id = typeof $id === 'string' ? $id : undefined;
     const maxChars = typeof $maxChars === 'number' ? $maxChars : undefined;
-    const format = typeof $format === 'string' ? $format : undefined;
+    const format = isStringFormat($format) ? $format : undefined;
+    const resolvedFormat = format ?? I18NConfig.getDefaultStringFormat();
     const formatVariables = decodedVariables as FormatVariables;
 
     const renderMessage: RenderFn = (msg, locales, fallback) => {
@@ -385,7 +391,7 @@ async function createTranslator(_messages?: _Messages): Promise<Translator> {
         variables: formatVariables,
         fallback,
         maxChars,
-        format,
+        format: resolvedFormat,
       });
     };
 

--- a/packages/next/src/server-dir/buildtime/getTranslationFunction.ts
+++ b/packages/next/src/server-dir/buildtime/getTranslationFunction.ts
@@ -56,6 +56,7 @@ type InitResult = {
   maxChars?: number;
   _hash?: string;
   variables: FormatVariables;
+  dataFormat: StringFormat;
   calculateHash: () => string;
   renderMessage: RenderFn;
 };
@@ -138,6 +139,7 @@ async function createTranslator(_messages?: _Messages): Promise<Translator> {
           variables,
           id,
           maxChars,
+          format,
         });
       }
 
@@ -193,6 +195,7 @@ async function createTranslator(_messages?: _Messages): Promise<Translator> {
       maxChars,
       _hash,
       variables: formatVariables,
+      dataFormat: resolvedFormat,
       calculateHash,
       renderMessage,
     };
@@ -223,19 +226,21 @@ async function createTranslator(_messages?: _Messages): Promise<Translator> {
     maxChars?: number;
     id?: string;
     hash: string;
+    dataFormat: StringFormat;
     renderMessage: RenderFn;
   }) {
-    const { source, context, maxChars, id, hash, renderMessage } = args;
+    const { source, context, maxChars, id, hash, dataFormat, renderMessage } =
+      args;
     try {
       I18NConfig.translate({
-        source: indexVars(source),
+        source: dataFormat === 'ICU' ? indexVars(source) : source,
         targetLocale: locale,
         options: {
           ...(context && { $context: context }),
           ...(maxChars != null && { $maxChars: maxChars }),
           ...(id && { $id: id }),
           $_hash: hash,
-          $format: 'ICU',
+          $format: dataFormat,
         },
       }).then((result) => {
         // eslint-disable-next-line no-console
@@ -273,7 +278,7 @@ async function createTranslator(_messages?: _Messages): Promise<Translator> {
       const init = initializeGT(message, options);
       if (!init) return;
 
-      const { id, context, maxChars, _hash, calculateHash } = init;
+      const { id, context, maxChars, _hash, dataFormat, calculateHash } = init;
       const { translationEntry, hash } = getTranslationData(
         calculateHash,
         id,
@@ -283,14 +288,14 @@ async function createTranslator(_messages?: _Messages): Promise<Translator> {
 
       try {
         preloadedTranslations![hash] = (await I18NConfig.translate({
-          source: indexVars(message),
+          source: dataFormat === 'ICU' ? indexVars(message) : message,
           targetLocale: locale,
           options: {
             ...(context && { $context: context }),
             ...(maxChars != null && { $maxChars: maxChars }),
             ...(id && { $id: id }),
             $_hash: hash,
-            $format: 'ICU',
+            $format: dataFormat,
           },
         })) as string;
       } catch (error) {
@@ -305,7 +310,15 @@ async function createTranslator(_messages?: _Messages): Promise<Translator> {
   const gt = (message: string, options: GTStringOptions = {}): string => {
     const init = initializeGT(message, options);
     if (!init) return '';
-    const { id, context, maxChars, _hash, calculateHash, renderMessage } = init;
+    const {
+      id,
+      context,
+      maxChars,
+      _hash,
+      dataFormat,
+      calculateHash,
+      renderMessage,
+    } = init;
 
     // Early: no translation needed
     if (!translationRequired) return renderMessage(message, [defaultLocale]);
@@ -344,6 +357,7 @@ async function createTranslator(_messages?: _Messages): Promise<Translator> {
       maxChars,
       id,
       hash,
+      dataFormat,
       renderMessage,
     });
     return renderMessage(message, [defaultLocale]);
@@ -448,6 +462,7 @@ async function createTranslator(_messages?: _Messages): Promise<Translator> {
       maxChars,
       id,
       hash: $_hash,
+      dataFormat: resolvedFormat,
       renderMessage,
     });
 

--- a/packages/next/src/server-dir/buildtime/getTranslations.tsx
+++ b/packages/next/src/server-dir/buildtime/getTranslations.tsx
@@ -143,6 +143,7 @@ export async function getTranslations(id?: string): Promise<
     // Extract format from options
     const { $format: format, ...variableOptions } =
       options as DictionaryTranslationOptions & { $format?: StringFormat };
+    const dataFormat = format ?? I18NConfig.getDefaultStringFormat();
     const maxChars =
       metadata?.$maxChars ??
       (typeof options.$maxChars === 'number' ? options.$maxChars : undefined);
@@ -166,7 +167,7 @@ export async function getTranslations(id?: string): Promise<
               ...declaredVars,
               [VAR_IDENTIFIER]: 'other',
             },
-            dataFormat: format,
+            dataFormat,
           }
         );
         const cutoffMessage = gt.formatCutoff(formattedMessage, {
@@ -245,13 +246,13 @@ export async function getTranslations(id?: string): Promise<
     const getHash = () => {
       if (metadata?.$_hash) return metadata.$_hash;
       const hash = hashSource({
-        source: indexVars(entry),
+        source: dataFormat === 'ICU' ? indexVars(entry) : entry,
         ...(metadata?.$context && { context: metadata.$context }),
         ...(metadata?.$maxChars != null && {
           maxChars: Math.abs(metadata.$maxChars),
         }),
         id,
-        dataFormat: 'ICU',
+        dataFormat,
       });
       // Inject hash if not there yet
       metadata = { ...metadata, $_hash: hash };

--- a/packages/next/src/server-dir/runtime/__tests__/tx.test.ts
+++ b/packages/next/src/server-dir/runtime/__tests__/tx.test.ts
@@ -9,6 +9,7 @@ const { mockLookupTranslation, mockTranslate } = vi.hoisted(() => ({
 vi.mock('../../../config-dir/getI18NConfig', () => ({
   getI18NConfig: () => ({
     getDefaultLocale: () => 'en',
+    getDefaultStringFormat: () => 'ICU',
     requiresTranslation: () => [true, false],
     getGTClass: () => ({
       formatMessage: (message: string) => message,

--- a/packages/next/src/server-dir/runtime/tx.ts
+++ b/packages/next/src/server-dir/runtime/tx.ts
@@ -109,13 +109,13 @@ export async function tx(
 
   // ----- CALCULATE HASH ----- //
 
+  const dataFormat = format ?? I18NConfig.getDefaultStringFormat();
   const hash = hashSource({
-    source: format === 'ICU' ? indexVars(message) : message,
+    source: dataFormat === 'ICU' ? indexVars(message) : message,
     ...(context && { context }),
     ...(maxChars != null && { maxChars: Math.abs(maxChars) }),
-    dataFormat: format || 'ICU',
+    dataFormat,
   });
-  const dataFormat = format || 'ICU';
   const source = dataFormat === 'ICU' ? indexVars(message) : message;
   const lookupOptions = {
     ...formatVariables,

--- a/packages/next/src/server-dir/runtime/tx.ts
+++ b/packages/next/src/server-dir/runtime/tx.ts
@@ -79,6 +79,7 @@ export async function tx(
   const defaultLocale = I18NConfig.getDefaultLocale();
   const [translationRequired] = I18NConfig.requiresTranslation(locale);
   const gt = I18NConfig.getGTClass();
+  const dataFormat = format ?? I18NConfig.getDefaultStringFormat();
 
   // ----- DEFINE RENDER FUNCTION ----- //
 
@@ -93,7 +94,7 @@ export async function tx(
           ...declaredVars,
           [VAR_IDENTIFIER]: 'other',
         },
-        dataFormat: format,
+        dataFormat,
       }
     );
     const cutoffMessage = gt.formatCutoff(formattedMessage, {
@@ -109,7 +110,6 @@ export async function tx(
 
   // ----- CALCULATE HASH ----- //
 
-  const dataFormat = format ?? I18NConfig.getDefaultStringFormat();
   const hash = hashSource({
     source: dataFormat === 'ICU' ? indexVars(message) : message,
     ...(context && { context }),


### PR DESCRIPTION
## Summary
- stacked on #1602
- add a defaultStringFormat option for GT config / gt.config.json flows
- pass the configured default through I18nManager and Next paths for strings without $format
- add changeset for affected packages

## Testing
- pnpm --filter @generaltranslation/format build
- pnpm --filter gt-i18n test
- pnpm --filter gt-next build
- pnpm build