### PR TITLE
fix(6): use react-core valid entrypoints

### DIFF
--- a/packages/next/src/__tests__/rscLeaks.test.ts
+++ b/packages/next/src/__tests__/rscLeaks.test.ts
@@ -31,8 +31,6 @@ const workspaceSourceMap: Record<string, string> = {
   'gt-react': 'packages/react/src/index.rsc.ts',
   'gt-react/internal': 'packages/react/src/internal.ts',
   '@generaltranslation/react-core': 'packages/react-core/src/index.ts',
-  '@generaltranslation/react-core/internal':
-    'packages/react-core/src/internal.ts',
   '@generaltranslation/react-core/components-rsc':
     'packages/react-core/src/components-rsc.ts',
 };

--- a/packages/next/src/index.types.ts
+++ b/packages/next/src/index.types.ts
@@ -17,6 +17,7 @@ import {
   Var as _Var,
   Branch as _Branch,
   Plural as _Plural,
+  Derive as _Derive,
   useLocaleDirection as _useLocaleDirection,
   useVersionId as _useVersionId,
 } from 'gt-react';
@@ -47,7 +48,6 @@ import {
   declareVar,
   decodeVars,
   _Messages,
-  Derive as _Derive,
   mFallback,
   gtFallback,
 } from 'gt-react/internal';

--- a/packages/react-core-linter/src/rules/static-jsx/__tests__/edge-imports.test.ts
+++ b/packages/react-core-linter/src/rules/static-jsx/__tests__/edge-imports.test.ts
@@ -276,24 +276,24 @@ describe('edge-imports: Branch import added from gt-next', () => {
 });
 
 // ===================================================================
-// 10. Import from @generaltranslation/react-core
+// 10. Import from @generaltranslation/react-core/components
 // ===================================================================
 
-describe('edge-imports: Branch import added from @generaltranslation/react-core', () => {
+describe('edge-imports: Branch import added from @generaltranslation/react-core/components', () => {
   ruleTester.run('branch-from-react-core', staticJsx, {
     valid: [],
     invalid: [
       {
         code: `
-          import { T } from '@generaltranslation/react-core';
+          import { T } from '@generaltranslation/react-core/components';
           function Component({ cond }) {
             return <T>{cond ? "a" : "b"}</T>;
           }
         `,
-        options: [{ libs: ['@generaltranslation/react-core'] }],
+        options: [{ libs: ['@generaltranslation/react-core/components'] }],
         errors: [{ messageId: 'dynamicContent' }],
         output: `
-          import { T, Branch } from '@generaltranslation/react-core';
+          import { T, Branch } from '@generaltranslation/react-core/components';
           function Component({ cond }) {
             return <T><Branch branch={cond} true="a">b</Branch></T>;
           }
@@ -859,22 +859,22 @@ describe('edge-imports: Var import added from gt-react-native', () => {
   });
 });
 
-// Var from @generaltranslation/react-core
-describe('edge-imports: Var import added from @generaltranslation/react-core', () => {
+// Var from @generaltranslation/react-core/components
+describe('edge-imports: Var import added from @generaltranslation/react-core/components', () => {
   ruleTester.run('var-from-react-core', staticJsx, {
     valid: [],
     invalid: [
       {
         code: `
-          import { T } from '@generaltranslation/react-core';
+          import { T } from '@generaltranslation/react-core/components';
           function Component({ name }) {
             return <T>{name}</T>;
           }
         `,
-        options: [{ libs: ['@generaltranslation/react-core'] }],
+        options: [{ libs: ['@generaltranslation/react-core/components'] }],
         errors: [{ messageId: 'dynamicContent' }],
         output: `
-          import { T, Var } from '@generaltranslation/react-core';
+          import { T, Var } from '@generaltranslation/react-core/components';
           function Component({ name }) {
             return <T><Var>{name}</Var></T>;
           }

--- a/packages/react-core-linter/src/rules/static-jsx/__tests__/edge-logical.test.ts
+++ b/packages/react-core-linter/src/rules/static-jsx/__tests__/edge-logical.test.ts
@@ -1073,21 +1073,21 @@ describe('logical-and: AND with gt-next library', () => {
   });
 });
 
-describe('logical-and: AND with @generaltranslation/react-core library', () => {
+describe('logical-and: AND with @generaltranslation/react-core/components library', () => {
   ruleTester.run('and-react-core', staticJsx, {
     valid: [],
     invalid: [
       {
         code: `
-          import { T } from '@generaltranslation/react-core';
+          import { T } from '@generaltranslation/react-core/components';
           function Component({ x }) {
             return <T>{x && "text"}</T>;
           }
         `,
-        options: [{ libs: ['@generaltranslation/react-core'] }],
+        options: [{ libs: ['@generaltranslation/react-core/components'] }],
         errors: [{ messageId: 'dynamicContent' }],
         output: `
-          import { T, Branch } from '@generaltranslation/react-core';
+          import { T, Branch } from '@generaltranslation/react-core/components';
           function Component({ x }) {
             return <T><Branch branch={!!x} true="text" /></T>;
           }

--- a/packages/react-core-linter/src/rules/static-jsx/__tests__/edge-scope-nesting.test.ts
+++ b/packages/react-core-linter/src/rules/static-jsx/__tests__/edge-scope-nesting.test.ts
@@ -518,21 +518,21 @@ describe('edge: dynamic content in T from gt-next', () => {
   });
 });
 
-describe('edge: dynamic content in T from @generaltranslation/react-core', () => {
+describe('edge: dynamic content in T from @generaltranslation/react-core/components', () => {
   ruleTester.run('dynamic-in-T-react-core', staticJsx, {
     valid: [],
     invalid: [
       {
         code: `
-          import { T } from '@generaltranslation/react-core';
+          import { T } from '@generaltranslation/react-core/components';
           function Component({ cond }) {
             return <T>{cond ? "a" : "b"}</T>;
           }
         `,
-        options: [{ libs: ['@generaltranslation/react-core'] }],
+        options: [{ libs: ['@generaltranslation/react-core/components'] }],
         errors: [{ messageId: 'dynamicContent' }],
         output: `
-          import { T, Branch } from '@generaltranslation/react-core';
+          import { T, Branch } from '@generaltranslation/react-core/components';
           function Component({ cond }) {
             return <T><Branch branch={cond} true="a">b</Branch></T>;
           }

--- a/packages/react-core-linter/src/rules/static-jsx/__tests__/static-jsx-auto-import.test.ts
+++ b/packages/react-core-linter/src/rules/static-jsx/__tests__/static-jsx-auto-import.test.ts
@@ -52,15 +52,15 @@ describe('static-jsx auto-fix should add Var import', () => {
     invalid: [
       {
         code: `
-          import { T } from '@generaltranslation/react-core';
+          import { T } from '@generaltranslation/react-core/components';
           function Component({ name }) {
             return <T>{name}</T>;
           }
         `,
-        options: [{ libs: ['@generaltranslation/react-core'] }],
+        options: [{ libs: ['@generaltranslation/react-core/components'] }],
         errors: [{ messageId: 'dynamicContent' }],
         output: `
-          import { T, Var } from '@generaltranslation/react-core';
+          import { T, Var } from '@generaltranslation/react-core/components';
           function Component({ name }) {
             return <T><Var>{name}</Var></T>;
           }

--- a/packages/react-core-linter/src/rules/static-jsx/__tests__/static-jsx-branch-wrap.test.ts
+++ b/packages/react-core-linter/src/rules/static-jsx/__tests__/static-jsx-branch-wrap.test.ts
@@ -490,21 +490,21 @@ describe('static-jsx: Branch import added alongside existing specifiers', () => 
   });
 });
 
-describe('static-jsx: Branch import from @generaltranslation/react-core', () => {
+describe('static-jsx: Branch import from @generaltranslation/react-core/components', () => {
   ruleTester.run('branch-import-react-core', staticJsx, {
     valid: [],
     invalid: [
       {
         code: `
-          import { T } from '@generaltranslation/react-core';
+          import { T } from '@generaltranslation/react-core/components';
           function Component({ cond }) {
             return <T>{cond ? "a" : "b"}</T>;
           }
         `,
-        options: [{ libs: ['@generaltranslation/react-core'] }],
+        options: [{ libs: ['@generaltranslation/react-core/components'] }],
         errors: [{ messageId: 'dynamicContent' }],
         output: `
-          import { T, Branch } from '@generaltranslation/react-core';
+          import { T, Branch } from '@generaltranslation/react-core/components';
           function Component({ cond }) {
             return <T><Branch branch={cond} true="a">b</Branch></T>;
           }

--- a/packages/react-core-linter/src/rules/static-jsx/__tests__/static-jsx.test.ts
+++ b/packages/react-core-linter/src/rules/static-jsx/__tests__/static-jsx.test.ts
@@ -20,57 +20,57 @@ describe('static-jsx rule', () => {
       valid: [
         {
           code: `
-            import { T } from '@generaltranslation/react-core';
+            import { T } from '@generaltranslation/react-core/components';
             function Component() {
               return <T>Hello world</T>;
             }
           `,
-          options: [{ libs: ['@generaltranslation/react-core'] }],
+          options: [{ libs: ['@generaltranslation/react-core/components'] }],
         },
         {
           code: `
-            import { T } from '@generaltranslation/react-core';
+            import { T } from '@generaltranslation/react-core/components';
             function Component() {
               return <T>{"static string"}</T>;
             }
           `,
-          options: [{ libs: ['@generaltranslation/react-core'] }],
+          options: [{ libs: ['@generaltranslation/react-core/components'] }],
         },
         {
           code: `
-            import { T } from '@generaltranslation/react-core';
+            import { T } from '@generaltranslation/react-core/components';
             function Component() {
               return <T>{123}</T>;
             }
           `,
-          options: [{ libs: ['@generaltranslation/react-core'] }],
+          options: [{ libs: ['@generaltranslation/react-core/components'] }],
         },
         {
           code: `
-            import { T } from '@generaltranslation/react-core';
+            import { T } from '@generaltranslation/react-core/components';
             function Component() {
               return <T>{\`template literal\`}</T>;
             }
           `,
-          options: [{ libs: ['@generaltranslation/react-core'] }],
+          options: [{ libs: ['@generaltranslation/react-core/components'] }],
         },
       ],
       invalid: [
         {
           code: `
-            import { T } from '@generaltranslation/react-core';
+            import { T } from '@generaltranslation/react-core/components';
             function Component({ name }) {
               return <T>{name}</T>;
             }
           `,
-          options: [{ libs: ['@generaltranslation/react-core'] }],
+          options: [{ libs: ['@generaltranslation/react-core/components'] }],
           errors: [
             {
               messageId: 'dynamicContent',
             },
           ],
           output: `
-            import { T } from '@generaltranslation/react-core';
+            import { T } from '@generaltranslation/react-core/components';
             function Component({ name }) {
               return <T><Var>{name}</Var></T>;
             }
@@ -78,20 +78,20 @@ describe('static-jsx rule', () => {
         },
         {
           code: `
-            import { T } from '@generaltranslation/react-core';
+            import { T } from '@generaltranslation/react-core/components';
             function Component() {
               const variable = "dynamic";
               return <T>{variable}</T>;
             }
           `,
-          options: [{ libs: ['@generaltranslation/react-core'] }],
+          options: [{ libs: ['@generaltranslation/react-core/components'] }],
           errors: [
             {
               messageId: 'dynamicContent',
             },
           ],
           output: `
-            import { T } from '@generaltranslation/react-core';
+            import { T } from '@generaltranslation/react-core/components';
             function Component() {
               const variable = "dynamic";
               return <T><Var>{variable}</Var></T>;
@@ -100,19 +100,19 @@ describe('static-jsx rule', () => {
         },
         {
           code: `
-            import { T } from '@generaltranslation/react-core';
+            import { T } from '@generaltranslation/react-core/components';
             function Component() {
               return <T>{someFunction()}</T>;
             }
           `,
-          options: [{ libs: ['@generaltranslation/react-core'] }],
+          options: [{ libs: ['@generaltranslation/react-core/components'] }],
           errors: [
             {
               messageId: 'dynamicContent',
             },
           ],
           output: `
-            import { T } from '@generaltranslation/react-core';
+            import { T } from '@generaltranslation/react-core/components';
             function Component() {
               return <T><Var>{someFunction()}</Var></T>;
             }
@@ -120,12 +120,12 @@ describe('static-jsx rule', () => {
         },
         {
           code: `
-            import { T } from '@generaltranslation/react-core';
+            import { T } from '@generaltranslation/react-core/components';
             function Component({ user }) {
               return <T>{\`Hello \${user.name}\`}</T>;
             }
           `,
-          options: [{ libs: ['@generaltranslation/react-core'] }],
+          options: [{ libs: ['@generaltranslation/react-core/components'] }],
           errors: [
             {
               messageId: 'dynamicContent',
@@ -145,7 +145,7 @@ describe('static-jsx rule', () => {
               return <div>{name}</div>;
             }
           `,
-          options: [{ libs: ['@generaltranslation/react-core'] }],
+          options: [{ libs: ['@generaltranslation/react-core/components'] }],
         },
         {
           code: `
@@ -154,7 +154,7 @@ describe('static-jsx rule', () => {
               return <OtherComponent>{name}</OtherComponent>;
             }
           `,
-          options: [{ libs: ['@generaltranslation/react-core'] }],
+          options: [{ libs: ['@generaltranslation/react-core/components'] }],
         },
       ],
       invalid: [],
@@ -198,7 +198,7 @@ describe('static-jsx rule', () => {
       valid: [
         {
           code: `
-            import { T } from '@generaltranslation/react-core';
+            import { T } from '@generaltranslation/react-core/components';
             function Component() {
               return (
                 <div>
@@ -208,13 +208,13 @@ describe('static-jsx rule', () => {
               );
             }
           `,
-          options: [{ libs: ['@generaltranslation/react-core'] }],
+          options: [{ libs: ['@generaltranslation/react-core/components'] }],
         },
       ],
       invalid: [
         {
           code: `
-            import { T } from '@generaltranslation/react-core';
+            import { T } from '@generaltranslation/react-core/components';
             function Component({ name }) {
               return (
                 <div>
@@ -224,7 +224,7 @@ describe('static-jsx rule', () => {
               );
             }
           `,
-          options: [{ libs: ['@generaltranslation/react-core'] }],
+          options: [{ libs: ['@generaltranslation/react-core/components'] }],
           errors: [
             {
               messageId: 'dynamicContent',

--- a/packages/react-core-linter/src/rules/static-string/__tests__/static-string-icu-autofix.test.ts
+++ b/packages/react-core-linter/src/rules/static-string/__tests__/static-string-icu-autofix.test.ts
@@ -866,27 +866,27 @@ describe('static-string: chained ternary with different variables + dynamic var 
 });
 
 // ===================================================================
-// 16. @generaltranslation/react-core library support
+// 16. @generaltranslation/react-core/hooks library support
 // ===================================================================
 
-// gt("Hello " + name)  [via @generaltranslation/react-core]
+// gt("Hello " + name)  [via @generaltranslation/react-core/hooks]
 // → gt("Hello {var0}", { var0: name })
-describe('static-string: works with @generaltranslation/react-core imports', () => {
+describe('static-string: works with @generaltranslation/react-core/hooks imports', () => {
   ruleTester.run('react-core-lib', staticString, {
     valid: [],
     invalid: [
       {
         code: `
-          import { useGT } from '@generaltranslation/react-core';
+          import { useGT } from '@generaltranslation/react-core/hooks';
           function Component() {
             const gt = useGT();
             return gt("Hello " + name);
           }
         `,
-        options: [{ libs: ['@generaltranslation/react-core'] }],
+        options: [{ libs: ['@generaltranslation/react-core/hooks'] }],
         errors: [{ messageId: 'variableInterpolationRequired' }],
         output: `
-          import { useGT } from '@generaltranslation/react-core';
+          import { useGT } from '@generaltranslation/react-core/hooks';
           function Component() {
             const gt = useGT();
             return gt("Hello {var0}", { var0: name });

--- a/packages/react-core-linter/src/rules/static-string/__tests__/static-string.test.ts
+++ b/packages/react-core-linter/src/rules/static-string/__tests__/static-string.test.ts
@@ -24,40 +24,48 @@ describe('static-string rule', () => {
               return <div>Hello world</div>;
             }
           `,
-          options: [{ libs: ['@generaltranslation/react-core'] }],
+          options: [{ libs: ['@generaltranslation/react-core/hooks'] }],
         },
         {
           code: `
-            import { useGT } from '@generaltranslation/react-core';
+            import { useGT } from '@generaltranslation/react-core/hooks';
             function Component() {
               const gt = useGT();
               return gt("Hello world");
             }
           `,
-          options: [{ libs: ['@generaltranslation/react-core'] }],
+          options: [{ libs: ['@generaltranslation/react-core/hooks'] }],
         },
         {
           code: `
-            import { useGT, derive } from '@generaltranslation/react-core';
+            import { useGT } from '@generaltranslation/react-core/hooks';
+            import { derive } from '@generaltranslation/react-core/pure';
             function Component() {
               const gt = useGT();
               return gt("Hello " + derive("world"));
             }
           `,
-          options: [{ libs: ['@generaltranslation/react-core'] }],
+          options: [
+            {
+              libs: [
+                '@generaltranslation/react-core/hooks',
+                '@generaltranslation/react-core/pure',
+              ],
+            },
+          ],
         },
       ],
       invalid: [
         {
           code: `
-            import { useGT } from '@generaltranslation/react-core';
+            import { useGT } from '@generaltranslation/react-core/hooks';
             function Component() {
               const gt = useGT();
               const name = "World";
               return gt("Hello " + name);
             }
           `,
-          options: [{ libs: ['@generaltranslation/react-core'] }],
+          options: [{ libs: ['@generaltranslation/react-core/hooks'] }],
           errors: [
             {
               messageId: 'variableInterpolationRequired',
@@ -66,14 +74,14 @@ describe('static-string rule', () => {
         },
         {
           code: `
-            import { useGT } from '@generaltranslation/react-core';
+            import { useGT } from '@generaltranslation/react-core/hooks';
             function Component() {
               const gt = useGT();
               const name = "World";
               return gt(\`Hello \${name}!\`);
             }
           `,
-          options: [{ libs: ['@generaltranslation/react-core'] }],
+          options: [{ libs: ['@generaltranslation/react-core/hooks'] }],
           errors: [
             {
               messageId: 'variableInterpolationRequired',
@@ -138,13 +146,21 @@ describe('static-string rule', () => {
       valid: [
         {
           code: `
-            import { useGT, derive } from '@generaltranslation/react-core';
+            import { useGT } from '@generaltranslation/react-core/hooks';
+            import { derive } from '@generaltranslation/react-core/pure';
             function Component() {
               const gt = useGT();
               return gt("Hello " + derive("world"));
             }
           `,
-          options: [{ libs: ['@generaltranslation/react-core'] }],
+          options: [
+            {
+              libs: [
+                '@generaltranslation/react-core/hooks',
+                '@generaltranslation/react-core/pure',
+              ],
+            },
+          ],
         },
       ],
       invalid: [],
@@ -157,13 +173,13 @@ describe('static-string rule', () => {
       invalid: [
         {
           code: `
-            import { useGT } from '@generaltranslation/react-core';
+            import { useGT } from '@generaltranslation/react-core/hooks';
             function Component() {
               const gt = useGT();
               return gt(["Hello", "World"]);
             }
           `,
-          options: [{ libs: ['@generaltranslation/react-core'] }],
+          options: [{ libs: ['@generaltranslation/react-core/hooks'] }],
           errors: [
             {
               messageId: 'staticStringRequired',

--- a/packages/react-core-linter/src/utils/constants.ts
+++ b/packages/react-core-linter/src/utils/constants.ts
@@ -5,7 +5,10 @@ export const GT_LIBRARIES = [
   'gt-next',
   'gt-react-native',
   'gt-i18n',
-  '@generaltranslation/react-core',
+  '@generaltranslation/react-core/components',
+  '@generaltranslation/react-core/components-rsc',
+  '@generaltranslation/react-core/hooks',
+  '@generaltranslation/react-core/pure',
 ];
 
 export type GTLibrary = (typeof GT_LIBRARIES)[number];

--- a/packages/react-core/src/components-rsc.ts
+++ b/packages/react-core/src/components-rsc.ts
@@ -40,6 +40,12 @@ export { getShouldTranslate } from './hooks/utils/getShouldTranslate';
 export { prepareT } from './utils/translation/prepareT.shared';
 export { createRenderVariable } from './utils/rendering/createRenderVariable';
 export { createRenderPipeline } from './utils/rendering/createRenderPipeline';
+export type {
+  RenderDefaultChildrenArgs,
+  RenderPipeline,
+  RenderPreparedTParams,
+  RenderTranslatedChildrenArgs,
+} from './utils/rendering/createRenderPipeline';
 // Pre-instantiated RSC render pipeline: bound to the RSC renderVariable, so
 // consumers never thread a variable renderer through rendering calls.
 export {

--- a/packages/react-core/src/components.ts
+++ b/packages/react-core/src/components.ts
@@ -15,3 +15,6 @@ export {
 export { GtInternalVar, Var } from './components/variables/Var';
 export { InternalLocaleSelector } from './components/helpers/InternalLocaleSelector';
 export { InternalRegionSelector } from './components/helpers/InternalRegionSelector';
+export { InternalGTProvider } from './context/InternalGTProvider';
+export type { InternalGTProviderProps } from './context/InternalGTProvider';
+export { I18nStore } from './i18n-store/I18nStore';

--- a/packages/react-core/src/deprecated/__tests__/react-core-package.test.ts
+++ b/packages/react-core/src/deprecated/__tests__/react-core-package.test.ts
@@ -138,7 +138,6 @@ describe('@generaltranslation/react-core package exports', () => {
       `
           const assert = require('node:assert/strict');
           const reactCore = require('@generaltranslation/react-core');
-          const internal = require('@generaltranslation/react-core/internal');
           const errors = require('@generaltranslation/react-core/errors');
           const pure = require('@generaltranslation/react-core/pure');
           const components = require('@generaltranslation/react-core/components');
@@ -147,7 +146,6 @@ describe('@generaltranslation/react-core package exports', () => {
 
           assert.equal(typeof reactCore.GTProvider, 'function');
           assert.equal(typeof reactCore.T, 'function');
-          assert.equal(typeof internal.renderDefaultChildren, 'function');
           assert.equal(typeof errors.createUnsupportedLocaleWarning, 'function');
           assert.equal(typeof pure.msg, 'function');
           assert.equal(typeof components.T, 'function');
@@ -164,7 +162,6 @@ describe('@generaltranslation/react-core package exports', () => {
       `
           import assert from 'node:assert/strict';
           import { GTProvider, T } from '@generaltranslation/react-core';
-          import { renderDefaultChildren } from '@generaltranslation/react-core/internal';
           import { createUnsupportedLocaleWarning } from '@generaltranslation/react-core/errors';
           import { msg } from '@generaltranslation/react-core/pure';
           import { T as ComponentsT } from '@generaltranslation/react-core/components';
@@ -173,7 +170,6 @@ describe('@generaltranslation/react-core package exports', () => {
 
           assert.equal(typeof GTProvider, 'function');
           assert.equal(typeof T, 'function');
-          assert.equal(typeof renderDefaultChildren, 'function');
           assert.equal(typeof createUnsupportedLocaleWarning, 'function');
           assert.equal(typeof msg, 'function');
           assert.equal(typeof ComponentsT, 'function');

--- a/packages/react-core/src/pure.ts
+++ b/packages/react-core/src/pure.ts
@@ -14,6 +14,11 @@ export {
 } from 'gt-i18n';
 
 export { default as getPluralBranch } from './utils/plurals/getPluralBranch';
+export { default as addGTIdentifier } from './utils/internal/addGTIdentifier';
+export { default as writeChildrenAsObjects } from './utils/internal/writeChildrenAsObjects';
+export { default as flattenDictionary } from './utils/dictionaries/flattenDictionary';
+export { default as getVariableProps } from './utils/variables/_getVariableProps';
+export { default as getVariableName } from './utils/variables/getVariableName';
 export { getFormatLocales } from './hooks/utils/getFormatLocales';
 export { getTranslationsSnapshot } from './functions/helpers/getTranslationsSnapshot';
 export { t } from './functions/translation/t';
@@ -24,8 +29,61 @@ export {
   getReactI18nCache,
   setReactI18nCache,
 } from './i18n-cache/singleton-operations';
+export {
+  defaultEnableI18nCookieName,
+  defaultLocaleCookieName,
+  defaultRegionCookieName,
+} from './utils/cookies';
+export {
+  getDictionaryEntry,
+  isValidDictionaryEntry,
+} from './utils/dictionaries/getDictionaryEntry';
+export { default as getEntryAndMetadata } from './utils/dictionaries/getEntryAndMetadata';
+export { default as isVariableObject } from './utils/rendering/isVariableObject';
+export { default as renderSkeleton } from './utils/rendering/renderSkeleton';
+export { default as mergeDictionaries } from './utils/dictionaries/mergeDictionaries';
+export { getDefaultRenderSettings } from './utils/rendering/getDefaultRenderSettings';
+export { reactHasUse } from './utils/promises/reactHasUse';
+export {
+  getSubtree,
+  getSubtreeWithCreation,
+} from './utils/dictionaries/getSubtree';
+export { injectEntry } from './utils/dictionaries/injectEntry';
+export { isDictionaryEntry } from './utils/dictionaries/isDictionaryEntry';
+export { stripMetadataFromEntries } from './utils/dictionaries/stripMetadataFromEntries';
+export { injectHashes } from './utils/dictionaries/injectHashes';
+export { injectTranslations } from './utils/dictionaries/injectTranslations';
+export { injectFallbacks } from './utils/dictionaries/injectFallbacks';
+export { injectAndMerge } from './utils/dictionaries/injectAndMerge';
+export { collectUntranslatedEntries } from './utils/dictionaries/collectUntranslatedEntries';
 
-export type { RelativeTimeFormatOptions, RenderVariable } from './utils/types';
+export type {
+  AuthFromEnvParams,
+  AuthFromEnvReturn,
+  CustomLoader,
+  Dictionary,
+  DictionaryContent,
+  DictionaryEntry,
+  DictionaryObject,
+  DictionaryTranslationOptions,
+  Entry,
+  FlattenedDictionary,
+  GTFunctionType,
+  GTProp,
+  InlineTranslationOptions,
+  LocalesDictionary,
+  MFunctionType,
+  Metadata,
+  RenderMethod,
+  RuntimeTranslationOptions,
+  TranslatedChildren,
+  Translations,
+  VariableProps,
+  _Message,
+  _Messages,
+  RelativeTimeFormatOptions,
+  RenderVariable,
+} from './utils/types';
 
 export {
   internalInitializeGTSRA,
@@ -37,7 +95,39 @@ export {
   ReactI18nCache,
   type ReactI18nCacheParams,
 } from './i18n-cache/ReactI18nCache';
-
+export {
+  getI18nStore,
+  setI18nStore,
+  isI18nStoreInitialized,
+} from './i18n-store/singleton-operations';
+export { I18nStore } from './i18n-store/I18nStore';
+export {
+  getI18nConfig,
+  initializeI18nConfig,
+  ReactI18nConfig,
+  setI18nConfig,
+} from './setup/i18nConfig';
+export {
+  getReadonlyConditionStoreWithFallback,
+  setReadonlyConditionStore,
+} from './condition-store/singleton-operations';
+export {
+  ReadonlyConditionStore,
+  WritableConditionStore,
+} from 'gt-i18n/internal';
+export type {
+  I18nConfigParams,
+  WritableConditionStoreParams,
+} from 'gt-i18n/internal/types';
+export type {
+  OnMissingDictionaryObj,
+  OnMissingDictionaryEntry,
+  OnMissingTranslation,
+} from './hooks/utils/missing-translation';
+export type {
+  DictionaryLookup,
+  TranslateLookup,
+} from './i18n-store/storeTypes';
 export {
   getDefaultLocale,
   getGTClass,

--- a/packages/react-core/src/utils/cookies.ts
+++ b/packages/react-core/src/utils/cookies.ts
@@ -1,0 +1,14 @@
+/**
+ * Cookie name for tracking the user's selected locale.
+ */
+export const defaultLocaleCookieName = 'generaltranslation.locale';
+
+/**
+ * Cookie name for tracking the user's selected region.
+ */
+export const defaultRegionCookieName = 'generaltranslation.region';
+
+/**
+ * Cookie name for persisting the enableI18n feature flag.
+ */
+export const defaultEnableI18nCookieName = 'generaltranslation.enable-i18n';

--- a/packages/react-core/src/utils/dictionaries/__tests__/collectUntranslatedEntries.test.ts
+++ b/packages/react-core/src/utils/dictionaries/__tests__/collectUntranslatedEntries.test.ts
@@ -1,0 +1,424 @@
+import { describe, it, expect } from 'vitest';
+import { collectUntranslatedEntries } from '../collectUntranslatedEntries';
+import { Dictionary } from '../../types';
+
+describe('collectUntranslatedEntries', () => {
+  describe('should collect simple untranslated entries', () => {
+    it('should return untranslated entry when key missing from translations', () => {
+      const dictionary: Dictionary = {
+        greeting: 'Hello world',
+      };
+      const translations: Dictionary = {};
+
+      const result = collectUntranslatedEntries(dictionary, translations);
+
+      expect(result).toEqual([
+        {
+          source: 'Hello world',
+          metadata: {
+            $id: 'greeting',
+            $context: undefined,
+            $_hash: '',
+          },
+        },
+      ]);
+    });
+
+    it('should return empty array when all entries are translated', () => {
+      const dictionary: Dictionary = {
+        greeting: 'Hello world',
+        farewell: 'Goodbye',
+      };
+      const translations: Dictionary = {
+        greeting: 'Hola mundo',
+        farewell: 'Adiós',
+      };
+
+      const result = collectUntranslatedEntries(dictionary, translations);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should collect multiple untranslated entries', () => {
+      const dictionary: Dictionary = {
+        greeting: 'Hello world',
+        farewell: 'Goodbye',
+        welcome: 'Welcome',
+      };
+      const translations: Dictionary = {
+        greeting: 'Hola mundo',
+      };
+
+      const result = collectUntranslatedEntries(dictionary, translations);
+
+      expect(result).toEqual([
+        {
+          source: 'Goodbye',
+          metadata: {
+            $id: 'farewell',
+            $context: undefined,
+            $_hash: '',
+          },
+        },
+        {
+          source: 'Welcome',
+          metadata: {
+            $id: 'welcome',
+            $context: undefined,
+            $_hash: '',
+          },
+        },
+      ]);
+    });
+  });
+
+  describe('should handle array-based dictionary entries', () => {
+    it('should collect untranslated entry with metadata', () => {
+      const dictionary: Dictionary = {
+        greeting: [
+          'Hello {name}',
+          { $context: 'personal-greeting', $_hash: 'abc123' },
+        ],
+      };
+      const translations: Dictionary = {};
+
+      const result = collectUntranslatedEntries(dictionary, translations);
+
+      expect(result).toEqual([
+        {
+          source: 'Hello {name}',
+          metadata: {
+            $id: 'greeting',
+            $context: 'personal-greeting',
+            $_hash: 'abc123',
+          },
+        },
+      ]);
+    });
+
+    it('should collect untranslated entry with partial metadata', () => {
+      const dictionary: Dictionary = {
+        greeting: ['Hello world', { $context: 'greeting' }],
+      };
+      const translations: Dictionary = {};
+
+      const result = collectUntranslatedEntries(dictionary, translations);
+
+      expect(result).toEqual([
+        {
+          source: 'Hello world',
+          metadata: {
+            $id: 'greeting',
+            $context: 'greeting',
+            $_hash: '',
+          },
+        },
+      ]);
+    });
+
+    it('should handle array entry without metadata', () => {
+      const dictionary: Dictionary = {
+        greeting: ['Hello world'],
+      };
+      const translations: Dictionary = {};
+
+      const result = collectUntranslatedEntries(dictionary, translations);
+
+      expect(result).toEqual([
+        {
+          source: 'Hello world',
+          metadata: {
+            $id: 'greeting',
+            $context: undefined,
+            $_hash: '',
+          },
+        },
+      ]);
+    });
+  });
+
+  describe('should handle nested dictionaries', () => {
+    it('should collect untranslated entries from nested structure', () => {
+      const dictionary: Dictionary = {
+        user: {
+          profile: {
+            name: 'Name',
+            bio: 'Biography',
+          },
+        },
+        settings: {
+          theme: 'Theme',
+        },
+      };
+      const translations: Dictionary = {
+        user: {
+          profile: {
+            name: 'Nombre',
+          },
+        },
+      };
+
+      const result = collectUntranslatedEntries(dictionary, translations);
+
+      expect(result).toEqual([
+        {
+          source: 'Biography',
+          metadata: {
+            $id: 'user.profile.bio',
+            $context: undefined,
+            $_hash: '',
+          },
+        },
+        {
+          source: 'Theme',
+          metadata: {
+            $id: 'settings.theme',
+            $context: undefined,
+            $_hash: '',
+          },
+        },
+      ]);
+    });
+
+    it('should handle deeply nested structures', () => {
+      const dictionary: Dictionary = {
+        app: {
+          nav: {
+            menu: {
+              items: {
+                home: 'Home',
+                about: 'About',
+              },
+            },
+          },
+        },
+      };
+      const translations: Dictionary = {
+        app: {
+          nav: {
+            menu: {
+              items: {
+                home: 'Inicio',
+              },
+            },
+          },
+        },
+      };
+
+      const result = collectUntranslatedEntries(dictionary, translations);
+
+      expect(result).toEqual([
+        {
+          source: 'About',
+          metadata: {
+            $id: 'app.nav.menu.items.about',
+            $context: undefined,
+            $_hash: '',
+          },
+        },
+      ]);
+    });
+
+    it('should handle missing nested translation structure', () => {
+      const dictionary: Dictionary = {
+        user: {
+          name: 'Name',
+          email: 'Email',
+        },
+      };
+      const translations: Dictionary = {};
+
+      const result = collectUntranslatedEntries(dictionary, translations);
+
+      expect(result).toEqual([
+        {
+          source: 'Name',
+          metadata: {
+            $id: 'user.name',
+            $context: undefined,
+            $_hash: '',
+          },
+        },
+        {
+          source: 'Email',
+          metadata: {
+            $id: 'user.email',
+            $context: undefined,
+            $_hash: '',
+          },
+        },
+      ]);
+    });
+  });
+
+  describe('should handle mixed entry types', () => {
+    it('should handle mix of strings and arrays in nested structure', () => {
+      const dictionary: Dictionary = {
+        messages: {
+          greeting: 'Hello',
+          welcome: ['Welcome {name}', { $context: 'personalized' }],
+          info: {
+            title: 'Information',
+            content: ['Important notice', { $_hash: 'def456' }],
+          },
+        },
+      };
+      const translations: Dictionary = {
+        messages: {
+          greeting: 'Hola',
+        },
+      };
+
+      const result = collectUntranslatedEntries(dictionary, translations);
+
+      expect(result).toEqual([
+        {
+          source: 'Welcome {name}',
+          metadata: {
+            $id: 'messages.welcome',
+            $context: 'personalized',
+            $_hash: '',
+          },
+        },
+        {
+          source: 'Information',
+          metadata: {
+            $id: 'messages.info.title',
+            $context: undefined,
+            $_hash: '',
+          },
+        },
+        {
+          source: 'Important notice',
+          metadata: {
+            $id: 'messages.info.content',
+            $context: undefined,
+            $_hash: 'def456',
+          },
+        },
+      ]);
+    });
+  });
+
+  describe('should handle custom id parameter', () => {
+    it('should use custom id as prefix for entry ids', () => {
+      const dictionary: Dictionary = {
+        greeting: 'Hello',
+        farewell: 'Goodbye',
+      };
+      const translations: Dictionary = {};
+
+      const result = collectUntranslatedEntries(
+        dictionary,
+        translations,
+        'custom'
+      );
+
+      expect(result).toEqual([
+        {
+          source: 'Hello',
+          metadata: {
+            $id: 'custom.greeting',
+            $context: undefined,
+            $_hash: '',
+          },
+        },
+        {
+          source: 'Goodbye',
+          metadata: {
+            $id: 'custom.farewell',
+            $context: undefined,
+            $_hash: '',
+          },
+        },
+      ]);
+    });
+
+    it('should handle nested structure with custom id', () => {
+      const dictionary: Dictionary = {
+        user: {
+          name: 'Name',
+        },
+      };
+      const translations: Dictionary = {};
+
+      const result = collectUntranslatedEntries(
+        dictionary,
+        translations,
+        'app'
+      );
+
+      expect(result).toEqual([
+        {
+          source: 'Name',
+          metadata: {
+            $id: 'app.user.name',
+            $context: undefined,
+            $_hash: '',
+          },
+        },
+      ]);
+    });
+  });
+
+  describe('should handle edge cases', () => {
+    it('should handle empty dictionaries', () => {
+      const dictionary: Dictionary = {};
+      const translations: Dictionary = {};
+
+      const result = collectUntranslatedEntries(dictionary, translations);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should handle empty source dictionary with translations', () => {
+      const dictionary: Dictionary = {};
+      const translations: Dictionary = {
+        greeting: 'Hello',
+      };
+
+      const result = collectUntranslatedEntries(dictionary, translations);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should handle mixed translated and untranslated nested entries', () => {
+      const dictionary: Dictionary = {
+        section1: {
+          item1: 'Item 1',
+          item2: 'Item 2',
+        },
+        section2: {
+          item3: 'Item 3',
+        },
+      };
+      const translations: Dictionary = {
+        section1: {
+          item1: 'Artículo 1',
+        },
+        section2: {},
+      };
+
+      const result = collectUntranslatedEntries(dictionary, translations);
+
+      expect(result).toEqual([
+        {
+          source: 'Item 2',
+          metadata: {
+            $id: 'section1.item2',
+            $context: undefined,
+            $_hash: '',
+          },
+        },
+        {
+          source: 'Item 3',
+          metadata: {
+            $id: 'section2.item3',
+            $context: undefined,
+            $_hash: '',
+          },
+        },
+      ]);
+    });
+  });
+});

--- a/packages/react-core/src/utils/dictionaries/__tests__/getDictionaryEntry.test.ts
+++ b/packages/react-core/src/utils/dictionaries/__tests__/getDictionaryEntry.test.ts
@@ -1,0 +1,282 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isValidDictionaryEntry,
+  getDictionaryEntry,
+} from '../getDictionaryEntry';
+import { Dictionary } from '../../types';
+
+describe('isValidDictionaryEntry', () => {
+  describe('should return true for valid DictionaryEntry types', () => {
+    it('should return true for string values', () => {
+      expect(isValidDictionaryEntry('Hello World')).toBe(true);
+      expect(isValidDictionaryEntry('')).toBe(true);
+      expect(isValidDictionaryEntry('Complex string with {variables}')).toBe(
+        true
+      );
+    });
+
+    it('should return true for valid single-element arrays', () => {
+      expect(isValidDictionaryEntry(['Hello World'])).toBe(true);
+      expect(isValidDictionaryEntry([''])).toBe(true);
+    });
+
+    it('should return true for valid two-element arrays with metadata', () => {
+      expect(isValidDictionaryEntry(['Hello', { $context: 'greeting' }])).toBe(
+        true
+      );
+      expect(isValidDictionaryEntry(['Text', {}])).toBe(true);
+      expect(
+        isValidDictionaryEntry(['Text', { $context: 'test', $id: 'test_id' }])
+      ).toBe(true);
+    });
+  });
+
+  describe('should return false for invalid types', () => {
+    it('should return false for non-string, non-array values', () => {
+      expect(isValidDictionaryEntry(42)).toBe(false);
+      expect(isValidDictionaryEntry(true)).toBe(false);
+      expect(isValidDictionaryEntry(false)).toBe(false);
+      expect(isValidDictionaryEntry(null)).toBe(false);
+      expect(isValidDictionaryEntry(undefined)).toBe(false);
+      expect(isValidDictionaryEntry({})).toBe(false);
+    });
+
+    it('should return false for arrays with non-string first element', () => {
+      expect(isValidDictionaryEntry([42, {}])).toBe(false);
+      expect(isValidDictionaryEntry([true, { $context: 'test' }])).toBe(false);
+      expect(isValidDictionaryEntry([null, {}])).toBe(false);
+      expect(isValidDictionaryEntry([undefined, {}])).toBe(false);
+      expect(isValidDictionaryEntry([[], {}])).toBe(false);
+      expect(isValidDictionaryEntry([{}, {}])).toBe(false);
+    });
+
+    it('should return false for arrays with more than 2 elements', () => {
+      // Note: The current implementation doesn't explicitly check array length > 2
+      // It only checks if first element is string and second is object/undefined
+      // Arrays with 3+ elements will pass if conditions are met
+      expect(isValidDictionaryEntry(['text', {}, 'extra'])).toBe(true); // This passes because conditions are met
+      expect(
+        isValidDictionaryEntry(['text', { $context: 'test' }, 'extra', 'more'])
+      ).toBe(true); // This passes too
+    });
+
+    it('should return false for arrays with non-object second element', () => {
+      expect(isValidDictionaryEntry(['text', 'not-object'])).toBe(false);
+      expect(isValidDictionaryEntry(['text', 42])).toBe(false);
+      expect(isValidDictionaryEntry(['text', true])).toBe(false);
+      // Note: Arrays are objects in JavaScript, so [] passes the object check
+      expect(isValidDictionaryEntry(['text', []])).toBe(true); // This actually passes
+    });
+
+    it('should return false for empty arrays', () => {
+      expect(isValidDictionaryEntry([])).toBe(false);
+    });
+  });
+});
+
+describe('getDictionaryEntry', () => {
+  const mockDictionary: Dictionary = {
+    greeting: 'Hello',
+    user: {
+      name: 'John Doe',
+      profile: {
+        bio: 'Software developer',
+        location: 'New York',
+        details: {
+          age: 'Twenty-five',
+          hobby: ['Gaming', { $context: 'hobby' }],
+        },
+      },
+    },
+    messages: {
+      welcome: ['Welcome back', { $context: 'greeting' }],
+      farewell: 'Goodbye',
+    },
+    arrayEntry: ['Simple array entry'],
+  };
+
+  describe('should return correct values for valid paths', () => {
+    it('should return top-level string entry', () => {
+      const result = getDictionaryEntry(mockDictionary, 'greeting');
+      expect(result).toBe('Hello');
+    });
+
+    it('should return top-level array entry', () => {
+      const result = getDictionaryEntry(mockDictionary, 'arrayEntry');
+      expect(result).toEqual(['Simple array entry']);
+    });
+
+    it('should return nested dictionary', () => {
+      const result = getDictionaryEntry(mockDictionary, 'user');
+      expect(result).toEqual({
+        name: 'John Doe',
+        profile: {
+          bio: 'Software developer',
+          location: 'New York',
+          details: {
+            age: 'Twenty-five',
+            hobby: ['Gaming', { $context: 'hobby' }],
+          },
+        },
+      });
+    });
+
+    it('should return nested string entry', () => {
+      const result = getDictionaryEntry(mockDictionary, 'user.name');
+      expect(result).toBe('John Doe');
+    });
+
+    it('should return deeply nested dictionary', () => {
+      const result = getDictionaryEntry(mockDictionary, 'user.profile');
+      expect(result).toEqual({
+        bio: 'Software developer',
+        location: 'New York',
+        details: {
+          age: 'Twenty-five',
+          hobby: ['Gaming', { $context: 'hobby' }],
+        },
+      });
+    });
+
+    it('should return deeply nested string entry', () => {
+      const result = getDictionaryEntry(mockDictionary, 'user.profile.bio');
+      expect(result).toBe('Software developer');
+    });
+
+    it('should return very deeply nested entry', () => {
+      const result = getDictionaryEntry(
+        mockDictionary,
+        'user.profile.details.age'
+      );
+      expect(result).toBe('Twenty-five');
+    });
+
+    it('should return array entry with metadata from nested path', () => {
+      const result = getDictionaryEntry(mockDictionary, 'messages.welcome');
+      expect(result).toEqual(['Welcome back', { $context: 'greeting' }]);
+    });
+
+    it('should return deeply nested array entry', () => {
+      const result = getDictionaryEntry(
+        mockDictionary,
+        'user.profile.details.hobby'
+      );
+      expect(result).toEqual(['Gaming', { $context: 'hobby' }]);
+    });
+  });
+
+  describe('should return undefined for invalid paths', () => {
+    it('should return undefined for non-existent top-level key', () => {
+      const result = getDictionaryEntry(mockDictionary, 'nonexistent');
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined for non-existent nested key', () => {
+      const result = getDictionaryEntry(mockDictionary, 'user.nonexistent');
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined for deeply non-existent nested key', () => {
+      const result = getDictionaryEntry(
+        mockDictionary,
+        'user.profile.nonexistent'
+      );
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined when trying to access property of string value', () => {
+      const result = getDictionaryEntry(mockDictionary, 'greeting.invalid');
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined when trying to access property of array value', () => {
+      const result = getDictionaryEntry(mockDictionary, 'arrayEntry.invalid');
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined for completely invalid path', () => {
+      const result = getDictionaryEntry(mockDictionary, 'a.b.c.d.e.f.g');
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('should handle edge cases', () => {
+    it('should handle empty string id', () => {
+      const result = getDictionaryEntry(mockDictionary, '');
+      // Note: The implementation splits empty string and iterates over [''],
+      // so it looks for dictionary[''] which doesn't exist
+      expect(result).toBeUndefined();
+    });
+
+    it('should handle empty dictionary', () => {
+      const emptyDict: Dictionary = {};
+      const result = getDictionaryEntry(emptyDict, 'any');
+      expect(result).toBeUndefined();
+    });
+
+    it('should handle single character keys', () => {
+      const dictWithSingleChar: Dictionary = {
+        a: 'value a',
+        b: {
+          c: 'value c',
+        },
+      };
+
+      expect(getDictionaryEntry(dictWithSingleChar, 'a')).toBe('value a');
+      expect(getDictionaryEntry(dictWithSingleChar, 'b.c')).toBe('value c');
+    });
+
+    it('should handle keys with special characters', () => {
+      const specialKeysDict: Dictionary = {
+        'key-with-dashes': 'dash value',
+        key_with_underscores: 'underscore value',
+        'key with spaces': {
+          'nested-key': 'nested value',
+        },
+      };
+
+      expect(getDictionaryEntry(specialKeysDict, 'key-with-dashes')).toBe(
+        'dash value'
+      );
+      expect(getDictionaryEntry(specialKeysDict, 'key_with_underscores')).toBe(
+        'underscore value'
+      );
+      expect(
+        getDictionaryEntry(specialKeysDict, 'key with spaces.nested-key')
+      ).toBe('nested value');
+    });
+
+    it('should handle numeric string keys', () => {
+      const numericKeysDict: Dictionary = {
+        '0': 'zero',
+        '123': {
+          '456': 'nested numeric',
+        },
+      };
+
+      expect(getDictionaryEntry(numericKeysDict, '0')).toBe('zero');
+      expect(getDictionaryEntry(numericKeysDict, '123.456')).toBe(
+        'nested numeric'
+      );
+    });
+
+    it('should handle paths with multiple dots correctly', () => {
+      const result = getDictionaryEntry(
+        mockDictionary,
+        'user.profile.details.age'
+      );
+      expect(result).toBe('Twenty-five');
+    });
+  });
+
+  describe('should not mutate original dictionary', () => {
+    it('should not modify the original dictionary', () => {
+      const originalDict = JSON.parse(JSON.stringify(mockDictionary));
+
+      getDictionaryEntry(mockDictionary, 'user.profile.bio');
+      getDictionaryEntry(mockDictionary, 'nonexistent.path');
+
+      expect(mockDictionary).toEqual(originalDict);
+    });
+  });
+});

--- a/packages/react-core/src/utils/dictionaries/__tests__/getEntryAndMetadata.test.ts
+++ b/packages/react-core/src/utils/dictionaries/__tests__/getEntryAndMetadata.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect } from 'vitest';
+import getEntryAndMetadata from '../getEntryAndMetadata';
+import { DictionaryEntry } from '../../types';
+
+describe('getEntryAndMetadata', () => {
+  describe('should handle string entries', () => {
+    it('should return string entry without metadata', () => {
+      const value: DictionaryEntry = 'Hello World';
+
+      const result = getEntryAndMetadata(value);
+
+      expect(result).toEqual({
+        entry: 'Hello World',
+      });
+    });
+
+    it('should handle empty string', () => {
+      const value: DictionaryEntry = '';
+
+      const result = getEntryAndMetadata(value);
+
+      expect(result).toEqual({
+        entry: '',
+      });
+    });
+  });
+
+  describe('should handle single-element arrays', () => {
+    it('should extract entry from single-element array', () => {
+      const value: DictionaryEntry = ['Hello World'];
+
+      const result = getEntryAndMetadata(value);
+
+      expect(result).toEqual({
+        entry: 'Hello World',
+      });
+    });
+
+    it('should handle empty string in single-element array', () => {
+      const value: DictionaryEntry = [''];
+
+      const result = getEntryAndMetadata(value);
+
+      expect(result).toEqual({
+        entry: '',
+      });
+    });
+
+    it('should handle single-element array with special characters', () => {
+      const value: DictionaryEntry = ['Hello {name}, welcome to {app}!'];
+
+      const result = getEntryAndMetadata(value);
+
+      expect(result).toEqual({
+        entry: 'Hello {name}, welcome to {app}!',
+      });
+    });
+  });
+
+  describe('should handle two-element arrays with metadata', () => {
+    it('should extract entry and metadata from two-element array', () => {
+      const value: DictionaryEntry = ['Hello World', { $context: 'greeting' }];
+
+      const result = getEntryAndMetadata(value);
+
+      expect(result).toEqual({
+        entry: 'Hello World',
+        metadata: { $context: 'greeting' },
+      });
+    });
+
+    it('should handle complex metadata object', () => {
+      const value: DictionaryEntry = [
+        'Welcome {name}',
+        {
+          $context: 'greeting',
+          $id: 'welcome_message',
+          $_hash: 'hash_value',
+          customField: 'custom_value',
+        },
+      ];
+
+      const result = getEntryAndMetadata(value);
+
+      expect(result).toEqual({
+        entry: 'Welcome {name}',
+        metadata: {
+          $context: 'greeting',
+          $id: 'welcome_message',
+          $_hash: 'hash_value',
+          customField: 'custom_value',
+        },
+      });
+    });
+
+    it('should handle empty metadata object', () => {
+      const value: DictionaryEntry = ['Hello', {}];
+
+      const result = getEntryAndMetadata(value);
+
+      expect(result).toEqual({
+        entry: 'Hello',
+        metadata: {},
+      });
+    });
+
+    it('should handle metadata with nested objects', () => {
+      const value: DictionaryEntry = [
+        'Complex message',
+        {
+          $context: 'complex',
+          nestedObject: {
+            key1: 'value1',
+            key2: 'value2',
+          },
+          arrayField: [1, 2, 3],
+        },
+      ];
+
+      const result = getEntryAndMetadata(value);
+
+      expect(result).toEqual({
+        entry: 'Complex message',
+        metadata: {
+          $context: 'complex',
+          nestedObject: {
+            key1: 'value1',
+            key2: 'value2',
+          },
+          arrayField: [1, 2, 3],
+        },
+      });
+    });
+  });
+
+  describe('should handle edge cases', () => {
+    it('should handle array with more than 2 elements (fallback to string)', () => {
+      // Note: This is technically an invalid DictionaryEntry, but testing the function's behavior
+      const value: unknown = ['Hello', { $context: 'greeting' }, 'extra'];
+
+      const result = getEntryAndMetadata(value);
+
+      expect(result).toEqual({
+        entry: value, // Should return the whole array as entry when not matching expected formats
+      });
+    });
+
+    it('should handle empty array (fallback to string)', () => {
+      // Note: This is technically an invalid DictionaryEntry, but testing the function's behavior
+      const value: unknown = [];
+
+      const result = getEntryAndMetadata(value);
+
+      expect(result).toEqual({
+        entry: value, // Should return the whole array as entry when not matching expected formats
+      });
+    });
+  });
+
+  describe('should preserve metadata structure', () => {
+    it('should not mutate original metadata object', () => {
+      const metadata = { $context: 'greeting', $id: 'test' };
+      const value: DictionaryEntry = ['Hello', metadata];
+      const originalMetadata = { ...metadata };
+
+      const result = getEntryAndMetadata(value);
+
+      expect(metadata).toEqual(originalMetadata);
+      expect(result.metadata).toEqual(metadata);
+      expect(result.metadata).toBe(metadata); // Should be the same reference
+    });
+
+    it('should handle metadata with special characters and symbols', () => {
+      const value: DictionaryEntry = [
+        'Message with symbols: @#$%^&*()',
+        {
+          $context: 'special-context_123',
+          $id: 'id-with-dashes_and_underscores',
+          'field-with-dashes': 'value',
+          field_with_underscores: 'value',
+          'field with spaces': 'value',
+        },
+      ];
+
+      const result = getEntryAndMetadata(value);
+
+      expect(result).toEqual({
+        entry: 'Message with symbols: @#$%^&*()',
+        metadata: {
+          $context: 'special-context_123',
+          $id: 'id-with-dashes_and_underscores',
+          'field-with-dashes': 'value',
+          field_with_underscores: 'value',
+          'field with spaces': 'value',
+        },
+      });
+    });
+
+    it('should handle null and undefined values in metadata', () => {
+      const value: DictionaryEntry = [
+        'Test message',
+        {
+          $context: 'test',
+          nullField: null,
+          undefinedField: undefined,
+          falseField: false,
+          zeroField: 0,
+          emptyStringField: '',
+        } as unknown,
+      ];
+
+      const result = getEntryAndMetadata(value);
+
+      expect(result).toEqual({
+        entry: 'Test message',
+        metadata: {
+          $context: 'test',
+          nullField: null,
+          undefinedField: undefined,
+          falseField: false,
+          zeroField: 0,
+          emptyStringField: '',
+        },
+      });
+    });
+  });
+});

--- a/packages/react-core/src/utils/dictionaries/__tests__/getSubtree.test.ts
+++ b/packages/react-core/src/utils/dictionaries/__tests__/getSubtree.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import { getSubtree } from '../getSubtree';
+import { Dictionary } from '../../types';
+
+describe('getSubtree', () => {
+  const mockDictionary: Dictionary = {
+    greeting: 'Hello',
+    user: {
+      name: 'John',
+      profile: {
+        bio: 'Software developer',
+        location: 'New York',
+      },
+    },
+    messages: {
+      welcome: ['Welcome to our app', { $context: 'greeting' }],
+      goodbye: 'Goodbye!',
+    },
+    nested: {
+      deeply: {
+        nested: {
+          value: 'Deep value',
+        },
+      },
+    },
+  };
+
+  describe('should return correct values for valid paths', () => {
+    it('should return top-level string entry', () => {
+      const result = getSubtree({ dictionary: mockDictionary, id: 'greeting' });
+      expect(result).toBe('Hello');
+    });
+
+    it('should return nested dictionary', () => {
+      const result = getSubtree({ dictionary: mockDictionary, id: 'user' });
+      expect(result).toEqual({
+        name: 'John',
+        profile: {
+          bio: 'Software developer',
+          location: 'New York',
+        },
+      });
+    });
+
+    it('should return nested string entry', () => {
+      const result = getSubtree({
+        dictionary: mockDictionary,
+        id: 'user.name',
+      });
+      expect(result).toBe('John');
+    });
+
+    it('should return deeply nested dictionary', () => {
+      const result = getSubtree({
+        dictionary: mockDictionary,
+        id: 'user.profile',
+      });
+      expect(result).toEqual({
+        bio: 'Software developer',
+        location: 'New York',
+      });
+    });
+
+    it('should return deeply nested string entry', () => {
+      const result = getSubtree({
+        dictionary: mockDictionary,
+        id: 'user.profile.bio',
+      });
+      expect(result).toBe('Software developer');
+    });
+
+    it('should return array-based dictionary entry', () => {
+      const result = getSubtree({
+        dictionary: mockDictionary,
+        id: 'messages.welcome',
+      });
+      expect(result).toEqual(['Welcome to our app', { $context: 'greeting' }]);
+    });
+
+    it('should return very deeply nested value', () => {
+      const result = getSubtree({
+        dictionary: mockDictionary,
+        id: 'nested.deeply.nested.value',
+      });
+      expect(result).toBe('Deep value');
+    });
+  });
+
+  describe('should handle invalid paths gracefully', () => {
+    it('should return undefined for non-existent top-level key', () => {
+      const result = getSubtree({
+        dictionary: mockDictionary,
+        id: 'nonexistent',
+      });
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined for non-existent nested key', () => {
+      const result = getSubtree({
+        dictionary: mockDictionary,
+        id: 'user.nonexistent',
+      });
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined when trying to access property of string value', () => {
+      const result = getSubtree({
+        dictionary: mockDictionary,
+        id: 'greeting.invalid',
+      });
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('should handle edge cases', () => {
+    it('should handle empty string id', () => {
+      const result = getSubtree({ dictionary: mockDictionary, id: '' });
+      expect(result).toEqual(mockDictionary);
+    });
+
+    it('should handle empty dictionary', () => {
+      const emptyDict: Dictionary = {};
+      const result = getSubtree({ dictionary: emptyDict, id: 'any' });
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/packages/react-core/src/utils/dictionaries/__tests__/indexDict.test.ts
+++ b/packages/react-core/src/utils/dictionaries/__tests__/indexDict.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect } from 'vitest';
+import { get, set } from '../indexDict';
+import { Dictionary } from '../../types';
+
+describe('indexDict', () => {
+  describe('get function', () => {
+    describe('should get values from object dictionaries', () => {
+      it('should get string value from object dictionary', () => {
+        const dictionary: Dictionary = { greeting: 'Hello' };
+        const result = get(dictionary, 'greeting');
+        expect(result).toBe('Hello');
+      });
+
+      it('should get nested object from dictionary', () => {
+        const dictionary: Dictionary = {
+          user: { name: 'John', age: 30 },
+        };
+        const result = get(dictionary, 'user');
+        expect(result).toEqual({ name: 'John', age: 30 });
+      });
+
+      it('should get array value from object dictionary', () => {
+        const dictionary: Dictionary = {
+          messages: ['Hello', 'Goodbye'],
+        };
+        const result = get(dictionary, 'messages');
+        expect(result).toEqual(['Hello', 'Goodbye']);
+      });
+
+      it('should return undefined for non-existent key', () => {
+        const dictionary: Dictionary = { greeting: 'Hello' };
+        const result = get(dictionary, 'nonexistent');
+        expect(result).toBeUndefined();
+      });
+
+      it('should handle numeric string keys', () => {
+        const dictionary: Dictionary = { '123': 'numeric key' };
+        const result = get(dictionary, '123');
+        expect(result).toBe('numeric key');
+      });
+    });
+
+    describe('should get values from array dictionaries', () => {
+      it('should get value from array dictionary by index', () => {
+        const dictionary: Dictionary = ['first', 'second', 'third'];
+        const result = get(dictionary, 1);
+        expect(result).toBe('second');
+      });
+
+      it('should get first element from array', () => {
+        const dictionary: Dictionary = ['hello', 'world'];
+        const result = get(dictionary, 0);
+        expect(result).toBe('hello');
+      });
+
+      it('should get last element from array', () => {
+        const dictionary: Dictionary = ['hello', 'world'];
+        const result = get(dictionary, 1);
+        expect(result).toBe('world');
+      });
+
+      it('should return undefined for out-of-bounds index', () => {
+        const dictionary: Dictionary = ['hello'];
+        const result = get(dictionary, 5);
+        expect(result).toBeUndefined();
+      });
+
+      it('should handle negative indices', () => {
+        const dictionary: Dictionary = ['hello', 'world'];
+        const result = get(dictionary, -1);
+        expect(result).toBeUndefined();
+      });
+
+      it('should get nested objects from array', () => {
+        const dictionary: Dictionary = [{ name: 'John' }, { name: 'Jane' }];
+        const result = get(dictionary, 0);
+        expect(result).toEqual({ name: 'John' });
+      });
+    });
+
+    describe('should handle edge cases and errors', () => {
+      it('should throw error for null dictionary', () => {
+        expect(() => get(null as unknown, 'key')).toThrow(
+          'Cannot index into an undefined dictionary'
+        );
+      });
+
+      it('should throw error for undefined dictionary', () => {
+        expect(() => get(undefined as unknown, 'key')).toThrow(
+          'Cannot index into an undefined dictionary'
+        );
+      });
+
+      it('should handle empty object dictionary', () => {
+        const dictionary: Dictionary = {};
+        const result = get(dictionary, 'any');
+        expect(result).toBeUndefined();
+      });
+
+      it('should handle empty array dictionary', () => {
+        const dictionary: Dictionary = [];
+        const result = get(dictionary, 0);
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+
+  describe('set function', () => {
+    describe('should set values in object dictionaries', () => {
+      it('should set string value in object dictionary', () => {
+        const dictionary: Dictionary = { existing: 'value' };
+        set(dictionary, 'greeting', 'Hello');
+        expect(dictionary).toEqual({ existing: 'value', greeting: 'Hello' });
+      });
+
+      it('should set nested object in dictionary', () => {
+        const dictionary: Dictionary = {};
+        const userObj = { name: 'John', age: 30 };
+        set(dictionary, 'user', userObj);
+        expect(dictionary).toEqual({ user: { name: 'John', age: 30 } });
+      });
+
+      it('should set array value in object dictionary', () => {
+        const dictionary: Dictionary = {};
+        const arrayValue = ['Hello', 'World'];
+        set(dictionary, 'messages', arrayValue);
+        expect(dictionary).toEqual({ messages: ['Hello', 'World'] });
+      });
+
+      it('should overwrite existing value', () => {
+        const dictionary: Dictionary = { greeting: 'Hello' };
+        set(dictionary, 'greeting', 'Goodbye');
+        expect(dictionary).toEqual({ greeting: 'Goodbye' });
+      });
+
+      it('should handle numeric string keys', () => {
+        const dictionary: Dictionary = {};
+        set(dictionary, '123', 'numeric key');
+        expect(dictionary).toEqual({ '123': 'numeric key' });
+      });
+
+      it('should set dictionary entry array format', () => {
+        const dictionary: Dictionary = {};
+        const entry = ['Hello {name}', { $context: 'greeting' }];
+        set(dictionary, 'greeting', entry);
+        expect(dictionary).toEqual({
+          greeting: ['Hello {name}', { $context: 'greeting' }],
+        });
+      });
+    });
+
+    describe('should set values in array dictionaries', () => {
+      it('should set value in array dictionary by index', () => {
+        const dictionary: Dictionary = ['first', 'second'];
+        set(dictionary, 1, 'updated');
+        expect(dictionary).toEqual(['first', 'updated']);
+      });
+
+      it('should set value at specific index in array', () => {
+        const dictionary: Dictionary = ['a', 'b', 'c'];
+        set(dictionary, 0, 'new first');
+        expect(dictionary).toEqual(['new first', 'b', 'c']);
+      });
+
+      it('should expand array when setting beyond current length', () => {
+        const dictionary: Dictionary = ['a', 'b'];
+        set(dictionary, 3, 'new value');
+        expect(dictionary).toEqual(['a', 'b', undefined, 'new value']);
+      });
+
+      it('should set nested object in array', () => {
+        const dictionary: Dictionary = [null, null];
+        const userObj = { name: 'John' };
+        set(dictionary, 1, userObj);
+        expect(dictionary).toEqual([null, { name: 'John' }]);
+      });
+
+      it('should set dictionary entry in array', () => {
+        const dictionary: Dictionary = [];
+        const entry = ['Hello world', { $context: 'greeting' }];
+        set(dictionary, 0, entry);
+        expect(dictionary).toEqual([['Hello world', { $context: 'greeting' }]]);
+      });
+    });
+
+    describe('should handle edge cases', () => {
+      it('should handle setting with numeric indices on objects', () => {
+        const dictionary: Dictionary = {};
+        set(dictionary, 0, 'zero');
+        expect(dictionary).toEqual({ '0': 'zero' });
+      });
+
+      it('should handle setting string keys on arrays', () => {
+        const dictionary: Dictionary = ['a', 'b'];
+        set(dictionary, 'length', 5);
+        expect((dictionary as unknown).length).toBe(5);
+      });
+
+      it('should preserve other properties when setting', () => {
+        const dictionary: Dictionary = { a: 'value a', b: 'value b' };
+        set(dictionary, 'c', 'value c');
+        expect(dictionary).toEqual({
+          a: 'value a',
+          b: 'value b',
+          c: 'value c',
+        });
+      });
+
+      it('should handle complex nested structures', () => {
+        const dictionary: Dictionary = {
+          users: [{ name: 'John' }, { name: 'Jane' }],
+        };
+        const newUser = { name: 'Bob', role: 'admin' };
+        set(dictionary, 'admin', newUser);
+        expect(dictionary).toEqual({
+          users: [{ name: 'John' }, { name: 'Jane' }],
+          admin: { name: 'Bob', role: 'admin' },
+        });
+      });
+    });
+  });
+
+  describe('integration tests', () => {
+    it('should work together - set then get', () => {
+      const dictionary: Dictionary = {};
+      set(dictionary, 'greeting', 'Hello World');
+      const result = get(dictionary, 'greeting');
+      expect(result).toBe('Hello World');
+    });
+
+    it('should work with array operations', () => {
+      const dictionary: Dictionary = [];
+      set(dictionary, 0, 'first');
+      set(dictionary, 1, 'second');
+      expect(get(dictionary, 0)).toBe('first');
+      expect(get(dictionary, 1)).toBe('second');
+    });
+
+    it('should handle complex mixed operations', () => {
+      const dictionary: Dictionary = { data: [] };
+      const dataArray = get(dictionary, 'data') as Dictionary;
+      set(dataArray, 0, { id: 1, name: 'Item 1' });
+      set(dataArray, 1, { id: 2, name: 'Item 2' });
+
+      expect(get(dictionary, 'data')).toEqual([
+        { id: 1, name: 'Item 1' },
+        { id: 2, name: 'Item 2' },
+      ]);
+      expect(get(get(dictionary, 'data') as Dictionary, 0)).toEqual({
+        id: 1,
+        name: 'Item 1',
+      });
+    });
+  });
+});

--- a/packages/react-core/src/utils/dictionaries/__tests__/injectAndMerge.test.ts
+++ b/packages/react-core/src/utils/dictionaries/__tests__/injectAndMerge.test.ts
@@ -1,0 +1,440 @@
+import { describe, it, expect } from 'vitest';
+import { injectAndMerge } from '../injectAndMerge';
+import { Dictionary } from '../../types';
+
+describe('injectAndMerge', () => {
+  describe('should successfully inject and merge dictionaries', () => {
+    it('should inject and merge simple dictionary at root level', () => {
+      const dictionary: Dictionary = {
+        existing: 'value',
+        target: {
+          old: 'old value',
+        },
+      };
+      const subtree: Dictionary = {
+        new: 'new value',
+      };
+
+      const result = injectAndMerge(dictionary, subtree, 'target');
+
+      expect(result).toEqual({
+        existing: 'value',
+        target: {
+          old: 'old value',
+          new: 'new value',
+        },
+      });
+    });
+
+    it('should merge overlapping keys with subtree taking precedence', () => {
+      const dictionary: Dictionary = {
+        target: {
+          shared: 'original',
+          unique: 'original unique',
+        },
+      };
+      const subtree: Dictionary = {
+        shared: 'overwritten',
+        newKey: 'new value',
+      };
+
+      const result = injectAndMerge(dictionary, subtree, 'target');
+
+      expect(result).toEqual({
+        target: {
+          shared: 'overwritten',
+          unique: 'original unique',
+          newKey: 'new value',
+        },
+      });
+    });
+
+    it('should inject and merge into nested dictionary', () => {
+      const dictionary: Dictionary = {
+        app: {
+          user: {
+            profile: {
+              name: 'John',
+              email: 'john@example.com',
+            },
+            settings: {
+              theme: 'dark',
+            },
+          },
+        },
+      };
+      const subtree: Dictionary = {
+        bio: 'Software developer',
+        location: 'New York',
+      };
+
+      const result = injectAndMerge(dictionary, subtree, 'app.user.profile');
+
+      expect(result).toEqual({
+        app: {
+          user: {
+            profile: {
+              name: 'John',
+              email: 'john@example.com',
+              bio: 'Software developer',
+              location: 'New York',
+            },
+            settings: {
+              theme: 'dark',
+            },
+          },
+        },
+      });
+    });
+
+    it('should inject and merge with deeply nested path', () => {
+      const dictionary: Dictionary = {
+        level1: {
+          level2: {
+            level3: {
+              level4: {
+                existing: 'value',
+              },
+            },
+          },
+        },
+      };
+      const subtree: Dictionary = {
+        newKey: 'new value',
+        nested: {
+          deep: 'deep value',
+        },
+      };
+
+      const result = injectAndMerge(
+        dictionary,
+        subtree,
+        'level1.level2.level3.level4'
+      );
+
+      expect(result).toEqual({
+        level1: {
+          level2: {
+            level3: {
+              level4: {
+                existing: 'value',
+                newKey: 'new value',
+                nested: {
+                  deep: 'deep value',
+                },
+              },
+            },
+          },
+        },
+      });
+    });
+
+    it('should handle complex nested merging', () => {
+      const dictionary: Dictionary = {
+        messages: {
+          errors: {
+            validation: 'Validation error',
+          },
+          success: {
+            saved: 'Saved successfully',
+          },
+        },
+      };
+      const subtree: Dictionary = {
+        network: 'Network error',
+        server: 'Server error',
+      };
+
+      const result = injectAndMerge(dictionary, subtree, 'messages.errors');
+
+      expect(result).toEqual({
+        messages: {
+          errors: {
+            validation: 'Validation error',
+            network: 'Network error',
+            server: 'Server error',
+          },
+          success: {
+            saved: 'Saved successfully',
+          },
+        },
+      });
+    });
+  });
+
+  describe('should handle dictionary entries in structures', () => {
+    it('should preserve dictionary entries during merge', () => {
+      const dictionary: Dictionary = {
+        messages: {
+          greeting: ['Hello {name}', { $context: 'personal' }],
+          existing: 'Existing message',
+        },
+      };
+      const subtree: Dictionary = {
+        farewell: ['Goodbye {name}', { $context: 'personal' }],
+        info: 'Info message',
+      };
+
+      const result = injectAndMerge(dictionary, subtree, 'messages');
+
+      expect(result).toEqual({
+        messages: {
+          greeting: ['Hello {name}', { $context: 'personal' }],
+          existing: 'Existing message',
+          farewell: ['Goodbye {name}', { $context: 'personal' }],
+          info: 'Info message',
+        },
+      });
+    });
+
+    it('should handle mixed entry types in merged subtree', () => {
+      const dictionary: Dictionary = {
+        ui: {
+          buttons: {
+            save: 'Save',
+          },
+        },
+      };
+      const subtree: Dictionary = {
+        cancel: ['Cancel', { $context: 'button' }],
+        delete: 'Delete',
+        confirm: [
+          'Are you sure?',
+          { $context: 'confirmation', $_hash: 'abc123' },
+        ],
+      };
+
+      const result = injectAndMerge(dictionary, subtree, 'ui.buttons');
+
+      expect(result).toEqual({
+        ui: {
+          buttons: {
+            save: 'Save',
+            cancel: ['Cancel', { $context: 'button' }],
+            delete: 'Delete',
+            confirm: [
+              'Are you sure?',
+              { $context: 'confirmation', $_hash: 'abc123' },
+            ],
+          },
+        },
+      });
+    });
+  });
+
+  describe('should handle error cases', () => {
+    it('should throw error when dictionary subtree is undefined', () => {
+      const dictionary: Dictionary = {
+        existing: 'value',
+      };
+      const subtree: Dictionary = {
+        new: 'new value',
+      };
+
+      expect(() => injectAndMerge(dictionary, subtree, 'nonexistent')).toThrow(
+        'Dictionary subtree "nonexistent" could not be found'
+      );
+    });
+
+    it('should throw error when trying to inject into a dictionary entry', () => {
+      const dictionary: Dictionary = {
+        greeting: 'Hello world',
+      };
+      const subtree: Dictionary = {
+        new: 'new value',
+      };
+
+      expect(() => injectAndMerge(dictionary, subtree, 'greeting')).toThrow(
+        'A dictionary entry cannot be injected as a subtree'
+      );
+    });
+
+    it('should throw error when trying to inject into array-format dictionary entry', () => {
+      const dictionary: Dictionary = {
+        greeting: ['Hello world', { $context: 'greeting' }],
+      };
+      const subtree: Dictionary = {
+        new: 'new value',
+      };
+
+      expect(() => injectAndMerge(dictionary, subtree, 'greeting')).toThrow(
+        'A dictionary entry cannot be injected as a subtree'
+      );
+    });
+
+    it('should throw error for non-existent nested path', () => {
+      const dictionary: Dictionary = {
+        level1: {
+          level2: 'string value',
+        },
+      };
+      const subtree: Dictionary = {
+        new: 'new value',
+      };
+
+      expect(() =>
+        injectAndMerge(dictionary, subtree, 'level1.level2.level3')
+      ).toThrow('Dictionary subtree "level1.level2.level3" could not be found');
+    });
+
+    it('should throw error when path traverses through dictionary entry', () => {
+      const dictionary: Dictionary = {
+        messages: {
+          greeting: 'Hello',
+        },
+      };
+      const subtree: Dictionary = {
+        new: 'new value',
+      };
+
+      expect(() =>
+        injectAndMerge(dictionary, subtree, 'messages.greeting.invalid')
+      ).toThrow(
+        'Dictionary subtree "messages.greeting.invalid" could not be found'
+      );
+    });
+  });
+
+  describe('should handle edge cases', () => {
+    it('should inject into empty target dictionary', () => {
+      const dictionary: Dictionary = {
+        target: {},
+      };
+      const subtree: Dictionary = {
+        first: 'first value',
+        second: 'second value',
+      };
+
+      const result = injectAndMerge(dictionary, subtree, 'target');
+
+      expect(result).toEqual({
+        target: {
+          first: 'first value',
+          second: 'second value',
+        },
+      });
+    });
+
+    it('should merge empty subtree without changing target', () => {
+      const dictionary: Dictionary = {
+        target: {
+          existing: 'value',
+          nested: {
+            deep: 'deep value',
+          },
+        },
+      };
+      const subtree: Dictionary = {};
+
+      const result = injectAndMerge(dictionary, subtree, 'target');
+
+      expect(result).toEqual({
+        target: {
+          existing: 'value',
+          nested: {
+            deep: 'deep value',
+          },
+        },
+      });
+    });
+
+    it('should preserve original dictionary reference (mutation)', () => {
+      const dictionary: Dictionary = {
+        target: {
+          original: 'value',
+        },
+      };
+      const subtree: Dictionary = {
+        new: 'new value',
+      };
+
+      const result = injectAndMerge(dictionary, subtree, 'target');
+
+      // The function should mutate the original dictionary
+      expect(result).toBe(dictionary);
+      expect(dictionary.target).toEqual({
+        original: 'value',
+        new: 'new value',
+      });
+    });
+  });
+
+  describe('should handle complex real-world scenarios', () => {
+    it('should merge user interface translations', () => {
+      const dictionary: Dictionary = {
+        ui: {
+          navigation: {
+            home: 'Home',
+            about: 'About',
+          },
+          forms: {
+            labels: {
+              name: 'Name',
+              email: 'Email',
+            },
+          },
+        },
+      };
+      const subtree: Dictionary = {
+        phone: 'Phone Number',
+        address: 'Address',
+        submit: ['Submit Form', { $context: 'button' }],
+      };
+
+      const result = injectAndMerge(dictionary, subtree, 'ui.forms.labels');
+
+      expect(result).toEqual({
+        ui: {
+          navigation: {
+            home: 'Home',
+            about: 'About',
+          },
+          forms: {
+            labels: {
+              name: 'Name',
+              email: 'Email',
+              phone: 'Phone Number',
+              address: 'Address',
+              submit: ['Submit Form', { $context: 'button' }],
+            },
+          },
+        },
+      });
+    });
+
+    it('should handle merging with overriding values', () => {
+      const dictionary: Dictionary = {
+        config: {
+          api: {
+            timeout: '30s',
+            retries: '3',
+          },
+          ui: {
+            theme: 'light',
+          },
+        },
+      };
+      const subtree: Dictionary = {
+        timeout: '60s',
+        baseUrl: 'https://api.example.com',
+        version: 'v2',
+      };
+
+      const result = injectAndMerge(dictionary, subtree, 'config.api');
+
+      expect(result).toEqual({
+        config: {
+          api: {
+            timeout: '60s', // overridden
+            retries: '3', // preserved
+            baseUrl: 'https://api.example.com', // added
+            version: 'v2', // added
+          },
+          ui: {
+            theme: 'light',
+          },
+        },
+      });
+    });
+  });
+});

--- a/packages/react-core/src/utils/dictionaries/__tests__/injectEntry.test.ts
+++ b/packages/react-core/src/utils/dictionaries/__tests__/injectEntry.test.ts
@@ -1,0 +1,281 @@
+import { describe, it, expect } from 'vitest';
+import { injectEntry } from '../injectEntry';
+import { Dictionary, DictionaryEntry } from '../../types';
+
+describe('injectEntry', () => {
+  describe('should inject entries into flat dictionary structure', () => {
+    it('should inject simple string entry at root level', () => {
+      const dictionary: Dictionary = {};
+      const entry: DictionaryEntry = 'Hello World';
+
+      injectEntry(entry, dictionary, 'greeting');
+
+      expect(dictionary).toEqual({
+        greeting: 'Hello World',
+      });
+    });
+
+    it('should inject array-based entry with metadata', () => {
+      const dictionary: Dictionary = {};
+      const entry: DictionaryEntry = ['Welcome', { $context: 'greeting' }];
+
+      injectEntry(entry, dictionary, 'welcome');
+
+      expect(dictionary).toEqual({
+        welcome: ['Welcome', { $context: 'greeting' }],
+      });
+    });
+
+    it('should inject entry with single-element array', () => {
+      const dictionary: Dictionary = {};
+      const entry: DictionaryEntry = ['Hello'];
+
+      injectEntry(entry, dictionary, 'simple');
+
+      expect(dictionary).toEqual({
+        simple: ['Hello'],
+      });
+    });
+  });
+
+  describe('should inject entries into nested dictionary structure', () => {
+    it('should inject entry into single-level nested path', () => {
+      const dictionary: Dictionary = {};
+      const sourceDictionary: Dictionary = { user: { name: '' } };
+      const entry: DictionaryEntry = 'John Doe';
+
+      injectEntry(entry, dictionary, 'user.name', sourceDictionary);
+
+      expect(dictionary).toEqual({
+        user: {
+          name: 'John Doe',
+        },
+      });
+    });
+
+    it('should inject entry into multi-level nested path', () => {
+      const dictionary: Dictionary = {};
+      const sourceDictionary: Dictionary = {
+        user: { profile: { occupation: '' } },
+      };
+      const entry: DictionaryEntry = 'Software Engineer';
+
+      injectEntry(
+        entry,
+        dictionary,
+        'user.profile.occupation',
+        sourceDictionary
+      );
+
+      expect(dictionary).toEqual({
+        user: {
+          profile: {
+            occupation: 'Software Engineer',
+          },
+        },
+      });
+    });
+
+    it('should inject entry into existing nested structure', () => {
+      const dictionary: Dictionary = {
+        user: {
+          name: 'John',
+        },
+      };
+      const sourceDictionary: Dictionary = { user: { email: '' } };
+      const entry: DictionaryEntry = 'john@example.com';
+
+      injectEntry(entry, dictionary, 'user.email', sourceDictionary);
+
+      expect(dictionary).toEqual({
+        user: {
+          name: 'John',
+          email: 'john@example.com',
+        },
+      });
+    });
+
+    it('should inject deeply nested entry with metadata', () => {
+      const dictionary: Dictionary = {};
+      const sourceDictionary: Dictionary = {
+        app: { messages: { system: { error: '' } } },
+      };
+      const entry: DictionaryEntry = ['Deep message', { $context: 'system' }];
+
+      injectEntry(
+        entry,
+        dictionary,
+        'app.messages.system.error',
+        sourceDictionary
+      );
+
+      expect(dictionary).toEqual({
+        app: {
+          messages: {
+            system: {
+              error: ['Deep message', { $context: 'system' }],
+            },
+          },
+        },
+      });
+    });
+  });
+
+  describe('should handle DictionaryEntry parameter type', () => {
+    it('should return entry when dictionary parameter is a DictionaryEntry', () => {
+      const dictionary: DictionaryEntry = 'Existing entry';
+      const entry: DictionaryEntry = 'New entry';
+
+      const result = injectEntry(entry, dictionary, 'any.path');
+
+      expect(result).toBe('New entry');
+    });
+
+    it('should return entry when dictionary parameter is array DictionaryEntry', () => {
+      const dictionary: DictionaryEntry = [
+        'Existing entry',
+        { $context: 'test' },
+      ];
+      const entry: DictionaryEntry = 'New entry';
+
+      const result = injectEntry(entry, dictionary, 'any.path');
+
+      expect(result).toBe('New entry');
+    });
+
+    it('should still mutate dictionary when it is a Dictionary object', () => {
+      const dictionary: Dictionary = { existing: 'value' };
+      const entry: DictionaryEntry = 'Hello World';
+
+      const result = injectEntry(entry, dictionary, 'greeting');
+
+      expect(dictionary).toEqual({
+        existing: 'value',
+        greeting: 'Hello World',
+      });
+      expect(result).toBeUndefined();
+    });
+
+    it('should inject complex entry into nested paths in Dictionary', () => {
+      const dictionary: Dictionary = {};
+      const sourceDictionary: Dictionary = { user: { profile: { bio: '' } } };
+      const entry: DictionaryEntry = ['Complex entry', { $context: 'test' }];
+
+      const result = injectEntry(
+        entry,
+        dictionary,
+        'user.profile.bio',
+        sourceDictionary
+      );
+
+      expect(result).toBeUndefined();
+      expect(dictionary).toEqual({
+        user: {
+          profile: {
+            bio: ['Complex entry', { $context: 'test' }],
+          },
+        },
+      });
+    });
+  });
+
+  describe('should handle edge cases and overwrites', () => {
+    it('should preserve array structure when injecting into nested array elements', () => {
+      const dictionary: Dictionary = {};
+      const sourceDictionary: Dictionary = {
+        hello: {
+          fruits: ['lemon', 'lime', 'pear'],
+        },
+      };
+      const entry: DictionaryEntry = 'citron';
+
+      injectEntry(entry, dictionary, 'hello.fruits.0', sourceDictionary);
+
+      expect(dictionary).toEqual({
+        hello: {
+          fruits: ['citron'],
+        },
+      });
+      expect(Array.isArray((dictionary as unknown).hello.fruits)).toBe(true);
+    });
+
+    it('should create array structure for multiple array element injections', () => {
+      const dictionary: Dictionary = {};
+      const sourceDictionary: Dictionary = {
+        hello: {
+          fruits: ['lemon', 'lime', 'pear'],
+        },
+      };
+
+      injectEntry('citron', dictionary, 'hello.fruits.0', sourceDictionary);
+      injectEntry(
+        'citron vert',
+        dictionary,
+        'hello.fruits.1',
+        sourceDictionary
+      );
+      injectEntry('poire', dictionary, 'hello.fruits.2', sourceDictionary);
+
+      expect(dictionary).toEqual({
+        hello: {
+          fruits: ['citron', 'citron vert', 'poire'],
+        },
+      });
+      expect(Array.isArray((dictionary as unknown).hello.fruits)).toBe(true);
+    });
+
+    it('should overwrite existing entry', () => {
+      const dictionary: Dictionary = {
+        greeting: 'Old greeting',
+      };
+      const entry: DictionaryEntry = 'New greeting';
+
+      injectEntry(entry, dictionary, 'greeting', {});
+
+      expect(dictionary).toEqual({
+        greeting: 'New greeting',
+      });
+    });
+
+    it('should throw error when trying to access property of primitive during navigation', () => {
+      const dictionary: Dictionary = {
+        user: 'Simple string',
+      };
+      const entry: DictionaryEntry = 'John';
+
+      expect(() => {
+        injectEntry(entry, dictionary, 'user.name', {});
+      }).toThrow();
+    });
+
+    it('should handle null parent values', () => {
+      const dictionary: Dictionary = {
+        user: null as unknown,
+      };
+      const sourceDictionary: Dictionary = { user: { name: '' } };
+      const entry: DictionaryEntry = 'John';
+
+      injectEntry(entry, dictionary, 'user.name', sourceDictionary);
+
+      expect(dictionary).toEqual({
+        user: {
+          name: 'John',
+        },
+      });
+    });
+
+    it('should handle empty string entry', () => {
+      const dictionary: Dictionary = {};
+      const sourceDictionary: Dictionary = { empty: { message: '' } };
+      const entry: DictionaryEntry = '';
+
+      injectEntry(entry, dictionary, 'empty.message', sourceDictionary);
+
+      expect(dictionary).toEqual({
+        empty: {
+          message: '',
+        },
+      });
+    });
+  });
+});

--- a/packages/react-core/src/utils/dictionaries/__tests__/injectFallbacks.test.ts
+++ b/packages/react-core/src/utils/dictionaries/__tests__/injectFallbacks.test.ts
@@ -1,0 +1,507 @@
+import { describe, it, expect } from 'vitest';
+import { injectFallbacks } from '../injectFallbacks';
+import { Dictionary } from '../../types';
+
+describe('injectFallbacks', () => {
+  describe('should inject fallbacks for missing translations', () => {
+    it('should inject source text when no translation exists', () => {
+      const dictionary: Dictionary = {
+        greeting: 'Hello world',
+      };
+      const translationsDictionary: Dictionary = {};
+      const missingTranslations = [
+        {
+          source: 'Hello world',
+          metadata: { $id: 'greeting', $_hash: 'abc123' },
+        },
+      ];
+
+      const result = injectFallbacks(
+        dictionary,
+        translationsDictionary,
+        missingTranslations,
+        ''
+      );
+
+      expect(result).toEqual({
+        greeting: 'Hello world',
+      });
+    });
+
+    it('should use existing translation when available', () => {
+      const dictionary: Dictionary = {
+        greeting: 'Hello world',
+      };
+      const translationsDictionary: Dictionary = {
+        greeting: 'Hola mundo',
+      };
+      const missingTranslations = [
+        {
+          source: 'Hello world',
+          metadata: { $id: 'greeting', $_hash: 'abc123' },
+        },
+      ];
+
+      const result = injectFallbacks(
+        dictionary,
+        translationsDictionary,
+        missingTranslations,
+        ''
+      );
+
+      expect(result).toEqual({
+        greeting: 'Hola mundo',
+      });
+    });
+
+    it('should use array-format translation when available', () => {
+      const dictionary: Dictionary = {
+        greeting: ['Hello {name}', { $context: 'personal' }],
+      };
+      const translationsDictionary: Dictionary = {
+        greeting: ['Hola {name}', { $context: 'personal' }],
+      };
+      const missingTranslations = [
+        {
+          source: 'Hello {name}',
+          metadata: { $id: 'greeting', $context: 'personal', $_hash: 'def456' },
+        },
+      ];
+
+      const result = injectFallbacks(
+        dictionary,
+        translationsDictionary,
+        missingTranslations,
+        ''
+      );
+
+      expect(result).toEqual({
+        greeting: 'Hola {name}',
+      });
+    });
+
+    it('should handle multiple missing translations', () => {
+      const dictionary: Dictionary = {
+        greeting: 'Hello',
+        farewell: 'Goodbye',
+        welcome: 'Welcome',
+      };
+      const translationsDictionary: Dictionary = {
+        greeting: 'Hola',
+      };
+      const missingTranslations = [
+        {
+          source: 'Goodbye',
+          metadata: { $id: 'farewell', $_hash: 'xyz789' },
+        },
+        {
+          source: 'Welcome',
+          metadata: { $id: 'welcome', $_hash: 'qwe456' },
+        },
+      ];
+
+      const result = injectFallbacks(
+        dictionary,
+        translationsDictionary,
+        missingTranslations,
+        ''
+      );
+
+      expect(result).toEqual({
+        greeting: 'Hola',
+        farewell: 'Goodbye',
+        welcome: 'Welcome',
+      });
+    });
+  });
+
+  describe('should handle nested dictionary paths', () => {
+    it('should inject fallback into nested path', () => {
+      const dictionary: Dictionary = {
+        user: {
+          profile: {
+            name: 'Name',
+            email: 'Email',
+          },
+        },
+      };
+      const translationsDictionary: Dictionary = {
+        user: {
+          profile: {
+            name: 'Nombre',
+          },
+        },
+      };
+      const missingTranslations = [
+        {
+          source: 'Email',
+          metadata: { $id: 'user.profile.email', $_hash: 'email123' },
+        },
+      ];
+
+      const result = injectFallbacks(
+        dictionary,
+        translationsDictionary,
+        missingTranslations,
+        ''
+      );
+
+      expect(result).toEqual({
+        user: {
+          profile: {
+            name: 'Nombre',
+            email: 'Email',
+          },
+        },
+      });
+    });
+
+    it('should create nested structure when missing', () => {
+      const dictionary: Dictionary = {
+        messages: {
+          errors: {
+            validation: 'Validation failed',
+          },
+        },
+      };
+      const translationsDictionary: Dictionary = {};
+      const missingTranslations = [
+        {
+          source: 'Validation failed',
+          metadata: { $id: 'messages.errors.validation', $_hash: 'val456' },
+        },
+      ];
+
+      const result = injectFallbacks(
+        dictionary,
+        translationsDictionary,
+        missingTranslations,
+        ''
+      );
+
+      expect(result).toEqual({
+        messages: {
+          errors: {
+            validation: 'Validation failed',
+          },
+        },
+      });
+    });
+
+    it('should handle deeply nested missing translations', () => {
+      const dictionary: Dictionary = {
+        app: {
+          ui: {
+            forms: {
+              labels: {
+                firstName: 'First Name',
+                lastName: 'Last Name',
+              },
+            },
+          },
+        },
+      };
+      const translationsDictionary: Dictionary = {
+        app: {
+          ui: {
+            forms: {
+              labels: {
+                firstName: 'Prénom',
+              },
+            },
+          },
+        },
+      };
+      const missingTranslations = [
+        {
+          source: 'Last Name',
+          metadata: { $id: 'app.ui.forms.labels.lastName', $_hash: 'last789' },
+        },
+      ];
+
+      const result = injectFallbacks(
+        dictionary,
+        translationsDictionary,
+        missingTranslations,
+        ''
+      );
+
+      expect(result).toEqual({
+        app: {
+          ui: {
+            forms: {
+              labels: {
+                firstName: 'Prénom',
+                lastName: 'Last Name',
+              },
+            },
+          },
+        },
+      });
+    });
+  });
+
+  describe('should handle entries with context metadata', () => {
+    it('should inject fallback for entry with context', () => {
+      const dictionary: Dictionary = {
+        submit: ['Submit', { $context: 'button' }],
+      };
+      const translationsDictionary: Dictionary = {};
+      const missingTranslations = [
+        {
+          source: 'Submit',
+          metadata: { $id: 'submit', $context: 'button', $_hash: 'sub123' },
+        },
+      ];
+
+      const result = injectFallbacks(
+        dictionary,
+        translationsDictionary,
+        missingTranslations,
+        ''
+      );
+
+      expect(result).toEqual({
+        submit: 'Submit',
+      });
+    });
+
+    it('should prefer translation with context over fallback', () => {
+      const dictionary: Dictionary = {
+        cancel: ['Cancel', { $context: 'button' }],
+      };
+      const translationsDictionary: Dictionary = {
+        cancel: ['Cancelar', { $context: 'button' }],
+      };
+      const missingTranslations = [
+        {
+          source: 'Cancel',
+          metadata: { $id: 'cancel', $context: 'button', $_hash: 'can456' },
+        },
+      ];
+
+      const result = injectFallbacks(
+        dictionary,
+        translationsDictionary,
+        missingTranslations,
+        ''
+      );
+
+      expect(result).toEqual({
+        cancel: 'Cancelar',
+      });
+    });
+
+    it('should handle mixed metadata scenarios', () => {
+      const dictionary: Dictionary = {
+        save: ['Save {item}', { $context: 'action', $_hash: 'save789' }],
+        delete: 'Delete',
+      };
+      const translationsDictionary: Dictionary = {};
+      const missingTranslations = [
+        {
+          source: 'Save {item}',
+          metadata: { $id: 'save', $context: 'action', $_hash: 'save789' },
+        },
+        {
+          source: 'Delete',
+          metadata: { $id: 'delete', $_hash: 'del123' },
+        },
+      ];
+
+      const result = injectFallbacks(
+        dictionary,
+        translationsDictionary,
+        missingTranslations,
+        ''
+      );
+
+      expect(result).toEqual({
+        save: 'Save {item}',
+        delete: 'Delete',
+      });
+    });
+  });
+
+  describe('should handle edge cases and complex scenarios', () => {
+    it('should handle empty missing translations array', () => {
+      const dictionary: Dictionary = {
+        greeting: 'Hello',
+      };
+      const translationsDictionary: Dictionary = {
+        greeting: 'Hola',
+      };
+      const missingTranslations: unknown[] = [];
+
+      const result = injectFallbacks(
+        dictionary,
+        translationsDictionary,
+        missingTranslations,
+        ''
+      );
+
+      expect(result).toEqual({
+        greeting: 'Hola',
+      });
+    });
+
+    it('should handle empty translations dictionary', () => {
+      const dictionary: Dictionary = {
+        message1: 'Message 1',
+        message2: 'Message 2',
+      };
+      const translationsDictionary: Dictionary = {};
+      const missingTranslations = [
+        {
+          source: 'Message 1',
+          metadata: { $id: 'message1', $_hash: 'msg1' },
+        },
+        {
+          source: 'Message 2',
+          metadata: { $id: 'message2', $_hash: 'msg2' },
+        },
+      ];
+
+      const result = injectFallbacks(
+        dictionary,
+        translationsDictionary,
+        missingTranslations,
+        ''
+      );
+
+      expect(result).toEqual({
+        message1: 'Message 1',
+        message2: 'Message 2',
+      });
+    });
+
+    it('should maintain reference to translationsDictionary', () => {
+      const dictionary: Dictionary = {
+        test: 'Test value',
+      };
+      const translationsDictionary: Dictionary = {
+        existing: 'Existing value',
+      };
+      const missingTranslations = [
+        {
+          source: 'Test value',
+          metadata: { $id: 'test', $_hash: 'test123' },
+        },
+      ];
+
+      const result = injectFallbacks(
+        dictionary,
+        translationsDictionary,
+        missingTranslations,
+        ''
+      );
+
+      expect(result).toBe(translationsDictionary);
+      expect(result).toEqual({
+        existing: 'Existing value',
+        test: 'Test value',
+      });
+    });
+  });
+
+  describe('should handle complex real-world scenarios', () => {
+    it('should handle mixed translation states', () => {
+      const dictionary: Dictionary = {
+        nav: {
+          home: 'Home',
+          about: 'About',
+          contact: 'Contact',
+        },
+        forms: {
+          name: ['Name', { $context: 'form-label' }],
+          email: ['Email', { $context: 'form-label' }],
+          submit: ['Submit Form', { $context: 'button' }],
+        },
+      };
+      const translationsDictionary: Dictionary = {
+        nav: {
+          home: 'Accueil',
+          about: 'À propos',
+        },
+        forms: {
+          name: ['Nom', { $context: 'form-label' }],
+        },
+      };
+      const missingTranslations = [
+        {
+          source: 'Contact',
+          metadata: { $id: 'nav.contact', $_hash: 'contact1' },
+        },
+        {
+          source: 'Email',
+          metadata: {
+            $id: 'forms.email',
+            $context: 'form-label',
+            $_hash: 'email2',
+          },
+        },
+        {
+          source: 'Submit Form',
+          metadata: {
+            $id: 'forms.submit',
+            $context: 'button',
+            $_hash: 'submit3',
+          },
+        },
+      ];
+
+      const result = injectFallbacks(
+        dictionary,
+        translationsDictionary,
+        missingTranslations,
+        ''
+      );
+
+      expect(result).toEqual({
+        nav: {
+          home: 'Accueil',
+          about: 'À propos',
+          contact: 'Contact',
+        },
+        forms: {
+          name: ['Nom', { $context: 'form-label' }],
+          email: 'Email',
+          submit: 'Submit Form',
+        },
+      });
+    });
+
+    it('should handle overwriting existing fallback with better translation', () => {
+      const dictionary: Dictionary = {
+        title: 'Page Title',
+        subtitle: 'Page Subtitle',
+      };
+      const translationsDictionary: Dictionary = {
+        title: 'Fallback Title',
+        subtitle: 'Proper Translation',
+      };
+      const missingTranslations = [
+        {
+          source: 'Page Title',
+          metadata: { $id: 'title', $_hash: 'title1' },
+        },
+        {
+          source: 'Page Subtitle',
+          metadata: { $id: 'subtitle', $_hash: 'sub1' },
+        },
+      ];
+
+      const result = injectFallbacks(
+        dictionary,
+        translationsDictionary,
+        missingTranslations,
+        ''
+      );
+
+      expect(result).toEqual({
+        title: 'Fallback Title',
+        subtitle: 'Proper Translation',
+      });
+    });
+  });
+});

--- a/packages/react-core/src/utils/dictionaries/__tests__/injectHashes.test.ts
+++ b/packages/react-core/src/utils/dictionaries/__tests__/injectHashes.test.ts
@@ -1,0 +1,439 @@
+import { describe, it, expect, vi } from 'vitest';
+import { injectHashes } from '../injectHashes';
+import { Dictionary } from '../../types';
+
+// Mock the hashSource function
+vi.mock('generaltranslation/id', () => ({
+  hashSource: vi.fn(
+    ({ source, context, id }) => `hash_${source}_${context || 'none'}_${id}`
+  ),
+}));
+
+describe('injectHashes', () => {
+  describe('should inject hashes for dictionary entries without hashes', () => {
+    it('should inject hash for simple string entry', () => {
+      const dictionary: Dictionary = {
+        greeting: 'Hello world',
+      };
+
+      const result = injectHashes(dictionary);
+
+      expect(result.dictionary).toEqual({
+        greeting: ['Hello world', { $_hash: 'hash_Hello world_none_greeting' }],
+      });
+      expect(result.updateDictionary).toBe(true);
+    });
+
+    it('should inject hash for array entry without metadata', () => {
+      const dictionary: Dictionary = {
+        welcome: ['Welcome to our app'],
+      };
+
+      const result = injectHashes(dictionary);
+
+      expect(result.dictionary).toEqual({
+        welcome: [
+          'Welcome to our app',
+          { $_hash: 'hash_Welcome to our app_none_welcome' },
+        ],
+      });
+      expect(result.updateDictionary).toBe(true);
+    });
+
+    it('should inject hash for array entry with existing metadata but no hash', () => {
+      const dictionary: Dictionary = {
+        greeting: ['Hello {name}', { $context: 'personal' }],
+      };
+
+      const result = injectHashes(dictionary);
+
+      expect(result.dictionary).toEqual({
+        greeting: [
+          'Hello {name}',
+          {
+            $context: 'personal',
+            $_hash: 'hash_Hello {name}_personal_greeting',
+          },
+        ],
+      });
+      expect(result.updateDictionary).toBe(true);
+    });
+
+    it('should not modify entries that already have hashes', () => {
+      const dictionary: Dictionary = {
+        greeting: ['Hello world', { $_hash: 'existing_hash' }],
+        farewell: 'Goodbye',
+      };
+
+      const result = injectHashes(dictionary);
+
+      expect(result.dictionary).toEqual({
+        greeting: ['Hello world', { $_hash: 'existing_hash' }],
+        farewell: ['Goodbye', { $_hash: 'hash_Goodbye_none_farewell' }],
+      });
+      expect(result.updateDictionary).toBe(true);
+    });
+
+    it('should handle multiple entries needing hashes', () => {
+      const dictionary: Dictionary = {
+        greeting: 'Hello',
+        farewell: 'Goodbye',
+        welcome: 'Welcome',
+      };
+
+      const result = injectHashes(dictionary);
+
+      expect(result.dictionary).toEqual({
+        greeting: ['Hello', { $_hash: 'hash_Hello_none_greeting' }],
+        farewell: ['Goodbye', { $_hash: 'hash_Goodbye_none_farewell' }],
+        welcome: ['Welcome', { $_hash: 'hash_Welcome_none_welcome' }],
+      });
+      expect(result.updateDictionary).toBe(true);
+    });
+  });
+
+  describe('should handle nested dictionary structures', () => {
+    it('should inject hashes for nested entries', () => {
+      const dictionary: Dictionary = {
+        user: {
+          profile: {
+            name: 'Name',
+            email: 'Email',
+          },
+        },
+      };
+
+      const result = injectHashes(dictionary);
+
+      expect(result.dictionary).toEqual({
+        user: {
+          profile: {
+            name: ['Name', { $_hash: 'hash_Name_none_user.profile.name' }],
+            email: ['Email', { $_hash: 'hash_Email_none_user.profile.email' }],
+          },
+        },
+      });
+      expect(result.updateDictionary).toBe(true);
+    });
+
+    it('should handle deeply nested structures', () => {
+      const dictionary: Dictionary = {
+        app: {
+          nav: {
+            menu: {
+              items: {
+                home: 'Home',
+                about: 'About',
+              },
+            },
+          },
+        },
+      };
+
+      const result = injectHashes(dictionary);
+
+      expect(result.dictionary).toEqual({
+        app: {
+          nav: {
+            menu: {
+              items: {
+                home: [
+                  'Home',
+                  { $_hash: 'hash_Home_none_app.nav.menu.items.home' },
+                ],
+                about: [
+                  'About',
+                  { $_hash: 'hash_About_none_app.nav.menu.items.about' },
+                ],
+              },
+            },
+          },
+        },
+      });
+      expect(result.updateDictionary).toBe(true);
+    });
+
+    it('should handle mixed nested structures with existing hashes', () => {
+      const dictionary: Dictionary = {
+        section1: {
+          item1: ['Item 1', { $_hash: 'existing_hash_1' }],
+          item2: 'Item 2',
+        },
+        section2: {
+          item3: 'Item 3',
+        },
+      };
+
+      const result = injectHashes(dictionary);
+
+      expect(result.dictionary).toEqual({
+        section1: {
+          item1: ['Item 1', { $_hash: 'existing_hash_1' }],
+          item2: ['Item 2', { $_hash: 'hash_Item 2_none_section1.item2' }],
+        },
+        section2: {
+          item3: ['Item 3', { $_hash: 'hash_Item 3_none_section2.item3' }],
+        },
+      });
+      expect(result.updateDictionary).toBe(true);
+    });
+  });
+
+  describe('should handle entries with context', () => {
+    it('should include context in hash generation', () => {
+      const dictionary: Dictionary = {
+        submit: ['Submit', { $context: 'button' }],
+        save: ['Save', { $context: 'action' }],
+      };
+
+      const result = injectHashes(dictionary);
+
+      expect(result.dictionary).toEqual({
+        submit: [
+          'Submit',
+          { $context: 'button', $_hash: 'hash_Submit_button_submit' },
+        ],
+        save: ['Save', { $context: 'action', $_hash: 'hash_Save_action_save' }],
+      });
+      expect(result.updateDictionary).toBe(true);
+    });
+
+    it('should handle entries with complex metadata', () => {
+      const dictionary: Dictionary = {
+        greeting: [
+          'Hello {name}',
+          { $context: 'personal', $id: 'greeting_id', customField: 'custom' },
+        ],
+      };
+
+      const result = injectHashes(dictionary);
+
+      expect(result.dictionary).toEqual({
+        greeting: [
+          'Hello {name}',
+          {
+            $context: 'personal',
+            $id: 'greeting_id',
+            customField: 'custom',
+            $_hash: 'hash_Hello {name}_personal_greeting',
+          },
+        ],
+      });
+      expect(result.updateDictionary).toBe(true);
+    });
+
+    it('should handle entries without context alongside those with context', () => {
+      const dictionary: Dictionary = {
+        title: 'Page Title',
+        button: ['Click me', { $context: 'action' }],
+      };
+
+      const result = injectHashes(dictionary);
+
+      expect(result.dictionary).toEqual({
+        title: ['Page Title', { $_hash: 'hash_Page Title_none_title' }],
+        button: [
+          'Click me',
+          { $context: 'action', $_hash: 'hash_Click me_action_button' },
+        ],
+      });
+      expect(result.updateDictionary).toBe(true);
+    });
+  });
+
+  describe('should handle custom id parameter', () => {
+    it('should use custom id as prefix for hash generation', () => {
+      const dictionary: Dictionary = {
+        greeting: 'Hello',
+        farewell: 'Goodbye',
+      };
+
+      const result = injectHashes(dictionary, 'custom.prefix');
+
+      expect(result.dictionary).toEqual({
+        greeting: [
+          'Hello',
+          { $_hash: 'hash_Hello_none_custom.prefix.greeting' },
+        ],
+        farewell: [
+          'Goodbye',
+          { $_hash: 'hash_Goodbye_none_custom.prefix.farewell' },
+        ],
+      });
+      expect(result.updateDictionary).toBe(true);
+    });
+
+    it('should handle nested structure with custom id', () => {
+      const dictionary: Dictionary = {
+        user: {
+          name: 'Name',
+          email: 'Email',
+        },
+      };
+
+      const result = injectHashes(dictionary, 'app.section');
+
+      expect(result.dictionary).toEqual({
+        user: {
+          name: ['Name', { $_hash: 'hash_Name_none_app.section.user.name' }],
+          email: [
+            'Email',
+            { $_hash: 'hash_Email_none_app.section.user.email' },
+          ],
+        },
+      });
+      expect(result.updateDictionary).toBe(true);
+    });
+  });
+
+  describe('should return correct updateDictionary flag', () => {
+    it('should return false when no updates needed', () => {
+      const dictionary: Dictionary = {
+        greeting: ['Hello world', { $_hash: 'existing_hash' }],
+        farewell: ['Goodbye', { $_hash: 'another_hash' }],
+      };
+
+      const result = injectHashes(dictionary);
+
+      expect(result.dictionary).toEqual({
+        greeting: ['Hello world', { $_hash: 'existing_hash' }],
+        farewell: ['Goodbye', { $_hash: 'another_hash' }],
+      });
+      expect(result.updateDictionary).toBe(false);
+    });
+
+    it('should return true when some entries need hashes', () => {
+      const dictionary: Dictionary = {
+        existing: ['Already has hash', { $_hash: 'existing' }],
+        needsHash: 'Needs a hash',
+      };
+
+      const result = injectHashes(dictionary);
+
+      expect(result.dictionary).toEqual({
+        existing: ['Already has hash', { $_hash: 'existing' }],
+        needsHash: [
+          'Needs a hash',
+          { $_hash: 'hash_Needs a hash_none_needsHash' },
+        ],
+      });
+      expect(result.updateDictionary).toBe(true);
+    });
+
+    it('should return true when nested entries need hashes', () => {
+      const dictionary: Dictionary = {
+        section: {
+          withHash: ['Has hash', { $_hash: 'existing' }],
+          nested: {
+            needsHash: 'Needs hash',
+          },
+        },
+      };
+
+      const result = injectHashes(dictionary);
+
+      expect(result.dictionary).toEqual({
+        section: {
+          withHash: ['Has hash', { $_hash: 'existing' }],
+          nested: {
+            needsHash: [
+              'Needs hash',
+              { $_hash: 'hash_Needs hash_none_section.nested.needsHash' },
+            ],
+          },
+        },
+      });
+      expect(result.updateDictionary).toBe(true);
+    });
+  });
+
+  describe('should handle edge cases', () => {
+    it('should handle empty dictionary', () => {
+      const dictionary: Dictionary = {};
+
+      const result = injectHashes(dictionary);
+
+      expect(result.dictionary).toEqual({});
+      expect(result.updateDictionary).toBe(false);
+    });
+
+    it('should handle dictionary with only non-entry values', () => {
+      const dictionary: Dictionary = {
+        section: {
+          subsection: {
+            deep: {},
+          },
+        },
+      };
+
+      const result = injectHashes(dictionary);
+
+      expect(result.dictionary).toEqual({
+        section: {
+          subsection: {
+            deep: {},
+          },
+        },
+      });
+      expect(result.updateDictionary).toBe(false);
+    });
+
+    it('should handle mixed dictionary with empty objects and entries', () => {
+      const dictionary: Dictionary = {
+        empty: {},
+        withEntry: {
+          message: 'Hello world',
+        },
+        alsoEmpty: {
+          nested: {},
+        },
+      };
+
+      const result = injectHashes(dictionary);
+
+      expect(result.dictionary).toEqual({
+        empty: {},
+        withEntry: {
+          message: [
+            'Hello world',
+            { $_hash: 'hash_Hello world_none_withEntry.message' },
+          ],
+        },
+        alsoEmpty: {
+          nested: {},
+        },
+      });
+      expect(result.updateDictionary).toBe(true);
+    });
+  });
+
+  describe('should maintain dictionary reference', () => {
+    it('should mutate the original dictionary object', () => {
+      const dictionary: Dictionary = {
+        greeting: 'Hello world',
+      };
+      const originalRef = dictionary;
+
+      const result = injectHashes(dictionary);
+
+      expect(result.dictionary).toBe(originalRef);
+      expect(dictionary).toEqual({
+        greeting: ['Hello world', { $_hash: 'hash_Hello world_none_greeting' }],
+      });
+    });
+
+    it('should maintain nested object references', () => {
+      const nestedObj = { message: 'Hello' };
+      const dictionary: Dictionary = {
+        section: nestedObj,
+      };
+
+      const result = injectHashes(dictionary);
+
+      expect(result.dictionary.section).toBe(nestedObj);
+      expect(nestedObj).toEqual({
+        message: ['Hello', { $_hash: 'hash_Hello_none_section.message' }],
+      });
+    });
+  });
+});

--- a/packages/react-core/src/utils/dictionaries/__tests__/injectTranslations.test.ts
+++ b/packages/react-core/src/utils/dictionaries/__tests__/injectTranslations.test.ts
@@ -1,0 +1,744 @@
+import { describe, it, expect } from 'vitest';
+import { injectTranslations } from '../injectTranslations';
+import { Dictionary, Translations } from '../../types';
+
+describe('injectTranslations', () => {
+  describe('should inject translations from translations object', () => {
+    it('should inject translation using hash lookup', () => {
+      const dictionary: Dictionary = {
+        greeting: 'Hello world',
+      };
+      const translationsDictionary: Dictionary = {};
+      const translations: Translations = {
+        hash123: 'Hola mundo',
+      };
+      const missingTranslations = [
+        {
+          source: 'Hello world',
+          metadata: { $id: 'greeting', $_hash: 'hash123' },
+        },
+      ];
+
+      const result = injectTranslations(
+        dictionary,
+        translationsDictionary,
+        translations,
+        missingTranslations,
+        ''
+      );
+
+      expect(result.dictionary).toEqual({
+        greeting: 'Hola mundo',
+      });
+      expect(result.updateDictionary).toBe(true);
+    });
+
+    it('should inject multiple translations', () => {
+      const dictionary: Dictionary = {
+        greeting: 'Hello',
+        farewell: 'Goodbye',
+      };
+      const translationsDictionary: Dictionary = {};
+      const translations: Translations = {
+        hello_hash: 'Hola',
+        goodbye_hash: 'Adiós',
+      };
+      const missingTranslations = [
+        {
+          source: 'Hello',
+          metadata: { $id: 'greeting', $_hash: 'hello_hash' },
+        },
+        {
+          source: 'Goodbye',
+          metadata: { $id: 'farewell', $_hash: 'goodbye_hash' },
+        },
+      ];
+
+      const result = injectTranslations(
+        dictionary,
+        translationsDictionary,
+        translations,
+        missingTranslations,
+        ''
+      );
+
+      expect(result.dictionary).toEqual({
+        greeting: 'Hola',
+        farewell: 'Adiós',
+      });
+      expect(result.updateDictionary).toBe(true);
+    });
+
+    it('should prefer hash lookup over existing translation in dictionary', () => {
+      const dictionary: Dictionary = {
+        greeting: 'Hello world',
+      };
+      const translationsDictionary: Dictionary = {
+        greeting: 'Existing translation',
+      };
+      const translations: Translations = {
+        hash123: 'Hash translation',
+      };
+      const missingTranslations = [
+        {
+          source: 'Hello world',
+          metadata: { $id: 'greeting', $_hash: 'hash123' },
+        },
+      ];
+
+      const result = injectTranslations(
+        dictionary,
+        translationsDictionary,
+        translations,
+        missingTranslations,
+        ''
+      );
+
+      expect(result.dictionary).toEqual({
+        greeting: 'Hash translation',
+      });
+      expect(result.updateDictionary).toBe(true);
+    });
+
+    it('should prefer hash lookup over existing array-format translation', () => {
+      const dictionary: Dictionary = {
+        greeting: ['Hello {name}', { $context: 'personal' }],
+      };
+      const translationsDictionary: Dictionary = {
+        greeting: ['Hola {name}', { $context: 'personal' }],
+      };
+      const translations: Translations = {
+        hash456: 'Hash-based translation',
+      };
+      const missingTranslations = [
+        {
+          source: 'Hello {name}',
+          metadata: {
+            $id: 'greeting',
+            $context: 'personal',
+            $_hash: 'hash456',
+          },
+        },
+      ];
+
+      const result = injectTranslations(
+        dictionary,
+        translationsDictionary,
+        translations,
+        missingTranslations,
+        ''
+      );
+
+      expect(result.dictionary).toEqual({
+        greeting: 'Hash-based translation',
+      });
+      expect(result.updateDictionary).toBe(true);
+    });
+  });
+
+  describe('should handle nested dictionary paths', () => {
+    it('should inject translation into nested path', () => {
+      const dictionary: Dictionary = {
+        user: {
+          profile: {
+            name: 'Name',
+          },
+        },
+      };
+      const translationsDictionary: Dictionary = {};
+      const translations: Translations = {
+        name_hash: 'Nombre',
+      };
+      const missingTranslations = [
+        {
+          source: 'Name',
+          metadata: { $id: 'user.profile.name', $_hash: 'name_hash' },
+        },
+      ];
+
+      const result = injectTranslations(
+        dictionary,
+        translationsDictionary,
+        translations,
+        missingTranslations,
+        ''
+      );
+
+      expect(result.dictionary).toEqual({
+        user: {
+          profile: {
+            name: 'Nombre',
+          },
+        },
+      });
+      expect(result.updateDictionary).toBe(true);
+    });
+
+    it('should handle deeply nested translations', () => {
+      const dictionary: Dictionary = {
+        app: {
+          nav: {
+            menu: {
+              items: {
+                home: 'Home',
+                about: 'About',
+              },
+            },
+          },
+        },
+      };
+      const translationsDictionary: Dictionary = {};
+      const translations: Translations = {
+        home_hash: 'Accueil',
+        about_hash: 'À propos',
+      };
+      const missingTranslations = [
+        {
+          source: 'Home',
+          metadata: { $id: 'app.nav.menu.items.home', $_hash: 'home_hash' },
+        },
+        {
+          source: 'About',
+          metadata: { $id: 'app.nav.menu.items.about', $_hash: 'about_hash' },
+        },
+      ];
+
+      const result = injectTranslations(
+        dictionary,
+        translationsDictionary,
+        translations,
+        missingTranslations,
+        ''
+      );
+
+      expect(result.dictionary).toEqual({
+        app: {
+          nav: {
+            menu: {
+              items: {
+                home: 'Accueil',
+                about: 'À propos',
+              },
+            },
+          },
+        },
+      });
+      expect(result.updateDictionary).toBe(true);
+    });
+
+    it('should merge with existing nested translations', () => {
+      const dictionary: Dictionary = {
+        messages: {
+          errors: {
+            validation: 'Validation error',
+            network: 'Network error',
+          },
+        },
+      };
+      const translationsDictionary: Dictionary = {
+        messages: {
+          errors: {
+            validation: 'Error de validación',
+          },
+        },
+      };
+      const translations: Translations = {
+        network_hash: 'Error de red',
+      };
+      const missingTranslations = [
+        {
+          source: 'Network error',
+          metadata: { $id: 'messages.errors.network', $_hash: 'network_hash' },
+        },
+      ];
+
+      const result = injectTranslations(
+        dictionary,
+        translationsDictionary,
+        translations,
+        missingTranslations,
+        ''
+      );
+
+      expect(result.dictionary).toEqual({
+        messages: {
+          errors: {
+            validation: 'Error de validación',
+            network: 'Error de red',
+          },
+        },
+      });
+      expect(result.updateDictionary).toBe(true);
+    });
+  });
+
+  describe('should handle missing translations gracefully', () => {
+    it('should skip injection when hash not found and no existing translation', () => {
+      const dictionary: Dictionary = {
+        greeting: 'Hello world',
+      };
+      const translationsDictionary: Dictionary = {};
+      const translations: Translations = {};
+      const missingTranslations = [
+        {
+          source: 'Hello world',
+          metadata: { $id: 'greeting', $_hash: 'nonexistent_hash' },
+        },
+      ];
+
+      const result = injectTranslations(
+        dictionary,
+        translationsDictionary,
+        translations,
+        missingTranslations,
+        ''
+      );
+
+      expect(result.dictionary).toEqual({});
+      expect(result.updateDictionary).toBe(false);
+    });
+
+    it('should skip injection when no translation available', () => {
+      const dictionary: Dictionary = {
+        greeting: 'Hello',
+        farewell: 'Goodbye',
+      };
+      const translationsDictionary: Dictionary = {};
+      const translations: Translations = {
+        hello_hash: 'Hola',
+      };
+      const missingTranslations = [
+        {
+          source: 'Hello',
+          metadata: { $id: 'greeting', $_hash: 'hello_hash' },
+        },
+        {
+          source: 'Goodbye',
+          metadata: { $id: 'farewell', $_hash: 'missing_hash' },
+        },
+      ];
+
+      const result = injectTranslations(
+        dictionary,
+        translationsDictionary,
+        translations,
+        missingTranslations,
+        ''
+      );
+
+      expect(result.dictionary).toEqual({
+        greeting: 'Hola',
+      });
+      expect(result.updateDictionary).toBe(true);
+    });
+
+    it('should handle partial translation scenarios', () => {
+      const dictionary: Dictionary = {
+        nav: {
+          home: 'Home',
+          about: 'About',
+          contact: 'Contact',
+        },
+      };
+      const translationsDictionary: Dictionary = {
+        nav: {
+          home: 'Accueil',
+        },
+      };
+      const translations: Translations = {
+        about_hash: 'À propos',
+      };
+      const missingTranslations = [
+        {
+          source: 'About',
+          metadata: { $id: 'nav.about', $_hash: 'about_hash' },
+        },
+        {
+          source: 'Contact',
+          metadata: { $id: 'nav.contact', $_hash: 'missing_hash' },
+        },
+      ];
+
+      const result = injectTranslations(
+        dictionary,
+        translationsDictionary,
+        translations,
+        missingTranslations,
+        ''
+      );
+
+      expect(result.dictionary).toEqual({
+        nav: {
+          home: 'Accueil',
+          about: 'À propos',
+        },
+      });
+      expect(result.updateDictionary).toBe(true);
+    });
+  });
+
+  describe('should handle entries with context metadata', () => {
+    it('should inject translation for entry with context', () => {
+      const dictionary: Dictionary = {
+        submit: ['Submit', { $context: 'button' }],
+      };
+      const translationsDictionary: Dictionary = {};
+      const translations: Translations = {
+        submit_hash: 'Enviar',
+      };
+      const missingTranslations = [
+        {
+          source: 'Submit',
+          metadata: {
+            $id: 'submit',
+            $context: 'button',
+            $_hash: 'submit_hash',
+          },
+        },
+      ];
+
+      const result = injectTranslations(
+        dictionary,
+        translationsDictionary,
+        translations,
+        missingTranslations,
+        ''
+      );
+
+      expect(result.dictionary).toEqual({
+        submit: 'Enviar',
+      });
+      expect(result.updateDictionary).toBe(true);
+    });
+
+    it('should handle mixed metadata scenarios', () => {
+      const dictionary: Dictionary = {
+        save: ['Save {item}', { $context: 'action' }],
+        delete: 'Delete',
+        confirm: [
+          'Are you sure?',
+          { $context: 'confirmation', $_hash: 'existing' },
+        ],
+      };
+      const translationsDictionary: Dictionary = {};
+      const translations: Translations = {
+        save_hash: 'Guardar {item}',
+        delete_hash: 'Eliminar',
+      };
+      const missingTranslations = [
+        {
+          source: 'Save {item}',
+          metadata: { $id: 'save', $context: 'action', $_hash: 'save_hash' },
+        },
+        {
+          source: 'Delete',
+          metadata: { $id: 'delete', $_hash: 'delete_hash' },
+        },
+      ];
+
+      const result = injectTranslations(
+        dictionary,
+        translationsDictionary,
+        translations,
+        missingTranslations,
+        ''
+      );
+
+      expect(result.dictionary).toEqual({
+        save: 'Guardar {item}',
+        delete: 'Eliminar',
+      });
+      expect(result.updateDictionary).toBe(true);
+    });
+  });
+
+  describe('should return correct updateDictionary flag', () => {
+    it('should return false when no translations are injected', () => {
+      const dictionary: Dictionary = {
+        greeting: 'Hello',
+      };
+      const translationsDictionary: Dictionary = {
+        existing: 'Existing value',
+      };
+      const translations: Translations = {};
+      const missingTranslations = [
+        {
+          source: 'Hello',
+          metadata: { $id: 'greeting', $_hash: 'missing_hash' },
+        },
+      ];
+
+      const result = injectTranslations(
+        dictionary,
+        translationsDictionary,
+        translations,
+        missingTranslations,
+        ''
+      );
+
+      expect(result.dictionary).toEqual({
+        existing: 'Existing value',
+      });
+      expect(result.updateDictionary).toBe(false);
+    });
+
+    it('should return true when at least one translation is injected', () => {
+      const dictionary: Dictionary = {
+        greeting: 'Hello',
+        farewell: 'Goodbye',
+      };
+      const translationsDictionary: Dictionary = {};
+      const translations: Translations = {
+        hello_hash: 'Hola',
+      };
+      const missingTranslations = [
+        {
+          source: 'Hello',
+          metadata: { $id: 'greeting', $_hash: 'hello_hash' },
+        },
+        {
+          source: 'Goodbye',
+          metadata: { $id: 'farewell', $_hash: 'missing_hash' },
+        },
+      ];
+
+      const result = injectTranslations(
+        dictionary,
+        translationsDictionary,
+        translations,
+        missingTranslations,
+        ''
+      );
+
+      expect(result.dictionary).toEqual({
+        greeting: 'Hola',
+      });
+      expect(result.updateDictionary).toBe(true);
+    });
+
+    it('should return true when all translations are injected', () => {
+      const dictionary: Dictionary = {
+        greeting: 'Hello',
+        farewell: 'Goodbye',
+      };
+      const translationsDictionary: Dictionary = {};
+      const translations: Translations = {
+        hello_hash: 'Hola',
+        goodbye_hash: 'Adiós',
+      };
+      const missingTranslations = [
+        {
+          source: 'Hello',
+          metadata: { $id: 'greeting', $_hash: 'hello_hash' },
+        },
+        {
+          source: 'Goodbye',
+          metadata: { $id: 'farewell', $_hash: 'goodbye_hash' },
+        },
+      ];
+
+      const result = injectTranslations(
+        dictionary,
+        translationsDictionary,
+        translations,
+        missingTranslations,
+        ''
+      );
+
+      expect(result.dictionary).toEqual({
+        greeting: 'Hola',
+        farewell: 'Adiós',
+      });
+      expect(result.updateDictionary).toBe(true);
+    });
+  });
+
+  describe('should handle edge cases', () => {
+    it('should handle empty missing translations array', () => {
+      const dictionary: Dictionary = {
+        greeting: 'Hello',
+      };
+      const translationsDictionary: Dictionary = {
+        existing: 'Existing',
+      };
+      const translations: Translations = {
+        hash: 'Translation',
+      };
+      const missingTranslations: unknown[] = [];
+
+      const result = injectTranslations(
+        dictionary,
+        translationsDictionary,
+        translations,
+        missingTranslations,
+        ''
+      );
+
+      expect(result.dictionary).toEqual({
+        existing: 'Existing',
+      });
+      expect(result.updateDictionary).toBe(false);
+    });
+
+    it('should handle empty translations object', () => {
+      const dictionary: Dictionary = {
+        greeting: 'Hello',
+      };
+      const translationsDictionary: Dictionary = {};
+      const translations: Translations = {};
+      const missingTranslations = [
+        {
+          source: 'Hello',
+          metadata: { $id: 'greeting', $_hash: 'any_hash' },
+        },
+      ];
+
+      const result = injectTranslations(
+        dictionary,
+        translationsDictionary,
+        translations,
+        missingTranslations,
+        ''
+      );
+
+      expect(result.dictionary).toEqual({});
+      expect(result.updateDictionary).toBe(false);
+    });
+
+    it('should maintain reference to translationsDictionary', () => {
+      const dictionary: Dictionary = {
+        greeting: 'Hello',
+      };
+      const translationsDictionary: Dictionary = {
+        existing: 'Existing',
+      };
+      const translations: Translations = {
+        hash123: 'Hola',
+      };
+      const missingTranslations = [
+        {
+          source: 'Hello',
+          metadata: { $id: 'greeting', $_hash: 'hash123' },
+        },
+      ];
+
+      const result = injectTranslations(
+        dictionary,
+        translationsDictionary,
+        translations,
+        missingTranslations,
+        ''
+      );
+
+      expect(result.dictionary).toBe(translationsDictionary);
+      expect(result.dictionary).toEqual({
+        existing: 'Existing',
+        greeting: 'Hola',
+      });
+    });
+  });
+
+  describe('should handle complex real-world scenarios', () => {
+    it('should handle mixed translation sources', () => {
+      const dictionary: Dictionary = {
+        ui: {
+          buttons: {
+            save: 'Save',
+            cancel: 'Cancel',
+            delete: 'Delete',
+          },
+          messages: {
+            success: ['Operation successful', { $context: 'notification' }],
+            error: 'An error occurred',
+          },
+        },
+      };
+      const translationsDictionary: Dictionary = {
+        ui: {
+          buttons: {
+            cancel: 'Cancelar', // existing translation
+          },
+        },
+      };
+      const translations: Translations = {
+        save_hash: 'Guardar',
+        success_hash: 'Operación exitosa',
+      };
+      const missingTranslations = [
+        {
+          source: 'Save',
+          metadata: { $id: 'ui.buttons.save', $_hash: 'save_hash' },
+        },
+        {
+          source: 'Delete',
+          metadata: { $id: 'ui.buttons.delete', $_hash: 'missing_hash' },
+        },
+        {
+          source: 'Operation successful',
+          metadata: {
+            $id: 'ui.messages.success',
+            $context: 'notification',
+            $_hash: 'success_hash',
+          },
+        },
+        {
+          source: 'An error occurred',
+          metadata: { $id: 'ui.messages.error', $_hash: 'error_missing' },
+        },
+      ];
+
+      const result = injectTranslations(
+        dictionary,
+        translationsDictionary,
+        translations,
+        missingTranslations,
+        ''
+      );
+
+      expect(result.dictionary).toEqual({
+        ui: {
+          buttons: {
+            cancel: 'Cancelar',
+            save: 'Guardar',
+          },
+          messages: {
+            success: 'Operación exitosa',
+          },
+        },
+      });
+      expect(result.updateDictionary).toBe(true);
+    });
+
+    it('should handle translation priority correctly', () => {
+      const dictionary: Dictionary = {
+        message: 'Hello world',
+      };
+      const translationsDictionary: Dictionary = {
+        message: ['Hola mundo', { $context: 'greeting' }], // existing translation
+      };
+      const translations: Translations = {
+        hash123: 'Translation from hash', // hash-based translation
+      };
+      const missingTranslations = [
+        {
+          source: 'Hello world',
+          metadata: { $id: 'message', $_hash: 'hash123' },
+        },
+      ];
+
+      const result = injectTranslations(
+        dictionary,
+        translationsDictionary,
+        translations,
+        missingTranslations,
+        ''
+      );
+
+      // Should prefer hash-based translation over existing
+      expect(result.dictionary).toEqual({
+        message: 'Translation from hash',
+      });
+      expect(result.updateDictionary).toBe(true);
+    });
+  });
+});

--- a/packages/react-core/src/utils/dictionaries/__tests__/isDictionaryEntry.test.ts
+++ b/packages/react-core/src/utils/dictionaries/__tests__/isDictionaryEntry.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import { isDictionaryEntry } from '../isDictionaryEntry';
+import { Dictionary, DictionaryEntry } from '../../types';
+
+describe('isDictionaryEntry', () => {
+  describe('should return true for valid DictionaryEntry types', () => {
+    it('should return true for simple string entry', () => {
+      const entry: DictionaryEntry = 'Hello world';
+      expect(isDictionaryEntry(entry)).toBe(true);
+    });
+
+    it('should return true for array with single string element', () => {
+      const entry: DictionaryEntry = ['Hello world'];
+      expect(isDictionaryEntry(entry)).toBe(true);
+    });
+
+    it('should return true for array with string and metadata', () => {
+      const entry: DictionaryEntry = ['Hello world', { $context: 'greeting' }];
+      expect(isDictionaryEntry(entry)).toBe(true);
+    });
+
+    it('should return true for array with string and complex metadata', () => {
+      const entry: DictionaryEntry = [
+        'Hello {name}',
+        { $context: 'greeting', $id: 'hello', customField: 'custom' },
+      ];
+      expect(isDictionaryEntry(entry)).toBe(true);
+    });
+
+    it('should return true for array with string and empty object metadata', () => {
+      const entry: DictionaryEntry = ['Hello', {}];
+      expect(isDictionaryEntry(entry)).toBe(false);
+    });
+  });
+
+  describe('should return false for invalid types', () => {
+    it('should return false for undefined', () => {
+      expect(isDictionaryEntry(undefined)).toBe(false);
+    });
+
+    it('should return false for null', () => {
+      expect(isDictionaryEntry(null)).toBe(false);
+    });
+
+    it('should return false for number', () => {
+      expect(isDictionaryEntry(42)).toBe(false);
+    });
+
+    it('should return false for boolean', () => {
+      expect(isDictionaryEntry(true)).toBe(false);
+      expect(isDictionaryEntry(false)).toBe(false);
+    });
+
+    it('should return false for plain object (Dictionary)', () => {
+      const dict: Dictionary = { hello: 'world' };
+      expect(isDictionaryEntry(dict)).toBe(false);
+    });
+
+    it('should return false for empty object', () => {
+      expect(isDictionaryEntry({})).toBe(false);
+    });
+  });
+
+  describe('should return false for invalid array formats', () => {
+    it('should return false for empty array', () => {
+      expect(isDictionaryEntry([])).toBe(false);
+    });
+
+    it('should return false for array with more than 2 elements', () => {
+      expect(isDictionaryEntry(['hello', {}, 'extra'])).toBe(false);
+    });
+
+    it('should return false for array with non-string first element', () => {
+      expect(isDictionaryEntry([42, { $context: 'number' }])).toBe(false);
+      expect(isDictionaryEntry([true, { $context: 'boolean' }])).toBe(false);
+      expect(isDictionaryEntry([null, { $context: 'null' }])).toBe(false);
+    });
+
+    it('should return false for array with non-object second element', () => {
+      expect(isDictionaryEntry(['hello', 'world'])).toBe(false);
+      expect(isDictionaryEntry(['hello', 42])).toBe(false);
+      expect(isDictionaryEntry(['hello', true])).toBe(false);
+      expect(isDictionaryEntry(['hello', null])).toBe(false);
+    });
+
+    it('should return false for array with 3 elements', () => {
+      expect(
+        isDictionaryEntry(['hello', { $context: 'greeting' }, 'extra'])
+      ).toBe(false);
+    });
+  });
+
+  describe('should handle edge cases correctly', () => {
+    it('should handle empty string', () => {
+      expect(isDictionaryEntry('')).toBe(true);
+    });
+
+    it('should handle array with empty string', () => {
+      expect(isDictionaryEntry([''])).toBe(true);
+    });
+
+    it('should handle array with empty string and metadata', () => {
+      expect(isDictionaryEntry(['', { $context: 'empty' }])).toBe(true);
+    });
+
+    it('should handle nested arrays', () => {
+      expect(isDictionaryEntry([['nested']])).toBe(false);
+    });
+
+    it('should handle function as input', () => {
+      expect(isDictionaryEntry(() => 'hello')).toBe(false);
+    });
+  });
+});

--- a/packages/react-core/src/utils/dictionaries/__tests__/mergeDictionaries.test.ts
+++ b/packages/react-core/src/utils/dictionaries/__tests__/mergeDictionaries.test.ts
@@ -1,0 +1,311 @@
+import { describe, it, expect } from 'vitest';
+import mergeDictionaries from '../mergeDictionaries';
+import { Dictionary } from '../../types';
+
+describe('mergeDictionaries', () => {
+  describe('should merge primitive and array values correctly', () => {
+    it('should merge simple string entries', () => {
+      const defaultDict: Dictionary = {
+        greeting: 'Hello',
+        farewell: 'Goodbye',
+      };
+      const localeDict: Dictionary = {
+        greeting: 'Hola',
+        welcome: 'Bienvenido',
+      };
+
+      const result = mergeDictionaries(defaultDict, localeDict);
+
+      expect(result).toEqual({
+        greeting: 'Hola', // localeDict overwrites defaultDict
+        farewell: 'Goodbye', // from defaultDict
+        welcome: 'Bienvenido', // from localeDict
+      });
+    });
+
+    it('should merge array-based dictionary entries', () => {
+      const defaultDict: Dictionary = {
+        message1: ['Hello world', { $context: 'greeting' }],
+        message2: ['How are you?', { $context: 'question' }],
+      };
+      const localeDict: Dictionary = {
+        message1: ['Hola mundo', { $context: 'greeting', $locale: 'es' }],
+        message3: ['Adios', { $context: 'farewell' }],
+      };
+
+      const result = mergeDictionaries(defaultDict, localeDict);
+
+      expect(result).toEqual({
+        message1: ['Hola mundo', { $context: 'greeting', $locale: 'es' }],
+        message2: ['How are you?', { $context: 'question' }],
+        message3: ['Adios', { $context: 'farewell' }],
+      });
+    });
+
+    it('should handle mixed primitive types and arrays', () => {
+      const defaultDict: Dictionary = {
+        simple: 'Simple text',
+        withMetadata: ['Text with metadata', { $context: 'test' }],
+      };
+      const localeDict: Dictionary = {
+        simple: ['Texto simple', { $context: 'simple' }],
+        withMetadata: 'Texto con metadatos',
+      };
+
+      const result = mergeDictionaries(defaultDict, localeDict);
+
+      expect(result).toEqual({
+        simple: ['Texto simple', { $context: 'simple' }],
+        withMetadata: 'Texto con metadatos',
+      });
+    });
+  });
+
+  describe('should merge nested dictionary structures recursively', () => {
+    it('should merge simple nested dictionaries', () => {
+      const defaultDict: Dictionary = {
+        user: {
+          name: 'John',
+          age: 'Twenty-five',
+        },
+        settings: {
+          theme: 'light',
+          language: 'en',
+        },
+      };
+      const localeDict: Dictionary = {
+        user: {
+          name: 'Juan',
+          location: 'Madrid',
+        },
+        app: {
+          name: 'Mi App',
+        },
+      };
+
+      const result = mergeDictionaries(defaultDict, localeDict);
+
+      expect(result).toEqual({
+        user: {
+          name: 'Juan', // overwritten
+          age: 'Twenty-five', // from default
+          location: 'Madrid', // from locale
+        },
+        settings: {
+          theme: 'light',
+          language: 'en',
+        },
+        app: {
+          name: 'Mi App',
+        },
+      });
+    });
+
+    it('should handle deeply nested structures', () => {
+      const defaultDict: Dictionary = {
+        level1: {
+          level2: {
+            level3: {
+              message: 'Deep message',
+              data: 'Deep data',
+            },
+            sibling: 'Sibling value',
+          },
+        },
+      };
+      const localeDict: Dictionary = {
+        level1: {
+          level2: {
+            level3: {
+              message: 'Mensaje profundo',
+              newField: 'Nuevo campo',
+            },
+            newSibling: 'Nuevo hermano',
+          },
+        },
+      };
+
+      const result = mergeDictionaries(defaultDict, localeDict);
+
+      expect(result).toEqual({
+        level1: {
+          level2: {
+            level3: {
+              message: 'Mensaje profundo',
+              data: 'Deep data',
+              newField: 'Nuevo campo',
+            },
+            sibling: 'Sibling value',
+            newSibling: 'Nuevo hermano',
+          },
+        },
+      });
+    });
+
+    it('should merge mixed flat and nested structures', () => {
+      const defaultDict: Dictionary = {
+        flatMessage: 'Flat message',
+        nested: {
+          message: 'Nested message',
+          data: ['Data with metadata', { $context: 'data' }],
+        },
+      };
+      const localeDict: Dictionary = {
+        flatMessage: ['Mensaje plano', { $context: 'flat' }],
+        nested: {
+          message: 'Mensaje anidado',
+          newEntry: 'Nueva entrada',
+        },
+        newFlat: 'Nuevo plano',
+      };
+
+      const result = mergeDictionaries(defaultDict, localeDict);
+
+      expect(result).toEqual({
+        flatMessage: ['Mensaje plano', { $context: 'flat' }],
+        newFlat: 'Nuevo plano',
+        nested: {
+          message: 'Mensaje anidado',
+          data: ['Data with metadata', { $context: 'data' }],
+          newEntry: 'Nueva entrada',
+        },
+      });
+    });
+  });
+
+  describe('should handle edge cases correctly', () => {
+    it('should handle empty dictionaries', () => {
+      const defaultDict: Dictionary = {};
+      const localeDict: Dictionary = {
+        message: 'Hello',
+      };
+
+      const result = mergeDictionaries(defaultDict, localeDict);
+
+      expect(result).toEqual({
+        message: 'Hello',
+      });
+    });
+
+    it('should handle both empty dictionaries', () => {
+      const defaultDict: Dictionary = {};
+      const localeDict: Dictionary = {};
+
+      const result = mergeDictionaries(defaultDict, localeDict);
+
+      expect(result).toEqual({});
+    });
+
+    it('should handle empty locale dictionary', () => {
+      const defaultDict: Dictionary = {
+        message: 'Hello',
+        nested: {
+          value: 'Nested value',
+        },
+      };
+      const localeDict: Dictionary = {};
+
+      const result = mergeDictionaries(defaultDict, localeDict);
+
+      expect(result).toEqual({
+        message: 'Hello',
+        nested: {
+          value: 'Nested value',
+        },
+      });
+    });
+
+    it('should handle undefined nested objects gracefully', () => {
+      const defaultDict: Dictionary = {
+        user: {
+          name: 'John',
+        },
+      };
+      const localeDict: Dictionary = {
+        settings: {
+          theme: 'dark',
+        },
+      };
+
+      const result = mergeDictionaries(defaultDict, localeDict);
+
+      expect(result).toEqual({
+        user: {
+          name: 'John',
+        },
+        settings: {
+          theme: 'dark',
+        },
+      });
+    });
+
+    it('should not mutate original dictionaries', () => {
+      const defaultDict: Dictionary = {
+        message: 'Hello',
+        nested: {
+          value: 'Original',
+        },
+      };
+      const localeDict: Dictionary = {
+        message: 'Hola',
+        nested: {
+          newValue: 'Nuevo',
+        },
+      };
+
+      const originalDefault = JSON.parse(JSON.stringify(defaultDict));
+      const originalLocale = JSON.parse(JSON.stringify(localeDict));
+
+      const result = mergeDictionaries(defaultDict, localeDict);
+
+      expect(defaultDict).toEqual(originalDefault);
+      expect(localeDict).toEqual(originalLocale);
+      expect(result).not.toBe(defaultDict);
+      expect(result).not.toBe(localeDict);
+    });
+
+    it('should handle complex mixed types correctly', () => {
+      const defaultDict: Dictionary = {
+        strings: {
+          hello: 'Hello',
+          world: 'World',
+        },
+        arrays: {
+          greeting: ['Hello World', { $context: 'greeting' }],
+          farewell: ['Goodbye', { $context: 'farewell' }],
+        },
+      };
+      const localeDict: Dictionary = {
+        strings: {
+          hello: 'Hola',
+          goodbye: 'Adios',
+        },
+        arrays: {
+          greeting: ['Hola Mundo', { $context: 'greeting', $locale: 'es' }],
+          welcome: ['Bienvenido', { $context: 'welcome' }],
+        },
+        newSection: {
+          message: 'Nuevo mensaje',
+        },
+      };
+
+      const result = mergeDictionaries(defaultDict, localeDict);
+
+      expect(result).toEqual({
+        strings: {
+          hello: 'Hola',
+          world: 'World',
+          goodbye: 'Adios',
+        },
+        arrays: {
+          greeting: ['Hola Mundo', { $context: 'greeting', $locale: 'es' }],
+          farewell: ['Goodbye', { $context: 'farewell' }],
+          welcome: ['Bienvenido', { $context: 'welcome' }],
+        },
+        newSection: {
+          message: 'Nuevo mensaje',
+        },
+      });
+    });
+  });
+});

--- a/packages/react-core/src/utils/dictionaries/__tests__/stripMetadataFromEntries.test.ts
+++ b/packages/react-core/src/utils/dictionaries/__tests__/stripMetadataFromEntries.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect } from 'vitest';
+import { stripMetadataFromEntries } from '../stripMetadataFromEntries';
+import { Dictionary } from '../../types';
+
+describe('stripMetadataFromEntries', () => {
+  describe('should strip metadata from dictionary entries', () => {
+    it('should return string entries unchanged', () => {
+      const dictionary: Dictionary = {
+        greeting: 'Hello World',
+        farewell: 'Goodbye',
+      };
+
+      const result = stripMetadataFromEntries(dictionary);
+
+      expect(result).toEqual({
+        greeting: 'Hello World',
+        farewell: 'Goodbye',
+      });
+    });
+
+    it('should strip metadata from array entries with metadata', () => {
+      const dictionary: Dictionary = {
+        welcome: ['Welcome back', { $context: 'greeting', $id: 'welcome_id' }],
+        error: [
+          'Something went wrong',
+          { $context: 'error', customField: 'value' },
+        ],
+      };
+
+      const result = stripMetadataFromEntries(dictionary);
+
+      expect(result).toEqual({
+        welcome: 'Welcome back',
+        error: 'Something went wrong',
+      });
+    });
+
+    it('should handle single-element arrays', () => {
+      const dictionary: Dictionary = {
+        simple: ['Simple text'],
+        another: ['Another text'],
+      };
+
+      const result = stripMetadataFromEntries(dictionary);
+
+      expect(result).toEqual({
+        simple: 'Simple text',
+        another: 'Another text',
+      });
+    });
+
+    it('should handle mixed entry types', () => {
+      const dictionary: Dictionary = {
+        string: 'Plain string',
+        withMetadata: ['Text with metadata', { $context: 'test' }],
+        singleArray: ['Single array element'],
+      };
+
+      const result = stripMetadataFromEntries(dictionary);
+
+      expect(result).toEqual({
+        string: 'Plain string',
+        withMetadata: 'Text with metadata',
+        singleArray: 'Single array element',
+      });
+    });
+  });
+
+  describe('should handle nested dictionary structures', () => {
+    it('should recursively strip metadata from nested dictionaries', () => {
+      const dictionary: Dictionary = {
+        user: {
+          profile: {
+            name: ['John Doe', { $context: 'name' }],
+            bio: 'Software developer',
+            location: ['New York', { $context: 'location', $id: 'loc_1' }],
+          },
+          settings: {
+            theme: 'dark',
+            language: ['English', { $context: 'language' }],
+          },
+        },
+        messages: {
+          welcome: ['Welcome!', { $context: 'greeting' }],
+          goodbye: 'See you later',
+        },
+      };
+
+      const result = stripMetadataFromEntries(dictionary);
+
+      expect(result).toEqual({
+        user: {
+          profile: {
+            name: 'John Doe',
+            bio: 'Software developer',
+            location: 'New York',
+          },
+          settings: {
+            theme: 'dark',
+            language: 'English',
+          },
+        },
+        messages: {
+          welcome: 'Welcome!',
+          goodbye: 'See you later',
+        },
+      });
+    });
+
+    it('should handle deeply nested structures', () => {
+      const dictionary: Dictionary = {
+        level1: {
+          level2: {
+            level3: {
+              level4: {
+                deepEntry: ['Deep value', { $context: 'deep', $id: 'deep_id' }],
+                normalEntry: 'Normal value',
+              },
+            },
+          },
+        },
+      };
+
+      const result = stripMetadataFromEntries(dictionary);
+
+      expect(result).toEqual({
+        level1: {
+          level2: {
+            level3: {
+              level4: {
+                deepEntry: 'Deep value',
+                normalEntry: 'Normal value',
+              },
+            },
+          },
+        },
+      });
+    });
+
+    it('should handle mixed nested and flat structures', () => {
+      const dictionary: Dictionary = {
+        flat: ['Flat entry', { $context: 'flat' }],
+        nested: {
+          entry1: ['Nested entry 1', { $context: 'nested' }],
+          entry2: 'Nested entry 2',
+          deeperNested: {
+            entry3: ['Deep entry', { $context: 'deep', customField: 'custom' }],
+          },
+        },
+      };
+
+      const result = stripMetadataFromEntries(dictionary);
+
+      expect(result).toEqual({
+        flat: 'Flat entry',
+        nested: {
+          entry1: 'Nested entry 1',
+          entry2: 'Nested entry 2',
+          deeperNested: {
+            entry3: 'Deep entry',
+          },
+        },
+      });
+    });
+  });
+
+  describe('should handle edge cases', () => {
+    it('should handle empty dictionary', () => {
+      const dictionary: Dictionary = {};
+
+      const result = stripMetadataFromEntries(dictionary);
+
+      expect(result).toEqual({});
+    });
+
+    it('should handle dictionary with empty nested objects', () => {
+      const dictionary: Dictionary = {
+        empty: {},
+        nonEmpty: {
+          entry: ['Text', { $context: 'test' }],
+        },
+      };
+
+      const result = stripMetadataFromEntries(dictionary);
+
+      expect(result).toEqual({
+        empty: {},
+        nonEmpty: {
+          entry: 'Text',
+        },
+      });
+    });
+
+    it('should handle complex metadata objects', () => {
+      const dictionary: Dictionary = {
+        complex: [
+          'Complex text',
+          {
+            $context: 'complex',
+            $id: 'complex_id',
+            $_hash: 'some_hash',
+            customField1: 'value1',
+            customField2: { nested: 'nested_value' },
+            customField3: [1, 2, 3],
+          },
+        ],
+      };
+
+      const result = stripMetadataFromEntries(dictionary);
+
+      expect(result).toEqual({
+        complex: 'Complex text',
+      });
+    });
+
+    it('should preserve original dictionary structure (not mutate)', () => {
+      const dictionary: Dictionary = {
+        test: ['Test text', { $context: 'test' }],
+        nested: {
+          entry: ['Nested text', { $context: 'nested' }],
+        },
+      };
+      const original = JSON.parse(JSON.stringify(dictionary)); // Deep copy for comparison
+
+      const result = stripMetadataFromEntries(dictionary);
+
+      expect(dictionary).toEqual(original); // Original should be unchanged
+      expect(result).not.toBe(dictionary); // Should be a new object
+      expect(result.test).toBe('Test text');
+    });
+  });
+});

--- a/packages/react-core/src/utils/dictionaries/collectUntranslatedEntries.ts
+++ b/packages/react-core/src/utils/dictionaries/collectUntranslatedEntries.ts
@@ -1,0 +1,63 @@
+import type { Dictionary } from '../types';
+import getEntryAndMetadata from './getEntryAndMetadata';
+import { get } from './indexDict';
+import { isDictionaryEntry } from './isDictionaryEntry';
+
+/**
+ * @description Collects all untranslated entries from a dictionary
+ * @param dictionary - The dictionary to collect untranslated entries from
+ * @param translationsDictionary - The translated dictionary to compare against
+ * @param id - The id of the dictionary to collect untranslated entries from
+ * @returns An array of untranslated entries
+ */
+export function collectUntranslatedEntries(
+  dictionary: Dictionary,
+  translationsDictionary: Dictionary,
+  id: string = ''
+): {
+  source: string;
+  metadata: {
+    $id: string;
+    $context?: string;
+    $maxChars?: number;
+    $_hash: string;
+  };
+}[] {
+  const untranslatedEntries: {
+    source: string;
+    metadata: {
+      $id: string;
+      $context?: string;
+      $maxChars?: number;
+      $_hash: string;
+    };
+  }[] = [];
+  Object.entries(dictionary).forEach(([key, value]) => {
+    const wholeId = id ? `${id}.${key}` : key;
+    if (isDictionaryEntry(value)) {
+      const { entry, metadata } = getEntryAndMetadata(value);
+
+      if (!get(translationsDictionary, key)) {
+        untranslatedEntries.push({
+          source: entry,
+          metadata: {
+            $id: wholeId,
+            $context: metadata?.$context,
+            $maxChars: metadata?.$maxChars,
+            $_hash: metadata?.$_hash || '',
+          },
+        });
+      }
+    } else {
+      untranslatedEntries.push(
+        ...collectUntranslatedEntries(
+          value,
+          (get(translationsDictionary, key) ||
+            (Array.isArray(value) ? [] : {})) as Dictionary,
+          wholeId
+        )
+      );
+    }
+  });
+  return untranslatedEntries;
+}

--- a/packages/react-core/src/utils/dictionaries/flattenDictionary.ts
+++ b/packages/react-core/src/utils/dictionaries/flattenDictionary.ts
@@ -1,0 +1,51 @@
+import type {
+  Dictionary,
+  DictionaryEntry,
+  FlattenedDictionary,
+} from '../types';
+import { get } from './indexDict';
+
+const createDuplicateKeyError = (key: string) =>
+  `Duplicate key found in dictionary: "${key}"`;
+
+/**
+ * Flattens a nested dictionary by concatenating nested keys.
+ * Throws an error if two keys result in the same flattened key.
+ * @param {Record<string, any>} dictionary - The dictionary to flatten.
+ * @param {string} [prefix=''] - The prefix for nested keys.
+ * @returns {Record<string, React.ReactNode>} The flattened dictionary object.
+ * @throws {Error} If two keys result in the same flattened key.
+ */
+export default function flattenDictionary(
+  dictionary: Dictionary,
+  prefix: string = ''
+): FlattenedDictionary {
+  const flattened: FlattenedDictionary = {};
+  for (const key in dictionary) {
+    if (Object.prototype.hasOwnProperty.call(dictionary, key)) {
+      const newKey = prefix ? `${prefix}.${key}` : key;
+      if (
+        typeof get(dictionary, key) === 'object' &&
+        get(dictionary, key) !== null &&
+        !Array.isArray(get(dictionary, key))
+      ) {
+        const nestedFlattened = flattenDictionary(
+          get(dictionary, key) as Dictionary,
+          newKey
+        );
+        for (const flatKey in nestedFlattened) {
+          if (Object.prototype.hasOwnProperty.call(flattened, flatKey)) {
+            throw new Error(createDuplicateKeyError(flatKey));
+          }
+          flattened[flatKey] = nestedFlattened[flatKey];
+        }
+      } else {
+        if (Object.prototype.hasOwnProperty.call(flattened, newKey)) {
+          throw new Error(createDuplicateKeyError(newKey));
+        }
+        flattened[newKey] = get(dictionary, key) as DictionaryEntry;
+      }
+    }
+  }
+  return flattened;
+}

--- a/packages/react-core/src/utils/dictionaries/getDictionaryEntry.ts
+++ b/packages/react-core/src/utils/dictionaries/getDictionaryEntry.ts
@@ -1,0 +1,37 @@
+import type { Dictionary, DictionaryEntry } from '../types';
+import { get } from './indexDict';
+
+export function isValidDictionaryEntry(
+  value: unknown
+): value is DictionaryEntry {
+  if (typeof value === 'string') {
+    return true;
+  }
+
+  if (Array.isArray(value)) {
+    if (typeof value?.[0] !== 'string') {
+      return false;
+    }
+    const provisionalMetadata = value?.[1];
+    if (typeof provisionalMetadata === 'undefined') return true;
+    if (provisionalMetadata && typeof provisionalMetadata === 'object')
+      return true;
+  }
+
+  return false;
+}
+
+export function getDictionaryEntry<T extends Dictionary>(
+  dictionary: T,
+  id: string
+): Dictionary | DictionaryEntry | undefined {
+  let current: Dictionary | DictionaryEntry = dictionary;
+  const dictionaryPath = id.split('.');
+  for (const key of dictionaryPath) {
+    if (typeof current !== 'object' && !Array.isArray(current)) {
+      return undefined;
+    }
+    current = get(current as Dictionary, key);
+  }
+  return current;
+}

--- a/packages/react-core/src/utils/dictionaries/getEntryAndMetadata.ts
+++ b/packages/react-core/src/utils/dictionaries/getEntryAndMetadata.ts
@@ -1,0 +1,16 @@
+import type { DictionaryEntry, MetaEntry } from '../types';
+
+export default function getEntryAndMetadata(value: DictionaryEntry): {
+  entry: string;
+  metadata?: MetaEntry;
+} {
+  if (Array.isArray(value)) {
+    if (value.length === 1) {
+      return { entry: value[0] };
+    }
+    if (value.length === 2) {
+      return { entry: value[0], metadata: value[1] as MetaEntry };
+    }
+  }
+  return { entry: value };
+}

--- a/packages/react-core/src/utils/dictionaries/getSubtree.ts
+++ b/packages/react-core/src/utils/dictionaries/getSubtree.ts
@@ -1,0 +1,58 @@
+import type { Dictionary, DictionaryEntry } from '../types';
+import { get, set } from './indexDict';
+
+export function getSubtree<T extends Dictionary>({
+  dictionary,
+  id,
+}: {
+  dictionary: T;
+  id: string;
+}): Dictionary | DictionaryEntry | undefined {
+  if (id === '') {
+    return dictionary;
+  }
+
+  let current: Dictionary | DictionaryEntry = dictionary;
+  const dictionaryPath = id.split('.');
+  for (const key of dictionaryPath) {
+    current = get(current as Dictionary, key);
+  }
+  return current;
+}
+
+/**
+ * @description A function that gets a subtree from a dictionary
+ * @param dictionary - new dictionary to get the subtree from
+ * @param id - id of the subtree to get
+ * @param sourceDictionary - source dictionary to model off of
+ * @returns
+ */
+export function getSubtreeWithCreation<T extends Dictionary>({
+  dictionary,
+  id,
+  sourceDictionary,
+}: {
+  dictionary: T;
+  id: string;
+  sourceDictionary: T;
+}): Dictionary | DictionaryEntry | undefined {
+  if (id === '') {
+    return dictionary;
+  }
+
+  let current: Dictionary | DictionaryEntry = dictionary;
+  const sourceCurrent: Dictionary | DictionaryEntry = sourceDictionary;
+  const dictionaryPath = id.split('.');
+  for (const key of dictionaryPath) {
+    if (get(current as Dictionary, key) === undefined) {
+      // We know this wont be type Dictionary because we should have already checked for that
+      if (Array.isArray(get(sourceCurrent as Dictionary, key))) {
+        set(current as Dictionary, key, [] as Dictionary);
+      } else {
+        set(current as Dictionary, key, {} as Dictionary);
+      }
+    }
+    current = get(current as Dictionary, key);
+  }
+  return current;
+}

--- a/packages/react-core/src/utils/dictionaries/indexDict.ts
+++ b/packages/react-core/src/utils/dictionaries/indexDict.ts
@@ -1,0 +1,35 @@
+import type { Dictionary, DictionaryEntry } from '../types';
+
+/**
+ * @description A function that gets a value from a dictionary, only one level
+ * @param dictionary - dictionary to get the value from
+ * @param id - id of the value to get
+ */
+export function get(dictionary: Dictionary, id: string | number) {
+  if (dictionary == null) {
+    throw new Error('Cannot index into an undefined dictionary');
+  }
+  if (Array.isArray(dictionary)) {
+    return dictionary[id as number];
+  }
+  return dictionary[id as string];
+}
+
+/**
+ * @description A function that sets a value in a dictionary
+ * @param dictionary - dictionary to set the value in
+ * @param id - id of the value to set
+ * @param value - value to set
+ */
+export function set(
+  dictionary: Dictionary,
+  id: string | number,
+  value: Dictionary | DictionaryEntry
+) {
+  if (Array.isArray(dictionary)) {
+    dictionary[id as number] = value;
+  } else {
+    (dictionary as Record<string, Dictionary | DictionaryEntry>)[id as string] =
+      value;
+  }
+}

--- a/packages/react-core/src/utils/dictionaries/injectAndMerge.ts
+++ b/packages/react-core/src/utils/dictionaries/injectAndMerge.ts
@@ -1,0 +1,64 @@
+import type { Dictionary, DictionaryEntry } from '../types';
+import { getDictionaryEntry } from './getDictionaryEntry';
+import { getSubtree } from './getSubtree';
+import { get, set } from './indexDict';
+import { isDictionaryEntry } from './isDictionaryEntry';
+import mergeDictionaries from './mergeDictionaries';
+
+const createSubtreeNotFoundError = (id: string) =>
+  `Dictionary subtree "${id}" could not be found`;
+
+const createDictionaryEntryError = () =>
+  'A dictionary entry cannot be injected as a subtree';
+
+const createCannotInjectDictionaryEntryError = () =>
+  'A dictionary entry cannot be merged into another dictionary entry';
+
+/**
+ * @description Given a subtree and a dictionary, injects the subtree into the dictionary at the given id
+ * @param dictionary - The dictionary to inject the subtree into
+ * @param subtree - The subtree to inject into the dictionary
+ * @param id - The id of the subtree to inject into the dictionary
+ */
+export function injectAndMerge(
+  dictionary: Dictionary,
+  subtree: Dictionary,
+  id: string
+) {
+  const dictionarySubtree = getSubtree({ dictionary, id });
+  if (!dictionarySubtree) {
+    throw new Error(createSubtreeNotFoundError(id));
+  }
+  if (isDictionaryEntry(dictionarySubtree)) {
+    throw new Error(createDictionaryEntryError());
+  }
+  const mergedSubtree = mergeDictionaries(
+    dictionarySubtree as Dictionary,
+    subtree
+  );
+  // Inject the merged subtree into the dictionary
+  return injectSubtree(dictionary, mergedSubtree, id);
+}
+
+function injectSubtree(
+  dictionary: Dictionary,
+  subtree: Dictionary,
+  id: string
+) {
+  const dictionarySubtree = getDictionaryEntry(dictionary, id);
+  if (!dictionarySubtree) {
+    throw new Error(createSubtreeNotFoundError(id));
+  }
+  if (isDictionaryEntry(dictionarySubtree)) {
+    throw new Error(createCannotInjectDictionaryEntryError());
+  }
+  const ids = id.split('.');
+  const shortenedId = ids.slice(0, -1);
+  const lastId = ids[ids.length - 1];
+  let current: Dictionary | DictionaryEntry = dictionary;
+  shortenedId.forEach((id) => {
+    current = get(current as Dictionary, id);
+  });
+  set(current as Dictionary, lastId, subtree);
+  return dictionary;
+}

--- a/packages/react-core/src/utils/dictionaries/injectEntry.ts
+++ b/packages/react-core/src/utils/dictionaries/injectEntry.ts
@@ -1,8 +1,4 @@
-import type {
-  Dictionary,
-  DictionaryEntry,
-  TranslatedChildren,
-} from '../types';
+import type { Dictionary, DictionaryEntry, TranslatedChildren } from '../types';
 import { get, set } from './indexDict';
 import { isDictionaryEntry } from './isDictionaryEntry';
 

--- a/packages/react-core/src/utils/dictionaries/injectEntry.ts
+++ b/packages/react-core/src/utils/dictionaries/injectEntry.ts
@@ -1,4 +1,4 @@
-import type { Dictionary, DictionaryEntry, TranslatedChildren } from '../types';
+import type { Dictionary, DictionaryEntry } from '../types';
 import { get, set } from './indexDict';
 import { isDictionaryEntry } from './isDictionaryEntry';
 
@@ -54,22 +54,4 @@ export function injectEntry(
   // Inject the entry into the last key
   const lastKey = keys[keys.length - 1];
   set(dictionary, lastKey, dictionaryEntry);
-}
-
-/**
- * @description Merge results into a dictionary
- * @param dictionary - The dictionary to merge the results into
- * @param results - The results to merge into the dictionary
- * @param sourceDictionary - The source dictionary to model the new dictionary after
- * @returns The merged dictionary
- */
-export function mergeResultsIntoDictionary(
-  dictionary: Dictionary,
-  results: [string, TranslatedChildren][],
-  sourceDictionary: Dictionary
-): Dictionary {
-  results.forEach(([id, result]) => {
-    injectEntry(result as string, dictionary, id, sourceDictionary);
-  });
-  return dictionary;
 }

--- a/packages/react-core/src/utils/dictionaries/injectEntry.ts
+++ b/packages/react-core/src/utils/dictionaries/injectEntry.ts
@@ -1,0 +1,79 @@
+import type {
+  Dictionary,
+  DictionaryEntry,
+  TranslatedChildren,
+} from '../types';
+import { get, set } from './indexDict';
+import { isDictionaryEntry } from './isDictionaryEntry';
+
+const DANGEROUS_KEYS = ['constructor', 'prototype', '__proto__'];
+function isDangerousKey(key: string): boolean {
+  if (DANGEROUS_KEYS.includes(key)) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * @description Injects an entry into a translations object
+ * @param translations - The translations object to inject the entry into
+ * @param entry - The entry to inject
+ * @param hash - The hash of the entry
+ * @param sourceDictionary - The source dictionary to model the new dictionary after
+ */
+export function injectEntry(
+  dictionaryEntry: DictionaryEntry,
+  dictionary: Dictionary | DictionaryEntry,
+  id: string,
+  sourceDictionary: Dictionary | DictionaryEntry
+) {
+  // If the dictionary is a DictionaryEntry, return it
+  if (isDictionaryEntry(dictionary)) {
+    return dictionaryEntry;
+  }
+
+  // Iterate over all but last key
+  const keys = id.split('.');
+  keys.forEach((key) => {
+    if (isDangerousKey(key)) {
+      throw new Error(`Invalid key: ${key}`);
+    }
+  });
+  dictionary ||= {};
+  for (const key of keys.slice(0, -1)) {
+    // Create new value if it doesn't exist
+    if (get(dictionary, key) == null) {
+      set(
+        dictionary,
+        key,
+        Array.isArray(get(sourceDictionary as Dictionary, key))
+          ? []
+          : ({} as Dictionary)
+      );
+    }
+    // Iterate
+    dictionary = get(dictionary, key) as Dictionary;
+    sourceDictionary = get(sourceDictionary as Dictionary, key) as Dictionary;
+  }
+  // Inject the entry into the last key
+  const lastKey = keys[keys.length - 1];
+  set(dictionary, lastKey, dictionaryEntry);
+}
+
+/**
+ * @description Merge results into a dictionary
+ * @param dictionary - The dictionary to merge the results into
+ * @param results - The results to merge into the dictionary
+ * @param sourceDictionary - The source dictionary to model the new dictionary after
+ * @returns The merged dictionary
+ */
+export function mergeResultsIntoDictionary(
+  dictionary: Dictionary,
+  results: [string, TranslatedChildren][],
+  sourceDictionary: Dictionary
+): Dictionary {
+  results.forEach(([id, result]) => {
+    injectEntry(result as string, dictionary, id, sourceDictionary);
+  });
+  return dictionary;
+}

--- a/packages/react-core/src/utils/dictionaries/injectFallbacks.ts
+++ b/packages/react-core/src/utils/dictionaries/injectFallbacks.ts
@@ -1,0 +1,49 @@
+import type { Dictionary } from '../types';
+import { getDictionaryEntry } from './getDictionaryEntry';
+import getEntryAndMetadata from './getEntryAndMetadata';
+import { injectEntry } from './injectEntry';
+import { isDictionaryEntry } from './isDictionaryEntry';
+
+/**
+ * @description Injects fallbacks into a dictionary
+ * @param dictionary - The dictionary to inject translations into
+ * @param translationsDictionary - The translations to inject into the dictionary
+ * @param translations - The translations to inject into the dictionary
+ * @param id - The id of the dictionary to inject translations into
+ */
+export function injectFallbacks(
+  dictionary: Dictionary,
+  translationsDictionary: Dictionary,
+  missingTranslations: {
+    source: string;
+    metadata: {
+      $id: string;
+      $context?: string;
+      $maxChars?: number;
+      $_hash: string;
+    };
+  }[],
+  prefixToRemove: string = ''
+) {
+  const prefixToRemoveArray = prefixToRemove ? prefixToRemove.split('.') : [];
+  missingTranslations.forEach(({ source, metadata }) => {
+    const { $id } = metadata;
+
+    const id =
+      prefixToRemoveArray.length > 0
+        ? $id.split('.').slice(prefixToRemoveArray.length).join('.')
+        : $id;
+
+    // Look up in translations object
+    const translationEntry = getDictionaryEntry(translationsDictionary, id);
+    // Look up in translations dictionary
+    let dictTransEntry = undefined;
+    if (isDictionaryEntry(translationEntry))
+      dictTransEntry = getEntryAndMetadata(translationEntry).entry;
+    // Fall back to source
+    const value = dictTransEntry || source;
+
+    injectEntry(value as string, translationsDictionary, id, dictionary);
+  });
+  return translationsDictionary;
+}

--- a/packages/react-core/src/utils/dictionaries/injectHashes.ts
+++ b/packages/react-core/src/utils/dictionaries/injectHashes.ts
@@ -1,0 +1,43 @@
+import { hashSource } from 'generaltranslation/id';
+import { indexVars } from 'generaltranslation/internal';
+import type { Dictionary } from '../types';
+import getEntryAndMetadata from './getEntryAndMetadata';
+import { isDictionaryEntry } from './isDictionaryEntry';
+import { set } from './indexDict';
+
+/**
+ * @description Given a dictionary, adds hashes to all dictionary entries
+ * @param dictionary - The dictionary to add hashes to
+ * @param id - The starting point of dictionary (if subtree)
+ */
+export function injectHashes(
+  dictionary: Dictionary,
+  id: string = ''
+): { dictionary: Dictionary; updateDictionary: boolean } {
+  let updateDictionary = false;
+  Object.entries(dictionary).forEach(([key, value]) => {
+    const wholeId = id ? `${id}.${key}` : key;
+    if (isDictionaryEntry(value)) {
+      // eslint-disable-next-line prefer-const
+      let { entry, metadata } = getEntryAndMetadata(value);
+      if (!metadata?.$_hash) {
+        metadata ||= {};
+        metadata.$_hash = hashSource({
+          source: indexVars(entry),
+          ...(metadata?.$context && { context: metadata.$context }),
+          ...(metadata?.$maxChars != null && {
+            maxChars: Math.abs(metadata.$maxChars),
+          }),
+          id: wholeId,
+          dataFormat: 'ICU',
+        });
+        set(dictionary, key, [entry, metadata]);
+        updateDictionary = true;
+      }
+    } else {
+      const { updateDictionary: updateFlag } = injectHashes(value, wholeId);
+      updateDictionary = updateDictionary || updateFlag;
+    }
+  });
+  return { dictionary, updateDictionary };
+}

--- a/packages/react-core/src/utils/dictionaries/injectTranslations.ts
+++ b/packages/react-core/src/utils/dictionaries/injectTranslations.ts
@@ -1,0 +1,58 @@
+import type { Dictionary, Translations } from '../types';
+import { getDictionaryEntry } from './getDictionaryEntry';
+import getEntryAndMetadata from './getEntryAndMetadata';
+import { injectEntry } from './injectEntry';
+import { isDictionaryEntry } from './isDictionaryEntry';
+
+/**
+ * @description Injects translations into a dictionary
+ * @param dictionary - The dictionary to inject translations into
+ * @param translationsDictionary - The translations to inject into the dictionary
+ * @param translations - The translations to inject into the dictionary
+ * @param id - The id of the dictionary to inject translations into
+ */
+export function injectTranslations(
+  dictionary: Dictionary,
+  translationsDictionary: Dictionary,
+  translations: Translations,
+  missingTranslations: {
+    source: string;
+    metadata: {
+      $id: string;
+      $context?: string;
+      $maxChars?: number;
+      $_hash: string;
+    };
+  }[],
+  prefixToRemove: string = ''
+): { dictionary: Dictionary; updateDictionary: boolean } {
+  let updateDictionary = false;
+  const prefixToRemoveArray = prefixToRemove ? prefixToRemove.split('.') : [];
+  missingTranslations.forEach(({ metadata }) => {
+    const { $_hash, $id } = metadata;
+
+    const id =
+      prefixToRemoveArray.length > 0
+        ? $id.split('.').slice(prefixToRemoveArray.length).join('.')
+        : $id;
+
+    // Look up in translations object
+    const translationEntry = getDictionaryEntry(translationsDictionary, id);
+    // Look up in translations dictionary
+    let dictTransEntry = undefined;
+    if (isDictionaryEntry(translationEntry))
+      dictTransEntry = getEntryAndMetadata(translationEntry).entry;
+    // Fall back to what was already in the translations dictionary
+    const value = translations[$_hash] || dictTransEntry;
+    if (!value) {
+      return;
+    }
+
+    injectEntry(value as string, translationsDictionary, id, dictionary);
+    updateDictionary = true;
+  });
+  return {
+    dictionary: translationsDictionary as Dictionary,
+    updateDictionary,
+  };
+}

--- a/packages/react-core/src/utils/dictionaries/isDictionaryEntry.ts
+++ b/packages/react-core/src/utils/dictionaries/isDictionaryEntry.ts
@@ -1,0 +1,48 @@
+import type { Dictionary, DictionaryEntry } from '../types';
+
+/**
+ * Type guard function that checks if a value is a DictionaryEntry
+ * @param value - The value to check
+ * @returns true if the value is a DictionaryEntry, false otherwise
+ */
+export function isDictionaryEntry(
+  value: Dictionary | DictionaryEntry | undefined
+): value is DictionaryEntry {
+  if (value === undefined) {
+    return false;
+  }
+
+  // Check if it's a string (Entry)
+  if (typeof value === 'string') {
+    return true;
+  }
+
+  // Check if it's an array
+  if (Array.isArray(value)) {
+    // Must have 1 or 2 elements
+    if (value.length !== 1 && value.length !== 2) {
+      return false;
+    }
+
+    // First element must be a string (Entry)
+    if (typeof value[0] !== 'string') {
+      return false;
+    }
+
+    // If there's a second element, it must be an object (MetaEntry)
+    if (
+      value.length === 2 &&
+      (typeof value[1] !== 'object' ||
+        value[1] === null ||
+        (!('$context' in value[1]) &&
+          !('$maxChars' in value[1]) &&
+          !('$_hash' in value[1])))
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+
+  return false;
+}

--- a/packages/react-core/src/utils/dictionaries/mergeDictionaries.ts
+++ b/packages/react-core/src/utils/dictionaries/mergeDictionaries.ts
@@ -1,0 +1,100 @@
+import type { Dictionary, DictionaryEntry } from '../types';
+
+const isPrimitiveOrArray = (value: unknown): boolean =>
+  typeof value === 'string' || Array.isArray(value);
+
+const isObjectDictionary = (value: unknown): boolean =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const isDictionaryEntry = (
+  value: Dictionary | DictionaryEntry | undefined
+): value is DictionaryEntry => {
+  if (value === undefined) {
+    return false;
+  }
+
+  if (typeof value === 'string') {
+    return true;
+  }
+
+  if (Array.isArray(value)) {
+    if (value.length !== 1 && value.length !== 2) {
+      return false;
+    }
+
+    if (typeof value[0] !== 'string') {
+      return false;
+    }
+
+    return (
+      value.length === 1 ||
+      (typeof value[1] === 'object' &&
+        value[1] !== null &&
+        ('$context' in value[1] ||
+          '$maxChars' in value[1] ||
+          '$_hash' in value[1]))
+    );
+  }
+
+  return false;
+};
+
+const get = (dictionary: Dictionary, id: string | number) => {
+  if (dictionary == null) {
+    throw new Error('Cannot index into an undefined dictionary');
+  }
+  if (Array.isArray(dictionary)) {
+    return dictionary[id as unknown as number];
+  }
+  return dictionary[id as string];
+};
+
+export default function mergeDictionaries(
+  defaultLocaleDictionary: Dictionary,
+  localeDictionary: Dictionary
+): Dictionary {
+  if (Array.isArray(defaultLocaleDictionary)) {
+    return defaultLocaleDictionary.map((value, key) => {
+      if (isDictionaryEntry(value)) {
+        return (localeDictionary as (Dictionary | DictionaryEntry)[])[key];
+      }
+      return mergeDictionaries(
+        value as Dictionary,
+        (localeDictionary as (Dictionary | DictionaryEntry)[])[
+          key
+        ] as Dictionary
+      );
+    });
+  }
+
+  const mergedDictionary: Dictionary = {
+    ...Object.fromEntries(
+      Object.entries(defaultLocaleDictionary).filter(([, value]) =>
+        isPrimitiveOrArray(value)
+      )
+    ),
+    ...Object.fromEntries(
+      Object.entries(localeDictionary).filter(([, value]) =>
+        isPrimitiveOrArray(value)
+      )
+    ),
+  };
+
+  const defaultDictionaryKeys = Object.entries(defaultLocaleDictionary)
+    .filter(([, value]) => isObjectDictionary(value))
+    .map(([key]) => key);
+
+  const localeDictionaryKeys = Object.entries(localeDictionary)
+    .filter(([, value]) => isObjectDictionary(value))
+    .map(([key]) => key);
+
+  const allKeys = new Set([...defaultDictionaryKeys, ...localeDictionaryKeys]);
+  for (const key of allKeys) {
+    mergedDictionary[key] = mergeDictionaries(
+      (get(defaultLocaleDictionary, key) || {}) as Dictionary,
+      (get(localeDictionary, key) || {}) as Dictionary
+    );
+  }
+
+  return mergedDictionary;
+}

--- a/packages/react-core/src/utils/dictionaries/mergeDictionaries.ts
+++ b/packages/react-core/src/utils/dictionaries/mergeDictionaries.ts
@@ -1,53 +1,12 @@
 import type { Dictionary, DictionaryEntry } from '../types';
+import { get } from './indexDict';
+import { isDictionaryEntry } from './isDictionaryEntry';
 
 const isPrimitiveOrArray = (value: unknown): boolean =>
   typeof value === 'string' || Array.isArray(value);
 
 const isObjectDictionary = (value: unknown): boolean =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
-
-const isDictionaryEntry = (
-  value: Dictionary | DictionaryEntry | undefined
-): value is DictionaryEntry => {
-  if (value === undefined) {
-    return false;
-  }
-
-  if (typeof value === 'string') {
-    return true;
-  }
-
-  if (Array.isArray(value)) {
-    if (value.length !== 1 && value.length !== 2) {
-      return false;
-    }
-
-    if (typeof value[0] !== 'string') {
-      return false;
-    }
-
-    return (
-      value.length === 1 ||
-      (typeof value[1] === 'object' &&
-        value[1] !== null &&
-        ('$context' in value[1] ||
-          '$maxChars' in value[1] ||
-          '$_hash' in value[1]))
-    );
-  }
-
-  return false;
-};
-
-const get = (dictionary: Dictionary, id: string | number) => {
-  if (dictionary == null) {
-    throw new Error('Cannot index into an undefined dictionary');
-  }
-  if (Array.isArray(dictionary)) {
-    return dictionary[id as unknown as number];
-  }
-  return dictionary[id as string];
-};
 
 export default function mergeDictionaries(
   defaultLocaleDictionary: Dictionary,

--- a/packages/react-core/src/utils/dictionaries/stripMetadataFromEntries.ts
+++ b/packages/react-core/src/utils/dictionaries/stripMetadataFromEntries.ts
@@ -1,0 +1,23 @@
+import type { Dictionary } from '../types';
+import getEntryAndMetadata from './getEntryAndMetadata';
+import { isDictionaryEntry } from './isDictionaryEntry';
+import { set } from './indexDict';
+
+/**
+ * @description Iterate over tree and remove metadata leaving just the entry
+ */
+export function stripMetadataFromEntries(dictionary: Dictionary): Dictionary {
+  let result: Dictionary = {};
+  if (Array.isArray(dictionary)) {
+    result = [];
+  }
+  Object.entries(dictionary).forEach(([key, value]) => {
+    if (isDictionaryEntry(value)) {
+      const { entry } = getEntryAndMetadata(value);
+      set(result, key, entry);
+    } else {
+      set(result, key, stripMetadataFromEntries(value));
+    }
+  });
+  return result;
+}

--- a/packages/react-core/src/utils/promises/reactHasUse.ts
+++ b/packages/react-core/src/utils/promises/reactHasUse.ts
@@ -1,0 +1,4 @@
+import * as React from 'react';
+
+export const reactHasUse =
+  typeof (React as typeof React & { use?: unknown }).use === 'function';

--- a/packages/react-core/src/utils/rendering/getDefaultRenderSettings.ts
+++ b/packages/react-core/src/utils/rendering/getDefaultRenderSettings.ts
@@ -1,0 +1,11 @@
+import type { RenderMethod } from '../types';
+
+export const getDefaultRenderSettings = (
+  environment: 'development' | 'production' | 'test' = 'production'
+): {
+  method: RenderMethod;
+  timeout: number;
+} => ({
+  method: 'default',
+  timeout: environment === 'development' ? 8000 : 12000,
+});

--- a/packages/react-core/src/utils/rendering/isVariableObject.ts
+++ b/packages/react-core/src/utils/rendering/isVariableObject.ts
@@ -1,0 +1,25 @@
+import type { Variable } from '@generaltranslation/format/types';
+
+export default function isVariableObject(obj: unknown): obj is Variable {
+  const variableObj = obj as Variable;
+  if (
+    variableObj &&
+    typeof variableObj === 'object' &&
+    typeof (variableObj as Variable).k === 'string'
+  ) {
+    const keys = Object.keys(variableObj);
+    if (keys.length === 1) return true;
+    if (keys.length === 2) {
+      if (typeof variableObj.i === 'number') return true;
+      if (typeof variableObj.v === 'string') return true;
+    }
+    if (keys.length === 3) {
+      if (
+        typeof variableObj.v === 'string' &&
+        typeof variableObj.i === 'number'
+      )
+        return true;
+    }
+  }
+  return false;
+}

--- a/packages/react-core/src/utils/rendering/renderSkeleton.tsx
+++ b/packages/react-core/src/utils/rendering/renderSkeleton.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+/**
+ * renderSkeleton is a function that handles the rendering behavior for the skeleton loading method.
+ * It replaces all content with empty strings
+ * @returns an empty string
+ */
+export default function renderSkeleton(): React.ReactNode {
+  return '';
+}

--- a/packages/react-core/src/utils/types.ts
+++ b/packages/react-core/src/utils/types.ts
@@ -10,6 +10,15 @@ import type {
 } from 'generaltranslation/types';
 import React from 'react';
 
+export type {
+  DictionaryTranslationOptions,
+  GTFunctionType,
+  InlineTranslationOptions,
+  MFunctionType,
+  RuntimeTranslationOptions,
+} from 'gt-i18n/types';
+export type { GTProp };
+
 /**
  * TaggedElement is a React element with a GTProp property.
  */
@@ -48,6 +57,34 @@ export type TranslatedElement = {
 export type TranslatedChild = TranslatedElement | string | Variable;
 export type TranslatedChildren = TranslatedChild | TranslatedChild[];
 
+// ----- DICTIONARY ----- //
+
+export type Entry = string;
+export type MetaEntry = {
+  $context?: string;
+  $maxChars?: number;
+  $_hash?: string;
+  [key: string]: unknown;
+};
+export type Metadata = MetaEntry;
+export type DictionaryEntry = Entry | [Entry] | [Entry, MetaEntry];
+export type Dictionary =
+  | {
+      [key: string]: Dictionary | DictionaryEntry;
+    }
+  | (Dictionary | DictionaryEntry)[];
+export type FlattenedDictionary = {
+  [key: string]: DictionaryEntry;
+};
+export type DictionaryContent = string;
+export type DictionaryObject = {
+  [id: string]: DictionaryContent;
+};
+export type LocalesDictionary = {
+  [locale: string]: DictionaryObject;
+};
+export type CustomLoader = (locale: string) => Promise<unknown>;
+
 export type RelativeTimeFormatOptions = Intl.RelativeTimeFormatOptions & {
   unit?: Intl.RelativeTimeFormatUnit;
   baseDate?: Date;
@@ -75,3 +112,24 @@ export type RenderVariable = ({
   locales: string[];
   enableI18n: boolean;
 }) => React.ReactNode;
+
+export type Translations = {
+  [hash: string]: TranslatedChildren | null;
+};
+export type RenderMethod = 'skeleton' | 'replace' | 'default';
+export type _Message = {
+  message: string;
+  $id?: string;
+  $context?: string;
+  $maxChars?: number;
+  $_hash?: string;
+};
+export type _Messages = _Message[];
+export type AuthFromEnvParams = {
+  projectId?: string;
+  devApiKey?: string;
+};
+export type AuthFromEnvReturn = {
+  projectId: string;
+  devApiKey?: string;
+};

--- a/packages/react-native/src/condition-store/NativeConditionStore.ts
+++ b/packages/react-native/src/condition-store/NativeConditionStore.ts
@@ -7,7 +7,7 @@ import {
   defaultEnableI18nCookieName as defaultEnableI18nStoreKey,
   defaultLocaleCookieName as defaultLocaleStoreKey,
   defaultRegionCookieName as defaultRegionStoreKey,
-} from '@generaltranslation/react-core/internal';
+} from '@generaltranslation/react-core/pure';
 import { getLocale } from '../utils/getLocale';
 import {
   getInitialEnableI18n,

--- a/packages/react-native/src/condition-store/__tests__/NativeConditionStore.test.ts
+++ b/packages/react-native/src/condition-store/__tests__/NativeConditionStore.test.ts
@@ -1,10 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { initializeI18nConfig } from '@generaltranslation/react-core/context';
+import { initializeI18nConfig } from '@generaltranslation/react-core/pure';
 import {
   defaultEnableI18nCookieName as defaultEnableI18nStoreKey,
   defaultLocaleCookieName as defaultLocaleStoreKey,
   defaultRegionCookieName as defaultRegionStoreKey,
-} from '@generaltranslation/react-core/internal';
+} from '@generaltranslation/react-core/pure';
 import { NativeConditionStore } from '../NativeConditionStore';
 
 const nativeStore = vi.hoisted(() => new Map<string, string>());

--- a/packages/react-native/src/index.tsx
+++ b/packages/react-native/src/index.tsx
@@ -17,11 +17,11 @@ import type {
   DictionaryTranslationOptions,
   InlineTranslationOptions,
   RuntimeTranslationOptions,
-} from '@generaltranslation/react-core/types';
+} from '@generaltranslation/react-core/pure';
 import type {
   RenderPipeline,
   RenderPreparedT,
-} from '@generaltranslation/react-core/context';
+} from '@generaltranslation/react-core/pure';
 
 export {
   // ===== Components ===== //
@@ -34,17 +34,22 @@ export {
   RelativeTime,
   Var,
   Num,
+} from '@generaltranslation/react-core/components';
+
+export {
   // ===== Hooks ===== //
   useLocale,
   useCustomMapping,
   useDefaultLocale,
   useEnableI18n,
   useLocales,
-  getFormatLocales,
   useFormatLocales,
   useGT,
   useMessages,
   useTranslations,
+} from '@generaltranslation/react-core/hooks';
+
+export {
   // ===== Functions ===== //
   msg,
   decodeMsg,
@@ -54,11 +59,12 @@ export {
   decodeVars,
   mFallback,
   gtFallback,
+  getFormatLocales,
   getTranslationsSnapshot,
   getReactI18nCache,
   setReactI18nCache,
   createRenderPipeline,
-} from '@generaltranslation/react-core/context';
+} from '@generaltranslation/react-core/pure';
 
 export {
   useRegion,

--- a/packages/react-native/src/provider/GTProvider.tsx
+++ b/packages/react-native/src/provider/GTProvider.tsx
@@ -1,4 +1,4 @@
-import type { InternalGTProviderProps } from '@generaltranslation/react-core/context';
+import type { InternalGTProviderProps } from '@generaltranslation/react-core/components';
 import { Suspense, use, useCallback, useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
 import { ActivityIndicator, StyleSheet, View } from 'react-native';

--- a/packages/react-native/src/provider/NativeGTProvider.tsx
+++ b/packages/react-native/src/provider/NativeGTProvider.tsx
@@ -2,7 +2,7 @@ import {
   I18nStore,
   InternalGTProvider,
   type InternalGTProviderProps,
-} from '@generaltranslation/react-core/context';
+} from '@generaltranslation/react-core/components';
 import { useMemo, useRef } from 'react';
 import type { LocaleCandidates } from 'gt-i18n/internal/types';
 import type { NativeConditionStoreParams } from '../condition-store/NativeConditionStore';

--- a/packages/react-native/src/provider/__tests__/loadTranslations.test.ts
+++ b/packages/react-native/src/provider/__tests__/loadTranslations.test.ts
@@ -6,7 +6,7 @@ const i18nCacheMock = vi.hoisted(() => ({
   loadTranslations: loadTranslationsMock,
 }));
 
-vi.mock('@generaltranslation/react-core/context', () => ({
+vi.mock('@generaltranslation/react-core/pure', () => ({
   getReactI18nCache: () => i18nCacheMock,
 }));
 

--- a/packages/react-native/src/provider/loadTranslations.ts
+++ b/packages/react-native/src/provider/loadTranslations.ts
@@ -1,4 +1,4 @@
-import { getReactI18nCache } from '@generaltranslation/react-core/context';
+import { getReactI18nCache } from '@generaltranslation/react-core/pure';
 import type { Hash } from 'gt-i18n/internal/types';
 import type { Translation } from 'gt-i18n/types';
 

--- a/packages/react-native/src/setup/__tests__/initializeGT.test.ts
+++ b/packages/react-native/src/setup/__tests__/initializeGT.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { getTranslationsSnapshot } from '@generaltranslation/react-core/context';
+import { getTranslationsSnapshot } from '@generaltranslation/react-core/pure';
 import { initializeGT } from '../initializeGT';
 
 describe('initializeGT', () => {

--- a/packages/react-native/src/setup/initializeGT.ts
+++ b/packages/react-native/src/setup/initializeGT.ts
@@ -1,7 +1,7 @@
 import {
   initializeI18nConfig,
   setReactI18nCache,
-} from '@generaltranslation/react-core/context';
+} from '@generaltranslation/react-core/pure';
 import { ReactI18nCache } from '@generaltranslation/react-core/pure';
 import type { ReactI18nCacheParams } from '@generaltranslation/react-core/pure';
 import { setupGTServicesEnabled } from 'gt-i18n/internal';

--- a/packages/react-native/src/utils/__tests__/getLocale.test.ts
+++ b/packages/react-native/src/utils/__tests__/getLocale.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { initializeI18nConfig } from '@generaltranslation/react-core/context';
-import { defaultLocaleCookieName as defaultLocaleStoreKey } from '@generaltranslation/react-core/internal';
+import { initializeI18nConfig } from '@generaltranslation/react-core/pure';
+import { defaultLocaleCookieName as defaultLocaleStoreKey } from '@generaltranslation/react-core/pure';
 import { getLocale } from '../getLocale';
 
 const nativeStore = vi.hoisted(() => new Map<string, string>());

--- a/packages/react-native/src/utils/getInitialNativeConditions.ts
+++ b/packages/react-native/src/utils/getInitialNativeConditions.ts
@@ -2,7 +2,7 @@ import type { WritableConditionStoreParams } from 'gt-i18n/internal/types';
 import {
   defaultEnableI18nCookieName as defaultEnableI18nStoreKey,
   defaultRegionCookieName as defaultRegionStoreKey,
-} from '@generaltranslation/react-core/internal';
+} from '@generaltranslation/react-core/pure';
 import { nativeStoreGet } from './nativeStore';
 
 type InitialRegionParams = Pick<WritableConditionStoreParams, 'region'> & {

--- a/packages/react-native/src/utils/getLocale.ts
+++ b/packages/react-native/src/utils/getLocale.ts
@@ -1,5 +1,5 @@
 import type { LocaleCandidates } from 'gt-i18n/internal/types';
-import { defaultLocaleCookieName as defaultLocaleStoreKey } from '@generaltranslation/react-core/internal';
+import { defaultLocaleCookieName as defaultLocaleStoreKey } from '@generaltranslation/react-core/pure';
 import { getNativeLocales } from './getNativeLocales';
 import { nativeStoreGet } from './nativeStore';
 import { resolveLocale } from './resolveLocale';

--- a/packages/react-native/src/utils/nativeStore.ts
+++ b/packages/react-native/src/utils/nativeStore.ts
@@ -1,4 +1,4 @@
-import { defaultLocaleCookieName as defaultLocaleStoreKey } from '@generaltranslation/react-core/internal';
+import { defaultLocaleCookieName as defaultLocaleStoreKey } from '@generaltranslation/react-core/pure';
 import { Platform } from 'react-native';
 import GtReactNative from '../NativeGtReactNative';
 import { ssrUnsupportedWarning } from '../errors-dir/warnings';

--- a/packages/react-native/src/utils/utils.ts
+++ b/packages/react-native/src/utils/utils.ts
@@ -1,7 +1,7 @@
 import type {
   AuthFromEnvParams,
   AuthFromEnvReturn,
-} from '@generaltranslation/react-core/types';
+} from '@generaltranslation/react-core/pure';
 
 export function readAuthFromEnv(params: AuthFromEnvParams): AuthFromEnvReturn {
   const { projectId, devApiKey } = params;

--- a/packages/react/src/hooks/useHandleMissingTranslations.ts
+++ b/packages/react/src/hooks/useHandleMissingTranslations.ts
@@ -1,11 +1,11 @@
 'server-only';
 
 import {
-  I18nStore,
   OnMissingDictionaryEntry,
   OnMissingDictionaryObj,
   OnMissingTranslation,
-} from '@generaltranslation/react-core/context';
+} from '@generaltranslation/react-core/pure';
+import { I18nStore } from '@generaltranslation/react-core/components';
 import { useMemo } from 'react';
 
 /**

--- a/packages/react/src/internal.ts
+++ b/packages/react/src/internal.ts
@@ -34,8 +34,8 @@ import {
   mFallback as _mFallback,
   gtFallback as _gtFallback,
 } from '@generaltranslation/react-core/pure';
-import { Derive as _Derive } from '@generaltranslation/react-core/components';
 import {
+  Derive as _Derive,
   renderDefaultChildren as _renderDefaultChildren,
   renderTranslatedChildren as _renderTranslatedChildren,
 } from '@generaltranslation/react-core/components-rsc';

--- a/packages/react/src/internal.ts
+++ b/packages/react/src/internal.ts
@@ -11,8 +11,6 @@ import {
   getPluralBranch as _getPluralBranch,
   getEntryAndMetadata as _getEntryAndMetadata,
   getVariableName as _getVariableName,
-  renderDefaultChildren as _renderDefaultChildren,
-  renderTranslatedChildren as _renderTranslatedChildren,
   renderSkeleton as _renderSkeleton,
   getDefaultRenderSettings as _getDefaultRenderSettings,
   mergeDictionaries as _mergeDictionaries,
@@ -33,10 +31,14 @@ import {
   derive as _derive,
   declareVar as _declareVar,
   decodeVars as _decodeVars,
-  Derive as _Derive,
   mFallback as _mFallback,
   gtFallback as _gtFallback,
-} from '@generaltranslation/react-core/internal';
+} from '@generaltranslation/react-core/pure';
+import { Derive as _Derive } from '@generaltranslation/react-core/components';
+import {
+  renderDefaultChildren as _renderDefaultChildren,
+  renderTranslatedChildren as _renderTranslatedChildren,
+} from '@generaltranslation/react-core/components-rsc';
 import {
   defaultEnableI18nCookieName as _defaultEnableI18nCookieName,
   defaultLocaleCookieName as _defaultLocaleCookieName,
@@ -66,7 +68,7 @@ import type {
   _Message as __Message,
   _Messages as __Messages,
   GTProp as _GTProp,
-} from '@generaltranslation/react-core/types';
+} from '@generaltranslation/react-core/pure';
 
 import type { SharedGTProviderProps } from './provider/GTProviderProps';
 

--- a/packages/react/src/provider/BrowserGTProvider.tsx
+++ b/packages/react/src/provider/BrowserGTProvider.tsx
@@ -1,7 +1,7 @@
 import {
   I18nStore,
   InternalGTProvider,
-} from '@generaltranslation/react-core/context';
+} from '@generaltranslation/react-core/components';
 import { useMemo, useRef } from 'react';
 import type { SharedGTProviderProps } from './GTProviderProps';
 import { ReadonlyBrowserConditionStore } from '../condition-store/ReadOnlyBrowserConditionStore';

--- a/packages/react/src/provider/GTProviderProps.ts
+++ b/packages/react/src/provider/GTProviderProps.ts
@@ -1,4 +1,4 @@
-import type { InternalGTProviderProps } from '@generaltranslation/react-core/context';
+import type { InternalGTProviderProps } from '@generaltranslation/react-core/components';
 import { BrowserConditionStoreParams } from '../condition-store/BrowserConditionStore';
 
 /**

--- a/packages/react/src/provider/ServerGTProvider.tsx
+++ b/packages/react/src/provider/ServerGTProvider.tsx
@@ -1,8 +1,8 @@
 import {
   I18nStore,
   InternalGTProvider,
-  ReadonlyConditionStore,
-} from '@generaltranslation/react-core/context';
+} from '@generaltranslation/react-core/components';
+import { ReadonlyConditionStore } from '@generaltranslation/react-core/pure';
 import { useMemo, useRef } from 'react';
 import type { SharedGTProviderProps } from './GTProviderProps';
 import { useHandleMissingTranslations } from '../hooks/useHandleMissingTranslations';

--- a/packages/react/src/setup/initializeGTSPA.ts
+++ b/packages/react/src/setup/initializeGTSPA.ts
@@ -5,8 +5,8 @@ import {
   setReactI18nCache,
   getReadonlyConditionStoreWithFallback,
   initializeI18nConfig,
-} from '@generaltranslation/react-core/context';
-import type { I18nConfigParams } from '@generaltranslation/react-core/context';
+} from '@generaltranslation/react-core/pure';
+import type { I18nConfigParams } from '@generaltranslation/react-core/pure';
 import { setupGTServicesEnabled } from 'gt-i18n/internal';
 import type { GTServicesEnabledParams } from 'gt-i18n/internal/types';
 import { BrowserI18nCache } from '../i18n-cache/BrowserI18nCache';

--- a/packages/react/tsdown.config.mts
+++ b/packages/react/tsdown.config.mts
@@ -5,13 +5,7 @@ import {
 } from '../../tsdown.preset.mts';
 
 const deps = {
-  neverBundle: [
-    /^react$/,
-    /^react\//,
-    /^react-dom$/,
-    /^react-dom\//,
-    /^@generaltranslation\/react-core$/,
-  ],
+  neverBundle: [/^react$/, /^react\//, /^react-dom$/, /^react-dom\//],
   alwaysBundle: [
     /^@generaltranslation\/format\//,
     /^@generaltranslation\/react-core\//,


### PR DESCRIPTION
## Stack

1. #1614 - setup valid react-core entrypoint APIs
2. #1615 - migrate consumers to valid react-core entrypoints (this PR)
3. #1616 - remove legacy react-core entrypoints

## Summary

- Move workspace consumers off legacy `@generaltranslation/react-core` root, `/context`, `/internal`, and `/types` imports and onto `/pure`, `/components`, `/components-rsc`, or `/hooks`.
- Use the `/pure` exports introduced in #1614 for type definitions, cookie keys, dictionary helpers, render helpers, setup helpers, and cache/store utilities.
- Keep compatibility aliases in `packages/react/src/internal.ts` intact; this PR changes where those aliases import from, not the alias surface itself.
- Leave the legacy react-core package entrypoints in package metadata as lame-duck exports. They are intentionally deleted in #1616.

## Testing

- `pnpm --filter @generaltranslation/react-core typecheck`
- `pnpm --filter @generaltranslation/react-core build`
- `pnpm --filter @generaltranslation/react-core test`
- `pnpm --filter gt-react build`
- `pnpm --filter gt-react test`
- `pnpm --filter gt-react-native typecheck`
- `pnpm --filter gt-react-native test`
- `pnpm --filter @generaltranslation/react-core-linter test`
- `pnpm --filter gt-next test`

No changeset.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR migrates all workspace consumers off the legacy `@generaltranslation/react-core` root, `/context`, `/internal`, and `/types` entrypoints onto the new subpath entrypoints (`/pure`, `/components`, `/components-rsc`, `/hooks`) that were introduced in the preceding PR (#1614).

- Across 32 files in `gt-react`, `gt-react-native`, `gt-next`, and `react-core-linter`, import paths are mechanically redirected: `/context` → `/components` (for React component types and `I18nStore`) or `/pure` (for pure utilities and config helpers); `/internal` → `/pure` (for cookie key constants, dictionaries, helpers) or `/components-rsc` (for render helpers and `Derive`); `/types` → `/pure` (for type definitions like `AuthFromEnvParams`).
- `Derive` is promoted from `gt-react/internal` to the public `gt-react` surface in `packages/next/src/index.types.ts`, and the `react-core-linter` `GT_LIBRARIES` constant is expanded from the single root specifier into the four new subpath specifiers.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all changes are mechanical import-path redirections with no runtime logic modifications; public APIs and deprecated compatibility aliases are fully preserved.

Every changed file is a direct substitution of one import specifier for another; no runtime behaviour, component logic, or exported API surface changes. The compatibility alias layer in gt-react/internal remains intact, and all packages listed in the PR testing matrix pass. The two observations are pre-planned trade-offs acknowledged in the PR description.

packages/next/src/__tests__/rscLeaks.test.ts and packages/react-core-linter/src/utils/constants.ts are worth a second look, but neither blocks the merge.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react/src/internal.ts | Migrates imports from /internal → /pure and /components-rsc; all deprecated compatibility aliases remain intact with their original names |
| packages/next/src/index.types.ts | Moves Derive import from gt-react/internal to the public gt-react entrypoint, which correctly exports it via index.types.ts → @generaltranslation/react-core/components |
| packages/react-core-linter/src/utils/constants.ts | Root @generaltranslation/react-core replaced by four subpath specifiers; removes linter coverage for code still using the root import until #1616 deletes it |
| packages/next/src/__tests__/rscLeaks.test.ts | Removes /internal from workspaceSourceMap; new /pure, /components, /hooks entrypoints imported by the RSC graph are not added, so they remain un-walked by the leak checker |
| packages/react-native/src/index.tsx | Splits one large /context re-export block into three targeted subpath blocks (/components, /hooks, /pure); getFormatLocales correctly moves to the functions group under /pure |
| packages/react/src/provider/ServerGTProvider.tsx | ReadonlyConditionStore correctly split to /pure; I18nStore and InternalGTProvider stay on /components |
| packages/react-core/src/deprecated/__tests__/react-core-package.test.ts | Removes /internal assertions from the deprecated package test, consistent with the entrypoint removal plan in #1616 |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[gt-react / gt-react-native / gt-next] -->|components, I18nStore,\nInternalGTProvider| B["@gt/react-core/components"]
    A -->|Derive, renderDefaultChildren,\nrenderTranslatedChildren| C["@gt/react-core/components-rsc"]
    A -->|useGT, useLocale,\nuseTranslations, hooks| D["@gt/react-core/hooks"]
    A -->|pure utils: msg, derive,\ncookie keys, config, types| E["@gt/react-core/pure"]
    F["Legacy entrypoints\n(lame-duck, deleted in #1616)"] -.->|/context| B
    F -.->|/internal| C
    F -.->|/internal + /types| E
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[gt-react / gt-react-native / gt-next] -->|components, I18nStore,\nInternalGTProvider| B["@gt/react-core/components"]
    A -->|Derive, renderDefaultChildren,\nrenderTranslatedChildren| C["@gt/react-core/components-rsc"]
    A -->|useGT, useLocale,\nuseTranslations, hooks| D["@gt/react-core/hooks"]
    A -->|pure utils: msg, derive,\ncookie keys, config, types| E["@gt/react-core/pure"]
    F["Legacy entrypoints\n(lame-duck, deleted in #1616)"] -.->|/context| B
    F -.->|/internal| C
    F -.->|/internal + /types| E
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fnext%2Fsrc%2F__tests__%2FrscLeaks.test.ts%3A29-36%0A**New%20RSC-graph%20entrypoints%20not%20added%20to%20the%20leak%20walker**%0A%0A%60%2Finternal%60%20is%20correctly%20removed%20since%20it's%20being%20deprecated.%20However%2C%20the%20RSC%20graph%20now%20imports%20directly%20from%20%60%40generaltranslation%2Freact-core%2Fpure%60%20%28visible%20in%20%60index.rsc.ts%60%20and%20%60components-rsc.ts%60%29%2C%20but%20%60%2Fpure%60%20is%20absent%20from%20%60workspaceSourceMap%60.%20When%20the%20walker%20encounters%20%60import%20%E2%80%A6%20from%20'%40generaltranslation%2Freact-core%2Fpure'%60%20it%20treats%20it%20as%20an%20external%20package%20and%20skips%20traversal%20entirely%20%E2%80%94%20so%20any%20accidental%20context%2Fhook%20import%20inside%20%60%2Fpure%60%20would%20go%20undetected.%20The%20same%20applies%20to%20%60%2Fcomponents%60%20and%20%60%2Fhooks%60.%20Adding%20entries%20for%20all%20three%20new%20subpath%20entrypoints%20would%20extend%20the%20same%20%22no%20context%20leak%22%20guarantee%20that%20previously%20covered%20%60%2Finternal%60.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Freact-core-linter%2Fsrc%2Futils%2Fconstants.ts%3A3-12%0A**Root%20specifier%20removal%20silently%20drops%20linter%20coverage%20for%20transitional%20code**%0A%0A%60%40generaltranslation%2Freact-core%60%20%28the%20root%20import%29%20is%20replaced%20by%20four%20subpath%20specifiers.%20External%20consumers%20whose%20ESLint%20config%20still%20passes%20%60libs%3A%20%5B'%40generaltranslation%2Freact-core'%5D%60%20will%20no%20longer%20have%20the%20%60static-jsx%60%20or%20%60static-string%60%20rules%20fire%20on%20their%20code%20%E2%80%94%20the%20linter%20just%20won't%20recognize%20the%20import%20as%20a%20GT%20library%20at%20all%2C%20giving%20a%20false%20clean%20report.%20Since%20the%20root%20entrypoint%20is%20marked%20lame-duck%20%28deleted%20in%20%231616%29%2C%20this%20is%20expected%2C%20but%20a%20comment%20or%20a%20deprecation%20note%20in%20the%20exported%20type%20would%20help%20consumers%20understand%20why%20their%20linter%20went%20silent.%0A%0A&repo=generaltranslation%2Fgt&pr=1615&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fodysseus%2Fuse-react-core-valid-entrypoints%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fodysseus%2Fuse-react-core-valid-entrypoints%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fnext%2Fsrc%2F__tests__%2FrscLeaks.test.ts%3A29-36%0A**New%20RSC-graph%20entrypoints%20not%20added%20to%20the%20leak%20walker**%0A%0A%60%2Finternal%60%20is%20correctly%20removed%20since%20it's%20being%20deprecated.%20However%2C%20the%20RSC%20graph%20now%20imports%20directly%20from%20%60%40generaltranslation%2Freact-core%2Fpure%60%20%28visible%20in%20%60index.rsc.ts%60%20and%20%60components-rsc.ts%60%29%2C%20but%20%60%2Fpure%60%20is%20absent%20from%20%60workspaceSourceMap%60.%20When%20the%20walker%20encounters%20%60import%20%E2%80%A6%20from%20'%40generaltranslation%2Freact-core%2Fpure'%60%20it%20treats%20it%20as%20an%20external%20package%20and%20skips%20traversal%20entirely%20%E2%80%94%20so%20any%20accidental%20context%2Fhook%20import%20inside%20%60%2Fpure%60%20would%20go%20undetected.%20The%20same%20applies%20to%20%60%2Fcomponents%60%20and%20%60%2Fhooks%60.%20Adding%20entries%20for%20all%20three%20new%20subpath%20entrypoints%20would%20extend%20the%20same%20%22no%20context%20leak%22%20guarantee%20that%20previously%20covered%20%60%2Finternal%60.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Freact-core-linter%2Fsrc%2Futils%2Fconstants.ts%3A3-12%0A**Root%20specifier%20removal%20silently%20drops%20linter%20coverage%20for%20transitional%20code**%0A%0A%60%40generaltranslation%2Freact-core%60%20%28the%20root%20import%29%20is%20replaced%20by%20four%20subpath%20specifiers.%20External%20consumers%20whose%20ESLint%20config%20still%20passes%20%60libs%3A%20%5B'%40generaltranslation%2Freact-core'%5D%60%20will%20no%20longer%20have%20the%20%60static-jsx%60%20or%20%60static-string%60%20rules%20fire%20on%20their%20code%20%E2%80%94%20the%20linter%20just%20won't%20recognize%20the%20import%20as%20a%20GT%20library%20at%20all%2C%20giving%20a%20false%20clean%20report.%20Since%20the%20root%20entrypoint%20is%20marked%20lame-duck%20%28deleted%20in%20%231616%29%2C%20this%20is%20expected%2C%20but%20a%20comment%20or%20a%20deprecation%20note%20in%20the%20exported%20type%20would%20help%20consumers%20understand%20why%20their%20linter%20went%20silent.%0A%0A&repo=generaltranslation%2Fgt&pr=1615&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/next/src/__tests__/rscLeaks.test.ts:29-36
**New RSC-graph entrypoints not added to the leak walker**

`/internal` is correctly removed since it's being deprecated. However, the RSC graph now imports directly from `@generaltranslation/react-core/pure` (visible in `index.rsc.ts` and `components-rsc.ts`), but `/pure` is absent from `workspaceSourceMap`. When the walker encounters `import … from '@generaltranslation/react-core/pure'` it treats it as an external package and skips traversal entirely — so any accidental context/hook import inside `/pure` would go undetected. The same applies to `/components` and `/hooks`. Adding entries for all three new subpath entrypoints would extend the same "no context leak" guarantee that previously covered `/internal`.

### Issue 2 of 2
packages/react-core-linter/src/utils/constants.ts:3-12
**Root specifier removal silently drops linter coverage for transitional code**

`@generaltranslation/react-core` (the root import) is replaced by four subpath specifiers. External consumers whose ESLint config still passes `libs: ['@generaltranslation/react-core']` will no longer have the `static-jsx` or `static-string` rules fire on their code — the linter just won't recognize the import as a GT library at all, giving a false clean report. Since the root entrypoint is marked lame-duck (deleted in #1616), this is expected, but a comment or a deprecation note in the exported type would help consumers understand why their linter went silent.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: bundle react-core subpaths in gt-re..."](https://github.com/generaltranslation/gt/commit/df13992b3b3f13510bb059fe434a0c0a66a8650e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38496852)</sub>

<!-- /greptile_comment -->