### PR TITLE
fix: preserve save-local transform format

### DIFF
--- a/.changeset/fix-save-local-po-transform.md
+++ b/.changeset/fix-save-local-po-transform.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+Preserve transformed file format metadata when saving local edits for POT to PO outputs.

--- a/packages/cli/src/api/__tests__/collectUserEditDiffs.test.ts
+++ b/packages/cli/src/api/__tests__/collectUserEditDiffs.test.ts
@@ -191,6 +191,113 @@ describe('collectAndSendUserEditDiffs', () => {
     expect(gt.submitUserEditDiffs).toHaveBeenCalledTimes(1);
   });
 
+  it('submits transformed POT local edits with the translated PO format', async () => {
+    const settings = createMockSettings({
+      configDirectory: tempDir,
+      config: path.join(tempDir, 'gt.config.json'),
+      defaultLocale: 'en',
+      locales: ['de'],
+      _branchId: 'branch1',
+      files: {
+        resolvedPaths: {
+          pot: [path.join(tempDir, 'messages.pot')],
+        },
+        placeholderPaths: {
+          pot: [path.join(tempDir, 'messages.pot')],
+        },
+        transformPaths: {
+          pot: {
+            match: '^(.*)$',
+            replace: '{locale}.$1',
+          },
+        },
+        transformFormats: {
+          pot: 'PO',
+        },
+      },
+    });
+
+    const sourceContent = 'msgid "Save settings"\nmsgstr ""\n';
+    const serverContent =
+      'msgid "Save settings"\nmsgstr "Einstellungen speichern"\n';
+    const localContent =
+      'msgid "Save settings"\nmsgstr "Einstellungen sichern"\n';
+    fs.writeFileSync(path.join(tempDir, 'messages.pot'), sourceContent);
+    fs.writeFileSync(path.join(tempDir, 'de.messages.po'), localContent);
+
+    writeLockFile({
+      version: 1,
+      entries: {
+        branch1: {
+          file1: {
+            version1: {
+              de: {
+                updatedAt: new Date().toISOString(),
+                postProcessHash: hashStringSync(serverContent),
+              },
+            },
+          },
+        },
+      },
+    });
+
+    vi.mocked(gt.queryFileData).mockResolvedValue({
+      translatedFiles: [
+        {
+          branchId: 'branch1',
+          fileId: 'file1',
+          versionId: 'version1',
+          locale: 'de',
+          completedAt: new Date().toISOString(),
+        },
+      ],
+    });
+
+    vi.mocked(gt.downloadFileBatch).mockResolvedValue({
+      files: [
+        {
+          branchId: 'branch1',
+          fileId: 'file1',
+          versionId: 'version1',
+          locale: 'de',
+          data: serverContent,
+        },
+      ],
+    });
+
+    vi.mocked(getGitUnifiedDiff).mockResolvedValue('mock-diff');
+
+    const files: FileReference[] = [
+      {
+        fileName: 'messages.pot',
+        fileFormat: 'POT',
+        transformFormat: 'PO',
+        branchId: 'branch1',
+        fileId: 'file1',
+        versionId: 'version1',
+      },
+    ];
+
+    await collectAndSendUserEditDiffs(files, settings);
+
+    expect(getGitUnifiedDiff).toHaveBeenCalledWith(
+      expect.any(String),
+      'de.messages.po'
+    );
+    expect(gt.submitUserEditDiffs).toHaveBeenCalledWith({
+      diffs: [
+        expect.objectContaining({
+          fileName: 'messages.pot',
+          fileFormat: 'PO',
+          transformFormat: 'PO',
+          locale: 'de',
+          diff: 'mock-diff',
+          localContent,
+        }),
+      ],
+    });
+  });
+
   it('uses the latest downloaded version when the uploaded version has changed', async () => {
     const settings = buildSettings();
     const translatedPath = path.join(tempDir, 'docs', 'ja', 'doc.md');

--- a/packages/cli/src/api/collectUserEditDiffs.ts
+++ b/packages/cli/src/api/collectUserEditDiffs.ts
@@ -67,6 +67,7 @@ export async function collectAndSendUserEditDiffs(
   type DiffCandidate = {
     branchId: string;
     fileName: string;
+    transformFormat?: FileReference['transformFormat'];
     fileId: string;
     versionId: string;
     locale: string; // resolved
@@ -105,6 +106,7 @@ export async function collectAndSendUserEditDiffs(
       candidates.push({
         branchId: uploadedFile.branchId,
         fileName: uploadedFile.fileName,
+        transformFormat: uploadedFile.transformFormat,
         fileId: uploadedFile.fileId,
         versionId: latestDownloaded.versionId,
         locale: locale,
@@ -213,6 +215,12 @@ export async function collectAndSendUserEditDiffs(
 
           collectedDiffs.push({
             fileName: c.fileName,
+            ...(c.transformFormat
+              ? {
+                  fileFormat: c.transformFormat,
+                  transformFormat: c.transformFormat,
+                }
+              : {}),
             locale: c.locale,
             diff,
             branchId: c.branchId,

--- a/packages/cli/src/api/saveLocalEdits.ts
+++ b/packages/cli/src/api/saveLocalEdits.ts
@@ -36,6 +36,7 @@ export async function saveLocalEdits(settings: Settings): Promise<void> {
     branchId: branchResult.currentBranch.id,
     fileId: file.fileId,
     versionId: file.versionId,
+    transformFormat: file.transformFormat,
   })) satisfies FileReference[];
 
   const spinner = logger.createSpinner('dots');

--- a/packages/core/src/translate/submitUserEditDiffs.ts
+++ b/packages/core/src/translate/submitUserEditDiffs.ts
@@ -1,9 +1,12 @@
 import { TranslationRequestConfig } from '../types';
 import apiRequest from './utils/apiRequest';
 import { processBatches } from './utils/batch';
+import type { FileFormat } from '../types-dir/api/file';
 
 export type SubmitUserEditDiff = {
   fileName: string;
+  fileFormat?: FileFormat;
+  transformFormat?: FileFormat;
   locale: string;
   diff: string;
   branchId: string;


### PR DESCRIPTION
## Summary
- preserve transformed file format metadata when save-local submits user edit diffs
- add a regression test for POT sources transformed to PO outputs
- add a patch changeset for `gt` and `generaltranslation`

## Testing
- `pnpm --filter gt test src/api/__tests__/collectUserEditDiffs.test.ts`
- `pnpm --filter gt test`
- `pnpm --filter gt typecheck`
- `pnpm --filter generaltranslation typecheck`
- `pnpm --filter generaltranslation test`
- `pnpm lint`
- `pnpm format`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1613"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784327018&installation_id=127936663&pr_number=1613&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1613&signature=0135961b00d250b944083e994611f420483ecf948e20e26929c8d094e0513f1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Preserves transformed file format metadata when collecting and submitting save-local user edit diffs.
- Forwards optional `fileFormat` and `transformFormat` fields through the submit payload.
- Adds a regression test for POT sources transformed into PO local outputs.
- Adds patch changesets for `gt` and `generaltranslation`.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The change is mostly localized, but the save-local upload conversion still omits transform metadata needed by the new diff-submission path.

Focused coverage exists for the lower-level collection/submission behavior, and execution confirmed the remaining save-local conversion gap for transformed POT-to-PO edits.

packages/cli/src/api/saveLocalEdits.ts
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a focused Vitest repro that mocks aggregateFiles to return a POT aggregated file with transformFormat set to PO and intercepted the FileReference uploads passed to collectAndSendUserEditDiffs.
- The test output showed the aggregated file contained transformFormat: PO before saveLocalEdits mapped it, but the captured uploads object only included fileName, fileFormat, branchId, fileId, and versionId.
- Compared base and head runs; the head run invoked mocked submitUserEditDiffs with STATUS=200 OK and payload included fileFormat: PO, transformFormat: PO, locale: de, diff: mock-diff, and the de.messages.po localContent.

<a href="https://app.greptile.com/trex/runs/11455770/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: preserve save-local transform forma..."](https://github.com/generaltranslation/gt/commit/8b75a9a6b97e464b33a5fb0386e36bba5db10529) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38261532)</sub>

<!-- /greptile_comment -->