### PR TITLE
fix: surface gt.config.json parse errors instead of silently ignoring them

### DIFF
--- a/.changeset/cli-config-parse-errors.md
+++ b/.changeset/cli-config-parse-errors.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+fix: surface config file errors instead of silently ignoring them. A malformed `gt.config.json` (invalid JSON) was swallowed and treated as empty config, dropping every setting with no warning; an explicit `--config` path that doesn't exist was also ignored. Both now fail with a clear message and a non-zero exit code.

--- a/packages/cli/src/config/generateSettings.ts
+++ b/packages/cli/src/config/generateSettings.ts
@@ -5,7 +5,7 @@ import {
   warnApiKeyInConfig,
   warnDeprecatedField,
 } from '../console/logging.js';
-import { loadConfig } from '../fs/config/loadConfig.js';
+import { parseConfigFile } from '../fs/config/loadConfig.js';
 import { FilesOptions, Settings } from '../types/index.js';
 import {
   defaultBaseUrl,
@@ -20,6 +20,7 @@ import {
 import { resolveProjectId } from '../fs/utils.js';
 import crypto from 'node:crypto';
 import { execSync } from 'node:child_process';
+import fs from 'node:fs';
 import path from 'node:path';
 import chalk from 'chalk';
 import { resolveConfig } from './resolveConfig.js';
@@ -97,21 +98,27 @@ export async function generateSettings(
   if (flags.config && !flags.config.endsWith('.json')) {
     flags.config = `${flags.config}.json`;
   }
-  if (flags.config) {
-    gtConfig = loadConfig(flags.config);
-  } else {
-    const config = resolveConfig(cwd);
-    if (config) {
-      gtConfig = config.config as GenerateSettingsInput;
-      flags.config = config.path;
+  try {
+    if (flags.config) {
+      if (!fs.existsSync(flags.config)) {
+        return logErrorAndExit(`Config file not found: ${flags.config}`);
+      }
+      gtConfig = parseConfigFile(flags.config);
     } else {
-      if (options?.requireConfig) {
+      const config = resolveConfig(cwd);
+      if (config) {
+        gtConfig = config.config as GenerateSettingsInput;
+        flags.config = config.path;
+      } else if (options?.requireConfig) {
         return logErrorAndExit(
           'No gt.config.json file was found. Run `npx gt init` to create one, pass --config, or run this command from your project root.'
         );
+      } else {
+        gtConfig = {};
       }
-      gtConfig = {};
     }
+  } catch (error) {
+    return logErrorAndExit((error as Error).message);
   }
 
   // Warn if apiKey is present in gt.config.json

--- a/packages/cli/src/config/resolveConfig.ts
+++ b/packages/cli/src/config/resolveConfig.ts
@@ -1,37 +1,24 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { loadConfig } from '../fs/config/loadConfig.js';
+import { parseConfigFile } from '../fs/config/loadConfig.js';
 
 export function resolveConfig(cwd: string): {
   path: string;
   config: Record<string, unknown>;
 } | null {
-  const configFilepath = 'gt.config.json';
-  if (fs.existsSync(path.join(cwd, configFilepath))) {
-    return {
-      path: path.join(cwd, configFilepath),
-      config: loadConfig(path.join(cwd, configFilepath)),
-    };
-  }
-  if (fs.existsSync(path.join(cwd, 'src/gt.config.json'))) {
-    return {
-      path: path.join(cwd, 'src/gt.config.json'),
-      config: loadConfig(path.join(cwd, 'src/gt.config.json')),
-    };
-  }
-  // Support config under .gt for parity with .locadex
-  if (fs.existsSync(path.join(cwd, '.gt/gt.config.json'))) {
-    return {
-      path: path.join(cwd, '.gt/gt.config.json'),
-      config: loadConfig(path.join(cwd, '.gt/gt.config.json')),
-    };
-  }
-  // Backward compatibility: support legacy .locadex directory
-  if (fs.existsSync(path.join(cwd, '.locadex/gt.config.json'))) {
-    return {
-      path: path.join(cwd, '.locadex/gt.config.json'),
-      config: loadConfig(path.join(cwd, '.locadex/gt.config.json')),
-    };
+  const candidates = [
+    'gt.config.json',
+    'src/gt.config.json',
+    // Support config under .gt for parity with .locadex
+    '.gt/gt.config.json',
+    // Backward compatibility: support legacy .locadex directory
+    '.locadex/gt.config.json',
+  ];
+  for (const candidate of candidates) {
+    const filepath = path.join(cwd, candidate);
+    if (fs.existsSync(filepath)) {
+      return { path: filepath, config: parseConfigFile(filepath) };
+    }
   }
   return null;
 }

--- a/packages/cli/src/fs/config/__tests__/loadConfig.test.ts
+++ b/packages/cli/src/fs/config/__tests__/loadConfig.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { loadConfig, parseConfigFile } from '../loadConfig.js';
+
+describe('parseConfigFile', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gt-config-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('returns {} when the file does not exist', () => {
+    expect(parseConfigFile(path.join(dir, 'missing.json'))).toEqual({});
+  });
+
+  it('parses a valid config file', () => {
+    const file = path.join(dir, 'gt.config.json');
+    fs.writeFileSync(file, '{ "defaultLocale": "en", "locales": ["fr"] }');
+    expect(parseConfigFile(file)).toEqual({
+      defaultLocale: 'en',
+      locales: ['fr'],
+    });
+  });
+
+  it('throws on an existing file with invalid JSON instead of silently returning {}', () => {
+    const file = path.join(dir, 'gt.config.json');
+    fs.writeFileSync(file, '{ "defaultLocale": "en", INVALID }');
+    // loadConfig swallows this and loses every setting; parseConfigFile must not
+    expect(loadConfig(file)).toEqual({});
+    expect(() => parseConfigFile(file)).toThrow(/Failed to parse config file/);
+  });
+});

--- a/packages/cli/src/fs/config/loadConfig.ts
+++ b/packages/cli/src/fs/config/loadConfig.ts
@@ -10,3 +10,25 @@ export function loadConfig(filepath: string): Record<string, unknown> {
     return {};
   }
 }
+
+/**
+ * Parse a JSON config file (e.g. gt.config.json). Unlike {@link loadConfig},
+ * a file that exists but contains invalid JSON throws instead of being
+ * silently treated as empty config — otherwise a typo in gt.config.json
+ * drops every setting with no feedback. A missing file still returns `{}`.
+ */
+export function parseConfigFile(filepath: string): Record<string, unknown> {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(filepath, 'utf-8');
+  } catch {
+    return {};
+  }
+  try {
+    return JSON.parse(raw) as Record<string, unknown>;
+  } catch (error) {
+    throw new Error(
+      `Failed to parse config file "${filepath}": ${(error as Error).message}`
+    );
+  }
+}

--- a/packages/cli/src/fs/config/loadConfig.ts
+++ b/packages/cli/src/fs/config/loadConfig.ts
@@ -21,8 +21,15 @@ export function parseConfigFile(filepath: string): Record<string, unknown> {
   let raw: string;
   try {
     raw = fs.readFileSync(filepath, 'utf-8');
-  } catch {
-    return {};
+  } catch (error) {
+    // Only a missing file is benign; other read errors (permissions, EISDIR,
+    // transient IO) must surface rather than masquerade as empty config.
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return {};
+    }
+    throw new Error(
+      `Failed to read config file "${filepath}": ${(error as Error).message}`
+    );
   }
   try {
     return JSON.parse(raw) as Record<string, unknown>;

--- a/packages/cli/src/utils/monorepoVersionCheck.ts
+++ b/packages/cli/src/utils/monorepoVersionCheck.ts
@@ -333,8 +333,15 @@ export function checkMonorepoVersionConsistency(
 ): void {
   const cwd = process.cwd();
 
-  // Check if skipped via config
-  const resolved = resolveConfig(cwd);
+  // Check if skipped via config. This runs in a preAction hook before every
+  // command, so a malformed gt.config.json must not crash here — the command
+  // itself surfaces the parse error cleanly via generateSettings.
+  let resolved: ReturnType<typeof resolveConfig> = null;
+  try {
+    resolved = resolveConfig(cwd);
+  } catch {
+    return;
+  }
   if (resolved?.config?.skipVersionCheck) return;
 
   const rootDir = findMonorepoRoot(cwd);


### PR DESCRIPTION
## Problem

`loadConfig` swallowed **all** read/parse errors and returned `{}`. Two real failure modes were silent:

1. **Malformed `gt.config.json`** (a JSON syntax error / typo) was treated as empty config — every setting (`locales`, `defaultLocale`, files config, …) was dropped, the CLI reported `Done!` and exited `0`.
2. An explicit `--config path/that/does/not/exist.json` was ignored rather than erroring.

Reproduced against the built CLI:

```
$ printf '{ "defaultLocale": "en", "locales": ["fr"], INVALID }' > gt.config.json
$ gt translate --dry-run
...
└  Done!          # exit 0, locales silently lost
```

## Fix

Add `parseConfigFile()` which:
- returns `{}` when the file does not exist (unchanged behavior for probing), but
- **throws on an existing file with invalid JSON**, with a message naming the file.

Wire it into the two `gt.config.json` read paths — `resolveConfig` (already `existsSync`-guarded) and the explicit `--config` branch of `generateSettings`, which now also errors when the given path is missing. Errors surface through `logErrorAndExit` (clear message, non-zero exit).

The lenient `loadConfig` is intentionally **kept** for `tsconfig` reads in the setup wizard, since tsconfig files are commonly JSONC (comments / trailing commas) and must not hard-fail.

After the fix:

```
malformed gt.config.json   -> "Failed to parse config file ..."   exit 1
missing --config path      -> "Config file not found: ..."        exit 1
valid gt.config.json       -> Done!                               exit 0
```

## Tests

Added `loadConfig.test.ts` covering `parseConfigFile`: missing file → `{}`, valid file → parsed, existing-but-invalid → throws (and documents that `loadConfig` still swallows it). Full `gt` suite passes (1916 tests).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1624"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784447580&installation_id=127936663&pr_number=1624&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1624&signature=bea692f7da9ae8c9b2a909802b2db95ca27b475989849b408e1ba05b5e71f115"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two silent failure modes in CLI config loading: a malformed `gt.config.json` was swallowed and treated as empty config, and an explicit `--config` path that doesn't exist was silently ignored. The fix introduces `parseConfigFile`, which throws on invalid JSON while still returning `{}` for missing files, and wires it into both config read paths with proper error surfacing via `logErrorAndExit`.

- **`parseConfigFile`** replaces `loadConfig` for strict JSON configs; the original `loadConfig` is intentionally kept for JSONC-tolerant reads (e.g., `tsconfig`).
- **`generateSettings`** now checks existence of an explicit `--config` path before reading, and wraps the entire config-load block in a try/catch that routes errors to `logErrorAndExit`.
- **`resolveConfig`** is refactored to a candidates-loop, eliminating four nearly identical `existsSync`+`loadConfig` blocks.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the fix correctly surfaces config errors and all existing tests pass.

The read-error catch in parseConfigFile is broader than documented — it catches every I/O failure, not just missing-file (ENOENT), so an unreadable-but-existing config file would silently produce empty settings. This is an edge case and not a regression from prior behaviour, but it leaves a small gap in the stated contract.

packages/cli/src/fs/config/loadConfig.ts — the read-error catch should be narrowed to ENOENT only.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/fs/config/loadConfig.ts | Adds parseConfigFile that throws on invalid JSON and returns {} for missing files. The read-error catch is too broad — it swallows any I/O failure (permissions, etc.), not just ENOENT. |
| packages/cli/src/config/generateSettings.ts | Wraps config loading in try/catch, adds existsSync check for explicit --config path, and surfaces errors via logErrorAndExit. Logic is correct. |
| packages/cli/src/config/resolveConfig.ts | Refactored to a candidates loop; now uses parseConfigFile instead of loadConfig. Clean and correct — parse errors propagate up to generateSettings's catch. |
| packages/cli/src/fs/config/__tests__/loadConfig.test.ts | New test file covering missing file, valid JSON, and invalid JSON cases for parseConfigFile. Also documents that loadConfig still swallows errors. |
| .changeset/cli-config-parse-errors.md | Patch changeset for the gt package describing the fix correctly. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[generateSettings called] --> B{flags.config set?}
    B -- yes --> C{fs.existsSync?}
    C -- no --> D[logErrorAndExit: Config file not found]
    C -- yes --> E[parseConfigFile]
    E -- valid JSON --> F[gtConfig = parsed result]
    E -- invalid JSON --> G[throws Error]
    G --> H[catch: logErrorAndExit with error message]
    B -- no --> I[resolveConfig: probe candidate paths]
    I -- found --> J[parseConfigFile]
    J -- valid JSON --> K[gtConfig = parsed result]
    J -- invalid JSON --> L[throws Error]
    L --> H
    I -- not found --> M{requireConfig?}
    M -- yes --> N[logErrorAndExit: no config found]
    M -- no --> O[gtConfig = empty]
    F --> P[merge flags + config, return Settings]
    K --> P
    O --> P
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[generateSettings called] --> B{flags.config set?}
    B -- yes --> C{fs.existsSync?}
    C -- no --> D[logErrorAndExit: Config file not found]
    C -- yes --> E[parseConfigFile]
    E -- valid JSON --> F[gtConfig = parsed result]
    E -- invalid JSON --> G[throws Error]
    G --> H[catch: logErrorAndExit with error message]
    B -- no --> I[resolveConfig: probe candidate paths]
    I -- found --> J[parseConfigFile]
    J -- valid JSON --> K[gtConfig = parsed result]
    J -- invalid JSON --> L[throws Error]
    L --> H
    I -- not found --> M{requireConfig?}
    M -- yes --> N[logErrorAndExit: no config found]
    M -- no --> O[gtConfig = empty]
    F --> P[merge flags + config, return Settings]
    K --> P
    O --> P
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fcli%2Fsrc%2Ffs%2Fconfig%2FloadConfig.ts%3A21-26%0AThe%20read-error%20%60catch%60%20block%20swallows%20every%20%60fs.readFileSync%60%20failure%20%E2%80%94%20not%20just%20%60ENOENT%60%20%28file%20not%20found%29.%20If%20the%20config%20file%20exists%20but%20is%20unreadable%20%28e.g.%2C%20a%20permission%20change%20between%20the%20caller's%20%60existsSync%60%20check%20and%20the%20actual%20read%29%2C%20%60parseConfigFile%60%20silently%20returns%20%60%7B%7D%60%20instead%20of%20throwing%2C%20giving%20the%20appearance%20of%20an%20empty%20config.%20Narrowing%20to%20%60ENOENT%60%20only%20makes%20the%20stated%20contract%20%28%22a%20missing%20file%20returns%20%60%7B%7D%60%22%29%20precise%20and%20lets%20real%20I%2FO%20errors%20surface.%0A%0A%60%60%60suggestion%0A%20%20let%20raw%3A%20string%3B%0A%20%20try%20%7B%0A%20%20%20%20raw%20%3D%20fs.readFileSync%28filepath%2C%20'utf-8'%29%3B%0A%20%20%7D%20catch%20%28error%29%20%7B%0A%20%20%20%20if%20%28%28error%20as%20NodeJS.ErrnoException%29.code%20%3D%3D%3D%20'ENOENT'%29%20%7B%0A%20%20%20%20%20%20return%20%7B%7D%3B%0A%20%20%20%20%7D%0A%20%20%20%20throw%20new%20Error%28%0A%20%20%20%20%20%20%60Failed%20to%20read%20config%20file%20%22%24%7Bfilepath%7D%22%3A%20%24%7B%28error%20as%20Error%29.message%7D%60%0A%20%20%20%20%29%3B%0A%20%20%7D%0A%60%60%60%0A%0A&repo=generaltranslation%2Fgt&pr=1624&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22fix%2Fcli-config-parse-errors%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fcli-config-parse-errors%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fcli%2Fsrc%2Ffs%2Fconfig%2FloadConfig.ts%3A21-26%0AThe%20read-error%20%60catch%60%20block%20swallows%20every%20%60fs.readFileSync%60%20failure%20%E2%80%94%20not%20just%20%60ENOENT%60%20%28file%20not%20found%29.%20If%20the%20config%20file%20exists%20but%20is%20unreadable%20%28e.g.%2C%20a%20permission%20change%20between%20the%20caller's%20%60existsSync%60%20check%20and%20the%20actual%20read%29%2C%20%60parseConfigFile%60%20silently%20returns%20%60%7B%7D%60%20instead%20of%20throwing%2C%20giving%20the%20appearance%20of%20an%20empty%20config.%20Narrowing%20to%20%60ENOENT%60%20only%20makes%20the%20stated%20contract%20%28%22a%20missing%20file%20returns%20%60%7B%7D%60%22%29%20precise%20and%20lets%20real%20I%2FO%20errors%20surface.%0A%0A%60%60%60suggestion%0A%20%20let%20raw%3A%20string%3B%0A%20%20try%20%7B%0A%20%20%20%20raw%20%3D%20fs.readFileSync%28filepath%2C%20'utf-8'%29%3B%0A%20%20%7D%20catch%20%28error%29%20%7B%0A%20%20%20%20if%20%28%28error%20as%20NodeJS.ErrnoException%29.code%20%3D%3D%3D%20'ENOENT'%29%20%7B%0A%20%20%20%20%20%20return%20%7B%7D%3B%0A%20%20%20%20%7D%0A%20%20%20%20throw%20new%20Error%28%0A%20%20%20%20%20%20%60Failed%20to%20read%20config%20file%20%22%24%7Bfilepath%7D%22%3A%20%24%7B%28error%20as%20Error%29.message%7D%60%0A%20%20%20%20%29%3B%0A%20%20%7D%0A%60%60%60%0A%0A&repo=generaltranslation%2Fgt&pr=1624&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/cli/src/fs/config/loadConfig.ts:21-26
The read-error `catch` block swallows every `fs.readFileSync` failure — not just `ENOENT` (file not found). If the config file exists but is unreadable (e.g., a permission change between the caller's `existsSync` check and the actual read), `parseConfigFile` silently returns `{}` instead of throwing, giving the appearance of an empty config. Narrowing to `ENOENT` only makes the stated contract ("a missing file returns `{}`") precise and lets real I/O errors surface.

```suggestion
  let raw: string;
  try {
    raw = fs.readFileSync(filepath, 'utf-8');
  } catch (error) {
    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
      return {};
    }
    throw new Error(
      `Failed to read config file "${filepath}": ${(error as Error).message}`
    );
  }
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: surface gt.config.json parse errors..."](https://github.com/generaltranslation/gt/commit/a070e87f897274b80fa72aa604df7eb63cd87b91) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38608152)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->