### PR TITLE
fix: resolve size-limit preset with pnpm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,17 +76,10 @@ jobs:
         run: pnpm rebuild --filter='...[origin/${{ github.base_ref }}]'
 
       - name: Build packages
-        run: pnpm exec turbo build --filter='...[origin/${{ github.base_ref }}]' --filter='!gt-next-middleware-e2e' --filter='!base' --filter='!general-cases' --filter='!cli-test-app' --filter='!./examples/*'
+        run: pnpm exec turbo build --filter='...[origin/${{ github.base_ref }}]' --filter='!gt-next-middleware-e2e' --filter='!./examples/*'
 
       - name: Run tests
-        shell: bash
-        run: |
-          next_internal_filter=""
-          if ! git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -q "^packages/next-internal/"; then
-            next_internal_filter="--filter=!@generaltranslation/next-internal"
-          fi
-
-          pnpm exec turbo test --only --ui=stream --filter='...[origin/${{ github.base_ref }}]' --filter='!gt-next-middleware-e2e' --filter='!base' --filter='!general-cases' --filter='!cli-test-app' --filter='!./examples/*' $next_internal_filter
+        run: pnpm exec turbo test --filter='...[origin/${{ github.base_ref }}]' --filter='!gt-next-middleware-e2e' --filter='!./examples/*'
 
   test-builds:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
         run: pnpm exec turbo build --filter='...[origin/${{ github.base_ref }}]' --filter='!gt-next-middleware-e2e' --filter='!./examples/*'
 
       - name: Run tests
-        run: pnpm exec turbo test --filter='...[origin/${{ github.base_ref }}]' --filter='!gt-next-middleware-e2e' --filter='!./examples/*'
+        run: pnpm exec turbo test --filter='...[origin/${{ github.base_ref }}]' --filter='!gt-next-middleware-e2e' --filter='!@generaltranslation/next-internal' --filter='!./examples/*'
 
   test-builds:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,10 +76,10 @@ jobs:
         run: pnpm rebuild --filter='...[origin/${{ github.base_ref }}]'
 
       - name: Build packages
-        run: pnpm exec turbo build --filter='...[origin/${{ github.base_ref }}]' --filter='!gt-next-middleware-e2e' --filter='!./examples/*'
+        run: pnpm exec turbo build --filter='...[origin/${{ github.base_ref }}]' --filter='!gt-next-middleware-e2e' --filter='!base' --filter='!general-cases' --filter='!cli-test-app' --filter='!./examples/*'
 
       - name: Run tests
-        run: pnpm exec turbo test --only --filter='...[origin/${{ github.base_ref }}]' --filter='!gt-next-middleware-e2e' --filter='!./examples/*'
+        run: pnpm exec turbo test --only --filter='...[origin/${{ github.base_ref }}]' --filter='!gt-next-middleware-e2e' --filter='!base' --filter='!general-cases' --filter='!cli-test-app' --filter='!./examples/*'
 
   test-builds:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
         run: pnpm exec turbo build --filter='...[origin/${{ github.base_ref }}]' --filter='!gt-next-middleware-e2e' --filter='!base' --filter='!general-cases' --filter='!cli-test-app' --filter='!./examples/*'
 
       - name: Run tests
-        run: pnpm exec turbo test --only --filter='...[origin/${{ github.base_ref }}]' --filter='!gt-next-middleware-e2e' --filter='!base' --filter='!general-cases' --filter='!cli-test-app' --filter='!./examples/*'
+        run: pnpm exec turbo test --only --concurrency=1 --ui=stream --filter='...[origin/${{ github.base_ref }}]' --filter='!gt-next-middleware-e2e' --filter='!base' --filter='!general-cases' --filter='!cli-test-app' --filter='!./examples/*'
 
   test-builds:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
         run: pnpm exec turbo build --filter='...[origin/${{ github.base_ref }}]' --filter='!gt-next-middleware-e2e' --filter='!./examples/*'
 
       - name: Run tests
-        run: pnpm exec turbo test --filter='...[origin/${{ github.base_ref }}]' --filter='!gt-next-middleware-e2e' --filter='!./examples/*'
+        run: pnpm exec turbo test --only --filter='...[origin/${{ github.base_ref }}]' --filter='!gt-next-middleware-e2e' --filter='!./examples/*'
 
   test-builds:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,14 @@ jobs:
         run: pnpm exec turbo build --filter='...[origin/${{ github.base_ref }}]' --filter='!gt-next-middleware-e2e' --filter='!base' --filter='!general-cases' --filter='!cli-test-app' --filter='!./examples/*'
 
       - name: Run tests
-        run: pnpm exec turbo test --only --concurrency=1 --ui=stream --filter='...[origin/${{ github.base_ref }}]' --filter='!gt-next-middleware-e2e' --filter='!base' --filter='!general-cases' --filter='!cli-test-app' --filter='!./examples/*'
+        shell: bash
+        run: |
+          next_internal_filter=""
+          if ! git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -q "^packages/next-internal/"; then
+            next_internal_filter="--filter=!@generaltranslation/next-internal"
+          fi
+
+          pnpm exec turbo test --only --ui=stream --filter='...[origin/${{ github.base_ref }}]' --filter='!gt-next-middleware-e2e' --filter='!base' --filter='!general-cases' --filter='!cli-test-app' --filter='!./examples/*' $next_internal_filter
 
   test-builds:
     strategy:

--- a/packages/python-extractor/src/__tests__/index.test.ts
+++ b/packages/python-extractor/src/__tests__/index.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect } from 'vitest';
+import { afterAll, describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { disposeParser } from '../parser.js';
 import {
   extractFromPythonSource,
   PYTHON_GT_PACKAGES,
@@ -16,6 +17,10 @@ import type { ExtractionResult, ExtractionMetadata } from '../types.js';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const fixture = (name: string) =>
   fs.readFileSync(path.join(__dirname, 'fixtures', name), 'utf8');
+
+afterAll(async () => {
+  await disposeParser();
+});
 
 describe('python-extractor', () => {
   describe('extractFromPythonSource', () => {

--- a/packages/python-extractor/src/parser.ts
+++ b/packages/python-extractor/src/parser.ts
@@ -16,6 +16,21 @@ export function getParser(): Promise<Parser> {
   return parserPromise;
 }
 
+export async function disposeParser(): Promise<void> {
+  const parser = parserPromise;
+  parserPromise = null;
+
+  if (!parser) {
+    return;
+  }
+
+  try {
+    (await parser).delete();
+  } catch {
+    // Failed initialization leaves no parser instance to free.
+  }
+}
+
 async function initParser(): Promise<Parser> {
   const parserWasmPath = await resolveWasmPath(
     'web-tree-sitter/web-tree-sitter.wasm'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,7 @@ catalogs:
       specifier: ^3.2.4
       version: 3.2.4
 
-packageExtensionsChecksum: sha256-Nl4WlL1iwcV5ja94I0rgz2K5f3KvZmGHwjVmuuINZFo=
+packageExtensionsChecksum: sha256-c4YdP+zIovX6rm25GpZXMz04+bWZU6X2blcAuY/p05Y=
 
 importers:
 
@@ -35812,6 +35812,7 @@ snapshots:
 
   size-limit@12.1.0(jiti@2.6.1):
     dependencies:
+      '@size-limit/preset-small-lib': 12.1.0(size-limit@12.1.0(jiti@2.6.1))
       bytes-iec: 3.1.1
       lilconfig: 3.1.3
       nanospinner: 1.2.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -41,3 +41,6 @@ packageExtensions:
   '@expo/cli@*':
     dependencies:
       metro-runtime: '*'
+  size-limit@*:
+    dependencies:
+      '@size-limit/preset-small-lib': '*'


### PR DESCRIPTION
## Summary

- Add a pnpm package extension so `size-limit` can resolve `@size-limit/preset-small-lib` from the global virtual store layout.
- Update the lockfile snapshot/checksum for the package extension against the latest `odysseus`.
- Run CI tests with `turbo test --only` after the existing build step so the test step does not re-enter build dependencies.
- Exclude no-test app workspaces (`base`, `general-cases`, `cli-test-app`) from generic package CI so Next fixture builds stay in their dedicated jobs.
- Dispose the Python extractor's singleton `web-tree-sitter` parser after tests so Vitest can exit cleanly after printing its summary.
- Keep `@generaltranslation/next-internal`'s nested Playwright/dev-server test out of the generic package test lane unless `packages/next-internal` changes.

## Testing

- `pnpm install`
- `pnpm install --frozen-lockfile`
- `RUSTFLAGS='-C link-arg=--allow-undefined' TURBO_ENV_MODE=loose pnpm exec turbo build --filter=generaltranslation --filter=gt-i18n --filter='@generaltranslation/react-core' --filter=gt-react --filter=gt-tanstack-start --filter=gt-next`
- `pnpm size`
- `pnpm --filter @generaltranslation/python-extractor test`
- `pnpm --filter @generaltranslation/python-extractor typecheck`
- `pnpm --filter @generaltranslation/python-extractor format`
- `PORT=4321 CI=true TURBO_ENV_MODE=loose pnpm exec turbo test --only --concurrency=1 --ui=stream --filter='...[origin/odysseus]' --filter='!gt-next-middleware-e2e' --filter='!base' --filter='!general-cases' --filter='!cli-test-app' --filter='!./examples/*' --output-logs=full`
- `PORT=4321 CI=true TURBO_ENV_MODE=loose pnpm exec turbo test --only --ui=stream --filter='...[origin/odysseus]' --filter='!gt-next-middleware-e2e' --filter='!base' --filter='!general-cases' --filter='!cli-test-app' --filter='!./examples/*' --filter='!@generaltranslation/next-internal' --output-logs=errors-only`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes `size-limit` resolution under pnpm's virtual store layout by adding a `packageExtensions` entry in `pnpm-workspace.yaml`, and addresses a Vitest hang after `python-extractor` tests by disposing the singleton `web-tree-sitter` parser in `afterAll`. CI is also tightened to use `turbo test --only` (skipping redundant re-builds) and to gate `next-internal` Playwright tests behind a path filter.

- **`pnpm-workspace.yaml` / `pnpm-lock.yaml`**: Adds `size-limit@* → @size-limit/preset-small-lib: '*'` package extension so pnpm resolves the preset from its virtual store; lockfile checksum and snapshot updated accordingly.
- **`parser.ts` / `index.test.ts`**: Exports a `disposeParser()` function that nulls the singleton, awaits any in-flight initialization, and calls `.delete()` on the `Parser` instance; `afterAll` calls it so Vitest exits cleanly.
- **`.github/workflows/ci.yml`**: Excludes `base`, `general-cases`, and `cli-test-app` from both build and test steps; conditionally excludes `@generaltranslation/next-internal` from tests unless `packages/next-internal/` files are touched.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all changes are infrastructure fixes with no impact on library runtime behaviour.

The three independent fixes (pnpm preset resolution, Vitest hang, CI scope) are each small and self-contained. No production code paths are touched.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Build and test steps updated: added workspace exclusions (base, general-cases, cli-test-app), added --only to turbo test, and added conditional next-internal filter based on git diff. |
| packages/python-extractor/src/parser.ts | Adds disposeParser() export that atomically nulls the singleton promise and calls .delete() on the resolved Parser; error is silently caught for failed-init case. |
| packages/python-extractor/src/__tests__/index.test.ts | Adds afterAll hook that calls disposeParser() to allow Vitest to exit cleanly after the test suite. |
| pnpm-workspace.yaml | Adds size-limit packageExtension declaring @size-limit/preset-small-lib as a dependency so pnpm can resolve it in the virtual store layout. |
| pnpm-lock.yaml | packageExtensionsChecksum updated and @size-limit/preset-small-lib snapshot entry added to size-limit@12.1.0 to reflect the new workspace extension. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["ci: keep next-internal e2e out of generi..."](https://github.com/generaltranslation/gt/commit/8031da4fab0c651a26b8ff5047944f94e5235f5c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38542396)</sub>

<!-- /greptile_comment -->