### PR TITLE
fix: skip file enqueue using lockfile

### DIFF
--- a/.changeset/eager-tables-battle.md
+++ b/.changeset/eager-tables-battle.md
@@ -1,0 +1,5 @@
+---
+"gt": patch
+---
+
+Use `gt-lock.json` to skip enqueue step

--- a/packages/cli/src/fs/config/__tests__/downloadedVersions.test.ts
+++ b/packages/cli/src/fs/config/__tests__/downloadedVersions.test.ts
@@ -176,6 +176,7 @@ describe('readLockfile / writeLockfile', () => {
                 ja: {
                   updatedAt: '2025-01-01T00:00:00Z',
                   postProcessHash: 'hash123',
+                  fileName: 'locales/ja/file.json',
                 },
               },
             },
@@ -191,6 +192,9 @@ describe('readLockfile / writeLockfile', () => {
       expect(data.entries[0].fileId).toBe('file1');
       expect(data.entries[0].versionId).toBe('ver1');
       expect(data.entries[0].translations.ja.postProcessHash).toBe('hash123');
+      expect(data.entries[0].translations.ja.fileName).toBe(
+        'locales/ja/file.json'
+      );
       expect(originalV1).not.toBeNull();
     });
 

--- a/packages/cli/src/fs/config/__tests__/downloadedVersions.test.ts
+++ b/packages/cli/src/fs/config/__tests__/downloadedVersions.test.ts
@@ -93,6 +93,79 @@ describe('readLockfile / writeLockfile', () => {
       expect(data.branchId).toBe('brc_new');
     });
 
+    it('returns empty v2 when strict branch does not match v2 lockfile', () => {
+      writeLockFile({
+        version: 2,
+        branchId: 'brc_old',
+        entries: [
+          {
+            fileId: 'f1',
+            versionId: 'v1',
+            translations: {
+              es: { updatedAt: '2025-01-01T00:00:00Z' },
+            },
+          },
+        ],
+      });
+
+      const { data } = readLockfile(settings('brc_new'), {
+        branchId: 'brc_new',
+        strictBranch: true,
+      });
+
+      expect(data.branchId).toBe('brc_new');
+      expect(data.entries).toEqual([]);
+    });
+
+    it('accepts empty v2 branchId in strict mode when allowed', () => {
+      writeLockFile({
+        version: 2,
+        branchId: '',
+        entries: [
+          {
+            fileId: 'f1',
+            versionId: 'v1',
+            translations: {
+              es: { updatedAt: '2025-01-01T00:00:00Z' },
+            },
+          },
+        ],
+      });
+
+      const { data } = readLockfile(settings('brc_new'), {
+        branchId: 'brc_new',
+        strictBranch: true,
+        allowEmptyBranchId: true,
+      });
+
+      expect(data.branchId).toBe('brc_new');
+      expect(data.entries).toHaveLength(1);
+    });
+
+    it('uses the explicit read branchId over settings._branchId', () => {
+      writeLockFile({
+        version: 2,
+        branchId: 'brc_requested',
+        entries: [
+          {
+            fileId: 'f1',
+            versionId: 'v1',
+            translations: {
+              es: { updatedAt: '2025-01-01T00:00:00Z' },
+            },
+          },
+        ],
+      });
+
+      const { data } = readLockfile(settings('brc_settings'), {
+        branchId: 'brc_requested',
+        strictBranch: true,
+      });
+
+      expect(data.branchId).toBe('brc_requested');
+      expect(data.entries).toHaveLength(1);
+    });
+
     it('converts v1 lockfile to v2 for the current branch', () => {
       writeLockFile({
         version: 1,

--- a/packages/cli/src/fs/config/downloadedVersions.ts
+++ b/packages/cli/src/fs/config/downloadedVersions.ts
@@ -49,6 +49,12 @@ export type DownloadedVersionsV1 = {
   };
 };
 
+export type ReadLockfileOptions = {
+  branchId?: string;
+  strictBranch?: boolean;
+  allowEmptyBranchId?: boolean;
+};
+
 // ── Conversion helpers ──────────────────────────────────────────────
 
 function convertV1ToV2(
@@ -135,12 +141,15 @@ function convertV2ToV1Branch(
  * If the file is v1, `originalV1` contains the full v1 data so that
  * `writeLockfile` can merge changes back without losing other branches.
  */
-export function readLockfile(settings: Settings): {
+export function readLockfile(
+  settings: Settings,
+  options: ReadLockfileOptions = {}
+): {
   data: DownloadedVersions;
   entryMap: EntryMap;
   originalV1: DownloadedVersionsV1 | null;
 } {
-  let branchId = settings._branchId ?? '';
+  let branchId = options.branchId ?? settings._branchId ?? '';
 
   let data: DownloadedVersions;
   let originalV1: DownloadedVersionsV1 | null = null;
@@ -154,11 +163,20 @@ export function readLockfile(settings: Settings): {
       if (!raw || typeof raw !== 'object' || !raw.entries) {
         data = { version: 2, branchId, entries: [] };
       } else if (raw.version === 2 && Array.isArray(raw.entries)) {
-        data = raw as DownloadedVersions;
-        if (branchId) data.branchId = branchId;
+        const rawBranchId = typeof raw.branchId === 'string' ? raw.branchId : '';
+        if (
+          options.strictBranch &&
+          rawBranchId !== branchId &&
+          !(options.allowEmptyBranchId && rawBranchId === '')
+        ) {
+          data = { version: 2, branchId, entries: [] };
+        } else {
+          data = raw as DownloadedVersions;
+          if (branchId) data.branchId = branchId;
+        }
       } else {
         originalV1 = raw as DownloadedVersionsV1;
-        if (!branchId) {
+        if (!branchId && !options.strictBranch) {
           const branches = Object.keys(originalV1.entries);
           if (branches.length > 0) branchId = branches[0];
         }
@@ -168,55 +186,6 @@ export function readLockfile(settings: Settings): {
   } catch (error) {
     logger.error(`An error occurred while reading ${GT_LOCK_FILE}: ${error}`);
     data = { version: 2, branchId, entries: [] };
-  }
-
-  return { data, entryMap: buildEntryMap(data.entries), originalV1 };
-}
-
-/**
- * Reads lockfile entries for one exact branch.
- *
- * Unlike `readLockfile`, this does not rewrite a v2 lockfile's branch id to
- * match settings. That makes it suitable for cache decisions where entries from
- * another branch must not be treated as current.
- */
-export function readLockfileForBranch(
-  branchId: string,
-  options: { allowEmptyBranchId?: boolean } = {}
-): {
-  data: DownloadedVersions;
-  entryMap: EntryMap;
-  originalV1: DownloadedVersionsV1 | null;
-} {
-  let data: DownloadedVersions = { version: 2, branchId, entries: [] };
-  let originalV1: DownloadedVersionsV1 | null = null;
-
-  try {
-    const rootPath = path.join(process.cwd(), GT_LOCK_FILE);
-    if (!fs.existsSync(rootPath)) {
-      return { data, entryMap: buildEntryMap(data.entries), originalV1 };
-    }
-
-    const raw = JSON.parse(fs.readFileSync(rootPath, 'utf8'));
-    if (!raw || typeof raw !== 'object' || !raw.entries) {
-      return { data, entryMap: buildEntryMap(data.entries), originalV1 };
-    }
-
-    if (raw.version === 2 && Array.isArray(raw.entries)) {
-      if (
-        raw.branchId !== branchId &&
-        !(options.allowEmptyBranchId && raw.branchId === '')
-      ) {
-        return { data, entryMap: buildEntryMap(data.entries), originalV1 };
-      }
-      data = raw as DownloadedVersions;
-      data.branchId = branchId;
-    } else {
-      originalV1 = raw as DownloadedVersionsV1;
-      data = convertV1ToV2(originalV1, branchId);
-    }
-  } catch (error) {
-    logger.error(`An error occurred while reading ${GT_LOCK_FILE}: ${error}`);
   }
 
   return { data, entryMap: buildEntryMap(data.entries), originalV1 };

--- a/packages/cli/src/fs/config/downloadedVersions.ts
+++ b/packages/cli/src/fs/config/downloadedVersions.ts
@@ -174,6 +174,55 @@ export function readLockfile(settings: Settings): {
 }
 
 /**
+ * Reads lockfile entries for one exact branch.
+ *
+ * Unlike `readLockfile`, this does not rewrite a v2 lockfile's branch id to
+ * match settings. That makes it suitable for cache decisions where entries from
+ * another branch must not be treated as current.
+ */
+export function readLockfileForBranch(
+  branchId: string,
+  options: { allowEmptyBranchId?: boolean } = {}
+): {
+  data: DownloadedVersions;
+  entryMap: EntryMap;
+  originalV1: DownloadedVersionsV1 | null;
+} {
+  let data: DownloadedVersions = { version: 2, branchId, entries: [] };
+  let originalV1: DownloadedVersionsV1 | null = null;
+
+  try {
+    const rootPath = path.join(process.cwd(), GT_LOCK_FILE);
+    if (!fs.existsSync(rootPath)) {
+      return { data, entryMap: buildEntryMap(data.entries), originalV1 };
+    }
+
+    const raw = JSON.parse(fs.readFileSync(rootPath, 'utf8'));
+    if (!raw || typeof raw !== 'object' || !raw.entries) {
+      return { data, entryMap: buildEntryMap(data.entries), originalV1 };
+    }
+
+    if (raw.version === 2 && Array.isArray(raw.entries)) {
+      if (
+        raw.branchId !== branchId &&
+        !(options.allowEmptyBranchId && raw.branchId === '')
+      ) {
+        return { data, entryMap: buildEntryMap(data.entries), originalV1 };
+      }
+      data = raw as DownloadedVersions;
+      data.branchId = branchId;
+    } else {
+      originalV1 = raw as DownloadedVersionsV1;
+      data = convertV1ToV2(originalV1, branchId);
+    }
+  } catch (error) {
+    logger.error(`An error occurred while reading ${GT_LOCK_FILE}: ${error}`);
+  }
+
+  return { data, entryMap: buildEntryMap(data.entries), originalV1 };
+}
+
+/**
  * Writes the lockfile. If `originalV1` is provided, merges the current
  * branch's data back into the v1 structure (preserving other branches)
  * and writes v1 format. Otherwise writes v2.

--- a/packages/cli/src/fs/config/downloadedVersions.ts
+++ b/packages/cli/src/fs/config/downloadedVersions.ts
@@ -163,7 +163,8 @@ export function readLockfile(
       if (!raw || typeof raw !== 'object' || !raw.entries) {
         data = { version: 2, branchId, entries: [] };
       } else if (raw.version === 2 && Array.isArray(raw.entries)) {
-        const rawBranchId = typeof raw.branchId === 'string' ? raw.branchId : '';
+        const rawBranchId =
+          typeof raw.branchId === 'string' ? raw.branchId : '';
         if (
           options.strictBranch &&
           rawBranchId !== branchId &&

--- a/packages/cli/src/fs/config/downloadedVersions.ts
+++ b/packages/cli/src/fs/config/downloadedVersions.ts
@@ -95,6 +95,7 @@ function convertV1ToV2(
         ...(entry.postProcessHash
           ? { postProcessHash: entry.postProcessHash }
           : {}),
+        ...(entry.fileName ? { fileName: entry.fileName } : {}),
       };
     }
 

--- a/packages/cli/src/workflows/__tests__/download.test.ts
+++ b/packages/cli/src/workflows/__tests__/download.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import path from 'node:path';
+import { downloadFileBatch } from '../../api/downloadFileBatch.js';
+import { createMockSettings } from '../../api/__mocks__/settings.js';
+import { clearLocaleDirs } from '../../fs/clearLocaleDirs.js';
+import type { BranchData } from '../../types/branch.js';
+import type { Settings } from '../../types/index.js';
+import { gt } from '../../utils/gt.js';
+import { runDownloadWorkflow } from '../download.js';
+
+vi.mock('../../utils/gt.js', () => ({
+  gt: {
+    queryFileData: vi.fn(),
+    resolveAliasLocale: vi.fn((locale: string) => locale),
+  },
+}));
+
+vi.mock('../../fs/clearLocaleDirs.js', () => ({
+  clearLocaleDirs: vi.fn(),
+}));
+
+vi.mock('../../api/downloadFileBatch.js', () => ({
+  downloadFileBatch: vi.fn(),
+}));
+
+vi.mock('../../console/logger.js', () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    createProgressBar: vi.fn(() => ({
+      start: vi.fn(),
+      stop: vi.fn(),
+      advance: vi.fn(),
+    })),
+    createSpinner: vi.fn(() => ({
+      start: vi.fn(),
+      stop: vi.fn(),
+    })),
+  },
+}));
+
+describe('runDownloadWorkflow', () => {
+  const branchData: BranchData = {
+    currentBranch: { id: 'branch-1', name: 'main' },
+    incomingBranch: null,
+    checkedOutBranch: null,
+  };
+
+  const settings = createMockSettings({
+    config: path.join('/tmp/project', 'gt.config.json'),
+    locales: ['es'],
+    options: {
+      experimentalClearLocaleDirs: true,
+    },
+  }) as Settings;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(downloadFileBatch).mockResolvedValue({
+      successful: [],
+      failed: [],
+      skipped: [],
+    });
+  });
+
+  it('does not clear locale directories for translations that are not completed', async () => {
+    vi.mocked(gt.queryFileData).mockResolvedValue({
+      translatedFiles: [],
+    });
+
+    await runDownloadWorkflow({
+      fileVersionData: {
+        'file-1': {
+          versionId: 'version-1',
+          fileName: 'messages/en.json',
+        },
+      },
+      jobData: {
+        jobData: {},
+        locales: ['es'],
+        message: '',
+      },
+      branchData,
+      locales: ['es'],
+      timeoutDuration: 1,
+      resolveOutputPath: () => 'messages/es.json',
+      options: settings,
+    });
+
+    expect(clearLocaleDirs).not.toHaveBeenCalled();
+    expect(downloadFileBatch).not.toHaveBeenCalled();
+  });
+
+  it('clears locale directories after translations are confirmed completed', async () => {
+    vi.mocked(gt.queryFileData).mockResolvedValue({
+      translatedFiles: [
+        {
+          branchId: 'branch-1',
+          fileId: 'file-1',
+          versionId: 'version-1',
+          locale: 'es',
+          completedAt: '2026-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    await runDownloadWorkflow({
+      fileVersionData: {
+        'file-1': {
+          versionId: 'version-1',
+          fileName: 'messages/en.json',
+        },
+      },
+      jobData: {
+        jobData: {},
+        locales: ['es'],
+        message: '',
+      },
+      branchData,
+      locales: ['es'],
+      timeoutDuration: 1,
+      resolveOutputPath: () => 'messages/es.json',
+      options: settings,
+    });
+
+    expect(clearLocaleDirs).toHaveBeenCalledTimes(1);
+    expect(clearLocaleDirs).toHaveBeenCalledWith(
+      new Set(['messages/es.json']),
+      ['es'],
+      undefined,
+      '/tmp/project'
+    );
+    expect(downloadFileBatch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/cli/src/workflows/__tests__/filterFilesForEnqueue.test.ts
+++ b/packages/cli/src/workflows/__tests__/filterFilesForEnqueue.test.ts
@@ -6,7 +6,7 @@ import type { FileReference } from 'generaltranslation/types';
 import { createMockSettings } from '../../api/__mocks__/settings.js';
 import type { BranchData } from '../../types/branch.js';
 import type { Settings } from '../../types/index.js';
-import { filterFilesForEnqueue } from '../filterFilesForEnqueue.js';
+import { filterFilesForEnqueue } from '../utils/filterFilesForEnqueue.js';
 
 describe('filterFilesForEnqueue', () => {
   const originalCwd = process.cwd();

--- a/packages/cli/src/workflows/__tests__/filterFilesForEnqueue.test.ts
+++ b/packages/cli/src/workflows/__tests__/filterFilesForEnqueue.test.ts
@@ -80,6 +80,35 @@ describe('filterFilesForEnqueue', () => {
     );
   }
 
+  function writeV1Lockfile(): void {
+    fs.writeFileSync(
+      path.join(tempDir, 'gt-lock.json'),
+      JSON.stringify(
+        {
+          version: 1,
+          entries: {
+            'branch-1': {
+              'file-1': {
+                'version-1': {
+                  es: {
+                    updatedAt: '2026-01-01T00:00:00.000Z',
+                    fileName: 'messages/es.json',
+                  },
+                  fr: {
+                    updatedAt: '2026-01-01T00:00:00.000Z',
+                    fileName: 'messages/fr.json',
+                  },
+                },
+              },
+            },
+          },
+        },
+        null,
+        2
+      )
+    );
+  }
+
   beforeEach(() => {
     tempDir = fs.realpathSync(
       fs.mkdtempSync(path.join(os.tmpdir(), 'enqueue-filter-'))
@@ -98,6 +127,19 @@ describe('filterFilesForEnqueue', () => {
 
   it('skips enqueue when the current branch lockfile has every locale locally', () => {
     writeLockfile();
+
+    const result = filterFilesForEnqueue({
+      files: [file],
+      settings: settings(),
+      branchData,
+    });
+
+    expect(result.filesToEnqueue).toEqual([]);
+    expect(result.skippedFiles).toEqual([file]);
+  });
+
+  it('skips enqueue when a v1 lockfile has every locale locally', () => {
+    writeV1Lockfile();
 
     const result = filterFilesForEnqueue({
       files: [file],

--- a/packages/cli/src/workflows/__tests__/filterFilesForEnqueue.test.ts
+++ b/packages/cli/src/workflows/__tests__/filterFilesForEnqueue.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { FileReference } from 'generaltranslation/types';
+import { createMockSettings } from '../../api/__mocks__/settings.js';
+import type { BranchData } from '../../types/branch.js';
+import type { Settings } from '../../types/index.js';
+import { filterFilesForEnqueue } from '../filterFilesForEnqueue.js';
+
+describe('filterFilesForEnqueue', () => {
+  const originalCwd = process.cwd();
+  let tempDir: string;
+
+  const branchData: BranchData = {
+    currentBranch: { id: 'branch-1', name: 'main' },
+    incomingBranch: null,
+    checkedOutBranch: null,
+  };
+
+  const file: FileReference = {
+    branchId: 'branch-1',
+    fileId: 'file-1',
+    versionId: 'version-1',
+    fileName: 'messages/en.json',
+    fileFormat: 'JSON',
+  };
+
+  function settings(): Settings {
+    return createMockSettings({
+      defaultLocale: 'en',
+      locales: ['es', 'fr'],
+      files: {
+        resolvedPaths: {
+          json: [path.join(tempDir, 'messages/en.json')],
+        },
+        placeholderPaths: {
+          json: [path.join(tempDir, 'messages/[locale].json')],
+        },
+        transformPaths: {},
+        transformFormats: {},
+        publishPaths: new Set(),
+        unpublishPaths: new Set(),
+        parsingFlags: {},
+        gtJson: {
+          parsingFlags: {},
+        },
+      },
+    });
+  }
+
+  function writeLockfile(branchId = 'branch-1'): void {
+    fs.writeFileSync(
+      path.join(tempDir, 'gt-lock.json'),
+      JSON.stringify(
+        {
+          version: 2,
+          branchId,
+          entries: [
+            {
+              fileId: 'file-1',
+              versionId: 'version-1',
+              fileName: 'messages/en.json',
+              translations: {
+                es: {
+                  updatedAt: '2026-01-01T00:00:00.000Z',
+                  fileName: 'messages/es.json',
+                },
+                fr: {
+                  updatedAt: '2026-01-01T00:00:00.000Z',
+                  fileName: 'messages/fr.json',
+                },
+              },
+            },
+          ],
+        },
+        null,
+        2
+      )
+    );
+  }
+
+  beforeEach(() => {
+    tempDir = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'enqueue-filter-'))
+    );
+    process.chdir(tempDir);
+    fs.mkdirSync(path.join(tempDir, 'messages'), { recursive: true });
+    fs.writeFileSync(path.join(tempDir, 'messages/en.json'), '{}');
+    fs.writeFileSync(path.join(tempDir, 'messages/es.json'), '{}');
+    fs.writeFileSync(path.join(tempDir, 'messages/fr.json'), '{}');
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('skips enqueue when the current branch lockfile has every locale locally', () => {
+    writeLockfile();
+
+    const result = filterFilesForEnqueue({
+      files: [file],
+      settings: settings(),
+      branchData,
+    });
+
+    expect(result.filesToEnqueue).toEqual([]);
+    expect(result.skippedFiles).toEqual([file]);
+  });
+
+  it('enqueues when the lockfile belongs to a different branch', () => {
+    writeLockfile('branch-2');
+
+    const result = filterFilesForEnqueue({
+      files: [file],
+      settings: settings(),
+      branchData,
+    });
+
+    expect(result.filesToEnqueue).toEqual([file]);
+    expect(result.skippedFiles).toEqual([]);
+  });
+
+  it('uses legacy empty-branch lockfiles when branching is disabled', () => {
+    writeLockfile('');
+
+    const result = filterFilesForEnqueue({
+      files: [file],
+      settings: settings(),
+      branchData,
+    });
+
+    expect(result.filesToEnqueue).toEqual([]);
+    expect(result.skippedFiles).toEqual([file]);
+  });
+
+  it('does not use legacy empty-branch lockfiles when branching is enabled', () => {
+    writeLockfile('');
+
+    const result = filterFilesForEnqueue({
+      files: [file],
+      settings: createMockSettings({
+        ...settings(),
+        branchOptions: {
+          enabled: true,
+          currentBranch: 'main',
+          autoDetectBranches: false,
+          remoteName: 'origin',
+        },
+      }),
+      branchData,
+    });
+
+    expect(result.filesToEnqueue).toEqual([file]);
+    expect(result.skippedFiles).toEqual([]);
+  });
+
+  it('enqueues when any target locale output is missing locally', () => {
+    writeLockfile();
+    fs.rmSync(path.join(tempDir, 'messages/fr.json'));
+
+    const result = filterFilesForEnqueue({
+      files: [file],
+      settings: settings(),
+      branchData,
+    });
+
+    expect(result.filesToEnqueue).toEqual([file]);
+    expect(result.skippedFiles).toEqual([]);
+  });
+
+  it('does not skip when force is enabled', () => {
+    writeLockfile();
+
+    const result = filterFilesForEnqueue({
+      files: [file],
+      settings: settings(),
+      branchData,
+      force: true,
+    });
+
+    expect(result.filesToEnqueue).toEqual([file]);
+    expect(result.skippedFiles).toEqual([]);
+  });
+});

--- a/packages/cli/src/workflows/download.ts
+++ b/packages/cli/src/workflows/download.ts
@@ -67,40 +67,14 @@ export async function runDownloadWorkflow({
     }
     branchData = branchResult;
   }
+  options._branchId = branchData.currentBranch.id;
+
   // Prepare the query data
   const fileQueryData = prepareFileQueryData(
     fileVersionData,
     locales,
     branchData
   );
-
-  // Clear translated files before any downloads (if enabled)
-  if (
-    options.options?.experimentalClearLocaleDirs === true &&
-    fileQueryData.length > 0
-  ) {
-    const translatedFiles = new Set(
-      fileQueryData
-        .map((file) => {
-          const outputPath = resolveOutputPath(file.fileName, file.locale);
-          // Only clear if the output path is different from the source (i.e., there's a transform)
-          return outputPath !== null && outputPath !== file.fileName
-            ? outputPath
-            : null;
-        })
-        .filter((path): path is string => path !== null)
-    );
-
-    // Derive cwd from config path
-    const cwd = path.dirname(options.config);
-
-    await clearLocaleDirs(
-      translatedFiles,
-      locales,
-      options.options?.clearLocaleDirsExclude,
-      cwd
-    );
-  }
 
   // Initialize download status
   const fileTracker: FileStatusTracker = {
@@ -168,6 +142,13 @@ export async function runDownloadWorkflow({
     }
   }
 
+  await clearCompletedLocaleDirs({
+    fileTracker,
+    locales,
+    resolveOutputPath,
+    options,
+  });
+
   // Step 2: Download translations
   const downloadStep = new DownloadTranslationsStep(gt, options);
   const downloadResult = await downloadStep.run({
@@ -183,6 +164,48 @@ export async function runDownloadWorkflow({
   }
 
   return downloadResult;
+}
+
+async function clearCompletedLocaleDirs({
+  fileTracker,
+  locales,
+  resolveOutputPath,
+  options,
+}: {
+  fileTracker: FileStatusTracker;
+  locales: string[];
+  resolveOutputPath: (sourcePath: string, locale: string) => string | null;
+  options: Settings;
+}): Promise<void> {
+  if (
+    options.options?.experimentalClearLocaleDirs !== true ||
+    fileTracker.completed.size === 0
+  ) {
+    return;
+  }
+
+  const translatedFiles = new Set(
+    Array.from(fileTracker.completed.values())
+      .map((file) => {
+        const outputPath = resolveOutputPath(file.fileName, file.locale);
+        // Only clear if the output path is different from the source.
+        return outputPath !== null && outputPath !== file.fileName
+          ? outputPath
+          : null;
+      })
+      .filter((filePath): filePath is string => filePath !== null)
+  );
+
+  if (translatedFiles.size === 0) return;
+
+  const cwd = path.dirname(options.config);
+
+  await clearLocaleDirs(
+    translatedFiles,
+    locales,
+    options.options?.clearLocaleDirsExclude,
+    cwd
+  );
 }
 
 /**

--- a/packages/cli/src/workflows/enqueue.ts
+++ b/packages/cli/src/workflows/enqueue.ts
@@ -6,7 +6,7 @@ import { EnqueueFilesResult, FileToUpload } from 'generaltranslation/types';
 import { EnqueueStep } from './steps/EnqueueStep.js';
 import { BranchStep } from './steps/BranchStep.js';
 import { logger } from '../console/logger.js';
-import { filterFilesForEnqueue } from './filterFilesForEnqueue.js';
+import { filterFilesForEnqueue } from './utils/filterFilesForEnqueue.js';
 
 /**
  * Enqueues translations for a given set of files

--- a/packages/cli/src/workflows/enqueue.ts
+++ b/packages/cli/src/workflows/enqueue.ts
@@ -68,7 +68,9 @@ export async function runEnqueueWorkflow({
 
     logger.debug('Enqueue result: ' + JSON.stringify(enqueueResult, null, 2));
 
-    logEnqueueResult(enqueueResult, files);
+    if (filesToEnqueue.length > 0 || skippedFiles.length === 0) {
+      logEnqueueResult(enqueueResult, filesToEnqueue.length);
+    }
     return enqueueResult;
   } catch (error) {
     return logErrorAndExit(
@@ -89,11 +91,11 @@ export async function runEnqueueWorkflow({
  */
 function logEnqueueResult(
   enqueueResult: EnqueueFilesResult,
-  files: FileToUpload[]
+  fileCount: number
 ): void {
   if (Object.keys(enqueueResult.jobData).length === 0) {
     logger.success(
-      `All ${files.length} files already translated. 0 files enqueued.`
+      `All ${fileCount} ${fileCount === 1 ? 'file' : 'files'} already translated. 0 files enqueued.`
     );
   } else {
     logger.success(enqueueResult.message);

--- a/packages/cli/src/workflows/enqueue.ts
+++ b/packages/cli/src/workflows/enqueue.ts
@@ -6,6 +6,7 @@ import { EnqueueFilesResult, FileToUpload } from 'generaltranslation/types';
 import { EnqueueStep } from './steps/EnqueueStep.js';
 import { BranchStep } from './steps/BranchStep.js';
 import { logger } from '../console/logger.js';
+import { filterFilesForEnqueue } from './filterFilesForEnqueue.js';
 
 /**
  * Enqueues translations for a given set of files
@@ -46,12 +47,23 @@ export async function runEnqueueWorkflow({
     logger.debug('Branch data: ' + JSON.stringify(branchData, null, 2));
 
     // (2) Enqueue the files
-    const enqueueResult = await enqueueStep.run(
-      files.map((files) => ({
-        branchId: branchData.currentBranch.id,
-        ...files,
-      }))
-    );
+    const filesWithBranch = files.map((files) => ({
+      branchId: branchData.currentBranch.id,
+      ...files,
+    }));
+    const { filesToEnqueue, skippedFiles } = filterFilesForEnqueue({
+      files: filesWithBranch,
+      settings,
+      branchData,
+      force: options.force,
+    });
+    if (skippedFiles.length > 0) {
+      logger.info(
+        `Skipped enqueue for ${skippedFiles.length} unchanged file${skippedFiles.length !== 1 ? 's' : ''}`
+      );
+    }
+
+    const enqueueResult = await enqueueStep.run(filesToEnqueue);
     await enqueueStep.wait();
 
     logger.debug('Enqueue result: ' + JSON.stringify(enqueueResult, null, 2));

--- a/packages/cli/src/workflows/filterFilesForEnqueue.ts
+++ b/packages/cli/src/workflows/filterFilesForEnqueue.ts
@@ -1,0 +1,80 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type { FileReference } from 'generaltranslation/types';
+import { createFileMapping } from '../formats/files/fileMapping.js';
+import { readLockfileForBranch } from '../fs/config/downloadedVersions.js';
+import type { BranchData } from '../types/branch.js';
+import type { Settings } from '../types/index.js';
+
+export type EnqueueFilterResult = {
+  filesToEnqueue: FileReference[];
+  skippedFiles: FileReference[];
+};
+
+/**
+ * Filters only the enqueue payload. The caller should keep the full file list
+ * for download tracking so existing translations can still be restored after a
+ * locale directory clear.
+ */
+export function filterFilesForEnqueue({
+  files,
+  settings,
+  branchData,
+  force,
+}: {
+  files: FileReference[];
+  settings: Settings;
+  branchData: BranchData;
+  force?: boolean;
+}): EnqueueFilterResult {
+  if (force || files.length === 0 || settings.locales.length === 0) {
+    return { filesToEnqueue: files, skippedFiles: [] };
+  }
+
+  const { entryMap } = readLockfileForBranch(branchData.currentBranch.id, {
+    allowEmptyBranchId: !settings.branchOptions.enabled,
+  });
+  if (entryMap.size === 0) {
+    return { filesToEnqueue: files, skippedFiles: [] };
+  }
+
+  const fileMapping = createFileMapping(
+    settings.files.resolvedPaths,
+    settings.files.placeholderPaths,
+    settings.files.transformPaths,
+    settings.files.transformFormats,
+    settings.locales,
+    settings.defaultLocale
+  );
+
+  const filesToEnqueue: FileReference[] = [];
+  const skippedFiles: FileReference[] = [];
+
+  for (const file of files) {
+    const entry = entryMap.get(file.fileId);
+    if (!entry || entry.staged || entry.versionId !== file.versionId) {
+      filesToEnqueue.push(file);
+      continue;
+    }
+
+    const hasEveryLocale = settings.locales.every((locale) => {
+      const expectedOutputPath = fileMapping[locale]?.[file.fileName];
+      if (!expectedOutputPath) return false;
+
+      const translation = entry.translations[locale];
+      return (
+        !!translation?.updatedAt &&
+        translation.fileName === expectedOutputPath &&
+        fs.existsSync(path.resolve(expectedOutputPath))
+      );
+    });
+
+    if (hasEveryLocale) {
+      skippedFiles.push(file);
+    } else {
+      filesToEnqueue.push(file);
+    }
+  }
+
+  return { filesToEnqueue, skippedFiles };
+}

--- a/packages/cli/src/workflows/stage.ts
+++ b/packages/cli/src/workflows/stage.ts
@@ -12,7 +12,7 @@ import { TagStep } from './steps/TagStep.js';
 import { UserEditDiffsStep } from './steps/UserEditDiffsStep.js';
 import { BranchData } from '../types/branch.js';
 import { calculateTimeoutMs } from '../utils/calculateTimeoutMs.js';
-import { filterFilesForEnqueue } from './filterFilesForEnqueue.js';
+import { filterFilesForEnqueue } from './utils/filterFilesForEnqueue.js';
 
 /**
  * Sends multiple files for translation to the API using a workflow pattern

--- a/packages/cli/src/workflows/stage.ts
+++ b/packages/cli/src/workflows/stage.ts
@@ -12,6 +12,7 @@ import { TagStep } from './steps/TagStep.js';
 import { UserEditDiffsStep } from './steps/UserEditDiffsStep.js';
 import { BranchData } from '../types/branch.js';
 import { calculateTimeoutMs } from '../utils/calculateTimeoutMs.js';
+import { filterFilesForEnqueue } from './filterFilesForEnqueue.js';
 
 /**
  * Sends multiple files for translation to the API using a workflow pattern
@@ -80,7 +81,19 @@ export async function runStageFilesWorkflow({
     await setupStep.wait();
 
     // then run the enqueue step
-    const enqueueResult = await enqueueStep.run(uploadedFiles);
+    const { filesToEnqueue, skippedFiles } = filterFilesForEnqueue({
+      files: uploadedFiles,
+      settings,
+      branchData,
+      force: options.force,
+    });
+    if (skippedFiles.length > 0) {
+      logger.info(
+        `Skipped enqueue for ${skippedFiles.length} unchanged file${skippedFiles.length !== 1 ? 's' : ''}`
+      );
+    }
+
+    const enqueueResult = await enqueueStep.run(filesToEnqueue);
     await enqueueStep.wait();
 
     return { branchData, enqueueResult };

--- a/packages/cli/src/workflows/steps/EnqueueStep.ts
+++ b/packages/cli/src/workflows/steps/EnqueueStep.ts
@@ -12,6 +12,7 @@ export class EnqueueStep extends WorkflowStep<
 > {
   private spinner = logger.createSpinner('dots');
   private result: EnqueueFilesResult | null = null;
+  private spinnerStarted = false;
 
   constructor(
     private gt: GT,
@@ -22,7 +23,17 @@ export class EnqueueStep extends WorkflowStep<
   }
 
   async run(files: FileReference[]): Promise<EnqueueFilesResult> {
+    if (files.length === 0) {
+      this.result = {
+        jobData: {},
+        locales: this.settings.locales,
+        message: 'No files need to be enqueued',
+      };
+      return this.result;
+    }
+
     this.spinner.start('Enqueuing translations...');
+    this.spinnerStarted = true;
 
     this.result = await this.gt.enqueueFiles(files, {
       sourceLocale: this.settings.defaultLocale,
@@ -36,7 +47,7 @@ export class EnqueueStep extends WorkflowStep<
   }
 
   async wait(): Promise<void> {
-    if (this.result) {
+    if (this.result && this.spinnerStarted) {
       this.spinner.stop(chalk.green('Translations enqueued successfully'));
     }
   }

--- a/packages/cli/src/workflows/utils/filterFilesForEnqueue.ts
+++ b/packages/cli/src/workflows/utils/filterFilesForEnqueue.ts
@@ -1,10 +1,10 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import type { FileReference } from 'generaltranslation/types';
-import { createFileMapping } from '../formats/files/fileMapping.js';
-import { readLockfileForBranch } from '../fs/config/downloadedVersions.js';
-import type { BranchData } from '../types/branch.js';
-import type { Settings } from '../types/index.js';
+import { createFileMapping } from '../../formats/files/fileMapping.js';
+import { readLockfileForBranch } from '../../fs/config/downloadedVersions.js';
+import type { BranchData } from '../../types/branch.js';
+import type { Settings } from '../../types/index.js';
 
 export type EnqueueFilterResult = {
   filesToEnqueue: FileReference[];

--- a/packages/cli/src/workflows/utils/filterFilesForEnqueue.ts
+++ b/packages/cli/src/workflows/utils/filterFilesForEnqueue.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import type { FileReference } from 'generaltranslation/types';
 import { createFileMapping } from '../../formats/files/fileMapping.js';
-import { readLockfileForBranch } from '../../fs/config/downloadedVersions.js';
+import { readLockfile } from '../../fs/config/downloadedVersions.js';
 import type { BranchData } from '../../types/branch.js';
 import type { Settings } from '../../types/index.js';
 
@@ -31,7 +31,9 @@ export function filterFilesForEnqueue({
     return { filesToEnqueue: files, skippedFiles: [] };
   }
 
-  const { entryMap } = readLockfileForBranch(branchData.currentBranch.id, {
+  const { entryMap } = readLockfile(settings, {
+    branchId: branchData.currentBranch.id,
+    strictBranch: true,
     allowEmptyBranchId: !settings.branchOptions.enabled,
   });
   if (entryMap.size === 0) {


### PR DESCRIPTION
<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1639"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784774186&installation_id=127936663&pr_number=1639&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1639&signature=8d3fc535266c9753cbb01fa73c9a931f15d4c521df4471b7f8991afc11b01bda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a lockfile-based skip optimization: before enqueueing files, `filterFilesForEnqueue` checks the `gt-lock.json` to see if every target locale translation is already present on disk at the expected path and at the current version — if so, those files skip the enqueue API call entirely. It also fixes `clearLocaleDirs` to run only after translations are confirmed complete (post-poll) rather than upfront, and fixes V1→V2 lockfile conversion to preserve per-locale `fileName`.

- **New `filterFilesForEnqueue` utility** reads the lockfile with `strictBranch` enforcement, guards against branch mismatch, and correctly passes through staged/version-changed entries.
- **V1 lockfile fix** (`convertV1ToV2`): `fileName` is now carried over in the conversion, enabling the skip check to work for legacy lockfiles.
- **`clearLocaleDirs` refactor** in `download.ts`: clearing is deferred until polling confirms which translations completed, preventing premature locale directory wipes.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the two issues raised in the previous review have been resolved and the new lockfile-based skip logic handles all tested edge cases correctly.

Both previously-flagged concerns are addressed: convertV1ToV2 now preserves translation.fileName so the skip check works for legacy lockfiles, and the condition guarding logEnqueueResult prevents the double-message when all files are skipped.

No files require special attention.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/cli/src/workflows/utils/filterFilesForEnqueue.ts | New utility that filters files before enqueue using the lockfile — checks branch match, version parity, and local file existence. Logic is sound and edge cases are handled. |
| packages/cli/src/fs/config/downloadedVersions.ts | Adds ReadLockfileOptions for strictBranch/allowEmptyBranchId, preserves fileName in V1→V2 conversion. |
| packages/cli/src/workflows/enqueue.ts | Integrates filterFilesForEnqueue and avoids the double-message when all files are skipped. |
| packages/cli/src/workflows/download.ts | Moves clearLocaleDirs to post-poll — genuine behavior fix. |
| packages/cli/src/workflows/steps/EnqueueStep.ts | Correctly guards API call and spinner when files=[]. |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `packages/cli/src/workflows/enqueue.ts`, line 60-71 ([link](https://github.com/generaltranslation/gt/blob/fa10b52ceb158ca89643f6ed8ce983fcacfa5e84/packages/cli/src/workflows/enqueue.ts#L60-L71)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Redundant success message when all files are skipped**

   When every file is filtered out, `enqueueStep.run([])` early-returns with `{ jobData: {}, message: 'No files need to be enqueued' }`. `logEnqueueResult` then sees an empty `jobData` and emits `"All N files already translated. 0 files enqueued."` — immediately after the user already saw `"Skipped enqueue for N unchanged files"` from `logger.info`. The two messages describe the same outcome and can confuse users about whether the operation was a local cache hit or an API-confirmed no-op.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/cli/src/workflows/enqueue.ts
   Line: 60-71

   Comment:
   **Redundant success message when all files are skipped**

   When every file is filtered out, `enqueueStep.run([])` early-returns with `{ jobData: {}, message: 'No files need to be enqueued' }`. `logEnqueueResult` then sees an empty `jobData` and emits `"All N files already translated. 0 files enqueued."` — immediately after the user already saw `"Skipped enqueue for N unchanged files"` from `logger.info`. The two messages describe the same outcome and can confuse users about whether the operation was a local cache hit or an API-confirmed no-op.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fcli%2Fsrc%2Fworkflows%2Fenqueue.ts%0ALine%3A%2060-71%0A%0AComment%3A%0A**Redundant%20success%20message%20when%20all%20files%20are%20skipped**%0A%0AWhen%20every%20file%20is%20filtered%20out%2C%20%60enqueueStep.run%28%5B%5D%29%60%20early-returns%20with%20%60%7B%20jobData%3A%20%7B%7D%2C%20message%3A%20'No%20files%20need%20to%20be%20enqueued'%20%7D%60.%20%60logEnqueueResult%60%20then%20sees%20an%20empty%20%60jobData%60%20and%20emits%20%60%22All%20N%20files%20already%20translated.%200%20files%20enqueued.%22%60%20%E2%80%94%20immediately%20after%20the%20user%20already%20saw%20%60%22Skipped%20enqueue%20for%20N%20unchanged%20files%22%60%20from%20%60logger.info%60.%20The%20two%20messages%20describe%20the%20same%20outcome%20and%20can%20confuse%20users%20about%20whether%20the%20operation%20was%20a%20local%20cache%20hit%20or%20an%20API-confirmed%20no-op.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=generaltranslation%2Fgt&pr=1639&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22f%2Fskip-enqueue-with-lockfile%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22f%2Fskip-enqueue-with-lockfile%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fcli%2Fsrc%2Fworkflows%2Fenqueue.ts%0ALine%3A%2060-71%0A%0AComment%3A%0A**Redundant%20success%20message%20when%20all%20files%20are%20skipped**%0A%0AWhen%20every%20file%20is%20filtered%20out%2C%20%60enqueueStep.run%28%5B%5D%29%60%20early-returns%20with%20%60%7B%20jobData%3A%20%7B%7D%2C%20message%3A%20'No%20files%20need%20to%20be%20enqueued'%20%7D%60.%20%60logEnqueueResult%60%20then%20sees%20an%20empty%20%60jobData%60%20and%20emits%20%60%22All%20N%20files%20already%20translated.%200%20files%20enqueued.%22%60%20%E2%80%94%20immediately%20after%20the%20user%20already%20saw%20%60%22Skipped%20enqueue%20for%20N%20unchanged%20files%22%60%20from%20%60logger.info%60.%20The%20two%20messages%20describe%20the%20same%20outcome%20and%20can%20confuse%20users%20about%20whether%20the%20operation%20was%20a%20local%20cache%20hit%20or%20an%20API-confirmed%20no-op.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=generaltranslation%2Fgt&pr=1639&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

2. `packages/cli/src/workflows/filterFilesForEnqueue.ts`, line 64-69 ([link](https://github.com/generaltranslation/gt/blob/fa10b52ceb158ca89643f6ed8ce983fcacfa5e84/packages/cli/src/workflows/filterFilesForEnqueue.ts#L64-L69)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Skip optimization silently disabled for V1 lockfiles**

   `readLockfileForBranch` calls `convertV1ToV2` for legacy lockfiles, but that conversion only preserves `updatedAt` and `postProcessHash` — it does not populate `translation.fileName`. As a result, `translation.fileName === expectedOutputPath` is always `undefined === string → false`, so `hasEveryLocale` is always `false` and every file is re-enqueued. Users with a V1 `gt-lock.json` will never see the skip optimisation until after their first successful download (which rewrites the lockfile in V2 with `fileName` populated). There is no log message or comment explaining this degraded mode, making it hard to diagnose if a user wonders why the skip isn't working.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/cli/src/workflows/filterFilesForEnqueue.ts
   Line: 64-69

   Comment:
   **Skip optimization silently disabled for V1 lockfiles**

   `readLockfileForBranch` calls `convertV1ToV2` for legacy lockfiles, but that conversion only preserves `updatedAt` and `postProcessHash` — it does not populate `translation.fileName`. As a result, `translation.fileName === expectedOutputPath` is always `undefined === string → false`, so `hasEveryLocale` is always `false` and every file is re-enqueued. Users with a V1 `gt-lock.json` will never see the skip optimisation until after their first successful download (which rewrites the lockfile in V2 with `fileName` populated). There is no log message or comment explaining this degraded mode, making it hard to diagnose if a user wonders why the skip isn't working.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fcli%2Fsrc%2Fworkflows%2FfilterFilesForEnqueue.ts%0ALine%3A%2064-69%0A%0AComment%3A%0A**Skip%20optimization%20silently%20disabled%20for%20V1%20lockfiles**%0A%0A%60readLockfileForBranch%60%20calls%20%60convertV1ToV2%60%20for%20legacy%20lockfiles%2C%20but%20that%20conversion%20only%20preserves%20%60updatedAt%60%20and%20%60postProcessHash%60%20%E2%80%94%20it%20does%20not%20populate%20%60translation.fileName%60.%20As%20a%20result%2C%20%60translation.fileName%20%3D%3D%3D%20expectedOutputPath%60%20is%20always%20%60undefined%20%3D%3D%3D%20string%20%E2%86%92%20false%60%2C%20so%20%60hasEveryLocale%60%20is%20always%20%60false%60%20and%20every%20file%20is%20re-enqueued.%20Users%20with%20a%20V1%20%60gt-lock.json%60%20will%20never%20see%20the%20skip%20optimisation%20until%20after%20their%20first%20successful%20download%20%28which%20rewrites%20the%20lockfile%20in%20V2%20with%20%60fileName%60%20populated%29.%20There%20is%20no%20log%20message%20or%20comment%20explaining%20this%20degraded%20mode%2C%20making%20it%20hard%20to%20diagnose%20if%20a%20user%20wonders%20why%20the%20skip%20isn't%20working.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=generaltranslation%2Fgt&pr=1639&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22f%2Fskip-enqueue-with-lockfile%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22f%2Fskip-enqueue-with-lockfile%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fcli%2Fsrc%2Fworkflows%2FfilterFilesForEnqueue.ts%0ALine%3A%2064-69%0A%0AComment%3A%0A**Skip%20optimization%20silently%20disabled%20for%20V1%20lockfiles**%0A%0A%60readLockfileForBranch%60%20calls%20%60convertV1ToV2%60%20for%20legacy%20lockfiles%2C%20but%20that%20conversion%20only%20preserves%20%60updatedAt%60%20and%20%60postProcessHash%60%20%E2%80%94%20it%20does%20not%20populate%20%60translation.fileName%60.%20As%20a%20result%2C%20%60translation.fileName%20%3D%3D%3D%20expectedOutputPath%60%20is%20always%20%60undefined%20%3D%3D%3D%20string%20%E2%86%92%20false%60%2C%20so%20%60hasEveryLocale%60%20is%20always%20%60false%60%20and%20every%20file%20is%20re-enqueued.%20Users%20with%20a%20V1%20%60gt-lock.json%60%20will%20never%20see%20the%20skip%20optimisation%20until%20after%20their%20first%20successful%20download%20%28which%20rewrites%20the%20lockfile%20in%20V2%20with%20%60fileName%60%20populated%29.%20There%20is%20no%20log%20message%20or%20comment%20explaining%20this%20degraded%20mode%2C%20making%20it%20hard%20to%20diagnose%20if%20a%20user%20wonders%20why%20the%20skip%20isn't%20working.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=generaltranslation%2Fgt&pr=1639&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix: review"](https://github.com/generaltranslation/gt/commit/ab42115378971db3b7c462331f2a7c2c0dd34d48) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39197610)</sub>

<!-- /greptile_comment -->