### PR TITLE
fix: validate redirect target origin in locale middleware

### DIFF
--- a/.changeset/middleware-redirect-origin.md
+++ b/.changeset/middleware-redirect-origin.md
@@ -1,0 +1,7 @@
+---
+"gt-next": patch
+---
+
+Patch a security issue in the locale middleware where a redirect target could
+resolve to an unintended origin. Redirect and rewrite targets are now
+constrained to the request's own origin.

--- a/packages/next/src/middleware-dir/__tests__/middleware.edge.test.ts
+++ b/packages/next/src/middleware-dir/__tests__/middleware.edge.test.ts
@@ -458,4 +458,57 @@ describe('Middleware Integration Tests', () => {
       expect(getResponseType(nextRes)).toBe('next');
     });
   });
+
+  // ================================================================
+  // Category 6: Security — open redirect prevention (CWE-601)
+  // ================================================================
+
+  describe('Category 6: Security — open redirect prevention', () => {
+    function getResponseHost(res: Response): string {
+      const loc = res.headers.get('location');
+      return loc ? new URL(loc).host : '';
+    }
+
+    it('6.1: reset cookie, /en//evil.com → redirect stays same-origin', () => {
+      setEnvConfig();
+      const middleware = createNextMiddleware({ prefixDefaultLocale: false });
+
+      // Stripping the "/en" locale prefix yields "//evil.com", which without
+      // the same-origin guard resolves to http://evil.com/ (open redirect).
+      const res = middleware(
+        createRequest('/en//evil.com', {
+          cookies: {
+            [LOCALE_COOKIE]: 'en',
+            [RESET_COOKIE]: 'true',
+          },
+        })
+      );
+
+      expect(getResponseType(res)).toBe('redirect');
+      expect(getResponseHost(res)).toBe('localhost:3000');
+      expect(getResponseHost(res)).not.toBe('evil.com');
+      expect(getResponsePath(res)).toBe('/');
+    });
+
+    it('6.2: reset cookie, mismatched locale prefix /fr//evil.com → same-origin', () => {
+      setEnvConfig();
+      const middleware = createNextMiddleware({ prefixDefaultLocale: false });
+
+      // userLocale resolves to en (cookie); pathnameLocale fr → "/fr" stripped
+      // leaving "//evil.com".
+      const res = middleware(
+        createRequest('/fr//evil.com', {
+          cookies: {
+            [LOCALE_COOKIE]: 'en',
+            [RESET_COOKIE]: 'true',
+          },
+        })
+      );
+
+      expect(getResponseType(res)).toBe('redirect');
+      expect(getResponseHost(res)).toBe('localhost:3000');
+      expect(getResponseHost(res)).not.toBe('evil.com');
+      expect(getResponsePath(res)).toBe('/');
+    });
+  });
 });

--- a/packages/next/src/middleware-dir/utils.ts
+++ b/packages/next/src/middleware-dir/utils.ts
@@ -44,6 +44,14 @@ export function getResponse({
     });
   } else {
     const responseUrl = new URL(responsePath, originalUrl);
+    // Security: locale routing only ever targets same-origin paths. A
+    // responsePath that resolves off-origin (e.g. a leading "//" or "/\"
+    // surviving from the request path after the locale prefix is stripped)
+    // would otherwise produce an open redirect / cross-origin rewrite
+    // (CWE-601). Force the target back to the request's own origin.
+    if (responseUrl.origin !== originalUrl.origin) {
+      responseUrl.href = new URL('/', originalUrl).href;
+    }
     responseUrl.search = originalUrl.search;
     response =
       type === 'rewrite'


### PR DESCRIPTION
<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1655"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784879093&installation_id=127936663&pr_number=1655&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1655&signature=483d6f7032dd5f9df1e76fe9e2d15052da499d8ed27dcbdf87508dba3abb9181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR patches a CWE-601 open redirect / cross-origin rewrite vulnerability in the Next.js locale middleware. When a locale prefix (e.g. `/en`) was stripped from a crafted path like `/en//evil.com`, the resulting `//evil.com` would be resolved by the `URL` constructor as `http://evil.com/`, producing an off-origin redirect.

- **`packages/next/src/middleware-dir/utils.ts`**: Adds a same-origin guard in `getResponse` — after constructing `responseUrl`, it compares `responseUrl.origin` against `originalUrl.origin` and falls back to the site root (`/`) if they differ. This applies to both redirect and rewrite response types.
- **`packages/next/src/middleware-dir/__tests__/middleware.edge.test.ts`**: Adds two regression tests (Category 6) covering the reset-cookie redirect path with `//evil.com` crafted via the `/en/` and `/fr/` locale prefix strip operations.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a tightly scoped, single-location guard that only fires on adversarial inputs and falls back conservatively to the site root.

The origin comparison is the correct primitive for same-origin enforcement, both redirect and rewrite paths are covered by a single guard, the fallback to '/' is intentionally conservative, and two regression tests demonstrate the exact attack pattern is now contained. The legitimate request flow is unaffected since well-formed locale-stripped paths always resolve to the same origin.

No files require special attention; all three changed files look correct.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/next/src/middleware-dir/utils.ts | Adds a same-origin guard before issuing redirects/rewrites; correctly addresses the open redirect vulnerability with a conservative root fallback. |
| packages/next/src/middleware-dir/__tests__/middleware.edge.test.ts | Adds two regression tests verifying that `//evil.com`-style crafted paths are contained to the same origin after locale prefix stripping. |
| .changeset/middleware-redirect-origin.md | Changeset entry correctly marks this as a patch to `gt-next` with an accurate security description. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant Middleware as Next.js Middleware
    participant getResponse as getResponse()

    Browser->>Middleware: GET /en//evil.com (with reset cookie)
    Note over Middleware: stripLocalePrefix("/en//evil.com") → "//evil.com"
    Middleware->>getResponse: "type=redirect, responsePath="//evil.com""
    Note over getResponse: new URL("//evil.com", originalUrl)<br/>resolves to http://evil.com/ ⚠️
    Note over getResponse: Guard: responseUrl.origin !== originalUrl.origin?<br/>YES → reset href to new URL("/", originalUrl)
    getResponse-->>Middleware: redirect to http://localhost:3000/
    Middleware-->>Browser: 307 Location: http://localhost:3000/ ✅

    Browser->>Middleware: GET /en/about (normal request)
    Middleware->>getResponse: "type=redirect, responsePath="/about""
    Note over getResponse: new URL("/about", originalUrl)<br/>resolves to http://localhost:3000/about<br/>Guard: origins match → no change
    getResponse-->>Middleware: redirect to http://localhost:3000/about
    Middleware-->>Browser: 307 Location: http://localhost:3000/about ✅
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant Middleware as Next.js Middleware
    participant getResponse as getResponse()

    Browser->>Middleware: GET /en//evil.com (with reset cookie)
    Note over Middleware: stripLocalePrefix("/en//evil.com") → "//evil.com"
    Middleware->>getResponse: "type=redirect, responsePath="//evil.com""
    Note over getResponse: new URL("//evil.com", originalUrl)<br/>resolves to http://evil.com/ ⚠️
    Note over getResponse: Guard: responseUrl.origin !== originalUrl.origin?<br/>YES → reset href to new URL("/", originalUrl)
    getResponse-->>Middleware: redirect to http://localhost:3000/
    Middleware-->>Browser: 307 Location: http://localhost:3000/ ✅

    Browser->>Middleware: GET /en/about (normal request)
    Middleware->>getResponse: "type=redirect, responsePath="/about""
    Note over getResponse: new URL("/about", originalUrl)<br/>resolves to http://localhost:3000/about<br/>Guard: origins match → no change
    getResponse-->>Middleware: redirect to http://localhost:3000/about
    Middleware-->>Browser: 307 Location: http://localhost:3000/about ✅
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: validate redirect target origin in ..."](https://github.com/generaltranslation/gt/commit/7ffc8107baf2fd54f7358e12531711f5a6801ffc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39497691)</sub>

<!-- /greptile_comment -->