### PR TITLE
fix: persist browser locale selections

### DIFF
--- a/packages/react/src/provider/BrowserGTProvider.tsx
+++ b/packages/react/src/provider/BrowserGTProvider.tsx
@@ -4,7 +4,7 @@ import {
 } from '@generaltranslation/react-core/components';
 import { useMemo, useRef } from 'react';
 import type { SharedGTProviderProps } from './GTProviderProps';
-import { ReadonlyBrowserConditionStore } from '../condition-store/ReadOnlyBrowserConditionStore';
+import { BrowserConditionStore } from '../condition-store/BrowserConditionStore';
 
 /**
  * Consumes snapshot from server
@@ -12,7 +12,7 @@ import { ReadonlyBrowserConditionStore } from '../condition-store/ReadOnlyBrowse
  */
 export function BrowserGTProvider(props: SharedGTProviderProps) {
   const conditionStore = useMemo(() => {
-    return new ReadonlyBrowserConditionStore(props);
+    return new BrowserConditionStore(props);
   }, [props.locale, props.region, props.enableI18n, props._reload]);
 
   const i18nStoreRef = useRef<I18nStore | null>(null);

--- a/packages/react/src/provider/__tests__/BrowserGTProvider.test.tsx
+++ b/packages/react/src/provider/__tests__/BrowserGTProvider.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+
+const mockBrowserConditionStore = vi.hoisted(() => vi.fn());
+
+vi.mock('../../condition-store/BrowserConditionStore', () => ({
+  BrowserConditionStore: class {
+    constructor(config: unknown) {
+      mockBrowserConditionStore(config);
+    }
+
+    getLocale = () => 'fr';
+    setLocale = () => {};
+    getRegion = () => undefined;
+    setRegion = () => {};
+    getEnableI18n = () => true;
+    setEnableI18n = () => {};
+  },
+}));
+
+vi.mock('../../condition-store/ReadOnlyBrowserConditionStore', () => ({
+  ReadonlyBrowserConditionStore: class {
+    constructor() {
+      throw new Error('ReadonlyBrowserConditionStore should not be used');
+    }
+  },
+}));
+
+describe('BrowserGTProvider', () => {
+  it('uses the writable browser condition store', async () => {
+    const { BrowserGTProvider } = await import('../BrowserGTProvider');
+
+    renderToStaticMarkup(
+      <BrowserGTProvider locale='fr' translations={{ fr: {} }}>
+        <span>content</span>
+      </BrowserGTProvider>
+    );
+
+    expect(mockBrowserConditionStore).toHaveBeenCalledWith(
+      expect.objectContaining({
+        locale: 'fr',
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- switch the browser GT provider to use the writable browser condition store
- add a regression test for the provider-store wiring

## Testing
- `pnpm --filter gt-tanstack-start... build`
- `pnpm --filter gt-react test`
- `pnpm --filter gt-tanstack-start test`
- `pnpm --filter gt-tanstack-start typecheck`
- `pnpm lint`

Note: `pnpm --filter gt-react typecheck` still fails on the existing `ImportMeta.env` type error in `packages/react/src/i18n-cache/BrowserI18nCache.ts`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1638"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784774007&installation_id=127936663&pr_number=1638&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1638&signature=36366ff3dbda2cf4dcfdd707d27c17aebcd7d8beb8d59c7abbe3702225635653"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Switches `BrowserGTProvider` from `ReadonlyBrowserConditionStore` (which stored locale in memory and never reflected cookie updates within the same mount) to `BrowserConditionStore` (which reads locale from the cookie on every `getLocale()` call), so that client-initiated locale changes are persisted across re-renders without requiring a full page reload.

- **`BrowserGTProvider.tsx`**: One-line constructor change; the writable `BrowserConditionStore` now backs the provider, fixing locale persistence. The `useMemo` dependency array is unchanged.
- **`BrowserGTProvider.test.tsx`**: New test that asserts `BrowserConditionStore` is constructed with the correct props and that the old `ReadonlyBrowserConditionStore` is never instantiated (serves as a regression guard).

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The locale-persistence fix is correct, but the store swap silently drops the enableI18n initialisation that the old store provided, so a consumer passing enableI18n={false} will find i18n unexpectedly active on first mount.

The core locale-persistence mechanism is sound — BrowserConditionStore reads from cookies rather than memory, so user selections survive re-renders. However, the old ReadonlyBrowserConditionStore wrote config.enableI18n to the cookie in its constructor; BrowserConditionStore does not. Any first-time visitor who is served enableI18n=false via props will get getEnableI18n() === true until they set the cookie themselves, meaning the feature-flag prop is silently ignored on first mount.

packages/react/src/provider/BrowserGTProvider.tsx — verify whether BrowserConditionStore needs to initialise the enableI18n cookie from props, mirroring what ReadonlyBrowserConditionStore did.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react/src/provider/BrowserGTProvider.tsx | Swaps ReadonlyBrowserConditionStore for BrowserConditionStore so locale selections are read from cookies rather than memory; introduces a regression where enableI18n=false is not written to the cookie on first mount. |
| packages/react/src/provider/__tests__/BrowserGTProvider.test.tsx | New regression test that verifies the provider constructs a BrowserConditionStore (not the old ReadonlyBrowserConditionStore) with the correct props; correct and well-structured. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Server
    participant BrowserGTProvider
    participant BrowserConditionStore
    participant Cookie

    Server->>BrowserGTProvider: "render(props.locale='en')"
    BrowserGTProvider->>BrowserConditionStore: new BrowserConditionStore(props)
    BrowserConditionStore->>Cookie: "setCookieValue(locale='en')"
    Note over BrowserConditionStore: enableI18n NOT written to cookie

    BrowserGTProvider->>BrowserConditionStore: getLocale()
    BrowserConditionStore->>Cookie: getCookieValue(locale)
    Cookie-->>BrowserConditionStore: 'en'
    BrowserConditionStore-->>BrowserGTProvider: 'en'

    Note over BrowserGTProvider: User changes locale
    BrowserGTProvider->>BrowserConditionStore: setLocale('fr')
    BrowserConditionStore->>Cookie: "setCookieValue(locale='fr')"
    BrowserConditionStore->>BrowserGTProvider: reload()

    Note over BrowserGTProvider: After reload, server reads cookie
    Server->>BrowserGTProvider: "render(props.locale='fr')"
    BrowserGTProvider->>BrowserConditionStore: new BrowserConditionStore(props)
    BrowserConditionStore->>Cookie: "setCookieValue(locale='fr')"
    BrowserGTProvider->>BrowserConditionStore: getLocale()
    BrowserConditionStore->>Cookie: getCookieValue(locale)
    Cookie-->>BrowserConditionStore: 'fr'
    BrowserConditionStore-->>BrowserGTProvider: 'fr'
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Server
    participant BrowserGTProvider
    participant BrowserConditionStore
    participant Cookie

    Server->>BrowserGTProvider: "render(props.locale='en')"
    BrowserGTProvider->>BrowserConditionStore: new BrowserConditionStore(props)
    BrowserConditionStore->>Cookie: "setCookieValue(locale='en')"
    Note over BrowserConditionStore: enableI18n NOT written to cookie

    BrowserGTProvider->>BrowserConditionStore: getLocale()
    BrowserConditionStore->>Cookie: getCookieValue(locale)
    Cookie-->>BrowserConditionStore: 'en'
    BrowserConditionStore-->>BrowserGTProvider: 'en'

    Note over BrowserGTProvider: User changes locale
    BrowserGTProvider->>BrowserConditionStore: setLocale('fr')
    BrowserConditionStore->>Cookie: "setCookieValue(locale='fr')"
    BrowserConditionStore->>BrowserGTProvider: reload()

    Note over BrowserGTProvider: After reload, server reads cookie
    Server->>BrowserGTProvider: "render(props.locale='fr')"
    BrowserGTProvider->>BrowserConditionStore: new BrowserConditionStore(props)
    BrowserConditionStore->>Cookie: "setCookieValue(locale='fr')"
    BrowserGTProvider->>BrowserConditionStore: getLocale()
    BrowserConditionStore->>Cookie: getCookieValue(locale)
    Cookie-->>BrowserConditionStore: 'fr'
    BrowserConditionStore-->>BrowserGTProvider: 'fr'
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Freact%2Fsrc%2Fprovider%2FBrowserGTProvider.tsx%3A14-16%0A**%60enableI18n%60%20prop%20not%20persisted%20to%20cookie%20on%20first%20mount**%0A%0A%60BrowserConditionStore%60's%20constructor%20initialises%20the%20locale%20and%20region%20cookies%20from%20%60config%60%2C%20but%20it%20never%20writes%20%60enableI18n%60%20to%20the%20cookie.%20%60getEnableI18n%28%29%60%20reads%20the%20cookie%20on%20every%20call%3B%20when%20no%20cookie%20has%20been%20set%20yet%20it%20falls%20back%20to%20%60customGetEnableI18n%3F.%28%29%20%3F%3F%20true%60.%20As%20a%20result%2C%20if%20a%20consumer%20passes%20%60enableI18n%3D%7Bfalse%7D%60%20to%20%60BrowserGTProvider%60%20on%20the%20very%20first%20render%20%28before%20the%20user%20has%20ever%20toggled%20that%20setting%20themselves%29%2C%20%60getEnableI18n%28%29%60%20returns%20%60true%60%20and%20i18n%20is%20silently%20left%20enabled.%0A%0AThe%20old%20%60ReadonlyBrowserConditionStore%60%20constructor%20explicitly%20wrote%20%60config.enableI18n%60%20to%20the%20cookie%20%28%60setCookieValue%28%7B%20cookieName%3A%20this.enableI18nCookieName%2C%20value%3A%20%E2%80%A6%20%7D%29%60%29%2C%20so%20this%20is%20a%20regression%20introduced%20by%20the%20store%20swap.%0A%0A&repo=generaltranslation%2Fgt&pr=1638&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fodysseus%2Fwritable-browser-locale-store%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fodysseus%2Fwritable-browser-locale-store%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Freact%2Fsrc%2Fprovider%2FBrowserGTProvider.tsx%3A14-16%0A**%60enableI18n%60%20prop%20not%20persisted%20to%20cookie%20on%20first%20mount**%0A%0A%60BrowserConditionStore%60's%20constructor%20initialises%20the%20locale%20and%20region%20cookies%20from%20%60config%60%2C%20but%20it%20never%20writes%20%60enableI18n%60%20to%20the%20cookie.%20%60getEnableI18n%28%29%60%20reads%20the%20cookie%20on%20every%20call%3B%20when%20no%20cookie%20has%20been%20set%20yet%20it%20falls%20back%20to%20%60customGetEnableI18n%3F.%28%29%20%3F%3F%20true%60.%20As%20a%20result%2C%20if%20a%20consumer%20passes%20%60enableI18n%3D%7Bfalse%7D%60%20to%20%60BrowserGTProvider%60%20on%20the%20very%20first%20render%20%28before%20the%20user%20has%20ever%20toggled%20that%20setting%20themselves%29%2C%20%60getEnableI18n%28%29%60%20returns%20%60true%60%20and%20i18n%20is%20silently%20left%20enabled.%0A%0AThe%20old%20%60ReadonlyBrowserConditionStore%60%20constructor%20explicitly%20wrote%20%60config.enableI18n%60%20to%20the%20cookie%20%28%60setCookieValue%28%7B%20cookieName%3A%20this.enableI18nCookieName%2C%20value%3A%20%E2%80%A6%20%7D%29%60%29%2C%20so%20this%20is%20a%20regression%20introduced%20by%20the%20store%20swap.%0A%0A&repo=generaltranslation%2Fgt&pr=1638&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/react/src/provider/BrowserGTProvider.tsx:14-16
**`enableI18n` prop not persisted to cookie on first mount**

`BrowserConditionStore`'s constructor initialises the locale and region cookies from `config`, but it never writes `enableI18n` to the cookie. `getEnableI18n()` reads the cookie on every call; when no cookie has been set yet it falls back to `customGetEnableI18n?.() ?? true`. As a result, if a consumer passes `enableI18n={false}` to `BrowserGTProvider` on the very first render (before the user has ever toggled that setting themselves), `getEnableI18n()` returns `true` and i18n is silently left enabled.

The old `ReadonlyBrowserConditionStore` constructor explicitly wrote `config.enableI18n` to the cookie (`setCookieValue({ cookieName: this.enableI18nCookieName, value: … })`), so this is a regression introduced by the store swap.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: persist browser locale selections"](https://github.com/generaltranslation/gt/commit/86d687e89f8678f06fc73ed5bf2e4a0e8bf19ea7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39197280)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->