### PR TITLE
fix: read pages locale from cookie header

### DIFF
--- a/.changeset/pages-cookie-header-locale.md
+++ b/.changeset/pages-cookie-header-locale.md
@@ -1,0 +1,5 @@
+---
+"gt-next": patch
+---
+
+Read Pages Router locale cookies from raw request headers.

--- a/packages/next/src/pages-dir/__tests__/parseLocale.test.ts
+++ b/packages/next/src/pages-dir/__tests__/parseLocale.test.ts
@@ -78,4 +78,15 @@ describe('parseLocale', () => {
 
     expect(parseLocale(context)).toBe('es');
   });
+
+  it('uses the raw cookie header when parsed cookies are unavailable', () => {
+    const context = createContext({
+      headers: {
+        cookie: 'other=value; generaltranslation.locale=fr',
+        'accept-language': 'en-US,en;q=0.8',
+      },
+    });
+
+    expect(parseLocale(context)).toBe('fr');
+  });
 });

--- a/packages/next/src/pages-dir/parseLocale.ts
+++ b/packages/next/src/pages-dir/parseLocale.ts
@@ -20,7 +20,9 @@ export function parseLocale<
 
   addHeaderCandidates(preferredLocales, context.req.headers[headerName]);
 
-  const cookieLocale = context.req.cookies?.[cookieName];
+  const cookieLocale =
+    context.req.cookies?.[cookieName] ||
+    getCookieHeaderValue(context.req.headers.cookie, cookieName);
   if (cookieLocale) {
     preferredLocales.push(cookieLocale);
   }
@@ -81,4 +83,26 @@ function getAcceptLanguageCandidates(headerValue: HeaderValue): string[] {
         .map((item) => item.split(';')?.[0].trim())
         .filter(Boolean) || []
   );
+}
+
+function getCookieHeaderValue(
+  headerValue: HeaderValue,
+  cookieName: string
+): string | undefined {
+  const headerValues = Array.isArray(headerValue) ? headerValue : [headerValue];
+  for (const value of headerValues) {
+    const cookies = value?.split(';') || [];
+    for (const cookie of cookies) {
+      const [name, ...rawValue] = cookie.trim().split('=');
+      if (name === cookieName && rawValue.length > 0) {
+        const value = rawValue.join('=');
+        try {
+          return decodeURIComponent(value);
+        } catch {
+          return value;
+        }
+      }
+    }
+  }
+  return undefined;
 }


### PR DESCRIPTION
## Summary
- fall back to the raw Cookie header when Pages Router parsed cookies are unavailable
- keep locale cookies ahead of Accept-Language during pages server-side locale resolution

## Testing
- pnpm --filter gt-next test
- linked next-pages-router: pnpm build
- linked next-pages-router dev: /, changed locale selector en -> fr, verified client and SSR cookie locale fr with no page errors
- linked next-pages-router production: /, changed locale selector en -> fr, verified client and SSR cookie locale fr with no page errors

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1651"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784856054&installation_id=127936663&pr_number=1651&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1651&signature=ad3c67023cda558fcb001fcb12a929380d6d07c3c166d10c6961e86691c62505"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes locale resolution in the Pages Router by falling back to the raw `cookie` request header when `req.cookies` (Next.js parsed cookies) is unavailable, and ensures cookie-derived locales are ranked ahead of `Accept-Language`.

- Adds `getCookieHeaderValue` helper that manually splits and decodes the `cookie` header, handling both string and string-array header values, URL-encoded values, and `=`-containing cookie values.
- Priority order is preserved: middleware locale header → parsed/raw cookie → `Accept-Language`.
- One new test covers the raw-cookie fallback path; coverage for the case where both `req.cookies` and the raw header are simultaneously present (priority verification) is absent.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The change is narrowly scoped to a cookie fallback path that only activates when Next.js has not pre-parsed the cookies, making it low-risk for the common case.

The raw-cookie parsing logic is correct and well-contained. The two findings are a variable-shadowing style issue and a gap in test coverage for the priority-ordering invariant — neither affects current runtime behavior.

packages/next/src/pages-dir/__tests__/parseLocale.test.ts could use an additional test asserting that a parsed cookie beats a conflicting raw cookie header value.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/next/src/pages-dir/parseLocale.ts | Adds `getCookieHeaderValue` helper that parses the raw `cookie` header as a fallback when `req.cookies` is unavailable; variable shadowing (`value` identifier reused in inner scope) is the only notable issue. |
| packages/next/src/pages-dir/__tests__/parseLocale.test.ts | Adds one test covering the raw-cookie fallback path; missing coverage for the priority case where both parsed cookies and raw cookie header are simultaneously populated. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[parseLocale called] --> B[Push middleware header locale]
    B --> C{req.cookies has cookieName?}
    C -- Yes --> D[Use parsed cookie locale]
    C -- No --> E{Raw cookie header contains cookieName?}
    E -- Yes --> F[Parse and decode from raw header]
    E -- No --> G[No cookie locale]
    D --> H[Push cookie locale to preferredLocales]
    F --> H
    G --> I{ignorePreferredLanguages?}
    H --> I
    I -- No --> J[Push Accept-Language candidates]
    I -- Yes --> K[determineLocale against configured locales]
    J --> K
    K --> L[Return resolved locale]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[parseLocale called] --> B[Push middleware header locale]
    B --> C{req.cookies has cookieName?}
    C -- Yes --> D[Use parsed cookie locale]
    C -- No --> E{Raw cookie header contains cookieName?}
    E -- Yes --> F[Parse and decode from raw header]
    E -- No --> G[No cookie locale]
    D --> H[Push cookie locale to preferredLocales]
    F --> H
    G --> I{ignorePreferredLanguages?}
    H --> I
    I -- No --> J[Push Accept-Language candidates]
    I -- Yes --> K[determineLocale against configured locales]
    J --> K
    K --> L[Return resolved locale]
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fnext%2Fsrc%2Fpages-dir%2FparseLocale.ts%3A98%0A**Variable%20shadowing%20inside%20%60getCookieHeaderValue%60**%0A%0AThe%20inner%20%60const%20value%20%3D%20rawValue.join%28'%3D'%29%60%20%28line%2098%29%20re-uses%20the%20same%20identifier%20as%20the%20outer%20loop%20variable%20%60for%20%28const%20value%20of%20headerValues%29%60%20%28line%2093%29.%20TypeScript%2FESLint%20%60no-shadow%60%20rules%20flag%20this%2C%20and%20it%20makes%20the%20function%20harder%20to%20follow%20at%20a%20glance%20since%20both%20bindings%20are%20in%20scope%20simultaneously%20inside%20the%20%60if%60%20block.%20Renaming%20the%20inner%20one%20to%20something%20like%20%60cookieValue%60%20would%20eliminate%20the%20ambiguity.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fnext%2Fsrc%2Fpages-dir%2F__tests__%2FparseLocale.test.ts%3A82-91%0A**Missing%20test%20for%20priority%20when%20both%20sources%20are%20populated**%0A%0AThe%20new%20test%20verifies%20the%20raw-cookie%20fallback%20fires%20when%20%60context.req.cookies%60%20is%20empty%20%28%60%7B%7D%60%29%2C%20but%20there%20is%20no%20test%20that%20confirms%20parsed%20cookies%20%28%60context.req.cookies%5BcookieName%5D%60%29%20take%20precedence%20over%20the%20raw%20%60cookie%60%20header%20when%20both%20carry%20different%20locale%20values.%20Without%20this%2C%20a%20future%20refactor%20that%20accidentally%20inverts%20the%20%60%7C%7C%60%20operands%20or%20switches%20to%20%60%3F%3F%60%20on%20the%20raw-header%20side%20could%20go%20undetected%20by%20the%20test%20suite.%0A%0A&repo=generaltranslation%2Fgt&pr=1651&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fodysseus%2Fnext-pages-cookie-locale%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fodysseus%2Fnext-pages-cookie-locale%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fnext%2Fsrc%2Fpages-dir%2FparseLocale.ts%3A98%0A**Variable%20shadowing%20inside%20%60getCookieHeaderValue%60**%0A%0AThe%20inner%20%60const%20value%20%3D%20rawValue.join%28'%3D'%29%60%20%28line%2098%29%20re-uses%20the%20same%20identifier%20as%20the%20outer%20loop%20variable%20%60for%20%28const%20value%20of%20headerValues%29%60%20%28line%2093%29.%20TypeScript%2FESLint%20%60no-shadow%60%20rules%20flag%20this%2C%20and%20it%20makes%20the%20function%20harder%20to%20follow%20at%20a%20glance%20since%20both%20bindings%20are%20in%20scope%20simultaneously%20inside%20the%20%60if%60%20block.%20Renaming%20the%20inner%20one%20to%20something%20like%20%60cookieValue%60%20would%20eliminate%20the%20ambiguity.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fnext%2Fsrc%2Fpages-dir%2F__tests__%2FparseLocale.test.ts%3A82-91%0A**Missing%20test%20for%20priority%20when%20both%20sources%20are%20populated**%0A%0AThe%20new%20test%20verifies%20the%20raw-cookie%20fallback%20fires%20when%20%60context.req.cookies%60%20is%20empty%20%28%60%7B%7D%60%29%2C%20but%20there%20is%20no%20test%20that%20confirms%20parsed%20cookies%20%28%60context.req.cookies%5BcookieName%5D%60%29%20take%20precedence%20over%20the%20raw%20%60cookie%60%20header%20when%20both%20carry%20different%20locale%20values.%20Without%20this%2C%20a%20future%20refactor%20that%20accidentally%20inverts%20the%20%60%7C%7C%60%20operands%20or%20switches%20to%20%60%3F%3F%60%20on%20the%20raw-header%20side%20could%20go%20undetected%20by%20the%20test%20suite.%0A%0A&repo=generaltranslation%2Fgt&pr=1651&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/next/src/pages-dir/parseLocale.ts:98
**Variable shadowing inside `getCookieHeaderValue`**

The inner `const value = rawValue.join('=')` (line 98) re-uses the same identifier as the outer loop variable `for (const value of headerValues)` (line 93). TypeScript/ESLint `no-shadow` rules flag this, and it makes the function harder to follow at a glance since both bindings are in scope simultaneously inside the `if` block. Renaming the inner one to something like `cookieValue` would eliminate the ambiguity.

### Issue 2 of 2
packages/next/src/pages-dir/__tests__/parseLocale.test.ts:82-91
**Missing test for priority when both sources are populated**

The new test verifies the raw-cookie fallback fires when `context.req.cookies` is empty (`{}`), but there is no test that confirms parsed cookies (`context.req.cookies[cookieName]`) take precedence over the raw `cookie` header when both carry different locale values. Without this, a future refactor that accidentally inverts the `||` operands or switches to `??` on the raw-header side could go undetected by the test suite.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: read pages locale from cookie heade..."](https://github.com/generaltranslation/gt/commit/8cb073251d50434fb675b93e0dd82d83508868d8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39446699)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->