### PR TITLE
feat(cli): Add retry mechanism

### DIFF
--- a/.changeset/cuddly-friends-design.md
+++ b/.changeset/cuddly-friends-design.md
@@ -1,0 +1,5 @@
+---
+"generaltranslation": patch
+---
+
+Add retry mechanism for rate limits

--- a/packages/core/src/translate/utils/__tests__/apiRequest.test.ts
+++ b/packages/core/src/translate/utils/__tests__/apiRequest.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import apiRequest from '../apiRequest';
+import fetchWithTimeout from '../fetchWithTimeout';
+import validateResponse from '../validateResponse';
+
+vi.mock('../fetchWithTimeout');
+vi.mock('../validateResponse');
+
+const config = {
+  projectId: 'project-id',
+  apiKey: 'api-key',
+};
+
+function createResponse(overrides: Partial<Response> = {}): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    headers: new Headers(),
+    json: vi.fn().mockResolvedValue({ success: true }),
+    text: vi.fn(),
+    ...overrides,
+  } as unknown as Response;
+}
+
+describe.sequential('apiRequest', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(validateResponse).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('retries 429 responses after the rate limit window', async () => {
+    vi.useFakeTimers();
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+
+    const rateLimitedResponse = createResponse({
+      ok: false,
+      status: 429,
+      statusText: 'Too Many Requests',
+    });
+    const successResponse = createResponse();
+
+    vi.mocked(fetchWithTimeout)
+      .mockResolvedValueOnce(rateLimitedResponse)
+      .mockResolvedValueOnce(successResponse);
+
+    const request = apiRequest(config, '/test');
+
+    await Promise.resolve();
+
+    expect(fetchWithTimeout).toHaveBeenCalledTimes(1);
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 60_000);
+
+    await vi.runOnlyPendingTimersAsync();
+    await expect(request).resolves.toEqual({ success: true });
+
+    expect(fetchWithTimeout).toHaveBeenCalledTimes(2);
+    expect(validateResponse).toHaveBeenCalledWith(successResponse);
+    expect(validateResponse).not.toHaveBeenCalledWith(rateLimitedResponse);
+  });
+
+  it('uses RateLimit-Reset as the 429 retry delay when present', async () => {
+    vi.useFakeTimers();
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+
+    const rateLimitedResponse = createResponse({
+      ok: false,
+      status: 429,
+      statusText: 'Too Many Requests',
+      headers: new Headers({ 'RateLimit-Reset': '12' }),
+    });
+    const successResponse = createResponse();
+
+    vi.mocked(fetchWithTimeout)
+      .mockResolvedValueOnce(rateLimitedResponse)
+      .mockResolvedValueOnce(successResponse);
+
+    const request = apiRequest(config, '/test');
+
+    await Promise.resolve();
+
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 12_000);
+
+    await vi.runOnlyPendingTimersAsync();
+    await expect(request).resolves.toEqual({ success: true });
+  });
+
+  it('uses Retry-After before RateLimit-Reset for 429 retry timing', async () => {
+    vi.useFakeTimers();
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+
+    const rateLimitedResponse = createResponse({
+      ok: false,
+      status: 429,
+      statusText: 'Too Many Requests',
+      headers: new Headers({
+        'RateLimit-Reset': '12',
+        'Retry-After': '8',
+      }),
+    });
+    const successResponse = createResponse();
+
+    vi.mocked(fetchWithTimeout)
+      .mockResolvedValueOnce(rateLimitedResponse)
+      .mockResolvedValueOnce(successResponse);
+
+    const request = apiRequest(config, '/test');
+
+    await Promise.resolve();
+
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 8_000);
+
+    await vi.runOnlyPendingTimersAsync();
+    await expect(request).resolves.toEqual({ success: true });
+  });
+
+  it('falls back to the rate limit window for invalid 429 retry headers', async () => {
+    vi.useFakeTimers();
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+
+    const rateLimitedResponse = createResponse({
+      ok: false,
+      status: 429,
+      statusText: 'Too Many Requests',
+      headers: new Headers({
+        'RateLimit-Reset': 'later',
+        'Retry-After': 'later',
+      }),
+    });
+    const successResponse = createResponse();
+
+    vi.mocked(fetchWithTimeout)
+      .mockResolvedValueOnce(rateLimitedResponse)
+      .mockResolvedValueOnce(successResponse);
+
+    const request = apiRequest(config, '/test');
+
+    await Promise.resolve();
+
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 60_000);
+
+    await vi.runOnlyPendingTimersAsync();
+    await expect(request).resolves.toEqual({ success: true });
+  });
+
+  it('does not retry 429 responses when retries are disabled', async () => {
+    const rateLimitedResponse = createResponse({
+      ok: false,
+      status: 429,
+      statusText: 'Too Many Requests',
+    });
+    const rateLimitError = new Error('rate limited');
+
+    vi.mocked(fetchWithTimeout).mockResolvedValueOnce(rateLimitedResponse);
+    vi.mocked(validateResponse).mockRejectedValueOnce(rateLimitError);
+
+    await expect(
+      apiRequest(config, '/test', { retryPolicy: 'none' })
+    ).rejects.toThrow(rateLimitError);
+
+    expect(fetchWithTimeout).toHaveBeenCalledTimes(1);
+    expect(validateResponse).toHaveBeenCalledWith(rateLimitedResponse);
+  });
+});

--- a/packages/core/src/translate/utils/__tests__/apiRequest.test.ts
+++ b/packages/core/src/translate/utils/__tests__/apiRequest.test.ts
@@ -166,4 +166,34 @@ describe.sequential('apiRequest', () => {
     expect(fetchWithTimeout).toHaveBeenCalledTimes(1);
     expect(validateResponse).toHaveBeenCalledWith(rateLimitedResponse);
   });
+
+  it('surfaces the final 429 validation error after exhausting retries', async () => {
+    vi.useFakeTimers();
+
+    const rateLimitedResponses = Array.from({ length: 4 }, () =>
+      createResponse({
+        ok: false,
+        status: 429,
+        statusText: 'Too Many Requests',
+      })
+    );
+    const rateLimitError = new Error('rate limited');
+
+    vi.mocked(fetchWithTimeout)
+      .mockResolvedValueOnce(rateLimitedResponses[0])
+      .mockResolvedValueOnce(rateLimitedResponses[1])
+      .mockResolvedValueOnce(rateLimitedResponses[2])
+      .mockResolvedValueOnce(rateLimitedResponses[3]);
+    vi.mocked(validateResponse).mockRejectedValueOnce(rateLimitError);
+
+    const request = apiRequest(config, '/test');
+    const expectation = expect(request).rejects.toThrow(rateLimitError);
+
+    await vi.runAllTimersAsync();
+    await expectation;
+
+    expect(fetchWithTimeout).toHaveBeenCalledTimes(4);
+    expect(validateResponse).toHaveBeenCalledTimes(1);
+    expect(validateResponse).toHaveBeenCalledWith(rateLimitedResponses[3]);
+  });
 });

--- a/packages/core/src/translate/utils/apiRequest.ts
+++ b/packages/core/src/translate/utils/apiRequest.ts
@@ -28,7 +28,7 @@ function getRetryDelay(policy: RetryPolicy, attempt: number): number {
   }
 }
 
-function parseDelaySeconds(value: string | null): number | undefined {
+function parseDelayMs(value: string | null): number | undefined {
   if (!value) {
     return undefined;
   }
@@ -42,9 +42,9 @@ function parseDelaySeconds(value: string | null): number | undefined {
 }
 
 function parseRetryAfter(value: string | null): number | undefined {
-  const secondsDelay = parseDelaySeconds(value);
-  if (secondsDelay !== undefined) {
-    return secondsDelay;
+  const delayMs = parseDelayMs(value);
+  if (delayMs !== undefined) {
+    return delayMs;
   }
 
   if (!value) {
@@ -62,7 +62,7 @@ function parseRetryAfter(value: string | null): number | undefined {
 function getRateLimitRetryDelay(response: Response): number {
   return (
     parseRetryAfter(response.headers.get('Retry-After')) ??
-    parseDelaySeconds(response.headers.get('RateLimit-Reset')) ??
+    parseDelayMs(response.headers.get('RateLimit-Reset')) ??
     RATE_LIMIT_RETRY_DELAY_MS
   );
 }

--- a/packages/core/src/translate/utils/apiRequest.ts
+++ b/packages/core/src/translate/utils/apiRequest.ts
@@ -8,6 +8,8 @@ import generateRequestHeaders from './generateRequestHeaders';
 
 const MAX_RETRIES = 3;
 const INITIAL_DELAY_MS = 500;
+const RATE_LIMIT_RETRY_DELAY_MS = 60_000;
+const MS_PER_SECOND = 1000;
 
 type RetryPolicy = 'exponential' | 'linear' | 'none';
 
@@ -26,10 +28,61 @@ function getRetryDelay(policy: RetryPolicy, attempt: number): number {
   }
 }
 
+function parseDelaySeconds(value: string | null): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const seconds = Number(value.split(',')[0].split(';')[0].trim());
+  if (!Number.isFinite(seconds) || seconds < 0) {
+    return undefined;
+  }
+
+  return seconds * MS_PER_SECOND;
+}
+
+function parseRetryAfter(value: string | null): number | undefined {
+  const secondsDelay = parseDelaySeconds(value);
+  if (secondsDelay !== undefined) {
+    return secondsDelay;
+  }
+
+  if (!value) {
+    return undefined;
+  }
+
+  const retryDate = Date.parse(value);
+  if (Number.isNaN(retryDate)) {
+    return undefined;
+  }
+
+  return Math.max(retryDate - Date.now(), 0);
+}
+
+function getRateLimitRetryDelay(response: Response): number {
+  return (
+    parseRetryAfter(response.headers.get('Retry-After')) ??
+    parseDelaySeconds(response.headers.get('RateLimit-Reset')) ??
+    RATE_LIMIT_RETRY_DELAY_MS
+  );
+}
+
+function getResponseRetryDelay(
+  response: Response,
+  policy: RetryPolicy,
+  attempt: number
+): number {
+  if (response.status === 429) {
+    return getRateLimitRetryDelay(response);
+  }
+
+  return getRetryDelay(policy, attempt);
+}
+
 /**
  * @internal
  *
- * Makes an API request with automatic retry for 5XX errors.
+ * Makes an API request with automatic retry for 429 and 5XX errors.
  *
  * Encapsulates URL construction, fetch with timeout, error handling,
  * response validation, and JSON parsing.
@@ -75,9 +128,12 @@ export default async function apiRequest<T>(
       handleFetchError(error, timeout);
     }
 
-    // Retry on 5XX server errors.
-    if (response!.status >= 500 && attempt < maxRetries) {
-      await sleep(getRetryDelay(retryPolicy, attempt));
+    // Retry on rate limits and 5XX server errors.
+    if (
+      (response!.status === 429 || response!.status >= 500) &&
+      attempt < maxRetries
+    ) {
+      await sleep(getResponseRetryDelay(response!, retryPolicy, attempt));
       continue;
     }
 


### PR DESCRIPTION
<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1635"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784758522&installation_id=127936663&pr_number=1635&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1635&signature=821af303d0bb5d912b09bdc4436effd98bc841221674e7d61b675ca5ed720a27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a 429 (rate-limit) retry path to `apiRequest`, complementing the existing 5XX retry logic. When a 429 is received, the delay is driven by `Retry-After` (with HTTP-date support), then `RateLimit-Reset`, then a 60-second constant fallback; setting `retryPolicy: 'none'` disables 429 retries as well.

- **`parseDelaySeconds` / `parseRetryAfter`**: New helpers correctly parse numeric delay-seconds headers and fall back to HTTP-date parsing for `Retry-After`. The `??` chain in `getRateLimitRetryDelay` correctly treats `0` as "retry immediately" (not nullish), so a `RateLimit-Reset: 0` header bypasses the 60-second fallback — matching RFC semantics.
- **Retry loop**: 429 responses respect `maxRetries` the same way 5XX responses do; on the final attempt the response is forwarded to `validateResponse` rather than silently dropped.
- **Test suite**: Five focused tests cover the happy path, header priority, invalid-header fallback, and the `retryPolicy: 'none'` escape hatch; the exhaustion case (all retries yield 429) is not covered.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the retry logic is correct and well-tested for the common cases.

The core implementation is logically sound — header parsing handles edge cases (invalid values, HTTP-date format, `??` vs falsy `0`), and the retry loop correctly routes 429s through the rate-limit delay while still respecting `maxRetries`. The two gaps are a misleading internal function name (`parseDelaySeconds` returns ms) and a missing test for the all-retries-exhausted 429 scenario.

The exhaustion-path in `apiRequest.ts` (what happens after all three 429 retries are spent) has no test coverage in `apiRequest.test.ts`.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/translate/utils/apiRequest.ts | Adds 429 retry logic with server-header-driven delay (Retry-After / RateLimit-Reset with 60s fallback); implementation is correct but parseDelaySeconds is named misleadingly — it returns milliseconds. |
| packages/core/src/translate/utils/__tests__/apiRequest.test.ts | New test file covering 429 retry scenarios well; missing a case for all-retries-exhausted on persistent 429 and for HTTP-date format Retry-After headers. |
| .changeset/cuddly-friends-design.md | Standard patch-level changeset entry describing the 429 retry feature; no issues. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant C as Caller
    participant A as apiRequest
    participant F as fetchWithTimeout
    participant V as validateResponse

    C->>A: apiRequest(config, endpoint)
    loop attempt 0..maxRetries
        A->>F: fetch(url, init, timeout)
        alt Network error
            F-->>A: throws
            A->>A: sleep(exponential/linear delay)
        else 429 Too Many Requests
            F-->>A: Response(429)
            A->>A: parse Retry-After / RateLimit-Reset / fallback 60s
            A->>A: sleep(rateLimitDelay)
        else 5XX Server Error
            F-->>A: Response(5xx)
            A->>A: sleep(exponential/linear delay)
        else Success (2xx)
            F-->>A: Response(2xx)
            A->>V: validateResponse(response)
            V-->>A: ok
            A-->>C: response.json()
        end
    end
    A-->>C: throws (max retries exceeded / validateResponse error)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant C as Caller
    participant A as apiRequest
    participant F as fetchWithTimeout
    participant V as validateResponse

    C->>A: apiRequest(config, endpoint)
    loop attempt 0..maxRetries
        A->>F: fetch(url, init, timeout)
        alt Network error
            F-->>A: throws
            A->>A: sleep(exponential/linear delay)
        else 429 Too Many Requests
            F-->>A: Response(429)
            A->>A: parse Retry-After / RateLimit-Reset / fallback 60s
            A->>A: sleep(rateLimitDelay)
        else 5XX Server Error
            F-->>A: Response(5xx)
            A->>A: sleep(exponential/linear delay)
        else Success (2xx)
            F-->>A: Response(2xx)
            A->>V: validateResponse(response)
            V-->>A: ok
            A-->>C: response.json()
        end
    end
    A-->>C: throws (max retries exceeded / validateResponse error)
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fcore%2Fsrc%2Ftranslate%2Futils%2FapiRequest.ts%3A31%0A**Misleading%20function%20name%20%E2%80%94%20returns%20milliseconds%2C%20not%20seconds.**%20%60parseDelaySeconds%60%20returns%20a%20value%20in%20milliseconds%20%28it%20multiplies%20by%20%60MS_PER_SECOND%60%20internally%29%2C%20so%20a%20caller%20or%20future%20maintainer%20reading%20the%20name%20would%20reasonably%20expect%20the%20return%20unit%20to%20be%20seconds.%20This%20inconsistency%20can%20lead%20to%20an%20accidental%20double-conversion%20if%20someone%20adds%20code%20that%20treats%20the%20return%20value%20as%20seconds.%0A%0A%60%60%60suggestion%0Afunction%20parseDelayMs%28value%3A%20string%20%7C%20null%29%3A%20number%20%7C%20undefined%20%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fcore%2Fsrc%2Ftranslate%2Futils%2F__tests__%2FapiRequest.test.ts%3A151-168%0A**Missing%20test%3A%20max%20retries%20exhausted%20on%20persistent%20429.**%20All%20five%20tests%20exercise%20a%20single%20429%20followed%20by%20eventual%20success%20%28or%20%60retryPolicy%3A%20'none'%60%29.%20There%20is%20no%20coverage%20for%20the%20scenario%20where%20all%20retry%20attempts%20return%20429%2C%20which%20should%20surface%20the%20error%20from%20%60validateResponse%60%20on%20the%20final%20attempt.%20Without%20this%20test%2C%20a%20regression%20that%20silently%20swallows%20the%20final-attempt%20error%20would%20go%20undetected.%0A%0A&repo=generaltranslation%2Fgt&pr=1635&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/core/src/translate/utils/apiRequest.ts:31
**Misleading function name — returns milliseconds, not seconds.** `parseDelaySeconds` returns a value in milliseconds (it multiplies by `MS_PER_SECOND` internally), so a caller or future maintainer reading the name would reasonably expect the return unit to be seconds. This inconsistency can lead to an accidental double-conversion if someone adds code that treats the return value as seconds.

```suggestion
function parseDelayMs(value: string | null): number | undefined {
```

### Issue 2 of 2
packages/core/src/translate/utils/__tests__/apiRequest.test.ts:151-168
**Missing test: max retries exhausted on persistent 429.** All five tests exercise a single 429 followed by eventual success (or `retryPolicy: 'none'`). There is no coverage for the scenario where all retry attempts return 429, which should surface the error from `validateResponse` on the final attempt. Without this test, a regression that silently swallows the final-attempt error would go undetected.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["changeset"](https://github.com/generaltranslation/gt/commit/92a02cf55c61bc55ab8ec3a8dab3f0b24dd24182) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39159414)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->