### PR TITLE
fix: add legacy gt-react import source flag

### DIFF
--- a/packages/cli/src/config/defaults.ts
+++ b/packages/cli/src/config/defaults.ts
@@ -9,6 +9,7 @@ export const GT_PARSING_FLAGS_DEFAULT: GTParsingFlags = {
   autoderive: false,
   includeSourceCodeContext: false,
   enableAutoJsxInjection: false,
+  legacyGtReactImportSource: false,
 };
 
 /**

--- a/packages/cli/src/react/jsx/utils/__tests__/getPathsAndAliases.test.ts
+++ b/packages/cli/src/react/jsx/utils/__tests__/getPathsAndAliases.test.ts
@@ -2,7 +2,10 @@ import { describe, it, expect } from 'vitest';
 import { parse } from '@babel/parser';
 import { getPathsAndAliases } from '../getPathsAndAliases.js';
 import { Libraries } from '../../../../types/libraries.js';
-import { T_GLOBAL_REGISTRATION_FUNCTION_MARKER } from '../constants.js';
+import {
+  T_GLOBAL_REGISTRATION_FUNCTION_MARKER,
+  T_REGISTRATION_FUNCTION,
+} from '../constants.js';
 
 const pkgs = [Libraries.GT_REACT];
 
@@ -18,6 +21,14 @@ function getGlobalEntries(code: string) {
   const { inlineTranslationPaths } = getPathsAndAliases(ast, pkgs);
   return inlineTranslationPaths.filter(
     (p) => p.originalName === T_GLOBAL_REGISTRATION_FUNCTION_MARKER
+  );
+}
+
+function getInlineEntries(code: string) {
+  const ast = parseCode(code);
+  const { inlineTranslationPaths } = getPathsAndAliases(ast, pkgs);
+  return inlineTranslationPaths.filter(
+    (p) => p.originalName === T_REGISTRATION_FUNCTION
   );
 }
 
@@ -57,4 +68,15 @@ describe('getPathsAndAliases - global t macro detection', () => {
     );
     expect(entries).toHaveLength(2);
   });
+});
+
+describe('getPathsAndAliases - gt-react entrypoints', () => {
+  for (const source of ['gt-react', 'gt-react/browser', 'gt-react/client']) {
+    it(`detects t imported from ${source}`, () => {
+      const entries = getInlineEntries(
+        `import { t } from '${source}';\nconst x = t\`hello\`;`
+      );
+      expect(entries).toHaveLength(1);
+    });
+  }
 });

--- a/packages/cli/src/react/jsx/utils/constants.ts
+++ b/packages/cli/src/react/jsx/utils/constants.ts
@@ -10,9 +10,18 @@ export const INLINE_MESSAGE_HOOK_ASYNC = 'getMessages';
 export const TRANSLATION_COMPONENT = 'T';
 export const DERIVE_COMPONENT = 'Derive';
 export const BRANCH_COMPONENT = 'Branch';
-export const DEFAULT_GT_IMPORT_SOURCE = 'gt-react/browser';
+export const DEFAULT_GT_IMPORT_SOURCE = 'gt-react';
+export const LEGACY_GT_IMPORT_SOURCE = 'gt-react/browser';
 export const INTERNAL_TRANSLATION_COMPONENT = 'GtInternalTranslateJsx';
 export const INTERNAL_VAR_COMPONENT = 'GtInternalVar';
+
+export function getGtReactImportSource(
+  legacyGtReactImportSource: boolean
+): typeof DEFAULT_GT_IMPORT_SOURCE | typeof LEGACY_GT_IMPORT_SOURCE {
+  return legacyGtReactImportSource
+    ? LEGACY_GT_IMPORT_SOURCE
+    : DEFAULT_GT_IMPORT_SOURCE;
+}
 
 // Variable components
 export const VAR_COMPONENT = 'Var';

--- a/packages/cli/src/react/jsx/utils/jsxParsing/__tests__/autoJsxInjectionPass.test.ts
+++ b/packages/cli/src/react/jsx/utils/jsxParsing/__tests__/autoJsxInjectionPass.test.ts
@@ -31,7 +31,10 @@ const generate = (generateModule as unknown).default || generateModule;
 //  Helper
 // ================================================================ //
 
-function injectAndAnalyze(sourceCode: string) {
+function injectAndAnalyze(
+  sourceCode: string,
+  legacyGtReactImportSource = false
+) {
   const ast = parse(sourceCode, {
     sourceType: 'module',
     plugins: ['jsx', 'typescript'],
@@ -47,7 +50,7 @@ function injectAndAnalyze(sourceCode: string) {
     aliases[localName] = originalName;
   }
 
-  ensureTAndVarImported(ast, aliases);
+  ensureTAndVarImported(ast, aliases, legacyGtReactImportSource);
   autoInsertJsxComponents(ast, aliases);
 
   const code = generate(ast).code;
@@ -993,6 +996,15 @@ describe('autoInsertJsxComponents — injection pass', () => {
         export default function Page() { return <div>Hello</div>; }
       `;
       const r = injectAndAnalyze(code);
+      expect(r.tCount).toBe(1);
+      expect(r.imports).toContain('gt-react');
+    });
+
+    it('injects legacy import when configured', () => {
+      const code = `
+        export default function Page() { return <div>Hello</div>; }
+      `;
+      const r = injectAndAnalyze(code, true);
       expect(r.tCount).toBe(1);
       expect(r.imports).toContain('gt-react/browser');
     });

--- a/packages/cli/src/react/jsx/utils/jsxParsing/autoInsertion.ts
+++ b/packages/cli/src/react/jsx/utils/jsxParsing/autoInsertion.ts
@@ -20,7 +20,7 @@ import {
   VARIABLE_COMPONENTS,
   BRANCH_COMPONENT,
   PLURAL_COMPONENT,
-  DEFAULT_GT_IMPORT_SOURCE,
+  getGtReactImportSource,
   DERIVE_COMPONENT,
   BRANCH_CONTROL_PROPS,
   PLURAL_CONTROL_PROPS,
@@ -38,14 +38,15 @@ export function isAutoInserted(node: t.Node): boolean {
 
 /**
  * Ensure GtInternalTranslateJsx and GtInternalVar are imported in the AST.
- * Always adds: import { GtInternalTranslateJsx, GtInternalVar } from 'gt-react/browser';
+ * Adds: import { GtInternalTranslateJsx, GtInternalVar } from 'gt-react';
  * These are distinct from user T/Var so there's no ambiguity.
  *
  * Updates importAliases in-place.
  */
 export function ensureTAndVarImported(
   ast: t.File,
-  importAliases: Record<string, string>
+  importAliases: Record<string, string>,
+  legacyGtReactImportSource = false
 ): void {
   // Check if internal components are already imported
   const hasInternalT = Object.values(importAliases).includes(
@@ -80,7 +81,7 @@ export function ensureTAndVarImported(
 
   const importDecl = t.importDeclaration(
     specifiers,
-    t.stringLiteral(DEFAULT_GT_IMPORT_SOURCE)
+    t.stringLiteral(getGtReactImportSource(legacyGtReactImportSource))
   );
 
   traverse(ast, {

--- a/packages/cli/src/react/parse/createInlineUpdates.ts
+++ b/packages/cli/src/react/parse/createInlineUpdates.ts
@@ -128,7 +128,11 @@ export async function createInlineUpdates(
         }
 
         // Ensure GtInternalTranslateJsx and GtInternalVar are imported in the AST
-        ensureTAndVarImported(ast, importAliases);
+        ensureTAndVarImported(
+          ast,
+          importAliases,
+          parsingFlags.legacyGtReactImportSource
+        );
 
         // Insert T/Var into the AST
         autoInsertJsxComponents(ast, importAliases);

--- a/packages/cli/src/types/parsing.ts
+++ b/packages/cli/src/types/parsing.ts
@@ -36,11 +36,13 @@ export type BaseParsingFlags = Record<string, unknown>;
  * @property {boolean | { jsx?: boolean; strings?: boolean }} autoderive - Whether to enable autoderive. A plain boolean enables/disables both JSX and strings. An object enables selectively.
  * @property {boolean} includeSourceCodeContext - Include surrounding source code lines as context for translations.
  * @property {boolean} enableAutoJsxInjection - Whether to enable auto-jsx injection for the internal <_T> and <_Var> components.
+ * @property {boolean} legacyGtReactImportSource - Whether compiler-injected gt-react imports should use gt-react/browser.
  */
 export type GTParsingFlags = BaseParsingFlags & {
   autoderive: boolean | { jsx?: boolean; strings?: boolean };
   includeSourceCodeContext: boolean;
   enableAutoJsxInjection: boolean;
+  legacyGtReactImportSource: boolean;
 };
 
 /**

--- a/packages/compiler/src/config.ts
+++ b/packages/compiler/src/config.ts
@@ -13,6 +13,7 @@ type GTConfig = {
       parsingFlags?: {
         enableAutoJsxInjection?: boolean;
         autoderive?: boolean | { jsx?: boolean; strings?: boolean };
+        legacyGtReactImportSource?: boolean;
         /** Dev hot reload: inject runtime translate calls and enable Suspense-based <T> */
         devHotReload?: boolean | { strings?: boolean; jsx?: boolean };
       };
@@ -40,6 +41,8 @@ export interface PluginConfig {
   enableAutoJsxInjection?: boolean;
   /** Automatically treat interpolated/concatenated values as derive() calls */
   autoderive?: boolean | { jsx?: boolean; strings?: boolean };
+  /** Emit compiler-injected gt-react imports from gt-react/browser */
+  legacyGtReactImportSource?: boolean;
   /** Debug: write a hash → jsxChildren manifest file on build */
   _debugHashManifest?: boolean;
   /** Dev hot reload: inject runtime translate calls and enable Suspense-based <T> */
@@ -64,6 +67,8 @@ export interface PluginSettings {
   enableAutoJsxInjection: boolean;
   /** Automatically treat interpolated/concatenated values as derive() calls */
   autoderive: { jsx: boolean; strings: boolean };
+  /** Emit compiler-injected gt-react imports from gt-react/browser */
+  legacyGtReactImportSource: boolean;
   /** Debug: write a hash → jsxChildren manifest file on build */
   _debugHashManifest: boolean;
   /** Dev hot reload: inject runtime translate calls and enable Suspense-based <T> */

--- a/packages/compiler/src/passes/__tests__/jsxInsertionEdgeCases.test.ts
+++ b/packages/compiler/src/passes/__tests__/jsxInsertionEdgeCases.test.ts
@@ -8,13 +8,19 @@ import { initializeState } from '../../state/utils/initializeState';
 
 // --- Helpers ---
 
-function transform(code: string): {
+function transform(
+  code: string,
+  overrides: Record<string, unknown> = {}
+): {
   code: string;
   gtTranslateCalls: t.CallExpression[];
   gtVarCalls: t.CallExpression[];
   imports: t.ImportDeclaration[];
 } {
-  const state = initializeState({ enableAutoJsxInjection: true }, 'test.tsx');
+  const state = initializeState(
+    { enableAutoJsxInjection: true, ...overrides },
+    'test.tsx'
+  );
   const ast = parser.parse(code, {
     sourceType: 'module',
     plugins: ['typescript'],
@@ -476,6 +482,30 @@ describe('jsxInsertionPass edge cases', () => {
   // ===== 12. Already imported GtInternalTranslateJsx =====
 
   describe('existing GT import', () => {
+    it('injects import from gt-react by default', () => {
+      const code = `
+        import { jsx } from 'react/jsx-runtime';
+        jsx("div", { children: "Hello" });
+      `;
+      const { imports } = transform(code);
+      const gtImports = imports.filter((i) => i.source.value === 'gt-react');
+      expect(gtImports).toHaveLength(1);
+    });
+
+    it('injects import from gt-react/browser with legacy flag', () => {
+      const code = `
+        import { jsx } from 'react/jsx-runtime';
+        jsx("div", { children: "Hello" });
+      `;
+      const { imports } = transform(code, {
+        legacyGtReactImportSource: true,
+      });
+      const gtImports = imports.filter(
+        (i) => i.source.value === 'gt-react/browser'
+      );
+      expect(gtImports).toHaveLength(1);
+    });
+
     it('does not inject duplicate import when already imported', () => {
       const code = `
         import { GtInternalTranslateJsx, GtInternalVar } from 'gt-react/browser';

--- a/packages/compiler/src/passes/__tests__/jsxInsertionPass.test.ts
+++ b/packages/compiler/src/passes/__tests__/jsxInsertionPass.test.ts
@@ -8,13 +8,19 @@ import { initializeState } from '../../state/utils/initializeState';
 
 // --- Helpers ---
 
-function transform(code: string): {
+function transform(
+  code: string,
+  overrides: Record<string, unknown> = {}
+): {
   code: string;
   gtTranslateCalls: t.CallExpression[];
   gtVarCalls: t.CallExpression[];
   imports: t.ImportDeclaration[];
 } {
-  const state = initializeState({ enableAutoJsxInjection: true }, 'test.tsx');
+  const state = initializeState(
+    { enableAutoJsxInjection: true, ...overrides },
+    'test.tsx'
+  );
   const ast = parser.parse(code, {
     sourceType: 'module',
     plugins: ['typescript'],
@@ -479,7 +485,7 @@ describe('jsxInsertionPass', () => {
       jsx("div", { children: "Hello" });
     `;
     const { imports } = transform(code);
-    const gtImport = imports.find((i) => i.source.value === 'gt-react/browser');
+    const gtImport = imports.find((i) => i.source.value === 'gt-react');
     expect(gtImport).toBeDefined();
     const names = gtImport!.specifiers
       .filter((s): s is t.ImportSpecifier => t.isImportSpecifier(s))
@@ -488,13 +494,25 @@ describe('jsxInsertionPass', () => {
     expect(names).toContain('GtInternalVar');
   });
 
+  it('injects import from gt-react/browser with legacy flag', () => {
+    const code = `
+      import { jsx } from 'react/jsx-runtime';
+      jsx("div", { children: "Hello" });
+    `;
+    const { imports } = transform(code, {
+      legacyGtReactImportSource: true,
+    });
+    const gtImport = imports.find((i) => i.source.value === 'gt-react/browser');
+    expect(gtImport).toBeDefined();
+  });
+
   it('does NOT inject import when no insertions', () => {
     const code = `
       import { jsx } from 'react/jsx-runtime';
       jsx("div", {});
     `;
     const { imports } = transform(code);
-    const gtImport = imports.find((i) => i.source.value === 'gt-react/browser');
+    const gtImport = imports.find((i) => i.source.value === 'gt-react');
     expect(gtImport).toBeUndefined();
   });
 

--- a/packages/compiler/src/passes/__tests__/macroExpansionPass.test.ts
+++ b/packages/compiler/src/passes/__tests__/macroExpansionPass.test.ts
@@ -201,13 +201,21 @@ describe('macroExpansionPass', () => {
 
   it('adds auto-import when macros are expanded', () => {
     const { imports } = transform('const x = t`hello`;');
+    const gtImport = imports.find((i) => i.source.value === 'gt-react');
+    expect(gtImport).toBeDefined();
+  });
+
+  it('adds legacy auto-import when configured', () => {
+    const { imports } = transform('const x = t`hello`;', {
+      legacyGtReactImportSource: true,
+    });
     const gtImport = imports.find((i) => i.source.value === 'gt-react/browser');
     expect(gtImport).toBeDefined();
   });
 
   it('does NOT add auto-import when no macros are found', () => {
     const { imports } = transform('const x = t("hello");');
-    const gtImport = imports.find((i) => i.source.value === 'gt-react/browser');
+    const gtImport = imports.find((i) => i.source.value === 'gt-react');
     expect(gtImport).toBeUndefined();
   });
 
@@ -215,9 +223,7 @@ describe('macroExpansionPass', () => {
     const { tCalls, imports } = transform(
       'const a = t`hello ${name}`;\nconst b = t`goodbye ${name}`;'
     );
-    const gtImports = imports.filter(
-      (i) => i.source.value === 'gt-react/browser'
-    );
+    const gtImports = imports.filter((i) => i.source.value === 'gt-react');
     expect(gtImports).toHaveLength(1);
     expect(tCalls).toHaveLength(2);
     expect(getMessageString(tCalls[0])).toBe('hello {0}');
@@ -236,9 +242,25 @@ describe('macroExpansionPass', () => {
     expect(getMessageString(tCalls[0])).toBe('hello {0}');
   });
 
+  it('transforms tagged template when t is imported from gt-react', () => {
+    const { tCalls } = transform(
+      "import { t } from 'gt-react';\nconst x = t`hello ${name}`;"
+    );
+    expect(tCalls).toHaveLength(1);
+    expect(getMessageString(tCalls[0])).toBe('hello {0}');
+  });
+
+  it('transforms tagged template when t is imported from gt-react/client', () => {
+    const { tCalls } = transform(
+      "import { t } from 'gt-react/client';\nconst x = t`hello ${name}`;"
+    );
+    expect(tCalls).toHaveLength(1);
+    expect(getMessageString(tCalls[0])).toBe('hello {0}');
+  });
+
   // --- Scope guarding ---
 
-  it('does NOT transform tagged template t imported from a non-browser GT source', () => {
+  it('does NOT transform tagged template t imported from a non-react GT source', () => {
     const { ast } = transform(
       "import { t } from 'gt-next';\nconst x = t`hello ${name}`;"
     );
@@ -293,7 +315,7 @@ describe('macroExpansionPass', () => {
     });
     expect(tCalls).toHaveLength(1);
     expect(getMessageString(tCalls[0])).toBe('hello');
-    const gtImport = imports.find((i) => i.source.value === 'gt-react/browser');
+    const gtImport = imports.find((i) => i.source.value === 'gt-react');
     expect(gtImport).toBeUndefined();
   });
 

--- a/packages/compiler/src/passes/__tests__/runtimeTranslatePass.test.ts
+++ b/packages/compiler/src/passes/__tests__/runtimeTranslatePass.test.ts
@@ -351,11 +351,26 @@ describe('runtimeTranslatePass', () => {
   // ===== Import handling =====
 
   describe('import handling', () => {
-    it('injects import from gt-react/browser', () => {
+    it('injects import from gt-react', () => {
       const { imports } = transform(`
         ${USEGT_SETUP}
         const msg = t("Hello");
       `);
+
+      const specifiers = getImportSpecifiers(imports, 'gt-react');
+      expect(specifiers).toContain(
+        GT_OTHER_FUNCTIONS.GtInternalRuntimeTranslateString
+      );
+    });
+
+    it('injects import from gt-react/browser with legacy flag', () => {
+      const { imports } = transform(
+        `
+        ${USEGT_SETUP}
+        const msg = t("Hello");
+      `,
+        { legacyGtReactImportSource: true }
+      );
 
       const specifiers = getImportSpecifiers(imports, 'gt-react/browser');
       expect(specifiers).toContain(
@@ -396,7 +411,7 @@ describe('runtimeTranslatePass', () => {
       `);
 
       expect(runtimeCalls).toHaveLength(0);
-      const specifiers = getImportSpecifiers(imports, 'gt-react/browser');
+      const specifiers = getImportSpecifiers(imports, 'gt-react');
       expect(specifiers).not.toContain(
         GT_OTHER_FUNCTIONS.GtInternalRuntimeTranslateString
       );
@@ -421,6 +436,24 @@ describe('runtimeTranslatePass', () => {
         strings: true,
         jsx: false,
       });
+    });
+
+    it('respects legacyGtReactImportSource from gtConfig', () => {
+      const state = initializeState(
+        {
+          gtConfig: {
+            files: {
+              gt: {
+                parsingFlags: {
+                  legacyGtReactImportSource: true,
+                },
+              },
+            },
+          },
+        },
+        'test.tsx'
+      );
+      expect(state.settings.legacyGtReactImportSource).toBe(true);
     });
 
     it('direct option overrides gtConfig', () => {

--- a/packages/compiler/src/passes/__tests__/runtimeTranslatePass.test.ts
+++ b/packages/compiler/src/passes/__tests__/runtimeTranslatePass.test.ts
@@ -456,6 +456,25 @@ describe('runtimeTranslatePass', () => {
       expect(state.settings.legacyGtReactImportSource).toBe(true);
     });
 
+    it('direct legacyGtReactImportSource option overrides gtConfig', () => {
+      const state = initializeState(
+        {
+          legacyGtReactImportSource: false,
+          gtConfig: {
+            files: {
+              gt: {
+                parsingFlags: {
+                  legacyGtReactImportSource: true,
+                },
+              },
+            },
+          },
+        },
+        'test.tsx'
+      );
+      expect(state.settings.legacyGtReactImportSource).toBe(false);
+    });
+
     it('direct option overrides gtConfig', () => {
       const state = initializeState(
         {

--- a/packages/compiler/src/passes/__tests__/stringExtractionE2E.test.ts
+++ b/packages/compiler/src/passes/__tests__/stringExtractionE2E.test.ts
@@ -381,7 +381,7 @@ describe('t() string extraction E2E', () => {
 // Unlike gt()/msg()/t(), tagged templates convert dynamic
 // expressions into ICU {0} placeholders rather than rejecting them.
 // The collection pass extracts via processTaggedTemplateExpression
-// for unbound t or t imported from gt-react/browser.
+// for unbound t or t imported from gt-react entrypoints.
 // ─────────────────────────────────────────────────────
 
 describe('t`` tagged template extraction E2E', () => {
@@ -455,6 +455,20 @@ describe('t`` tagged template extraction E2E', () => {
 
   it('extracts tagged template imported from gt-react/browser', () => {
     const state = collect(`import { t } from 'gt-react/browser';\nt\`Hello\`;`);
+    const content = getRuntimeContent(state);
+    expect(content).toHaveLength(1);
+    expect(content[0].message).toBe('Hello');
+  });
+
+  it('extracts tagged template imported from gt-react', () => {
+    const state = collect(`import { t } from 'gt-react';\nt\`Hello\`;`);
+    const content = getRuntimeContent(state);
+    expect(content).toHaveLength(1);
+    expect(content[0].message).toBe('Hello');
+  });
+
+  it('extracts tagged template imported from gt-react/client', () => {
+    const state = collect(`import { t } from 'gt-react/client';\nt\`Hello\`;`);
     const content = getRuntimeContent(state);
     expect(content).toHaveLength(1);
     expect(content[0].message).toBe('Hello');

--- a/packages/compiler/src/processing/collection/processTaggedTemplateExpression.ts
+++ b/packages/compiler/src/processing/collection/processTaggedTemplateExpression.ts
@@ -11,7 +11,7 @@ import { isStringTranslationTaggedTemplate } from '../../utils/parsing/isStringT
  *
  * Only extracts when:
  * - t is unbound (global macro)
- * - t is imported from gt-react/browser
+ * - t is imported from a gt-react entrypoint
  *
  * Does NOT transform the AST — read-only extraction.
  * If the message contains derive() (returns TemplateLiteral), it's skipped.

--- a/packages/compiler/src/processing/jsx-insertion/processProgram.ts
+++ b/packages/compiler/src/processing/jsx-insertion/processProgram.ts
@@ -30,7 +30,10 @@ export function processProgram({
       if (!didInsert) return;
 
       if (!isAlreadyImported()) {
-        injectJsxInsertionImport(path);
+        injectJsxInsertionImport(
+          path,
+          state.settings.legacyGtReactImportSource
+        );
       }
 
       // If only jsxs was imported (no jsx), inject jsx import.

--- a/packages/compiler/src/processing/macro-expansion/processProgram.ts
+++ b/packages/compiler/src/processing/macro-expansion/processProgram.ts
@@ -29,7 +29,7 @@ export function processProgram({
       // (2) If the macro import injection is disabled, return.
       if (!state.settings.enableMacroImportInjection) return;
       // Inject the macro import.
-      injectMacroImport(path);
+      injectMacroImport(path, state.settings.legacyGtReactImportSource);
     },
   };
 }

--- a/packages/compiler/src/processing/macro-expansion/processTaggedTemplateExpression.ts
+++ b/packages/compiler/src/processing/macro-expansion/processTaggedTemplateExpression.ts
@@ -11,7 +11,7 @@ import { isStringTranslationTaggedTemplate } from '../../utils/parsing/isStringT
  *
  * Only transforms when:
  * - t is unbound (global macro via gt-react/macros)
- * - t is imported from gt-react/browser
+ * - t is imported from a gt-react entrypoint
  * Skips when t is bound to a non-GT import (e.g., i18next)
  */
 export function processTaggedTemplateExpression(

--- a/packages/compiler/src/processing/runtime-translate/processProgram.ts
+++ b/packages/compiler/src/processing/runtime-translate/processProgram.ts
@@ -54,6 +54,7 @@ export function processProgram({
         const injectedPath = injectRuntimeTranslateImport(path, {
           needsString,
           needsJsx,
+          legacyGtReactImportSource: state.settings.legacyGtReactImportSource,
         });
         if (injectedPath) {
           importAnchor.path = injectedPath;

--- a/packages/compiler/src/state/utils/initializeState.ts
+++ b/packages/compiler/src/state/utils/initializeState.ts
@@ -43,7 +43,9 @@ export function initializeState(
     gtConfig?.files?.gt?.parsingFlags?.devHotReload ?? false;
   const rawAutoderive = gtConfig?.files?.gt?.parsingFlags?.autoderive ?? false;
   const legacyGtReactImportSource =
-    gtConfig?.files?.gt?.parsingFlags?.legacyGtReactImportSource ?? false;
+    options.legacyGtReactImportSource ??
+    gtConfig?.files?.gt?.parsingFlags?.legacyGtReactImportSource ??
+    false;
 
   const autoderive = resolveAutoderive(options.autoderive ?? rawAutoderive);
 
@@ -55,7 +57,12 @@ export function initializeState(
 
   // Spread options but exclude already-resolved fields
   // eslint-disable-next-line no-unused-vars
-  const { autoderive: _a, devHotReload: _b, ...restOptions } = options;
+  const {
+    autoderive: _a,
+    devHotReload: _b,
+    legacyGtReactImportSource: _c,
+    ...restOptions
+  } = options;
 
   const settings: PluginSettings = {
     ...DEFAULT_SETTINGS,

--- a/packages/compiler/src/state/utils/initializeState.ts
+++ b/packages/compiler/src/state/utils/initializeState.ts
@@ -23,6 +23,7 @@ const DEFAULT_SETTINGS: PluginSettings = {
   enableMacroImportInjection: true,
   enableAutoJsxInjection: false,
   autoderive: { jsx: false, strings: false },
+  legacyGtReactImportSource: false,
   _debugHashManifest: false,
   devHotReload: { strings: false, jsx: false },
 };
@@ -41,6 +42,8 @@ export function initializeState(
   const rawDevHotReload =
     gtConfig?.files?.gt?.parsingFlags?.devHotReload ?? false;
   const rawAutoderive = gtConfig?.files?.gt?.parsingFlags?.autoderive ?? false;
+  const legacyGtReactImportSource =
+    gtConfig?.files?.gt?.parsingFlags?.legacyGtReactImportSource ?? false;
 
   const autoderive = resolveAutoderive(options.autoderive ?? rawAutoderive);
 
@@ -58,6 +61,7 @@ export function initializeState(
     ...DEFAULT_SETTINGS,
     enableAutoJsxInjection, // can be overridden by options.enableAutoJsxInjection
     autoderive,
+    legacyGtReactImportSource,
     devHotReload,
     ...restOptions,
     filename,

--- a/packages/compiler/src/transform/jsx-insertion/injectJsxInsertionImport.ts
+++ b/packages/compiler/src/transform/jsx-insertion/injectJsxInsertionImport.ts
@@ -1,15 +1,16 @@
 import * as t from '@babel/types';
 import { NodePath } from '@babel/traverse';
-import {
-  GT_COMPONENT_TYPES,
-  GT_IMPORT_SOURCES,
-} from '../../utils/constants/gt/constants';
+import { GT_COMPONENT_TYPES } from '../../utils/constants/gt/constants';
+import { getGtReactImportSource } from '../../utils/constants/gt/helpers';
 
 /**
- * Inject `import { GtInternalTranslateJsx, GtInternalVar } from 'gt-react/browser'`
+ * Inject `import { GtInternalTranslateJsx, GtInternalVar } from 'gt-react'`
  * as the first statement in the program.
  */
-export function injectJsxInsertionImport(path: NodePath<t.Program>): void {
+export function injectJsxInsertionImport(
+  path: NodePath<t.Program>,
+  legacyGtReactImportSource: boolean
+): void {
   const tName = GT_COMPONENT_TYPES.GtInternalTranslateJsx;
   const varName = GT_COMPONENT_TYPES.GtInternalVar;
 
@@ -18,7 +19,7 @@ export function injectJsxInsertionImport(path: NodePath<t.Program>): void {
       t.importSpecifier(t.identifier(tName), t.identifier(tName)),
       t.importSpecifier(t.identifier(varName), t.identifier(varName)),
     ],
-    t.stringLiteral(GT_IMPORT_SOURCES.GT_REACT_BROWSER)
+    t.stringLiteral(getGtReactImportSource(legacyGtReactImportSource))
   );
 
   path.unshiftContainer('body', importDecl);

--- a/packages/compiler/src/transform/macro-expansion/__tests__/injectMacroImport.test.ts
+++ b/packages/compiler/src/transform/macro-expansion/__tests__/injectMacroImport.test.ts
@@ -21,28 +21,38 @@ function parseAndGetProgramPath(code: string) {
 }
 
 describe('injectMacroImport', () => {
-  it('adds import { t } from gt-react/browser', () => {
+  it('adds import { t } from gt-react', () => {
     const { programPath } = parseAndGetProgramPath('const x = 1;');
-    injectMacroImport(programPath);
+    injectMacroImport(programPath, false);
     const firstStmt = programPath.node.body[0];
     expect(t.isImportDeclaration(firstStmt)).toBe(true);
     expect((firstStmt as t.ImportDeclaration).source.value).toBe(
-      GT_IMPORT_SOURCES.GT_REACT_BROWSER
+      GT_IMPORT_SOURCES.GT_REACT
     );
     const specifier = (firstStmt as t.ImportDeclaration).specifiers[0];
     expect(t.isImportSpecifier(specifier)).toBe(true);
     expect((specifier as t.ImportSpecifier).local.name).toBe('t');
   });
 
-  it('adds import as the first statement in the program body', () => {
-    const { programPath } = parseAndGetProgramPath(
-      "import React from 'react';\nconst x = 1;"
-    );
-    injectMacroImport(programPath);
+  it('adds import { t } from gt-react/browser with legacy flag', () => {
+    const { programPath } = parseAndGetProgramPath('const x = 1;');
+    injectMacroImport(programPath, true);
     const firstStmt = programPath.node.body[0];
     expect(t.isImportDeclaration(firstStmt)).toBe(true);
     expect((firstStmt as t.ImportDeclaration).source.value).toBe(
       GT_IMPORT_SOURCES.GT_REACT_BROWSER
+    );
+  });
+
+  it('adds import as the first statement in the program body', () => {
+    const { programPath } = parseAndGetProgramPath(
+      "import React from 'react';\nconst x = 1;"
+    );
+    injectMacroImport(programPath, false);
+    const firstStmt = programPath.node.body[0];
+    expect(t.isImportDeclaration(firstStmt)).toBe(true);
+    expect((firstStmt as t.ImportDeclaration).source.value).toBe(
+      GT_IMPORT_SOURCES.GT_REACT
     );
   });
 });

--- a/packages/compiler/src/transform/macro-expansion/injectMacroImport.ts
+++ b/packages/compiler/src/transform/macro-expansion/injectMacroImport.ts
@@ -1,19 +1,20 @@
 import * as t from '@babel/types';
 import { NodePath } from '@babel/traverse';
-import {
-  GT_IMPORT_SOURCES,
-  GT_OTHER_FUNCTIONS,
-} from '../../utils/constants/gt/constants';
+import { GT_OTHER_FUNCTIONS } from '../../utils/constants/gt/constants';
+import { getGtReactImportSource } from '../../utils/constants/gt/helpers';
 
 /**
- * Inject `import { t } from 'gt-react/browser'` as the first statement in the program.
+ * Inject `import { t } from 'gt-react'` as the first statement in the program.
  */
-export function injectMacroImport(path: NodePath<t.Program>): void {
+export function injectMacroImport(
+  path: NodePath<t.Program>,
+  legacyGtReactImportSource: boolean
+): void {
   const tName = GT_OTHER_FUNCTIONS.t;
 
   const importDecl = t.importDeclaration(
     [t.importSpecifier(t.identifier(tName), t.identifier(tName))],
-    t.stringLiteral(GT_IMPORT_SOURCES.GT_REACT_BROWSER)
+    t.stringLiteral(getGtReactImportSource(legacyGtReactImportSource))
   );
 
   path.unshiftContainer('body', importDecl);

--- a/packages/compiler/src/transform/runtime-translate/injectRuntimeTranslateImport.ts
+++ b/packages/compiler/src/transform/runtime-translate/injectRuntimeTranslateImport.ts
@@ -1,17 +1,23 @@
 import * as t from '@babel/types';
 import { NodePath } from '@babel/traverse';
-import {
-  GT_IMPORT_SOURCES,
-  GT_OTHER_FUNCTIONS,
-} from '../../utils/constants/gt/constants';
+import { GT_OTHER_FUNCTIONS } from '../../utils/constants/gt/constants';
+import { getGtReactImportSource } from '../../utils/constants/gt/helpers';
 
 /**
  * Inject runtime translate import with only the specifiers needed.
- * `import { GtInternalRuntimeTranslateString, GtInternalRuntimeTranslateJsx } from 'gt-react/browser'`
+ * `import { GtInternalRuntimeTranslateString, GtInternalRuntimeTranslateJsx } from 'gt-react'`
  */
 export function injectRuntimeTranslateImport(
   path: NodePath<t.Program>,
-  { needsString, needsJsx }: { needsString: boolean; needsJsx: boolean }
+  {
+    needsString,
+    needsJsx,
+    legacyGtReactImportSource,
+  }: {
+    needsString: boolean;
+    needsJsx: boolean;
+    legacyGtReactImportSource: boolean;
+  }
 ): NodePath<t.ImportDeclaration> | null {
   const specifiers: t.ImportSpecifier[] = [];
 
@@ -29,7 +35,7 @@ export function injectRuntimeTranslateImport(
 
   const importDecl = t.importDeclaration(
     specifiers,
-    t.stringLiteral(GT_IMPORT_SOURCES.GT_REACT_BROWSER)
+    t.stringLiteral(getGtReactImportSource(legacyGtReactImportSource))
   );
 
   const [inserted] = path.unshiftContainer('body', importDecl);

--- a/packages/compiler/src/transform/validation/__tests__/robustStringExtraction.test.ts
+++ b/packages/compiler/src/transform/validation/__tests__/robustStringExtraction.test.ts
@@ -43,6 +43,7 @@ function createState(overrides?: Partial<PluginSettings>): TransformState {
     enableMacroImportInjection: true,
     enableAutoJsxInjection: false,
     autoderive: { jsx: false, strings: false },
+    legacyGtReactImportSource: false,
     _debugHashManifest: false,
     devHotReload: { strings: false, jsx: false },
     ...overrides,

--- a/packages/compiler/src/transform/validation/__tests__/validateTranslationFunctionCallback.test.ts
+++ b/packages/compiler/src/transform/validation/__tests__/validateTranslationFunctionCallback.test.ts
@@ -34,6 +34,7 @@ describe('validateTranslationFunctionCallback', () => {
       enableMacroImportInjection: true,
       enableAutoJsxInjection: false,
       autoderive: { jsx: false, strings: false },
+      legacyGtReactImportSource: false,
       _debugHashManifest: false,
       devHotReload: { strings: false, jsx: false },
     };
@@ -987,6 +988,7 @@ describe('validateTranslationFunctionCallback', () => {
         enableMacroImportInjection: true,
         enableAutoJsxInjection: false,
         autoderive: { jsx: true, strings: true },
+        legacyGtReactImportSource: false,
         _debugHashManifest: false,
         devHotReload: { strings: false, jsx: false },
       };
@@ -1311,6 +1313,7 @@ describe('validateTranslationFunctionCallback', () => {
         enableMacroImportInjection: true,
         enableAutoJsxInjection: false,
         autoderive: { jsx: true, strings: false },
+        legacyGtReactImportSource: false,
         _debugHashManifest: false,
         devHotReload: { strings: false, jsx: false },
       };
@@ -1392,6 +1395,7 @@ describe('validateTranslationFunctionCallback', () => {
         enableMacroImportInjection: true,
         enableAutoJsxInjection: false,
         autoderive: { jsx: false, strings: true },
+        legacyGtReactImportSource: false,
         _debugHashManifest: false,
         devHotReload: { strings: false, jsx: false },
       };

--- a/packages/compiler/src/utils/constants/gt/helpers.ts
+++ b/packages/compiler/src/utils/constants/gt/helpers.ts
@@ -169,6 +169,24 @@ export function isGTImportSource(name: string): name is GT_IMPORT_SOURCES {
   ).includes(name);
 }
 
+export function isGTReactImportSource(name: string): name is GT_IMPORT_SOURCES {
+  return (
+    [
+      GT_IMPORT_SOURCES.GT_REACT,
+      GT_IMPORT_SOURCES.GT_REACT_CLIENT,
+      GT_IMPORT_SOURCES.GT_REACT_BROWSER,
+    ] as string[]
+  ).includes(name);
+}
+
+export function getGtReactImportSource(
+  legacyGtReactImportSource: boolean
+): GT_IMPORT_SOURCES.GT_REACT | GT_IMPORT_SOURCES.GT_REACT_BROWSER {
+  return legacyGtReactImportSource
+    ? GT_IMPORT_SOURCES.GT_REACT_BROWSER
+    : GT_IMPORT_SOURCES.GT_REACT;
+}
+
 /**
  * Check if is a html content prop
  */

--- a/packages/compiler/src/utils/constants/gt/helpers.ts
+++ b/packages/compiler/src/utils/constants/gt/helpers.ts
@@ -169,7 +169,12 @@ export function isGTImportSource(name: string): name is GT_IMPORT_SOURCES {
   ).includes(name);
 }
 
-export function isGTReactImportSource(name: string): name is GT_IMPORT_SOURCES {
+export function isGTReactImportSource(
+  name: string
+): name is
+  | GT_IMPORT_SOURCES.GT_REACT
+  | GT_IMPORT_SOURCES.GT_REACT_CLIENT
+  | GT_IMPORT_SOURCES.GT_REACT_BROWSER {
   return (
     [
       GT_IMPORT_SOURCES.GT_REACT,

--- a/packages/compiler/src/utils/parsing/isStringTranslationTaggedTemplate.ts
+++ b/packages/compiler/src/utils/parsing/isStringTranslationTaggedTemplate.ts
@@ -1,13 +1,13 @@
 import type { NodePath } from '@babel/traverse';
 import * as t from '@babel/types';
-import { GT_IMPORT_SOURCES } from '../constants/gt/constants';
+import { isGTReactImportSource } from '../constants/gt/helpers';
 
 /**
  * Checks whether a tagged template expression should be treated as the GT
  * string translation macro.
  *
  * The macro is valid when it is an unbound bare identifier, or when it is
- * imported from gt-react/browser. This covers global `t`, but not explicit
+ * imported from gt-react. This covers global `t`, but not explicit
  * member access such as `globalThis.t` or `window.t`. Other bindings are left
  * alone so local/i18next t tags do not get transformed or extracted.
  */
@@ -31,6 +31,6 @@ export function isStringTranslationTaggedTemplate(
   const importDecl = binding.path.parentPath;
   return (
     importDecl?.isImportDeclaration() === true &&
-    importDecl.node.source.value === GT_IMPORT_SOURCES.GT_REACT_BROWSER
+    isGTReactImportSource(importDecl.node.source.value)
   );
 }


### PR DESCRIPTION
## Summary
- Add `legacyGtReactImportSource` as a compiler option and `files.gt.parsingFlags` config flag.
- Default compiler/CLI injected gt-react imports to `gt-react`, with legacy mode emitting `gt-react/browser`.
- Keep recognizing `gt-react`, `gt-react/browser`, and `gt-react/client` for existing imports and tagged-template handling.

## Testing
- `pnpm exec vitest run src/passes/__tests__/macroExpansionPass.test.ts src/passes/__tests__/jsxInsertionPass.test.ts src/passes/__tests__/jsxInsertionEdgeCases.test.ts src/passes/__tests__/runtimeTranslatePass.test.ts src/passes/__tests__/stringExtractionE2E.test.ts src/transform/macro-expansion/__tests__/injectMacroImport.test.ts` in `packages/compiler`
- `pnpm exec vitest run --config=./vitest.config.ts src/react/jsx/utils/jsxParsing/__tests__/autoJsxInjectionPass.test.ts src/react/jsx/utils/__tests__/getPathsAndAliases.test.ts` in `packages/cli`
- `pnpm exec oxfmt --check $(git diff --name-only)`
- `pnpm exec oxlint $(git diff --name-only)`
- `pnpm --filter @generaltranslation/compiler typecheck`
- `pnpm --filter gt typecheck`

No changeset.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1625"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784483819&installation_id=127936663&pr_number=1625&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1625&signature=fc1ff5d46bc7365d2d9c7484b15b939afad19a1daeb3dc17ab19ec47e509d5cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a `legacyGtReactImportSource` flag (available as both a compiler option and a `files.gt.parsingFlags` config key) that controls whether compiler-injected `gt-react` imports are emitted as `gt-react` (new default) or `gt-react/browser` (legacy). It also broadens tagged-template extraction to recognize all three `gt-react` entrypoints (`gt-react`, `gt-react/client`, `gt-react/browser`).

- **Import source default changed**: all three inject helpers (`injectMacroImport`, `injectJsxInsertionImport`, `injectRuntimeTranslateImport`) now emit `import … from 'gt-react'` by default; setting the flag restores the previous `gt-react/browser` behaviour.
- **Broader entrypoint recognition**: `isStringTranslationTaggedTemplate` and the CLI's `getPathsAndAliases` now accept `gt-react` and `gt-react/client` as valid sources for the `t` macro, in addition to the previously supported `gt-react/browser`.
- **New helpers**: `isGTReactImportSource` and `getGtReactImportSource` are added to the compiler's helper module; a parallel `getGtReactImportSource` is added to the CLI constants.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the change is well-contained and thoroughly tested. The only finding is a minor type inaccuracy in the new `isGTReactImportSource` predicate that does not affect runtime behaviour.

The flag plumbing is consistent throughout both packages, the priority chain (gtConfig → direct option) matches the existing `enableAutoJsxInjection` pattern, and all three inject sites are covered. The new `isGTReactImportSource` type predicate narrows to the full `GT_IMPORT_SOURCES` enum rather than the three-member union it actually validates, which could mislead downstream TypeScript consumers but has no runtime impact.

packages/compiler/src/utils/constants/gt/helpers.ts — the `isGTReactImportSource` return type predicate is overly broad.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/compiler/src/utils/constants/gt/helpers.ts | Adds `isGTReactImportSource` and `getGtReactImportSource` helpers. The type predicate return type is overly broad. |
| packages/compiler/src/config.ts | Adds `legacyGtReactImportSource` to `GTConfig`, `PluginConfig`, and `PluginSettings` with correct documentation. |
| packages/compiler/src/state/utils/initializeState.ts | Reads `legacyGtReactImportSource` from gtConfig with gtConfig → options priority chain consistent with other settings. |
| packages/compiler/src/utils/parsing/isStringTranslationTaggedTemplate.ts | Expands recognized import sources for `t` tagged template from `gt-react/browser` only to all three gt-react entrypoints via the new `isGTReactImportSource` guard. |
| packages/compiler/src/transform/macro-expansion/injectMacroImport.ts | Adds `legacyGtReactImportSource` parameter and delegates to `getGtReactImportSource` for the import source string. |
| packages/cli/src/react/jsx/utils/constants.ts | Changes `DEFAULT_GT_IMPORT_SOURCE` from `gt-react/browser` to `gt-react`, adds `LEGACY_GT_IMPORT_SOURCE`, and mirrors `getGtReactImportSource` helper for the CLI package. |
| packages/cli/src/types/parsing.ts | Adds `legacyGtReactImportSource: boolean` to `GTParsingFlags` with JSDoc. |

</details>

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fcompiler%2Fsrc%2Futils%2Fconstants%2Fgt%2Fhelpers.ts%3A172%0AThe%20type%20predicate%20%60name%20is%20GT_IMPORT_SOURCES%60%20is%20overly%20broad%20%E2%80%94%20it%20claims%20any%20passing%20value%20is%20one%20of%20the%207%20%60GT_IMPORT_SOURCES%60%20members%20%28including%20%60gt-next%60%2C%20%60gt-next%2Fclient%60%2C%20etc.%29%2C%20but%20the%20runtime%20check%20only%20validates%20against%20three%20specific%20gt-react%20entrypoints.%20Callers%20relying%20on%20TypeScript%20narrowing%20after%20this%20guard%20may%20get%20a%20wider%20type%20than%20expected.%0A%0A%60%60%60suggestion%0Aexport%20function%20isGTReactImportSource%28%0A%20%20name%3A%20string%0A%29%3A%20name%20is%0A%20%20%7C%20GT_IMPORT_SOURCES.GT_REACT%0A%20%20%7C%20GT_IMPORT_SOURCES.GT_REACT_CLIENT%0A%20%20%7C%20GT_IMPORT_SOURCES.GT_REACT_BROWSER%20%7B%0A%60%60%60%0A%0A&repo=generaltranslation%2Fgt&pr=1625&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fodysseus%2Fgt-react-import-source-compat%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fodysseus%2Fgt-react-import-source-compat%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fcompiler%2Fsrc%2Futils%2Fconstants%2Fgt%2Fhelpers.ts%3A172%0AThe%20type%20predicate%20%60name%20is%20GT_IMPORT_SOURCES%60%20is%20overly%20broad%20%E2%80%94%20it%20claims%20any%20passing%20value%20is%20one%20of%20the%207%20%60GT_IMPORT_SOURCES%60%20members%20%28including%20%60gt-next%60%2C%20%60gt-next%2Fclient%60%2C%20etc.%29%2C%20but%20the%20runtime%20check%20only%20validates%20against%20three%20specific%20gt-react%20entrypoints.%20Callers%20relying%20on%20TypeScript%20narrowing%20after%20this%20guard%20may%20get%20a%20wider%20type%20than%20expected.%0A%0A%60%60%60suggestion%0Aexport%20function%20isGTReactImportSource%28%0A%20%20name%3A%20string%0A%29%3A%20name%20is%0A%20%20%7C%20GT_IMPORT_SOURCES.GT_REACT%0A%20%20%7C%20GT_IMPORT_SOURCES.GT_REACT_CLIENT%0A%20%20%7C%20GT_IMPORT_SOURCES.GT_REACT_BROWSER%20%7B%0A%60%60%60%0A%0A&repo=generaltranslation%2Fgt&pr=1625&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/compiler/src/utils/constants/gt/helpers.ts:172
The type predicate `name is GT_IMPORT_SOURCES` is overly broad — it claims any passing value is one of the 7 `GT_IMPORT_SOURCES` members (including `gt-next`, `gt-next/client`, etc.), but the runtime check only validates against three specific gt-react entrypoints. Callers relying on TypeScript narrowing after this guard may get a wider type than expected.

```suggestion
export function isGTReactImportSource(
  name: string
): name is
  | GT_IMPORT_SOURCES.GT_REACT
  | GT_IMPORT_SOURCES.GT_REACT_CLIENT
  | GT_IMPORT_SOURCES.GT_REACT_BROWSER {
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: add legacy gt-react import source f..."](https://github.com/generaltranslation/gt/commit/9594c9a655f68088601e8e583a087d193e954b01) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38703236)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->