### PR TITLE
chore: Update api headers

### DIFF
--- a/.changeset/gt-api-headers.md
+++ b/.changeset/gt-api-headers.md
@@ -1,6 +1,6 @@
 ---
-'generaltranslation': patch
-'gt': patch
+"generaltranslation": patch
+"gt": patch
 ---
 
-Use `gt-project-id` instead of `x-gt-project-id` for API request headers.
+Use `gt-project-id` instead of `x-gt-project-id` for API request headers. Update the API key header to use standard `Authorization: Bearer <api-key>` prefix.

--- a/.changeset/gt-api-headers.md
+++ b/.changeset/gt-api-headers.md
@@ -1,0 +1,6 @@
+---
+'generaltranslation': patch
+'gt': patch
+---
+
+Use `gt-project-id` instead of `x-gt-project-id` for API request headers.

--- a/packages/cli/src/utils/headers.ts
+++ b/packages/cli/src/utils/headers.ts
@@ -1,9 +1,9 @@
 export function getAuthHeaders(projectId: string, apiKey: string) {
   const authHeaders: Record<string, string> = {
-    "x-gt-project-id": projectId,
+    'x-gt-project-id': projectId,
   };
   if (apiKey) {
-    authHeaders["Authorization"] = `Bearer ${apiKey}`;
+    authHeaders['Authorization'] = `Bearer ${apiKey}`;
   }
   return authHeaders;
 }

--- a/packages/cli/src/utils/headers.ts
+++ b/packages/cli/src/utils/headers.ts
@@ -1,6 +1,6 @@
 export function getAuthHeaders(projectId: string, apiKey: string) {
   const authHeaders: Record<string, string> = {
-    'x-gt-project-id': projectId,
+    'gt-project-id': projectId,
   };
   if (apiKey) {
     authHeaders['Authorization'] = `Bearer ${apiKey}`;

--- a/packages/cli/src/utils/headers.ts
+++ b/packages/cli/src/utils/headers.ts
@@ -1,13 +1,9 @@
 export function getAuthHeaders(projectId: string, apiKey: string) {
   const authHeaders: Record<string, string> = {
-    'x-gt-project-id': projectId,
+    "x-gt-project-id": projectId,
   };
   if (apiKey) {
-    if (apiKey.startsWith('gtx-internal-')) {
-      authHeaders['x-gt-internal-api-key'] = apiKey;
-    } else {
-      authHeaders['x-gt-api-key'] = apiKey;
-    }
+    authHeaders["Authorization"] = `Bearer ${apiKey}`;
   }
   return authHeaders;
 }

--- a/packages/core/src/projects/__tests__/getProjectData.test.ts
+++ b/packages/core/src/projects/__tests__/getProjectData.test.ts
@@ -31,7 +31,7 @@ describe.sequential('_getProjectData', () => {
     vi.clearAllMocks();
     vi.mocked(generateRequestHeaders).mockReturnValue({
       'Content-Type': 'application/json',
-      'Authorization': 'Bearer test-api-key',
+      Authorization: 'Bearer test-api-key',
       'gt-project-id': 'test-project',
     });
   });
@@ -57,7 +57,7 @@ describe.sequential('_getProjectData', () => {
         method: 'GET',
         headers: {
           'Content-Type': 'application/json',
-          'Authorization': 'Bearer test-api-key',
+          Authorization: 'Bearer test-api-key',
           'gt-project-id': 'test-project',
         },
       },
@@ -233,7 +233,7 @@ describe.sequential('_getProjectData', () => {
         method: 'GET',
         headers: {
           'Content-Type': 'application/json',
-          'Authorization': 'Bearer test-api-key',
+          Authorization: 'Bearer test-api-key',
           'gt-project-id': 'test-project',
         },
       },

--- a/packages/core/src/projects/__tests__/getProjectData.test.ts
+++ b/packages/core/src/projects/__tests__/getProjectData.test.ts
@@ -31,8 +31,8 @@ describe.sequential('_getProjectData', () => {
     vi.clearAllMocks();
     vi.mocked(generateRequestHeaders).mockReturnValue({
       'Content-Type': 'application/json',
-      'x-gt-api-key': 'test-api-key',
-      'x-gt-project-id': 'test-project',
+      'Authorization': 'Bearer test-api-key',
+      'gt-project-id': 'test-project',
     });
   });
 
@@ -57,8 +57,8 @@ describe.sequential('_getProjectData', () => {
         method: 'GET',
         headers: {
           'Content-Type': 'application/json',
-          'x-gt-api-key': 'test-api-key',
-          'x-gt-project-id': 'test-project',
+          'Authorization': 'Bearer test-api-key',
+          'gt-project-id': 'test-project',
         },
       },
       5000
@@ -233,8 +233,8 @@ describe.sequential('_getProjectData', () => {
         method: 'GET',
         headers: {
           'Content-Type': 'application/json',
-          'x-gt-api-key': 'test-api-key',
-          'x-gt-project-id': 'test-project',
+          'Authorization': 'Bearer test-api-key',
+          'gt-project-id': 'test-project',
         },
       },
       expect.any(Number)

--- a/packages/core/src/translate/utils/__tests__/generateRequestHeaders.test.ts
+++ b/packages/core/src/translate/utils/__tests__/generateRequestHeaders.test.ts
@@ -14,7 +14,7 @@ describe('generateRequestHeaders', () => {
 
     expect(headers).toEqual({
       'Content-Type': 'application/json',
-      'x-gt-project-id': 'test-project',
+      'gt-project-id': 'test-project',
       'gt-api-version': API_VERSION,
     });
   });
@@ -30,8 +30,8 @@ describe('generateRequestHeaders', () => {
 
     expect(headers).toEqual({
       'Content-Type': 'application/json',
-      'x-gt-api-key': 'test-api-key',
-      'x-gt-project-id': 'test-project',
+      'Authorization': 'Bearer test-api-key',
+      'gt-project-id': 'test-project',
       'gt-api-version': API_VERSION,
     });
   });
@@ -46,7 +46,7 @@ describe('generateRequestHeaders', () => {
 
     expect(headers).toEqual({
       'Content-Type': 'application/json',
-      'x-gt-project-id': 'test-project',
+      'gt-project-id': 'test-project',
       'gt-api-version': API_VERSION,
     });
   });
@@ -62,7 +62,7 @@ describe('generateRequestHeaders', () => {
 
     expect(headers).toEqual({
       'Content-Type': 'application/json',
-      'x-gt-project-id': 'test-project',
+      'gt-project-id': 'test-project',
       'gt-api-version': API_VERSION,
     });
   });

--- a/packages/core/src/translate/utils/__tests__/generateRequestHeaders.test.ts
+++ b/packages/core/src/translate/utils/__tests__/generateRequestHeaders.test.ts
@@ -30,7 +30,7 @@ describe('generateRequestHeaders', () => {
 
     expect(headers).toEqual({
       'Content-Type': 'application/json',
-      'Authorization': 'Bearer test-api-key',
+      Authorization: 'Bearer test-api-key',
       'gt-project-id': 'test-project',
       'gt-api-version': API_VERSION,
     });

--- a/packages/core/src/translate/utils/generateRequestHeaders.ts
+++ b/packages/core/src/translate/utils/generateRequestHeaders.ts
@@ -7,7 +7,7 @@ export default function generateRequestHeaders(
 ) {
   const authHeaders: Record<string, string> = {
     ...(!excludeContentType && { 'Content-Type': 'application/json' }),
-    'x-gt-project-id': config.projectId,
+    'gt-project-id': config.projectId,
   };
 
   if (config.apiKey) {

--- a/packages/core/src/translate/utils/generateRequestHeaders.ts
+++ b/packages/core/src/translate/utils/generateRequestHeaders.ts
@@ -1,20 +1,20 @@
-import { TranslationRequestConfig } from "../../types";
-import { API_VERSION } from "../api";
+import { TranslationRequestConfig } from '../../types';
+import { API_VERSION } from '../api';
 
 export default function generateRequestHeaders(
   config: TranslationRequestConfig,
-  excludeContentType = false,
+  excludeContentType = false
 ) {
   const authHeaders: Record<string, string> = {
-    ...(!excludeContentType && { "Content-Type": "application/json" }),
-    "x-gt-project-id": config.projectId,
+    ...(!excludeContentType && { 'Content-Type': 'application/json' }),
+    'x-gt-project-id': config.projectId,
   };
 
   if (config.apiKey) {
-    authHeaders["Authorization"] = `Bearer ${config.apiKey}`;
+    authHeaders['Authorization'] = `Bearer ${config.apiKey}`;
   }
 
-  authHeaders["gt-api-version"] = API_VERSION;
+  authHeaders['gt-api-version'] = API_VERSION;
 
   return authHeaders;
 }

--- a/packages/core/src/translate/utils/generateRequestHeaders.ts
+++ b/packages/core/src/translate/utils/generateRequestHeaders.ts
@@ -1,24 +1,20 @@
-import { TranslationRequestConfig } from '../../types';
-import { API_VERSION } from '../api';
+import { TranslationRequestConfig } from "../../types";
+import { API_VERSION } from "../api";
 
 export default function generateRequestHeaders(
   config: TranslationRequestConfig,
-  excludeContentType = false
+  excludeContentType = false,
 ) {
   const authHeaders: Record<string, string> = {
-    ...(!excludeContentType && { 'Content-Type': 'application/json' }),
-    'x-gt-project-id': config.projectId,
+    ...(!excludeContentType && { "Content-Type": "application/json" }),
+    "x-gt-project-id": config.projectId,
   };
 
   if (config.apiKey) {
-    if (config.apiKey.startsWith('gtx-internal-')) {
-      authHeaders['x-gt-internal-api-key'] = config.apiKey;
-    } else {
-      authHeaders['x-gt-api-key'] = config.apiKey;
-    }
+    authHeaders["Authorization"] = `Bearer ${config.apiKey}`;
   }
 
-  authHeaders['gt-api-version'] = API_VERSION;
+  authHeaders["gt-api-version"] = API_VERSION;
 
   return authHeaders;
 }


### PR DESCRIPTION
<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1648"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784853304&installation_id=127936663&pr_number=1648&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1648&signature=89e426a25e422bd7e04a017da73490661d859208135d097814541f116239a434"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR migrates API request headers away from custom `x-gt-*` header names to more conventional alternatives: `x-gt-project-id` becomes `gt-project-id`, and API key authentication moves from `x-gt-api-key` / `x-gt-internal-api-key` to a standard `Authorization: Bearer <apiKey>` header. The special `gtx-internal-` key prefix branch is removed, with all key types now using the same Bearer scheme.

- **`generateRequestHeaders.ts` and `headers.ts`**: Header construction updated in both `core` and `cli` packages; old header names have been fully replaced with no remaining references across the codebase.
- **Tests**: All affected unit tests are updated to assert the new header shapes, including the `getProjectData` mocked return values.
- **Changeset**: Describes only the `gt-project-id` rename; the `Authorization: Bearer` migration and removal of the internal-key branch are not mentioned.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The code changes are internally consistent and all old header names have been removed from the codebase, but the changeset understates the scope of the change.

The actual implementation in generateRequestHeaders.ts and headers.ts is clean and complete — a grep confirms no stale references to the old x-gt-* headers remain anywhere. The only gap is the changeset description, which only mentions the gt-project-id rename but omits the shift to Authorization: Bearer and the removal of the gtx-internal- branch. For published packages, an incomplete changelog entry can leave upgraders unaware of how their outbound request headers will change.

.changeset/gt-api-headers.md should be updated to also document the Authorization: Bearer header migration and the removal of the gtx-internal- key differentiation.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .changeset/gt-api-headers.md | Changeset only documents the gt-project-id rename; the larger Authorization: Bearer header migration and removal of gtx-internal- key differentiation are undocumented. |
| packages/core/src/translate/utils/generateRequestHeaders.ts | Cleanly migrates project-id header and API key auth to standard Authorization: Bearer format; no remaining references to old headers. |
| packages/cli/src/utils/headers.ts | Mirrors the same header rename as core; consistent with the core changes. |
| packages/core/src/translate/utils/__tests__/generateRequestHeaders.test.ts | Tests updated to reflect new header names; all four cases (no key, with key, undefined, empty string) are covered. |
| packages/core/src/projects/__tests__/getProjectData.test.ts | Mock return values updated to match new header format; test assertions are consistent. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client as Client (core/cli)
    participant API as GT API

    Note over Client,API: Before this PR
    Client->>API: x-gt-project-id: id
    Client->>API: x-gt-api-key: key (regular)
    Client->>API: "x-gt-internal-api-key: key (gtx-internal-*)"

    Note over Client,API: After this PR
    Client->>API: gt-project-id: id
    Client->>API: Authorization: Bearer key (all keys)
    Client->>API: gt-api-version: version
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client as Client (core/cli)
    participant API as GT API

    Note over Client,API: Before this PR
    Client->>API: x-gt-project-id: id
    Client->>API: x-gt-api-key: key (regular)
    Client->>API: "x-gt-internal-api-key: key (gtx-internal-*)"

    Note over Client,API: After this PR
    Client->>API: gt-project-id: id
    Client->>API: Authorization: Bearer key (all keys)
    Client->>API: gt-api-version: version
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.changeset%2Fgt-api-headers.md%3A6%0A**Incomplete%20changeset%20description**%0A%0AThe%20changeset%20only%20documents%20the%20%60gt-project-id%60%20rename%2C%20but%20this%20PR%20also%20changes%20how%20API%20keys%20are%20transmitted%3A%20the%20old%20%60x-gt-api-key%60%20%2F%20%60x-gt-internal-api-key%60%20headers%20are%20replaced%20with%20a%20standard%20%60Authorization%3A%20Bearer%20%3CapiKey%3E%60%20header%2C%20and%20the%20special%20%60gtx-internal-%60%20key%20prefix%20branch%20is%20silently%20dropped.%20Any%20consumer%20who%20was%20relying%20on%20the%20presence%20of%20%60x-gt-api-key%60%20in%20the%20request%20%28e.g.%2C%20an%20intermediate%20proxy%20or%20API%20gateway%20inspecting%20headers%29%20would%20see%20a%20silent%2C%20undocumented%20change%20when%20upgrading.%20The%20changeset%20description%20should%20cover%20both%20modifications.%0A%0A&repo=generaltranslation%2Fgt&pr=1648&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.changeset/gt-api-headers.md:6
**Incomplete changeset description**

The changeset only documents the `gt-project-id` rename, but this PR also changes how API keys are transmitted: the old `x-gt-api-key` / `x-gt-internal-api-key` headers are replaced with a standard `Authorization: Bearer <apiKey>` header, and the special `gtx-internal-` key prefix branch is silently dropped. Any consumer who was relying on the presence of `x-gt-api-key` in the request (e.g., an intermediate proxy or API gateway inspecting headers) would see a silent, undocumented change when upgrading. The changeset description should cover both modifications.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["lint"](https://github.com/generaltranslation/gt/commit/7163c47e8c44422e6cf2e8de76739d59420ec16b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39441201)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->