### PR TITLE
fix: keep gt-next runtime credentials out of config params

### DIFF
--- a/packages/next/src/__tests__/config.test.ts
+++ b/packages/next/src/__tests__/config.test.ts
@@ -1000,11 +1000,10 @@ describe('withGTConfig', () => {
     it('devApiKey in production throws devApiKeyIncludedInProductionError', async () => {
       const withGTConfig = await getWithGTConfig();
       process.env.NODE_ENV = 'production';
+      process.env.GT_DEV_API_KEY = 'gt-dev-xyz';
       vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-      expect(() => withGTConfig({}, { devApiKey: 'gt-dev-xyz' })).toThrow(
-        /development API key/i
-      );
+      expect(() => withGTConfig()).toThrow(/development API key/i);
     });
 
     it('invalid locales + GT services enabled throws invalidLocalesError', async () => {
@@ -1178,6 +1177,7 @@ describe('withGTConfig', () => {
       expect(raw).not.toContain('prop-api-key');
       expect(raw).not.toContain('prop-dev-key');
       expect(raw).not.toContain('prop-project-id');
+      expect(result.env!._GENERALTRANSLATION_GT_SERVICES_ENABLED).toBe('false');
     });
 
     it('boolean flags are string "true"/"false", not booleans', async () => {

--- a/packages/next/src/__tests__/config.test.ts
+++ b/packages/next/src/__tests__/config.test.ts
@@ -57,6 +57,7 @@ beforeEach(() => {
   delete process.env.GT_PROJECT_ID;
   delete process.env.GT_API_KEY;
   delete process.env.GT_DEV_API_KEY;
+  delete process.env.NEXT_PUBLIC_GT_DEV_API_KEY;
   delete process.env.TURBOPACK;
   process.env.NODE_ENV = 'development';
   vi.clearAllMocks();
@@ -362,7 +363,7 @@ describe('withGTConfig', () => {
   // ==============================
   // 3. Config merge precedence
   // ==============================
-  describe('3. Config merge precedence: props > env > config file > defaults', () => {
+  describe('3. Config merge precedence: props > config file > defaults', () => {
     it('config file values override defaults', async () => {
       const withGTConfig = await getWithGTConfig();
       vi.mocked(fs.existsSync).mockImplementation((p) => {
@@ -379,7 +380,7 @@ describe('withGTConfig', () => {
       expect(params.maxBatchSize).toBe(99);
     });
 
-    it('GT_PROJECT_ID env var overrides config file projectId', async () => {
+    it('omits projectId from serialized config params', async () => {
       const withGTConfig = await getWithGTConfig();
       process.env.GT_PROJECT_ID = 'env-project-id';
       vi.mocked(fs.existsSync).mockImplementation((p) => {
@@ -393,17 +394,17 @@ describe('withGTConfig', () => {
       const result = withGTConfig();
       const params = parseConfigParams(result);
 
-      expect(params.projectId).toBe('env-project-id');
+      expect(params.projectId).toBeUndefined();
     });
 
-    it('props override env vars', async () => {
+    it('omits prop projectId from serialized config params', async () => {
       const withGTConfig = await getWithGTConfig();
       process.env.GT_PROJECT_ID = 'env-project-id';
 
       const result = withGTConfig({}, { projectId: 'props-project-id' });
       const params = parseConfigParams(result);
 
-      expect(params.projectId).toBe('props-project-id');
+      expect(params.projectId).toBeUndefined();
     });
 
     it('full chain: each layer contributes different values', async () => {
@@ -428,8 +429,8 @@ describe('withGTConfig', () => {
 
       // From config file (not overridden)
       expect(params.maxBatchSize).toBe(99);
-      // From env (overrides config file)
-      expect(params.projectId).toBe('env-project-id');
+      // Runtime credentials are read directly from process.env, not serialized.
+      expect(params.projectId).toBeUndefined();
       // From props (overrides all)
       expect(params.defaultLocale).toBe('fr');
       expect(params.maxConcurrentRequests).toBe(200);
@@ -609,74 +610,97 @@ describe('withGTConfig', () => {
   // 5. Environment variable handling
   // ==============================
   describe('5. Environment variable handling', () => {
-    it('GT_PROJECT_ID sets projectId in merged config', async () => {
+    it('does not serialize runtime credential env vars into config params', async () => {
       const withGTConfig = await getWithGTConfig();
       process.env.GT_PROJECT_ID = 'my-project';
+      process.env.GT_API_KEY = 'gt-api-xyz';
+      process.env.GT_DEV_API_KEY = 'gt-dev-xyz';
 
       const result = withGTConfig();
       const params = parseConfigParams(result);
+      const raw = result.env!._GENERALTRANSLATION_I18N_CONFIG_PARAMS!;
 
-      expect(params.projectId).toBe('my-project');
+      expect(params.projectId).toBeUndefined();
+      expect(params.apiKey).toBeUndefined();
+      expect(params.devApiKey).toBeUndefined();
+      expect(raw).not.toContain('my-project');
+      expect(raw).not.toContain('gt-api-xyz');
+      expect(raw).not.toContain('gt-dev-xyz');
     });
 
-    it('GT_API_KEY with gt-api- prefix in production sets apiKey', async () => {
+    it('uses GT_API_KEY in production without prefix parsing', async () => {
       const withGTConfig = await getWithGTConfig();
       process.env.NODE_ENV = 'production';
-      process.env.GT_API_KEY = 'gt-api-xyz';
+      process.env.GT_API_KEY = 'plain-production-key';
       process.env.GT_PROJECT_ID = 'proj';
 
       const result = withGTConfig();
       const params = parseConfigParams(result);
 
-      expect(params.apiKey).toBe('gt-api-xyz');
-    });
-
-    it('GT_DEV_API_KEY with gt-dev- prefix in development sets devApiKey', async () => {
-      const withGTConfig = await getWithGTConfig();
-      process.env.NODE_ENV = 'development';
-      process.env.GT_DEV_API_KEY = 'gt-dev-xyz';
-
-      const result = withGTConfig();
-      const params = parseConfigParams(result);
-
-      expect(params.devApiKey).toBe('gt-dev-xyz');
-    });
-
-    it('GT_API_KEY in development (no dev key) sets apiKey', async () => {
-      const withGTConfig = await getWithGTConfig();
-      process.env.NODE_ENV = 'development';
-      process.env.GT_API_KEY = 'gt-api-xyz';
-
-      const result = withGTConfig();
-      const params = parseConfigParams(result);
-
-      expect(params.apiKey).toBe('gt-api-xyz');
-    });
-
-    it('GT_DEV_API_KEY preferred over GT_API_KEY in development', async () => {
-      const withGTConfig = await getWithGTConfig();
-      process.env.NODE_ENV = 'development';
-      process.env.GT_DEV_API_KEY = 'gt-dev-preferred';
-      process.env.GT_API_KEY = 'gt-api-fallback';
-
-      const result = withGTConfig();
-      const params = parseConfigParams(result);
-
-      expect(params.devApiKey).toBe('gt-dev-preferred');
-      // apiKey should not be set from GT_API_KEY since GT_DEV_API_KEY took precedence
+      expect(result.env!._GENERALTRANSLATION_GT_SERVICES_ENABLED).toBe('true');
       expect(params.apiKey).toBeUndefined();
     });
 
-    it('key with unknown prefix sets neither apiKey nor devApiKey', async () => {
+    it('uses GT_DEV_API_KEY in development without prefix parsing', async () => {
+      const withGTConfig = await getWithGTConfig();
+      process.env.NODE_ENV = 'development';
+      process.env.GT_DEV_API_KEY = 'plain-dev-key';
+      process.env.GT_PROJECT_ID = 'proj';
+
+      const result = withGTConfig();
+      const params = parseConfigParams(result);
+
+      expect(result.env!._GENERALTRANSLATION_GT_SERVICES_ENABLED).toBe('true');
+      expect(params.devApiKey).toBeUndefined();
+    });
+
+    it('uses NEXT_PUBLIC_GT_DEV_API_KEY before GT_DEV_API_KEY', async () => {
+      const withGTConfig = await getWithGTConfig();
+      process.env.NODE_ENV = 'development';
+      process.env.NEXT_PUBLIC_GT_DEV_API_KEY = 'public-dev-key';
+      process.env.GT_DEV_API_KEY = 'server-dev-key';
+      process.env.GT_PROJECT_ID = 'proj';
+
+      const result = withGTConfig();
+      const params = parseConfigParams(result);
+
+      expect(result.env!._GENERALTRANSLATION_GT_SERVICES_ENABLED).toBe('true');
+      expect(params.devApiKey).toBeUndefined();
+      expect(result.env!._GENERALTRANSLATION_I18N_CONFIG_PARAMS).not.toContain(
+        'public-dev-key'
+      );
+      expect(result.env!._GENERALTRANSLATION_I18N_CONFIG_PARAMS).not.toContain(
+        'server-dev-key'
+      );
+    });
+
+    it('does not reject keys with unknown prefixes', async () => {
       const withGTConfig = await getWithGTConfig();
       process.env.NODE_ENV = 'development';
       process.env.GT_API_KEY = 'gt-unknown-xyz';
+      process.env.GT_PROJECT_ID = 'proj';
 
       const result = withGTConfig();
       const params = parseConfigParams(result);
 
+      expect(() => withGTConfig()).not.toThrow();
       expect(params.apiKey).toBeUndefined();
       expect(params.devApiKey).toBeUndefined();
+    });
+
+    it('runtime credentials are read directly from process.env', async () => {
+      const { getRuntimeCredentials } =
+        await import('../config-dir/utils/runtimeCredentials');
+      process.env.GT_API_KEY = 'plain-api-key';
+      process.env.NEXT_PUBLIC_GT_DEV_API_KEY = 'public-dev-key';
+      process.env.GT_DEV_API_KEY = 'server-dev-key';
+      process.env.GT_PROJECT_ID = 'project-id';
+
+      expect(getRuntimeCredentials()).toEqual({
+        apiKey: 'plain-api-key',
+        devApiKey: 'public-dev-key',
+        projectId: 'project-id',
+      });
     });
   });
 
@@ -1132,15 +1156,28 @@ describe('withGTConfig', () => {
       expect(result.env!._GENERALTRANSLATION_I18N_CONFIG_PARAMS).toBeDefined();
     });
 
-    it('I18N_CONFIG_PARAMS contains full merged config as JSON string', async () => {
+    it('I18N_CONFIG_PARAMS contains sanitized merged config as JSON string', async () => {
       const withGTConfig = await getWithGTConfig();
-      const result = withGTConfig();
+      const result = withGTConfig(
+        {},
+        {
+          apiKey: 'prop-api-key',
+          devApiKey: 'prop-dev-key',
+          projectId: 'prop-project-id',
+        }
+      );
 
       const raw = result.env!._GENERALTRANSLATION_I18N_CONFIG_PARAMS;
       expect(typeof raw).toBe('string');
       const parsed = JSON.parse(raw!);
       expect(parsed).toHaveProperty('defaultLocale');
       expect(parsed).toHaveProperty('_usingPlugin', true);
+      expect(parsed.apiKey).toBeUndefined();
+      expect(parsed.devApiKey).toBeUndefined();
+      expect(parsed.projectId).toBeUndefined();
+      expect(raw).not.toContain('prop-api-key');
+      expect(raw).not.toContain('prop-dev-key');
+      expect(raw).not.toContain('prop-project-id');
     });
 
     it('boolean flags are string "true"/"false", not booleans', async () => {

--- a/packages/next/src/config-dir/__tests__/I18NConfiguration.test.ts
+++ b/packages/next/src/config-dir/__tests__/I18NConfiguration.test.ts
@@ -319,6 +319,36 @@ describe('I18NConfiguration', () => {
     );
   });
 
+  it('hydrates runtime credentials from process.env with sanitized config params', () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    vi.stubEnv('GT_API_KEY', 'plain-api-key');
+    vi.stubEnv('NEXT_PUBLIC_GT_DEV_API_KEY', 'public-dev-key');
+    vi.stubEnv('GT_DEV_API_KEY', 'server-dev-key');
+    vi.stubEnv('GT_PROJECT_ID', 'runtime-project-id');
+    vi.stubEnv(
+      '_GENERALTRANSLATION_I18N_CONFIG_PARAMS',
+      JSON.stringify({
+        defaultLocale: 'en',
+        locales: ['en', 'es'],
+      })
+    );
+
+    const config = getI18NConfig();
+
+    expect(config.getClientSideConfig()).toEqual(
+      expect.objectContaining({
+        devApiKey: 'public-dev-key',
+        developmentApiEnabled: true,
+        projectId: 'runtime-project-id',
+      })
+    );
+    expectCacheParams({
+      apiKey: 'plain-api-key',
+      devApiKey: 'public-dev-key',
+      projectId: 'runtime-project-id',
+    });
+  });
+
   it('initializes locale metadata in the default config fallback', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 

--- a/packages/next/src/config-dir/getI18NConfig.ts
+++ b/packages/next/src/config-dir/getI18NConfig.ts
@@ -7,6 +7,7 @@ import {
 } from '../errors/createErrors';
 import { getDefaultRenderSettings } from 'gt-react/internal';
 import { initializeI18nConfig } from 'gt-i18n/internal';
+import { getRuntimeCredentials } from './utils/runtimeCredentials';
 
 type GlobalWithI18NConfig = typeof globalThis & {
   _GENERALTRANSLATION_I18N_CONFIG_INSTANCE?: I18NConfiguration;
@@ -25,6 +26,7 @@ export function getI18NConfig(): I18NConfiguration {
     const configParams = {
       ...defaultWithGTConfigProps,
       ...JSON.parse(I18NConfigParams),
+      ...getRuntimeCredentials(),
     } as ConstructorParameters<typeof I18NConfiguration>[0];
     initializeI18nConfig(configParams);
     globalObj._GENERALTRANSLATION_I18N_CONFIG_INSTANCE = new I18NConfiguration(
@@ -36,19 +38,7 @@ export function getI18NConfig(): I18NConfiguration {
     //  - not translating at all
     //  - using only default locales
 
-    // Parse: projectId
-    const projectId = process.env.GT_PROJECT_ID || '';
-
-    // Parse: apiKey, devApiKey
-    let apiKey, devApiKey;
-    const envApiKey =
-      process.env.GT_DEV_API_KEY || process.env.GT_API_KEY || '';
-    const apiKeyType = envApiKey?.split('-')?.[1];
-    if (apiKeyType === 'api') {
-      apiKey = envApiKey;
-    } else if (apiKeyType === 'dev') {
-      devApiKey = envApiKey;
-    }
+    const { apiKey, devApiKey, projectId = '' } = getRuntimeCredentials();
 
     // Parse: defaultLocale
     // Currently, you have to specify the default locale in the config

--- a/packages/next/src/config-dir/utils/runtimeCredentials.ts
+++ b/packages/next/src/config-dir/utils/runtimeCredentials.ts
@@ -1,0 +1,32 @@
+type RuntimeCredentials = {
+  apiKey?: string;
+  devApiKey?: string;
+  projectId?: string;
+};
+
+export function getRuntimeCredentials(): RuntimeCredentials {
+  return {
+    apiKey: process.env.GT_API_KEY,
+    devApiKey:
+      process.env.NEXT_PUBLIC_GT_DEV_API_KEY || process.env.GT_DEV_API_KEY,
+    projectId: process.env.GT_PROJECT_ID,
+  };
+}
+
+export function getDefinedRuntimeCredentials(): RuntimeCredentials {
+  return Object.fromEntries(
+    Object.entries(getRuntimeCredentials()).filter(([, value]) => value)
+  ) as RuntimeCredentials;
+}
+
+export function withoutRuntimeCredentials<T extends RuntimeCredentials>(
+  config: T
+): Omit<T, keyof RuntimeCredentials> {
+  const {
+    apiKey: _apiKey,
+    devApiKey: _devApiKey,
+    projectId: _projectId,
+    ...rest
+  } = config;
+  return rest;
+}

--- a/packages/next/src/config-dir/utils/runtimeCredentials.ts
+++ b/packages/next/src/config-dir/utils/runtimeCredentials.ts
@@ -13,12 +13,6 @@ export function getRuntimeCredentials(): RuntimeCredentials {
   };
 }
 
-export function getDefinedRuntimeCredentials(): RuntimeCredentials {
-  return Object.fromEntries(
-    Object.entries(getRuntimeCredentials()).filter(([, value]) => value)
-  ) as RuntimeCredentials;
-}
-
 export function withoutRuntimeCredentials<T extends RuntimeCredentials>(
   config: T
 ): Omit<T, keyof RuntimeCredentials> {

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -39,7 +39,7 @@ import { resolveConfigFilepath } from './config-dir/utils/resolveConfigFilepath'
 import { ssgChecks } from './plugin/checks/ssgChecks';
 import { cacheComponentsChecks } from './plugin/checks/cacheComponentsChecks';
 import {
-  getDefinedRuntimeCredentials,
+  getRuntimeCredentials,
   withoutRuntimeCredentials,
 } from './config-dir/utils/runtimeCredentials';
 
@@ -151,7 +151,7 @@ export function withGTConfig<TNextConfig extends object = NextConfig>(
     console.error('Error reading GT config file:', error);
   }
 
-  const runtimeCredentials = getDefinedRuntimeCredentials();
+  const runtimeCredentials = getRuntimeCredentials();
 
   // ---------- CHECK FOR CONFIG CONFLICTS ---------- //
 

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -38,6 +38,10 @@ import {
 import { resolveConfigFilepath } from './config-dir/utils/resolveConfigFilepath';
 import { ssgChecks } from './plugin/checks/ssgChecks';
 import { cacheComponentsChecks } from './plugin/checks/cacheComponentsChecks';
+import {
+  getDefinedRuntimeCredentials,
+  withoutRuntimeCredentials,
+} from './config-dir/utils/runtimeCredentials';
 
 type AutoderiveConfig = boolean | { jsx?: boolean; strings?: boolean };
 
@@ -147,32 +151,7 @@ export function withGTConfig<TNextConfig extends object = NextConfig>(
     console.error('Error reading GT config file:', error);
   }
 
-  // ---------- LOAD ENVIRONMENT VARIABLES ---------- //
-
-  // resolve project ID
-  const projectId: string | undefined = process.env.GT_PROJECT_ID;
-
-  // resolve API keys
-  const envApiKey: string | undefined =
-    process.env.NODE_ENV === 'production'
-      ? process.env.GT_API_KEY
-      : process.env.GT_DEV_API_KEY || process.env.GT_API_KEY;
-  let apiKey, devApiKey;
-  if (envApiKey) {
-    const apiKeyType = envApiKey?.split('-')?.[1];
-    if (apiKeyType === 'api') {
-      apiKey = envApiKey;
-    } else if (apiKeyType === 'dev') {
-      devApiKey = envApiKey;
-    }
-  }
-
-  // conditionally add environment variables to config
-  const envConfig: Partial<InternalGTConfigProps> = {
-    ...(projectId ? { projectId } : {}),
-    ...(apiKey ? { apiKey } : {}),
-    ...(devApiKey ? { devApiKey } : {}),
-  };
+  const runtimeCredentials = getDefinedRuntimeCredentials();
 
   // ---------- CHECK FOR CONFIG CONFLICTS ---------- //
 
@@ -240,15 +219,18 @@ export function withGTConfig<TNextConfig extends object = NextConfig>(
     ...props.experimentalCompilerOptions,
   };
 
-  // precedence: input > env > config file > defaults
+  // precedence: input > config file > defaults
   const mergedConfig: InternalGTConfigProps = {
     ...defaultWithGTConfigProps,
     ...loadedConfig,
-    ...envConfig,
     ...props,
     headersAndCookies: mergedHeadersAndCookies,
     experimentalCompilerOptions: mergedExperimentalCompilerOptions,
     _usingPlugin: true, // flag to indicate plugin usage
+  };
+  const runtimeConfig: InternalGTConfigProps = {
+    ...mergedConfig,
+    ...runtimeCredentials,
   };
 
   // clear up any issues with the compiler options
@@ -374,17 +356,17 @@ export function withGTConfig<TNextConfig extends object = NextConfig>(
 
   // Check if using Services
   const gtRuntimeTranslationEnabled = !!(
-    mergedConfig.runtimeUrl === defaultWithGTConfigProps.runtimeUrl &&
-    ((process.env.NODE_ENV === 'production' && mergedConfig.apiKey) ||
-      (process.env.NODE_ENV === 'development' && mergedConfig.devApiKey))
+    runtimeConfig.runtimeUrl === defaultWithGTConfigProps.runtimeUrl &&
+    ((process.env.NODE_ENV === 'production' && runtimeConfig.apiKey) ||
+      (process.env.NODE_ENV === 'development' && runtimeConfig.devApiKey))
   );
   const gtRemoteCacheEnabled = !!(
-    mergedConfig.cacheUrl === defaultWithGTConfigProps.cacheUrl &&
-    mergedConfig.loadTranslationsType === 'remote'
+    runtimeConfig.cacheUrl === defaultWithGTConfigProps.cacheUrl &&
+    runtimeConfig.loadTranslationsType === 'remote'
   );
   const gtServicesEnabled = !!(
     (gtRuntimeTranslationEnabled || gtRemoteCacheEnabled) &&
-    mergedConfig.projectId
+    runtimeConfig.projectId
   );
 
   // Standardize locales
@@ -474,7 +456,7 @@ export function withGTConfig<TNextConfig extends object = NextConfig>(
   // Set default cache expiry if and only if no dev key
   if (
     mergedConfig.loadTranslationsType == 'remote' &&
-    !mergedConfig.devApiKey &&
+    !runtimeConfig.devApiKey &&
     typeof mergedConfig.cacheExpiryTime === 'undefined'
   ) {
     mergedConfig.cacheExpiryTime = defaultCacheExpiryTime;
@@ -510,8 +492,8 @@ export function withGTConfig<TNextConfig extends object = NextConfig>(
 
   // Check: projectId is not required for remote infrastructure, but warn if missing for dev, nothing for prod
   if (
-    (mergedConfig.cacheUrl || mergedConfig.runtimeUrl) &&
-    !mergedConfig.projectId &&
+    (runtimeConfig.cacheUrl || runtimeConfig.runtimeUrl) &&
+    !runtimeConfig.projectId &&
     process.env.NODE_ENV === 'development' &&
     mergedConfig.loadTranslationsType === 'remote' &&
     !mergedConfig.loadDictionaryEnabled // skip warn if using local dictionary
@@ -520,15 +502,15 @@ export function withGTConfig<TNextConfig extends object = NextConfig>(
   }
 
   // Check: dev API key should not be included in production
-  if (process.env.NODE_ENV === 'production' && mergedConfig.devApiKey) {
+  if (process.env.NODE_ENV === 'production' && runtimeConfig.devApiKey) {
     throw new Error(devApiKeyIncludedInProductionError);
   }
 
   // Check: An API key is required for runtime translation
   if (
-    mergedConfig.projectId && // must have projectId for this check to matter anyways
-    mergedConfig.runtimeUrl &&
-    !(mergedConfig.apiKey || mergedConfig.devApiKey) &&
+    runtimeConfig.projectId && // must have projectId for this check to matter anyways
+    runtimeConfig.runtimeUrl &&
+    !(runtimeConfig.apiKey || runtimeConfig.devApiKey) &&
     process.env.NODE_ENV === 'development'
   ) {
     console.warn(APIKeyMissingWarn);
@@ -550,7 +532,9 @@ export function withGTConfig<TNextConfig extends object = NextConfig>(
   }
 
   // ---------- STORE CONFIGURATIONS ---------- //
-  const I18NConfigParams = JSON.stringify(mergedConfig);
+  const I18NConfigParams = JSON.stringify(
+    withoutRuntimeCredentials(mergedConfig)
+  );
 
   const { type: _type, ...compilerOptions } =
     mergedConfig.experimentalCompilerOptions || {};


### PR DESCRIPTION
## Summary
- read gt-next runtime credentials directly from process.env
- omit projectId, apiKey, and devApiKey from serialized config params
- cover sanitized params and runtime credential hydration in tests

## Tests
- pnpm --filter gt-next test
- pnpm --filter gt-next typecheck
- pnpm exec oxlint packages/next/src/config.ts packages/next/src/config-dir/getI18NConfig.ts packages/next/src/config-dir/utils/runtimeCredentials.ts packages/next/src/__tests__/config.test.ts packages/next/src/config-dir/__tests__/I18NConfiguration.test.ts
- pnpm exec oxfmt --check packages/next/src/config.ts packages/next/src/config-dir/getI18NConfig.ts packages/next/src/config-dir/utils/runtimeCredentials.ts packages/next/src/__tests__/config.test.ts packages/next/src/config-dir/__tests__/I18NConfiguration.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1637"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784771532&installation_id=127936663&pr_number=1637&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1637&signature=aac7dfaf3139085706912e1bc175c23f1c487e9664d7bd6c3a28bf3a6d2524eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves `gt-next` runtime credentials (`projectId`, `apiKey`, `devApiKey`) out of the serialized `_GENERALTRANSLATION_I18N_CONFIG_PARAMS` env var and instead reads them directly from `process.env` at request time via a new `runtimeCredentials.ts` utility.

- A new `runtimeCredentials.ts` module exports `getRuntimeCredentials`, `getDefinedRuntimeCredentials`, and `withoutRuntimeCredentials`; `config.ts` uses the "defined-only" variant so build-time service checks still see props-based credentials, while `getI18NConfig.ts` uses the full variant so runtime env values always win.
- The old key-prefix detection logic (`gt-api-` / `gt-dev-`) is removed in favour of separate, named env vars; `NEXT_PUBLIC_GT_DEV_API_KEY` is added as a higher-priority source for `devApiKey`.
- Tests are updated throughout to assert that credential values are absent from the serialized config string.

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The core serialization change is sound, but the primary getI18NConfig path now reads devApiKey from the runtime environment without the production guard that the fallback path has, meaning a misplaced dev key in a production deployment goes undetected.

The build-time guard in config.ts catches GT_DEV_API_KEY only when the key is present in the build environment. After this PR, getI18NConfig.ts reads credentials at request time via getRuntimeCredentials(), but the primary branch (when _GENERALTRANSLATION_I18N_CONFIG_PARAMS is set) has no matching runtime guard. A production server with GT_DEV_API_KEY in its runtime environment (but not at build time) would silently initialize I18NConfiguration with a dev key.

packages/next/src/config-dir/getI18NConfig.ts — the primary config-params branch should mirror the devApiKey production check present in the fallback branch.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/next/src/config-dir/utils/runtimeCredentials.ts | New utility exposing three helpers: getRuntimeCredentials (always returns all three credential fields, including undefined), getDefinedRuntimeCredentials (filters falsy values), and withoutRuntimeCredentials (strips credentials from a config object). The unconditional return of both apiKey and devApiKey simultaneously is a behavioral change from the old prefix-based routing. |
| packages/next/src/config-dir/getI18NConfig.ts | Primary path now spreads getRuntimeCredentials() (including undefined values) over config params at request time. Missing the devApiKey-in-production guard that exists in the fallback path, creating a window where a misplaced GT_DEV_API_KEY in a production runtime env is silently accepted. |
| packages/next/src/config.ts | Correctly separates mergedConfig (no credentials) from runtimeConfig (with credentials from getDefinedRuntimeCredentials) for build-time service checks; serializes only withoutRuntimeCredentials(mergedConfig). All credential-dependent checks now use runtimeConfig. Logic is sound at build time. |
| packages/next/src/__tests__/config.test.ts | Tests updated to assert credentials are absent from serialized config params and that service-enable flags are correctly set. Adds coverage for NEXT_PUBLIC_GT_DEV_API_KEY precedence and raw string exclusion. Does not test simultaneous apiKey+devApiKey in the primary getI18NConfig path. |
| packages/next/src/config-dir/__tests__/I18NConfiguration.test.ts | New test verifies that sanitized config params are correctly hydrated with runtime credentials from process.env, including NEXT_PUBLIC_GT_DEV_API_KEY precedence and correct projectId resolution. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant NXC as next.config.js (build time)
    participant CFG as config.ts::withGTConfig
    participant ENV as process.env
    participant SER as _GENERALTRANSLATION_I18N_CONFIG_PARAMS
    participant APP as Next.js App (runtime)
    participant GIC as getI18NConfig.ts
    participant RC as runtimeCredentials.ts
    participant I18N as I18NConfiguration

    NXC->>CFG: withGTConfig(nextConfig, props)
    CFG->>ENV: getDefinedRuntimeCredentials()
    ENV-->>CFG: "{projectId, apiKey, devApiKey} (defined only)"
    CFG->>CFG: "mergedConfig = defaults + loadedConfig + props"
    CFG->>CFG: "runtimeConfig = mergedConfig + runtimeCredentials"
    CFG->>CFG: "validate & service-enable checks (use runtimeConfig)"
    CFG->>SER: JSON.stringify(withoutRuntimeCredentials(mergedConfig))
    note over SER: No projectId / apiKey / devApiKey

    APP->>GIC: getI18NConfig()
    GIC->>SER: read _GENERALTRANSLATION_I18N_CONFIG_PARAMS
    GIC->>RC: getRuntimeCredentials()
    RC->>ENV: GT_API_KEY, NEXT_PUBLIC_GT_DEV_API_KEY or GT_DEV_API_KEY, GT_PROJECT_ID
    ENV-->>RC: credential values (may be undefined)
    RC-->>GIC: "{apiKey, devApiKey, projectId}"
    GIC->>GIC: "configParams = defaults + parsed + credentials"
    note over GIC: No devApiKey-in-production guard here
    GIC->>I18N: new I18NConfiguration(configParams)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant NXC as next.config.js (build time)
    participant CFG as config.ts::withGTConfig
    participant ENV as process.env
    participant SER as _GENERALTRANSLATION_I18N_CONFIG_PARAMS
    participant APP as Next.js App (runtime)
    participant GIC as getI18NConfig.ts
    participant RC as runtimeCredentials.ts
    participant I18N as I18NConfiguration

    NXC->>CFG: withGTConfig(nextConfig, props)
    CFG->>ENV: getDefinedRuntimeCredentials()
    ENV-->>CFG: "{projectId, apiKey, devApiKey} (defined only)"
    CFG->>CFG: "mergedConfig = defaults + loadedConfig + props"
    CFG->>CFG: "runtimeConfig = mergedConfig + runtimeCredentials"
    CFG->>CFG: "validate & service-enable checks (use runtimeConfig)"
    CFG->>SER: JSON.stringify(withoutRuntimeCredentials(mergedConfig))
    note over SER: No projectId / apiKey / devApiKey

    APP->>GIC: getI18NConfig()
    GIC->>SER: read _GENERALTRANSLATION_I18N_CONFIG_PARAMS
    GIC->>RC: getRuntimeCredentials()
    RC->>ENV: GT_API_KEY, NEXT_PUBLIC_GT_DEV_API_KEY or GT_DEV_API_KEY, GT_PROJECT_ID
    ENV-->>RC: credential values (may be undefined)
    RC-->>GIC: "{apiKey, devApiKey, projectId}"
    GIC->>GIC: "configParams = defaults + parsed + credentials"
    note over GIC: No devApiKey-in-production guard here
    GIC->>I18N: new I18NConfiguration(configParams)
```

</a>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/next/src/config-dir/getI18NConfig.ts`, line 26-34 ([link](https://github.com/generaltranslation/gt/blob/b060bb2ebd2bebd3c621c931afab10be7ef1eb52/packages/next/src/config-dir/getI18NConfig.ts#L26-L34)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Missing dev-key production guard in primary path**

   The fallback path (no `_GENERALTRANSLATION_I18N_CONFIG_PARAMS`) correctly throws `devApiKeyIncludedInProductionError` when `devApiKey` is present in production. The primary path does not. Before this PR, the primary path read credentials from the build-time serialized config, so the guard in `config.ts` (which runs at build time) was sufficient. Now `getRuntimeCredentials()` is called at request time — if `GT_DEV_API_KEY` or `NEXT_PUBLIC_GT_DEV_API_KEY` is mistakenly set in a production runtime environment (e.g. a Kubernetes pod) but was absent at build time, the dev key silently enters `configParams` with no error thrown.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/next/src/config-dir/getI18NConfig.ts
   Line: 26-34

   Comment:
   **Missing dev-key production guard in primary path**

   The fallback path (no `_GENERALTRANSLATION_I18N_CONFIG_PARAMS`) correctly throws `devApiKeyIncludedInProductionError` when `devApiKey` is present in production. The primary path does not. Before this PR, the primary path read credentials from the build-time serialized config, so the guard in `config.ts` (which runs at build time) was sufficient. Now `getRuntimeCredentials()` is called at request time — if `GT_DEV_API_KEY` or `NEXT_PUBLIC_GT_DEV_API_KEY` is mistakenly set in a production runtime environment (e.g. a Kubernetes pod) but was absent at build time, the dev key silently enters `configParams` with no error thrown.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fnext%2Fsrc%2Fconfig-dir%2FgetI18NConfig.ts%0ALine%3A%2026-34%0A%0AComment%3A%0A**Missing%20dev-key%20production%20guard%20in%20primary%20path**%0A%0AThe%20fallback%20path%20%28no%20%60_GENERALTRANSLATION_I18N_CONFIG_PARAMS%60%29%20correctly%20throws%20%60devApiKeyIncludedInProductionError%60%20when%20%60devApiKey%60%20is%20present%20in%20production.%20The%20primary%20path%20does%20not.%20Before%20this%20PR%2C%20the%20primary%20path%20read%20credentials%20from%20the%20build-time%20serialized%20config%2C%20so%20the%20guard%20in%20%60config.ts%60%20%28which%20runs%20at%20build%20time%29%20was%20sufficient.%20Now%20%60getRuntimeCredentials%28%29%60%20is%20called%20at%20request%20time%20%E2%80%94%20if%20%60GT_DEV_API_KEY%60%20or%20%60NEXT_PUBLIC_GT_DEV_API_KEY%60%20is%20mistakenly%20set%20in%20a%20production%20runtime%20environment%20%28e.g.%20a%20Kubernetes%20pod%29%20but%20was%20absent%20at%20build%20time%2C%20the%20dev%20key%20silently%20enters%20%60configParams%60%20with%20no%20error%20thrown.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=generaltranslation%2Fgt&pr=1637&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fodysseus%2Fsanitize-next-env-config%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fodysseus%2Fsanitize-next-env-config%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fnext%2Fsrc%2Fconfig-dir%2FgetI18NConfig.ts%0ALine%3A%2026-34%0A%0AComment%3A%0A**Missing%20dev-key%20production%20guard%20in%20primary%20path**%0A%0AThe%20fallback%20path%20%28no%20%60_GENERALTRANSLATION_I18N_CONFIG_PARAMS%60%29%20correctly%20throws%20%60devApiKeyIncludedInProductionError%60%20when%20%60devApiKey%60%20is%20present%20in%20production.%20The%20primary%20path%20does%20not.%20Before%20this%20PR%2C%20the%20primary%20path%20read%20credentials%20from%20the%20build-time%20serialized%20config%2C%20so%20the%20guard%20in%20%60config.ts%60%20%28which%20runs%20at%20build%20time%29%20was%20sufficient.%20Now%20%60getRuntimeCredentials%28%29%60%20is%20called%20at%20request%20time%20%E2%80%94%20if%20%60GT_DEV_API_KEY%60%20or%20%60NEXT_PUBLIC_GT_DEV_API_KEY%60%20is%20mistakenly%20set%20in%20a%20production%20runtime%20environment%20%28e.g.%20a%20Kubernetes%20pod%29%20but%20was%20absent%20at%20build%20time%2C%20the%20dev%20key%20silently%20enters%20%60configParams%60%20with%20no%20error%20thrown.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=generaltranslation%2Fgt&pr=1637&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Apackages%2Fnext%2Fsrc%2Fconfig-dir%2FgetI18NConfig.ts%3A26-34%0A**Missing%20dev-key%20production%20guard%20in%20primary%20path**%0A%0AThe%20fallback%20path%20%28no%20%60_GENERALTRANSLATION_I18N_CONFIG_PARAMS%60%29%20correctly%20throws%20%60devApiKeyIncludedInProductionError%60%20when%20%60devApiKey%60%20is%20present%20in%20production.%20The%20primary%20path%20does%20not.%20Before%20this%20PR%2C%20the%20primary%20path%20read%20credentials%20from%20the%20build-time%20serialized%20config%2C%20so%20the%20guard%20in%20%60config.ts%60%20%28which%20runs%20at%20build%20time%29%20was%20sufficient.%20Now%20%60getRuntimeCredentials%28%29%60%20is%20called%20at%20request%20time%20%E2%80%94%20if%20%60GT_DEV_API_KEY%60%20or%20%60NEXT_PUBLIC_GT_DEV_API_KEY%60%20is%20mistakenly%20set%20in%20a%20production%20runtime%20environment%20%28e.g.%20a%20Kubernetes%20pod%29%20but%20was%20absent%20at%20build%20time%2C%20the%20dev%20key%20silently%20enters%20%60configParams%60%20with%20no%20error%20thrown.%0A%0A%23%23%23%20Issue%202%20of%203%0Apackages%2Fnext%2Fsrc%2Fconfig-dir%2Futils%2FruntimeCredentials.ts%3A7-13%0A**Both%20%60apiKey%60%20and%20%60devApiKey%60%20can%20now%20be%20set%20simultaneously**%0A%0AThe%20old%20credential-loading%20code%20%28in%20both%20%60config.ts%60%20and%20%60getI18NConfig.ts%60%29%20used%20the%20key%20prefix%20%28%60gt-api-%60%20vs%20%60gt-dev-%60%29%20to%20assign%20a%20value%20to%20either%20%60apiKey%60%20or%20%60devApiKey%60%2C%20never%20both.%20%60getRuntimeCredentials%60%20now%20returns%20both%20fields%20independently%20from%20separate%20env%20vars.%20If%20a%20developer%20has%20both%20%60GT_API_KEY%60%20and%20%60GT_DEV_API_KEY%60%20set%2C%20%60I18NConfiguration%60%20will%20receive%20both%20simultaneously.%20The%20existing%20tests%20don't%20exercise%20this%20scenario%20through%20the%20primary%20%60getI18NConfig%60%20path%20%28%60I18NConfigParams%60%20present%29%2C%20so%20it's%20unclear%20how%20%60I18NConfiguration%60%20handles%20conflicting%20keys.%0A%0A%23%23%23%20Issue%203%20of%203%0Apackages%2Fnext%2Fsrc%2Fconfig-dir%2FgetI18NConfig.ts%3A26-30%0A**%60getRuntimeCredentials%28%29%60%20spreads%20%60undefined%60%20values%2C%20shadowing%20defaults**%0A%0A%60getRuntimeCredentials%28%29%60%20returns%20%60%7B%20apiKey%3A%20undefined%2C%20devApiKey%3A%20undefined%2C%20projectId%3A%20undefined%20%7D%60%20for%20any%20unset%20env%20var.%20Spreading%20this%20last%20means%20those%20keys%20are%20explicitly%20set%20to%20%60undefined%60%20on%20%60configParams%60%2C%20overriding%20anything%20from%20%60defaultWithGTConfigProps%60.%20By%20contrast%2C%20%60config.ts%60%20uses%20%60getDefinedRuntimeCredentials%28%29%60%20%28filters%20out%20falsy%20values%29%20so%20props-based%20credentials%20survive%20when%20env%20vars%20are%20absent%20at%20build%20time.%20This%20intentional%20asymmetry%20means%20credentials%20passed%20as%20props%20to%20%60withGTConfig%60%20work%20at%20build%20time%20%28service-enable%20checks%20pass%29%20but%20are%20silently%20absent%20at%20runtime%20if%20the%20corresponding%20env%20vars%20are%20not%20set.%0A%0A&repo=generaltranslation%2Fgt&pr=1637&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fodysseus%2Fsanitize-next-env-config%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fodysseus%2Fsanitize-next-env-config%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Apackages%2Fnext%2Fsrc%2Fconfig-dir%2FgetI18NConfig.ts%3A26-34%0A**Missing%20dev-key%20production%20guard%20in%20primary%20path**%0A%0AThe%20fallback%20path%20%28no%20%60_GENERALTRANSLATION_I18N_CONFIG_PARAMS%60%29%20correctly%20throws%20%60devApiKeyIncludedInProductionError%60%20when%20%60devApiKey%60%20is%20present%20in%20production.%20The%20primary%20path%20does%20not.%20Before%20this%20PR%2C%20the%20primary%20path%20read%20credentials%20from%20the%20build-time%20serialized%20config%2C%20so%20the%20guard%20in%20%60config.ts%60%20%28which%20runs%20at%20build%20time%29%20was%20sufficient.%20Now%20%60getRuntimeCredentials%28%29%60%20is%20called%20at%20request%20time%20%E2%80%94%20if%20%60GT_DEV_API_KEY%60%20or%20%60NEXT_PUBLIC_GT_DEV_API_KEY%60%20is%20mistakenly%20set%20in%20a%20production%20runtime%20environment%20%28e.g.%20a%20Kubernetes%20pod%29%20but%20was%20absent%20at%20build%20time%2C%20the%20dev%20key%20silently%20enters%20%60configParams%60%20with%20no%20error%20thrown.%0A%0A%23%23%23%20Issue%202%20of%203%0Apackages%2Fnext%2Fsrc%2Fconfig-dir%2Futils%2FruntimeCredentials.ts%3A7-13%0A**Both%20%60apiKey%60%20and%20%60devApiKey%60%20can%20now%20be%20set%20simultaneously**%0A%0AThe%20old%20credential-loading%20code%20%28in%20both%20%60config.ts%60%20and%20%60getI18NConfig.ts%60%29%20used%20the%20key%20prefix%20%28%60gt-api-%60%20vs%20%60gt-dev-%60%29%20to%20assign%20a%20value%20to%20either%20%60apiKey%60%20or%20%60devApiKey%60%2C%20never%20both.%20%60getRuntimeCredentials%60%20now%20returns%20both%20fields%20independently%20from%20separate%20env%20vars.%20If%20a%20developer%20has%20both%20%60GT_API_KEY%60%20and%20%60GT_DEV_API_KEY%60%20set%2C%20%60I18NConfiguration%60%20will%20receive%20both%20simultaneously.%20The%20existing%20tests%20don't%20exercise%20this%20scenario%20through%20the%20primary%20%60getI18NConfig%60%20path%20%28%60I18NConfigParams%60%20present%29%2C%20so%20it's%20unclear%20how%20%60I18NConfiguration%60%20handles%20conflicting%20keys.%0A%0A%23%23%23%20Issue%203%20of%203%0Apackages%2Fnext%2Fsrc%2Fconfig-dir%2FgetI18NConfig.ts%3A26-30%0A**%60getRuntimeCredentials%28%29%60%20spreads%20%60undefined%60%20values%2C%20shadowing%20defaults**%0A%0A%60getRuntimeCredentials%28%29%60%20returns%20%60%7B%20apiKey%3A%20undefined%2C%20devApiKey%3A%20undefined%2C%20projectId%3A%20undefined%20%7D%60%20for%20any%20unset%20env%20var.%20Spreading%20this%20last%20means%20those%20keys%20are%20explicitly%20set%20to%20%60undefined%60%20on%20%60configParams%60%2C%20overriding%20anything%20from%20%60defaultWithGTConfigProps%60.%20By%20contrast%2C%20%60config.ts%60%20uses%20%60getDefinedRuntimeCredentials%28%29%60%20%28filters%20out%20falsy%20values%29%20so%20props-based%20credentials%20survive%20when%20env%20vars%20are%20absent%20at%20build%20time.%20This%20intentional%20asymmetry%20means%20credentials%20passed%20as%20props%20to%20%60withGTConfig%60%20work%20at%20build%20time%20%28service-enable%20checks%20pass%29%20but%20are%20silently%20absent%20at%20runtime%20if%20the%20corresponding%20env%20vars%20are%20not%20set.%0A%0A&repo=generaltranslation%2Fgt&pr=1637&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
packages/next/src/config-dir/getI18NConfig.ts:26-34
**Missing dev-key production guard in primary path**

The fallback path (no `_GENERALTRANSLATION_I18N_CONFIG_PARAMS`) correctly throws `devApiKeyIncludedInProductionError` when `devApiKey` is present in production. The primary path does not. Before this PR, the primary path read credentials from the build-time serialized config, so the guard in `config.ts` (which runs at build time) was sufficient. Now `getRuntimeCredentials()` is called at request time — if `GT_DEV_API_KEY` or `NEXT_PUBLIC_GT_DEV_API_KEY` is mistakenly set in a production runtime environment (e.g. a Kubernetes pod) but was absent at build time, the dev key silently enters `configParams` with no error thrown.

### Issue 2 of 3
packages/next/src/config-dir/utils/runtimeCredentials.ts:7-13
**Both `apiKey` and `devApiKey` can now be set simultaneously**

The old credential-loading code (in both `config.ts` and `getI18NConfig.ts`) used the key prefix (`gt-api-` vs `gt-dev-`) to assign a value to either `apiKey` or `devApiKey`, never both. `getRuntimeCredentials` now returns both fields independently from separate env vars. If a developer has both `GT_API_KEY` and `GT_DEV_API_KEY` set, `I18NConfiguration` will receive both simultaneously. The existing tests don't exercise this scenario through the primary `getI18NConfig` path (`I18NConfigParams` present), so it's unclear how `I18NConfiguration` handles conflicting keys.

### Issue 3 of 3
packages/next/src/config-dir/getI18NConfig.ts:26-30
**`getRuntimeCredentials()` spreads `undefined` values, shadowing defaults**

`getRuntimeCredentials()` returns `{ apiKey: undefined, devApiKey: undefined, projectId: undefined }` for any unset env var. Spreading this last means those keys are explicitly set to `undefined` on `configParams`, overriding anything from `defaultWithGTConfigProps`. By contrast, `config.ts` uses `getDefinedRuntimeCredentials()` (filters out falsy values) so props-based credentials survive when env vars are absent at build time. This intentional asymmetry means credentials passed as props to `withGTConfig` work at build time (service-enable checks pass) but are silently absent at runtime if the corresponding env vars are not set.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: keep gt-next runtime credentials ou..."](https://github.com/generaltranslation/gt/commit/b060bb2ebd2bebd3c621c931afab10be7ef1eb52) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39192334)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->