### PR TITLE
fix: skip enqueue for finished txs

### DIFF
--- a/.changeset/hip-women-follow.md
+++ b/.changeset/hip-women-follow.md
@@ -1,0 +1,5 @@
+---
+"gt": patch
+---
+
+Skip enqueue for already translated files

--- a/packages/cli/src/utils/__tests__/persistPostprocessHashes.test.ts
+++ b/packages/cli/src/utils/__tests__/persistPostprocessHashes.test.ts
@@ -1,0 +1,65 @@
+import * as fs from 'node:fs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  findOrCreateEntry,
+  readLockfile,
+  writeLockfile,
+} from '../../fs/config/downloadedVersions.js';
+import type { Settings } from '../../types/index.js';
+import { persistPostProcessHashes } from '../persistPostprocessHashes.js';
+
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+}));
+
+vi.mock('../../fs/config/downloadedVersions.js', () => ({
+  findOrCreateEntry: vi.fn(),
+  readLockfile: vi.fn(),
+  writeLockfile: vi.fn(),
+}));
+
+vi.mock('../hash.js', () => ({
+  hashStringSync: vi.fn(() => 'translated-hash'),
+}));
+
+describe('persistPostProcessHashes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue('translated content');
+    vi.mocked(readLockfile).mockReturnValue({
+      data: { version: 2, branchId: 'branch-1', entries: [] },
+      entryMap: new Map(),
+      originalV1: null,
+    });
+    vi.mocked(findOrCreateEntry).mockReturnValue({
+      fileId: 'file-1',
+      versionId: 'version-1',
+      translations: {},
+    });
+  });
+
+  it('uses downloaded metadata to read the branch-scoped lockfile', () => {
+    persistPostProcessHashes(
+      {} as Settings,
+      new Set(['out/es/messages.json']),
+      new Map([
+        [
+          'out/es/messages.json',
+          {
+            branchId: 'branch-1',
+            fileId: 'file-1',
+            versionId: 'version-1',
+            locale: 'es',
+          },
+        ],
+      ])
+    );
+
+    expect(readLockfile).toHaveBeenCalledWith(
+      expect.objectContaining({ _branchId: 'branch-1' })
+    );
+    expect(writeLockfile).toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/utils/persistPostprocessHashes.ts
+++ b/packages/cli/src/utils/persistPostprocessHashes.ts
@@ -26,7 +26,13 @@ export function persistPostProcessHashes(
     return;
   }
 
-  const { data, entryMap, originalV1 } = readLockfile(settings);
+  const branchId = findDownloadedBranchId(includeFiles, downloadedMeta);
+  if (!branchId) return;
+
+  const { data, entryMap, originalV1 } = readLockfile({
+    ...settings,
+    _branchId: branchId,
+  });
   let lockUpdated = false;
 
   for (const filePath of includeFiles) {
@@ -58,4 +64,15 @@ export function persistPostProcessHashes(
   if (lockUpdated) {
     writeLockfile(data, originalV1);
   }
+}
+
+function findDownloadedBranchId(
+  includeFiles: Set<string>,
+  downloadedMeta: Map<string, DownloadMeta>
+): string | undefined {
+  for (const filePath of includeFiles) {
+    const meta = downloadedMeta.get(filePath);
+    if (meta) return meta.branchId;
+  }
+  return undefined;
 }

--- a/packages/cli/src/workflows/__tests__/download.test.ts
+++ b/packages/cli/src/workflows/__tests__/download.test.ts
@@ -118,5 +118,11 @@ describe('runDownloadWorkflow', () => {
     expect(exclude).toBeUndefined();
     expect(cwd).toBe('/project');
     expect(downloadFileBatch).toHaveBeenCalledTimes(1);
+    const [, , downloadSettings] = vi.mocked(downloadFileBatch).mock.calls[0];
+    expect(downloadSettings).toEqual(
+      expect.objectContaining({ _branchId: 'branch-1' })
+    );
+    expect(downloadSettings).not.toBe(settings);
+    expect(settings._branchId).toBeUndefined();
   });
 });

--- a/packages/cli/src/workflows/__tests__/download.test.ts
+++ b/packages/cli/src/workflows/__tests__/download.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Settings } from '../../types/index.js';
+import { clearLocaleDirs } from '../../fs/clearLocaleDirs.js';
+import { gt } from '../../utils/gt.js';
+import { downloadFileBatch } from '../../api/downloadFileBatch.js';
+import { runDownloadWorkflow } from '../download.js';
+
+vi.mock('../../console/logger.js', () => ({
+  logger: {
+    warn: vi.fn(),
+    error: vi.fn(),
+    createProgressBar: vi.fn(() => ({
+      start: vi.fn(),
+      stop: vi.fn(),
+      advance: vi.fn(),
+    })),
+  },
+}));
+
+vi.mock('../../fs/clearLocaleDirs.js', () => ({
+  clearLocaleDirs: vi.fn(),
+}));
+
+vi.mock('../../utils/gt.js', () => ({
+  gt: {
+    queryFileData: vi.fn(),
+    resolveAliasLocale: vi.fn((locale: string) => locale),
+  },
+}));
+
+vi.mock('../../api/downloadFileBatch.js', () => ({
+  downloadFileBatch: vi.fn(),
+}));
+
+describe('runDownloadWorkflow', () => {
+  const settings = {
+    config: '/project/gt.config.json',
+    options: {
+      experimentalClearLocaleDirs: true,
+    },
+  } as Settings;
+
+  const branchData = {
+    currentBranch: { id: 'branch-1', name: 'main' },
+    incomingBranch: null,
+    checkedOutBranch: null,
+  };
+
+  const fileVersionData = {
+    'file-1': {
+      versionId: 'version-1',
+      fileName: 'messages/en.json',
+    },
+  };
+
+  const jobData = {
+    jobData: {},
+    locales: ['es'],
+    message: 'No files need to be enqueued',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(downloadFileBatch).mockResolvedValue({
+      successful: [],
+      failed: [],
+      skipped: [],
+    });
+  });
+
+  it('does not clear locale dirs when no translations are completed', async () => {
+    vi.mocked(gt.queryFileData).mockResolvedValue({
+      translatedFiles: [],
+    });
+
+    await runDownloadWorkflow({
+      fileVersionData,
+      jobData,
+      branchData,
+      locales: ['es'],
+      timeoutDuration: 1,
+      resolveOutputPath: (_sourcePath, locale) => `messages/${locale}.json`,
+      options: settings,
+    });
+
+    expect(clearLocaleDirs).not.toHaveBeenCalled();
+    expect(downloadFileBatch).not.toHaveBeenCalled();
+  });
+
+  it('clears locale dirs only after translations are confirmed completed', async () => {
+    vi.mocked(gt.queryFileData).mockResolvedValue({
+      translatedFiles: [
+        {
+          branchId: 'branch-1',
+          fileId: 'file-1',
+          versionId: 'version-1',
+          locale: 'es',
+          completedAt: '2026-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    await runDownloadWorkflow({
+      fileVersionData,
+      jobData,
+      branchData,
+      locales: ['es'],
+      timeoutDuration: 1,
+      resolveOutputPath: (_sourcePath, locale) => `messages/${locale}.json`,
+      options: settings,
+    });
+
+    expect(clearLocaleDirs).toHaveBeenCalledTimes(1);
+    const [translatedFiles, locales, exclude, cwd] =
+      vi.mocked(clearLocaleDirs).mock.calls[0];
+    expect([...translatedFiles]).toEqual(['messages/es.json']);
+    expect(locales).toEqual(['es']);
+    expect(exclude).toBeUndefined();
+    expect(cwd).toBe('/project');
+    expect(downloadFileBatch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/cli/src/workflows/download.ts
+++ b/packages/cli/src/workflows/download.ts
@@ -67,6 +67,7 @@ export async function runDownloadWorkflow({
     }
     branchData = branchResult;
   }
+  // readLockfile uses _branchId to select branch-specific lockfile entries.
   options._branchId = branchData.currentBranch.id;
   // Prepare the query data
   const fileQueryData = prepareFileQueryData(

--- a/packages/cli/src/workflows/download.ts
+++ b/packages/cli/src/workflows/download.ts
@@ -68,7 +68,11 @@ export async function runDownloadWorkflow({
     branchData = branchResult;
   }
   // readLockfile uses _branchId to select branch-specific lockfile entries.
-  options._branchId = branchData.currentBranch.id;
+  // Keep it on a scoped copy so the caller's settings object is not mutated.
+  const settingsForBranch: Settings = {
+    ...options,
+    _branchId: branchData.currentBranch.id,
+  };
   // Prepare the query data
   const fileQueryData = prepareFileQueryData(
     fileVersionData,
@@ -150,7 +154,7 @@ export async function runDownloadWorkflow({
   });
 
   // Step 2: Download translations
-  const downloadStep = new DownloadTranslationsStep(gt, options);
+  const downloadStep = new DownloadTranslationsStep(gt, settingsForBranch);
   const downloadResult = await downloadStep.run({
     fileTracker,
     resolveOutputPath,

--- a/packages/cli/src/workflows/download.ts
+++ b/packages/cli/src/workflows/download.ts
@@ -67,40 +67,13 @@ export async function runDownloadWorkflow({
     }
     branchData = branchResult;
   }
+  options._branchId = branchData.currentBranch.id;
   // Prepare the query data
   const fileQueryData = prepareFileQueryData(
     fileVersionData,
     locales,
     branchData
   );
-
-  // Clear translated files before any downloads (if enabled)
-  if (
-    options.options?.experimentalClearLocaleDirs === true &&
-    fileQueryData.length > 0
-  ) {
-    const translatedFiles = new Set(
-      fileQueryData
-        .map((file) => {
-          const outputPath = resolveOutputPath(file.fileName, file.locale);
-          // Only clear if the output path is different from the source (i.e., there's a transform)
-          return outputPath !== null && outputPath !== file.fileName
-            ? outputPath
-            : null;
-        })
-        .filter((path): path is string => path !== null)
-    );
-
-    // Derive cwd from config path
-    const cwd = path.dirname(options.config);
-
-    await clearLocaleDirs(
-      translatedFiles,
-      locales,
-      options.options?.clearLocaleDirsExclude,
-      cwd
-    );
-  }
 
   // Initialize download status
   const fileTracker: FileStatusTracker = {
@@ -168,6 +141,13 @@ export async function runDownloadWorkflow({
     }
   }
 
+  await clearCompletedLocaleDirs({
+    fileTracker,
+    locales,
+    resolveOutputPath,
+    options,
+  });
+
   // Step 2: Download translations
   const downloadStep = new DownloadTranslationsStep(gt, options);
   const downloadResult = await downloadStep.run({
@@ -183,6 +163,48 @@ export async function runDownloadWorkflow({
   }
 
   return downloadResult;
+}
+
+async function clearCompletedLocaleDirs({
+  fileTracker,
+  locales,
+  resolveOutputPath,
+  options,
+}: {
+  fileTracker: FileStatusTracker;
+  locales: string[];
+  resolveOutputPath: (sourcePath: string, locale: string) => string | null;
+  options: Settings;
+}): Promise<void> {
+  if (
+    options.options?.experimentalClearLocaleDirs !== true ||
+    fileTracker.completed.size === 0
+  ) {
+    return;
+  }
+
+  const translatedFiles = new Set(
+    Array.from(fileTracker.completed.values())
+      .map((file) => {
+        const outputPath = resolveOutputPath(file.fileName, file.locale);
+        // Only clear if the output path is different from the source.
+        return outputPath !== null && outputPath !== file.fileName
+          ? outputPath
+          : null;
+      })
+      .filter((filePath): filePath is string => filePath !== null)
+  );
+
+  if (translatedFiles.size === 0) return;
+
+  const cwd = path.dirname(options.config);
+
+  await clearLocaleDirs(
+    translatedFiles,
+    locales,
+    options.options?.clearLocaleDirsExclude,
+    cwd
+  );
 }
 
 /**

--- a/packages/cli/src/workflows/enqueue.ts
+++ b/packages/cli/src/workflows/enqueue.ts
@@ -6,6 +6,7 @@ import { EnqueueFilesResult, FileToUpload } from 'generaltranslation/types';
 import { EnqueueStep } from './steps/EnqueueStep.js';
 import { BranchStep } from './steps/BranchStep.js';
 import { logger } from '../console/logger.js';
+import { filterFilesForEnqueue } from './utils/filterFilesForEnqueue.js';
 
 /**
  * Enqueues translations for a given set of files
@@ -46,17 +47,30 @@ export async function runEnqueueWorkflow({
     logger.debug('Branch data: ' + JSON.stringify(branchData, null, 2));
 
     // (2) Enqueue the files
-    const enqueueResult = await enqueueStep.run(
-      files.map((files) => ({
-        branchId: branchData.currentBranch.id,
-        ...files,
-      }))
-    );
+    const filesWithBranch = files.map((files) => ({
+      branchId: branchData.currentBranch.id,
+      ...files,
+    }));
+    const { filesToEnqueue, skippedFiles } = await filterFilesForEnqueue({
+      gt,
+      files: filesWithBranch,
+      locales: settings.locales,
+      force: options.force,
+    });
+    if (skippedFiles.length > 0) {
+      logger.info(
+        `Skipped enqueue for ${skippedFiles.length} already translated file${skippedFiles.length === 1 ? '' : 's'}`
+      );
+    }
+
+    const enqueueResult = await enqueueStep.run(filesToEnqueue);
     await enqueueStep.wait();
 
     logger.debug('Enqueue result: ' + JSON.stringify(enqueueResult, null, 2));
 
-    logEnqueueResult(enqueueResult, files);
+    if (filesToEnqueue.length > 0 || skippedFiles.length === 0) {
+      logEnqueueResult(enqueueResult, filesToEnqueue.length);
+    }
     return enqueueResult;
   } catch (error) {
     return logErrorAndExit(
@@ -77,11 +91,11 @@ export async function runEnqueueWorkflow({
  */
 function logEnqueueResult(
   enqueueResult: EnqueueFilesResult,
-  files: FileToUpload[]
+  fileCount: number
 ): void {
   if (Object.keys(enqueueResult.jobData).length === 0) {
     logger.success(
-      `All ${files.length} files already translated. 0 files enqueued.`
+      `All ${fileCount} ${fileCount === 1 ? 'file' : 'files'} already translated. 0 files enqueued.`
     );
   } else {
     logger.success(enqueueResult.message);

--- a/packages/cli/src/workflows/enqueue.ts
+++ b/packages/cli/src/workflows/enqueue.ts
@@ -68,9 +68,7 @@ export async function runEnqueueWorkflow({
 
     logger.debug('Enqueue result: ' + JSON.stringify(enqueueResult, null, 2));
 
-    if (filesToEnqueue.length > 0 || skippedFiles.length === 0) {
-      logEnqueueResult(enqueueResult, filesToEnqueue.length);
-    }
+    logEnqueueResult(enqueueResult, filesToEnqueue.length);
     return enqueueResult;
   } catch (error) {
     return logErrorAndExit(

--- a/packages/cli/src/workflows/enqueue.ts
+++ b/packages/cli/src/workflows/enqueue.ts
@@ -68,7 +68,10 @@ export async function runEnqueueWorkflow({
 
     logger.debug('Enqueue result: ' + JSON.stringify(enqueueResult, null, 2));
 
-    logEnqueueResult(enqueueResult, filesToEnqueue.length);
+    logEnqueueResult(
+      enqueueResult,
+      filesToEnqueue.length === 0 ? files.length : filesToEnqueue.length
+    );
     return enqueueResult;
   } catch (error) {
     return logErrorAndExit(

--- a/packages/cli/src/workflows/stage.ts
+++ b/packages/cli/src/workflows/stage.ts
@@ -12,6 +12,7 @@ import { TagStep } from './steps/TagStep.js';
 import { UserEditDiffsStep } from './steps/UserEditDiffsStep.js';
 import { BranchData } from '../types/branch.js';
 import { calculateTimeoutMs } from '../utils/calculateTimeoutMs.js';
+import { filterFilesForEnqueue } from './utils/filterFilesForEnqueue.js';
 
 /**
  * Sends multiple files for translation to the API using a workflow pattern
@@ -80,7 +81,19 @@ export async function runStageFilesWorkflow({
     await setupStep.wait();
 
     // then run the enqueue step
-    const enqueueResult = await enqueueStep.run(uploadedFiles);
+    const { filesToEnqueue, skippedFiles } = await filterFilesForEnqueue({
+      gt,
+      files: uploadedFiles,
+      locales: settings.locales,
+      force: options.force,
+    });
+    if (skippedFiles.length > 0) {
+      logger.info(
+        `Skipped enqueue for ${skippedFiles.length} already translated file${skippedFiles.length === 1 ? '' : 's'}`
+      );
+    }
+
+    const enqueueResult = await enqueueStep.run(filesToEnqueue);
     await enqueueStep.wait();
 
     return { branchData, enqueueResult };

--- a/packages/cli/src/workflows/steps/EnqueueStep.ts
+++ b/packages/cli/src/workflows/steps/EnqueueStep.ts
@@ -12,6 +12,7 @@ export class EnqueueStep extends WorkflowStep<
 > {
   private spinner = logger.createSpinner('dots');
   private result: EnqueueFilesResult | null = null;
+  private spinnerStarted = false;
 
   constructor(
     private gt: GT,
@@ -22,7 +23,17 @@ export class EnqueueStep extends WorkflowStep<
   }
 
   async run(files: FileReference[]): Promise<EnqueueFilesResult> {
+    if (files.length === 0) {
+      this.result = {
+        jobData: {},
+        locales: this.settings.locales,
+        message: 'No files need to be enqueued',
+      };
+      return this.result;
+    }
+
     this.spinner.start('Enqueuing translations...');
+    this.spinnerStarted = true;
 
     this.result = await this.gt.enqueueFiles(files, {
       sourceLocale: this.settings.defaultLocale,
@@ -36,7 +47,7 @@ export class EnqueueStep extends WorkflowStep<
   }
 
   async wait(): Promise<void> {
-    if (this.result) {
+    if (this.result && this.spinnerStarted) {
       this.spinner.stop(chalk.green('Translations enqueued successfully'));
     }
   }

--- a/packages/cli/src/workflows/steps/PollJobsStep.ts
+++ b/packages/cli/src/workflows/steps/PollJobsStep.ts
@@ -5,6 +5,10 @@ import { GT } from 'generaltranslation';
 import { EnqueueFilesResult } from 'generaltranslation/types';
 import { TEMPLATE_FILE_NAME } from '../../utils/constants.js';
 import type { FileProperties } from '../../types/files.js';
+import {
+  getFileTranslationKey,
+  queryCompletedTranslationKeys,
+} from '../utils/queryCompletedTranslations.js';
 
 export type PollJobsInput = {
   fileTracker: FileStatusTracker;
@@ -54,32 +58,19 @@ export class PollTranslationJobsStep extends WorkflowStep<
     // Build a map of branchId:fileId:versionId:locale -> FileProperties
     const filePropertiesMap = new Map<string, FileProperties>();
     fileQueryData.forEach((item) => {
-      filePropertiesMap.set(
-        `${item.branchId}:${item.fileId}:${item.versionId}:${item.locale}`,
-        item
-      );
+      filePropertiesMap.set(getFileTranslationKey(item), item);
     });
 
     // Initial query to check which files already have translations
     // Skip when force retranslation is enabled, since the server
     // no longer marks force-retranslated files as incomplete
     if (!forceRetranslation) {
-      const initialFileData = await this.gt.queryFileData({
-        translatedFiles: fileQueryData.map((item) => ({
-          fileId: item.fileId,
-          versionId: item.versionId,
-          branchId: item.branchId,
-          locale: item.locale,
-        })),
-      });
-      const existingTranslations = initialFileData.translatedFiles || [];
+      const completedKeys = await queryCompletedTranslationKeys(
+        this.gt,
+        fileQueryData
+      );
 
-      // Mark all existing translations as completed
-      existingTranslations.forEach((translation) => {
-        if (!translation.completedAt) {
-          return;
-        }
-        const fileKey = `${translation.branchId}:${translation.fileId}:${translation.versionId}:${translation.locale}`;
+      completedKeys.forEach((fileKey) => {
         const fileProperties = filePropertiesMap.get(fileKey);
         if (fileProperties) {
           fileTracker.completed.set(fileKey, fileProperties);
@@ -122,7 +113,7 @@ export class PollTranslationJobsStep extends WorkflowStep<
 
     // Categorize each file query item
     for (const item of fileQueryData) {
-      const fileKey = `${item.branchId}:${item.fileId}:${item.versionId}:${item.locale}`;
+      const fileKey = getFileTranslationKey(item);
 
       // Check if translation already exists (completedAt is truthy)
       const existingTranslation = fileTracker.completed.get(fileKey);

--- a/packages/cli/src/workflows/steps/__tests__/EnqueueStep.test.ts
+++ b/packages/cli/src/workflows/steps/__tests__/EnqueueStep.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { GT } from 'generaltranslation';
+import type { Settings } from '../../../types/index.js';
+import { EnqueueStep } from '../EnqueueStep.js';
+
+const spinner = {
+  start: vi.fn(),
+  stop: vi.fn(),
+};
+
+vi.mock('../../../console/logger.js', () => ({
+  logger: {
+    createSpinner: vi.fn(() => spinner),
+  },
+}));
+
+describe('EnqueueStep', () => {
+  const gt = {
+    enqueueFiles: vi.fn(),
+  };
+
+  const settings = {
+    defaultLocale: 'en',
+    locales: ['es'],
+    stageTranslations: false,
+  } as Settings;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not call the enqueue API when there are no files to enqueue', async () => {
+    const step = new EnqueueStep(gt as unknown as GT, settings);
+
+    const result = await step.run([]);
+    await step.wait();
+
+    expect(result).toEqual({
+      jobData: {},
+      locales: ['es'],
+      message: 'No files need to be enqueued',
+    });
+    expect(gt.enqueueFiles).not.toHaveBeenCalled();
+    expect(spinner.start).not.toHaveBeenCalled();
+    expect(spinner.stop).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/workflows/utils/__tests__/filterFilesForEnqueue.test.ts
+++ b/packages/cli/src/workflows/utils/__tests__/filterFilesForEnqueue.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { GT } from 'generaltranslation';
+import type { FileReference } from 'generaltranslation/types';
+import { filterFilesForEnqueue } from '../filterFilesForEnqueue.js';
+
+describe('filterFilesForEnqueue', () => {
+  const file: FileReference = {
+    branchId: 'branch-1',
+    fileId: 'file-1',
+    versionId: 'version-1',
+    fileName: 'messages/en.json',
+    fileFormat: 'JSON',
+  };
+
+  const completedTranslation = (locale: string) => ({
+    branchId: file.branchId,
+    fileId: file.fileId,
+    versionId: file.versionId,
+    locale,
+    completedAt: '2026-01-01T00:00:00.000Z',
+  });
+
+  const gt = {
+    queryFileData: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('skips enqueue when every target locale is already completed', async () => {
+    gt.queryFileData.mockResolvedValue({
+      translatedFiles: [completedTranslation('es'), completedTranslation('fr')],
+    });
+
+    const result = await filterFilesForEnqueue({
+      gt: gt as unknown as GT,
+      files: [file],
+      locales: ['es', 'fr'],
+    });
+
+    expect(result.filesToEnqueue).toEqual([]);
+    expect(result.skippedFiles).toEqual([file]);
+    expect(gt.queryFileData).toHaveBeenCalledWith({
+      translatedFiles: [
+        {
+          branchId: 'branch-1',
+          fileId: 'file-1',
+          versionId: 'version-1',
+          locale: 'es',
+        },
+        {
+          branchId: 'branch-1',
+          fileId: 'file-1',
+          versionId: 'version-1',
+          locale: 'fr',
+        },
+      ],
+    });
+  });
+
+  it('enqueues when any target locale is incomplete', async () => {
+    gt.queryFileData.mockResolvedValue({
+      translatedFiles: [
+        completedTranslation('es'),
+        {
+          ...completedTranslation('fr'),
+          completedAt: null,
+        },
+      ],
+    });
+
+    const result = await filterFilesForEnqueue({
+      gt: gt as unknown as GT,
+      files: [file],
+      locales: ['es', 'fr'],
+    });
+
+    expect(result.filesToEnqueue).toEqual([file]);
+    expect(result.skippedFiles).toEqual([]);
+  });
+
+  it('does not query status when force is enabled', async () => {
+    const result = await filterFilesForEnqueue({
+      gt: gt as unknown as GT,
+      files: [file],
+      locales: ['es'],
+      force: true,
+    });
+
+    expect(result.filesToEnqueue).toEqual([file]);
+    expect(result.skippedFiles).toEqual([]);
+    expect(gt.queryFileData).not.toHaveBeenCalled();
+  });
+
+  it('falls back to enqueueing when status query fails', async () => {
+    gt.queryFileData.mockRejectedValue(new Error('query failed'));
+
+    const result = await filterFilesForEnqueue({
+      gt: gt as unknown as GT,
+      files: [file],
+      locales: ['es'],
+    });
+
+    expect(result.filesToEnqueue).toEqual([file]);
+    expect(result.skippedFiles).toEqual([]);
+  });
+});

--- a/packages/cli/src/workflows/utils/filterFilesForEnqueue.ts
+++ b/packages/cli/src/workflows/utils/filterFilesForEnqueue.ts
@@ -1,0 +1,71 @@
+import type { GT } from 'generaltranslation';
+import type { FileReference } from 'generaltranslation/types';
+import type { FileProperties } from '../../types/files.js';
+import {
+  getFileTranslationKey,
+  queryCompletedTranslationKeys,
+} from './queryCompletedTranslations.js';
+
+type FilterFilesForEnqueueClient = Pick<GT, 'queryFileData'>;
+
+export type EnqueueFilterResult = {
+  filesToEnqueue: FileReference[];
+  skippedFiles: FileReference[];
+};
+
+export async function filterFilesForEnqueue({
+  gt,
+  files,
+  locales,
+  force,
+}: {
+  gt: FilterFilesForEnqueueClient;
+  files: FileReference[];
+  locales: string[];
+  force?: boolean;
+}): Promise<EnqueueFilterResult> {
+  if (force || files.length === 0 || locales.length === 0) {
+    return { filesToEnqueue: files, skippedFiles: [] };
+  }
+
+  const fileQueryData: FileProperties[] = files.flatMap((file) =>
+    locales.map((locale) => ({
+      branchId: file.branchId,
+      fileId: file.fileId,
+      versionId: file.versionId,
+      fileName: file.fileName,
+      locale,
+    }))
+  );
+
+  let completedKeys: Set<string>;
+  try {
+    completedKeys = await queryCompletedTranslationKeys(gt, fileQueryData);
+  } catch {
+    return { filesToEnqueue: files, skippedFiles: [] };
+  }
+
+  const filesToEnqueue: FileReference[] = [];
+  const skippedFiles: FileReference[] = [];
+
+  for (const file of files) {
+    const hasEveryLocale = locales.every((locale) =>
+      completedKeys.has(
+        getFileTranslationKey({
+          branchId: file.branchId,
+          fileId: file.fileId,
+          versionId: file.versionId,
+          locale,
+        })
+      )
+    );
+
+    if (hasEveryLocale) {
+      skippedFiles.push(file);
+    } else {
+      filesToEnqueue.push(file);
+    }
+  }
+
+  return { filesToEnqueue, skippedFiles };
+}

--- a/packages/cli/src/workflows/utils/queryCompletedTranslations.ts
+++ b/packages/cli/src/workflows/utils/queryCompletedTranslations.ts
@@ -1,0 +1,34 @@
+import type { GT } from 'generaltranslation';
+import type { FileProperties } from '../../types/files.js';
+
+export type QueryCompletedTranslationsClient = Pick<GT, 'queryFileData'>;
+
+export function getFileTranslationKey(
+  file: Pick<FileProperties, 'branchId' | 'fileId' | 'versionId' | 'locale'>
+): string {
+  return `${file.branchId}:${file.fileId}:${file.versionId}:${file.locale}`;
+}
+
+export async function queryCompletedTranslationKeys(
+  gt: QueryCompletedTranslationsClient,
+  fileQueryData: FileProperties[]
+): Promise<Set<string>> {
+  if (fileQueryData.length === 0) {
+    return new Set();
+  }
+
+  const fileData = await gt.queryFileData({
+    translatedFiles: fileQueryData.map((file) => ({
+      fileId: file.fileId,
+      versionId: file.versionId,
+      branchId: file.branchId,
+      locale: file.locale,
+    })),
+  });
+
+  return new Set(
+    (fileData.translatedFiles || [])
+      .filter((file) => !!file.completedAt)
+      .map(getFileTranslationKey)
+  );
+}


### PR DESCRIPTION
<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1642"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784780492&installation_id=127936663&pr_number=1642&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1642&signature=9195c19752011ddba824b70517adf1465975ff8a8d99084f0704d1349529757c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a pre-enqueue check that queries the GT API for already-completed translations and skips enqueueing any file for which every target locale is confirmed translated. It also refactors `clearLocaleDirs` in the download workflow to only clear directories for files that are confirmed completed (rather than clearing eagerly before polling), and extracts shared key-building logic into `queryCompletedTranslations.ts`.

- **`filterFilesForEnqueue`** (new): queries `queryFileData` once before enqueue, skips files whose every target locale has a non-null `completedAt`; falls back to full enqueue on API error and bypasses the check when `force` is set.
- **`EnqueueStep`**: short-circuits on an empty files list so the spinner is never started, guarding `wait()` with a `spinnerStarted` flag to prevent stopping an unstarted spinner.
- **`download.ts`**: `clearLocaleDirs` is now deferred until after polling so it only clears directories for files that actually completed, rather than clearing all queried files up front.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the new pre-enqueue filter has a conservative fallback (enqueue everything on error), force-retranslation bypasses the check entirely, and the download workflow still clears locale dirs before downloading.

All three changed workflows (enqueue, stage, download) follow the same safe pattern: query completion status, skip confirmed-done files, fall back to full enqueue on any API failure. The spinner guard in EnqueueStep correctly prevents stopping an unstarted spinner. The clearLocaleDirs refactor preserves the pre-download timing. New unit and integration tests cover the key paths.

The staging else-branch in download.ts is the only spot still using an inline key format instead of getFileTranslationKey; no functional impact today but worth a follow-up.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/workflows/utils/filterFilesForEnqueue.ts | New utility that pre-filters files before enqueue by checking if all target locales are already translated; falls back to enqueuing on API errors. |
| packages/cli/src/workflows/utils/queryCompletedTranslations.ts | New shared utility extracting getFileTranslationKey and queryCompletedTranslationKeys, eliminating duplicated inline key construction across PollJobsStep, filterFilesForEnqueue, and download. |
| packages/cli/src/workflows/enqueue.ts | Integrates filterFilesForEnqueue before the EnqueueStep call; logEnqueueResult now receives filesToEnqueue.length instead of the full files array. |
| packages/cli/src/workflows/stage.ts | Same filterFilesForEnqueue pattern applied to the stage workflow after the setup step completes. |
| packages/cli/src/workflows/steps/EnqueueStep.ts | Adds an early-exit path for empty file lists so the spinner is never started, and guards wait() behind spinnerStarted to avoid stopping an unstarted spinner. |
| packages/cli/src/workflows/steps/PollJobsStep.ts | Refactored to use shared getFileTranslationKey and queryCompletedTranslationKeys helpers, removing duplicated key-building logic. |
| packages/cli/src/workflows/download.ts | clearLocaleDirs moved from a pre-poll blanket clear to a post-poll targeted clear of only confirmed-completed files; also adds options._branchId mutation (noted by a previous reviewer). |
| packages/cli/src/workflows/steps/__tests__/EnqueueStep.test.ts | New unit test confirming the no-op path when files list is empty: API not called, spinner not started/stopped. |
| packages/cli/src/workflows/utils/__tests__/filterFilesForEnqueue.test.ts | New unit tests covering all-locales-complete skip, partial-locale enqueue, force bypass, and API-error fallback scenarios. |
| packages/cli/src/workflows/__tests__/download.test.ts | New integration tests for the refactored clearLocaleDirs timing: verifies it is not called when no translations are completed and is called with the right args after completion. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant C as CLI
    participant FE as filterFilesForEnqueue
    participant API as GT API (queryFileData)
    participant ES as EnqueueStep
    participant EA as GT API (enqueueFiles)

    C->>FE: files[], locales[], force?
    alt "force=true OR no files"
        FE-->>C: "{ filesToEnqueue: files, skippedFiles: [] }"
    else normal path
        FE->>API: queryFileData(file x locale combos)
        API-->>FE: translatedFiles[]
        FE->>FE: filter by completedAt to completedKeys Set
        loop each file
            FE->>FE: "hasEveryLocale = locales.every(l => completedKeys.has(key))"
        end
        FE-->>C: "{ filesToEnqueue, skippedFiles }"
    end
    alt "skippedFiles.length > 0"
        C->>C: logger.info(Skipped N already translated files)
    end
    ES->>ES: run(filesToEnqueue)
    alt "filesToEnqueue.length === 0"
        ES-->>C: "{ jobData: {}, locales, message: No files need to be enqueued }"
    else files to enqueue
        ES->>EA: enqueueFiles(filesToEnqueue)
        EA-->>ES: EnqueueFilesResult
        ES-->>C: EnqueueFilesResult
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant C as CLI
    participant FE as filterFilesForEnqueue
    participant API as GT API (queryFileData)
    participant ES as EnqueueStep
    participant EA as GT API (enqueueFiles)

    C->>FE: files[], locales[], force?
    alt "force=true OR no files"
        FE-->>C: "{ filesToEnqueue: files, skippedFiles: [] }"
    else normal path
        FE->>API: queryFileData(file x locale combos)
        API-->>FE: translatedFiles[]
        FE->>FE: filter by completedAt to completedKeys Set
        loop each file
            FE->>FE: "hasEveryLocale = locales.every(l => completedKeys.has(key))"
        end
        FE-->>C: "{ filesToEnqueue, skippedFiles }"
    end
    alt "skippedFiles.length > 0"
        C->>C: logger.info(Skipped N already translated files)
    end
    ES->>ES: run(filesToEnqueue)
    alt "filesToEnqueue.length === 0"
        ES-->>C: "{ jobData: {}, locales, message: No files need to be enqueued }"
    else files to enqueue
        ES->>EA: enqueueFiles(filesToEnqueue)
        EA-->>ES: EnqueueFilesResult
        ES-->>C: EnqueueFilesResult
    end
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: comment"](https://github.com/generaltranslation/gt/commit/c418b3c5ab9982689fb1f67516de7eb6503e4a1c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39208807)</sub>

<!-- /greptile_comment -->