### PR TITLE
feat: add locale-aware next link

### DIFF
--- a/.changeset/locale-aware-next-link.md
+++ b/.changeset/locale-aware-next-link.md
@@ -1,0 +1,5 @@
+---
+"gt-next": patch
+---
+
+Add a locale-aware Link component for Next.js applications.

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -84,6 +84,10 @@
       "types": "./dist/middleware.d.ts",
       "default": "./dist/middleware.js"
     },
+    "./link": {
+      "types": "./dist/link.d.ts",
+      "default": "./dist/link.js"
+    },
     "./types": {
       "types": "./dist/types.d.ts",
       "default": "./dist/types.js"
@@ -126,6 +130,9 @@
       "middleware": [
         "./dist/middleware.d.ts"
       ],
+      "link": [
+        "./dist/link.d.ts"
+      ],
       "types": [
         "./dist/types.d.ts"
       ],
@@ -166,6 +173,9 @@
       ],
       "gt-next/middleware": [
         "/dist/middleware"
+      ],
+      "gt-next/link": [
+        "/dist/link"
       ],
       "gt-next/types": [
         "/dist/types"

--- a/packages/next/src/link.ts
+++ b/packages/next/src/link.ts
@@ -1,0 +1,4 @@
+'use client';
+
+export { Link, default } from './link/Link';
+export type { LinkProps } from './link/Link';

--- a/packages/next/src/link/Link.tsx
+++ b/packages/next/src/link/Link.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import NextLink from 'next/link';
+import {
+  forwardRef,
+  type ComponentProps,
+  type ComponentRef,
+  type ForwardedRef,
+} from 'react';
+import { useLocale } from 'gt-react';
+
+type NextLinkProps = ComponentProps<typeof NextLink>;
+type LinkRef = ComponentRef<typeof NextLink>;
+type LinkHref = NextLinkProps['href'];
+
+export type LinkProps = NextLinkProps;
+
+type ResolvedLinkProps = Omit<LinkProps, 'locale'> & {
+  locale: NonNullable<LinkProps['locale']>;
+};
+
+const LinkWithLocale = forwardRef<LinkRef, Omit<LinkProps, 'locale'>>(
+  function LinkWithLocale({ href, ...props }, ref) {
+    const locale = useLocale();
+    return renderLink({ ...props, href, locale }, ref);
+  }
+);
+
+/**
+ * Locale-aware wrapper around Next.js's `<Link>` component.
+ *
+ * Internal hrefs are prefixed with the current GT locale by default. Pass a
+ * locale string to use a specific locale, or pass `locale={false}` to leave the
+ * href unchanged. External URLs are never prefixed.
+ *
+ * @example
+ * ```tsx
+ * import Link from 'gt-next/link';
+ *
+ * export function Navigation() {
+ *   return <Link href="/home">Home</Link>; // /en/home
+ * }
+ * ```
+ *
+ * @example
+ * ```tsx
+ * import Link from 'gt-next/link';
+ *
+ * export function LocaleSwitcher() {
+ *   return <Link href="/home" locale="fr">French</Link>; // /fr/home
+ * }
+ * ```
+ *
+ * @example
+ * ```tsx
+ * import Link from 'gt-next/link';
+ *
+ * export function UnlocalizedLink() {
+ *   return <Link href="/legal" locale={false}>Legal</Link>; // /legal
+ * }
+ * ```
+ *
+ * @example
+ * ```tsx
+ * import Link from 'gt-next/link';
+ *
+ * export function ExternalLink() {
+ *   return <Link href="https://example.com">Example</Link>; // https://example.com
+ * }
+ * ```
+ *
+ * @see https://nextjs.org/docs/app/api-reference/components/link
+ * @param href - The destination URL or URL object. Internal paths are localized.
+ * @param locale - Locale to prefix, or `false` to disable GT locale prefixing.
+ * @returns The rendered Next.js link.
+ */
+export const Link = forwardRef<LinkRef, LinkProps>(function Link(
+  { href, locale, ...props },
+  ref
+) {
+  if (locale === undefined) {
+    return <LinkWithLocale {...props} href={href} ref={ref} />;
+  }
+
+  return renderLink({ ...props, href, locale }, ref);
+});
+
+function renderLink(
+  { href, locale, ...props }: ResolvedLinkProps,
+  ref: ForwardedRef<LinkRef>
+) {
+  return (
+    <NextLink
+      {...props}
+      href={localizeHref(href, locale)}
+      locale={false}
+      ref={ref}
+    />
+  );
+}
+
+function localizeHref(href: LinkHref, locale: LinkProps['locale']): LinkHref {
+  if (!locale) return href;
+
+  if (typeof href === 'string') {
+    return localizePath(href, locale);
+  }
+
+  if (typeof href.pathname !== 'string') return href;
+
+  const localizedPathname = localizePath(href.pathname, locale);
+  if (localizedPathname === href.pathname) return href;
+
+  return {
+    ...href,
+    pathname: localizedPathname,
+  };
+}
+
+function localizePath(href: string, locale: string): string {
+  if (!href.startsWith('/') || href.startsWith('//')) return href;
+
+  const url = new URL(href, 'http://localhost');
+  url.pathname =
+    url.pathname === '/'
+      ? `/${encodeURIComponent(locale)}`
+      : `/${encodeURIComponent(locale)}${url.pathname}`;
+
+  return `${url.pathname}${url.search}${url.hash}`;
+}
+
+export default Link;


### PR DESCRIPTION
## Summary
- Add `gt-next/link` as a client wrapper around `next/link`.
- Prefix internal hrefs with the active `useLocale()` value, or an explicit `locale` prop.
- Match Next.js `locale` prop shape: `string | false | undefined`; `false` opts out of GT locale prefixing.
- Leave external hrefs unchanged.

## Testing
- `pnpm --filter gt-next typecheck`
- `pnpm --filter gt-next build:no-swc-plugin`
- `pnpm --filter gt-next test:js`
- `pnpm format`
- `pnpm lint`
- Linked `base/next-app-router-locale-routing` from `gt-test-apps` to this worktree and production-verified `locale={false}` renders `/plain` while default locale rendering produces `/fr`.
- Previously browser-verified dev and production internal/external href behavior plus client navigation.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `gt-next/link` subpackage export — a `'use client'` wrapper around `next/link` that auto-prefixes internal paths with the active GT locale and passes `locale={false}` to the underlying `NextLink` to suppress Next.js's own i18n routing.

- Adds `packages/next/src/link/Link.tsx`: a `forwardRef` component with two code paths — one that reads locale from `useLocale()` at render time (`LinkWithLocale`), and one that accepts an explicit `locale` prop (including `false` to opt out). The `localizePath` helper parses paths with the URL constructor to safely handle query strings and fragments.
- Registers the new `gt-next/link` entry point in `package.json` exports, `typesVersions`, and the internal path alias map, and adds a patch-level changeset entry.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the new Link component is additive, isolated behind its own entry point, and leaves all existing paths untouched.

The change introduces a new, self-contained gt-next/link export. The path-prefixing logic correctly handles string hrefs, URL objects, external URLs, protocol-relative URLs, and the locale={false} opt-out. The 'use client' boundary is correctly placed, the package.json entry-point additions follow established patterns, and no existing code is modified.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/next/src/link/Link.tsx | Core locale-aware Link component; logic for path prefixing, URL object handling, and locale={false} opt-out is sound. No new bugs found beyond what was flagged in prior threads. |
| packages/next/src/link.ts | Barrel re-export file; 'use client' directive is correctly placed first and consistent with Link.tsx. |
| packages/next/package.json | Adds ./link entry to exports, typesVersions, and path aliases; follows the same pattern as other existing entry points. |
| .changeset/locale-aware-next-link.md | Standard patch-level changeset for gt-next; correctly categorized as patch. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["<Link href locale ...>"] --> B{locale === undefined?}
    B -- yes --> C["LinkWithLocale\n(reads useLocale() hook)"]
    B -- no --> D["renderLink(href, locale)"]
    C --> D

    D --> E["localizeHref(href, locale)"]
    E --> F{locale falsy?}
    F -- yes --> G["return href unchanged"]
    F -- no --> H{href is string?}
    H -- yes --> I["localizePath(href, locale)"]
    H -- no --> J{href.pathname is string?}
    J -- no --> G
    J -- yes --> K["localizePath(href.pathname, locale)"]
    K --> L["{ ...href, pathname: localizedPathname }"]

    I --> M{starts with '/'? not '//'?}
    M -- no --> G
    M -- yes --> N["new URL(href, 'http://localhost')\nprepend /{locale} to pathname\nreturn pathname+search+hash"]

    G --> O["<NextLink href=... locale={false} />"]
    L --> O
    N --> O
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["<Link href locale ...>"] --> B{locale === undefined?}
    B -- yes --> C["LinkWithLocale\n(reads useLocale() hook)"]
    B -- no --> D["renderLink(href, locale)"]
    C --> D

    D --> E["localizeHref(href, locale)"]
    E --> F{locale falsy?}
    F -- yes --> G["return href unchanged"]
    F -- no --> H{href is string?}
    H -- yes --> I["localizePath(href, locale)"]
    H -- no --> J{href.pathname is string?}
    J -- no --> G
    J -- yes --> K["localizePath(href.pathname, locale)"]
    K --> L["{ ...href, pathname: localizedPathname }"]

    I --> M{starts with '/'? not '//'?}
    M -- no --> G
    M -- yes --> N["new URL(href, 'http://localhost')\nprepend /{locale} to pathname\nreturn pathname+search+hash"]

    G --> O["<NextLink href=... locale={false} />"]
    L --> O
    N --> O
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["feat: add locale-aware next link"](https://github.com/generaltranslation/gt/commit/c496746a15c2554be36ba9f350e605210871af44) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40185193)</sub>

<!-- /greptile_comment -->