### PR TITLE
fix(5): use allowed react-core entrypoints

### DIFF
--- a/packages/next/src/__tests__/rscLeaks.test.ts
+++ b/packages/next/src/__tests__/rscLeaks.test.ts
@@ -30,9 +30,7 @@ const workspaceSourceMap: Record<string, string> = {
   '#context-server': 'packages/react/src/index.server.ts',
   'gt-react': 'packages/react/src/index.rsc.ts',
   'gt-react/internal': 'packages/react/src/internal.ts',
-  '@generaltranslation/react-core': 'packages/react-core/src/index.ts',
-  '@generaltranslation/react-core/internal':
-    'packages/react-core/src/internal.ts',
+  '@generaltranslation/react-core/pure': 'packages/react-core/src/pure.ts',
   '@generaltranslation/react-core/components-rsc':
     'packages/react-core/src/components-rsc.ts',
 };
@@ -40,6 +38,9 @@ const workspaceSourceMap: Record<string, string> = {
 // Specifiers that must never be imported from the RSC/server graph.
 const forbiddenSpecifiers = [
   '@generaltranslation/react-core/context',
+  '@generaltranslation/react-core/internal',
+  '@generaltranslation/react-core/types',
+  '@generaltranslation/react-core/errors',
   'next/navigation',
 ];
 

--- a/packages/react-core-linter/src/rules/static-jsx/__tests__/edge-imports.test.ts
+++ b/packages/react-core-linter/src/rules/static-jsx/__tests__/edge-imports.test.ts
@@ -276,24 +276,24 @@ describe('edge-imports: Branch import added from gt-next', () => {
 });
 
 // ===================================================================
-// 10. Import from @generaltranslation/react-core
+// 10. Import from @generaltranslation/react-core/components
 // ===================================================================
 
-describe('edge-imports: Branch import added from @generaltranslation/react-core', () => {
+describe('edge-imports: Branch import added from @generaltranslation/react-core/components', () => {
   ruleTester.run('branch-from-react-core', staticJsx, {
     valid: [],
     invalid: [
       {
         code: `
-          import { T } from '@generaltranslation/react-core';
+          import { T } from '@generaltranslation/react-core/components';
           function Component({ cond }) {
             return <T>{cond ? "a" : "b"}</T>;
           }
         `,
-        options: [{ libs: ['@generaltranslation/react-core'] }],
+        options: [{ libs: ['@generaltranslation/react-core/components'] }],
         errors: [{ messageId: 'dynamicContent' }],
         output: `
-          import { T, Branch } from '@generaltranslation/react-core';
+          import { T, Branch } from '@generaltranslation/react-core/components';
           function Component({ cond }) {
             return <T><Branch branch={cond} true="a">b</Branch></T>;
           }
@@ -859,22 +859,22 @@ describe('edge-imports: Var import added from gt-react-native', () => {
   });
 });
 
-// Var from @generaltranslation/react-core
-describe('edge-imports: Var import added from @generaltranslation/react-core', () => {
+// Var from @generaltranslation/react-core/components
+describe('edge-imports: Var import added from @generaltranslation/react-core/components', () => {
   ruleTester.run('var-from-react-core', staticJsx, {
     valid: [],
     invalid: [
       {
         code: `
-          import { T } from '@generaltranslation/react-core';
+          import { T } from '@generaltranslation/react-core/components';
           function Component({ name }) {
             return <T>{name}</T>;
           }
         `,
-        options: [{ libs: ['@generaltranslation/react-core'] }],
+        options: [{ libs: ['@generaltranslation/react-core/components'] }],
         errors: [{ messageId: 'dynamicContent' }],
         output: `
-          import { T, Var } from '@generaltranslation/react-core';
+          import { T, Var } from '@generaltranslation/react-core/components';
           function Component({ name }) {
             return <T><Var>{name}</Var></T>;
           }

--- a/packages/react-core-linter/src/rules/static-jsx/__tests__/edge-logical.test.ts
+++ b/packages/react-core-linter/src/rules/static-jsx/__tests__/edge-logical.test.ts
@@ -1073,21 +1073,21 @@ describe('logical-and: AND with gt-next library', () => {
   });
 });
 
-describe('logical-and: AND with @generaltranslation/react-core library', () => {
+describe('logical-and: AND with @generaltranslation/react-core/components library', () => {
   ruleTester.run('and-react-core', staticJsx, {
     valid: [],
     invalid: [
       {
         code: `
-          import { T } from '@generaltranslation/react-core';
+          import { T } from '@generaltranslation/react-core/components';
           function Component({ x }) {
             return <T>{x && "text"}</T>;
           }
         `,
-        options: [{ libs: ['@generaltranslation/react-core'] }],
+        options: [{ libs: ['@generaltranslation/react-core/components'] }],
         errors: [{ messageId: 'dynamicContent' }],
         output: `
-          import { T, Branch } from '@generaltranslation/react-core';
+          import { T, Branch } from '@generaltranslation/react-core/components';
           function Component({ x }) {
             return <T><Branch branch={!!x} true="text" /></T>;
           }

--- a/packages/react-core-linter/src/rules/static-jsx/__tests__/edge-scope-nesting.test.ts
+++ b/packages/react-core-linter/src/rules/static-jsx/__tests__/edge-scope-nesting.test.ts
@@ -518,21 +518,21 @@ describe('edge: dynamic content in T from gt-next', () => {
   });
 });
 
-describe('edge: dynamic content in T from @generaltranslation/react-core', () => {
+describe('edge: dynamic content in T from @generaltranslation/react-core/components', () => {
   ruleTester.run('dynamic-in-T-react-core', staticJsx, {
     valid: [],
     invalid: [
       {
         code: `
-          import { T } from '@generaltranslation/react-core';
+          import { T } from '@generaltranslation/react-core/components';
           function Component({ cond }) {
             return <T>{cond ? "a" : "b"}</T>;
           }
         `,
-        options: [{ libs: ['@generaltranslation/react-core'] }],
+        options: [{ libs: ['@generaltranslation/react-core/components'] }],
         errors: [{ messageId: 'dynamicContent' }],
         output: `
-          import { T, Branch } from '@generaltranslation/react-core';
+          import { T, Branch } from '@generaltranslation/react-core/components';
           function Component({ cond }) {
             return <T><Branch branch={cond} true="a">b</Branch></T>;
           }

--- a/packages/react-core-linter/src/rules/static-jsx/__tests__/static-jsx-auto-import.test.ts
+++ b/packages/react-core-linter/src/rules/static-jsx/__tests__/static-jsx-auto-import.test.ts
@@ -52,15 +52,15 @@ describe('static-jsx auto-fix should add Var import', () => {
     invalid: [
       {
         code: `
-          import { T } from '@generaltranslation/react-core';
+          import { T } from '@generaltranslation/react-core/components';
           function Component({ name }) {
             return <T>{name}</T>;
           }
         `,
-        options: [{ libs: ['@generaltranslation/react-core'] }],
+        options: [{ libs: ['@generaltranslation/react-core/components'] }],
         errors: [{ messageId: 'dynamicContent' }],
         output: `
-          import { T, Var } from '@generaltranslation/react-core';
+          import { T, Var } from '@generaltranslation/react-core/components';
           function Component({ name }) {
             return <T><Var>{name}</Var></T>;
           }

--- a/packages/react-core-linter/src/rules/static-jsx/__tests__/static-jsx-branch-wrap.test.ts
+++ b/packages/react-core-linter/src/rules/static-jsx/__tests__/static-jsx-branch-wrap.test.ts
@@ -490,21 +490,21 @@ describe('static-jsx: Branch import added alongside existing specifiers', () => 
   });
 });
 
-describe('static-jsx: Branch import from @generaltranslation/react-core', () => {
+describe('static-jsx: Branch import from @generaltranslation/react-core/components', () => {
   ruleTester.run('branch-import-react-core', staticJsx, {
     valid: [],
     invalid: [
       {
         code: `
-          import { T } from '@generaltranslation/react-core';
+          import { T } from '@generaltranslation/react-core/components';
           function Component({ cond }) {
             return <T>{cond ? "a" : "b"}</T>;
           }
         `,
-        options: [{ libs: ['@generaltranslation/react-core'] }],
+        options: [{ libs: ['@generaltranslation/react-core/components'] }],
         errors: [{ messageId: 'dynamicContent' }],
         output: `
-          import { T, Branch } from '@generaltranslation/react-core';
+          import { T, Branch } from '@generaltranslation/react-core/components';
           function Component({ cond }) {
             return <T><Branch branch={cond} true="a">b</Branch></T>;
           }

--- a/packages/react-core-linter/src/rules/static-jsx/__tests__/static-jsx.test.ts
+++ b/packages/react-core-linter/src/rules/static-jsx/__tests__/static-jsx.test.ts
@@ -20,57 +20,57 @@ describe('static-jsx rule', () => {
       valid: [
         {
           code: `
-            import { T } from '@generaltranslation/react-core';
+            import { T } from '@generaltranslation/react-core/components';
             function Component() {
               return <T>Hello world</T>;
             }
           `,
-          options: [{ libs: ['@generaltranslation/react-core'] }],
+          options: [{ libs: ['@generaltranslation/react-core/components'] }],
         },
         {
           code: `
-            import { T } from '@generaltranslation/react-core';
+            import { T } from '@generaltranslation/react-core/components';
             function Component() {
               return <T>{"static string"}</T>;
             }
           `,
-          options: [{ libs: ['@generaltranslation/react-core'] }],
+          options: [{ libs: ['@generaltranslation/react-core/components'] }],
         },
         {
           code: `
-            import { T } from '@generaltranslation/react-core';
+            import { T } from '@generaltranslation/react-core/components';
             function Component() {
               return <T>{123}</T>;
             }
           `,
-          options: [{ libs: ['@generaltranslation/react-core'] }],
+          options: [{ libs: ['@generaltranslation/react-core/components'] }],
         },
         {
           code: `
-            import { T } from '@generaltranslation/react-core';
+            import { T } from '@generaltranslation/react-core/components';
             function Component() {
               return <T>{\`template literal\`}</T>;
             }
           `,
-          options: [{ libs: ['@generaltranslation/react-core'] }],
+          options: [{ libs: ['@generaltranslation/react-core/components'] }],
         },
       ],
       invalid: [
         {
           code: `
-            import { T } from '@generaltranslation/react-core';
+            import { T } from '@generaltranslation/react-core/components';
             function Component({ name }) {
               return <T>{name}</T>;
             }
           `,
-          options: [{ libs: ['@generaltranslation/react-core'] }],
+          options: [{ libs: ['@generaltranslation/react-core/components'] }],
           errors: [
             {
               messageId: 'dynamicContent',
             },
           ],
           output: `
-            import { T } from '@generaltranslation/react-core';
+            import { T } from '@generaltranslation/react-core/components';
             function Component({ name }) {
               return <T><Var>{name}</Var></T>;
             }
@@ -78,20 +78,20 @@ describe('static-jsx rule', () => {
         },
         {
           code: `
-            import { T } from '@generaltranslation/react-core';
+            import { T } from '@generaltranslation/react-core/components';
             function Component() {
               const variable = "dynamic";
               return <T>{variable}</T>;
             }
           `,
-          options: [{ libs: ['@generaltranslation/react-core'] }],
+          options: [{ libs: ['@generaltranslation/react-core/components'] }],
           errors: [
             {
               messageId: 'dynamicContent',
             },
           ],
           output: `
-            import { T } from '@generaltranslation/react-core';
+            import { T } from '@generaltranslation/react-core/components';
             function Component() {
               const variable = "dynamic";
               return <T><Var>{variable}</Var></T>;
@@ -100,19 +100,19 @@ describe('static-jsx rule', () => {
         },
         {
           code: `
-            import { T } from '@generaltranslation/react-core';
+            import { T } from '@generaltranslation/react-core/components';
             function Component() {
               return <T>{someFunction()}</T>;
             }
           `,
-          options: [{ libs: ['@generaltranslation/react-core'] }],
+          options: [{ libs: ['@generaltranslation/react-core/components'] }],
           errors: [
             {
               messageId: 'dynamicContent',
             },
           ],
           output: `
-            import { T } from '@generaltranslation/react-core';
+            import { T } from '@generaltranslation/react-core/components';
             function Component() {
               return <T><Var>{someFunction()}</Var></T>;
             }
@@ -120,12 +120,12 @@ describe('static-jsx rule', () => {
         },
         {
           code: `
-            import { T } from '@generaltranslation/react-core';
+            import { T } from '@generaltranslation/react-core/components';
             function Component({ user }) {
               return <T>{\`Hello \${user.name}\`}</T>;
             }
           `,
-          options: [{ libs: ['@generaltranslation/react-core'] }],
+          options: [{ libs: ['@generaltranslation/react-core/components'] }],
           errors: [
             {
               messageId: 'dynamicContent',
@@ -145,7 +145,7 @@ describe('static-jsx rule', () => {
               return <div>{name}</div>;
             }
           `,
-          options: [{ libs: ['@generaltranslation/react-core'] }],
+          options: [{ libs: ['@generaltranslation/react-core/components'] }],
         },
         {
           code: `
@@ -154,7 +154,7 @@ describe('static-jsx rule', () => {
               return <OtherComponent>{name}</OtherComponent>;
             }
           `,
-          options: [{ libs: ['@generaltranslation/react-core'] }],
+          options: [{ libs: ['@generaltranslation/react-core/components'] }],
         },
       ],
       invalid: [],
@@ -198,7 +198,7 @@ describe('static-jsx rule', () => {
       valid: [
         {
           code: `
-            import { T } from '@generaltranslation/react-core';
+            import { T } from '@generaltranslation/react-core/components';
             function Component() {
               return (
                 <div>
@@ -208,13 +208,13 @@ describe('static-jsx rule', () => {
               );
             }
           `,
-          options: [{ libs: ['@generaltranslation/react-core'] }],
+          options: [{ libs: ['@generaltranslation/react-core/components'] }],
         },
       ],
       invalid: [
         {
           code: `
-            import { T } from '@generaltranslation/react-core';
+            import { T } from '@generaltranslation/react-core/components';
             function Component({ name }) {
               return (
                 <div>
@@ -224,7 +224,7 @@ describe('static-jsx rule', () => {
               );
             }
           `,
-          options: [{ libs: ['@generaltranslation/react-core'] }],
+          options: [{ libs: ['@generaltranslation/react-core/components'] }],
           errors: [
             {
               messageId: 'dynamicContent',

--- a/packages/react-core-linter/src/rules/static-string/__tests__/static-string-icu-autofix.test.ts
+++ b/packages/react-core-linter/src/rules/static-string/__tests__/static-string-icu-autofix.test.ts
@@ -866,27 +866,27 @@ describe('static-string: chained ternary with different variables + dynamic var 
 });
 
 // ===================================================================
-// 16. @generaltranslation/react-core library support
+// 16. @generaltranslation/react-core/hooks library support
 // ===================================================================
 
-// gt("Hello " + name)  [via @generaltranslation/react-core]
+// gt("Hello " + name)  [via @generaltranslation/react-core/hooks]
 // → gt("Hello {var0}", { var0: name })
-describe('static-string: works with @generaltranslation/react-core imports', () => {
+describe('static-string: works with @generaltranslation/react-core/hooks imports', () => {
   ruleTester.run('react-core-lib', staticString, {
     valid: [],
     invalid: [
       {
         code: `
-          import { useGT } from '@generaltranslation/react-core';
+          import { useGT } from '@generaltranslation/react-core/hooks';
           function Component() {
             const gt = useGT();
             return gt("Hello " + name);
           }
         `,
-        options: [{ libs: ['@generaltranslation/react-core'] }],
+        options: [{ libs: ['@generaltranslation/react-core/hooks'] }],
         errors: [{ messageId: 'variableInterpolationRequired' }],
         output: `
-          import { useGT } from '@generaltranslation/react-core';
+          import { useGT } from '@generaltranslation/react-core/hooks';
           function Component() {
             const gt = useGT();
             return gt("Hello {var0}", { var0: name });

--- a/packages/react-core-linter/src/rules/static-string/__tests__/static-string.test.ts
+++ b/packages/react-core-linter/src/rules/static-string/__tests__/static-string.test.ts
@@ -24,40 +24,48 @@ describe('static-string rule', () => {
               return <div>Hello world</div>;
             }
           `,
-          options: [{ libs: ['@generaltranslation/react-core'] }],
+          options: [{ libs: ['@generaltranslation/react-core/hooks'] }],
         },
         {
           code: `
-            import { useGT } from '@generaltranslation/react-core';
+            import { useGT } from '@generaltranslation/react-core/hooks';
             function Component() {
               const gt = useGT();
               return gt("Hello world");
             }
           `,
-          options: [{ libs: ['@generaltranslation/react-core'] }],
+          options: [{ libs: ['@generaltranslation/react-core/hooks'] }],
         },
         {
           code: `
-            import { useGT, derive } from '@generaltranslation/react-core';
+            import { useGT } from '@generaltranslation/react-core/hooks';
+            import { derive } from '@generaltranslation/react-core/pure';
             function Component() {
               const gt = useGT();
               return gt("Hello " + derive("world"));
             }
           `,
-          options: [{ libs: ['@generaltranslation/react-core'] }],
+          options: [
+            {
+              libs: [
+                '@generaltranslation/react-core/hooks',
+                '@generaltranslation/react-core/pure',
+              ],
+            },
+          ],
         },
       ],
       invalid: [
         {
           code: `
-            import { useGT } from '@generaltranslation/react-core';
+            import { useGT } from '@generaltranslation/react-core/hooks';
             function Component() {
               const gt = useGT();
               const name = "World";
               return gt("Hello " + name);
             }
           `,
-          options: [{ libs: ['@generaltranslation/react-core'] }],
+          options: [{ libs: ['@generaltranslation/react-core/hooks'] }],
           errors: [
             {
               messageId: 'variableInterpolationRequired',
@@ -66,14 +74,14 @@ describe('static-string rule', () => {
         },
         {
           code: `
-            import { useGT } from '@generaltranslation/react-core';
+            import { useGT } from '@generaltranslation/react-core/hooks';
             function Component() {
               const gt = useGT();
               const name = "World";
               return gt(\`Hello \${name}!\`);
             }
           `,
-          options: [{ libs: ['@generaltranslation/react-core'] }],
+          options: [{ libs: ['@generaltranslation/react-core/hooks'] }],
           errors: [
             {
               messageId: 'variableInterpolationRequired',
@@ -138,13 +146,21 @@ describe('static-string rule', () => {
       valid: [
         {
           code: `
-            import { useGT, derive } from '@generaltranslation/react-core';
+            import { useGT } from '@generaltranslation/react-core/hooks';
+            import { derive } from '@generaltranslation/react-core/pure';
             function Component() {
               const gt = useGT();
               return gt("Hello " + derive("world"));
             }
           `,
-          options: [{ libs: ['@generaltranslation/react-core'] }],
+          options: [
+            {
+              libs: [
+                '@generaltranslation/react-core/hooks',
+                '@generaltranslation/react-core/pure',
+              ],
+            },
+          ],
         },
       ],
       invalid: [],
@@ -157,13 +173,13 @@ describe('static-string rule', () => {
       invalid: [
         {
           code: `
-            import { useGT } from '@generaltranslation/react-core';
+            import { useGT } from '@generaltranslation/react-core/hooks';
             function Component() {
               const gt = useGT();
               return gt(["Hello", "World"]);
             }
           `,
-          options: [{ libs: ['@generaltranslation/react-core'] }],
+          options: [{ libs: ['@generaltranslation/react-core/hooks'] }],
           errors: [
             {
               messageId: 'staticStringRequired',

--- a/packages/react-core-linter/src/utils/constants.ts
+++ b/packages/react-core-linter/src/utils/constants.ts
@@ -5,7 +5,10 @@ export const GT_LIBRARIES = [
   'gt-next',
   'gt-react-native',
   'gt-i18n',
-  '@generaltranslation/react-core',
+  '@generaltranslation/react-core/components',
+  '@generaltranslation/react-core/components-rsc',
+  '@generaltranslation/react-core/hooks',
+  '@generaltranslation/react-core/pure',
 ];
 
 export type GTLibrary = (typeof GT_LIBRARIES)[number];

--- a/packages/react-core/src/components.ts
+++ b/packages/react-core/src/components.ts
@@ -15,3 +15,5 @@ export {
 export { GtInternalVar, Var } from './components/variables/Var';
 export { InternalLocaleSelector } from './components/helpers/InternalLocaleSelector';
 export { InternalRegionSelector } from './components/helpers/InternalRegionSelector';
+export { InternalGTProvider } from './context/InternalGTProvider';
+export type { InternalGTProviderProps } from './context/InternalGTProvider';

--- a/packages/react-core/src/pure.ts
+++ b/packages/react-core/src/pure.ts
@@ -37,6 +37,44 @@ export {
   ReactI18nCache,
   type ReactI18nCacheParams,
 } from './i18n-cache/ReactI18nCache';
+export {
+  getI18nStore,
+  setI18nStore,
+  isI18nStoreInitialized,
+} from './i18n-store/singleton-operations';
+export { I18nStore } from './i18n-store/I18nStore';
+export {
+  getI18nConfig,
+  initializeI18nConfig,
+  ReactI18nConfig,
+  setI18nConfig,
+} from './setup/i18nConfig';
+export {
+  getReadonlyConditionStoreWithFallback,
+  setReadonlyConditionStore,
+} from './condition-store/singleton-operations';
+export {
+  ReadonlyConditionStore,
+  WritableConditionStore,
+} from 'gt-i18n/internal';
+export type {
+  I18nConfigParams,
+  WritableConditionStoreParams,
+} from 'gt-i18n/internal/types';
+export type {
+  OnMissingDictionaryObj,
+  OnMissingDictionaryEntry,
+  OnMissingTranslation,
+} from './hooks/utils/missing-translation';
+export type {
+  DictionaryLookup,
+  TranslateLookup,
+} from './i18n-store/storeTypes';
+export type {
+  DictionaryTranslationOptions,
+  InlineTranslationOptions,
+  RuntimeTranslationOptions,
+} from 'gt-i18n/types';
 
 export {
   getDefaultLocale,

--- a/packages/react-native/src/condition-store/NativeConditionStore.ts
+++ b/packages/react-native/src/condition-store/NativeConditionStore.ts
@@ -3,11 +3,6 @@ import type {
   WritableConditionStoreInterface,
   WritableConditionStoreParams,
 } from 'gt-i18n/internal/types';
-import {
-  defaultEnableI18nCookieName as defaultEnableI18nStoreKey,
-  defaultLocaleCookieName as defaultLocaleStoreKey,
-  defaultRegionCookieName as defaultRegionStoreKey,
-} from '@generaltranslation/react-core/internal';
 import { getLocale } from '../utils/getLocale';
 import {
   getInitialEnableI18n,
@@ -15,6 +10,11 @@ import {
 } from '../utils/getInitialNativeConditions';
 import { nativeStoreGet, nativeStoreSet } from '../utils/nativeStore';
 import { resolveLocale } from '../utils/resolveLocale';
+import {
+  defaultEnableI18nStoreKey,
+  defaultLocaleStoreKey,
+  defaultRegionStoreKey,
+} from '../utils/storeKeys';
 
 export type NativeConditionStoreParams = WritableConditionStoreParams & {
   localeStoreKey?: string;

--- a/packages/react-native/src/condition-store/__tests__/NativeConditionStore.test.ts
+++ b/packages/react-native/src/condition-store/__tests__/NativeConditionStore.test.ts
@@ -1,10 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { initializeI18nConfig } from '@generaltranslation/react-core/context';
+import { initializeI18nConfig } from '@generaltranslation/react-core/pure';
 import {
-  defaultEnableI18nCookieName as defaultEnableI18nStoreKey,
-  defaultLocaleCookieName as defaultLocaleStoreKey,
-  defaultRegionCookieName as defaultRegionStoreKey,
-} from '@generaltranslation/react-core/internal';
+  defaultEnableI18nStoreKey,
+  defaultLocaleStoreKey,
+  defaultRegionStoreKey,
+} from '../../utils/storeKeys';
 import { NativeConditionStore } from '../NativeConditionStore';
 
 const nativeStore = vi.hoisted(() => new Map<string, string>());

--- a/packages/react-native/src/index.tsx
+++ b/packages/react-native/src/index.tsx
@@ -17,11 +17,11 @@ import type {
   DictionaryTranslationOptions,
   InlineTranslationOptions,
   RuntimeTranslationOptions,
-} from '@generaltranslation/react-core/types';
+} from '@generaltranslation/react-core/pure';
 import type {
   RenderPipeline,
   RenderPreparedT,
-} from '@generaltranslation/react-core/context';
+} from '@generaltranslation/react-core/pure';
 
 export {
   // ===== Components ===== //
@@ -34,18 +34,24 @@ export {
   RelativeTime,
   Var,
   Num,
+} from '@generaltranslation/react-core/components';
+
+export {
   // ===== Hooks ===== //
   useLocale,
   useCustomMapping,
   useDefaultLocale,
   useEnableI18n,
   useLocales,
-  getFormatLocales,
   useFormatLocales,
   useGT,
   useMessages,
   useTranslations,
+} from '@generaltranslation/react-core/hooks';
+
+export {
   // ===== Functions ===== //
+  getFormatLocales,
   msg,
   decodeMsg,
   decodeOptions,
@@ -58,7 +64,7 @@ export {
   getReactI18nCache,
   setReactI18nCache,
   createRenderPipeline,
-} from '@generaltranslation/react-core/context';
+} from '@generaltranslation/react-core/pure';
 
 export {
   useRegion,

--- a/packages/react-native/src/provider/GTProvider.tsx
+++ b/packages/react-native/src/provider/GTProvider.tsx
@@ -1,4 +1,4 @@
-import type { InternalGTProviderProps } from '@generaltranslation/react-core/context';
+import type { InternalGTProviderProps } from '@generaltranslation/react-core/components';
 import { Suspense, use, useCallback, useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
 import { ActivityIndicator, StyleSheet, View } from 'react-native';

--- a/packages/react-native/src/provider/NativeGTProvider.tsx
+++ b/packages/react-native/src/provider/NativeGTProvider.tsx
@@ -1,8 +1,8 @@
 import {
-  I18nStore,
   InternalGTProvider,
   type InternalGTProviderProps,
-} from '@generaltranslation/react-core/context';
+} from '@generaltranslation/react-core/components';
+import { I18nStore } from '@generaltranslation/react-core/pure';
 import { useMemo, useRef } from 'react';
 import type { LocaleCandidates } from 'gt-i18n/internal/types';
 import type { NativeConditionStoreParams } from '../condition-store/NativeConditionStore';
@@ -29,9 +29,12 @@ export function NativeGTProvider(props: NativeGTProviderProps) {
     props._reload,
   ]);
 
-  const i18nStoreRef = useRef<I18nStore | null>(null);
+  const i18nStoreRef = useRef<InternalGTProviderProps['i18nStore'] | null>(
+    null
+  );
   if (i18nStoreRef.current == null) {
-    i18nStoreRef.current = new I18nStore();
+    i18nStoreRef.current =
+      new I18nStore() as unknown as InternalGTProviderProps['i18nStore'];
   }
 
   return (

--- a/packages/react-native/src/provider/__tests__/loadTranslations.test.ts
+++ b/packages/react-native/src/provider/__tests__/loadTranslations.test.ts
@@ -6,7 +6,7 @@ const i18nCacheMock = vi.hoisted(() => ({
   loadTranslations: loadTranslationsMock,
 }));
 
-vi.mock('@generaltranslation/react-core/context', () => ({
+vi.mock('@generaltranslation/react-core/pure', () => ({
   getReactI18nCache: () => i18nCacheMock,
 }));
 

--- a/packages/react-native/src/provider/loadTranslations.ts
+++ b/packages/react-native/src/provider/loadTranslations.ts
@@ -1,8 +1,11 @@
-import { getReactI18nCache } from '@generaltranslation/react-core/context';
+import { getReactI18nCache } from '@generaltranslation/react-core/pure';
 import type { Hash } from 'gt-i18n/internal/types';
 import type { Translation } from 'gt-i18n/types';
 
 export type LocaleTranslations = Record<Hash, Translation>;
+type TranslationCache = {
+  loadTranslations(locale: string): Promise<LocaleTranslations>;
+};
 
 const translationPromises = new WeakMap<
   object,
@@ -10,7 +13,7 @@ const translationPromises = new WeakMap<
 >();
 
 export function loadTranslations(locale: string): Promise<LocaleTranslations> {
-  const i18nCache = getReactI18nCache();
+  const i18nCache = getReactI18nCache() as TranslationCache;
   let i18nCacheTranslationPromises = translationPromises.get(i18nCache);
   if (i18nCacheTranslationPromises == null) {
     i18nCacheTranslationPromises = new Map();
@@ -29,6 +32,9 @@ export function loadTranslations(locale: string): Promise<LocaleTranslations> {
       return {};
     });
     i18nCacheTranslationPromises.set(locale, promise);
+  }
+  if (promise == null) {
+    throw new Error('Translation promise was not initialized.');
   }
   return promise;
 }

--- a/packages/react-native/src/setup/__tests__/initializeGT.test.ts
+++ b/packages/react-native/src/setup/__tests__/initializeGT.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { getTranslationsSnapshot } from '@generaltranslation/react-core/context';
+import { getTranslationsSnapshot } from '@generaltranslation/react-core/pure';
 import { initializeGT } from '../initializeGT';
 
 describe('initializeGT', () => {

--- a/packages/react-native/src/setup/initializeGT.ts
+++ b/packages/react-native/src/setup/initializeGT.ts
@@ -1,7 +1,7 @@
 import {
   initializeI18nConfig,
   setReactI18nCache,
-} from '@generaltranslation/react-core/context';
+} from '@generaltranslation/react-core/pure';
 import { ReactI18nCache } from '@generaltranslation/react-core/pure';
 import type { ReactI18nCacheParams } from '@generaltranslation/react-core/pure';
 import { setupGTServicesEnabled } from 'gt-i18n/internal';
@@ -14,10 +14,14 @@ export type InitializeGTParams = I18nConfigParams &
   GTServicesEnabledParams &
   ReactI18nCacheParams;
 
+const ReactI18nCacheWithConfig = ReactI18nCache as new (
+  config: ReactI18nCacheParams
+) => ReactI18nCache;
+
 export function initializeGT(config: InitializeGTParams): void {
   setupGTServicesEnabled(config);
   initializeI18nConfig(config, 'server-render');
 
-  const i18nCache = new ReactI18nCache(config);
+  const i18nCache = new ReactI18nCacheWithConfig(config);
   setReactI18nCache(i18nCache);
 }

--- a/packages/react-native/src/utils/__tests__/getLocale.test.ts
+++ b/packages/react-native/src/utils/__tests__/getLocale.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { initializeI18nConfig } from '@generaltranslation/react-core/context';
-import { defaultLocaleCookieName as defaultLocaleStoreKey } from '@generaltranslation/react-core/internal';
 import { getLocale } from '../getLocale';
+import { defaultLocaleStoreKey } from '../storeKeys';
+import { initializeI18nConfig } from '@generaltranslation/react-core/pure';
 
 const nativeStore = vi.hoisted(() => new Map<string, string>());
 

--- a/packages/react-native/src/utils/getInitialNativeConditions.ts
+++ b/packages/react-native/src/utils/getInitialNativeConditions.ts
@@ -1,8 +1,5 @@
 import type { WritableConditionStoreParams } from 'gt-i18n/internal/types';
-import {
-  defaultEnableI18nCookieName as defaultEnableI18nStoreKey,
-  defaultRegionCookieName as defaultRegionStoreKey,
-} from '@generaltranslation/react-core/internal';
+import { defaultEnableI18nStoreKey, defaultRegionStoreKey } from './storeKeys';
 import { nativeStoreGet } from './nativeStore';
 
 type InitialRegionParams = Pick<WritableConditionStoreParams, 'region'> & {

--- a/packages/react-native/src/utils/getLocale.ts
+++ b/packages/react-native/src/utils/getLocale.ts
@@ -1,8 +1,8 @@
 import type { LocaleCandidates } from 'gt-i18n/internal/types';
-import { defaultLocaleCookieName as defaultLocaleStoreKey } from '@generaltranslation/react-core/internal';
 import { getNativeLocales } from './getNativeLocales';
 import { nativeStoreGet } from './nativeStore';
 import { resolveLocale } from './resolveLocale';
+import { defaultLocaleStoreKey } from './storeKeys';
 
 export type GetLocaleParams = {
   localeStoreKey?: string;

--- a/packages/react-native/src/utils/nativeStore.ts
+++ b/packages/react-native/src/utils/nativeStore.ts
@@ -1,7 +1,7 @@
-import { defaultLocaleCookieName as defaultLocaleStoreKey } from '@generaltranslation/react-core/internal';
 import { Platform } from 'react-native';
 import GtReactNative from '../NativeGtReactNative';
 import { ssrUnsupportedWarning } from '../errors-dir/warnings';
+import { defaultLocaleStoreKey } from './storeKeys';
 
 /**
  * Get the locale from the native store.

--- a/packages/react-native/src/utils/storeKeys.ts
+++ b/packages/react-native/src/utils/storeKeys.ts
@@ -1,0 +1,3 @@
+export const defaultLocaleStoreKey = 'generaltranslation.locale';
+export const defaultRegionStoreKey = 'generaltranslation.region';
+export const defaultEnableI18nStoreKey = 'generaltranslation.enable-i18n';

--- a/packages/react-native/src/utils/utils.ts
+++ b/packages/react-native/src/utils/utils.ts
@@ -1,7 +1,12 @@
-import type {
-  AuthFromEnvParams,
-  AuthFromEnvReturn,
-} from '@generaltranslation/react-core/types';
+export type AuthFromEnvParams = {
+  projectId?: string;
+  devApiKey?: string;
+};
+
+export type AuthFromEnvReturn = {
+  projectId: string;
+  devApiKey?: string;
+};
 
 export function readAuthFromEnv(params: AuthFromEnvParams): AuthFromEnvReturn {
   const { projectId, devApiKey } = params;

--- a/packages/react/src/hooks/useHandleMissingTranslations.ts
+++ b/packages/react/src/hooks/useHandleMissingTranslations.ts
@@ -1,11 +1,11 @@
 'server-only';
 
 import {
-  I18nStore,
   OnMissingDictionaryEntry,
   OnMissingDictionaryObj,
   OnMissingTranslation,
-} from '@generaltranslation/react-core/context';
+} from '@generaltranslation/react-core/pure';
+import type { InternalGTProviderProps } from '@generaltranslation/react-core/components';
 import { useMemo } from 'react';
 
 /**
@@ -14,7 +14,9 @@ import { useMemo } from 'react';
  * is acceptable for dev hot reload because we MUST trigger a translate
  * call on the server to persist translations
  */
-export function useHandleMissingTranslations(i18nStore: I18nStore): {
+export function useHandleMissingTranslations(
+  i18nStore: InternalGTProviderProps['i18nStore']
+): {
   onMissingTranslation: OnMissingTranslation;
   onMissingDictionaryEntry: OnMissingDictionaryEntry;
   onMissingDictionaryObj: OnMissingDictionaryObj;

--- a/packages/react/src/internal.ts
+++ b/packages/react/src/internal.ts
@@ -1,449 +1,197 @@
-// No useContext related exports should go through here!
+// No useContext related exports should go through here.
 
 import {
-  addGTIdentifier as _addGTIdentifier,
-  writeChildrenAsObjects as _writeChildrenAsObjects,
-  isVariableObject as _isVariableObject,
-  flattenDictionary as _flattenDictionary,
-  getDictionaryEntry as _getDictionaryEntry,
-  isValidDictionaryEntry as _isValidDictionaryEntry,
-  getVariableProps as _getVariableProps,
-  getPluralBranch as _getPluralBranch,
-  getEntryAndMetadata as _getEntryAndMetadata,
-  getVariableName as _getVariableName,
-  renderDefaultChildren as _renderDefaultChildren,
-  renderTranslatedChildren as _renderTranslatedChildren,
-  renderSkeleton as _renderSkeleton,
-  getDefaultRenderSettings as _getDefaultRenderSettings,
-  mergeDictionaries as _mergeDictionaries,
-  reactHasUse as _reactHasUse,
-  getSubtree as _getSubtree,
-  getSubtreeWithCreation as _getSubtreeWithCreation,
-  injectEntry as _injectEntry,
-  isDictionaryEntry as _isDictionaryEntry,
-  stripMetadataFromEntries as _stripMetadataFromEntries,
-  injectHashes as _injectHashes,
-  injectTranslations as _injectTranslations,
-  injectFallbacks as _injectFallbacks,
-  injectAndMerge as _injectAndMerge,
-  collectUntranslatedEntries as _collectUntranslatedEntries,
-  msg as _msg,
-  decodeMsg as _decodeMsg,
-  decodeOptions as _decodeOptions,
-  derive as _derive,
-  declareVar as _declareVar,
-  decodeVars as _decodeVars,
-  Derive as _Derive,
-  mFallback as _mFallback,
-  gtFallback as _gtFallback,
-} from '@generaltranslation/react-core/internal';
+  decodeMsg,
+  decodeOptions,
+  decodeVars,
+  declareVar,
+  derive,
+  gtFallback,
+  mFallback,
+  msg,
+} from '@generaltranslation/react-core/pure';
+import { Derive } from '@generaltranslation/react-core/components';
 import {
-  defaultEnableI18nCookieName as _defaultEnableI18nCookieName,
-  defaultLocaleCookieName as _defaultLocaleCookieName,
-  defaultRegionCookieName as _defaultRegionCookieName,
+  renderDefaultChildren,
+  renderTranslatedChildren,
+} from '@generaltranslation/react-core/components-rsc';
+import {
+  defaultEnableI18nCookieName,
+  defaultLocaleCookieName,
+  defaultRegionCookieName,
 } from './cookie-names';
 
+import type { GTProp } from '@generaltranslation/format/types';
 import type {
-  MFunctionType as _MFunctionType,
-  GTFunctionType as _GTFunctionType,
-  Dictionary as _Dictionary,
-  RenderMethod as _RenderMethod,
-  TranslatedChildren as _TranslatedChildren,
-  Translations as _Translations,
-  RenderVariable as _RenderVariable,
-  VariableProps as _VariableProps,
-  DictionaryEntry as _DictionaryEntry,
-  FlattenedDictionary as _FlattenedDictionary,
-  Metadata as _Metadata,
-  Entry as _Entry,
-  DictionaryTranslationOptions as _DictionaryTranslationOptions,
-  InlineTranslationOptions as _InlineTranslationOptions,
-  RuntimeTranslationOptions as _RuntimeTranslationOptions,
-  LocalesDictionary as _LocalesDictionary,
-  DictionaryContent as _DictionaryContent,
-  DictionaryObject as _DictionaryObject,
-  CustomLoader as _CustomLoader,
-  _Message as __Message,
-  _Messages as __Messages,
-  GTProp as _GTProp,
-} from '@generaltranslation/react-core/types';
-
+  DictionaryTranslationOptions,
+  GTFunctionType,
+  InlineTranslationOptions,
+  MFunctionType,
+  RuntimeTranslationOptions,
+} from 'gt-i18n/types';
+import type { RenderVariable } from '@generaltranslation/react-core/pure';
 import type { SharedGTProviderProps } from './provider/GTProviderProps';
 
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-type RenderMethod = _RenderMethod;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-type Dictionary = _Dictionary;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-type DictionaryEntry = _DictionaryEntry;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-type FlattenedDictionary = _FlattenedDictionary;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-type Metadata = _Metadata;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-type GTProp = _GTProp;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-type Entry = _Entry;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-type TranslatedChildren = _TranslatedChildren;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-type Translations = _Translations;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use SharedGTProviderProps from gt-react instead.
- */
-type ClientProviderProps = SharedGTProviderProps;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use SharedGTProviderProps from gt-react instead.
- */
-type GTProviderProps = SharedGTProviderProps;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-type DictionaryTranslationOptions = _DictionaryTranslationOptions;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-type InlineTranslationOptions = _InlineTranslationOptions;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-type RuntimeTranslationOptions = _RuntimeTranslationOptions;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-type DictionaryContent = _DictionaryContent;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-type DictionaryObject = _DictionaryObject;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-type LocalesDictionary = _LocalesDictionary;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-type CustomLoader = _CustomLoader;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-type RenderVariable = _RenderVariable;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-type VariableProps = _VariableProps;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-type MFunctionType = _MFunctionType;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-type GTFunctionType = _GTFunctionType;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-type _Message = __Message;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-type _Messages = __Messages;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const defaultEnableI18nCookieName = _defaultEnableI18nCookieName;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const defaultLocaleCookieName = _defaultLocaleCookieName;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const defaultRegionCookieName = _defaultRegionCookieName;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const reactHasUse = _reactHasUse;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const Derive = _Derive;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const addGTIdentifier = _addGTIdentifier;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const writeChildrenAsObjects = _writeChildrenAsObjects;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const isVariableObject = _isVariableObject;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const flattenDictionary = _flattenDictionary;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const getDictionaryEntry = _getDictionaryEntry;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const isValidDictionaryEntry = _isValidDictionaryEntry;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const getVariableProps = _getVariableProps;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const getPluralBranch = _getPluralBranch;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const getEntryAndMetadata = _getEntryAndMetadata;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const getVariableName = _getVariableName;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const renderDefaultChildren = _renderDefaultChildren;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const renderTranslatedChildren = _renderTranslatedChildren;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const renderSkeleton = _renderSkeleton;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const mergeDictionaries = _mergeDictionaries;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const getSubtree = _getSubtree;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const getSubtreeWithCreation = _getSubtreeWithCreation;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const injectEntry = _injectEntry;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const isDictionaryEntry = _isDictionaryEntry;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const stripMetadataFromEntries = _stripMetadataFromEntries;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const injectHashes = _injectHashes;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const injectTranslations = _injectTranslations;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const injectFallbacks = _injectFallbacks;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const injectAndMerge = _injectAndMerge;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const collectUntranslatedEntries = _collectUntranslatedEntries;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const msg = _msg;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const decodeMsg = _decodeMsg;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const decodeOptions = _decodeOptions;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const derive = _derive;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const declareVar = _declareVar;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const decodeVars = _decodeVars;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const mFallback = _mFallback;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const gtFallback = _gtFallback;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const getDefaultRenderSettings = _getDefaultRenderSettings;
-
-export type {
-  RenderMethod,
-  Dictionary,
-  DictionaryEntry,
-  FlattenedDictionary,
-  Metadata,
-  GTProp,
-  Entry,
-  TranslatedChildren,
-  Translations,
-  ClientProviderProps,
-  GTProviderProps,
-  DictionaryTranslationOptions,
-  InlineTranslationOptions,
-  RuntimeTranslationOptions,
-  DictionaryContent,
-  DictionaryObject,
-  LocalesDictionary,
-  CustomLoader,
-  RenderVariable,
-  VariableProps,
-  MFunctionType,
-  GTFunctionType,
-  _Message,
-  _Messages,
+export type Entry = string;
+export type Metadata = {
+  $context?: string;
+  $maxChars?: number;
+  $_hash?: string;
+  [key: string]: unknown;
 };
+export type DictionaryEntry = Entry | [Entry] | [Entry, Metadata];
+export type Dictionary =
+  | {
+      [key: string]: Dictionary | DictionaryEntry;
+    }
+  | (Dictionary | DictionaryEntry)[];
+export type FlattenedDictionary = Record<string, DictionaryEntry>;
+export type RenderMethod = 'skeleton' | 'replace' | 'default';
+export type TranslatedChildren = unknown;
+export type Translations = Record<string, TranslatedChildren | null>;
+export type DictionaryContent = string;
+export type DictionaryObject = Record<string, DictionaryContent>;
+export type LocalesDictionary = Record<string, DictionaryObject>;
+export type CustomLoader = (locale: string) => Promise<unknown>;
+export type VariableProps = Record<string, unknown>;
+export type _Message = {
+  message: string;
+  $id?: string;
+  $context?: string;
+  $maxChars?: number;
+  $_hash?: string;
+};
+export type _Messages = _Message[];
+
+export type GTProviderProps = SharedGTProviderProps;
+export type ClientProviderProps = SharedGTProviderProps;
+
+const isPrimitiveOrArray = (value: unknown): boolean =>
+  typeof value === 'string' || Array.isArray(value);
+
+const isObjectDictionary = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+function get(
+  dictionary: Dictionary,
+  key: string
+): Dictionary | DictionaryEntry | undefined {
+  return (dictionary as Record<string, Dictionary | DictionaryEntry>)[key];
+}
+
+export function isValidDictionaryEntry(
+  value: unknown
+): value is DictionaryEntry {
+  if (typeof value === 'string') return true;
+  if (!Array.isArray(value) || typeof value[0] !== 'string') return false;
+  const metadata = value[1];
+  return metadata === undefined || (metadata && typeof metadata === 'object');
+}
+
+export const isDictionaryEntry = isValidDictionaryEntry;
+
+export function getDictionaryEntry(
+  dictionary: Dictionary,
+  id: string
+): Dictionary | DictionaryEntry | undefined {
+  let current: Dictionary | DictionaryEntry = dictionary;
+  for (const key of id.split('.')) {
+    if (typeof current !== 'object' && !Array.isArray(current)) {
+      return undefined;
+    }
+    const next = get(current as Dictionary, key);
+    if (next === undefined) return undefined;
+    current = next;
+  }
+  return current;
+}
+
+export function mergeDictionaries(
+  defaultLocaleDictionary: Dictionary,
+  localeDictionary: Dictionary
+): Dictionary {
+  if (Array.isArray(defaultLocaleDictionary)) {
+    return defaultLocaleDictionary.map((value, key) => {
+      if (isDictionaryEntry(value)) {
+        return (
+          (localeDictionary as (Dictionary | DictionaryEntry)[])[key] ?? value
+        );
+      }
+      return mergeDictionaries(
+        value as Dictionary,
+        (localeDictionary as (Dictionary | DictionaryEntry)[])[
+          key
+        ] as Dictionary
+      );
+    });
+  }
+
+  const mergedDictionary: Dictionary = {
+    ...Object.fromEntries(
+      Object.entries(defaultLocaleDictionary).filter(([, value]) =>
+        isPrimitiveOrArray(value)
+      )
+    ),
+    ...Object.fromEntries(
+      Object.entries(localeDictionary).filter(([, value]) =>
+        isPrimitiveOrArray(value)
+      )
+    ),
+  };
+
+  const defaultDictionaryKeys = Object.entries(defaultLocaleDictionary)
+    .filter(([, value]) => isObjectDictionary(value))
+    .map(([key]) => key);
+  const localeDictionaryKeys = Object.entries(localeDictionary)
+    .filter(([, value]) => isObjectDictionary(value))
+    .map(([key]) => key);
+
+  for (const key of new Set([
+    ...defaultDictionaryKeys,
+    ...localeDictionaryKeys,
+  ])) {
+    mergedDictionary[key] = mergeDictionaries(
+      (get(defaultLocaleDictionary, key) || {}) as Dictionary,
+      (get(localeDictionary, key) || {}) as Dictionary
+    );
+  }
+
+  return mergedDictionary;
+}
+
+export const getDefaultRenderSettings = (
+  environment: 'development' | 'production' | 'test' = 'production'
+): {
+  method: RenderMethod;
+  timeout: number;
+} => ({
+  method: 'default',
+  timeout: environment === 'development' ? 8000 : 12000,
+});
 
 export {
   defaultEnableI18nCookieName,
   defaultLocaleCookieName,
   defaultRegionCookieName,
-  reactHasUse,
-  Derive,
-  addGTIdentifier,
-  writeChildrenAsObjects,
-  isVariableObject,
-  flattenDictionary,
-  getDictionaryEntry,
-  isValidDictionaryEntry,
-  getVariableProps,
-  getPluralBranch,
-  getEntryAndMetadata,
-  getVariableName,
-  renderDefaultChildren,
-  renderTranslatedChildren,
-  renderSkeleton,
-  mergeDictionaries,
-  getSubtree,
-  getSubtreeWithCreation,
-  injectEntry,
-  isDictionaryEntry,
-  stripMetadataFromEntries,
-  injectHashes,
-  injectTranslations,
-  injectFallbacks,
-  injectAndMerge,
-  collectUntranslatedEntries,
-  msg,
   decodeMsg,
   decodeOptions,
-  derive,
-  declareVar,
   decodeVars,
-  mFallback,
+  declareVar,
+  Derive,
+  derive,
   gtFallback,
-  getDefaultRenderSettings,
+  mFallback,
+  msg,
+  renderDefaultChildren,
+  renderTranslatedChildren,
+};
+
+export type {
+  DictionaryTranslationOptions,
+  GTFunctionType,
+  GTProp,
+  InlineTranslationOptions,
+  MFunctionType,
+  RenderVariable,
+  RuntimeTranslationOptions,
 };

--- a/packages/react/src/provider/BrowserGTProvider.tsx
+++ b/packages/react/src/provider/BrowserGTProvider.tsx
@@ -1,7 +1,8 @@
 import {
-  I18nStore,
   InternalGTProvider,
-} from '@generaltranslation/react-core/context';
+  type InternalGTProviderProps,
+} from '@generaltranslation/react-core/components';
+import { I18nStore } from '@generaltranslation/react-core/pure';
 import { useMemo, useRef } from 'react';
 import type { SharedGTProviderProps } from './GTProviderProps';
 import { ReadonlyBrowserConditionStore } from '../condition-store/ReadOnlyBrowserConditionStore';
@@ -15,9 +16,12 @@ export function BrowserGTProvider(props: SharedGTProviderProps) {
     return new ReadonlyBrowserConditionStore(props);
   }, [props.locale, props.region, props.enableI18n, props._reload]);
 
-  const i18nStoreRef = useRef<I18nStore | null>(null);
+  const i18nStoreRef = useRef<InternalGTProviderProps['i18nStore'] | null>(
+    null
+  );
   if (i18nStoreRef.current == null) {
-    i18nStoreRef.current = new I18nStore();
+    i18nStoreRef.current =
+      new I18nStore() as unknown as InternalGTProviderProps['i18nStore'];
   }
 
   return (

--- a/packages/react/src/provider/GTProviderProps.ts
+++ b/packages/react/src/provider/GTProviderProps.ts
@@ -1,4 +1,4 @@
-import type { InternalGTProviderProps } from '@generaltranslation/react-core/context';
+import type { InternalGTProviderProps } from '@generaltranslation/react-core/components';
 import { BrowserConditionStoreParams } from '../condition-store/BrowserConditionStore';
 
 /**

--- a/packages/react/src/provider/ServerGTProvider.tsx
+++ b/packages/react/src/provider/ServerGTProvider.tsx
@@ -1,8 +1,11 @@
 import {
-  I18nStore,
   InternalGTProvider,
+  type InternalGTProviderProps,
+} from '@generaltranslation/react-core/components';
+import {
+  I18nStore,
   ReadonlyConditionStore,
-} from '@generaltranslation/react-core/context';
+} from '@generaltranslation/react-core/pure';
 import { useMemo, useRef } from 'react';
 import type { SharedGTProviderProps } from './GTProviderProps';
 import { useHandleMissingTranslations } from '../hooks/useHandleMissingTranslations';
@@ -21,9 +24,12 @@ export function ServerGTProvider({
     return new ReadonlyConditionStore({ locale, region, enableI18n });
   }, [locale, region, enableI18n]);
 
-  const i18nStoreRef = useRef<I18nStore | null>(null);
+  const i18nStoreRef = useRef<InternalGTProviderProps['i18nStore'] | null>(
+    null
+  );
   if (i18nStoreRef.current == null) {
-    i18nStoreRef.current = new I18nStore();
+    i18nStoreRef.current =
+      new I18nStore() as unknown as InternalGTProviderProps['i18nStore'];
   }
 
   const {

--- a/packages/react/src/setup/initializeGTSPA.ts
+++ b/packages/react/src/setup/initializeGTSPA.ts
@@ -5,8 +5,8 @@ import {
   setReactI18nCache,
   getReadonlyConditionStoreWithFallback,
   initializeI18nConfig,
-} from '@generaltranslation/react-core/context';
-import type { I18nConfigParams } from '@generaltranslation/react-core/context';
+} from '@generaltranslation/react-core/pure';
+import type { I18nConfigParams } from '@generaltranslation/react-core/pure';
 import { setupGTServicesEnabled } from 'gt-i18n/internal';
 import type { GTServicesEnabledParams } from 'gt-i18n/internal/types';
 import { BrowserI18nCache } from '../i18n-cache/BrowserI18nCache';


### PR DESCRIPTION
## Summary
- move workspace consumers off disallowed `@generaltranslation/react-core` root/context/internal/types entrypoints
- expose needed non-component helpers through `@generaltranslation/react-core/pure` and `InternalGTProvider` through `/components`
- keep deprecated-backed React Native store/auth helpers local instead of moving deprecated APIs into a valid React Core entrypoint

## Testing
- `pnpm --filter gt-react test`
- `pnpm --filter gt-react-native test`
- `pnpm --filter @generaltranslation/react-core-linter test`
- `pnpm --filter @generaltranslation/react-core test`
- `pnpm --filter gt-next test`
- `pnpm --filter @generaltranslation/react-core-linter typecheck`
- `pnpm --filter gt-react-native... build`
- `pnpm --filter gt-next... build`
- `pnpm format`
- `pnpm lint`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1609"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784316095&installation_id=127936663&pr_number=1609&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1609&signature=40bf03a7b50b97bf9b2ac2afdf03f53bf4953b744c2e9868174fa3fc7d1008de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Moves workspace consumers away from disallowed `@generaltranslation/react-core` root, context, internal, and type entrypoints.
- Adds/updates `gt-react` conditional client, server, RSC, browser, and type entrypoints.
- Exposes shared non-component helpers through `@generaltranslation/react-core/pure` and `InternalGTProvider` through `/components`.
- Updates Next, TanStack Start, React Native, compiler, CLI, linter, and related tests for the new import paths.

<details open><summary><h3>Confidence Score: 1/5</h3></summary>

Not safe to merge until the package entrypoint and export-compatibility regressions are addressed.

The changes affect public React package resolution, client/server initializer wiring, internal subpath compatibility, compiler macro detection, and locale behavior; focused execution confirmed the reported failure modes.

packages/react/package.json, packages/react/src/index.client.ts, packages/react/src/internal.ts, packages/compiler/src/utils/parsing/isStringTranslationTaggedTemplate.ts, packages/react/src/index.rsc.ts
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Verified default entrypoint client-only behavior by running a focused Node repro script that resolves imports to the dist/index.server.\* targets and maps default server targets to index.server source containing GTProvider, useGT, and T exports.
- Attempted a scoped package build/import path, but local pnpm cannot run on the available Node v20.9.0, so the runtime import reached the same default server targets but failed because dist artifacts are not built in this checkout.
- Ran a focused Vitest repro against packages/react/src/index.client.ts and confirmed the client initializeGT identity matches the react-core/pure server-render initializeGT and is not identical to internalInitializeGTSPA.
- Ran a TypeScript fixture importing gt-react/internal symbols and observed missing-export diagnostics when gt-react/internal mapped to the package internal source.
- Executed a focused TS repro for array dictionary merge and observed that the merged result places "Default one" at index 1 and hasOwnProperty reports index 1 as present, contrary to the expectation that the missing locale would remain undefined.
- Executed a Babel parser/rewrite repro harness for old and new macro import sources and observed that the old gt-react/browser and gt-react/client imports were skipped while gt-react was accepted and produced runtime messages.
- Ran a focused Vitest repro for an omitted RSC locale path, and observed getLocaleDirection returns a value (rtl) when the locale is provided, while omitting the locale yields undefined being passed to getLocaleDirection.
- Compared before/after trex-artifacts for allowed entrypoints and found that after the head checkout, all pure exports are present and there are no disallowed imports, with exit code 0.
- Compared before/after linter allowed subpaths and found head output enabling additional subpaths, with all tests passing (7/7) in the after state.
- Compared before/after baseline/head import checks for store-key helpers, showing that before, getTranslationsSnapshot and related internal members were missing, while after, the head checkout includes the full set of internal exports and the checks report the expected status and commands used.

<a href="https://app.greptile.com/trex/runs/11434575/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `packages/react/src/index.client.ts`, line 72-88 ([link](https://github.com/generaltranslation/gt/blob/3332c97584acdcc0ce443478df920f1d470eac4f/packages/react/src/index.client.ts#L72-L88)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Client initialize uses server**

   The browser/client root exports `initializeGT` from `@generaltranslation/react-core/pure`, where `initializeGT` is the SRA/server-render initializer. A browser consumer importing `initializeGT` from `gt-react` under the `browser` condition will initialize the server-render runtime instead of the SPA runtime, so client cache/setup and missing-translation behavior can be configured for the wrong mode. The client entry should expose the SPA initializer as the root `initializeGT` value.

   

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Repro: generated failing Vitest test comparing client initializeGT export identity](https://app.greptile.com/trex/artifacts/6b1a391d-ed6e-43a2-b9e9-3ce9c654d797)**

   - Contains supporting evidence from the run (text/typescript; charset=utf-8).

   **[Repro: Vitest config resolving gt-react dependencies to focused facades](https://app.greptile.com/trex/artifacts/2516bfc5-dfb8-426b-b075-0f7ac763b9e3)**

   - Contains supporting evidence from the run (text/javascript; charset=utf-8).

   **[Repro: react-core pure facade exposing server-render initializeGT](https://app.greptile.com/trex/artifacts/a102c44b-e1f0-420e-a1dc-57e975237167)**

   - Contains supporting evidence from the run (text/typescript; charset=utf-8).

   **[Repro: react-core context facade exposing internalInitializeGTSPA](https://app.greptile.com/trex/artifacts/62bde295-ce07-48e6-b0cb-304d369bc0d3)**

   - Contains supporting evidence from the run (text/typescript; charset=utf-8).

   **[Repro: react-core hooks facade used by client entrypoint imports](https://app.greptile.com/trex/artifacts/202f4691-0550-448a-9c71-8581baefb881)**

   - Contains supporting evidence from the run (text/typescript; charset=utf-8).

   **[Repro: react-core components facade used by client entrypoint imports](https://app.greptile.com/trex/artifacts/c63a287c-e99c-4746-a82d-de7af2acbfe1)**

   - Contains supporting evidence from the run (text/typescript; charset=utf-8).

   **[Repro: minimal React facade for client entrypoint import execution](https://app.greptile.com/trex/artifacts/596ca649-8d1f-44f7-a5f0-8baac972d364)**

   - Contains supporting evidence from the run (text/typescript; charset=utf-8).

   **[Repro: minimal JSX runtime facade for client entrypoint import execution](https://app.greptile.com/trex/artifacts/16840755-c365-46c3-9519-0553a552d8c8)**

   - Contains supporting evidence from the run (text/typescript; charset=utf-8).

   **[Repro: minimal generaltranslation internal facade for client entrypoint import execution](https://app.greptile.com/trex/artifacts/0bb4547b-d93b-4b44-8bb1-0441f02c6469)**

   - Contains supporting evidence from the run (text/typescript; charset=utf-8).

   **[Repro: verbose Vitest output showing initializeGT equals pure server initializer and not SPA initializer](https://app.greptile.com/trex/artifacts/1c6e92e3-996a-41b8-a72b-2a92bddf9c26)**

   - Keeps the command output available without making the summary code-heavy.

   <a href="https://app.greptile.com/trex/runs/11434575/artifacts?artifact=6b1a391d-ed6e-43a2-b9e9-3ce9c654d797"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1" height="32"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/react/src/index.client.ts
   Line: 72-88

   Comment:
   **Client initialize uses server**

   The browser/client root exports `initializeGT` from `@generaltranslation/react-core/pure`, where `initializeGT` is the SRA/server-render initializer. A browser consumer importing `initializeGT` from `gt-react` under the `browser` condition will initialize the server-render runtime instead of the SPA runtime, so client cache/setup and missing-translation behavior can be configured for the wrong mode. The client entry should expose the SPA initializer as the root `initializeGT` value.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Freact%2Fsrc%2Findex.client.ts%0ALine%3A%2072-88%0A%0AComment%3A%0A**Client%20initialize%20uses%20server**%0A%0AThe%20browser%2Fclient%20root%20exports%20%60initializeGT%60%20from%20%60%40generaltranslation%2Freact-core%2Fpure%60%2C%20where%20%60initializeGT%60%20is%20the%20SRA%2Fserver-render%20initializer.%20A%20browser%20consumer%20importing%20%60initializeGT%60%20from%20%60gt-react%60%20under%20the%20%60browser%60%20condition%20will%20initialize%20the%20server-render%20runtime%20instead%20of%20the%20SPA%20runtime%2C%20so%20client%20cache%2Fsetup%20and%20missing-translation%20behavior%20can%20be%20configured%20for%20the%20wrong%20mode.%20The%20client%20entry%20should%20expose%20the%20SPA%20initializer%20as%20the%20root%20%60initializeGT%60%20value.%0A%0A%60%60%60suggestion%0Aexport%20%7B%0A%20%20msg%2C%0A%20%20decodeMsg%2C%0A%20%20decodeOptions%2C%0A%20%20derive%2C%0A%20%20declareVar%2C%0A%20%20decodeVars%2C%0A%20%20mFallback%2C%0A%20%20gtFallback%2C%0A%20%20getFormatLocales%2C%0A%20%20internalInitializeGTSPA%20as%20initializeGT%2C%0A%20%20getDefaultLocale%2C%0A%20%20getGTClass%2C%0A%20%20getLocaleProperties%2C%0A%20%20getLocales%2C%0A%20%20getVersionId%2C%0A%7D%20from%20'%40generaltranslation%2Freact-core%2Fpure'%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=generaltranslation%2Fgt&pr=1609&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fodysseus%2Fremove-react-core-deprecated-dir%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fodysseus%2Fremove-react-core-deprecated-dir%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Freact%2Fsrc%2Findex.client.ts%0ALine%3A%2072-88%0A%0AComment%3A%0A**Client%20initialize%20uses%20server**%0A%0AThe%20browser%2Fclient%20root%20exports%20%60initializeGT%60%20from%20%60%40generaltranslation%2Freact-core%2Fpure%60%2C%20where%20%60initializeGT%60%20is%20the%20SRA%2Fserver-render%20initializer.%20A%20browser%20consumer%20importing%20%60initializeGT%60%20from%20%60gt-react%60%20under%20the%20%60browser%60%20condition%20will%20initialize%20the%20server-render%20runtime%20instead%20of%20the%20SPA%20runtime%2C%20so%20client%20cache%2Fsetup%20and%20missing-translation%20behavior%20can%20be%20configured%20for%20the%20wrong%20mode.%20The%20client%20entry%20should%20expose%20the%20SPA%20initializer%20as%20the%20root%20%60initializeGT%60%20value.%0A%0A%60%60%60suggestion%0Aexport%20%7B%0A%20%20msg%2C%0A%20%20decodeMsg%2C%0A%20%20decodeOptions%2C%0A%20%20derive%2C%0A%20%20declareVar%2C%0A%20%20decodeVars%2C%0A%20%20mFallback%2C%0A%20%20gtFallback%2C%0A%20%20getFormatLocales%2C%0A%20%20internalInitializeGTSPA%20as%20initializeGT%2C%0A%20%20getDefaultLocale%2C%0A%20%20getGTClass%2C%0A%20%20getLocaleProperties%2C%0A%20%20getLocales%2C%0A%20%20getVersionId%2C%0A%7D%20from%20'%40generaltranslation%2Freact-core%2Fpure'%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=generaltranslation%2Fgt&pr=1609&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>


2. `packages/react/src/index.rsc.ts`, line 84-89 ([link](https://github.com/generaltranslation/gt/blob/3332c97584acdcc0ce443478df920f1d470eac4f/packages/react/src/index.rsc.ts#L84-L89)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Keep locale optional**

   The previous `useLocaleDirection()` API allowed callers to omit the locale and used the current locale from context/request state. This RSC entrypoint now passes the argument directly to the GT class, so existing calls like `useLocaleDirection()` pass `undefined` and can return the wrong direction or throw instead of using the current request locale. Please keep the locale optional here and default it to `getLocale()` before calling the GT class.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Repro: focused Vitest test for omitted RSC useLocaleDirection locale](https://app.greptile.com/trex/artifacts/c3d443a6-8ed7-44b2-89c7-15455dc30015)**

   - Contains supporting evidence from the run (text/typescript; charset=utf-8).

   **[Repro: failing Vitest output showing undefined passed instead of current locale](https://app.greptile.com/trex/artifacts/01518a68-5892-4031-ba9d-47a6a8db0d38)**

   - Keeps the command output available without making the summary code-heavy.

   <a href="https://app.greptile.com/trex/runs/11434575/artifacts?artifact=c3d443a6-8ed7-44b2-89c7-15455dc30015"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1" height="32"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/react/src/index.rsc.ts
   Line: 84-89

   Comment:
   **Keep locale optional**

   The previous `useLocaleDirection()` API allowed callers to omit the locale and used the current locale from context/request state. This RSC entrypoint now passes the argument directly to the GT class, so existing calls like `useLocaleDirection()` pass `undefined` and can return the wrong direction or throw instead of using the current request locale. Please keep the locale optional here and default it to `getLocale()` before calling the GT class.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Freact%2Fsrc%2Findex.rsc.ts%0ALine%3A%2084-89%0A%0AComment%3A%0A**Keep%20locale%20optional**%0A%0AThe%20previous%20%60useLocaleDirection%28%29%60%20API%20allowed%20callers%20to%20omit%20the%20locale%20and%20used%20the%20current%20locale%20from%20context%2Frequest%20state.%20This%20RSC%20entrypoint%20now%20passes%20the%20argument%20directly%20to%20the%20GT%20class%2C%20so%20existing%20calls%20like%20%60useLocaleDirection%28%29%60%20pass%20%60undefined%60%20and%20can%20return%20the%20wrong%20direction%20or%20throw%20instead%20of%20using%20the%20current%20request%20locale.%20Please%20keep%20the%20locale%20optional%20here%20and%20default%20it%20to%20%60getLocale%28%29%60%20before%20calling%20the%20GT%20class.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=generaltranslation%2Fgt&pr=1609&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fodysseus%2Fremove-react-core-deprecated-dir%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fodysseus%2Fremove-react-core-deprecated-dir%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Freact%2Fsrc%2Findex.rsc.ts%0ALine%3A%2084-89%0A%0AComment%3A%0A**Keep%20locale%20optional**%0A%0AThe%20previous%20%60useLocaleDirection%28%29%60%20API%20allowed%20callers%20to%20omit%20the%20locale%20and%20used%20the%20current%20locale%20from%20context%2Frequest%20state.%20This%20RSC%20entrypoint%20now%20passes%20the%20argument%20directly%20to%20the%20GT%20class%2C%20so%20existing%20calls%20like%20%60useLocaleDirection%28%29%60%20pass%20%60undefined%60%20and%20can%20return%20the%20wrong%20direction%20or%20throw%20instead%20of%20using%20the%20current%20request%20locale.%20Please%20keep%20the%20locale%20optional%20here%20and%20default%20it%20to%20%60getLocale%28%29%60%20before%20calling%20the%20GT%20class.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=generaltranslation%2Fgt&pr=1609&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%206%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%206%0Apackages%2Freact%2Fpackage.json%3A81-89%0A**Default%20entrypoint%20client-only**%0A%0AThe%20default%20%60gt-react%60%20export%20now%20resolves%20to%20%60index.server%60%2C%20but%20that%20file%20starts%20with%20%60'use%20client'%60%20and%20exports%20hookful%20client%2Fcontext%20components.%20Plain%20Node%20SSR%2C%20tests%2C%20and%20bundlers%20that%20do%20not%20set%20the%20%60react-server%60%20or%20%60browser%60%20condition%20will%20load%20a%20client-boundary%20entrypoint%20for%20%60import%20%7B%20T%2C%20GTProvider%2C%20useGT%20%7D%20from%20'gt-react'%60.%20That%20can%20make%20server-side%20imports%20behave%20as%20client%20components%20or%20fail%20in%20environments%20that%20expected%20the%20root%20package%20to%20remain%20usable%20outside%20a%20client%20boundary.%0A%0A%23%23%23%20Issue%202%20of%206%0Apackages%2Freact%2Fsrc%2Findex.client.ts%3A72-88%0A**Client%20initialize%20uses%20server**%0A%0AThe%20browser%2Fclient%20root%20exports%20%60initializeGT%60%20from%20%60%40generaltranslation%2Freact-core%2Fpure%60%2C%20where%20%60initializeGT%60%20is%20the%20SRA%2Fserver-render%20initializer.%20A%20browser%20consumer%20importing%20%60initializeGT%60%20from%20%60gt-react%60%20under%20the%20%60browser%60%20condition%20will%20initialize%20the%20server-render%20runtime%20instead%20of%20the%20SPA%20runtime%2C%20so%20client%20cache%2Fsetup%20and%20missing-translation%20behavior%20can%20be%20configured%20for%20the%20wrong%20mode.%20The%20client%20entry%20should%20expose%20the%20SPA%20initializer%20as%20the%20root%20%60initializeGT%60%20value.%0A%0A%60%60%60suggestion%0Aexport%20%7B%0A%20%20msg%2C%0A%20%20decodeMsg%2C%0A%20%20decodeOptions%2C%0A%20%20derive%2C%0A%20%20declareVar%2C%0A%20%20decodeVars%2C%0A%20%20mFallback%2C%0A%20%20gtFallback%2C%0A%20%20getFormatLocales%2C%0A%20%20internalInitializeGTSPA%20as%20initializeGT%2C%0A%20%20getDefaultLocale%2C%0A%20%20getGTClass%2C%0A%20%20getLocaleProperties%2C%0A%20%20getLocales%2C%0A%20%20getVersionId%2C%0A%7D%20from%20'%40generaltranslation%2Freact-core%2Fpure'%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%206%0Apackages%2Freact%2Fsrc%2Finternal.ts%3A172-194%0A**Preserve%20internal%20exports**%0A%0AThe%20%60gt-react%2Finternal%60%20subpath%20is%20still%20exported%2C%20but%20this%20replacement%20only%20re-exports%20a%20small%20subset%20of%20the%20previous%20internal%20surface.%20Existing%20callers%20of%20names%20that%20were%20previously%20available%20from%20this%20subpath%2C%20such%20as%20%60flattenDictionary%60%2C%20%60renderSkeleton%60%2C%20%60injectTranslations%60%2C%20%60injectFallbacks%60%2C%20%60collectUntranslatedEntries%60%2C%20%60getSubtree%60%2C%20%60addGTIdentifier%60%2C%20%60writeChildrenAsObjects%60%2C%20and%20%60injectHashes%60%2C%20will%20now%20hit%20missing-export%20build%20or%20runtime%20errors%20even%20though%20%60gt-react%2Finternal%60%20still%20resolves.%20Please%20keep%20forwarding%20the%20old%20internal%20surface%20from%20a%20valid%20entrypoint%2C%20or%20remove%20the%20subpath%20only%20as%20an%20explicit%20breaking%20migration.%0A%0A%23%23%23%20Issue%204%20of%206%0Apackages%2Freact%2Fsrc%2Finternal.ts%3A113-118%0A**Array%20merge%20masks%20misses**%0A%0AFor%20array%20dictionaries%2C%20this%20now%20falls%20back%20to%20the%20default-locale%20entry%20when%20the%20locale%20dictionary%20has%20no%20value%20at%20the%20same%20index.%20The%20previous%20helper%20returned%20the%20locale%20value%20directly%2C%20so%20missing%20array%20entries%20stayed%20missing%20and%20could%20be%20detected%20by%20downstream%20translation%20handling.%20With%20this%20fallback%2C%20an%20untranslated%20array%20item%20can%20be%20silently%20replaced%20with%20default-locale%20content%20and%20reported%20as%20if%20it%20had%20a%20value.%0A%0A%23%23%23%20Issue%205%20of%206%0Apackages%2Fcompiler%2Fsrc%2Futils%2Fparsing%2FisStringTranslationTaggedTemplate.ts%3A31-36%0A**Old%20macro%20imports%20ignored**%0A%0AThe%20tagged-template%20detector%20now%20accepts%20only%20%60t%60%20imported%20from%20exactly%20%60gt-react%60.%20Existing%20projects%20that%20still%20contain%20%60import%20%7B%20t%20%7D%20from%20'gt-react%2Fbrowser'%60%20or%20%60gt-react%2Fclient%60%20during%20migration%20will%20have%20tagged%20template%20calls%20silently%20skipped%20by%20extraction%2Fexpansion%20instead%20of%20translated%20or%20reported.%20That%20can%20leave%20required%20strings%20out%20of%20generated%20translations.%20Keep%20the%20old%20sources%20recognized%20for%20diagnostics%2Fmigration%2C%20or%20emit%20a%20clear%20migration%20error%20rather%20than%20returning%20false.%0A%0A%281%20more%20issue%20omitted%20due%20to%20length%20limits.%20Use%20individual%20%22Fix%20in%20Claude%20Code%22%20links%20for%20remaining%20issues.%29%0A&repo=generaltranslation%2Fgt&pr=1609&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fodysseus%2Fremove-react-core-deprecated-dir%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fodysseus%2Fremove-react-core-deprecated-dir%22.%0A%0AFix%20the%20following%206%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%206%0Apackages%2Freact%2Fpackage.json%3A81-89%0A**Default%20entrypoint%20client-only**%0A%0AThe%20default%20%60gt-react%60%20export%20now%20resolves%20to%20%60index.server%60%2C%20but%20that%20file%20starts%20with%20%60'use%20client'%60%20and%20exports%20hookful%20client%2Fcontext%20components.%20Plain%20Node%20SSR%2C%20tests%2C%20and%20bundlers%20that%20do%20not%20set%20the%20%60react-server%60%20or%20%60browser%60%20condition%20will%20load%20a%20client-boundary%20entrypoint%20for%20%60import%20%7B%20T%2C%20GTProvider%2C%20useGT%20%7D%20from%20'gt-react'%60.%20That%20can%20make%20server-side%20imports%20behave%20as%20client%20components%20or%20fail%20in%20environments%20that%20expected%20the%20root%20package%20to%20remain%20usable%20outside%20a%20client%20boundary.%0A%0A%23%23%23%20Issue%202%20of%206%0Apackages%2Freact%2Fsrc%2Findex.client.ts%3A72-88%0A**Client%20initialize%20uses%20server**%0A%0AThe%20browser%2Fclient%20root%20exports%20%60initializeGT%60%20from%20%60%40generaltranslation%2Freact-core%2Fpure%60%2C%20where%20%60initializeGT%60%20is%20the%20SRA%2Fserver-render%20initializer.%20A%20browser%20consumer%20importing%20%60initializeGT%60%20from%20%60gt-react%60%20under%20the%20%60browser%60%20condition%20will%20initialize%20the%20server-render%20runtime%20instead%20of%20the%20SPA%20runtime%2C%20so%20client%20cache%2Fsetup%20and%20missing-translation%20behavior%20can%20be%20configured%20for%20the%20wrong%20mode.%20The%20client%20entry%20should%20expose%20the%20SPA%20initializer%20as%20the%20root%20%60initializeGT%60%20value.%0A%0A%60%60%60suggestion%0Aexport%20%7B%0A%20%20msg%2C%0A%20%20decodeMsg%2C%0A%20%20decodeOptions%2C%0A%20%20derive%2C%0A%20%20declareVar%2C%0A%20%20decodeVars%2C%0A%20%20mFallback%2C%0A%20%20gtFallback%2C%0A%20%20getFormatLocales%2C%0A%20%20internalInitializeGTSPA%20as%20initializeGT%2C%0A%20%20getDefaultLocale%2C%0A%20%20getGTClass%2C%0A%20%20getLocaleProperties%2C%0A%20%20getLocales%2C%0A%20%20getVersionId%2C%0A%7D%20from%20'%40generaltranslation%2Freact-core%2Fpure'%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%206%0Apackages%2Freact%2Fsrc%2Finternal.ts%3A172-194%0A**Preserve%20internal%20exports**%0A%0AThe%20%60gt-react%2Finternal%60%20subpath%20is%20still%20exported%2C%20but%20this%20replacement%20only%20re-exports%20a%20small%20subset%20of%20the%20previous%20internal%20surface.%20Existing%20callers%20of%20names%20that%20were%20previously%20available%20from%20this%20subpath%2C%20such%20as%20%60flattenDictionary%60%2C%20%60renderSkeleton%60%2C%20%60injectTranslations%60%2C%20%60injectFallbacks%60%2C%20%60collectUntranslatedEntries%60%2C%20%60getSubtree%60%2C%20%60addGTIdentifier%60%2C%20%60writeChildrenAsObjects%60%2C%20and%20%60injectHashes%60%2C%20will%20now%20hit%20missing-export%20build%20or%20runtime%20errors%20even%20though%20%60gt-react%2Finternal%60%20still%20resolves.%20Please%20keep%20forwarding%20the%20old%20internal%20surface%20from%20a%20valid%20entrypoint%2C%20or%20remove%20the%20subpath%20only%20as%20an%20explicit%20breaking%20migration.%0A%0A%23%23%23%20Issue%204%20of%206%0Apackages%2Freact%2Fsrc%2Finternal.ts%3A113-118%0A**Array%20merge%20masks%20misses**%0A%0AFor%20array%20dictionaries%2C%20this%20now%20falls%20back%20to%20the%20default-locale%20entry%20when%20the%20locale%20dictionary%20has%20no%20value%20at%20the%20same%20index.%20The%20previous%20helper%20returned%20the%20locale%20value%20directly%2C%20so%20missing%20array%20entries%20stayed%20missing%20and%20could%20be%20detected%20by%20downstream%20translation%20handling.%20With%20this%20fallback%2C%20an%20untranslated%20array%20item%20can%20be%20silently%20replaced%20with%20default-locale%20content%20and%20reported%20as%20if%20it%20had%20a%20value.%0A%0A%23%23%23%20Issue%205%20of%206%0Apackages%2Fcompiler%2Fsrc%2Futils%2Fparsing%2FisStringTranslationTaggedTemplate.ts%3A31-36%0A**Old%20macro%20imports%20ignored**%0A%0AThe%20tagged-template%20detector%20now%20accepts%20only%20%60t%60%20imported%20from%20exactly%20%60gt-react%60.%20Existing%20projects%20that%20still%20contain%20%60import%20%7B%20t%20%7D%20from%20'gt-react%2Fbrowser'%60%20or%20%60gt-react%2Fclient%60%20during%20migration%20will%20have%20tagged%20template%20calls%20silently%20skipped%20by%20extraction%2Fexpansion%20instead%20of%20translated%20or%20reported.%20That%20can%20leave%20required%20strings%20out%20of%20generated%20translations.%20Keep%20the%20old%20sources%20recognized%20for%20diagnostics%2Fmigration%2C%20or%20emit%20a%20clear%20migration%20error%20rather%20than%20returning%20false.%0A%0A%23%23%23%20Issue%206%20of%206%0Apackages%2Freact%2Fsrc%2Findex.rsc.ts%3A84-89%0A**Keep%20locale%20optional**%0A%0AThe%20previous%20%60useLocaleDirection%28%29%60%20API%20allowed%20callers%20to%20omit%20the%20locale%20and%20used%20the%20current%20locale%20from%20context%2Frequest%20state.%20This%20RSC%20entrypoint%20now%20passes%20the%20argument%20directly%20to%20the%20GT%20class%2C%20so%20existing%20calls%20like%20%60useLocaleDirection%28%29%60%20pass%20%60undefined%60%20and%20can%20return%20the%20wrong%20direction%20or%20throw%20instead%20of%20using%20the%20current%20request%20locale.%20Please%20keep%20the%20locale%20optional%20here%20and%20default%20it%20to%20%60getLocale%28%29%60%20before%20calling%20the%20GT%20class.%0A%0A&repo=generaltranslation%2Fgt&pr=1609&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 6 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 6
packages/react/package.json:81-89
**Default entrypoint client-only**

The default `gt-react` export now resolves to `index.server`, but that file starts with `'use client'` and exports hookful client/context components. Plain Node SSR, tests, and bundlers that do not set the `react-server` or `browser` condition will load a client-boundary entrypoint for `import { T, GTProvider, useGT } from 'gt-react'`. That can make server-side imports behave as client components or fail in environments that expected the root package to remain usable outside a client boundary.

### Issue 2 of 6
packages/react/src/index.client.ts:72-88
**Client initialize uses server**

The browser/client root exports `initializeGT` from `@generaltranslation/react-core/pure`, where `initializeGT` is the SRA/server-render initializer. A browser consumer importing `initializeGT` from `gt-react` under the `browser` condition will initialize the server-render runtime instead of the SPA runtime, so client cache/setup and missing-translation behavior can be configured for the wrong mode. The client entry should expose the SPA initializer as the root `initializeGT` value.

```suggestion
export {
  msg,
  decodeMsg,
  decodeOptions,
  derive,
  declareVar,
  decodeVars,
  mFallback,
  gtFallback,
  getFormatLocales,
  internalInitializeGTSPA as initializeGT,
  getDefaultLocale,
  getGTClass,
  getLocaleProperties,
  getLocales,
  getVersionId,
} from '@generaltranslation/react-core/pure';
```

### Issue 3 of 6
packages/react/src/internal.ts:172-194
**Preserve internal exports**

The `gt-react/internal` subpath is still exported, but this replacement only re-exports a small subset of the previous internal surface. Existing callers of names that were previously available from this subpath, such as `flattenDictionary`, `renderSkeleton`, `injectTranslations`, `injectFallbacks`, `collectUntranslatedEntries`, `getSubtree`, `addGTIdentifier`, `writeChildrenAsObjects`, and `injectHashes`, will now hit missing-export build or runtime errors even though `gt-react/internal` still resolves. Please keep forwarding the old internal surface from a valid entrypoint, or remove the subpath only as an explicit breaking migration.

### Issue 4 of 6
packages/react/src/internal.ts:113-118
**Array merge masks misses**

For array dictionaries, this now falls back to the default-locale entry when the locale dictionary has no value at the same index. The previous helper returned the locale value directly, so missing array entries stayed missing and could be detected by downstream translation handling. With this fallback, an untranslated array item can be silently replaced with default-locale content and reported as if it had a value.

### Issue 5 of 6
packages/compiler/src/utils/parsing/isStringTranslationTaggedTemplate.ts:31-36
**Old macro imports ignored**

The tagged-template detector now accepts only `t` imported from exactly `gt-react`. Existing projects that still contain `import { t } from 'gt-react/browser'` or `gt-react/client` during migration will have tagged template calls silently skipped by extraction/expansion instead of translated or reported. That can leave required strings out of generated translations. Keep the old sources recognized for diagnostics/migration, or emit a clear migration error rather than returning false.

### Issue 6 of 6
packages/react/src/index.rsc.ts:84-89
**Keep locale optional**

The previous `useLocaleDirection()` API allowed callers to omit the locale and used the current locale from context/request state. This RSC entrypoint now passes the argument directly to the GT class, so existing calls like `useLocaleDirection()` pass `undefined` and can return the wrong direction or throw instead of using the current request locale. Please keep the locale optional here and default it to `getLocale()` before calling the GT class.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: use allowed react-core entrypoints"](https://github.com/generaltranslation/gt/commit/3332c97584acdcc0ce443478df920f1d470eac4f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38217799)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->