### PR TITLE
fix: harden swc plugin cargo fetches

### DIFF
--- a/packages/next/src/plugin/constants.ts
+++ b/packages/next/src/plugin/constants.ts
@@ -2,6 +2,7 @@ export const BABEL_PLUGIN_SUPPORT = '17.0.0';
 
 export const SWC_PLUGIN_SUPPORT = '16.1.0';
 
+// Minimum Next versions for feature-specific plugin behavior.
 export const ROOT_PARAM_STABILITY = {
   unsupported: '0.0.0',
   unstable: '15.2.0',

--- a/packages/next/swc-plugin/.cargo/config.toml
+++ b/packages/next/swc-plugin/.cargo/config.toml
@@ -1,4 +1,10 @@
 # Multi-platform build aliases
+[net]
+retry = 10
+
+[http]
+multiplexing = false
+
 [alias]
 # WASM builds (original SWC plugin targets)
 build-plugin = "build --target wasm32-wasip1 --release"


### PR DESCRIPTION
## Summary
- increase Cargo network retries for the gt-next SWC plugin
- disable Cargo HTTP multiplexing to reduce flaky sparse registry downloads in CI

## Testing
- pnpm exec turbo build --filter=generaltranslation --filter=gt-i18n --filter='@generaltranslation/react-core' --filter=gt-react --filter=gt-tanstack-start --filter=gt-next

## Changeset
- None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1662"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785106690&installation_id=127936663&pr_number=1662&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1662&signature=2d7b9c0ca3fcc5f12af3c3ab8a20ee602424596fa9a575b94884316b857e2c91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds two Cargo configuration knobs to the SWC plugin's local `.cargo/config.toml` to reduce flaky CI build failures caused by transient network issues and HTTP/2 multiplexing problems with sparse registries.

- `[net] retry = 10` raises Cargo's network retry limit from the default of 2 to 10, giving more headroom when fetching crates under unreliable CI network conditions.
- `[http] multiplexing = false` disables HTTP/2 multiplexing, a well-known workaround for intermittent sparse-registry download errors that some CI environments trigger.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — this is a narrow CI hardening change with no logic or runtime impact beyond build-time network behavior.

The change only touches `.cargo/config.toml` inside the SWC plugin subdirectory. Both settings (net.retry and http.multiplexing) are standard, well-documented Cargo knobs that improve resilience without altering build outputs, binary behavior, or any application logic.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/next/swc-plugin/.cargo/config.toml | Adds [net] retry=10 and [http] multiplexing=false to harden Cargo network fetches in CI; existing alias and target sections are unchanged. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[cargo build] --> B{Fetch crate from sparse registry}
    B -->|HTTP/1.1 only\nmultiplexing=false| C[Download crate]
    C --> D{Success?}
    D -->|Yes| E[Build continues]
    D -->|No - network error| F{retry <= 10?}
    F -->|Yes - increment retry| B
    F -->|No - max retries exceeded| G[Build fails]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[cargo build] --> B{Fetch crate from sparse registry}
    B -->|HTTP/1.1 only\nmultiplexing=false| C[Download crate]
    C --> D{Success?}
    D -->|Yes| E[Build continues]
    D -->|No - network error| F{retry <= 10?}
    F -->|Yes - increment retry| B
    F -->|No - max retries exceeded| G[Build fails]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: harden swc plugin cargo fetches"](https://github.com/generaltranslation/gt/commit/71c436ae47cf960d22dabe904a506a8e61dc80ca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40219079)</sub>

<!-- /greptile_comment -->