### PR TITLE
fix: initialize runtime locale state

### DIFF
--- a/packages/next/src/__tests__/config.test.ts
+++ b/packages/next/src/__tests__/config.test.ts
@@ -1000,11 +1000,10 @@ describe('withGTConfig', () => {
     it('devApiKey in production throws devApiKeyIncludedInProductionError', async () => {
       const withGTConfig = await getWithGTConfig();
       process.env.NODE_ENV = 'production';
+      process.env.GT_DEV_API_KEY = 'gt-dev-xyz';
       vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-      expect(() => withGTConfig({}, { devApiKey: 'gt-dev-xyz' })).toThrow(
-        /development API key/i
-      );
+      expect(() => withGTConfig()).toThrow(/development API key/i);
     });
 
     it('invalid locales + GT services enabled throws invalidLocalesError', async () => {
@@ -1178,6 +1177,7 @@ describe('withGTConfig', () => {
       expect(raw).not.toContain('prop-api-key');
       expect(raw).not.toContain('prop-dev-key');
       expect(raw).not.toContain('prop-project-id');
+      expect(result.env!._GENERALTRANSLATION_GT_SERVICES_ENABLED).toBe('false');
     });
 
     it('boolean flags are string "true"/"false", not booleans', async () => {

--- a/packages/next/src/__tests__/config.test.ts
+++ b/packages/next/src/__tests__/config.test.ts
@@ -57,6 +57,7 @@ beforeEach(() => {
   delete process.env.GT_PROJECT_ID;
   delete process.env.GT_API_KEY;
   delete process.env.GT_DEV_API_KEY;
+  delete process.env.NEXT_PUBLIC_GT_DEV_API_KEY;
   delete process.env.TURBOPACK;
   process.env.NODE_ENV = 'development';
   vi.clearAllMocks();
@@ -362,7 +363,7 @@ describe('withGTConfig', () => {
   // ==============================
   // 3. Config merge precedence
   // ==============================
-  describe('3. Config merge precedence: props > env > config file > defaults', () => {
+  describe('3. Config merge precedence: props > config file > defaults', () => {
     it('config file values override defaults', async () => {
       const withGTConfig = await getWithGTConfig();
       vi.mocked(fs.existsSync).mockImplementation((p) => {
@@ -379,7 +380,7 @@ describe('withGTConfig', () => {
       expect(params.maxBatchSize).toBe(99);
     });
 
-    it('GT_PROJECT_ID env var overrides config file projectId', async () => {
+    it('omits projectId from serialized config params', async () => {
       const withGTConfig = await getWithGTConfig();
       process.env.GT_PROJECT_ID = 'env-project-id';
       vi.mocked(fs.existsSync).mockImplementation((p) => {
@@ -393,17 +394,17 @@ describe('withGTConfig', () => {
       const result = withGTConfig();
       const params = parseConfigParams(result);
 
-      expect(params.projectId).toBe('env-project-id');
+      expect(params.projectId).toBeUndefined();
     });
 
-    it('props override env vars', async () => {
+    it('omits prop projectId from serialized config params', async () => {
       const withGTConfig = await getWithGTConfig();
       process.env.GT_PROJECT_ID = 'env-project-id';
 
       const result = withGTConfig({}, { projectId: 'props-project-id' });
       const params = parseConfigParams(result);
 
-      expect(params.projectId).toBe('props-project-id');
+      expect(params.projectId).toBeUndefined();
     });
 
     it('full chain: each layer contributes different values', async () => {
@@ -428,8 +429,8 @@ describe('withGTConfig', () => {
 
       // From config file (not overridden)
       expect(params.maxBatchSize).toBe(99);
-      // From env (overrides config file)
-      expect(params.projectId).toBe('env-project-id');
+      // Runtime credentials are read directly from process.env, not serialized.
+      expect(params.projectId).toBeUndefined();
       // From props (overrides all)
       expect(params.defaultLocale).toBe('fr');
       expect(params.maxConcurrentRequests).toBe(200);
@@ -609,74 +610,97 @@ describe('withGTConfig', () => {
   // 5. Environment variable handling
   // ==============================
   describe('5. Environment variable handling', () => {
-    it('GT_PROJECT_ID sets projectId in merged config', async () => {
+    it('does not serialize runtime credential env vars into config params', async () => {
       const withGTConfig = await getWithGTConfig();
       process.env.GT_PROJECT_ID = 'my-project';
+      process.env.GT_API_KEY = 'gt-api-xyz';
+      process.env.GT_DEV_API_KEY = 'gt-dev-xyz';
 
       const result = withGTConfig();
       const params = parseConfigParams(result);
+      const raw = result.env!._GENERALTRANSLATION_I18N_CONFIG_PARAMS!;
 
-      expect(params.projectId).toBe('my-project');
+      expect(params.projectId).toBeUndefined();
+      expect(params.apiKey).toBeUndefined();
+      expect(params.devApiKey).toBeUndefined();
+      expect(raw).not.toContain('my-project');
+      expect(raw).not.toContain('gt-api-xyz');
+      expect(raw).not.toContain('gt-dev-xyz');
     });
 
-    it('GT_API_KEY with gt-api- prefix in production sets apiKey', async () => {
+    it('uses GT_API_KEY in production without prefix parsing', async () => {
       const withGTConfig = await getWithGTConfig();
       process.env.NODE_ENV = 'production';
-      process.env.GT_API_KEY = 'gt-api-xyz';
+      process.env.GT_API_KEY = 'plain-production-key';
       process.env.GT_PROJECT_ID = 'proj';
 
       const result = withGTConfig();
       const params = parseConfigParams(result);
 
-      expect(params.apiKey).toBe('gt-api-xyz');
-    });
-
-    it('GT_DEV_API_KEY with gt-dev- prefix in development sets devApiKey', async () => {
-      const withGTConfig = await getWithGTConfig();
-      process.env.NODE_ENV = 'development';
-      process.env.GT_DEV_API_KEY = 'gt-dev-xyz';
-
-      const result = withGTConfig();
-      const params = parseConfigParams(result);
-
-      expect(params.devApiKey).toBe('gt-dev-xyz');
-    });
-
-    it('GT_API_KEY in development (no dev key) sets apiKey', async () => {
-      const withGTConfig = await getWithGTConfig();
-      process.env.NODE_ENV = 'development';
-      process.env.GT_API_KEY = 'gt-api-xyz';
-
-      const result = withGTConfig();
-      const params = parseConfigParams(result);
-
-      expect(params.apiKey).toBe('gt-api-xyz');
-    });
-
-    it('GT_DEV_API_KEY preferred over GT_API_KEY in development', async () => {
-      const withGTConfig = await getWithGTConfig();
-      process.env.NODE_ENV = 'development';
-      process.env.GT_DEV_API_KEY = 'gt-dev-preferred';
-      process.env.GT_API_KEY = 'gt-api-fallback';
-
-      const result = withGTConfig();
-      const params = parseConfigParams(result);
-
-      expect(params.devApiKey).toBe('gt-dev-preferred');
-      // apiKey should not be set from GT_API_KEY since GT_DEV_API_KEY took precedence
+      expect(result.env!._GENERALTRANSLATION_GT_SERVICES_ENABLED).toBe('true');
       expect(params.apiKey).toBeUndefined();
     });
 
-    it('key with unknown prefix sets neither apiKey nor devApiKey', async () => {
+    it('uses GT_DEV_API_KEY in development without prefix parsing', async () => {
+      const withGTConfig = await getWithGTConfig();
+      process.env.NODE_ENV = 'development';
+      process.env.GT_DEV_API_KEY = 'plain-dev-key';
+      process.env.GT_PROJECT_ID = 'proj';
+
+      const result = withGTConfig();
+      const params = parseConfigParams(result);
+
+      expect(result.env!._GENERALTRANSLATION_GT_SERVICES_ENABLED).toBe('true');
+      expect(params.devApiKey).toBeUndefined();
+    });
+
+    it('uses NEXT_PUBLIC_GT_DEV_API_KEY before GT_DEV_API_KEY', async () => {
+      const withGTConfig = await getWithGTConfig();
+      process.env.NODE_ENV = 'development';
+      process.env.NEXT_PUBLIC_GT_DEV_API_KEY = 'public-dev-key';
+      process.env.GT_DEV_API_KEY = 'server-dev-key';
+      process.env.GT_PROJECT_ID = 'proj';
+
+      const result = withGTConfig();
+      const params = parseConfigParams(result);
+
+      expect(result.env!._GENERALTRANSLATION_GT_SERVICES_ENABLED).toBe('true');
+      expect(params.devApiKey).toBeUndefined();
+      expect(result.env!._GENERALTRANSLATION_I18N_CONFIG_PARAMS).not.toContain(
+        'public-dev-key'
+      );
+      expect(result.env!._GENERALTRANSLATION_I18N_CONFIG_PARAMS).not.toContain(
+        'server-dev-key'
+      );
+    });
+
+    it('does not reject keys with unknown prefixes', async () => {
       const withGTConfig = await getWithGTConfig();
       process.env.NODE_ENV = 'development';
       process.env.GT_API_KEY = 'gt-unknown-xyz';
+      process.env.GT_PROJECT_ID = 'proj';
 
       const result = withGTConfig();
       const params = parseConfigParams(result);
 
+      expect(() => withGTConfig()).not.toThrow();
       expect(params.apiKey).toBeUndefined();
       expect(params.devApiKey).toBeUndefined();
+    });
+
+    it('runtime credentials are read directly from process.env', async () => {
+      const { getRuntimeCredentials } =
+        await import('../config-dir/utils/runtimeCredentials');
+      process.env.GT_API_KEY = 'plain-api-key';
+      process.env.NEXT_PUBLIC_GT_DEV_API_KEY = 'public-dev-key';
+      process.env.GT_DEV_API_KEY = 'server-dev-key';
+      process.env.GT_PROJECT_ID = 'project-id';
+
+      expect(getRuntimeCredentials()).toEqual({
+        apiKey: 'plain-api-key',
+        devApiKey: 'public-dev-key',
+        projectId: 'project-id',
+      });
     });
   });
 
@@ -1132,15 +1156,28 @@ describe('withGTConfig', () => {
       expect(result.env!._GENERALTRANSLATION_I18N_CONFIG_PARAMS).toBeDefined();
     });
 
-    it('I18N_CONFIG_PARAMS contains full merged config as JSON string', async () => {
+    it('I18N_CONFIG_PARAMS contains sanitized merged config as JSON string', async () => {
       const withGTConfig = await getWithGTConfig();
-      const result = withGTConfig();
+      const result = withGTConfig(
+        {},
+        {
+          apiKey: 'prop-api-key',
+          devApiKey: 'prop-dev-key',
+          projectId: 'prop-project-id',
+        }
+      );
 
       const raw = result.env!._GENERALTRANSLATION_I18N_CONFIG_PARAMS;
       expect(typeof raw).toBe('string');
       const parsed = JSON.parse(raw!);
       expect(parsed).toHaveProperty('defaultLocale');
       expect(parsed).toHaveProperty('_usingPlugin', true);
+      expect(parsed.apiKey).toBeUndefined();
+      expect(parsed.devApiKey).toBeUndefined();
+      expect(parsed.projectId).toBeUndefined();
+      expect(raw).not.toContain('prop-api-key');
+      expect(raw).not.toContain('prop-dev-key');
+      expect(raw).not.toContain('prop-project-id');
     });
 
     it('boolean flags are string "true"/"false", not booleans', async () => {

--- a/packages/next/src/config-dir/__tests__/I18NConfiguration.test.ts
+++ b/packages/next/src/config-dir/__tests__/I18NConfiguration.test.ts
@@ -319,6 +319,36 @@ describe('I18NConfiguration', () => {
     );
   });
 
+  it('hydrates runtime credentials from process.env with sanitized config params', () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    vi.stubEnv('GT_API_KEY', 'plain-api-key');
+    vi.stubEnv('NEXT_PUBLIC_GT_DEV_API_KEY', 'public-dev-key');
+    vi.stubEnv('GT_DEV_API_KEY', 'server-dev-key');
+    vi.stubEnv('GT_PROJECT_ID', 'runtime-project-id');
+    vi.stubEnv(
+      '_GENERALTRANSLATION_I18N_CONFIG_PARAMS',
+      JSON.stringify({
+        defaultLocale: 'en',
+        locales: ['en', 'es'],
+      })
+    );
+
+    const config = getI18NConfig();
+
+    expect(config.getClientSideConfig()).toEqual(
+      expect.objectContaining({
+        devApiKey: 'public-dev-key',
+        developmentApiEnabled: true,
+        projectId: 'runtime-project-id',
+      })
+    );
+    expectCacheParams({
+      apiKey: 'plain-api-key',
+      devApiKey: 'public-dev-key',
+      projectId: 'runtime-project-id',
+    });
+  });
+
   it('initializes locale metadata in the default config fallback', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 

--- a/packages/next/src/config-dir/__tests__/I18NConfiguration.test.ts
+++ b/packages/next/src/config-dir/__tests__/I18NConfiguration.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { I18NConfiguration } from '../I18NConfiguration';
 import { getI18NConfig } from '../getI18NConfig';
 import { defaultWithGTConfigProps } from '../props/defaultWithGTConfigProps';
+import { devApiKeyIncludedInProductionError } from '../../errors/createErrors';
 import { initializeI18nConfig } from 'gt-i18n/internal';
 
 const mockI18nCacheParams = vi.hoisted(() => vi.fn());
@@ -347,6 +348,20 @@ describe('I18NConfiguration', () => {
       devApiKey: 'public-dev-key',
       projectId: 'runtime-project-id',
     });
+  });
+
+  it('rejects development runtime credentials in production with config params', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('NEXT_PUBLIC_GT_DEV_API_KEY', 'public-dev-key');
+    vi.stubEnv(
+      '_GENERALTRANSLATION_I18N_CONFIG_PARAMS',
+      JSON.stringify({
+        defaultLocale: 'en',
+        locales: ['en', 'es'],
+      })
+    );
+
+    expect(() => getI18NConfig()).toThrow(devApiKeyIncludedInProductionError);
   });
 
   it('initializes locale metadata in the default config fallback', () => {

--- a/packages/next/src/config-dir/getI18NConfig.ts
+++ b/packages/next/src/config-dir/getI18NConfig.ts
@@ -28,6 +28,9 @@ export function getI18NConfig(): I18NConfiguration {
       ...JSON.parse(I18NConfigParams),
       ...getRuntimeCredentials(),
     } as ConstructorParameters<typeof I18NConfiguration>[0];
+    if (process.env.NODE_ENV === 'production' && configParams.devApiKey) {
+      throw new Error(devApiKeyIncludedInProductionError);
+    }
     initializeI18nConfig(configParams);
     globalObj._GENERALTRANSLATION_I18N_CONFIG_INSTANCE = new I18NConfiguration(
       configParams

--- a/packages/next/src/config-dir/getI18NConfig.ts
+++ b/packages/next/src/config-dir/getI18NConfig.ts
@@ -7,6 +7,7 @@ import {
 } from '../errors/createErrors';
 import { getDefaultRenderSettings } from 'gt-react/internal';
 import { initializeI18nConfig } from 'gt-i18n/internal';
+import { getRuntimeCredentials } from './utils/runtimeCredentials';
 
 type GlobalWithI18NConfig = typeof globalThis & {
   _GENERALTRANSLATION_I18N_CONFIG_INSTANCE?: I18NConfiguration;
@@ -25,6 +26,7 @@ export function getI18NConfig(): I18NConfiguration {
     const configParams = {
       ...defaultWithGTConfigProps,
       ...JSON.parse(I18NConfigParams),
+      ...getRuntimeCredentials(),
     } as ConstructorParameters<typeof I18NConfiguration>[0];
     initializeI18nConfig(configParams);
     globalObj._GENERALTRANSLATION_I18N_CONFIG_INSTANCE = new I18NConfiguration(
@@ -36,19 +38,7 @@ export function getI18NConfig(): I18NConfiguration {
     //  - not translating at all
     //  - using only default locales
 
-    // Parse: projectId
-    const projectId = process.env.GT_PROJECT_ID || '';
-
-    // Parse: apiKey, devApiKey
-    let apiKey, devApiKey;
-    const envApiKey =
-      process.env.GT_DEV_API_KEY || process.env.GT_API_KEY || '';
-    const apiKeyType = envApiKey?.split('-')?.[1];
-    if (apiKeyType === 'api') {
-      apiKey = envApiKey;
-    } else if (apiKeyType === 'dev') {
-      devApiKey = envApiKey;
-    }
+    const { apiKey, devApiKey, projectId = '' } = getRuntimeCredentials();
 
     // Parse: defaultLocale
     // Currently, you have to specify the default locale in the config

--- a/packages/next/src/config-dir/initializeGTNextContext.ts
+++ b/packages/next/src/config-dir/initializeGTNextContext.ts
@@ -1,0 +1,26 @@
+import {
+  getTranslationsSnapshot as getReactTranslationsSnapshot,
+  initializeGT,
+} from 'gt-react/context';
+import { getI18NConfig } from './getI18NConfig';
+
+let initialized = false;
+
+export function initializeGTNextContext() {
+  const config = getI18NConfig();
+  if (!initialized) {
+    initializeGT({
+      defaultLocale: config.getDefaultLocale(),
+      locales: config.getLocales(),
+      ...config.getClientSideConfig(),
+      loadTranslations: (locale: string) => config.getCachedTranslations(locale),
+    });
+    initialized = true;
+  }
+  return config;
+}
+
+export async function getTranslationsSnapshot(locale: string) {
+  initializeGTNextContext();
+  return await getReactTranslationsSnapshot(locale);
+}

--- a/packages/next/src/config-dir/utils/runtimeCredentials.ts
+++ b/packages/next/src/config-dir/utils/runtimeCredentials.ts
@@ -1,0 +1,32 @@
+type RuntimeCredentials = {
+  apiKey?: string;
+  devApiKey?: string;
+  projectId?: string;
+};
+
+export function getRuntimeCredentials(): RuntimeCredentials {
+  return {
+    apiKey: process.env.GT_API_KEY,
+    devApiKey:
+      process.env.NEXT_PUBLIC_GT_DEV_API_KEY || process.env.GT_DEV_API_KEY,
+    projectId: process.env.GT_PROJECT_ID,
+  };
+}
+
+export function getDefinedRuntimeCredentials(): RuntimeCredentials {
+  return Object.fromEntries(
+    Object.entries(getRuntimeCredentials()).filter(([, value]) => value)
+  ) as RuntimeCredentials;
+}
+
+export function withoutRuntimeCredentials<T extends RuntimeCredentials>(
+  config: T
+): Omit<T, keyof RuntimeCredentials> {
+  const {
+    apiKey: _apiKey,
+    devApiKey: _devApiKey,
+    projectId: _projectId,
+    ...rest
+  } = config;
+  return rest;
+}

--- a/packages/next/src/config-dir/utils/runtimeCredentials.ts
+++ b/packages/next/src/config-dir/utils/runtimeCredentials.ts
@@ -13,12 +13,6 @@ export function getRuntimeCredentials(): RuntimeCredentials {
   };
 }
 
-export function getDefinedRuntimeCredentials(): RuntimeCredentials {
-  return Object.fromEntries(
-    Object.entries(getRuntimeCredentials()).filter(([, value]) => value)
-  ) as RuntimeCredentials;
-}
-
 export function withoutRuntimeCredentials<T extends RuntimeCredentials>(
   config: T
 ): Omit<T, keyof RuntimeCredentials> {

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -39,7 +39,7 @@ import { resolveConfigFilepath } from './config-dir/utils/resolveConfigFilepath'
 import { ssgChecks } from './plugin/checks/ssgChecks';
 import { cacheComponentsChecks } from './plugin/checks/cacheComponentsChecks';
 import {
-  getDefinedRuntimeCredentials,
+  getRuntimeCredentials,
   withoutRuntimeCredentials,
 } from './config-dir/utils/runtimeCredentials';
 
@@ -151,7 +151,7 @@ export function withGTConfig<TNextConfig extends object = NextConfig>(
     console.error('Error reading GT config file:', error);
   }
 
-  const runtimeCredentials = getDefinedRuntimeCredentials();
+  const runtimeCredentials = getRuntimeCredentials();
 
   // ---------- CHECK FOR CONFIG CONFLICTS ---------- //
 

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -38,6 +38,10 @@ import {
 import { resolveConfigFilepath } from './config-dir/utils/resolveConfigFilepath';
 import { ssgChecks } from './plugin/checks/ssgChecks';
 import { cacheComponentsChecks } from './plugin/checks/cacheComponentsChecks';
+import {
+  getDefinedRuntimeCredentials,
+  withoutRuntimeCredentials,
+} from './config-dir/utils/runtimeCredentials';
 
 type AutoderiveConfig = boolean | { jsx?: boolean; strings?: boolean };
 
@@ -147,32 +151,7 @@ export function withGTConfig<TNextConfig extends object = NextConfig>(
     console.error('Error reading GT config file:', error);
   }
 
-  // ---------- LOAD ENVIRONMENT VARIABLES ---------- //
-
-  // resolve project ID
-  const projectId: string | undefined = process.env.GT_PROJECT_ID;
-
-  // resolve API keys
-  const envApiKey: string | undefined =
-    process.env.NODE_ENV === 'production'
-      ? process.env.GT_API_KEY
-      : process.env.GT_DEV_API_KEY || process.env.GT_API_KEY;
-  let apiKey, devApiKey;
-  if (envApiKey) {
-    const apiKeyType = envApiKey?.split('-')?.[1];
-    if (apiKeyType === 'api') {
-      apiKey = envApiKey;
-    } else if (apiKeyType === 'dev') {
-      devApiKey = envApiKey;
-    }
-  }
-
-  // conditionally add environment variables to config
-  const envConfig: Partial<InternalGTConfigProps> = {
-    ...(projectId ? { projectId } : {}),
-    ...(apiKey ? { apiKey } : {}),
-    ...(devApiKey ? { devApiKey } : {}),
-  };
+  const runtimeCredentials = getDefinedRuntimeCredentials();
 
   // ---------- CHECK FOR CONFIG CONFLICTS ---------- //
 
@@ -240,15 +219,18 @@ export function withGTConfig<TNextConfig extends object = NextConfig>(
     ...props.experimentalCompilerOptions,
   };
 
-  // precedence: input > env > config file > defaults
+  // precedence: input > config file > defaults
   const mergedConfig: InternalGTConfigProps = {
     ...defaultWithGTConfigProps,
     ...loadedConfig,
-    ...envConfig,
     ...props,
     headersAndCookies: mergedHeadersAndCookies,
     experimentalCompilerOptions: mergedExperimentalCompilerOptions,
     _usingPlugin: true, // flag to indicate plugin usage
+  };
+  const runtimeConfig: InternalGTConfigProps = {
+    ...mergedConfig,
+    ...runtimeCredentials,
   };
 
   // clear up any issues with the compiler options
@@ -374,17 +356,17 @@ export function withGTConfig<TNextConfig extends object = NextConfig>(
 
   // Check if using Services
   const gtRuntimeTranslationEnabled = !!(
-    mergedConfig.runtimeUrl === defaultWithGTConfigProps.runtimeUrl &&
-    ((process.env.NODE_ENV === 'production' && mergedConfig.apiKey) ||
-      (process.env.NODE_ENV === 'development' && mergedConfig.devApiKey))
+    runtimeConfig.runtimeUrl === defaultWithGTConfigProps.runtimeUrl &&
+    ((process.env.NODE_ENV === 'production' && runtimeConfig.apiKey) ||
+      (process.env.NODE_ENV === 'development' && runtimeConfig.devApiKey))
   );
   const gtRemoteCacheEnabled = !!(
-    mergedConfig.cacheUrl === defaultWithGTConfigProps.cacheUrl &&
-    mergedConfig.loadTranslationsType === 'remote'
+    runtimeConfig.cacheUrl === defaultWithGTConfigProps.cacheUrl &&
+    runtimeConfig.loadTranslationsType === 'remote'
   );
   const gtServicesEnabled = !!(
     (gtRuntimeTranslationEnabled || gtRemoteCacheEnabled) &&
-    mergedConfig.projectId
+    runtimeConfig.projectId
   );
 
   // Standardize locales
@@ -474,7 +456,7 @@ export function withGTConfig<TNextConfig extends object = NextConfig>(
   // Set default cache expiry if and only if no dev key
   if (
     mergedConfig.loadTranslationsType == 'remote' &&
-    !mergedConfig.devApiKey &&
+    !runtimeConfig.devApiKey &&
     typeof mergedConfig.cacheExpiryTime === 'undefined'
   ) {
     mergedConfig.cacheExpiryTime = defaultCacheExpiryTime;
@@ -510,8 +492,8 @@ export function withGTConfig<TNextConfig extends object = NextConfig>(
 
   // Check: projectId is not required for remote infrastructure, but warn if missing for dev, nothing for prod
   if (
-    (mergedConfig.cacheUrl || mergedConfig.runtimeUrl) &&
-    !mergedConfig.projectId &&
+    (runtimeConfig.cacheUrl || runtimeConfig.runtimeUrl) &&
+    !runtimeConfig.projectId &&
     process.env.NODE_ENV === 'development' &&
     mergedConfig.loadTranslationsType === 'remote' &&
     !mergedConfig.loadDictionaryEnabled // skip warn if using local dictionary
@@ -520,15 +502,15 @@ export function withGTConfig<TNextConfig extends object = NextConfig>(
   }
 
   // Check: dev API key should not be included in production
-  if (process.env.NODE_ENV === 'production' && mergedConfig.devApiKey) {
+  if (process.env.NODE_ENV === 'production' && runtimeConfig.devApiKey) {
     throw new Error(devApiKeyIncludedInProductionError);
   }
 
   // Check: An API key is required for runtime translation
   if (
-    mergedConfig.projectId && // must have projectId for this check to matter anyways
-    mergedConfig.runtimeUrl &&
-    !(mergedConfig.apiKey || mergedConfig.devApiKey) &&
+    runtimeConfig.projectId && // must have projectId for this check to matter anyways
+    runtimeConfig.runtimeUrl &&
+    !(runtimeConfig.apiKey || runtimeConfig.devApiKey) &&
     process.env.NODE_ENV === 'development'
   ) {
     console.warn(APIKeyMissingWarn);
@@ -550,7 +532,9 @@ export function withGTConfig<TNextConfig extends object = NextConfig>(
   }
 
   // ---------- STORE CONFIGURATIONS ---------- //
-  const I18NConfigParams = JSON.stringify(mergedConfig);
+  const I18NConfigParams = JSON.stringify(
+    withoutRuntimeCredentials(mergedConfig)
+  );
 
   const { type: _type, ...compilerOptions } =
     mergedConfig.experimentalCompilerOptions || {};

--- a/packages/next/src/index.client.ts
+++ b/packages/next/src/index.client.ts
@@ -1,6 +1,12 @@
 'use client';
 
 import {
+  useGTClass,
+  useLocaleProperties,
+  useLocaleDirection,
+  useVersionId,
+} from 'gt-react/client';
+import {
   Var,
   Num,
   Currency,
@@ -10,15 +16,12 @@ import {
   T,
   Branch,
   Plural,
+  LocaleSelector,
   useGT,
   useTranslations,
   useLocale,
   useLocales,
   useDefaultLocale,
-  useGTClass,
-  useLocaleProperties,
-  useLocaleDirection,
-  useVersionId,
   useMessages,
   msg,
   decodeMsg,
@@ -28,22 +31,15 @@ import {
   decodeVars,
   mFallback,
   gtFallback,
-} from 'gt-react/client';
-import {
-  gtProviderUseClientError,
-  txUseClientError,
-} from './errors/createErrors';
+} from 'gt-react/context';
+import { txUseClientError } from './errors/createErrors';
 import type {
   DictionaryTranslationOptions,
   InlineTranslationOptions,
   RuntimeTranslationOptions,
 } from 'gt-react';
-export { LocaleSelector } from 'gt-react/context';
-
-// Mock <GTProvider> which throws an error
-export function GTProvider() {
-  throw new Error(gtProviderUseClientError);
-}
+export { PagesGTProvider as GTProvider } from './provider/PagesGTProvider';
+export { getTranslationsSnapshot } from './config-dir/initializeGTNextContext';
 
 // Mock <Tx> which throws an error
 export function Tx() {
@@ -60,6 +56,7 @@ export {
   Derive,
   Branch,
   Plural,
+  LocaleSelector,
   useGT,
   useTranslations,
   useLocale,

--- a/packages/next/src/index.rsc.ts
+++ b/packages/next/src/index.rsc.ts
@@ -34,6 +34,7 @@ import {
   useGT,
 } from './server-dir/buildtime/getTranslationFunction';
 import type { LocaleProperties } from '@generaltranslation/format/types';
+export { getTranslationsSnapshot } from './config-dir/initializeGTNextContext';
 export { LocaleSelector } from 'gt-react/context';
 
 export function useGTClass() {

--- a/packages/next/src/index.server.ts
+++ b/packages/next/src/index.server.ts
@@ -36,6 +36,7 @@ import {
   useGT,
 } from './server-dir/buildtime/getTranslationFunction';
 import type { LocaleProperties } from '@generaltranslation/format/types';
+export { getTranslationsSnapshot } from './config-dir/initializeGTNextContext';
 export { LocaleSelector } from 'gt-react/context';
 
 export function useGTClass() {

--- a/packages/next/src/index.types.ts
+++ b/packages/next/src/index.types.ts
@@ -1,6 +1,7 @@
 import { typesFileError } from './errors/createErrors';
-import { GTProvider as _GTProvider } from './provider/GTProvider';
+import { PagesGTProvider as _GTProvider } from './provider/PagesGTProvider';
 import { T as _T } from './server-dir/buildtime/T';
+import { getTranslationsSnapshot as _getTranslationsSnapshot } from 'gt-react/context';
 import {
   useTranslations as _useTranslations,
   useLocale as _useLocale,
@@ -50,6 +51,11 @@ import {
 export const GTProvider: typeof _GTProvider = () => {
   throw new Error(typesFileError);
 };
+
+export const getTranslationsSnapshot: typeof _getTranslationsSnapshot =
+  async () => {
+    throw new Error(typesFileError);
+  };
 
 /**
  * Build-time translation component that renders its children in the user's given locale.

--- a/packages/next/src/provider/PagesGTProvider.tsx
+++ b/packages/next/src/provider/PagesGTProvider.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { GTProvider as ReactGTProvider } from 'gt-react/context';
+import { initializeGTNextContext } from '../config-dir/initializeGTNextContext';
+
+type ReactGTProviderProps = Parameters<typeof ReactGTProvider>[0];
+type PagesGTProviderProps = Omit<
+  ReactGTProviderProps,
+  'locale' | 'translations'
+> &
+  Partial<Pick<ReactGTProviderProps, 'locale' | 'translations'>>;
+
+export function PagesGTProvider({
+  locale,
+  translations,
+  ...props
+}: PagesGTProviderProps) {
+  const config = initializeGTNextContext();
+  const resolvedLocale = locale ?? config.getDefaultLocale();
+  const translationsLocale = Array.isArray(resolvedLocale)
+    ? (resolvedLocale[0] ?? config.getDefaultLocale())
+    : resolvedLocale;
+  return (
+    <ReactGTProvider
+      {...props}
+      locale={resolvedLocale}
+      translations={translations ?? { [translationsLocale]: {} }}
+    />
+  );
+}

--- a/packages/react/src/condition-store/BrowserConditionStore.ts
+++ b/packages/react/src/condition-store/BrowserConditionStore.ts
@@ -50,6 +50,7 @@ export class BrowserConditionStore implements WritableConditionStoreInterface {
         i18nConfig.determineLocale(config.locale) ||
         i18nConfig.getDefaultLocale(),
     });
+    this.updateEnableI18n(config.enableI18n ?? true);
   }
 
   getLocale = (): string => {

--- a/packages/react/src/condition-store/__tests__/BrowserConditionStore.test.ts
+++ b/packages/react/src/condition-store/__tests__/BrowserConditionStore.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockSetCookieValue = vi.hoisted(() => vi.fn());
+
+vi.mock('../cookies', () => ({
+  getCookieValue: vi.fn(),
+  setCookieValue: (...args: unknown[]) => mockSetCookieValue(...args),
+}));
+
+vi.mock('gt-i18n/internal', () => ({
+  getI18nConfig: () => ({
+    determineLocale: (locale: string | string[] | undefined) => {
+      return Array.isArray(locale) ? locale[0] : locale;
+    },
+    getDefaultLocale: () => 'en',
+  }),
+}));
+
+import { BrowserConditionStore } from '../BrowserConditionStore';
+
+describe('BrowserConditionStore', () => {
+  beforeEach(() => {
+    mockSetCookieValue.mockReset();
+  });
+
+  it('persists the initial locale and enableI18n state', () => {
+    new BrowserConditionStore({
+      locale: 'fr',
+      enableI18n: false,
+      localeCookieName: 'locale-cookie',
+      enableI18nCookieName: 'enable-cookie',
+    });
+
+    expect(mockSetCookieValue).toHaveBeenCalledWith({
+      cookieName: 'locale-cookie',
+      value: 'fr',
+    });
+    expect(mockSetCookieValue).toHaveBeenCalledWith({
+      cookieName: 'enable-cookie',
+      value: 'false',
+    });
+  });
+});

--- a/packages/react/src/condition-store/createBrowserConditionStore.ts
+++ b/packages/react/src/condition-store/createBrowserConditionStore.ts
@@ -45,7 +45,7 @@ export function createOrUpdateBrowserConditionStore(
     const conditionStore = getBrowserConditionStore();
     conditionStore.updateLocale(locale);
     conditionStore.updateEnableI18n(enableI18n);
-    return;
+    return conditionStore;
   }
   const conditionStore = new BrowserConditionStore({
     ...config,
@@ -55,6 +55,7 @@ export function createOrUpdateBrowserConditionStore(
     enableI18n,
   });
   setBrowserConditionStore(conditionStore);
+  return conditionStore;
 }
 
 export function determineLocale({

--- a/packages/react/src/provider/BrowserGTProvider.tsx
+++ b/packages/react/src/provider/BrowserGTProvider.tsx
@@ -1,10 +1,14 @@
 import {
   I18nStore,
   InternalGTProvider,
-  ReadonlyConditionStore,
 } from '@generaltranslation/react-core/context';
 import { useMemo, useRef } from 'react';
 import type { SharedGTProviderProps } from './GTProviderProps';
+import { BrowserConditionStore } from '../condition-store/BrowserConditionStore';
+import {
+  defaultEnableI18nCookieName,
+  defaultLocaleCookieName,
+} from '../internal';
 
 /**
  * Consumes snapshot from server
@@ -16,8 +20,14 @@ export function BrowserGTProvider({
   ...props
 }: SharedGTProviderProps) {
   const conditionStore = useMemo(() => {
-    return new ReadonlyConditionStore({ locale, enableI18n });
-  }, [locale, enableI18n]);
+    return new BrowserConditionStore({
+      ...props,
+      locale,
+      enableI18n,
+      localeCookieName: defaultLocaleCookieName,
+      enableI18nCookieName: defaultEnableI18nCookieName,
+    });
+  }, [props, locale, enableI18n]);
 
   const i18nStoreRef = useRef<I18nStore | null>(null);
   if (i18nStoreRef.current == null) {

--- a/packages/react/src/provider/BrowserGTProvider.tsx
+++ b/packages/react/src/provider/BrowserGTProvider.tsx
@@ -4,11 +4,7 @@ import {
 } from '@generaltranslation/react-core/context';
 import { useMemo, useRef } from 'react';
 import type { SharedGTProviderProps } from './GTProviderProps';
-import { BrowserConditionStore } from '../condition-store/BrowserConditionStore';
-import {
-  defaultEnableI18nCookieName,
-  defaultLocaleCookieName,
-} from '../internal';
+import { createOrUpdateBrowserConditionStore } from '../condition-store/createBrowserConditionStore';
 
 /**
  * Consumes snapshot from server
@@ -20,11 +16,9 @@ export function BrowserGTProvider({
   ...props
 }: SharedGTProviderProps) {
   const conditionStore = useMemo(() => {
-    return new BrowserConditionStore({
+    return createOrUpdateBrowserConditionStore({
       locale,
       enableI18n,
-      localeCookieName: defaultLocaleCookieName,
-      enableI18nCookieName: defaultEnableI18nCookieName,
     });
   }, [locale, enableI18n]);
 

--- a/packages/react/src/provider/BrowserGTProvider.tsx
+++ b/packages/react/src/provider/BrowserGTProvider.tsx
@@ -21,13 +21,12 @@ export function BrowserGTProvider({
 }: SharedGTProviderProps) {
   const conditionStore = useMemo(() => {
     return new BrowserConditionStore({
-      ...props,
       locale,
       enableI18n,
       localeCookieName: defaultLocaleCookieName,
       enableI18nCookieName: defaultEnableI18nCookieName,
     });
-  }, [props, locale, enableI18n]);
+  }, [locale, enableI18n]);
 
   const i18nStoreRef = useRef<I18nStore | null>(null);
   if (i18nStoreRef.current == null) {

--- a/packages/react/src/provider/__tests__/BrowserGTProvider.test.tsx
+++ b/packages/react/src/provider/__tests__/BrowserGTProvider.test.tsx
@@ -4,12 +4,25 @@ import { describe, expect, it, vi } from 'vitest';
 
 const mockBrowserConditionStore = vi.hoisted(() => vi.fn());
 
+vi.mock('../../condition-store/createBrowserConditionStore', () => ({
+  createOrUpdateBrowserConditionStore: (config: unknown) => {
+    mockBrowserConditionStore(config);
+    return {
+      updateLocale: () => {},
+      updateEnableI18n: () => {},
+      reload: () => {},
+      getLocale: () => 'fr',
+      setLocale: () => {},
+      getRegion: () => undefined,
+      setRegion: () => {},
+      getEnableI18n: () => true,
+      setEnableI18n: () => {},
+    };
+  },
+}));
+
 vi.mock('../../condition-store/BrowserConditionStore', () => ({
   BrowserConditionStore: class {
-    constructor(config: unknown) {
-      mockBrowserConditionStore(config);
-    }
-
     getLocale = () => 'fr';
     setLocale = () => {};
     getRegion = () => undefined;

--- a/packages/react/src/provider/__tests__/BrowserGTProvider.test.tsx
+++ b/packages/react/src/provider/__tests__/BrowserGTProvider.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+
+const mockBrowserConditionStore = vi.hoisted(() => vi.fn());
+
+vi.mock('../../condition-store/BrowserConditionStore', () => ({
+  BrowserConditionStore: class {
+    constructor(config: unknown) {
+      mockBrowserConditionStore(config);
+    }
+
+    getLocale = () => 'fr';
+    setLocale = () => {};
+    getRegion = () => undefined;
+    setRegion = () => {};
+    getEnableI18n = () => true;
+    setEnableI18n = () => {};
+  },
+}));
+
+vi.mock('../../condition-store/ReadOnlyBrowserConditionStore', () => ({
+  ReadonlyBrowserConditionStore: class {
+    constructor() {
+      throw new Error('ReadonlyBrowserConditionStore should not be used');
+    }
+  },
+}));
+
+describe('BrowserGTProvider', () => {
+  it('uses the writable browser condition store', async () => {
+    const { BrowserGTProvider } = await import('../BrowserGTProvider');
+
+    renderToStaticMarkup(
+      <BrowserGTProvider locale='fr' translations={{ fr: {} }}>
+        <span>content</span>
+      </BrowserGTProvider>
+    );
+
+    expect(mockBrowserConditionStore).toHaveBeenCalledWith(
+      expect.objectContaining({
+        locale: 'fr',
+      })
+    );
+  });
+});

--- a/packages/tanstack-start/src/functions/__tests__/determineLocale.test.ts
+++ b/packages/tanstack-start/src/functions/__tests__/determineLocale.test.ts
@@ -6,10 +6,13 @@ const mockCookie = vi.hoisted(() => vi.fn());
 vi.mock('@tanstack/react-start', () => ({
   createIsomorphicFn: () => ({
     server: (serverFn: unknown) => ({
-      client: (clientFn: unknown) => ({
-        client: clientFn,
-        server: serverFn,
-      }),
+      client: (clientFn: unknown) =>
+        Object.assign((...args: unknown[]) => {
+          return (serverFn as (...args: unknown[]) => unknown)(...args);
+        }, {
+          client: clientFn,
+          server: serverFn,
+        }),
     }),
   }),
 }));
@@ -20,6 +23,7 @@ vi.mock('@tanstack/react-start/server', () => ({
 }));
 
 import { determineLocale } from '../determineLocale';
+import { parseLocale } from '../parseLocale';
 import { initializeI18nConfig } from 'gt-i18n/internal';
 
 const localeConfig = {
@@ -114,5 +118,12 @@ describe('determineLocale', () => {
         }
       ).client(localeConfig)
     ).toBe('fr');
+  });
+
+  it('parses the locale from initialized config', () => {
+    mockCookie.mockReturnValue(undefined);
+    mockRequestHeader.mockReturnValue('es,en;q=0.8');
+
+    expect(parseLocale()).toBe('es');
   });
 });

--- a/packages/tanstack-start/src/functions/parseLocale.ts
+++ b/packages/tanstack-start/src/functions/parseLocale.ts
@@ -1,0 +1,14 @@
+import { getI18nConfig } from 'gt-i18n/internal';
+import { determineLocale } from './determineLocale';
+
+/**
+ * Resolves the current request/browser locale from the active gt config.
+ */
+export function parseLocale(): string {
+  const config = getI18nConfig();
+  return determineLocale({
+    defaultLocale: config.getDefaultLocale(),
+    locales: config.getLocales(),
+    customMapping: config.getCustomMapping(),
+  });
+}

--- a/packages/tanstack-start/src/index.client.ts
+++ b/packages/tanstack-start/src/index.client.ts
@@ -47,3 +47,4 @@ export {
   // ===== Setup ===== //
   initializeGT,
 } from 'gt-react/context';
+export { parseLocale } from './functions/parseLocale';

--- a/packages/tanstack-start/src/index.server.ts
+++ b/packages/tanstack-start/src/index.server.ts
@@ -38,3 +38,4 @@ export {
   // ===== Setup ===== //
   initializeGT,
 } from 'gt-react/context';
+export { parseLocale } from './functions/parseLocale';

--- a/packages/tanstack-start/src/index.types.ts
+++ b/packages/tanstack-start/src/index.types.ts
@@ -38,3 +38,4 @@ export {
   // ===== Setup ===== //
   initializeGT,
 } from 'gt-react/context';
+export { parseLocale } from './functions/parseLocale';


### PR DESCRIPTION
## Summary
- Initialize gt-next Pages Router browser runtime from `withGTConfig` env-backed config params.
- Keep runtime credentials read from `process.env` and reject dev keys in production config-param initialization.
- Persist initial browser `enableI18n` state to cookies and export TanStack Start `parseLocale()`.

## Testing
- `pnpm --filter gt-next test:js -- packages/next/src/config-dir/__tests__/I18NConfiguration.test.ts packages/next/src/__tests__/rscComponentWrappers.test.tsx`
- `pnpm --filter gt-next build:no-swc-plugin`
- `pnpm --filter gt-react test -- packages/react/src/condition-store/__tests__/BrowserConditionStore.test.ts packages/react/src/provider/__tests__/BrowserGTProvider.test.tsx`
- `pnpm --filter gt-tanstack-start test -- packages/tanstack-start/src/functions/__tests__/determineLocale.test.ts`
- `pnpm --filter gt-next... --filter gt-tanstack-start... build`
- Linked gt-test-apps: `pnpm build:next-pages-router`
- Linked gt-test-apps: `pnpm build:tanstack-start`
- Linked gt-test-apps production servers: Next Pages `/` returned 200; TanStack `/` returned 200.
- Linked gt-test-apps dev servers: Next Pages `/` returned 200; TanStack `/` returned 200 and `generaltranslation.locale=fr` rendered the `fr` option selected.

No changeset.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1640"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784775311&installation_id=127936663&pr_number=1640&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1640&signature=9d0d395e35c0090a05e8877e17595e78d67ae6e01b6aae307f879f3af4f43264"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires up the gt-next Pages Router browser runtime by initializing locale state from `withGTConfig` env-backed params, persisting the initial `enableI18n` state to cookies, and exporting `parseLocale()` for TanStack Start. It also refactors credential handling so that `apiKey`, `devApiKey`, and `projectId` are read exclusively from `process.env` at runtime (via the new `getRuntimeCredentials` utility) and stripped from the serialized `_GENERALTRANSLATION_I18N_CONFIG_PARAMS` env var.

- **`PagesGTProvider` / `initializeGTNextContext`**: A new `'use client'` provider lazily boots the gt-react runtime on first render using a module-level `initialized` flag; `getTranslationsSnapshot` is re-exported from all three entry points.
- **Credential sanitization**: `withGTConfig` now builds a separate `runtimeConfig` for service-enablement checks and serializes `withoutRuntimeCredentials(mergedConfig)`, ensuring credentials never reach the browser bundle.
- **`BrowserGTProvider` / `BrowserConditionStore`**: Switches from `ReadonlyConditionStore` to the writable `BrowserConditionStore` so the initial `enableI18n` state is persisted to a cookie on mount alongside the existing locale cookie write."

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the two concerns are both contained to initialization paths with no data-loss risk.

The credential sanitization and Pages Router bootstrap logic are well-tested. Two localized issues are worth a follow-up: cookie writes inside `useMemo` (React 18 strict mode can re-run the factory) and `getRuntimeCredentials` always returning explicit `undefined` values that silently override prop-based credentials in `runtimeConfig`.

`packages/react/src/provider/BrowserGTProvider.tsx` (useMemo side-effect) and `packages/next/src/config-dir/utils/runtimeCredentials.ts` (undefined-value spread behavior).
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/next/src/config-dir/utils/runtimeCredentials.ts | New utility to read runtime credentials from process.env; always returns all three keys (including undefined when unset), which silently overrides prop-based credentials when spread. |
| packages/next/src/config-dir/initializeGTNextContext.ts | New module that lazily initializes the gt-react runtime (via module-level `initialized` flag) and re-exports getTranslationsSnapshot; the singleton guard is correct but is never reset across config changes. |
| packages/next/src/provider/PagesGTProvider.tsx | New client-side GTProvider for the Pages Router; calls initializeGTNextContext() synchronously during render to bootstrap config and falls back to empty translations when none are passed. |
| packages/next/src/config-dir/getI18NConfig.ts | Now merges runtime credentials on top of the parsed config params; includes production dev-key guard on the newly hydrated credentials path. |
| packages/next/src/config.ts | Refactors credential handling: a separate runtimeConfig is used for service-enablement checks, and withoutRuntimeCredentials strips credentials before serialization. |
| packages/react/src/condition-store/BrowserConditionStore.ts | Constructor now persists the initial enableI18n state to a cookie via updateEnableI18n; this adds a cookie write side-effect that fires on every useMemo recompute. |
| packages/react/src/provider/BrowserGTProvider.tsx | Switched from ReadonlyConditionStore to BrowserConditionStore; both locale and enableI18n cookies are now written inside useMemo, which is not safe for side effects in React 18 strict mode. |
| packages/tanstack-start/src/functions/parseLocale.ts | New thin wrapper around determineLocale that reads config from the shared gt-i18n registry; isomorphic and straightforward. |
| packages/next/src/index.client.ts | Replaces mock GTProvider error-thrower with PagesGTProvider and re-exports getTranslationsSnapshot and LocaleSelector from updated sources. |
| packages/next/src/index.types.ts | Updates type stubs to reference PagesGTProvider and adds a getTranslationsSnapshot stub that throws the typesFileError. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Next as next.config.js (withGTConfig)
    participant Env as process.env
    participant Params as _I18N_CONFIG_PARAMS (env var)
    participant getI18N as getI18NConfig()
    participant initCtx as initializeGTNextContext()
    participant Provider as PagesGTProvider
    participant Browser as BrowserConditionStore

    Next->>Env: getRuntimeCredentials()
    Next->>Next: "build runtimeConfig = mergedConfig + runtimeCredentials"
    Next->>Next: validate gtServicesEnabled via runtimeConfig
    Next->>Params: serialize withoutRuntimeCredentials(mergedConfig)

    Note over Provider,Browser: Client / Pages Router hydration

    Provider->>initCtx: initializeGTNextContext()
    initCtx->>getI18N: getI18NConfig()
    getI18N->>Params: parse _GENERALTRANSLATION_I18N_CONFIG_PARAMS
    getI18N->>Env: getRuntimeCredentials() hydrate credentials
    getI18N-->>initCtx: I18NConfiguration (singleton)
    initCtx->>initCtx: initializeGT(config) once guarded by initialized flag
    initCtx-->>Provider: config
    Provider->>Browser: new BrowserConditionStore
    Browser->>Browser: setCookieValue(localeCookieName, locale)
    Browser->>Browser: setCookieValue(enableI18nCookieName, enableI18n)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Next as next.config.js (withGTConfig)
    participant Env as process.env
    participant Params as _I18N_CONFIG_PARAMS (env var)
    participant getI18N as getI18NConfig()
    participant initCtx as initializeGTNextContext()
    participant Provider as PagesGTProvider
    participant Browser as BrowserConditionStore

    Next->>Env: getRuntimeCredentials()
    Next->>Next: "build runtimeConfig = mergedConfig + runtimeCredentials"
    Next->>Next: validate gtServicesEnabled via runtimeConfig
    Next->>Params: serialize withoutRuntimeCredentials(mergedConfig)

    Note over Provider,Browser: Client / Pages Router hydration

    Provider->>initCtx: initializeGTNextContext()
    initCtx->>getI18N: getI18NConfig()
    getI18N->>Params: parse _GENERALTRANSLATION_I18N_CONFIG_PARAMS
    getI18N->>Env: getRuntimeCredentials() hydrate credentials
    getI18N-->>initCtx: I18NConfiguration (singleton)
    initCtx->>initCtx: initializeGT(config) once guarded by initialized flag
    initCtx-->>Provider: config
    Provider->>Browser: new BrowserConditionStore
    Browser->>Browser: setCookieValue(localeCookieName, locale)
    Browser->>Browser: setCookieValue(enableI18nCookieName, enableI18n)
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Freact%2Fsrc%2Fprovider%2FBrowserGTProvider.tsx%3A22-29%0A**Cookie%20side-effect%20inside%20%60useMemo%60**%0A%0A%60BrowserConditionStore%60's%20constructor%20now%20calls%20%60setCookieValue%60%20twice%20%E2%80%94%20once%20for%20the%20locale%20%28pre-existing%29%20and%20once%20for%20%60enableI18n%60%20%28new%20in%20this%20PR%29.%20React%20treats%20%60useMemo%60%20as%20a%20pure%20computation%20and%20is%20allowed%20to%20discard%20and%20re-run%20the%20factory%20at%20any%20time%3B%20in%20React%2018%20Strict%20Mode%20it%20actively%20exercises%20this%20on%20mount.%20Each%20re-invocation%20will%20write%20both%20cookies%20again%2C%20and%20the%20%60conditionStore%60%20reference%20will%20be%20silently%20replaced.%20Consider%20moving%20the%20cookie-persisting%20construction%20into%20a%20%60useRef%60%20initializer%20%28run%20once%29%20or%20accepting%20the%20idempotent%20double-write%20as%20an%20intentional%20trade-off%20and%20documenting%20it.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fnext%2Fsrc%2Fconfig-dir%2Futils%2FruntimeCredentials.ts%3A7-13%0A**Unset%20env%20vars%20spread%20as%20%60undefined%60%2C%20silently%20discarding%20prop-based%20credentials**%0A%0A%60getRuntimeCredentials%28%29%60%20always%20returns%20an%20object%20with%20all%20three%20keys%2C%20using%20%60undefined%60%20when%20the%20env%20var%20is%20absent.%20In%20%60config.ts%60%2C%20%60runtimeConfig%20%3D%20%7B%20...mergedConfig%2C%20...runtimeCredentials%20%7D%60%20means%20an%20unset%20%60GT_PROJECT_ID%60%20writes%20%60projectId%3A%20undefined%60%20over%20any%20prop-passed%20%60projectId%60%20in%20%60mergedConfig%60%2C%20causing%20%60gtServicesEnabled%60%20to%20evaluate%20to%20%60false%60.%20A%20user%20who%20previously%20called%20%60withGTConfig%28%7B%7D%2C%20%7B%20projectId%3A%20'id'%2C%20apiKey%3A%20'key'%20%7D%29%60%20without%20env%20vars%20will%20silently%20lose%20GT%20services%20after%20this%20change%20with%20no%20warning.%20The%20PR%20intentionally%20moves%20credentials%20to%20env%20vars%2C%20but%20filtering%20out%20%60undefined%60%20values%20would%20preserve%20backward-compat%20for%20the%20validation%20path%20and%20only%20let%20set%20env%20vars%20win.%0A%0A&repo=generaltranslation%2Fgt&pr=1640&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fodysseus%2Fruntime-env-cookie-fixes%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fodysseus%2Fruntime-env-cookie-fixes%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Freact%2Fsrc%2Fprovider%2FBrowserGTProvider.tsx%3A22-29%0A**Cookie%20side-effect%20inside%20%60useMemo%60**%0A%0A%60BrowserConditionStore%60's%20constructor%20now%20calls%20%60setCookieValue%60%20twice%20%E2%80%94%20once%20for%20the%20locale%20%28pre-existing%29%20and%20once%20for%20%60enableI18n%60%20%28new%20in%20this%20PR%29.%20React%20treats%20%60useMemo%60%20as%20a%20pure%20computation%20and%20is%20allowed%20to%20discard%20and%20re-run%20the%20factory%20at%20any%20time%3B%20in%20React%2018%20Strict%20Mode%20it%20actively%20exercises%20this%20on%20mount.%20Each%20re-invocation%20will%20write%20both%20cookies%20again%2C%20and%20the%20%60conditionStore%60%20reference%20will%20be%20silently%20replaced.%20Consider%20moving%20the%20cookie-persisting%20construction%20into%20a%20%60useRef%60%20initializer%20%28run%20once%29%20or%20accepting%20the%20idempotent%20double-write%20as%20an%20intentional%20trade-off%20and%20documenting%20it.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fnext%2Fsrc%2Fconfig-dir%2Futils%2FruntimeCredentials.ts%3A7-13%0A**Unset%20env%20vars%20spread%20as%20%60undefined%60%2C%20silently%20discarding%20prop-based%20credentials**%0A%0A%60getRuntimeCredentials%28%29%60%20always%20returns%20an%20object%20with%20all%20three%20keys%2C%20using%20%60undefined%60%20when%20the%20env%20var%20is%20absent.%20In%20%60config.ts%60%2C%20%60runtimeConfig%20%3D%20%7B%20...mergedConfig%2C%20...runtimeCredentials%20%7D%60%20means%20an%20unset%20%60GT_PROJECT_ID%60%20writes%20%60projectId%3A%20undefined%60%20over%20any%20prop-passed%20%60projectId%60%20in%20%60mergedConfig%60%2C%20causing%20%60gtServicesEnabled%60%20to%20evaluate%20to%20%60false%60.%20A%20user%20who%20previously%20called%20%60withGTConfig%28%7B%7D%2C%20%7B%20projectId%3A%20'id'%2C%20apiKey%3A%20'key'%20%7D%29%60%20without%20env%20vars%20will%20silently%20lose%20GT%20services%20after%20this%20change%20with%20no%20warning.%20The%20PR%20intentionally%20moves%20credentials%20to%20env%20vars%2C%20but%20filtering%20out%20%60undefined%60%20values%20would%20preserve%20backward-compat%20for%20the%20validation%20path%20and%20only%20let%20set%20env%20vars%20win.%0A%0A&repo=generaltranslation%2Fgt&pr=1640&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/react/src/provider/BrowserGTProvider.tsx:22-29
**Cookie side-effect inside `useMemo`**

`BrowserConditionStore`'s constructor now calls `setCookieValue` twice — once for the locale (pre-existing) and once for `enableI18n` (new in this PR). React treats `useMemo` as a pure computation and is allowed to discard and re-run the factory at any time; in React 18 Strict Mode it actively exercises this on mount. Each re-invocation will write both cookies again, and the `conditionStore` reference will be silently replaced. Consider moving the cookie-persisting construction into a `useRef` initializer (run once) or accepting the idempotent double-write as an intentional trade-off and documenting it.

### Issue 2 of 2
packages/next/src/config-dir/utils/runtimeCredentials.ts:7-13
**Unset env vars spread as `undefined`, silently discarding prop-based credentials**

`getRuntimeCredentials()` always returns an object with all three keys, using `undefined` when the env var is absent. In `config.ts`, `runtimeConfig = { ...mergedConfig, ...runtimeCredentials }` means an unset `GT_PROJECT_ID` writes `projectId: undefined` over any prop-passed `projectId` in `mergedConfig`, causing `gtServicesEnabled` to evaluate to `false`. A user who previously called `withGTConfig({}, { projectId: 'id', apiKey: 'key' })` without env vars will silently lose GT services after this change with no warning. The PR intentionally moves credentials to env vars, but filtering out `undefined` values would preserve backward-compat for the validation path and only let set env vars win.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: initialize linked runtime locale st..."](https://github.com/generaltranslation/gt/commit/5be5766d860db1b76923e5a80e19b39bdba1b80c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39199593)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->