### PR TITLE
chore: consolidate odysseus next changesets

### DIFF
--- a/.changeset/consolidated-next-odysseus.md
+++ b/.changeset/consolidated-next-odysseus.md
@@ -1,0 +1,11 @@
+---
+"gt-next": patch
+---
+
+PR: #1659
+Commit: 807dc305c4b5e4ce8f6982d96886a530910f3f37
+Author: @ErnestM1234
+
+Add a locale-aware Link component for Next.js applications.
+
+Transpile gt-next in Next apps so package runtime config is compiled with app env values. See #1661.

--- a/.changeset/locale-aware-next-link.md
+++ b/.changeset/locale-aware-next-link.md
@@ -1,5 +1,0 @@
----
-"gt-next": patch
----
-
-Add a locale-aware Link component for Next.js applications.

--- a/.changeset/next-transpile-package.md
+++ b/.changeset/next-transpile-package.md
@@ -1,5 +1,0 @@
----
-"gt-next": patch
----
-
-Transpile gt-next in Next apps so package runtime config is compiled with app env values.


### PR DESCRIPTION
## Summary
- Replace the two pending `gt-next` Odysseus changesets with one consolidated changeset.
- Include explicit PR, commit, and author metadata for the changelog entry.
- Leave package source and release workflow files unchanged.

## Testing
- `pnpm install`
- Reproduced `pnpm run version-packages` in a temporary Odysseus worktree with this changeset replacement applied before committing it.

## Notes
- This is a targeted workaround for the current Odysseus release failure in GitHub changelog metadata generation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1667"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785112355&installation_id=127936663&pr_number=1667&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1667&signature=71a65aab22b8c8def36e53d96eda06f7152ea899bd40f85abed8acb6e9f43183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->