### PR TITLE
fix(1): keep next runtime credentials out of config params

### DIFF
--- a/.changeset/runtime-env-credentials.md
+++ b/.changeset/runtime-env-credentials.md
@@ -1,0 +1,5 @@
+---
+"gt-next": patch
+---
+
+Read Next runtime credentials from environment variables and keep them out of serialized config.

--- a/packages/next/src/__tests__/config.test.ts
+++ b/packages/next/src/__tests__/config.test.ts
@@ -57,6 +57,8 @@ beforeEach(() => {
   delete process.env.GT_PROJECT_ID;
   delete process.env.GT_API_KEY;
   delete process.env.GT_DEV_API_KEY;
+  delete process.env.NEXT_PUBLIC_GT_PROJECT_ID;
+  delete process.env.NEXT_PUBLIC_GT_DEV_API_KEY;
   delete process.env.TURBOPACK;
   process.env.NODE_ENV = 'development';
   vi.clearAllMocks();
@@ -379,7 +381,7 @@ describe('withGTConfig', () => {
       expect(params.maxBatchSize).toBe(99);
     });
 
-    it('GT_PROJECT_ID env var overrides config file projectId', async () => {
+    it('GT_PROJECT_ID env var is not serialized when config file has projectId', async () => {
       const withGTConfig = await getWithGTConfig();
       process.env.GT_PROJECT_ID = 'env-project-id';
       vi.mocked(fs.existsSync).mockImplementation((p) => {
@@ -393,17 +395,17 @@ describe('withGTConfig', () => {
       const result = withGTConfig();
       const params = parseConfigParams(result);
 
-      expect(params.projectId).toBe('env-project-id');
+      expect(params.projectId).toBeUndefined();
     });
 
-    it('props override env vars', async () => {
+    it('props projectId is not serialized when overriding env vars', async () => {
       const withGTConfig = await getWithGTConfig();
       process.env.GT_PROJECT_ID = 'env-project-id';
 
       const result = withGTConfig({}, { projectId: 'props-project-id' });
       const params = parseConfigParams(result);
 
-      expect(params.projectId).toBe('props-project-id');
+      expect(params.projectId).toBeUndefined();
     });
 
     it('full chain: each layer contributes different values', async () => {
@@ -428,8 +430,8 @@ describe('withGTConfig', () => {
 
       // From config file (not overridden)
       expect(params.maxBatchSize).toBe(99);
-      // From env (overrides config file)
-      expect(params.projectId).toBe('env-project-id');
+      // From env (not serialized)
+      expect(params.projectId).toBeUndefined();
       // From props (overrides all)
       expect(params.defaultLocale).toBe('fr');
       expect(params.maxConcurrentRequests).toBe(200);
@@ -609,74 +611,77 @@ describe('withGTConfig', () => {
   // 5. Environment variable handling
   // ==============================
   describe('5. Environment variable handling', () => {
-    it('GT_PROJECT_ID sets projectId in merged config', async () => {
+    it('GT_PROJECT_ID enables services but is not serialized', async () => {
       const withGTConfig = await getWithGTConfig();
       process.env.GT_PROJECT_ID = 'my-project';
+      process.env.GT_DEV_API_KEY = 'dev-key-value';
 
       const result = withGTConfig();
       const params = parseConfigParams(result);
 
-      expect(params.projectId).toBe('my-project');
+      expect(result.env!._GENERALTRANSLATION_GT_SERVICES_ENABLED).toBe('true');
+      expect(params.projectId).toBeUndefined();
     });
 
-    it('GT_API_KEY with gt-api- prefix in production sets apiKey', async () => {
+    it('GT_API_KEY in production enables services but is not serialized', async () => {
       const withGTConfig = await getWithGTConfig();
       process.env.NODE_ENV = 'production';
-      process.env.GT_API_KEY = 'gt-api-xyz';
+      process.env.GT_API_KEY = 'api-key-value';
       process.env.GT_PROJECT_ID = 'proj';
 
       const result = withGTConfig();
       const params = parseConfigParams(result);
 
-      expect(params.apiKey).toBe('gt-api-xyz');
-    });
-
-    it('GT_DEV_API_KEY with gt-dev- prefix in development sets devApiKey', async () => {
-      const withGTConfig = await getWithGTConfig();
-      process.env.NODE_ENV = 'development';
-      process.env.GT_DEV_API_KEY = 'gt-dev-xyz';
-
-      const result = withGTConfig();
-      const params = parseConfigParams(result);
-
-      expect(params.devApiKey).toBe('gt-dev-xyz');
-    });
-
-    it('GT_API_KEY in development (no dev key) sets apiKey', async () => {
-      const withGTConfig = await getWithGTConfig();
-      process.env.NODE_ENV = 'development';
-      process.env.GT_API_KEY = 'gt-api-xyz';
-
-      const result = withGTConfig();
-      const params = parseConfigParams(result);
-
-      expect(params.apiKey).toBe('gt-api-xyz');
-    });
-
-    it('GT_DEV_API_KEY preferred over GT_API_KEY in development', async () => {
-      const withGTConfig = await getWithGTConfig();
-      process.env.NODE_ENV = 'development';
-      process.env.GT_DEV_API_KEY = 'gt-dev-preferred';
-      process.env.GT_API_KEY = 'gt-api-fallback';
-
-      const result = withGTConfig();
-      const params = parseConfigParams(result);
-
-      expect(params.devApiKey).toBe('gt-dev-preferred');
-      // apiKey should not be set from GT_API_KEY since GT_DEV_API_KEY took precedence
+      expect(result.env!._GENERALTRANSLATION_GT_SERVICES_ENABLED).toBe('true');
       expect(params.apiKey).toBeUndefined();
     });
 
-    it('key with unknown prefix sets neither apiKey nor devApiKey', async () => {
+    it('GT_DEV_API_KEY in development enables services but is not serialized', async () => {
       const withGTConfig = await getWithGTConfig();
       process.env.NODE_ENV = 'development';
-      process.env.GT_API_KEY = 'gt-unknown-xyz';
+      process.env.GT_PROJECT_ID = 'proj';
+      process.env.GT_DEV_API_KEY = 'dev-key-value';
 
       const result = withGTConfig();
       const params = parseConfigParams(result);
 
-      expect(params.apiKey).toBeUndefined();
+      expect(result.env!._GENERALTRANSLATION_GT_SERVICES_ENABLED).toBe('true');
       expect(params.devApiKey).toBeUndefined();
+    });
+
+    it('GT_API_KEY in development is not serialized', async () => {
+      const withGTConfig = await getWithGTConfig();
+      process.env.NODE_ENV = 'development';
+      process.env.GT_API_KEY = 'api-key-value';
+
+      const result = withGTConfig();
+      const params = parseConfigParams(result);
+
+      expect(params.apiKey).toBeUndefined();
+    });
+
+    it('NEXT_PUBLIC_GT_DEV_API_KEY is not serialized', async () => {
+      const withGTConfig = await getWithGTConfig();
+      process.env.NODE_ENV = 'development';
+      process.env.NEXT_PUBLIC_GT_DEV_API_KEY = 'public-dev-key-value';
+
+      const result = withGTConfig();
+      const params = parseConfigParams(result);
+
+      expect(params.devApiKey).toBeUndefined();
+    });
+
+    it('does not parse key prefixes', async () => {
+      const withGTConfig = await getWithGTConfig();
+      process.env.NODE_ENV = 'development';
+      process.env.GT_PROJECT_ID = 'proj';
+      process.env.GT_DEV_API_KEY = 'not-prefixed';
+
+      const result = withGTConfig();
+      const params = parseConfigParams(result);
+
+      expect(params.devApiKey).toBeUndefined();
+      expect(result.env!._GENERALTRANSLATION_GT_SERVICES_ENABLED).toBe('true');
     });
   });
 
@@ -1132,15 +1137,25 @@ describe('withGTConfig', () => {
       expect(result.env!._GENERALTRANSLATION_I18N_CONFIG_PARAMS).toBeDefined();
     });
 
-    it('I18N_CONFIG_PARAMS contains full merged config as JSON string', async () => {
+    it('I18N_CONFIG_PARAMS contains non-credential config as JSON string', async () => {
       const withGTConfig = await getWithGTConfig();
-      const result = withGTConfig();
+      const result = withGTConfig(
+        {},
+        {
+          projectId: 'project-id',
+          apiKey: 'api-key',
+          devApiKey: 'dev-key',
+        }
+      );
 
       const raw = result.env!._GENERALTRANSLATION_I18N_CONFIG_PARAMS;
       expect(typeof raw).toBe('string');
       const parsed = JSON.parse(raw!);
       expect(parsed).toHaveProperty('defaultLocale');
       expect(parsed).toHaveProperty('_usingPlugin', true);
+      expect(parsed.projectId).toBeUndefined();
+      expect(parsed.apiKey).toBeUndefined();
+      expect(parsed.devApiKey).toBeUndefined();
     });
 
     it('boolean flags are string "true"/"false", not booleans', async () => {

--- a/packages/next/src/config-dir/props/withGTConfigProps.ts
+++ b/packages/next/src/config-dir/props/withGTConfigProps.ts
@@ -37,7 +37,7 @@ export const REQUEST_FUNCTION_TO_CONFIG_KEY = {
   getDomain: 'getDomainPath',
 } as const;
 
-export type withGTConfigProps = {
+export type BaseWithGTConfigProps = {
   // Additional top-level keys are forwarded as runtime translation metadata.
   [key: string]: unknown;
   // Request scoped filepath
@@ -45,9 +45,7 @@ export type withGTConfigProps = {
   config?: string;
   loadTranslationsPath?: string;
   loadDictionaryPath?: string;
-  // Cloud integration
-  apiKey?: string;
-  projectId?: string;
+  // Cloud integration. Credentials are read from environment variables.
   runtimeUrl?: string | null;
   cacheUrl?: string | null;
   cacheExpiryTime?: number;
@@ -90,4 +88,13 @@ export type withGTConfigProps = {
   getLocalePath?: string;
   getRegionPath?: string;
   getDomainPath?: string;
+};
+
+export type withGTConfigProps = BaseWithGTConfigProps & {
+  /** Use GT_API_KEY instead. */
+  apiKey?: never;
+  /** Use NEXT_PUBLIC_GT_DEV_API_KEY or GT_DEV_API_KEY instead. */
+  devApiKey?: never;
+  /** Use NEXT_PUBLIC_GT_PROJECT_ID or GT_PROJECT_ID instead. */
+  projectId?: never;
 };

--- a/packages/next/src/config-dir/utils/resolveRequestFunctionPaths.ts
+++ b/packages/next/src/config-dir/utils/resolveRequestFunctionPaths.ts
@@ -5,7 +5,7 @@ import {
   STATIC_REQUEST_FUNCTIONS,
 } from '../../request/types';
 import {
-  type withGTConfigProps,
+  type BaseWithGTConfigProps,
   REQUEST_FUNCTION_TO_CONFIG_KEY,
 } from '../props/withGTConfigProps';
 import { resolveConfigFilepath } from './resolveConfigFilepath';
@@ -29,7 +29,7 @@ export type RequestFunctionPaths = Partial<
  * @returns Object mapping function names to their resolved paths and enabled status
  */
 export function resolveRequestFunctionPaths(
-  mergedConfig: withGTConfigProps
+  mergedConfig: BaseWithGTConfigProps
 ): RequestFunctionPaths {
   const result = {} as RequestFunctionPaths;
 

--- a/packages/next/src/config-dir/utils/validateCompiler.ts
+++ b/packages/next/src/config-dir/utils/validateCompiler.ts
@@ -1,4 +1,4 @@
-import { type withGTConfigProps } from '../props/withGTConfigProps';
+import { type BaseWithGTConfigProps } from '../props/withGTConfigProps';
 import { babelPluginCompatible } from '../../plugin/getStableNextVersionInfo';
 import {
   babelCompilerTurbopackUnavailableWarning,
@@ -13,7 +13,7 @@ import { swcPluginCompatible } from '../../plugin/getStableNextVersionInfo';
  * @param mergedConfig - The merged config
  * @description If the compiler is not compatible, set the type to 'none'
  */
-export function validateCompiler(mergedConfig: withGTConfigProps) {
+export function validateCompiler(mergedConfig: BaseWithGTConfigProps) {
   const turboPackEnabled = !!process.env.TURBOPACK;
   if (!mergedConfig.experimentalCompilerOptions) return;
   const type = mergedConfig.experimentalCompilerOptions.type;

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -5,7 +5,10 @@ import {
   defaultWithGTConfigProps,
   defaultCacheExpiryTime,
 } from './config-dir/props/defaultWithGTConfigProps';
-import { type withGTConfigProps } from './config-dir/props/withGTConfigProps';
+import {
+  type BaseWithGTConfigProps,
+  type withGTConfigProps,
+} from './config-dir/props/withGTConfigProps';
 import {
   APIKeyMissingWarn,
   conflictingConfigurationBuildError,
@@ -39,6 +42,7 @@ import { resolveConfigFilepath } from './config-dir/utils/resolveConfigFilepath'
 import { ssgChecks } from './plugin/checks/ssgChecks';
 import { cacheComponentsChecks } from './plugin/checks/cacheComponentsChecks';
 import { I18nConfigParams } from 'gt-i18n/internal/types';
+import { getRuntimeCredentials } from './setup/runtimeCredentials';
 
 type AutoderiveConfig = boolean | { jsx?: boolean; strings?: boolean };
 
@@ -53,9 +57,15 @@ type ConfigFileShape = {
   };
 };
 
-type InternalGTConfigProps = withGTConfigProps &
+type RuntimeCredentialProps = {
+  apiKey?: string;
+  devApiKey?: string;
+  projectId?: string;
+};
+
+type InternalGTConfigProps = BaseWithGTConfigProps &
+  RuntimeCredentialProps &
   ConfigFileShape & {
-    devApiKey?: string;
     loadDictionaryEnabled?: boolean;
     loadTranslationsType?: 'remote' | 'custom' | 'disabled';
     _dictionaryFileType?: string;
@@ -78,16 +88,12 @@ type WithGTConfigResult<TNextConfig extends object> = TNextConfig & NextConfig;
  * } satisfies NextConfig;
  *
  * export default withGTConfig(nextConfig, {
- *   projectId: 'abc-123',
  *   locales: ['en', 'es', 'fr'],
  *   defaultLocale: 'en'
  * })
  *
  * @param {string|undefined} config - Optional config filepath (defaults to './gt.config.json'). If a file is found, it will be parsed for GT config variables.
  * @param {string|undefined} dictionary - Optional dictionary configuration file path. If a string is provided, it will be used as a path.
- * @param {string} [apiKey=defaultInitGTProps.apiKey] - API key for the GeneralTranslation service. Required if using the default GT base URL.
- * @param {string} [devApiKey=defaultInitGTProps.devApiKey] - API key for dev environment only.
- * @param {string} [projectId=defaultInitGTProps.projectId] - Project ID for the GeneralTranslation service. Required for most functionality.
  * @param {string|null} [runtimeUrl=defaultInitGTProps.runtimeUrl] - The base URL for the GT API. Set to an empty string to disable automatic translations. Set to null to disable.
  * @param {string|null} [cacheUrl=defaultInitGTProps.cacheUrl] - The URL for cached translations. Set to null to disable.
  * @param {string[]|undefined} - Whether to use local translations.
@@ -116,7 +122,7 @@ type WithGTConfigResult<TNextConfig extends object> = TNextConfig & NextConfig;
  * @param {withGTConfigProps} props - General Translation configuration properties
  * @returns {NextConfig} - An updated Next.js config with GT settings applied
  *
- * @throws {Error} If the project ID is missing and default URLs are used, or if the API key is required and missing.
+ * @throws {Error} If the project ID is missing and default URLs are used, or if the API key is required and missing from the environment.
  */
 export function withGTConfig<TNextConfig extends object = NextConfig>(
   nextConfig?: TNextConfig,
@@ -150,23 +156,7 @@ export function withGTConfig<TNextConfig extends object = NextConfig>(
 
   // ---------- LOAD ENVIRONMENT VARIABLES ---------- //
 
-  // resolve project ID
-  const projectId: string | undefined = process.env.GT_PROJECT_ID;
-
-  // resolve API keys
-  const envApiKey: string | undefined =
-    process.env.NODE_ENV === 'production'
-      ? process.env.GT_API_KEY
-      : process.env.GT_DEV_API_KEY || process.env.GT_API_KEY;
-  let apiKey, devApiKey;
-  if (envApiKey) {
-    const apiKeyType = envApiKey?.split('-')?.[1];
-    if (apiKeyType === 'api') {
-      apiKey = envApiKey;
-    } else if (apiKeyType === 'dev') {
-      devApiKey = envApiKey;
-    }
-  }
+  const { projectId, apiKey, devApiKey } = getRuntimeCredentials();
 
   // conditionally add environment variables to config
   const envConfig: Partial<InternalGTConfigProps> = {
@@ -551,7 +541,13 @@ export function withGTConfig<TNextConfig extends object = NextConfig>(
   }
 
   // ---------- STORE CONFIGURATIONS ---------- //
-  const I18NConfigParams = JSON.stringify(mergedConfig);
+  const {
+    projectId: _projectId,
+    apiKey: _apiKey,
+    devApiKey: _devApiKey,
+    ...privateConfigParams
+  } = mergedConfig;
+  const I18NConfigParams = JSON.stringify(privateConfigParams);
   const publicI18NConfigParams: Omit<
     I18nConfigParams,
     'projectId' | 'devApiKey' | 'apiKey'

--- a/packages/next/src/plugin/checks/cacheComponentsChecks.ts
+++ b/packages/next/src/plugin/checks/cacheComponentsChecks.ts
@@ -1,5 +1,5 @@
 import { NextConfig } from 'next';
-import { type withGTConfigProps } from '../../config-dir/props/withGTConfigProps';
+import { type BaseWithGTConfigProps } from '../../config-dir/props/withGTConfigProps';
 import {
   experimentalLocaleResolutionDeprecatedWarning,
   createCacheComponentsMissingRequestFunctionsWarning,
@@ -19,7 +19,7 @@ export function cacheComponentsChecks({
   localTranslationsEnabled,
   localDictionaryEnabled,
 }: {
-  mergedConfig: withGTConfigProps;
+  mergedConfig: BaseWithGTConfigProps;
   nextConfig: NextConfig;
   requestFunctionPaths: RequestFunctionPaths;
   localTranslationsEnabled: boolean;

--- a/packages/next/src/plugin/checks/ssgChecks.ts
+++ b/packages/next/src/plugin/checks/ssgChecks.ts
@@ -2,11 +2,11 @@ import {
   deprecatedExperimentalEnableSSGWarning,
   ssgMissingGetStaticLocaleFunctionError,
 } from '../../errors/ssg';
-import { type withGTConfigProps } from '../../config-dir/props/withGTConfigProps';
+import { type BaseWithGTConfigProps } from '../../config-dir/props/withGTConfigProps';
 import { RequestFunctionPaths } from '../../config-dir/utils/resolveRequestFunctionPaths';
 
 export function ssgChecks(
-  mergedConfig: withGTConfigProps,
+  mergedConfig: BaseWithGTConfigProps,
   requestFunctionPaths: RequestFunctionPaths
 ) {
   // Check (warn): if using deprecated experimentalEnableSSG configuration

--- a/packages/next/src/setup/__tests__/shared.test.ts
+++ b/packages/next/src/setup/__tests__/shared.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { getParams } from '../shared';
+
+let savedEnv: NodeJS.ProcessEnv;
+
+function setConfigEnv() {
+  process.env.NEXT_PUBLIC_GENERALTRANSLATION_I18N_CONFIG_PARAMS =
+    JSON.stringify({
+      defaultLocale: 'en',
+      locales: ['en', 'fr'],
+      runtimeUrl: 'https://runtime.example.com',
+    });
+  process.env._GENERALTRANSLATION_I18N_CONFIG_PARAMS = JSON.stringify({
+    cacheUrl: 'https://cache.example.com',
+    renderSettings: { timeout: 123 },
+    maxConcurrentRequests: 1,
+    maxBatchSize: 2,
+    batchInterval: 3,
+    _versionId: 'version-id',
+  });
+}
+
+describe('getParams', () => {
+  beforeEach(() => {
+    savedEnv = { ...process.env };
+    process.env = {};
+    setConfigEnv();
+  });
+
+  afterEach(() => {
+    process.env = savedEnv;
+  });
+
+  it('reads runtime credentials directly from process.env', () => {
+    process.env.GT_PROJECT_ID = 'project-id';
+    process.env.GT_API_KEY = 'api-key';
+    process.env.GT_DEV_API_KEY = 'dev-key';
+
+    const { i18nConfigParams, gtservicesEnabledParams, nextI18nCacheParams } =
+      getParams();
+
+    expect(i18nConfigParams).toMatchObject({
+      projectId: 'project-id',
+      apiKey: 'api-key',
+      devApiKey: 'dev-key',
+    });
+    expect(gtservicesEnabledParams).toMatchObject({
+      projectId: 'project-id',
+      apiKey: 'api-key',
+      devApiKey: 'dev-key',
+    });
+    expect(nextI18nCacheParams).toMatchObject({
+      projectId: 'project-id',
+      apiKey: 'api-key',
+      devApiKey: 'dev-key',
+    });
+  });
+
+  it('prefers public project and dev credentials when present', () => {
+    process.env.GT_PROJECT_ID = 'private-project-id';
+    process.env.NEXT_PUBLIC_GT_PROJECT_ID = 'public-project-id';
+    process.env.GT_DEV_API_KEY = 'private-dev-key';
+    process.env.NEXT_PUBLIC_GT_DEV_API_KEY = 'public-dev-key';
+
+    const { i18nConfigParams } = getParams();
+
+    expect(i18nConfigParams.projectId).toBe('public-project-id');
+    expect(i18nConfigParams.devApiKey).toBe('public-dev-key');
+  });
+});

--- a/packages/next/src/setup/runtimeCredentials.ts
+++ b/packages/next/src/setup/runtimeCredentials.ts
@@ -1,0 +1,9 @@
+export function getRuntimeCredentials() {
+  return {
+    projectId:
+      process.env.NEXT_PUBLIC_GT_PROJECT_ID || process.env.GT_PROJECT_ID,
+    apiKey: process.env.GT_API_KEY,
+    devApiKey:
+      process.env.NEXT_PUBLIC_GT_DEV_API_KEY || process.env.GT_DEV_API_KEY,
+  };
+}

--- a/packages/next/src/setup/shared.ts
+++ b/packages/next/src/setup/shared.ts
@@ -2,6 +2,7 @@ import { type I18nConfigParams } from 'gt-i18n/internal';
 import { type NextI18nCacheParams } from '../i18n-cache/NextI18nCache';
 import type { GTServicesEnabledParams } from 'gt-i18n/internal/types';
 import { loadTranslations } from '../config-dir/loadTranslation';
+import { getRuntimeCredentials } from './runtimeCredentials';
 
 // TODO: better way of communicating from build to runtime
 export function getParams(): {
@@ -16,9 +17,7 @@ export function getParams(): {
   const privateConfig = JSON.parse(
     process.env._GENERALTRANSLATION_I18N_CONFIG_PARAMS || '{}'
   );
-  const projectId = process.env.NEXT_PUBLIC_GT_PROJECT_ID;
-  const devApiKey = process.env.NEXT_PUBLIC_GT_DEV_API_KEY;
-  const apiKey = process.env.GT_API_KEY;
+  const { projectId, devApiKey, apiKey } = getRuntimeCredentials();
 
   // I18nConfigParams
   const i18nConfigParams: I18nConfigParams = {


### PR DESCRIPTION
## Summary
- read Next runtime credentials directly from `process.env` at runtime
- keep credential values out of serialized i18n config params
- mark `projectId`, `apiKey`, and `devApiKey` as unsupported on the public `withGTConfig()` props type
- update inline config docs/comments to point credential configuration at environment variables

## Testing
- `pnpm exec oxfmt --check packages/next/src/config-dir/props/withGTConfigProps.ts packages/next/src/config.ts packages/next/src/config-dir/utils/validateCompiler.ts packages/next/src/config-dir/utils/resolveRequestFunctionPaths.ts packages/next/src/plugin/checks/ssgChecks.ts packages/next/src/plugin/checks/cacheComponentsChecks.ts`
- `pnpm exec oxlint packages/next/src/config-dir/props/withGTConfigProps.ts packages/next/src/config.ts packages/next/src/config-dir/utils/validateCompiler.ts packages/next/src/config-dir/utils/resolveRequestFunctionPaths.ts packages/next/src/plugin/checks/ssgChecks.ts packages/next/src/plugin/checks/cacheComponentsChecks.ts`
- `pnpm --dir packages/next exec vitest run src/__tests__/config.test.ts`
- `pnpm --filter gt-next typecheck`
- `pnpm --filter gt-next build:no-swc-plugin`

Patch changeset added for `gt-next`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1645"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784842517&installation_id=127936663&pr_number=1645&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1645&signature=58a697c4d8f336554714c4193457626f6141796658d3a63eb91a8d3c3122f47f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves credential resolution for `projectId`, `apiKey`, and `devApiKey` out of the serialized Next.js config params and into a dedicated `getRuntimeCredentials()` helper that reads directly from `process.env` at both build and runtime. The public `withGTConfigProps` type now marks these three fields as `never`, enforcing environment-variable-only credential configuration.

- **New `runtimeCredentials.ts`**: Single source of truth for credential resolution, preferring `NEXT_PUBLIC_GT_PROJECT_ID`/`NEXT_PUBLIC_GT_DEV_API_KEY` over their private counterparts; called from both `config.ts` (build time) and `shared.ts` (runtime).
- **Credential stripping in `config.ts`**: Credentials are destructured out before `JSON.stringify`, so they never appear in `_GENERALTRANSLATION_I18N_CONFIG_PARAMS`; build-time checks (`gtServicesEnabled`, dev-key-in-prod guard, `APIKeyMissingWarn`) still operate on the full `mergedConfig` before stripping.
- **API key prefix validation removed**: The old split-on-`-` prefix check (`gt-api-` / `gt-dev-`) is gone; any value in `GT_API_KEY` or `GT_DEV_API_KEY` is now accepted directly — documented and tested explicitly.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — credentials are correctly stripped from serialized config, all build-time guards still operate on the full mergedConfig before stripping, and the new getRuntimeCredentials helper is shared correctly between build and runtime paths.

The change is a well-scoped refactor: the credential stripping is implemented via a destructuring spread before serialization, existing build-time validation (gtServicesEnabled, dev-key-in-production guard, APIKeyMissingWarn) is unaffected, and the new getRuntimeCredentials helper is straightforward. Tests are updated to verify credentials are absent from params while services-enabled flags are still set. No logic regressions found.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/next/src/setup/runtimeCredentials.ts | New file centralizing credential env-var reads; simple and correct. Prefers NEXT_PUBLIC_ variants over private ones for projectId and devApiKey. |
| packages/next/src/config.ts | Build-time credential loading refactored to use getRuntimeCredentials(); credentials stripped from serialized I18NConfigParams via destructuring before JSON.stringify. All build-time checks (gtServicesEnabled, dev-key-in-prod guard) still operate on the full mergedConfig. |
| packages/next/src/setup/shared.ts | Runtime credential reads now share getRuntimeCredentials(), adding GT_PROJECT_ID and GT_DEV_API_KEY fallbacks that were missing before (previously only read NEXT_PUBLIC_ variants). |
| packages/next/src/config-dir/props/withGTConfigProps.ts | Clean type split: BaseWithGTConfigProps (no credentials) + withGTConfigProps extending it with apiKey/devApiKey/projectId as `never`, enforcing env-var-only usage at the TypeScript level. |
| packages/next/src/setup/__tests__/shared.test.ts | New test file covering happy path (all three credentials) and NEXT_PUBLIC preference; test isolation uses process.env replacement pattern. |
| packages/next/src/__tests__/config.test.ts | Tests correctly updated: credential assertions changed from checking serialized values to checking they're absent from params, while services-enabled flag is verified instead. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Dev as Developer
    participant Config as withGTConfig() (build time)
    participant Env as process.env
    participant Params as I18NConfigParams (serialized)
    participant Runtime as getParams() (runtime)

    Dev->>Config: withGTConfig(nextConfig, props)
    Config->>Env: getRuntimeCredentials()
    Env-->>Config: "{ projectId, apiKey, devApiKey }"
    Config->>Config: merge into mergedConfig
    Config->>Config: build-time checks (gtServicesEnabled, dev-key-in-prod, APIKeyMissingWarn)
    Config->>Params: JSON.stringify(mergedConfig WITHOUT credentials)
    Config-->>Dev: NextConfig with env vars set

    Note over Runtime: At Next.js runtime
    Runtime->>Env: getRuntimeCredentials()
    Env-->>Runtime: "{ projectId, apiKey, devApiKey }"
    Runtime->>Params: parse _GENERALTRANSLATION_I18N_CONFIG_PARAMS
    Runtime->>Runtime: merge config + credentials
    Runtime-->>Runtime: i18nConfigParams, gtservicesEnabledParams, nextI18nCacheParams
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Dev as Developer
    participant Config as withGTConfig() (build time)
    participant Env as process.env
    participant Params as I18NConfigParams (serialized)
    participant Runtime as getParams() (runtime)

    Dev->>Config: withGTConfig(nextConfig, props)
    Config->>Env: getRuntimeCredentials()
    Env-->>Config: "{ projectId, apiKey, devApiKey }"
    Config->>Config: merge into mergedConfig
    Config->>Config: build-time checks (gtServicesEnabled, dev-key-in-prod, APIKeyMissingWarn)
    Config->>Params: JSON.stringify(mergedConfig WITHOUT credentials)
    Config-->>Dev: NextConfig with env vars set

    Note over Runtime: At Next.js runtime
    Runtime->>Env: getRuntimeCredentials()
    Env-->>Runtime: "{ projectId, apiKey, devApiKey }"
    Runtime->>Params: parse _GENERALTRANSLATION_I18N_CONFIG_PARAMS
    Runtime->>Runtime: merge config + credentials
    Runtime-->>Runtime: i18nConfigParams, gtservicesEnabledParams, nextI18nCacheParams
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(1): keep next runtime credentials ou..."](https://github.com/generaltranslation/gt/commit/4a2424c69942824deee0ee0d3ba57865f0efb9d2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39407210)</sub>

<!-- /greptile_comment -->