### PR TITLE
feat: add ar-OM

### DIFF
--- a/.changeset/four-signs-repair.md
+++ b/.changeset/four-signs-repair.md
@@ -1,0 +1,5 @@
+---
+"@generaltranslation/supported-locales": patch
+---
+
+Add `ar-OM`

--- a/packages/supported-locales/src/__tests__/supportedLocales.test.ts
+++ b/packages/supported-locales/src/__tests__/supportedLocales.test.ts
@@ -10,4 +10,10 @@ describe('@generaltranslation/supported-locales', () => {
     expect(getSupportedLocale('eo')).toBe('eo');
     expect(getSupportedLocale('eo-US')).toBe('eo');
   });
+
+  it('supports Omani Arabic', () => {
+    expect(listSupportedLocales()).toContain('ar-OM');
+    expect(getSupportedLocale('ar-OM')).toBe('ar-OM');
+    expect(getSupportedLocale('ar-Arab-OM')).toBe('ar-OM');
+  });
 });

--- a/packages/supported-locales/src/supportedLocales.ts
+++ b/packages/supported-locales/src/supportedLocales.ts
@@ -8,6 +8,7 @@ const supportedLocales = {
     'ar-EG', // Egypt
     'ar-LB', // Lebanon
     'ar-MA', // Morocco
+    'ar-OM', // Oman
     'ar-SA', // Saudi Arabia
   ],
   bg: ['bg'], // Bulgarian


### PR DESCRIPTION
<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1653"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784856361&installation_id=127936663&pr_number=1653&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1653&signature=b36f19d543d5d47095884085a664c95da326ecc1777cbea518384b2c57359d96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Omani Arabic (`ar-OM`) to the `@generaltranslation/supported-locales` package, placing it in the correct alphabetical position within the `ar` language group.

- Adds `'ar-OM'` between `ar-MA` and `ar-SA` in `supportedLocales.ts`, maintaining alphabetical order.
- Adds a test that verifies the locale appears in `listSupportedLocales()`, resolves exactly via `getSupportedLocale('ar-OM')`, and resolves from its script-tagged form `ar-Arab-OM`; ships a patch-level changeset.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a one-line locale addition with a matching test and a correct changeset.

The change only appends a single string to an existing array, is alphabetically ordered, is covered by a new test that exercises exact match and script-tagged fallback resolution, and ships with an appropriate patch-level changeset. No logic is modified.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/supported-locales/src/supportedLocales.ts | Adds `ar-OM` in the correct alphabetical position within the `ar` locale array; no logic changes. |
| packages/supported-locales/src/__tests__/supportedLocales.test.ts | New test covers list membership, exact match, and script-tagged fallback resolution for `ar-OM`. |
| .changeset/four-signs-repair.md | Correct patch-level changeset documenting the addition of `ar-OM`. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["getSupportedLocale(locale)"] --> B{isValidLocale?}
    B -- No --> C[return null]
    B -- Yes --> D["standardizeLocale(locale)"]
    D --> E["getLocaleProperties(locale)"]
    E --> F{languageCode in supportedLocales?}
    F -- No --> C
    F -- Yes --> G["Try: full locale, lang-region, lang-script, minimizedCode"]
    G --> H{Match found?}
    H -- Yes --> I[return matched locale]
    H -- No --> J["Retry with languageCode only"]
    J --> K{Match found?}
    K -- Yes --> I
    K -- No --> C

    style I fill:#22c55e,color:#fff
    style C fill:#ef4444,color:#fff
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["getSupportedLocale(locale)"] --> B{isValidLocale?}
    B -- No --> C[return null]
    B -- Yes --> D["standardizeLocale(locale)"]
    D --> E["getLocaleProperties(locale)"]
    E --> F{languageCode in supportedLocales?}
    F -- No --> C
    F -- Yes --> G["Try: full locale, lang-region, lang-script, minimizedCode"]
    G --> H{Match found?}
    H -- Yes --> I[return matched locale]
    H -- No --> J["Retry with languageCode only"]
    J --> K{Match found?}
    K -- Yes --> I
    K -- No --> C

    style I fill:#22c55e,color:#fff
    style C fill:#ef4444,color:#fff
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add"](https://github.com/generaltranslation/gt/commit/f84235cf05d95925acb07410e5f95d34d858bc10) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39447313)</sub>

<!-- /greptile_comment -->