### PR TITLE
fix: resolve tanstack provider locale on server

### DIFF
--- a/.changeset/tanstack-server-provider-locale.md
+++ b/.changeset/tanstack-server-provider-locale.md
@@ -1,0 +1,5 @@
+---
+"gt-tanstack-start": patch
+---
+
+Resolve TanStack Start provider locale during server rendering.

--- a/packages/tanstack-start/src/components/GTProvider.server.tsx
+++ b/packages/tanstack-start/src/components/GTProvider.server.tsx
@@ -1,0 +1,15 @@
+import {
+  GTProvider as ReactGTProvider,
+  type SharedGTProviderProps,
+} from 'gt-react';
+import { parseLocale } from '../functions/parseLocale';
+
+/**
+ * Server-side TanStack Start provider.
+ *
+ * The request locale must be resolved during SSR so the server-rendered HTML
+ * matches the browser condition store after locale cookie changes.
+ */
+export function GTProvider(props: SharedGTProviderProps) {
+  return <ReactGTProvider {...props} locale={parseLocale()} />;
+}

--- a/packages/tanstack-start/src/components/__tests__/GTProvider.server.test.tsx
+++ b/packages/tanstack-start/src/components/__tests__/GTProvider.server.test.tsx
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ReactElement } from 'react';
+
+const mockParseLocale = vi.hoisted(() => vi.fn());
+
+vi.mock('../../functions/parseLocale', () => ({
+  parseLocale: (...args: unknown[]) => mockParseLocale(...args),
+}));
+
+import { GTProvider } from '../GTProvider.server';
+
+describe('GTProvider', () => {
+  it('uses the server request locale for SSR provider state', () => {
+    mockParseLocale.mockReturnValue('fr');
+
+    const element = GTProvider({
+      locale: 'en',
+      translations: {},
+      dictionaries: {},
+      children: 'content',
+    }) as ReactElement<{ locale: string }>;
+
+    expect(element.props.locale).toBe('fr');
+  });
+});

--- a/packages/tanstack-start/src/index.server.ts
+++ b/packages/tanstack-start/src/index.server.ts
@@ -1,4 +1,5 @@
 export { parseLocale } from './functions/parseLocale';
+export { GTProvider } from './components/GTProvider.server';
 
 export {
   // ===== Components ===== //
@@ -12,7 +13,6 @@ export {
   RelativeTime,
   Var,
   Num,
-  GTProvider,
   // ===== Hooks ===== //
   useLocale,
   useSetLocale,


### PR DESCRIPTION
## Summary
- add a server-side TanStack Start GTProvider wrapper that resolves the request locale with parseLocale()
- keep the browser entrypoint on the existing gt-react provider
- add coverage that the server provider uses the request locale instead of a default prop

## Testing
- pnpm --filter gt-tanstack-start test
- pnpm --filter @generaltranslation/format --filter generaltranslation --filter gt-i18n --filter @generaltranslation/react-core --filter gt-react --filter gt-tanstack-start build
- linked tanstack-start dev: /ssr, changed locale selector en -> fr, verified provider locale fr with no page errors
- linked tanstack-start production preview: /ssr, changed locale selector en -> fr, verified provider locale fr with no page errors

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1652"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784856225&installation_id=127936663&pr_number=1652&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1652&signature=38d640a6260e131940cb9d7ea0ddd5378faed9c1310f0bb75181c5081f29b255"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a server-side `GTProvider` wrapper for TanStack Start that resolves the user's locale from the current SSR request (cookie → Accept-Language header → default) via the existing `parseLocale()` helper, ensuring the server-rendered HTML uses the correct locale rather than a static prop value.

- `GTProvider.server.tsx` wraps the `gt-react` provider and always overrides `locale` with `parseLocale()`, ensuring hydration parity; the server index now re-exports this wrapper while the client index continues to export the browser GTProvider directly from `gt-react`.
- A targeted unit test mocks `parseLocale` and verifies the resulting element carries the server-resolved locale regardless of what prop value was passed in.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the core SSR locale-resolution logic is correct and well-tested. One API design concern exists in the component signature but it does not affect runtime behavior.

The locale-override logic works correctly — `parseLocale()` is always used and the test confirms it. The only notable concern is that `GTProvider.server.tsx` accepts `SharedGTProviderProps` (which requires a `locale` string), yet the component always discards whatever value is passed. Callers are forced to supply a value that has no effect, which can mislead consumers of the API.

packages/tanstack-start/src/components/GTProvider.server.tsx — the component type signature deserves a second look.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/tanstack-start/src/components/GTProvider.server.tsx | New server-side GTProvider wrapper that overrides the `locale` prop with the server-resolved value from `parseLocale()`; the component accepts `SharedGTProviderProps` (where `locale: string` is required) but silently discards whatever value the caller supplies. |
| packages/tanstack-start/src/components/__tests__/GTProvider.server.test.tsx | Test verifies that the server provider's `locale` output matches `parseLocale()` rather than the prop value; uses direct function-call style (no React render) which is workable for this thin wrapper. |
| packages/tanstack-start/src/index.server.ts | Server entrypoint updated to re-export the new local GTProvider wrapper instead of the gt-react one; client entrypoint is unchanged and continues to export the browser GTProvider directly. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User as Caller (app code)
    participant ServerGTP as GTProvider.server.tsx
    participant ParseLocale as parseLocale()
    participant Cookie as Request Cookie
    participant Header as Accept-Language Header
    participant ReactGTP as gt-react GTProvider

    User->>ServerGTP: "<GTProvider locale="en" .../>"
    ServerGTP->>ParseLocale: parseLocale()
    ParseLocale->>Cookie: getCookie(defaultLocaleCookieName)
    Cookie-->>ParseLocale: "fr" (or undefined)
    ParseLocale->>Header: getRequestHeader("accept-language")
    Header-->>ParseLocale: locale candidates
    ParseLocale-->>ServerGTP: "fr"
    Note over ServerGTP: user-supplied locale "en" is discarded
    ServerGTP->>ReactGTP: "<ReactGTProvider {...props} locale="fr"/>"
    ReactGTP-->>User: "SSR HTML with locale="fr""
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User as Caller (app code)
    participant ServerGTP as GTProvider.server.tsx
    participant ParseLocale as parseLocale()
    participant Cookie as Request Cookie
    participant Header as Accept-Language Header
    participant ReactGTP as gt-react GTProvider

    User->>ServerGTP: "<GTProvider locale="en" .../>"
    ServerGTP->>ParseLocale: parseLocale()
    ParseLocale->>Cookie: getCookie(defaultLocaleCookieName)
    Cookie-->>ParseLocale: "fr" (or undefined)
    ParseLocale->>Header: getRequestHeader("accept-language")
    Header-->>ParseLocale: locale candidates
    ParseLocale-->>ServerGTP: "fr"
    Note over ServerGTP: user-supplied locale "en" is discarded
    ServerGTP->>ReactGTP: "<ReactGTProvider {...props} locale="fr"/>"
    ReactGTP-->>User: "SSR HTML with locale="fr""
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Ftanstack-start%2Fsrc%2Fcomponents%2FGTProvider.server.tsx%3A13-15%0AThe%20server%20wrapper%20accepts%20%60SharedGTProviderProps%60%20which%20makes%20%60locale%60%20a%20**required**%20%60string%60%2C%20but%20that%20value%20is%20always%20silently%20discarded%20%E2%80%94%20%60parseLocale%28%29%60%20wins%20unconditionally.%20Any%20caller%20that%20tries%20to%20set%20the%20locale%20via%20the%20prop%20%28e.g.%20for%20testing%2C%20for%20a%20static%20export%2C%20or%20when%20adapting%20this%20component%20for%20a%20different%20request%20context%29%20will%20be%20silently%20misled.%20Narrowing%20the%20type%20to%20%60Omit%3CSharedGTProviderProps%2C%20'locale'%3E%60%20both%20communicates%20the%20contract%20accurately%20and%20prevents%20callers%20from%20passing%20a%20value%20they%20believe%20will%20have%20an%20effect.%0A%0A%60%60%60suggestion%0Aexport%20function%20GTProvider%28props%3A%20Omit%3CSharedGTProviderProps%2C%20'locale'%3E%29%20%7B%0A%20%20return%20%3CReactGTProvider%20%7B...%28props%20as%20SharedGTProviderProps%29%7D%20locale%3D%7BparseLocale%28%29%7D%20%2F%3E%3B%0A%7D%0A%60%60%60%0A%0A&repo=generaltranslation%2Fgt&pr=1652&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fodysseus%2Ftanstack-ssr-locale%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fodysseus%2Ftanstack-ssr-locale%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Ftanstack-start%2Fsrc%2Fcomponents%2FGTProvider.server.tsx%3A13-15%0AThe%20server%20wrapper%20accepts%20%60SharedGTProviderProps%60%20which%20makes%20%60locale%60%20a%20**required**%20%60string%60%2C%20but%20that%20value%20is%20always%20silently%20discarded%20%E2%80%94%20%60parseLocale%28%29%60%20wins%20unconditionally.%20Any%20caller%20that%20tries%20to%20set%20the%20locale%20via%20the%20prop%20%28e.g.%20for%20testing%2C%20for%20a%20static%20export%2C%20or%20when%20adapting%20this%20component%20for%20a%20different%20request%20context%29%20will%20be%20silently%20misled.%20Narrowing%20the%20type%20to%20%60Omit%3CSharedGTProviderProps%2C%20'locale'%3E%60%20both%20communicates%20the%20contract%20accurately%20and%20prevents%20callers%20from%20passing%20a%20value%20they%20believe%20will%20have%20an%20effect.%0A%0A%60%60%60suggestion%0Aexport%20function%20GTProvider%28props%3A%20Omit%3CSharedGTProviderProps%2C%20'locale'%3E%29%20%7B%0A%20%20return%20%3CReactGTProvider%20%7B...%28props%20as%20SharedGTProviderProps%29%7D%20locale%3D%7BparseLocale%28%29%7D%20%2F%3E%3B%0A%7D%0A%60%60%60%0A%0A&repo=generaltranslation%2Fgt&pr=1652&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/tanstack-start/src/components/GTProvider.server.tsx:13-15
The server wrapper accepts `SharedGTProviderProps` which makes `locale` a **required** `string`, but that value is always silently discarded — `parseLocale()` wins unconditionally. Any caller that tries to set the locale via the prop (e.g. for testing, for a static export, or when adapting this component for a different request context) will be silently misled. Narrowing the type to `Omit<SharedGTProviderProps, 'locale'>` both communicates the contract accurately and prevents callers from passing a value they believe will have an effect.

```suggestion
export function GTProvider(props: Omit<SharedGTProviderProps, 'locale'>) {
  return <ReactGTProvider {...(props as SharedGTProviderProps)} locale={parseLocale()} />;
}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: resolve tanstack provider locale on..."](https://github.com/generaltranslation/gt/commit/a450785aeec14098cef63f252911fff61b4a6f3e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39447044)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->