### PR TITLE
F/aggregate on upload

### DIFF
--- a/.changeset/rude-moons-wink.md
+++ b/.changeset/rude-moons-wink.md
@@ -1,0 +1,5 @@
+---
+"gt": patch
+---
+
+Aggregate files on `upload` command. Ensures consistency with `stage` and `translate`

--- a/packages/cli/src/cli/base.ts
+++ b/packages/cli/src/cli/base.ts
@@ -26,7 +26,6 @@ import {
   TranslateFlags,
   SharedFlags,
 } from '../types/index.js';
-import { DataFormat } from '../types/data.js';
 import { generateSettings } from '../config/generateSettings.js';
 import chalk from 'chalk';
 import { FILE_EXT_TO_EXT_LABEL } from '../formats/files/supportedFiles.js';
@@ -519,37 +518,12 @@ export class BaseCLI {
   protected async handleUploadCommand(
     settings: Settings & UploadOptions
   ): Promise<void> {
-    // dataFormat for JSONs
-    let dataFormat: DataFormat;
-    if (this.library === 'next-intl') {
-      dataFormat = 'ICU';
-    } else if (this.library === 'i18next') {
-      if (this.additionalModules.includes('i18next-icu')) {
-        dataFormat = 'ICU';
-      } else {
-        dataFormat = 'I18NEXT';
-      }
-    } else {
-      dataFormat = 'JSX';
-    }
-
     if (!settings.files) {
       return;
     }
-    const {
-      resolvedPaths: sourceFiles,
-      placeholderPaths,
-      transformPaths,
-    } = settings.files;
 
     // Process all file types at once with a single call
-    await upload(
-      sourceFiles,
-      placeholderPaths,
-      transformPaths,
-      dataFormat,
-      settings
-    );
+    await upload(settings);
   }
 
   // Wizard for configuring gt.config.json

--- a/packages/cli/src/cli/commands/__tests__/upload.test.ts
+++ b/packages/cli/src/cli/commands/__tests__/upload.test.ts
@@ -35,9 +35,18 @@ vi.mock('./utils/validation.js', () => ({
 }));
 
 // Mock node:fs for existsSync/readFileSync (translation file reads)
-vi.mock('node:fs', () => ({
+const mockFs = vi.hoisted(() => ({
   existsSync: vi.fn(() => false),
   readFileSync: vi.fn(() => ''),
+}));
+
+vi.mock('node:fs', () => ({
+  default: mockFs,
+  existsSync: mockFs.existsSync,
+  readFileSync: mockFs.readFileSync,
+}));
+vi.mock('../../../fs/determineFramework/index.js', () => ({
+  determineLibrary: vi.fn(() => ({ library: 'base', additionalModules: [] })),
 }));
 
 import { readFile } from '../../../fs/findFilepath.js';
@@ -60,13 +69,44 @@ function makeSettings(
     locales: ['es', 'fr'],
     projectId: 'test-project',
     apiKey: 'test-key',
+    files: {
+      resolvedPaths: {},
+      placeholderPaths: {},
+      transformPaths: {},
+      transformFormats: {},
+      publishPaths: new Set<string>(),
+      unpublishPaths: new Set<string>(),
+      parsingFlags: {},
+      gtJson: {
+        parsingFlags: {},
+      },
+    },
     ...overrides,
   } as Settings & UploadOptions;
+}
+
+async function uploadWithFiles(
+  filePaths: ResolvedFiles,
+  settings: Settings & UploadOptions,
+  placeholderPaths: ResolvedFiles = {},
+  transformPaths: TransformFiles = {}
+) {
+  await upload({
+    ...settings,
+    files: {
+      ...settings.files,
+      resolvedPaths: filePaths,
+      placeholderPaths,
+      transformPaths,
+    },
+  } as Settings & UploadOptions);
 }
 
 describe('upload - Twilio Content JSON', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(existsSync).mockReturnValue(false);
+    vi.mocked(readFileSync).mockReturnValue('');
     vi.mocked(createFileMapping).mockReturnValue({});
   });
 
@@ -83,7 +123,7 @@ describe('upload - Twilio Content JSON', () => {
     };
     const settings = makeSettings({ options: {} });
 
-    await upload(filePaths, {}, {} as TransformFiles, 'JSX', settings);
+    await uploadWithFiles(filePaths, settings);
 
     expect(runUploadFilesWorkflow).toHaveBeenCalledTimes(1);
     const call = vi.mocked(runUploadFilesWorkflow).mock.calls[0][0];
@@ -107,7 +147,7 @@ describe('upload - Twilio Content JSON', () => {
     vi.mocked(existsSync).mockReturnValue(true);
     vi.mocked(readFileSync).mockReturnValue(translatedContent);
 
-    await upload(filePaths, {}, {} as TransformFiles, 'JSX', settings);
+    await uploadWithFiles(filePaths, settings);
 
     const call = vi.mocked(runUploadFilesWorkflow).mock.calls[0][0];
     const fileData = call.files[0];
@@ -131,7 +171,7 @@ describe('upload - Twilio Content JSON', () => {
     };
     const settings = makeSettings({ locales: ['es'], options: {} });
 
-    await upload(filePaths, {}, {} as TransformFiles, 'JSX', settings);
+    await uploadWithFiles(filePaths, settings);
 
     const call = vi.mocked(runUploadFilesWorkflow).mock.calls[0][0];
     expect(call.files).toHaveLength(2);
@@ -148,9 +188,68 @@ describe('upload - Twilio Content JSON', () => {
   });
 });
 
+describe('upload - companion metadata', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(existsSync).mockReturnValue(false);
+    vi.mocked(readFileSync).mockReturnValue('');
+    vi.mocked(createFileMapping).mockReturnValue({});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('attaches companion metadata to the source file instead of uploading it separately', async () => {
+    const sourceContent = JSON.stringify({
+      title: 'Hello',
+      body: 'World',
+    });
+    const metadataContent = JSON.stringify({
+      title: { context: 'Hero title' },
+      body: { maxChars: 120 },
+    });
+    setMockFiles({
+      'source.json': sourceContent,
+      'source.metadata.json': metadataContent,
+    });
+
+    const filePaths: ResolvedFiles = {
+      json: ['source.json', 'source.metadata.json'],
+    };
+    const settings = makeSettings({ locales: [], options: {} });
+
+    vi.mocked(existsSync).mockImplementation(
+      (filePath) => filePath === 'source.metadata.json'
+    );
+    vi.mocked(readFileSync).mockImplementation((filePath) => {
+      if (filePath === 'source.metadata.json') {
+        return metadataContent;
+      }
+      return '';
+    });
+
+    await uploadWithFiles(filePaths, settings);
+
+    expect(runUploadFilesWorkflow).toHaveBeenCalledTimes(1);
+    const call = vi.mocked(runUploadFilesWorkflow).mock.calls[0][0];
+
+    expect(call.files).toHaveLength(1);
+    expect(call.files[0].source.fileName).toBe('source.json');
+    expect(call.files[0].source.formatMetadata).toEqual({
+      keyedMetadata: {
+        title: { context: 'Hero title' },
+        body: { maxChars: 120 },
+      },
+    });
+  });
+});
+
 describe('upload - composite JSON', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(existsSync).mockReturnValue(false);
+    vi.mocked(readFileSync).mockReturnValue('');
     vi.mocked(createFileMapping).mockReturnValue({});
   });
 
@@ -187,7 +286,7 @@ describe('upload - composite JSON', () => {
       },
     });
 
-    await upload(filePaths, {}, {} as TransformFiles, 'JSX', settings);
+    await uploadWithFiles(filePaths, settings);
 
     expect(runUploadFilesWorkflow).toHaveBeenCalledTimes(1);
     const call = vi.mocked(runUploadFilesWorkflow).mock.calls[0][0];
@@ -238,7 +337,7 @@ describe('upload - composite JSON', () => {
       },
     });
 
-    await upload(filePaths, {}, {} as TransformFiles, 'JSX', settings);
+    await uploadWithFiles(filePaths, settings);
 
     expect(runUploadFilesWorkflow).toHaveBeenCalledTimes(1);
     const call = vi.mocked(runUploadFilesWorkflow).mock.calls[0][0];
@@ -280,7 +379,7 @@ describe('upload - composite JSON', () => {
       },
     });
 
-    await upload(filePaths, {}, {} as TransformFiles, 'JSX', settings);
+    await uploadWithFiles(filePaths, settings);
 
     const call = vi.mocked(runUploadFilesWorkflow).mock.calls[0][0];
     const fileData = call.files[0];
@@ -315,10 +414,10 @@ describe('upload - composite JSON', () => {
     vi.mocked(createFileMapping).mockReturnValue({
       es: { 'source.json': 'es/source.json' },
     });
-    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(existsSync).mockImplementation((p) => p === 'es/source.json');
     vi.mocked(readFileSync).mockReturnValue(translatedContent);
 
-    await upload(filePaths, {}, {} as TransformFiles, 'JSX', settings);
+    await uploadWithFiles(filePaths, settings);
 
     const call = vi.mocked(runUploadFilesWorkflow).mock.calls[0][0];
     const fileData = call.files[0];
@@ -370,7 +469,7 @@ describe('upload - composite JSON', () => {
     vi.mocked(existsSync).mockImplementation((p) => p === 'es/plain.json');
     vi.mocked(readFileSync).mockReturnValue(translatedPlain);
 
-    await upload(filePaths, {}, {} as TransformFiles, 'JSX', settings);
+    await uploadWithFiles(filePaths, settings);
 
     const call = vi.mocked(runUploadFilesWorkflow).mock.calls[0][0];
 

--- a/packages/cli/src/cli/commands/__tests__/upload.test.ts
+++ b/packages/cli/src/cli/commands/__tests__/upload.test.ts
@@ -22,7 +22,12 @@ vi.mock('../../../fs/findFilepath.js', () => ({
   getRelative: vi.fn((filePath: string) => filePath),
 }));
 vi.mock('../../../workflows/upload.js', () => ({
-  runUploadFilesWorkflow: vi.fn(),
+  runUploadFilesWorkflow: vi.fn(async () => ({
+    branchData: { currentBranch: { id: 'branch-id' } },
+  })),
+}));
+vi.mock('../../../workflows/publish.js', () => ({
+  runPublishWorkflow: vi.fn(),
 }));
 vi.mock('../../../formats/files/fileMapping.js', () => ({
   createFileMapping: vi.fn(() => ({})),
@@ -51,7 +56,9 @@ vi.mock('../../../fs/determineFramework/index.js', () => ({
 
 import { readFile } from '../../../fs/findFilepath.js';
 import { runUploadFilesWorkflow } from '../../../workflows/upload.js';
+import { runPublishWorkflow } from '../../../workflows/publish.js';
 import { createFileMapping } from '../../../formats/files/fileMapping.js';
+import { logger } from '../../../console/logger.js';
 import { existsSync, readFileSync } from 'node:fs';
 
 function setMockFiles(files: Record<string, string>) {
@@ -129,6 +136,8 @@ describe('upload - Twilio Content JSON', () => {
     const call = vi.mocked(runUploadFilesWorkflow).mock.calls[0][0];
     expect(call.files).toHaveLength(1);
     expect(call.files[0].source.fileFormat).toBe('TWILIO_CONTENT_JSON');
+    expect(runPublishWorkflow).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(runPublishWorkflow).mock.calls[0][2]).toBe('branch-id');
   });
 
   it('should use fileMapping for Twilio Content JSON files (no composite)', async () => {
@@ -185,6 +194,32 @@ describe('upload - Twilio Content JSON', () => {
 
     expect(jsonFile?.source.fileFormat).toBe('JSON');
     expect(twilioFile?.source.fileFormat).toBe('TWILIO_CONTENT_JSON');
+  });
+});
+
+describe('upload - empty file list', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(existsSync).mockReturnValue(false);
+    vi.mocked(readFileSync).mockReturnValue('');
+    vi.mocked(createFileMapping).mockReturnValue({});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('emits only the upload-specific empty files message', async () => {
+    setMockFiles({});
+
+    await uploadWithFiles({}, makeSettings({ options: {} }));
+
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenCalledWith(
+      'No files to upload were found. Check your configuration and try again.'
+    );
+    expect(runUploadFilesWorkflow).not.toHaveBeenCalled();
+    expect(runPublishWorkflow).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/cli/src/cli/commands/setupProject.ts
+++ b/packages/cli/src/cli/commands/setupProject.ts
@@ -36,6 +36,12 @@ export async function handleSetupProject(
     return null;
   }
 
+  if (allFiles.length === 0) {
+    logger.error(
+      'No files to upload were found. Check your configuration and try again.'
+    );
+  }
+
   // Upload files and run setup step
   let fileVersionData: FileTranslationData | undefined;
   let branchData: BranchData | undefined;

--- a/packages/cli/src/cli/commands/stage.ts
+++ b/packages/cli/src/cli/commands/stage.ts
@@ -44,6 +44,12 @@ export async function handleStage(
     return null;
   }
 
+  if (allFiles.length === 0 && !settings.publish) {
+    logger.error(
+      'No files to translate were found. Check your configuration and try again.'
+    );
+  }
+
   // Send translations to General Translation
   let fileVersionData: FileTranslationData | undefined;
   let jobData: EnqueueFilesResult | undefined;

--- a/packages/cli/src/cli/commands/upload.ts
+++ b/packages/cli/src/cli/commands/upload.ts
@@ -1,191 +1,60 @@
-import {
-  noSupportedFormatError,
-  noDefaultLocaleError,
-} from '../../console/index.js';
+import { noDefaultLocaleError } from '../../console/index.js';
 import { exitSync, logErrorAndExit } from '../../console/logging.js';
 import { logger } from '../../console/logger.js';
 import { getRelative, readFile } from '../../fs/findFilepath.js';
-import { ResolvedFiles, Settings, TransformFiles } from '../../types/index.js';
-import { FileFormat, DataFormat } from '../../types/data.js';
-import { SUPPORTED_FILE_EXTENSIONS } from '../../formats/files/supportedFiles.js';
+import { Settings } from '../../types/index.js';
 import { UploadOptions } from '../base.js';
-import sanitizeFileContent from '../../utils/sanitizeFileContent.js';
-import { parseJson } from '../../formats/json/parseJson.js';
 import { extractJson } from '../../formats/json/extractJson.js';
 import { validateJsonSchema } from '../../formats/json/utils.js';
-import {
-  resolveMintlifyRefs,
-  shouldResolveRefs,
-} from '../../utils/resolveMintlifyRefs.js';
 import { runUploadFilesWorkflow } from '../../workflows/upload.js';
 import { existsSync, readFileSync } from 'node:fs';
 import { createFileMapping } from '../../formats/files/fileMapping.js';
-import parseYaml from '../../formats/yaml/parseYaml.js';
 import type { FileToUpload } from 'generaltranslation/types';
-import { hashStringSync } from '../../utils/hash.js';
 import { hasValidCredentials } from './utils/validation.js';
-import { buildPublishMap } from '../../utils/resolvePublish.js';
 import { runPublishWorkflow } from '../../workflows/publish.js';
-import { getTransformFormatProperty } from '../../formats/files/transformFormat.js';
-
-const SUPPORTED_DATA_FORMATS = ['JSX', 'ICU', 'I18NEXT'];
+import { aggregateFiles } from '../../formats/files/aggregateFiles.js';
 
 /**
  * Sends multiple files to the API for translation
- * @param filePaths - Resolved file paths for different file types
- * @param placeholderPaths - Placeholder paths for translated files
- * @param transformPaths - Transform paths for file naming
- * @param dataFormat - Format of the data within the files
  * @param settings - Translation options including API settings
  * @returns Promise that resolves when translation is complete
  */
 export async function upload(
-  filePaths: ResolvedFiles,
-  placeholderPaths: ResolvedFiles,
-  transformPaths: TransformFiles,
-  dataFormat: DataFormat = 'JSX',
   settings: Settings & UploadOptions
 ): Promise<void> {
-  // Collect all files to translate
-  const allFiles: FileToUpload[] = [];
+  if (!settings.files) {
+    return;
+  }
+
   const additionalOptions = settings.options || {};
+  const {
+    resolvedPaths: filePaths,
+    placeholderPaths,
+    transformPaths,
+    transformFormats,
+  } = settings.files;
+
+  // Reuse the same source aggregation path as translate/stage so source
+  // parsing behavior stays consistent across commands.
+  const { files: allFiles, publishMap } = await aggregateFiles(settings);
   const compositeJsonFiles = new Map<
     string,
     { filePath: string; content: string }
   >();
 
-  // Process JSON files
   if (filePaths.json) {
-    if (!SUPPORTED_DATA_FORMATS.includes(dataFormat)) {
-      logErrorAndExit(noSupportedFormatError);
-    }
-
-    const jsonFiles = filePaths.json.map((filePath) => {
-      const content = readFile(filePath);
-
-      // Resolve $ref before parsing if configured
-      let contentForParsing = content;
-      if (shouldResolveRefs(filePath, additionalOptions)) {
-        try {
-          const json = JSON.parse(content);
-          const { resolved } = resolveMintlifyRefs(json, filePath);
-          contentForParsing = JSON.stringify(resolved, null, 2);
-        } catch {
-          // JSON parse errors are handled below by parseJson
-        }
-      }
-
-      const parsedJson = parseJson(
-        contentForParsing,
-        filePath,
-        additionalOptions,
-        settings.defaultLocale
-      );
-
+    const sourceFileNames = new Set(allFiles.map((file) => file.fileName));
+    for (const filePath of filePaths.json) {
       const relativePath = getRelative(filePath);
+      if (!sourceFileNames.has(relativePath)) continue;
 
       const jsonSchema = validateJsonSchema(additionalOptions, filePath);
       if (jsonSchema?.composite) {
-        compositeJsonFiles.set(relativePath, { filePath, content });
-      }
-
-      return {
-        content: parsedJson,
-        fileName: relativePath,
-        fileFormat: 'JSON' as FileFormat,
-        ...getTransformFormatProperty(settings, 'json'),
-        dataFormat,
-        locale: settings.defaultLocale,
-        fileId: hashStringSync(relativePath),
-        versionId: hashStringSync(parsedJson),
-      } satisfies FileToUpload;
-    });
-    allFiles.push(...jsonFiles);
-  }
-
-  // Process YAML files
-  if (filePaths.yaml) {
-    if (!SUPPORTED_DATA_FORMATS.includes(dataFormat)) {
-      logErrorAndExit(noSupportedFormatError);
-    }
-
-    const yamlFiles = filePaths.yaml.map((filePath) => {
-      const content = readFile(filePath);
-      const { content: parsedYaml, fileFormat } = parseYaml(
-        content,
-        filePath,
-        additionalOptions
-      );
-
-      const relativePath = getRelative(filePath);
-      return {
-        content: parsedYaml,
-        fileName: relativePath,
-        fileFormat,
-        ...getTransformFormatProperty(settings, 'yaml'),
-        dataFormat,
-        locale: settings.defaultLocale,
-        fileId: hashStringSync(relativePath),
-        versionId: hashStringSync(parsedYaml),
-      } satisfies FileToUpload;
-    });
-    allFiles.push(...yamlFiles);
-  }
-
-  // Process Twilio Content JSON files
-  if (filePaths.twilioContentJson) {
-    const twilioContentJsonFiles = filePaths.twilioContentJson.map(
-      (filePath) => {
-        const content = readFile(filePath);
-
-        const parsedJson = parseJson(
-          content,
+        compositeJsonFiles.set(relativePath, {
           filePath,
-          additionalOptions,
-          settings.defaultLocale
-        );
-
-        const relativePath = getRelative(filePath);
-
-        return {
-          content: parsedJson,
-          fileName: relativePath,
-          fileFormat: 'TWILIO_CONTENT_JSON' as const,
-          ...getTransformFormatProperty(settings, 'twilioContentJson'),
-          dataFormat: 'STRING' as const,
-          locale: settings.defaultLocale,
-          fileId: hashStringSync(relativePath),
-          versionId: hashStringSync(parsedJson),
-        } satisfies FileToUpload;
+          content: readFile(filePath),
+        });
       }
-    );
-    allFiles.push(...twilioContentJsonFiles);
-  }
-
-  for (const fileType of SUPPORTED_FILE_EXTENSIONS) {
-    if (
-      fileType === 'json' ||
-      fileType === 'yaml' ||
-      fileType === 'twilioContentJson'
-    )
-      continue;
-    if (filePaths[fileType]) {
-      const files = filePaths[fileType].map((filePath) => {
-        const content = readFile(filePath);
-        const sanitizedContent = sanitizeFileContent(content);
-        const relativePath = getRelative(filePath);
-        return {
-          content: sanitizedContent,
-          fileName: relativePath,
-          fileFormat: fileType.toUpperCase() as FileFormat,
-          ...getTransformFormatProperty(settings, fileType),
-          dataFormat,
-          locale: settings.defaultLocale,
-          fileId: hashStringSync(relativePath),
-          versionId: hashStringSync(sanitizedContent),
-        } satisfies FileToUpload;
-      });
-      allFiles.push(...files);
     }
   }
 
@@ -207,23 +76,14 @@ export async function upload(
     filePaths,
     placeholderPaths,
     transformPaths,
-    settings.files?.transformFormats || {},
+    transformFormats,
     locales,
     settings.defaultLocale
   );
 
   // construct object
   const uploadData = allFiles.map((file) => {
-    const sourceFile: FileToUpload = {
-      content: file.content,
-      fileName: file.fileName,
-      fileFormat: file.fileFormat,
-      transformFormat: file.transformFormat,
-      dataFormat: file.dataFormat,
-      locale: file.locale,
-      fileId: file.fileId,
-      versionId: file.versionId,
-    };
+    const sourceFile: FileToUpload = { ...file };
 
     const translations: FileToUpload[] = [];
     const compositeInfo = compositeJsonFiles.get(file.fileName);
@@ -280,7 +140,6 @@ export async function upload(
     });
 
     // Publish files to CDN if publish config exists
-    const publishMap = buildPublishMap(filePaths, settings);
     await runPublishWorkflow(
       allFiles,
       publishMap,

--- a/packages/cli/src/formats/files/aggregateFiles.ts
+++ b/packages/cli/src/formats/files/aggregateFiles.ts
@@ -393,12 +393,6 @@ export async function aggregateFiles(
     }
   }
 
-  if (files.length === 0 && !settings.publish) {
-    logger.error(
-      'No files to translate were found. Check your configuration and try again.'
-    );
-  }
-
   // Remove stale entries for files that were skipped during validation
   const validFileIds = new Set(files.map((f) => f.fileId));
   for (const fileId of publishMap.keys()) {


### PR DESCRIPTION
<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1605"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784243261&installation_id=127936663&pr_number=1605&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1605&signature=f78d312b1b2b0874f8904dd9b4e98acd2511dcfc8ccae2af91a4c960fb59f011"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors the `upload` command to delegate file collection to the shared `aggregateFiles` function, eliminating ~130 lines of duplicated parsing logic and making file processing consistent across `translate`, `stage`, and `upload`. It also fixes the `runUploadFilesWorkflow` mock that previously returned `undefined` and caused every test to silently fall into the `catch` path.

- **`upload.ts`**: File parsing logic removed; now calls `aggregateFiles` for source files + publish map, then only builds the `compositeJsonFiles` side-map for composite JSON extraction. Adds a correct early-return when no files are found.
- **`aggregateFiles.ts`**: The hardcoded \"No files to translate\" error was removed so each command can emit its own context-appropriate message; `stage.ts` and `setupProject.ts` each add their own error logging.
- **Tests**: `runUploadFilesWorkflow` mock now returns a valid `branchData` object, `runPublishWorkflow` is mocked and asserted, and two new `describe` blocks cover the empty-file path and companion-metadata attachment.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the refactoring is well-scoped and the previously broken test mock is now fixed.

The upload command now correctly delegates to aggregateFiles, which has been in production use for translate/stage. The test suite was also corrected: runUploadFilesWorkflow now returns a valid branchData object instead of undefined, so tests actually reach runPublishWorkflow as intended. No logic regressions were found across the changed files.

No files require special attention.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/cli/src/cli/commands/upload.ts | Heavily simplified — delegates to aggregateFiles for all file parsing; compositeJsonFiles side-map and translate-lookup logic retained cleanly. |
| packages/cli/src/formats/files/aggregateFiles.ts | Only change is removal of the hardcoded error message; callers now own that message. No logic change. |
| packages/cli/src/cli/commands/__tests__/upload.test.ts | Mock fixed to return valid branchData; publish workflow mock added; two new describe blocks added; aggregateFiles intentionally not mocked (integration-style). |
| packages/cli/src/cli/commands/stage.ts | Adds the 'no files' error message previously owned by aggregateFiles; consistent with existing pattern of continuing execution guarded by allFiles.length > 0. |
| packages/cli/src/cli/commands/setupProject.ts | Adds empty-file error log; workflow is still guarded by allFiles.length > 0 so behavior is unchanged when files are absent. |
| packages/cli/src/cli/base.ts | handleUploadCommand simplified: dataFormat computation and manual path destructuring removed; upload() now receives the full settings object. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CLI as BaseCLI
    participant U as upload()
    participant AG as aggregateFiles()
    participant UW as runUploadFilesWorkflow()
    participant PW as runPublishWorkflow()

    CLI->>U: upload(settings)
    U->>AG: aggregateFiles(settings)
    AG-->>U: "{ files: allFiles, publishMap }"
    Note over U: Build compositeJsonFiles side-map
    alt "allFiles.length === 0"
        U-->>CLI: logger.error + return
    else files found
        U->>UW: "runUploadFilesWorkflow({ files: uploadData })"
        UW-->>U: "{ branchData }"
        U->>PW: runPublishWorkflow(allFiles, publishMap, branchId, settings)
        PW-->>U: done
        U-->>CLI: void
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CLI as BaseCLI
    participant U as upload()
    participant AG as aggregateFiles()
    participant UW as runUploadFilesWorkflow()
    participant PW as runPublishWorkflow()

    CLI->>U: upload(settings)
    U->>AG: aggregateFiles(settings)
    AG-->>U: "{ files: allFiles, publishMap }"
    Note over U: Build compositeJsonFiles side-map
    alt "allFiles.length === 0"
        U-->>CLI: logger.error + return
    else files found
        U->>UW: "runUploadFilesWorkflow({ files: uploadData })"
        UW-->>U: "{ branchData }"
        U->>PW: runPublishWorkflow(allFiles, publishMap, branchId, settings)
        PW-->>U: done
        U-->>CLI: void
    end
```

</a>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `packages/cli/src/cli/commands/upload.ts`, line 61-66 ([link](https://github.com/generaltranslation/gt/blob/5900249e16c6009e17eaaf81b2def36185f3faee/packages/cli/src/cli/commands/upload.ts#L61-L66)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Misleading double error message when no files are found**

   `aggregateFiles` already calls `logger.error('No files to translate were found...')` before returning an empty array (line 397 of `aggregateFiles.ts`). When `upload` then checks `allFiles.length === 0`, it emits a second, correct message. A user who hits this path sees the first message say "translate" (wrong command context) immediately followed by "upload", producing two confusing error lines. The `aggregateFiles` error path is guarded by `!settings.publish` but the `upload.ts` check is not, so the messages can also fire inconsistently depending on that flag.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/cli/src/cli/commands/upload.ts
   Line: 61-66

   Comment:
   **Misleading double error message when no files are found**

   `aggregateFiles` already calls `logger.error('No files to translate were found...')` before returning an empty array (line 397 of `aggregateFiles.ts`). When `upload` then checks `allFiles.length === 0`, it emits a second, correct message. A user who hits this path sees the first message say "translate" (wrong command context) immediately followed by "upload", producing two confusing error lines. The `aggregateFiles` error path is guarded by `!settings.publish` but the `upload.ts` check is not, so the messages can also fire inconsistently depending on that flag.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fcli%2Fsrc%2Fcli%2Fcommands%2Fupload.ts%0ALine%3A%2061-66%0A%0AComment%3A%0A**Misleading%20double%20error%20message%20when%20no%20files%20are%20found**%0A%0A%60aggregateFiles%60%20already%20calls%20%60logger.error%28'No%20files%20to%20translate%20were%20found...'%29%60%20before%20returning%20an%20empty%20array%20%28line%20397%20of%20%60aggregateFiles.ts%60%29.%20When%20%60upload%60%20then%20checks%20%60allFiles.length%20%3D%3D%3D%200%60%2C%20it%20emits%20a%20second%2C%20correct%20message.%20A%20user%20who%20hits%20this%20path%20sees%20the%20first%20message%20say%20%22translate%22%20%28wrong%20command%20context%29%20immediately%20followed%20by%20%22upload%22%2C%20producing%20two%20confusing%20error%20lines.%20The%20%60aggregateFiles%60%20error%20path%20is%20guarded%20by%20%60!settings.publish%60%20but%20the%20%60upload.ts%60%20check%20is%20not%2C%20so%20the%20messages%20can%20also%20fire%20inconsistently%20depending%20on%20that%20flag.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=generaltranslation%2Fgt&pr=1605&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22f%2Faggregate-on-upload%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22f%2Faggregate-on-upload%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fcli%2Fsrc%2Fcli%2Fcommands%2Fupload.ts%0ALine%3A%2061-66%0A%0AComment%3A%0A**Misleading%20double%20error%20message%20when%20no%20files%20are%20found**%0A%0A%60aggregateFiles%60%20already%20calls%20%60logger.error%28'No%20files%20to%20translate%20were%20found...'%29%60%20before%20returning%20an%20empty%20array%20%28line%20397%20of%20%60aggregateFiles.ts%60%29.%20When%20%60upload%60%20then%20checks%20%60allFiles.length%20%3D%3D%3D%200%60%2C%20it%20emits%20a%20second%2C%20correct%20message.%20A%20user%20who%20hits%20this%20path%20sees%20the%20first%20message%20say%20%22translate%22%20%28wrong%20command%20context%29%20immediately%20followed%20by%20%22upload%22%2C%20producing%20two%20confusing%20error%20lines.%20The%20%60aggregateFiles%60%20error%20path%20is%20guarded%20by%20%60!settings.publish%60%20but%20the%20%60upload.ts%60%20check%20is%20not%2C%20so%20the%20messages%20can%20also%20fire%20inconsistently%20depending%20on%20that%20flag.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=generaltranslation%2Fgt&pr=1605&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

2. `packages/cli/src/cli/commands/__tests__/upload.test.ts`, line 24-26 ([link](https://github.com/generaltranslation/gt/blob/5900249e16c6009e17eaaf81b2def36185f3faee/packages/cli/src/cli/commands/__tests__/upload.test.ts#L24-L26)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`runUploadFilesWorkflow` mock silently swallows a TypeError in every test**

   The mock returns `undefined`, but `upload.ts` immediately destructures `const { branchData } = await runUploadFilesWorkflow(...)`. Destructuring `undefined` throws a `TypeError`, which lands in the `catch` block and calls `logErrorAndExit` (a no-op in tests). Every test therefore silently executes the catch path, meaning `runPublishWorkflow` is never reached and no test covers the post-workflow code. The fix is to give the mock a minimal return value: `vi.fn().mockResolvedValue({ branchData: { currentBranch: { id: 'branch-id' } } })`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/cli/src/cli/commands/__tests__/upload.test.ts
   Line: 24-26

   Comment:
   **`runUploadFilesWorkflow` mock silently swallows a TypeError in every test**

   The mock returns `undefined`, but `upload.ts` immediately destructures `const { branchData } = await runUploadFilesWorkflow(...)`. Destructuring `undefined` throws a `TypeError`, which lands in the `catch` block and calls `logErrorAndExit` (a no-op in tests). Every test therefore silently executes the catch path, meaning `runPublishWorkflow` is never reached and no test covers the post-workflow code. The fix is to give the mock a minimal return value: `vi.fn().mockResolvedValue({ branchData: { currentBranch: { id: 'branch-id' } } })`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fcli%2Fsrc%2Fcli%2Fcommands%2F__tests__%2Fupload.test.ts%0ALine%3A%2024-26%0A%0AComment%3A%0A**%60runUploadFilesWorkflow%60%20mock%20silently%20swallows%20a%20TypeError%20in%20every%20test**%0A%0AThe%20mock%20returns%20%60undefined%60%2C%20but%20%60upload.ts%60%20immediately%20destructures%20%60const%20%7B%20branchData%20%7D%20%3D%20await%20runUploadFilesWorkflow%28...%29%60.%20Destructuring%20%60undefined%60%20throws%20a%20%60TypeError%60%2C%20which%20lands%20in%20the%20%60catch%60%20block%20and%20calls%20%60logErrorAndExit%60%20%28a%20no-op%20in%20tests%29.%20Every%20test%20therefore%20silently%20executes%20the%20catch%20path%2C%20meaning%20%60runPublishWorkflow%60%20is%20never%20reached%20and%20no%20test%20covers%20the%20post-workflow%20code.%20The%20fix%20is%20to%20give%20the%20mock%20a%20minimal%20return%20value%3A%20%60vi.fn%28%29.mockResolvedValue%28%7B%20branchData%3A%20%7B%20currentBranch%3A%20%7B%20id%3A%20'branch-id'%20%7D%20%7D%20%7D%29%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=generaltranslation%2Fgt&pr=1605&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22f%2Faggregate-on-upload%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22f%2Faggregate-on-upload%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fcli%2Fsrc%2Fcli%2Fcommands%2F__tests__%2Fupload.test.ts%0ALine%3A%2024-26%0A%0AComment%3A%0A**%60runUploadFilesWorkflow%60%20mock%20silently%20swallows%20a%20TypeError%20in%20every%20test**%0A%0AThe%20mock%20returns%20%60undefined%60%2C%20but%20%60upload.ts%60%20immediately%20destructures%20%60const%20%7B%20branchData%20%7D%20%3D%20await%20runUploadFilesWorkflow%28...%29%60.%20Destructuring%20%60undefined%60%20throws%20a%20%60TypeError%60%2C%20which%20lands%20in%20the%20%60catch%60%20block%20and%20calls%20%60logErrorAndExit%60%20%28a%20no-op%20in%20tests%29.%20Every%20test%20therefore%20silently%20executes%20the%20catch%20path%2C%20meaning%20%60runPublishWorkflow%60%20is%20never%20reached%20and%20no%20test%20covers%20the%20post-workflow%20code.%20The%20fix%20is%20to%20give%20the%20mock%20a%20minimal%20return%20value%3A%20%60vi.fn%28%29.mockResolvedValue%28%7B%20branchData%3A%20%7B%20currentBranch%3A%20%7B%20id%3A%20'branch-id'%20%7D%20%7D%20%7D%29%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=generaltranslation%2Fgt&pr=1605&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix: move file check out of aggregation"](https://github.com/generaltranslation/gt/commit/b5e31e4d1beecc0a2b79bc3703766a28f810762c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38022029)</sub>

<!-- /greptile_comment -->