### PR TITLE
ci: retry odysseus changeset version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -298,7 +298,7 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          version: pnpm run version-packages
+          version: bash scripts/version-packages-with-retry.sh
           publish: pnpm run release
           commit: '[ci] odysseus release'
           title: '[ci] odysseus release'

--- a/scripts/version-packages-with-retry.sh
+++ b/scripts/version-packages-with-retry.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+max_attempts="${VERSION_PACKAGES_ATTEMPTS:-3}"
+delay_seconds="${VERSION_PACKAGES_RETRY_DELAY_SECONDS:-10}"
+attempt=1
+
+while true; do
+  if pnpm exec changeset version; then
+    break
+  fi
+
+  status=$?
+  if ! git diff --quiet --exit-code; then
+    echo "changeset version failed after modifying files; refusing to retry"
+    exit "$status"
+  fi
+
+  if [ "$attempt" -ge "$max_attempts" ]; then
+    exit "$status"
+  fi
+
+  attempt=$((attempt + 1))
+  echo "changeset version failed with exit code $status; retrying in ${delay_seconds}s (attempt ${attempt}/${max_attempts})"
+  sleep "$delay_seconds"
+done
+
+pnpm exec oxfmt packages/*/CHANGELOG.md

--- a/scripts/version-packages-with-retry.sh
+++ b/scripts/version-packages-with-retry.sh
@@ -8,10 +8,11 @@ attempt=1
 while true; do
   if pnpm exec changeset version; then
     break
+  else
+    status=$?
   fi
 
-  status=$?
-  if ! git diff --quiet --exit-code; then
+  if ! git diff HEAD --quiet --exit-code; then
     echo "changeset version failed after modifying files; refusing to retry"
     exit "$status"
   fi


### PR DESCRIPTION
## Summary
- Add a retry wrapper for the Odysseus `changeset version` step.
- Refuse to retry if a failed attempt leaves tracked file changes behind.
- Keep the normal release workflow path unchanged.

## Testing
- `bash -n scripts/version-packages-with-retry.sh`
- `pnpm exec oxfmt --check .github/workflows/release.yml scripts/version-packages-with-retry.sh`

## Notes
- The failed job hit a GitHub GraphQL premature-close error while generating changeset changelogs, so a rerun may pass. This change makes the Odysseus release path more tolerant of that transient failure.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1664"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785109487&installation_id=127936663&pr_number=1664&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1664&signature=e83fea6ede921272fb10f038d36c5781598981b5186705590e8e8b5d58a75786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a retry wrapper for the `changeset version` step in the Odysseus release workflow, replacing the direct `pnpm run version-packages` call with a bash script that retries on transient failures (e.g., GitHub GraphQL connection resets) while refusing to retry if the failed attempt leaves tracked file modifications behind.

- **Retry logic** (`scripts/version-packages-with-retry.sh`): attempts `pnpm exec changeset version` up to `VERSION_PACKAGES_ATTEMPTS` times (default 3) with a configurable delay, and exits immediately on failure if any tracked files were modified, preserving idempotency.
- **Workflow change** (`.github/workflows/release.yml`): the `changesets/action` version step is updated to invoke the new script; the publish step and all other workflow logic are unchanged.
- **Parity with original script**: the original `version-packages` npm script ran `changeset version && oxfmt packages/*/CHANGELOG.md`; the new script preserves both steps.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the retry wrapper is logically sound and the workflow change is minimal and self-contained.

The exit-code capture (`status=$?` inside the `else` branch) correctly preserves the non-zero code from `changeset version`. The dirty-tree guard uses `git diff HEAD`, which covers both staged and unstaged changes relative to the last commit, so a partial run that stages files will still block a retry. The retry count and loop termination are both correct. The `oxfmt` post-step matches the original `version-packages` npm script behaviour exactly. No logic errors or unsafe behaviours were found.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/version-packages-with-retry.sh | New retry wrapper for `changeset version`; exit-code capture, dirty-tree detection, and retry-count logic are all correctly implemented. |
| .github/workflows/release.yml | Single-line change replaces `pnpm run version-packages` with `bash scripts/version-packages-with-retry.sh`; no other workflow logic is affected. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([changesets/action invokes version step]) --> B[bash scripts/version-packages-with-retry.sh]
    B --> C[pnpm exec changeset version]
    C -->|exit 0| D[break out of retry loop]
    C -->|non-zero exit| E[capture status=$?]
    E --> F{git diff HEAD\ndetects changes?}
    F -->|yes - files modified| G[echo: refusing to retry\nexit with captured status]
    F -->|no - clean tree| H{attempt >= max_attempts?}
    H -->|yes - exhausted retries| I[exit with captured status]
    H -->|no| J[increment attempt\nsleep delay_seconds]
    J --> C
    D --> K[pnpm exec oxfmt packages/*/CHANGELOG.md]
    K --> L([version step complete])
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A([changesets/action invokes version step]) --> B[bash scripts/version-packages-with-retry.sh]
    B --> C[pnpm exec changeset version]
    C -->|exit 0| D[break out of retry loop]
    C -->|non-zero exit| E[capture status=$?]
    E --> F{git diff HEAD\ndetects changes?}
    F -->|yes - files modified| G[echo: refusing to retry\nexit with captured status]
    F -->|no - clean tree| H{attempt >= max_attempts?}
    H -->|yes - exhausted retries| I[exit with captured status]
    H -->|no| J[increment attempt\nsleep delay_seconds]
    J --> C
    D --> K[pnpm exec oxfmt packages/*/CHANGELOG.md]
    K --> L([version step complete])
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: preserve changeset retry failures"](https://github.com/generaltranslation/gt/commit/ab522af35e97f56cdbd91fccca9f2a6755cf25f6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40225358)</sub>

<!-- /greptile_comment -->