### PR TITLE
fix: preserve browser locale initialization

### DIFF
--- a/.changeset/browser-locale-provider-candidates.md
+++ b/.changeset/browser-locale-provider-candidates.md
@@ -1,0 +1,5 @@
+---
+"gt-react": patch
+---
+
+Preserve provider locale candidates during browser hydration.

--- a/packages/react/src/condition-store/BrowserConditionStore.ts
+++ b/packages/react/src/condition-store/BrowserConditionStore.ts
@@ -165,8 +165,9 @@ export class BrowserConditionStore implements WritableConditionStoreInterface {
 }
 
 function getBrowserLocale(cookieName: string, getLocale?: GetLocale): string {
-  const candidates = readBrowserLocale(cookieName);
+  const candidates = [];
   if (getLocale) candidates.push(getLocale());
+  candidates.push(...readBrowserLocale(cookieName));
   const i18nConfig = getI18nConfig();
   return (
     i18nConfig.determineLocale(candidates) || i18nConfig.getDefaultLocale()

--- a/packages/react/src/condition-store/__tests__/BrowserConditionStore.test.ts
+++ b/packages/react/src/condition-store/__tests__/BrowserConditionStore.test.ts
@@ -1,9 +1,10 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+const mockGetCookieValue = vi.hoisted(() => vi.fn());
 const mockSetCookieValue = vi.hoisted(() => vi.fn());
 
 vi.mock('../cookies', () => ({
-  getCookieValue: vi.fn(),
+  getCookieValue: (...args: unknown[]) => mockGetCookieValue(...args),
   setCookieValue: (...args: unknown[]) => mockSetCookieValue(...args),
 }));
 
@@ -20,7 +21,12 @@ import { BrowserConditionStore } from '../BrowserConditionStore';
 
 describe('BrowserConditionStore', () => {
   beforeEach(() => {
+    mockGetCookieValue.mockReset();
     mockSetCookieValue.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it('persists the initial locale, region, and enableI18n state', () => {
@@ -64,5 +70,20 @@ describe('BrowserConditionStore', () => {
       cookieName: 'generaltranslation.locale-reset',
       value: 'true',
     });
+  });
+
+  it('uses getLocale before browser fallbacks when reading locale state', () => {
+    vi.stubGlobal('navigator', { languages: ['fr'] });
+    mockGetCookieValue.mockImplementation(
+      ({ cookieName }: { cookieName: string }) =>
+        cookieName === 'locale-cookie' ? 'en' : undefined
+    );
+    const conditionStore = new BrowserConditionStore({
+      locale: 'en',
+      localeCookieName: 'locale-cookie',
+      _getLocale: () => 'zh',
+    });
+
+    expect(conditionStore.getLocale()).toBe('zh');
   });
 });

--- a/packages/react/src/condition-store/createBrowserConditionStore.test.ts
+++ b/packages/react/src/condition-store/createBrowserConditionStore.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('determineLocale', () => {
+  beforeEach(() => {
+    const cookies = new Map<string, string>();
+    vi.resetModules();
+    vi.stubGlobal('navigator', { languages: [] });
+    vi.stubGlobal('document', {
+      get cookie() {
+        return Array.from(cookies, ([name, value]) => `${name}=${value}`).join(
+          '; '
+        );
+      },
+      set cookie(value: string) {
+        const [cookie] = value.split(';');
+        const [name, cookieValue] = cookie.split('=');
+        cookies.set(name, cookieValue);
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('uses a string locale as a single locale candidate', async () => {
+    vi.stubGlobal('navigator', { languages: ['en-US'] });
+
+    const { initializeI18nConfig } = await import('gt-i18n/internal');
+    const { createOrUpdateBrowserConditionStore } =
+      await import('./createBrowserConditionStore');
+
+    initializeI18nConfig({
+      defaultLocale: 'en',
+      locales: ['fr', 'zh'],
+    });
+
+    expect(
+      createOrUpdateBrowserConditionStore({ locale: 'fr' }).getLocale()
+    ).toBe('fr');
+  });
+
+  it('preserves locale candidate arrays', async () => {
+    vi.stubGlobal('navigator', { languages: ['en-US'] });
+
+    const { initializeI18nConfig } = await import('gt-i18n/internal');
+    const { createOrUpdateBrowserConditionStore } =
+      await import('./createBrowserConditionStore');
+
+    initializeI18nConfig({
+      defaultLocale: 'en',
+      locales: ['fr', 'zh'],
+    });
+
+    expect(
+      createOrUpdateBrowserConditionStore({ locale: ['zh', 'fr'] }).getLocale()
+    ).toBe('zh');
+  });
+});

--- a/packages/react/src/condition-store/createBrowserConditionStore.test.ts
+++ b/packages/react/src/condition-store/createBrowserConditionStore.test.ts
@@ -56,4 +56,38 @@ describe('determineLocale', () => {
       createOrUpdateBrowserConditionStore({ locale: ['zh', 'fr'] }).getLocale()
     ).toBe('zh');
   });
+
+  it('prefers the provided locale over a cookie fallback', async () => {
+    const { initializeI18nConfig } = await import('gt-i18n/internal');
+    const { createOrUpdateBrowserConditionStore } =
+      await import('./createBrowserConditionStore');
+
+    initializeI18nConfig({
+      defaultLocale: 'en',
+      locales: ['fr', 'zh'],
+    });
+    document.cookie = 'generaltranslation.locale=en;path=/';
+
+    expect(
+      createOrUpdateBrowserConditionStore({ locale: 'fr' }).getLocale()
+    ).toBe('fr');
+  });
+
+  it('uses getLocale before cookie and browser fallbacks', async () => {
+    vi.stubGlobal('navigator', { languages: ['en-US'] });
+
+    const { initializeI18nConfig } = await import('gt-i18n/internal');
+    const { createOrUpdateBrowserConditionStore } =
+      await import('./createBrowserConditionStore');
+
+    initializeI18nConfig({
+      defaultLocale: 'en',
+      locales: ['fr', 'zh'],
+    });
+    document.cookie = 'generaltranslation.locale=en;path=/';
+
+    expect(
+      createOrUpdateBrowserConditionStore({ _getLocale: () => 'zh' }).getLocale()
+    ).toBe('zh');
+  });
 });

--- a/packages/react/src/condition-store/createBrowserConditionStore.ts
+++ b/packages/react/src/condition-store/createBrowserConditionStore.ts
@@ -4,7 +4,6 @@ import {
   BrowserConditionStore,
   BrowserConditionStoreParams,
 } from './BrowserConditionStore';
-import { readBrowserLocale } from './readBrowserLocale';
 import {
   defaultEnableI18nCookieName,
   defaultLocaleCookieName,
@@ -75,9 +74,17 @@ function determineLocale({
   locale,
 }: CreateBrowserConditionStoreParams): string {
   const candidates = [];
-  candidates.push(...readBrowserLocale(localeCookieName));
-  if (locale) candidates.push(...locale);
+  const cookieLocale = getCookieValue({
+    cookieName: localeCookieName,
+  });
+  if (cookieLocale) candidates.push(cookieLocale);
+  if (locale) {
+    candidates.push(...(Array.isArray(locale) ? locale : [locale]));
+  }
   if (getLocale) candidates.push(getLocale());
+  const navigatorLocales =
+    typeof navigator !== 'undefined' ? navigator.languages : [];
+  candidates.push(...navigatorLocales);
   return resolveLocale(candidates);
 }
 

--- a/packages/react/src/condition-store/createBrowserConditionStore.ts
+++ b/packages/react/src/condition-store/createBrowserConditionStore.ts
@@ -10,6 +10,7 @@ import {
   defaultRegionCookieName,
 } from '../internal';
 import { getCookieValue } from './cookies';
+import { readBrowserLocale } from './readBrowserLocale';
 import {
   getBrowserConditionStore,
   isBrowserConditionStoreInitialized,
@@ -36,8 +37,8 @@ export type CreateBrowserConditionStoreParams = Omit<
  *
  * This exists so we can keep the locale param as required in the constructor
  *
- * We want the values that we read from the cookies to override as this
- * persists state across page reloads
+ * Explicit values from the provider are treated as the source of truth. Cookie
+ * and browser values are fallbacks for SPA usage where no locale was provided.
  */
 export function createOrUpdateBrowserConditionStore(
   config: CreateBrowserConditionStoreParams
@@ -74,17 +75,11 @@ function determineLocale({
   locale,
 }: CreateBrowserConditionStoreParams): string {
   const candidates = [];
-  const cookieLocale = getCookieValue({
-    cookieName: localeCookieName,
-  });
-  if (cookieLocale) candidates.push(cookieLocale);
   if (locale) {
     candidates.push(...(Array.isArray(locale) ? locale : [locale]));
   }
   if (getLocale) candidates.push(getLocale());
-  const navigatorLocales =
-    typeof navigator !== 'undefined' ? navigator.languages : [];
-  candidates.push(...navigatorLocales);
+  candidates.push(...readBrowserLocale(localeCookieName));
   return resolveLocale(candidates);
 }
 

--- a/packages/react/src/condition-store/readBrowserLocale.ts
+++ b/packages/react/src/condition-store/readBrowserLocale.ts
@@ -10,7 +10,8 @@ export function readBrowserLocale(localeCookieName: string): string[] {
   if (cookieLocale) candidates.push(cookieLocale);
 
   // (2) Check navigator locales
-  const navigatorLocales = navigator?.languages || [];
+  const navigatorLocales =
+    typeof navigator !== 'undefined' ? navigator.languages : [];
   candidates.push(...navigatorLocales);
 
   return candidates;


### PR DESCRIPTION
## Summary
- preserve string locale values as single browser condition-store candidates
- prioritize explicit `GTProvider` locale, then `_getLocale`, then cookie, then navigator/browser fallbacks
- add coverage for string/array candidates, stale-cookie fallback behavior, and `_getLocale` precedence

## Testing
- `pnpm --filter gt-react test`
- `pnpm --filter gt-react build`
- `pnpm build:next-app-router-locale-routing` in linked gt-test-app worktree
- linked `next-app-router-locale-routing` dev: set stale `generaltranslation.locale=en`, loaded `/fr`, verified route/server/client locales all `fr`; loaded `/zh`, verified route/server/client locales all `zh`
- linked `next-app-router-locale-routing` production: set stale `generaltranslation.locale=en`, loaded `/fr`, verified route/server/client locales all `fr`