### PR TITLE
fix(9): initialize gt-next client boundary

### DIFF
--- a/packages/next/src/__tests__/rscComponentWrappers.test.tsx
+++ b/packages/next/src/__tests__/rscComponentWrappers.test.tsx
@@ -48,6 +48,10 @@ vi.mock('../setup/initGT.rsc', () => ({
   initializeGT: vi.fn(),
 }));
 
+vi.mock('../setup/initGT', () => ({
+  initializeGT: vi.fn(),
+}));
+
 vi.mock('../provider/GTProvider', () => ({
   GTProvider: vi.fn(),
 }));

--- a/packages/next/src/utils/client-boundary.tsx
+++ b/packages/next/src/utils/client-boundary.tsx
@@ -16,10 +16,13 @@ import { getI18nConfig, I18nConfig } from 'gt-i18n/internal';
 import { GTProvider, type SharedGTProviderProps } from 'gt-react';
 import { usePathname, useRouter } from 'next/navigation';
 import { useCallback, useEffect } from 'react';
+import { initializeGT } from '../setup/initGT';
 import {
   defaultLocaleRoutingEnabledCookieName,
   defaultReferrerLocaleCookieName,
 } from './cookies';
+
+initializeGT();
 
 /**
  * Small wrapper to embed nextjs app router behavior


### PR DESCRIPTION
## Summary
- Initialize GT from the gt-next client boundary so App Router provider hydration has browser singletons available.
- Mock the client initializer in the RSC surface test.

## Testing
- `pnpm --filter gt-next test:js`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR ensures the GT singleton is properly initialized on the browser side by calling `initializeGT()` at module scope in `client-boundary.tsx`, and guards `initGT.ts` against duplicate initialization so both the client boundary and the root client entry can coexist without overwrite warnings.

- **`client-boundary.tsx`**: adds a bare `initializeGT()` call at module scope so browser singletons are available before any client component renders; imports from `initGT.ts` (not `initGT.rsc.ts`), which is the correct non-server-only path.
- **`initGT.ts`**: wraps `initializeI18nConfig` and `setNextI18nCache` in init-check guards using `isI18nConfigInitialized()` and a `try/catch` on `getNextI18nCache()`; `setupGTServicesEnabled` remains unconditional.
- **`rscComponentWrappers.test.tsx`**: adds a `vi.mock` for `../setup/initGT` to suppress the module-level side effect in the RSC surface test.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The change is safe to merge; the module-level call and idempotency guards are logically correct and the test mock prevents unintended side effects in the RSC test suite.

The core logic — initializing the client singleton once from the client boundary and skipping duplicate setup on subsequent calls — is sound. The two concerns are the use of exception-as-signal for cache detection (fragile if the underlying contract changes) and setupGTServicesEnabled being unconditional while the rest of the function is now guarded. Neither causes a bug in the current codebase, but they represent future maintenance risk.

packages/next/src/setup/initGT.ts — the idempotency guard pattern is inconsistent across the three initialization steps and the try/catch cache check deserves a second look.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/next/src/setup/initGT.ts | Adds idempotency guards around initializeI18nConfig and setNextI18nCache; setupGTServicesEnabled remains unconditional; cache check uses try/catch exception-as-signal pattern |
| packages/next/src/utils/client-boundary.tsx | Adds module-level initializeGT() call so browser singletons are initialized at import time in the client boundary; correct file (initGT.ts, not initGT.rsc.ts) is imported |
| packages/next/src/__tests__/rscComponentWrappers.test.tsx | Adds vi.mock for ../setup/initGT to prevent module-level side effects from running in the RSC surface test; straightforward and correct |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CB as client-boundary.tsx (module load)
    participant IGT as initGT.ts initializeGT()
    participant RSC as initGT.rsc.ts initializeGT()
    participant I18nCfg as I18nConfig singleton
    participant Cache as NextI18nCache singleton
    participant SVC as GTServicesEnabled global

    Note over CB: Module imported during SSR or browser hydration
    CB->>IGT: initializeGT() [no args → getParams()]
    IGT->>SVC: setupGTServicesEnabled() [always]
    IGT->>I18nCfg: isI18nConfigInitialized()?
    alt not initialized
        IGT->>I18nCfg: initializeI18nConfig()
    end
    IGT->>Cache: getNextI18nCache() [try/catch]
    alt throws → not initialized
        IGT->>Cache: new NextI18nCache() + setNextI18nCache()
    end

    Note over RSC: RSC route initializes (may run before or after CB)
    RSC->>IGT: coreInitializeGT() [idempotent]
    IGT->>SVC: setupGTServicesEnabled() [always]
    IGT->>I18nCfg: isI18nConfigInitialized()? → skip if true
    IGT->>Cache: getNextI18nCache() → skip if already set
    RSC->>RSC: new AsyncConditionStore() + setAsyncConditionStore()
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CB as client-boundary.tsx (module load)
    participant IGT as initGT.ts initializeGT()
    participant RSC as initGT.rsc.ts initializeGT()
    participant I18nCfg as I18nConfig singleton
    participant Cache as NextI18nCache singleton
    participant SVC as GTServicesEnabled global

    Note over CB: Module imported during SSR or browser hydration
    CB->>IGT: initializeGT() [no args → getParams()]
    IGT->>SVC: setupGTServicesEnabled() [always]
    IGT->>I18nCfg: isI18nConfigInitialized()?
    alt not initialized
        IGT->>I18nCfg: initializeI18nConfig()
    end
    IGT->>Cache: getNextI18nCache() [try/catch]
    alt throws → not initialized
        IGT->>Cache: new NextI18nCache() + setNextI18nCache()
    end

    Note over RSC: RSC route initializes (may run before or after CB)
    RSC->>IGT: coreInitializeGT() [idempotent]
    IGT->>SVC: setupGTServicesEnabled() [always]
    IGT->>I18nCfg: isI18nConfigInitialized()? → skip if true
    IGT->>Cache: getNextI18nCache() → skip if already set
    RSC->>RSC: new AsyncConditionStore() + setAsyncConditionStore()
```

</a>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `packages/next/src/setup/initGT.ts`, line 31-36 ([link](https://github.com/generaltranslation/gt/blob/8fba0e233e4345091eb88c07430a5a1d69727f3a/packages/next/src/setup/initGT.ts#L31-L36)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Exception-driven control flow for cache init detection**

   `getNextI18nCache()` always throws when the cache is uninitialized (per its implementation in `singleton-operations.ts`), so the try/catch works correctly — but using exceptions as a detection signal is an antipattern. If `getI18nCache`'s error contract ever changes (e.g., returns `null` instead of throwing), this silently stops returning `false` and the idempotency guard breaks without any compile-time warning. An `isI18nCacheInitialized()` helper parallel to `isI18nConfigInitialized()` would be the safer, self-documenting approach.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/next/src/setup/initGT.ts
   Line: 31-36

   Comment:
   **Exception-driven control flow for cache init detection**

   `getNextI18nCache()` always throws when the cache is uninitialized (per its implementation in `singleton-operations.ts`), so the try/catch works correctly — but using exceptions as a detection signal is an antipattern. If `getI18nCache`'s error contract ever changes (e.g., returns `null` instead of throwing), this silently stops returning `false` and the idempotency guard breaks without any compile-time warning. An `isI18nCacheInitialized()` helper parallel to `isI18nConfigInitialized()` would be the safer, self-documenting approach.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fnext%2Fsrc%2Fsetup%2FinitGT.ts%0ALine%3A%2031-36%0A%0AComment%3A%0A**Exception-driven%20control%20flow%20for%20cache%20init%20detection**%0A%0A%60getNextI18nCache%28%29%60%20always%20throws%20when%20the%20cache%20is%20uninitialized%20%28per%20its%20implementation%20in%20%60singleton-operations.ts%60%29%2C%20so%20the%20try%2Fcatch%20works%20correctly%20%E2%80%94%20but%20using%20exceptions%20as%20a%20detection%20signal%20is%20an%20antipattern.%20If%20%60getI18nCache%60's%20error%20contract%20ever%20changes%20%28e.g.%2C%20returns%20%60null%60%20instead%20of%20throwing%29%2C%20this%20silently%20stops%20returning%20%60false%60%20and%20the%20idempotency%20guard%20breaks%20without%20any%20compile-time%20warning.%20An%20%60isI18nCacheInitialized%28%29%60%20helper%20parallel%20to%20%60isI18nConfigInitialized%28%29%60%20would%20be%20the%20safer%2C%20self-documenting%20approach.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=generaltranslation%2Fgt&pr=1619&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fodysseus%2Fdev-apps-language-testing%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fodysseus%2Fdev-apps-language-testing%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fnext%2Fsrc%2Fsetup%2FinitGT.ts%0ALine%3A%2031-36%0A%0AComment%3A%0A**Exception-driven%20control%20flow%20for%20cache%20init%20detection**%0A%0A%60getNextI18nCache%28%29%60%20always%20throws%20when%20the%20cache%20is%20uninitialized%20%28per%20its%20implementation%20in%20%60singleton-operations.ts%60%29%2C%20so%20the%20try%2Fcatch%20works%20correctly%20%E2%80%94%20but%20using%20exceptions%20as%20a%20detection%20signal%20is%20an%20antipattern.%20If%20%60getI18nCache%60's%20error%20contract%20ever%20changes%20%28e.g.%2C%20returns%20%60null%60%20instead%20of%20throwing%29%2C%20this%20silently%20stops%20returning%20%60false%60%20and%20the%20idempotency%20guard%20breaks%20without%20any%20compile-time%20warning.%20An%20%60isI18nCacheInitialized%28%29%60%20helper%20parallel%20to%20%60isI18nConfigInitialized%28%29%60%20would%20be%20the%20safer%2C%20self-documenting%20approach.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=generaltranslation%2Fgt&pr=1619&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>


2. `packages/next/src/setup/initGT.ts`, line 38 ([link](https://github.com/generaltranslation/gt/blob/8fba0e233e4345091eb88c07430a5a1d69727f3a/packages/next/src/setup/initGT.ts#L38)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`setupGTServicesEnabled` is not idempotency-guarded**

   `initializeI18nConfig` and `setNextI18nCache` are now skipped on repeat calls, but `setupGTServicesEnabled` always overwrites `globalThis.__generaltranslation.i18n.gtServicesEnabled`. In practice this is harmless because the value is derived solely from env vars (which are constant), but it is the only step inconsistent with the idempotency pattern the PR is introducing. If a caller ever passes explicit params on first call and then the client-boundary fires with `getParams()` defaults, only `setupGTServicesEnabled` will re-run with the new params rather than being skipped — quietly changing the effective GT services state.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/next/src/setup/initGT.ts
   Line: 38

   Comment:
   **`setupGTServicesEnabled` is not idempotency-guarded**

   `initializeI18nConfig` and `setNextI18nCache` are now skipped on repeat calls, but `setupGTServicesEnabled` always overwrites `globalThis.__generaltranslation.i18n.gtServicesEnabled`. In practice this is harmless because the value is derived solely from env vars (which are constant), but it is the only step inconsistent with the idempotency pattern the PR is introducing. If a caller ever passes explicit params on first call and then the client-boundary fires with `getParams()` defaults, only `setupGTServicesEnabled` will re-run with the new params rather than being skipped — quietly changing the effective GT services state.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fnext%2Fsrc%2Fsetup%2FinitGT.ts%0ALine%3A%2038%0A%0AComment%3A%0A**%60setupGTServicesEnabled%60%20is%20not%20idempotency-guarded**%0A%0A%60initializeI18nConfig%60%20and%20%60setNextI18nCache%60%20are%20now%20skipped%20on%20repeat%20calls%2C%20but%20%60setupGTServicesEnabled%60%20always%20overwrites%20%60globalThis.__generaltranslation.i18n.gtServicesEnabled%60.%20In%20practice%20this%20is%20harmless%20because%20the%20value%20is%20derived%20solely%20from%20env%20vars%20%28which%20are%20constant%29%2C%20but%20it%20is%20the%20only%20step%20inconsistent%20with%20the%20idempotency%20pattern%20the%20PR%20is%20introducing.%20If%20a%20caller%20ever%20passes%20explicit%20params%20on%20first%20call%20and%20then%20the%20client-boundary%20fires%20with%20%60getParams%28%29%60%20defaults%2C%20only%20%60setupGTServicesEnabled%60%20will%20re-run%20with%20the%20new%20params%20rather%20than%20being%20skipped%20%E2%80%94%20quietly%20changing%20the%20effective%20GT%20services%20state.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=generaltranslation%2Fgt&pr=1619&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fodysseus%2Fdev-apps-language-testing%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fodysseus%2Fdev-apps-language-testing%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fnext%2Fsrc%2Fsetup%2FinitGT.ts%0ALine%3A%2038%0A%0AComment%3A%0A**%60setupGTServicesEnabled%60%20is%20not%20idempotency-guarded**%0A%0A%60initializeI18nConfig%60%20and%20%60setNextI18nCache%60%20are%20now%20skipped%20on%20repeat%20calls%2C%20but%20%60setupGTServicesEnabled%60%20always%20overwrites%20%60globalThis.__generaltranslation.i18n.gtServicesEnabled%60.%20In%20practice%20this%20is%20harmless%20because%20the%20value%20is%20derived%20solely%20from%20env%20vars%20%28which%20are%20constant%29%2C%20but%20it%20is%20the%20only%20step%20inconsistent%20with%20the%20idempotency%20pattern%20the%20PR%20is%20introducing.%20If%20a%20caller%20ever%20passes%20explicit%20params%20on%20first%20call%20and%20then%20the%20client-boundary%20fires%20with%20%60getParams%28%29%60%20defaults%2C%20only%20%60setupGTServicesEnabled%60%20will%20re-run%20with%20the%20new%20params%20rather%20than%20being%20skipped%20%E2%80%94%20quietly%20changing%20the%20effective%20GT%20services%20state.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=generaltranslation%2Fgt&pr=1619&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fnext%2Fsrc%2Fsetup%2FinitGT.ts%3A31-36%0A**Exception-driven%20control%20flow%20for%20cache%20init%20detection**%0A%0A%60getNextI18nCache%28%29%60%20always%20throws%20when%20the%20cache%20is%20uninitialized%20%28per%20its%20implementation%20in%20%60singleton-operations.ts%60%29%2C%20so%20the%20try%2Fcatch%20works%20correctly%20%E2%80%94%20but%20using%20exceptions%20as%20a%20detection%20signal%20is%20an%20antipattern.%20If%20%60getI18nCache%60's%20error%20contract%20ever%20changes%20%28e.g.%2C%20returns%20%60null%60%20instead%20of%20throwing%29%2C%20this%20silently%20stops%20returning%20%60false%60%20and%20the%20idempotency%20guard%20breaks%20without%20any%20compile-time%20warning.%20An%20%60isI18nCacheInitialized%28%29%60%20helper%20parallel%20to%20%60isI18nConfigInitialized%28%29%60%20would%20be%20the%20safer%2C%20self-documenting%20approach.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fnext%2Fsrc%2Fsetup%2FinitGT.ts%3A38%0A**%60setupGTServicesEnabled%60%20is%20not%20idempotency-guarded**%0A%0A%60initializeI18nConfig%60%20and%20%60setNextI18nCache%60%20are%20now%20skipped%20on%20repeat%20calls%2C%20but%20%60setupGTServicesEnabled%60%20always%20overwrites%20%60globalThis.__generaltranslation.i18n.gtServicesEnabled%60.%20In%20practice%20this%20is%20harmless%20because%20the%20value%20is%20derived%20solely%20from%20env%20vars%20%28which%20are%20constant%29%2C%20but%20it%20is%20the%20only%20step%20inconsistent%20with%20the%20idempotency%20pattern%20the%20PR%20is%20introducing.%20If%20a%20caller%20ever%20passes%20explicit%20params%20on%20first%20call%20and%20then%20the%20client-boundary%20fires%20with%20%60getParams%28%29%60%20defaults%2C%20only%20%60setupGTServicesEnabled%60%20will%20re-run%20with%20the%20new%20params%20rather%20than%20being%20skipped%20%E2%80%94%20quietly%20changing%20the%20effective%20GT%20services%20state.%0A%0A&repo=generaltranslation%2Fgt&pr=1619&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fodysseus%2Fdev-apps-language-testing%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fodysseus%2Fdev-apps-language-testing%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fnext%2Fsrc%2Fsetup%2FinitGT.ts%3A31-36%0A**Exception-driven%20control%20flow%20for%20cache%20init%20detection**%0A%0A%60getNextI18nCache%28%29%60%20always%20throws%20when%20the%20cache%20is%20uninitialized%20%28per%20its%20implementation%20in%20%60singleton-operations.ts%60%29%2C%20so%20the%20try%2Fcatch%20works%20correctly%20%E2%80%94%20but%20using%20exceptions%20as%20a%20detection%20signal%20is%20an%20antipattern.%20If%20%60getI18nCache%60's%20error%20contract%20ever%20changes%20%28e.g.%2C%20returns%20%60null%60%20instead%20of%20throwing%29%2C%20this%20silently%20stops%20returning%20%60false%60%20and%20the%20idempotency%20guard%20breaks%20without%20any%20compile-time%20warning.%20An%20%60isI18nCacheInitialized%28%29%60%20helper%20parallel%20to%20%60isI18nConfigInitialized%28%29%60%20would%20be%20the%20safer%2C%20self-documenting%20approach.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fnext%2Fsrc%2Fsetup%2FinitGT.ts%3A38%0A**%60setupGTServicesEnabled%60%20is%20not%20idempotency-guarded**%0A%0A%60initializeI18nConfig%60%20and%20%60setNextI18nCache%60%20are%20now%20skipped%20on%20repeat%20calls%2C%20but%20%60setupGTServicesEnabled%60%20always%20overwrites%20%60globalThis.__generaltranslation.i18n.gtServicesEnabled%60.%20In%20practice%20this%20is%20harmless%20because%20the%20value%20is%20derived%20solely%20from%20env%20vars%20%28which%20are%20constant%29%2C%20but%20it%20is%20the%20only%20step%20inconsistent%20with%20the%20idempotency%20pattern%20the%20PR%20is%20introducing.%20If%20a%20caller%20ever%20passes%20explicit%20params%20on%20first%20call%20and%20then%20the%20client-boundary%20fires%20with%20%60getParams%28%29%60%20defaults%2C%20only%20%60setupGTServicesEnabled%60%20will%20re-run%20with%20the%20new%20params%20rather%20than%20being%20skipped%20%E2%80%94%20quietly%20changing%20the%20effective%20GT%20services%20state.%0A%0A&repo=generaltranslation%2Fgt&pr=1619&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/next/src/setup/initGT.ts:31-36
**Exception-driven control flow for cache init detection**

`getNextI18nCache()` always throws when the cache is uninitialized (per its implementation in `singleton-operations.ts`), so the try/catch works correctly — but using exceptions as a detection signal is an antipattern. If `getI18nCache`'s error contract ever changes (e.g., returns `null` instead of throwing), this silently stops returning `false` and the idempotency guard breaks without any compile-time warning. An `isI18nCacheInitialized()` helper parallel to `isI18nConfigInitialized()` would be the safer, self-documenting approach.

### Issue 2 of 2
packages/next/src/setup/initGT.ts:38
**`setupGTServicesEnabled` is not idempotency-guarded**

`initializeI18nConfig` and `setNextI18nCache` are now skipped on repeat calls, but `setupGTServicesEnabled` always overwrites `globalThis.__generaltranslation.i18n.gtServicesEnabled`. In practice this is harmless because the value is derived solely from env vars (which are constant), but it is the only step inconsistent with the idempotency pattern the PR is introducing. If a caller ever passes explicit params on first call and then the client-boundary fires with `getParams()` defaults, only `setupGTServicesEnabled` will re-run with the new params rather than being skipped — quietly changing the effective GT services state.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: initialize gt-next client boundary"](https://github.com/generaltranslation/gt/commit/8fba0e233e4345091eb88c07430a5a1d69727f3a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38560282)</sub>

<!-- /greptile_comment -->