### PR TITLE
fix: brand react i18n config checks

### DIFF
--- a/.changeset/stable-react-i18n-config-brand.md
+++ b/.changeset/stable-react-i18n-config-brand.md
@@ -1,0 +1,5 @@
+---
+'@generaltranslation/react-core': patch
+---
+
+Use a stable React i18n config brand instead of `instanceof` so config singletons initialized through one bundled entry point can be read from another.

--- a/packages/react-core/src/setup/__tests__/i18nConfig.test.ts
+++ b/packages/react-core/src/setup/__tests__/i18nConfig.test.ts
@@ -52,4 +52,25 @@ describe('react i18n config', () => {
       /Cannot read ReactI18nConfig after base I18nConfig setup/
     );
   });
+
+  it('accepts branded react i18n config instances from another bundle', async () => {
+    const { I18nConfig, setI18nConfig: setBaseI18nConfig } =
+      await import('gt-i18n/internal');
+    const { getI18nConfig } = await import('../i18nConfig');
+    const reactI18nConfigBrand = Symbol.for(
+      '@generaltranslation/react-core/ReactI18nConfig'
+    );
+
+    class CrossBundleReactI18nConfig extends I18nConfig {
+      constructor() {
+        super({ defaultLocale: 'en' });
+        Object.defineProperty(this, reactI18nConfigBrand, { value: true });
+      }
+    }
+
+    const config = new CrossBundleReactI18nConfig();
+    setBaseI18nConfig(config);
+
+    expect(getI18nConfig()).toBe(config);
+  });
 });

--- a/packages/react-core/src/setup/i18nConfig.ts
+++ b/packages/react-core/src/setup/i18nConfig.ts
@@ -14,6 +14,9 @@ import type { I18nConfigParams } from 'gt-i18n/internal/types';
 export type RenderStrategy = 'SPA' | 'server-render';
 
 const defaultRenderStrategy: RenderStrategy = 'server-render';
+const reactI18nConfigBrand = Symbol.for(
+  '@generaltranslation/react-core/ReactI18nConfig'
+);
 
 export class ReactI18nConfig extends I18nConfig {
   private renderStrategy: RenderStrategy;
@@ -24,6 +27,7 @@ export class ReactI18nConfig extends I18nConfig {
   ) {
     super(params);
     validateRenderStrategy(renderStrategy);
+    Object.defineProperty(this, reactI18nConfigBrand, { value: true });
     this.renderStrategy = renderStrategy;
   }
 
@@ -79,5 +83,7 @@ function validateRenderStrategy(
 function isReactI18nConfig(
   i18nConfig: I18nConfig
 ): i18nConfig is ReactI18nConfig {
-  return i18nConfig instanceof ReactI18nConfig;
+  const maybeReactI18nConfig = i18nConfig as I18nConfig &
+    Record<symbol, unknown>;
+  return maybeReactI18nConfig[reactI18nConfigBrand] === true;
 }


### PR DESCRIPTION
## Summary
- Replace the ReactI18nConfig `instanceof` guard with a stable `Symbol.for` brand check.
- Preserve the existing error for plain base I18nConfig initialization.
- Add regression coverage for ReactI18nConfig-compatible instances created from another bundled entry point.
- Add a patch changeset for `@generaltranslation/react-core`.

## Testing
- `pnpm --filter @generaltranslation/react-core... build`
- `pnpm --filter @generaltranslation/react-core typecheck`
- `pnpm --filter @generaltranslation/react-core exec vitest run src/setup/__tests__/i18nConfig.test.ts`
- `pnpm --filter @generaltranslation/react-core test`
- `pnpm format -- packages/react-core/src/setup/i18nConfig.ts packages/react-core/src/setup/__tests__/i18nConfig.test.ts .changeset/stable-react-i18n-config-brand.md`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1629"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784506308&installation_id=127936663&pr_number=1629&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1629&signature=c5dd1360bf32f6377d4fdc377065f36dfd565a975aeadb5b871296837a0f3d28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the `instanceof ReactI18nConfig` guard in `isReactI18nConfig` with a `Symbol.for`-based brand check, fixing a cross-bundle incompatibility where a `ReactI18nConfig` created in one bundled entry point would fail the guard when read from another.

- **`i18nConfig.ts`**: Stamps each `ReactI18nConfig` instance with a non-configurable `Symbol.for('@generaltranslation/react-core/ReactI18nConfig')` brand property, then checks for that brand plus the presence of a `getRenderStrategy` method instead of using `instanceof`.
- **`i18nConfig.test.ts`**: Adds a regression test that simulates a cross-bundle `I18nConfig` subclass bearing the same brand symbol and verifies `getI18nConfig()` accepts it without error.
- **Changeset**: Records the fix as a patch release for `@generaltranslation/react-core`.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is narrowly scoped to the brand-check function and the existing error path for plain I18nConfig objects is fully preserved.

The Symbol.for approach is the idiomatic solution to cross-bundle identity checks in JavaScript and the dual guard (brand + method presence) gives reasonable confidence that only intentional ReactI18nConfig-compatible instances pass. The new regression test directly exercises the cross-bundle path that previously broke, the non-configurable/non-writable descriptor is appropriate for a brand property, and no existing behavior changes for callers using a single bundle.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react-core/src/setup/i18nConfig.ts | Replaces instanceof with a stable Symbol.for brand + duck-type method check; logic is sound and the default non-configurable/non-writable descriptor is appropriate for a brand property. |
| packages/react-core/src/setup/__tests__/i18nConfig.test.ts | Adds a cross-bundle regression test that correctly simulates a foreign subclass bearing the brand symbol; existing tests for the base-config rejection path are preserved. |
| .changeset/stable-react-i18n-config-brand.md | Correct patch-level changeset entry for @generaltranslation/react-core with an accurate description of the fix. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["getI18nConfig() called"] --> B["getBaseI18nConfig()"]
    B --> C{isReactI18nConfig?}

    C -->|"BEFORE (instanceof)"| D1["i18nConfig instanceof ReactI18nConfig"]
    D1 -->|"Same bundle ✓"| E1["Returns config"]
    D1 -->|"Different bundle ✗"| F1["Throws error (false negative)"]

    C -->|"AFTER (Symbol.for brand)"| D2["Check brand symbol\nSymbol.for('@generaltranslation/react-core/ReactI18nConfig') === true"]
    D2 --> D3["Check getRenderStrategy is a function"]
    D3 -->|"Both pass ✓"| E2["Returns config\n(works cross-bundle)"]
    D3 -->|"Either fails ✗"| F2["Throws diagnostic error"]

    style F1 fill:#f88,color:#000
    style E2 fill:#8f8,color:#000
    style E1 fill:#8f8,color:#000
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["getI18nConfig() called"] --> B["getBaseI18nConfig()"]
    B --> C{isReactI18nConfig?}

    C -->|"BEFORE (instanceof)"| D1["i18nConfig instanceof ReactI18nConfig"]
    D1 -->|"Same bundle ✓"| E1["Returns config"]
    D1 -->|"Different bundle ✗"| F1["Throws error (false negative)"]

    C -->|"AFTER (Symbol.for brand)"| D2["Check brand symbol\nSymbol.for('@generaltranslation/react-core/ReactI18nConfig') === true"]
    D2 --> D3["Check getRenderStrategy is a function"]
    D3 -->|"Both pass ✓"| E2["Returns config\n(works cross-bundle)"]
    D3 -->|"Either fails ✗"| F2["Throws diagnostic error"]

    style F1 fill:#f88,color:#000
    style E2 fill:#8f8,color:#000
    style E1 fill:#8f8,color:#000
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: brand react i18n config checks"](https://github.com/generaltranslation/gt/commit/87b13d85c174f878e8c76d5e700a740fd1e4129c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38756317)</sub>

<!-- /greptile_comment -->