### PR TITLE
fix: import runtime helpers directly

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -20,6 +20,7 @@
     "@generaltranslation/compiler": "workspace:*",
     "@generaltranslation/format": "workspace:*",
     "@generaltranslation/next-internal": "workspace:*",
+    "@generaltranslation/react-core": "workspace:*",
     "@generaltranslation/supported-locales": "workspace:*",
     "generaltranslation": "workspace:*",
     "gt-react": "workspace:*",

--- a/packages/next/src/__tests__/rscComponentWrappers.test.tsx
+++ b/packages/next/src/__tests__/rscComponentWrappers.test.tsx
@@ -56,6 +56,12 @@ vi.mock('../provider/GTProvider', () => ({
   GTProvider: vi.fn(),
 }));
 
+vi.mock('gt-i18n', () => mockComponents);
+
+vi.mock('@generaltranslation/react-core/components-rsc', () => mockComponents);
+
+vi.mock('@generaltranslation/react-core/hooks', () => mockComponents);
+
 vi.mock('gt-react', () => mockComponents);
 
 describe('rsc component wrappers', () => {
@@ -88,7 +94,7 @@ describe('rsc component wrappers', () => {
     ],
     ['Var', () => import('../variables/Var'), mockComponents.Var],
   ])(
-    '%s passes request conditions to gt-react',
+    '%s passes request conditions to React Core',
     async (componentName, loadComponent, coreComponent) => {
       const module = await loadComponent();
       const component = module[componentName];

--- a/packages/next/src/branches/Branch.tsx
+++ b/packages/next/src/branches/Branch.tsx
@@ -1,4 +1,4 @@
-import { Branch as CoreBranch } from 'gt-react';
+import { Branch as CoreBranch } from '@generaltranslation/react-core/components-rsc';
 import { getRequestConditions } from '../request/getRequestConditions';
 import type { ReactNode } from 'react';
 

--- a/packages/next/src/branches/Plural.tsx
+++ b/packages/next/src/branches/Plural.tsx
@@ -1,4 +1,7 @@
-import { Plural as RscPlural, type PluralProps } from 'gt-react';
+import {
+  Plural as RscPlural,
+  type PluralProps,
+} from '@generaltranslation/react-core/components-rsc';
 import { getRequestConditions } from '../request/getRequestConditions';
 import type { ReactNode } from 'react';
 

--- a/packages/next/src/condition-store/AsyncConditionStore.ts
+++ b/packages/next/src/condition-store/AsyncConditionStore.ts
@@ -6,7 +6,7 @@ import { defaultLocaleHeaderName } from '../utils/headers';
 import {
   defaultLocaleCookieName,
   defaultRegionCookieName,
-} from 'gt-react/internal';
+} from '@generaltranslation/react-core/pure';
 import { createConditionStoreSingleton } from 'gt-i18n/internal';
 import { localeStore } from '../request/localeStore';
 

--- a/packages/next/src/config-dir/loadTranslation.ts
+++ b/packages/next/src/config-dir/loadTranslation.ts
@@ -1,4 +1,4 @@
-import { Translations } from 'gt-react/internal';
+import type { Translations } from '@generaltranslation/react-core/pure';
 import {
   customLoadTranslationsError,
   remoteTranslationsError,

--- a/packages/next/src/config-dir/props/defaultWithGTConfigProps.ts
+++ b/packages/next/src/config-dir/props/defaultWithGTConfigProps.ts
@@ -6,8 +6,8 @@ import {
 import {
   defaultLocaleCookieName,
   getDefaultRenderSettings,
-  RenderMethod,
-} from 'gt-react/internal';
+  type RenderMethod,
+} from '@generaltranslation/react-core/pure';
 import { defaultLocaleHeaderName } from '../../utils/headers';
 import {
   defaultLocaleRoutingEnabledCookieName,

--- a/packages/next/src/config-dir/props/withGTConfigProps.ts
+++ b/packages/next/src/config-dir/props/withGTConfigProps.ts
@@ -1,4 +1,4 @@
-import { RenderMethod } from 'gt-react/internal';
+import type { RenderMethod } from '@generaltranslation/react-core/pure';
 
 export type HeadersAndCookies = {
   localeHeaderName?: string;

--- a/packages/next/src/dictionary/getDictionary.ts
+++ b/packages/next/src/dictionary/getDictionary.ts
@@ -1,8 +1,8 @@
 import {
-  Dictionary,
-  DictionaryEntry,
   getDictionaryEntry as getEntry,
-} from 'gt-react/internal';
+  type Dictionary,
+  type DictionaryEntry,
+} from '@generaltranslation/react-core/pure';
 import { customLoadDictionaryWarning } from '../errors/createErrors';
 import { resolveDictionaryLoader } from '../resolvers/resolveDictionaryLoader';
 import { defaultWithGTConfigProps } from '../config-dir/props/defaultWithGTConfigProps';

--- a/packages/next/src/i18n-cache/NextI18nCache.ts
+++ b/packages/next/src/i18n-cache/NextI18nCache.ts
@@ -2,12 +2,13 @@ import { getI18nCache, setI18nCache, type I18nCache } from 'gt-i18n/internal';
 import type { Locale } from 'gt-i18n/internal/types';
 import type { Dictionary, Translation } from 'gt-i18n/types';
 import { isValidElement } from 'react';
-import { ReactI18nCache, type ReactI18nCacheParams } from 'gt-react';
 import {
   mergeDictionaries,
+  ReactI18nCache,
   type Dictionary as LegacyDictionary,
   type DictionaryEntry,
-} from 'gt-react/internal';
+  type ReactI18nCacheParams,
+} from '@generaltranslation/react-core/pure';
 import { getDictionary, getDictionaryEntry } from '../dictionary/getDictionary';
 import { createDictionarySubsetError } from '../errors/createErrors';
 import { resolveDictionaryLoader } from '../resolvers/resolveDictionaryLoader';

--- a/packages/next/src/i18n-cache/__tests__/NextI18nCache.test.ts
+++ b/packages/next/src/i18n-cache/__tests__/NextI18nCache.test.ts
@@ -27,7 +27,8 @@ vi.mock('gt-i18n/internal', () => ({
   I18nCache: class {},
 }));
 
-vi.mock('gt-react', () => ({
+vi.mock('@generaltranslation/react-core/pure', () => ({
+  mergeDictionaries: mockMergeDictionaries,
   ReactI18nCache: class {
     constructor(params: unknown) {
       mockReactI18nCacheConstructor(params);
@@ -37,10 +38,6 @@ vi.mock('gt-react', () => ({
       return mockLoadDictionary(locale);
     }
   },
-}));
-
-vi.mock('gt-react/internal', () => ({
-  mergeDictionaries: mockMergeDictionaries,
 }));
 
 vi.mock('../../dictionary/getDictionary', () => ({

--- a/packages/next/src/index.client.ts
+++ b/packages/next/src/index.client.ts
@@ -4,20 +4,24 @@ import { initializeGT } from './setup/initGT';
 initializeGT();
 
 import {
-  Var,
-  Num,
-  Currency,
-  DateTime,
-  RelativeTime,
-  Derive,
-  T,
-  Branch,
-  Plural,
   LocaleSelector,
   RegionSelector,
   GTProvider,
   useSetLocale,
   useLocaleSelector,
+} from 'gt-react';
+import {
+  Branch,
+  Plural,
+  Derive,
+  T,
+  Currency,
+  DateTime,
+  RelativeTime,
+  Var,
+  Num,
+} from '@generaltranslation/react-core/components';
+import {
   useGT,
   useTranslations,
   useLocale,
@@ -29,6 +33,8 @@ import {
   useLocaleProperties,
   useLocaleDirection,
   useVersionId,
+} from '@generaltranslation/react-core/hooks';
+import {
   msg,
   decodeMsg,
   decodeOptions,
@@ -37,18 +43,18 @@ import {
   decodeVars,
   mFallback,
   gtFallback,
-  getTranslationsSnapshot,
   getDefaultLocale,
   getGTClass,
   getLocaleProperties,
   getLocales,
   getVersionId,
-} from 'gt-react';
+} from 'gt-i18n';
+import { getTranslationsSnapshot } from '@generaltranslation/react-core/pure';
 import type {
   DictionaryTranslationOptions,
   InlineTranslationOptions,
   RuntimeTranslationOptions,
-} from 'gt-react';
+} from 'gt-i18n/types';
 import type {
   GetServerSideProps,
   GetServerSidePropsContext,

--- a/packages/next/src/index.rsc.ts
+++ b/packages/next/src/index.rsc.ts
@@ -35,7 +35,7 @@ export {
 export { Client_LocaleSelector as LocaleSelector } from './utils/client-boundary';
 export { Client_RegionSelector as RegionSelector } from './utils/client-boundary';
 
-// ===== gt-react ===== //
+// ===== Shared Runtime ===== //
 import {
   msg,
   decodeMsg,
@@ -43,7 +43,6 @@ import {
   declareVar,
   decodeVars,
   derive,
-  Derive,
   mFallback,
   gtFallback,
   getDefaultLocale,
@@ -51,7 +50,9 @@ import {
   getLocaleProperties,
   getLocales,
   getVersionId,
-  // ----- hooks ----- //
+} from 'gt-i18n';
+import { Derive } from '@generaltranslation/react-core/components-rsc';
+import {
   useGTClass,
   useLocaleProperties,
   useLocales,
@@ -62,7 +63,7 @@ import type {
   DictionaryTranslationOptions,
   InlineTranslationOptions,
   RuntimeTranslationOptions,
-} from 'gt-react';
+} from 'gt-i18n/types';
 import { getTranslationsSnapshotRscError } from './errors/createErrors';
 
 // ===== other ===== //

--- a/packages/next/src/index.server.ts
+++ b/packages/next/src/index.server.ts
@@ -10,25 +10,26 @@ export { parseLocale, withGTServerSideProps };
 export type { WithGTServerSideProps } from './pages-dir/withGTServerSideProps';
 
 export {
-  // ----- components ----- //
   GTProvider,
-  Var,
-  Num,
+  LocaleSelector,
+  RegionSelector,
+  useSetLocale,
+  useLocaleSelector,
+} from 'gt-react';
+
+export {
+  Branch,
+  Plural,
+  Derive,
+  T,
   Currency,
   DateTime,
   RelativeTime,
-  Derive,
-  Branch,
-  Plural,
-  T,
-  LocaleSelector,
-  RegionSelector,
-  // ----- hooks ----- //
-  useGT,
-  useTranslations,
-  useMessages,
-  useSetLocale,
-  useLocaleSelector,
+  Var,
+  Num,
+} from '@generaltranslation/react-core/components';
+
+export {
   useLocale,
   useRegion,
   useLocaleDirection,
@@ -37,7 +38,12 @@ export {
   useDefaultLocale,
   useGTClass,
   useLocaleProperties,
-  // ----- functions ----- //
+  useGT,
+  useMessages,
+  useTranslations,
+} from '@generaltranslation/react-core/hooks';
+
+export {
   msg,
   decodeMsg,
   decodeOptions,
@@ -46,16 +52,17 @@ export {
   derive,
   mFallback,
   gtFallback,
-  getTranslationsSnapshot,
   getDefaultLocale,
   getGTClass,
   getLocaleProperties,
   getLocales,
   getVersionId,
-} from 'gt-react';
+} from 'gt-i18n';
+
+export { getTranslationsSnapshot } from '@generaltranslation/react-core/pure';
 
 export type {
   DictionaryTranslationOptions,
   InlineTranslationOptions,
   RuntimeTranslationOptions,
-} from 'gt-react';
+} from 'gt-i18n/types';

--- a/packages/next/src/index.types.ts
+++ b/packages/next/src/index.types.ts
@@ -31,19 +31,21 @@ import {
   RegionSelector as _RegionSelector,
   useSetLocale as _useSetLocale,
   useLocaleSelector as _useLocaleSelector,
-  getTranslationsSnapshot,
+} from 'gt-react';
+import { getTranslationsSnapshot } from '@generaltranslation/react-core/pure';
+import {
   getDefaultLocale,
   getGTClass,
   getLocaleProperties,
   getLocales,
   getVersionId,
-} from 'gt-react';
+} from 'gt-i18n';
 import { GTProvider as _GTProvider } from 'gt-react';
 import type {
   DictionaryTranslationOptions,
   InlineTranslationOptions,
   RuntimeTranslationOptions,
-} from 'gt-react';
+} from 'gt-i18n/types';
 import type { StringFormat } from '@generaltranslation/format/types';
 import {
   msg,
@@ -52,10 +54,10 @@ import {
   derive,
   declareVar,
   decodeVars,
-  _Messages,
   mFallback,
   gtFallback,
-} from 'gt-react/internal';
+} from 'gt-i18n';
+import type { _Messages } from '@generaltranslation/react-core/pure';
 
 /**
  * Provides General Translation context to its children, which can then access `useGT`, `useLocale`, and `useDefaultLocale`.

--- a/packages/next/src/middleware-dir/createNextMiddleware.ts
+++ b/packages/next/src/middleware-dir/createNextMiddleware.ts
@@ -8,7 +8,7 @@ import {
   defaultReferrerLocaleCookieName,
   defaultResetLocaleCookieName,
 } from '../utils/cookies';
-import { defaultLocaleCookieName } from 'gt-react/internal';
+import { defaultLocaleCookieName } from '@generaltranslation/react-core/pure';
 import {
   PathConfig,
   getSharedPath,

--- a/packages/next/src/pages-dir/__tests__/withGTServerSideProps.test.ts
+++ b/packages/next/src/pages-dir/__tests__/withGTServerSideProps.test.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mockGetTranslationsSnapshot = vi.hoisted(() => vi.fn());
 const mockParseLocale = vi.hoisted(() => vi.fn());
 
-vi.mock('gt-react', () => ({
+vi.mock('@generaltranslation/react-core/pure', () => ({
   getTranslationsSnapshot: (...args: unknown[]) =>
     mockGetTranslationsSnapshot(...args),
 }));

--- a/packages/next/src/pages-dir/parseLocale.ts
+++ b/packages/next/src/pages-dir/parseLocale.ts
@@ -3,7 +3,7 @@ import type { ParsedUrlQuery } from 'querystring';
 import { getI18nConfig } from 'gt-i18n/internal';
 import { noLocalesCouldBeDeterminedWarning } from '../errors/ssg';
 import { defaultLocaleHeaderName } from '../utils/headers';
-import { defaultLocaleCookieName } from 'gt-react/internal';
+import { defaultLocaleCookieName } from '@generaltranslation/react-core/pure';
 
 type HeaderValue = string | string[] | undefined;
 

--- a/packages/next/src/pages-dir/withGTServerSideProps.ts
+++ b/packages/next/src/pages-dir/withGTServerSideProps.ts
@@ -4,7 +4,7 @@ import type {
   PreviewData,
 } from 'next';
 import type { ParsedUrlQuery } from 'querystring';
-import { getTranslationsSnapshot } from 'gt-react';
+import { getTranslationsSnapshot } from '@generaltranslation/react-core/pure';
 import { parseLocale } from './parseLocale';
 
 type GTServerSideProps = {

--- a/packages/next/src/resolvers/resolveDictionaryLoader.ts
+++ b/packages/next/src/resolvers/resolveDictionaryLoader.ts
@@ -1,4 +1,4 @@
-import { CustomLoader } from 'gt-react/internal';
+import type { CustomLoader } from '@generaltranslation/react-core/pure';
 import { unresolvedCustomLoadDictionaryError } from '../errors/createErrors';
 
 let customLoadDictionary: CustomLoader | undefined = undefined;

--- a/packages/next/src/resolvers/resolveTranslationLoader.ts
+++ b/packages/next/src/resolvers/resolveTranslationLoader.ts
@@ -1,4 +1,4 @@
-import { CustomLoader } from 'gt-react/internal';
+import type { CustomLoader } from '@generaltranslation/react-core/pure';
 import { unresolvedCustomLoadTranslationsError } from '../errors/createErrors';
 
 let customLoadTranslations: CustomLoader | undefined = undefined;

--- a/packages/next/src/server-dir/buildtime/T.tsx
+++ b/packages/next/src/server-dir/buildtime/T.tsx
@@ -1,5 +1,5 @@
 import { getRequestConditions } from '../../request/getRequestConditions';
-import { T as RscT } from 'gt-react';
+import { T as RscT } from '@generaltranslation/react-core/components-rsc';
 import { renderPreparedT } from './renderPipeline';
 import type { ReactNode } from 'react';
 

--- a/packages/next/src/server-dir/buildtime/__tests__/T.test.tsx
+++ b/packages/next/src/server-dir/buildtime/__tests__/T.test.tsx
@@ -12,15 +12,18 @@ vi.mock('../../../request/getRequestConditions', () => ({
   getRequestConditions: mockGetRequestConditions,
 }));
 
-vi.mock('gt-react', () => ({
+vi.mock('@generaltranslation/react-core/pure', () => ({
   createRenderPipeline: vi.fn(() => ({
     renderPreparedT: mockRenderPreparedT,
   })),
+}));
+
+vi.mock('@generaltranslation/react-core/components-rsc', () => ({
   T: mockRscT,
 }));
 
 describe('buildtime T', () => {
-  it('passes request conditions to gt-react T', async () => {
+  it('passes request conditions to React Core T', async () => {
     mockGetRequestConditions.mockResolvedValue({
       _locale: 'fr',
       _enableI18n: false,

--- a/packages/next/src/server-dir/buildtime/renderPipeline.ts
+++ b/packages/next/src/server-dir/buildtime/renderPipeline.ts
@@ -3,7 +3,10 @@ import { DateTime } from '../../variables/DateTime';
 import { Num } from '../../variables/Num';
 import { RelativeTime } from '../../variables/RelativeTime';
 import { Var } from '../../variables/Var';
-import { createRenderPipeline, type RenderPreparedT } from 'gt-react';
+import {
+  createRenderPipeline,
+  type RenderPreparedT,
+} from '@generaltranslation/react-core/pure';
 
 const renderPipeline = createRenderPipeline({
   Currency,

--- a/packages/next/src/server-dir/runtime/_Tx.tsx
+++ b/packages/next/src/server-dir/runtime/_Tx.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { TxProps } from '../../utils/types';
-import { Tx as Core_Tx } from 'gt-react';
+import { Tx as Core_Tx } from '@generaltranslation/react-core/components-rsc';
 import { getRequestConditions } from '../../request/getRequestConditions';
 
 /**

--- a/packages/next/src/types.ts
+++ b/packages/next/src/types.ts
@@ -2,7 +2,7 @@ import type {
   DictionaryTranslationOptions,
   InlineTranslationOptions,
   RuntimeTranslationOptions,
-} from 'gt-react/internal';
+} from 'gt-i18n/types';
 
 export type {
   DictionaryTranslationOptions,

--- a/packages/next/src/variables/Currency.tsx
+++ b/packages/next/src/variables/Currency.tsx
@@ -1,4 +1,7 @@
-import { Currency as RscCurrency, type CurrencyProps } from 'gt-react';
+import {
+  Currency as RscCurrency,
+  type CurrencyProps,
+} from '@generaltranslation/react-core/components-rsc';
 import { getRequestConditions } from '../request/getRequestConditions';
 import type { ReactNode } from 'react';
 

--- a/packages/next/src/variables/DateTime.tsx
+++ b/packages/next/src/variables/DateTime.tsx
@@ -1,4 +1,7 @@
-import { DateTime as RscDateTime, type DateTimeProps } from 'gt-react';
+import {
+  DateTime as RscDateTime,
+  type DateTimeProps,
+} from '@generaltranslation/react-core/components-rsc';
 import { getRequestConditions } from '../request/getRequestConditions';
 import type { ReactNode } from 'react';
 

--- a/packages/next/src/variables/Num.tsx
+++ b/packages/next/src/variables/Num.tsx
@@ -1,4 +1,7 @@
-import { Num as RscNum, type NumProps } from 'gt-react';
+import {
+  Num as RscNum,
+  type NumProps,
+} from '@generaltranslation/react-core/components-rsc';
 import { getRequestConditions } from '../request/getRequestConditions';
 import type { ReactNode } from 'react';
 

--- a/packages/next/src/variables/RelativeTime.tsx
+++ b/packages/next/src/variables/RelativeTime.tsx
@@ -1,7 +1,7 @@
 import {
   RelativeTime as RscRelativeTime,
   type RelativeTimeProps,
-} from 'gt-react';
+} from '@generaltranslation/react-core/components-rsc';
 import { getRequestConditions } from '../request/getRequestConditions';
 import type { ReactNode } from 'react';
 

--- a/packages/next/src/variables/Var.tsx
+++ b/packages/next/src/variables/Var.tsx
@@ -1,4 +1,4 @@
-import { Var as CoreVar } from 'gt-react';
+import { Var as CoreVar } from '@generaltranslation/react-core/components-rsc';
 import { getRequestConditions } from '../request/getRequestConditions';
 import type { ReactNode } from 'react';
 

--- a/packages/tanstack-start/src/functions/parseLocale.ts
+++ b/packages/tanstack-start/src/functions/parseLocale.ts
@@ -1,4 +1,4 @@
-import { defaultLocaleCookieName } from 'gt-react';
+import { defaultLocaleCookieName } from '@generaltranslation/react-core/pure';
 import { createIsomorphicFn } from '@tanstack/react-start';
 import {
   getRequestHeader,

--- a/packages/tanstack-start/src/index.client.ts
+++ b/packages/tanstack-start/src/index.client.ts
@@ -3,32 +3,40 @@
 export { parseLocale } from './functions/parseLocale';
 
 export {
-  // ===== Components ===== //
+  LocaleSelector,
+  GTProvider,
+  useSetLocale,
+  useSetEnableI18n,
+  useLocaleSelector,
+  // ===== Setup ===== //
+  initializeGT,
+} from 'gt-react';
+
+export {
   Branch,
   Plural,
   Derive,
-  LocaleSelector,
   T,
   Currency,
   DateTime,
   RelativeTime,
   Var,
   Num,
-  GTProvider,
-  // ===== Hooks ===== //
+} from '@generaltranslation/react-core/components';
+
+export {
   useLocale,
-  useSetLocale,
   useCustomMapping,
   useDefaultLocale,
   useEnableI18n,
-  useSetEnableI18n,
   useLocales,
-  useLocaleSelector,
   useFormatLocales,
   useGT,
   useMessages,
   useTranslations,
-  // ===== Functions ===== //
+} from '@generaltranslation/react-core/hooks';
+
+export {
   msg,
   decodeMsg,
   decodeOptions,
@@ -37,8 +45,9 @@ export {
   decodeVars,
   mFallback,
   gtFallback,
+} from 'gt-i18n';
+
+export {
   getTranslationsSnapshot,
   t,
-  // ===== Setup ===== //
-  initializeGT,
-} from 'gt-react';
+} from '@generaltranslation/react-core/pure';

--- a/packages/tanstack-start/src/index.server.ts
+++ b/packages/tanstack-start/src/index.server.ts
@@ -1,32 +1,40 @@
 export { parseLocale } from './functions/parseLocale';
 
 export {
-  // ===== Components ===== //
+  LocaleSelector,
+  GTProvider,
+  useSetLocale,
+  useSetEnableI18n,
+  useLocaleSelector,
+  // ===== Setup ===== //
+  initializeGT,
+} from 'gt-react';
+
+export {
   Branch,
   Plural,
   Derive,
-  LocaleSelector,
   T,
   Currency,
   DateTime,
   RelativeTime,
   Var,
   Num,
-  GTProvider,
-  // ===== Hooks ===== //
+} from '@generaltranslation/react-core/components';
+
+export {
   useLocale,
-  useSetLocale,
   useCustomMapping,
   useDefaultLocale,
   useEnableI18n,
-  useSetEnableI18n,
   useLocales,
-  useLocaleSelector,
   useFormatLocales,
   useGT,
   useMessages,
   useTranslations,
-  // ===== Functions ===== //
+} from '@generaltranslation/react-core/hooks';
+
+export {
   msg,
   decodeMsg,
   decodeOptions,
@@ -35,8 +43,9 @@ export {
   decodeVars,
   mFallback,
   gtFallback,
+} from 'gt-i18n';
+
+export {
   getTranslationsSnapshot,
   t,
-  // ===== Setup ===== //
-  initializeGT,
-} from 'gt-react';
+} from '@generaltranslation/react-core/pure';

--- a/packages/tanstack-start/src/index.types.ts
+++ b/packages/tanstack-start/src/index.types.ts
@@ -1,32 +1,40 @@
 export { parseLocale } from './functions/parseLocale';
 
 export {
-  // ===== Components ===== //
+  LocaleSelector,
+  GTProvider,
+  useSetLocale,
+  useSetEnableI18n,
+  useLocaleSelector,
+  // ===== Setup ===== //
+  initializeGT,
+} from 'gt-react';
+
+export {
   Branch,
   Plural,
   Derive,
-  LocaleSelector,
   T,
   Currency,
   DateTime,
   RelativeTime,
   Var,
   Num,
-  GTProvider,
-  // ===== Hooks ===== //
+} from '@generaltranslation/react-core/components';
+
+export {
   useLocale,
-  useSetLocale,
   useCustomMapping,
   useDefaultLocale,
   useEnableI18n,
-  useSetEnableI18n,
   useLocales,
-  useLocaleSelector,
   useFormatLocales,
   useGT,
   useMessages,
   useTranslations,
-  // ===== Functions ===== //
+} from '@generaltranslation/react-core/hooks';
+
+export {
   msg,
   decodeMsg,
   decodeOptions,
@@ -35,8 +43,9 @@ export {
   decodeVars,
   mFallback,
   gtFallback,
+} from 'gt-i18n';
+
+export {
   getTranslationsSnapshot,
   t,
-  // ===== Setup ===== //
-  initializeGT,
-} from 'gt-react';
+} from '@generaltranslation/react-core/pure';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -989,6 +989,9 @@ importers:
       '@generaltranslation/next-internal':
         specifier: workspace:*
         version: link:../next-internal
+      '@generaltranslation/react-core':
+        specifier: workspace:*
+        version: link:../react-core
       '@generaltranslation/supported-locales':
         specifier: workspace:*
         version: link:../supported-locales


### PR DESCRIPTION
## Summary
- Import Next runtime helpers from `gt-i18n` and `@generaltranslation/react-core` directly instead of routing through `gt-react` re-exports.
- Add `@generaltranslation/react-core` as a direct `gt-next` dependency for those public subpath imports.
- Update affected Next tests to mock the direct import targets.

## Testing
- `pnpm turbo build --filter=gt-next...`
- `pnpm --filter gt-next test`
- `pnpm --filter gt-tanstack-start build`
- `pnpm --filter gt-tanstack-start test`
- `pnpm lint`
- `pnpm format`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1668"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785112571&installation_id=127936663&pr_number=1668&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1668&signature=ccbebe4e75c4232e72c773fce0e4e1497b2916d3c8a1bafacb16b63bdf421a2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR eliminates the `gt-react` intermediary layer for runtime helpers in `gt-next` and `gt-tanstack-start` by importing directly from `@generaltranslation/react-core` subpaths (`/pure`, `/hooks`, `/components-rsc`) and `gt-i18n`. The corresponding tests are updated to mock the new direct import targets instead of the former `gt-react` / `gt-react/internal` paths.

- **Source changes**: All runtime helper imports across ~20 files are redirected from `gt-react` / `gt-react/internal` to `@generaltranslation/react-core/pure`, `@generaltranslation/react-core/components-rsc`, `@generaltranslation/react-core/hooks`, or `gt-i18n` as appropriate.
- **Dependency addition**: `@generaltranslation/react-core` is explicitly added to `packages/next/package.json` (already present in `gt-tanstack-start`), with the lockfile updated accordingly.
- **Test updates**: `T.test.tsx`, `NextI18nCache.test.ts`, `withGTServerSideProps.test.ts`, and `rscComponentWrappers.test.tsx` are updated to mock the new import sources.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Straightforward import path consolidation with no behaviour change; every new import path is verified to export the expected symbols.

Every redirected import was traced back to the corresponding subpath in `@generaltranslation/react-core` or `gt-i18n` and confirmed present. Tests are updated to mock the correct new targets. The residual `vi.mock('gt-react', ...)` in `rscComponentWrappers.test.tsx` is intentional — `client-boundary.tsx` still re-exports `LocaleSelector`/`RegionSelector` from `gt-react`. The new explicit `@generaltranslation/react-core` dependency in `packages/next/package.json` is reflected in `pnpm-lock.yaml`.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/next/package.json | Adds `@generaltranslation/react-core` as an explicit direct dependency, correctly reflecting the new direct imports introduced in this PR. |
| packages/next/src/index.rsc.ts | Splits the former `gt-react` import block into three targets: utility functions to `gt-i18n`, `Derive` to `@generaltranslation/react-core/components-rsc`, and hooks to `@generaltranslation/react-core/hooks`; all symbols verified present in those subpaths. |
| packages/next/src/i18n-cache/NextI18nCache.ts | Consolidates `ReactI18nCache` (was `gt-react`) and `mergeDictionaries` (was `gt-react/internal`) into a single import from `@generaltranslation/react-core/pure`; both symbols confirmed exported from that subpath. |
| packages/next/src/index.types.ts | Moves type imports to `gt-i18n/types`, utility functions to `gt-i18n`, and `_Messages` type to `@generaltranslation/react-core/pure`; shape types still pull from `gt-react`, keeping type-checking intact. |
| packages/next/src/__tests__/rscComponentWrappers.test.tsx | Adds mocks for `gt-i18n`, `@generaltranslation/react-core/components-rsc`, and `@generaltranslation/react-core/hooks`; retains the `gt-react` mock, which is still needed because `client-boundary.tsx` re-exports `LocaleSelector` and `RegionSelector` from `gt-react`. |
| packages/next/src/server-dir/buildtime/__tests__/T.test.tsx | Correctly splits the former single `gt-react` mock into `@generaltranslation/react-core/pure` for `createRenderPipeline` and `@generaltranslation/react-core/components-rsc` for the `T` RSC component. |
| packages/next/src/i18n-cache/__tests__/NextI18nCache.test.ts | Merges the former two separate mocks into a single `@generaltranslation/react-core/pure` mock, correctly reflecting that both `ReactI18nCache` and `mergeDictionaries` now come from the same subpath. |
| packages/tanstack-start/src/functions/parseLocale.ts | Redirects `defaultLocaleCookieName` from `gt-react` to `@generaltranslation/react-core/pure`; `gt-tanstack-start` already lists `@generaltranslation/react-core` as a dependency so no package.json change is needed. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Before
        A1[gt-next source files] -->|import helpers| B1[gt-react]
        B1 -->|re-export| C1[react-core]
        B1 -->|re-export| D1[gt-i18n]
    end

    subgraph After
        A2[gt-next source files] -->|components and hooks| C2[react-core subpaths]
        A2 -->|utility functions| D2[gt-i18n]
        A2 -->|client components| B2[gt-react]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    subgraph Before
        A1[gt-next source files] -->|import helpers| B1[gt-react]
        B1 -->|re-export| C1[react-core]
        B1 -->|re-export| D1[gt-i18n]
    end

    subgraph After
        A2[gt-next source files] -->|components and hooks| C2[react-core subpaths]
        A2 -->|utility functions| D2[gt-i18n]
        A2 -->|client components| B2[gt-react]
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: import runtime helpers directly"](https://github.com/generaltranslation/gt/commit/2ab9b8487ba9dbf324284b7f5b23c916d00d5c3b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40231167)</sub>

<!-- /greptile_comment -->