### PR TITLE
ci: log odysseus changeset state

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -294,6 +294,37 @@ jobs:
           mv .changeset/config.tmp.json .changeset/config.json
           git update-index --assume-unchanged .changeset/config.json
 
+      - name: Summarize Odysseus changesets
+        run: |
+          node <<'NODE'
+          const fs = require('fs');
+          const changesetDir = '.changeset';
+          const pre = JSON.parse(
+            fs.readFileSync(`${changesetDir}/pre.json`, 'utf8')
+          );
+          const files = fs
+            .readdirSync(changesetDir)
+            .filter((file) => file.endsWith('.md') && file !== 'README.md')
+            .map((file) => file.replace(/\.md$/, ''))
+            .sort();
+          const consumed = new Set(pre.changesets || []);
+          const unconsumed = files.filter((name) => !consumed.has(name));
+
+          console.log(`Changeset files: ${files.length}`);
+          console.log(`Consumed prerelease changesets: ${consumed.size}`);
+
+          if (unconsumed.length === 0) {
+            console.log(
+              'No unconsumed Odysseus changesets found; release PR creation will be skipped.'
+            );
+          } else {
+            console.log('Unconsumed Odysseus changesets:');
+            for (const name of unconsumed) {
+              console.log(`- ${name}`);
+            }
+          }
+          NODE
+
       - name: Create Odysseus Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1


### PR DESCRIPTION
## Summary
- add an Odysseus release workflow diagnostic that prints total, consumed, and unconsumed prerelease changesets
- make it clear when existing `.changeset/*.md` files are already listed in `.changeset/pre.json` and therefore will not open or update a release PR

## Diagnosis
- The Odysseus release workflow did create and update the prerelease PR: #1646.
- After #1646 merged, the follow-up release run published the unpublished `odysseus` versions.
- The remaining changeset files on `odysseus` are all already present in `.changeset/pre.json`, so Changesets reports no new changesets and skips creating another release PR until a new changeset is merged into `odysseus`.

## Testing
- Ran the embedded Node diagnostic locally against current `odysseus` state.
- Ran `git diff --check`.

No changeset added.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1656"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784914937&installation_id=127936663&pr_number=1656&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1656&signature=967549aae412c0a1d28a5c3c918f22ad9b68d6db682cde95faf481ea4516f7ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a diagnostic step to the Odysseus release workflow that summarizes the state of changeset files — printing total `.md` files, consumed prerelease changesets (from `pre.json`), and any unconsumed ones — to make it easier to understand why `changesets/action` skips release PR creation.

- Adds a `node` inline script step immediately before the `changesets/action` step that reads `.changeset/pre.json` and `.changeset/*.md` files and logs their relationship.
- The step is purely informational and does not alter any files or workflow state.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The change is a purely diagnostic step with no side effects on the release process — except that if `.changeset/pre.json` is missing, the uncaught read error will fail the step and block the actual publish step from running.

The inline Node script reads `pre.json` without a try/catch or `continue-on-error: true`. On the happy path (Odysseus always in prerelease mode) this is fine, but if `pre.json` is ever absent the diagnostic step will throw, exit non-zero, and prevent `changesets/action` from running — turning a harmless diagnostic into a release blocker.

.github/workflows/release.yml — specifically the new `Summarize Odysseus changesets` step and its `fs.readFileSync` call.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Adds a diagnostic Node.js script step to log changeset state; the step will throw an unhandled error and block the release if `.changeset/pre.json` is absent. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant WF as Workflow Runner
    participant FS as Filesystem
    participant Node as Node.js Script
    participant CA as changesets/action

    WF->>FS: Read .changeset/pre.json
    alt pre.json exists
        FS-->>Node: JSON content
        Node->>FS: readdirSync(.changeset)
        FS-->>Node: "list of *.md files"
        Node->>WF: Log total / consumed / unconsumed counts
        WF->>CA: Create Release PR or Publish to npm
    else pre.json missing
        FS-->>Node: ENOENT error (uncaught)
        Node-->>WF: Exit code 1 (step fails)
        Note over CA: Release step is skipped
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant WF as Workflow Runner
    participant FS as Filesystem
    participant Node as Node.js Script
    participant CA as changesets/action

    WF->>FS: Read .changeset/pre.json
    alt pre.json exists
        FS-->>Node: JSON content
        Node->>FS: readdirSync(.changeset)
        FS-->>Node: "list of *.md files"
        Node->>WF: Log total / consumed / unconsumed counts
        WF->>CA: Create Release PR or Publish to npm
    else pre.json missing
        FS-->>Node: ENOENT error (uncaught)
        Node-->>WF: Exit code 1 (step fails)
        Note over CA: Release step is skipped
    end
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Frelease.yml%3A302-304%0A**Unguarded%20%60pre.json%60%20read%20can%20block%20the%20release%20step**%0A%0A%60fs.readFileSync%60%20throws%20a%20fatal%20%60ENOENT%60%20if%20%60.changeset%2Fpre.json%60%20is%20absent%20%28e.g.%2C%20if%20prerelease%20mode%20was%20accidentally%20exited%20or%20the%20file%20was%20deleted%29.%20Because%20this%20diagnostic%20step%20has%20no%20error%20handling%20and%20no%20%60continue-on-error%3A%20true%60%2C%20that%20uncaught%20exception%20will%20exit%20the%20Node%20script%20with%20a%20non-zero%20code%2C%20failing%20the%20step%20and%20preventing%20the%20subsequent%20%22Create%20Odysseus%20Release%20Pull%20Request%20or%20Publish%20to%20npm%22%20step%20from%20ever%20running.%20Consider%20wrapping%20the%20read%20in%20a%20try%2Fcatch%20or%20adding%20%60continue-on-error%3A%20true%60%20to%20the%20step%20so%20a%20missing%20%60pre.json%60%20degrades%20gracefully%20to%20a%20warning%20rather%20than%20blocking%20the%20release.%0A%0A&repo=generaltranslation%2Fgt&pr=1656&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fodysseus%2Frelease-pr-diagnosis%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fodysseus%2Frelease-pr-diagnosis%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Frelease.yml%3A302-304%0A**Unguarded%20%60pre.json%60%20read%20can%20block%20the%20release%20step**%0A%0A%60fs.readFileSync%60%20throws%20a%20fatal%20%60ENOENT%60%20if%20%60.changeset%2Fpre.json%60%20is%20absent%20%28e.g.%2C%20if%20prerelease%20mode%20was%20accidentally%20exited%20or%20the%20file%20was%20deleted%29.%20Because%20this%20diagnostic%20step%20has%20no%20error%20handling%20and%20no%20%60continue-on-error%3A%20true%60%2C%20that%20uncaught%20exception%20will%20exit%20the%20Node%20script%20with%20a%20non-zero%20code%2C%20failing%20the%20step%20and%20preventing%20the%20subsequent%20%22Create%20Odysseus%20Release%20Pull%20Request%20or%20Publish%20to%20npm%22%20step%20from%20ever%20running.%20Consider%20wrapping%20the%20read%20in%20a%20try%2Fcatch%20or%20adding%20%60continue-on-error%3A%20true%60%20to%20the%20step%20so%20a%20missing%20%60pre.json%60%20degrades%20gracefully%20to%20a%20warning%20rather%20than%20blocking%20the%20release.%0A%0A&repo=generaltranslation%2Fgt&pr=1656&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/workflows/release.yml:302-304
**Unguarded `pre.json` read can block the release step**

`fs.readFileSync` throws a fatal `ENOENT` if `.changeset/pre.json` is absent (e.g., if prerelease mode was accidentally exited or the file was deleted). Because this diagnostic step has no error handling and no `continue-on-error: true`, that uncaught exception will exit the Node script with a non-zero code, failing the step and preventing the subsequent "Create Odysseus Release Pull Request or Publish to npm" step from ever running. Consider wrapping the read in a try/catch or adding `continue-on-error: true` to the step so a missing `pre.json` degrades gracefully to a warning rather than blocking the release.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: log odysseus changeset state"](https://github.com/generaltranslation/gt/commit/e8cbd0284cb58d2e44404bdb90dc4a5f22d06d2b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39618738)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->