### PR TITLE
fix: reduce gt-react internal surface

### DIFF
--- a/packages/react/src/__tests__/react-package.test.ts
+++ b/packages/react/src/__tests__/react-package.test.ts
@@ -75,7 +75,7 @@ describe('gt-react package exports', () => {
           assert.equal(typeof react.T, 'function');
           assert.equal(typeof react.GtInternalVar, 'function');
           assert.equal(typeof react.GtInternalRuntimeTranslateString, 'function');
-          assert.equal(typeof internal.renderDefaultChildren, 'function');
+          assert.equal(typeof internal.getDefaultRenderSettings, 'function');
         `,
     ]);
   });
@@ -87,13 +87,13 @@ describe('gt-react package exports', () => {
       `
           import assert from 'node:assert/strict';
           import { GTProvider, GtInternalRuntimeTranslateString, GtInternalVar, T } from 'gt-react';
-          import { renderDefaultChildren } from 'gt-react/internal';
+          import { getDefaultRenderSettings } from 'gt-react/internal';
 
           assert.equal(typeof GTProvider, 'function');
           assert.equal(typeof T, 'function');
           assert.equal(typeof GtInternalVar, 'function');
           assert.equal(typeof GtInternalRuntimeTranslateString, 'function');
-          assert.equal(typeof renderDefaultChildren, 'function');
+          assert.equal(typeof getDefaultRenderSettings, 'function');
         `,
     ]);
   });

--- a/packages/react/src/index.client.ts
+++ b/packages/react/src/index.client.ts
@@ -93,6 +93,12 @@ export {
 } from '@generaltranslation/react-core/pure';
 
 export type {
+  CustomLoader,
+  Dictionary,
+  DictionaryEntry,
+  RenderMethod,
+  Translations,
+  _Messages,
   RenderPipeline,
   RenderPreparedT,
 } from '@generaltranslation/react-core/pure';

--- a/packages/react/src/index.rsc.ts
+++ b/packages/react/src/index.rsc.ts
@@ -154,6 +154,15 @@ export { initializeGT } from '@generaltranslation/react-core/pure';
 
 // ===== Types ===== //
 export type {
+  CustomLoader,
+  Dictionary,
+  DictionaryEntry,
+  RenderMethod,
+  Translations,
+  _Messages,
+} from '@generaltranslation/react-core/pure';
+
+export type {
   CurrencyProps,
   DateTimeProps,
   JsxTranslationOptions,

--- a/packages/react/src/index.server.ts
+++ b/packages/react/src/index.server.ts
@@ -98,6 +98,12 @@ export {
 } from '@generaltranslation/react-core/pure';
 
 export type {
+  CustomLoader,
+  Dictionary,
+  DictionaryEntry,
+  RenderMethod,
+  Translations,
+  _Messages,
   RenderPipeline,
   RenderPreparedT,
 } from '@generaltranslation/react-core/pure';

--- a/packages/react/src/index.types.ts
+++ b/packages/react/src/index.types.ts
@@ -94,6 +94,12 @@ export {
 } from '@generaltranslation/react-core/pure';
 
 export type {
+  CustomLoader,
+  Dictionary,
+  DictionaryEntry,
+  RenderMethod,
+  Translations,
+  _Messages,
   RenderPipeline,
   RenderPreparedT,
 } from '@generaltranslation/react-core/pure';

--- a/packages/react/src/internal.ts
+++ b/packages/react/src/internal.ts
@@ -1,451 +1,127 @@
-// No useContext related exports should go through here!
-
-import {
-  addGTIdentifier as _addGTIdentifier,
-  writeChildrenAsObjects as _writeChildrenAsObjects,
-  isVariableObject as _isVariableObject,
-  flattenDictionary as _flattenDictionary,
-  getDictionaryEntry as _getDictionaryEntry,
-  isValidDictionaryEntry as _isValidDictionaryEntry,
-  getVariableProps as _getVariableProps,
-  getPluralBranch as _getPluralBranch,
-  getEntryAndMetadata as _getEntryAndMetadata,
-  getVariableName as _getVariableName,
-  renderSkeleton as _renderSkeleton,
-  getDefaultRenderSettings as _getDefaultRenderSettings,
-  mergeDictionaries as _mergeDictionaries,
-  reactHasUse as _reactHasUse,
-  getSubtree as _getSubtree,
-  getSubtreeWithCreation as _getSubtreeWithCreation,
-  injectEntry as _injectEntry,
-  isDictionaryEntry as _isDictionaryEntry,
-  stripMetadataFromEntries as _stripMetadataFromEntries,
-  injectHashes as _injectHashes,
-  injectTranslations as _injectTranslations,
-  injectFallbacks as _injectFallbacks,
-  injectAndMerge as _injectAndMerge,
-  collectUntranslatedEntries as _collectUntranslatedEntries,
-  msg as _msg,
-  decodeMsg as _decodeMsg,
-  decodeOptions as _decodeOptions,
-  derive as _derive,
-  declareVar as _declareVar,
-  decodeVars as _decodeVars,
-  mFallback as _mFallback,
-  gtFallback as _gtFallback,
-} from '@generaltranslation/react-core/pure';
-import {
-  Derive as _Derive,
-  renderDefaultChildren as _renderDefaultChildren,
-  renderTranslatedChildren as _renderTranslatedChildren,
-} from '@generaltranslation/react-core/components-rsc';
-import {
-  defaultEnableI18nCookieName as _defaultEnableI18nCookieName,
-  defaultLocaleCookieName as _defaultLocaleCookieName,
-  defaultRegionCookieName as _defaultRegionCookieName,
-} from './cookie-names';
+/**
+ * @deprecated gt-react/internal is deprecated. Use public gt-react exports
+ * instead. This subpath is kept only for gt-next compatibility.
+ */
 
 import type {
-  MFunctionType as _MFunctionType,
-  GTFunctionType as _GTFunctionType,
-  Dictionary as _Dictionary,
-  RenderMethod as _RenderMethod,
-  TranslatedChildren as _TranslatedChildren,
-  Translations as _Translations,
-  RenderVariable as _RenderVariable,
-  VariableProps as _VariableProps,
-  DictionaryEntry as _DictionaryEntry,
-  FlattenedDictionary as _FlattenedDictionary,
-  Metadata as _Metadata,
-  Entry as _Entry,
-  DictionaryTranslationOptions as _DictionaryTranslationOptions,
-  InlineTranslationOptions as _InlineTranslationOptions,
-  RuntimeTranslationOptions as _RuntimeTranslationOptions,
-  LocalesDictionary as _LocalesDictionary,
-  DictionaryContent as _DictionaryContent,
-  DictionaryObject as _DictionaryObject,
-  CustomLoader as _CustomLoader,
-  _Message as __Message,
-  _Messages as __Messages,
-  GTProp as _GTProp,
-} from '@generaltranslation/react-core/pure';
-
-import type { SharedGTProviderProps } from './provider/GTProviderProps';
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-type RenderMethod = _RenderMethod;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-type Dictionary = _Dictionary;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-type DictionaryEntry = _DictionaryEntry;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-type FlattenedDictionary = _FlattenedDictionary;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-type Metadata = _Metadata;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-type GTProp = _GTProp;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-type Entry = _Entry;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-type TranslatedChildren = _TranslatedChildren;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-type Translations = _Translations;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use SharedGTProviderProps from gt-react instead.
- */
-type ClientProviderProps = SharedGTProviderProps;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use SharedGTProviderProps from gt-react instead.
- */
-type GTProviderProps = SharedGTProviderProps;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-type DictionaryTranslationOptions = _DictionaryTranslationOptions;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-type InlineTranslationOptions = _InlineTranslationOptions;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-type RuntimeTranslationOptions = _RuntimeTranslationOptions;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-type DictionaryContent = _DictionaryContent;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-type DictionaryObject = _DictionaryObject;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-type LocalesDictionary = _LocalesDictionary;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-type CustomLoader = _CustomLoader;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-type RenderVariable = _RenderVariable;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-type VariableProps = _VariableProps;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-type MFunctionType = _MFunctionType;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-type GTFunctionType = _GTFunctionType;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-type _Message = __Message;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-type _Messages = __Messages;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const defaultEnableI18nCookieName = _defaultEnableI18nCookieName;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const defaultLocaleCookieName = _defaultLocaleCookieName;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const defaultRegionCookieName = _defaultRegionCookieName;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const reactHasUse = _reactHasUse;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const Derive = _Derive;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const addGTIdentifier = _addGTIdentifier;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const writeChildrenAsObjects = _writeChildrenAsObjects;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const isVariableObject = _isVariableObject;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const flattenDictionary = _flattenDictionary;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const getDictionaryEntry = _getDictionaryEntry;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const isValidDictionaryEntry = _isValidDictionaryEntry;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const getVariableProps = _getVariableProps;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const getPluralBranch = _getPluralBranch;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const getEntryAndMetadata = _getEntryAndMetadata;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const getVariableName = _getVariableName;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const renderDefaultChildren = _renderDefaultChildren;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const renderTranslatedChildren = _renderTranslatedChildren;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const renderSkeleton = _renderSkeleton;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const mergeDictionaries = _mergeDictionaries;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const getSubtree = _getSubtree;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const getSubtreeWithCreation = _getSubtreeWithCreation;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const injectEntry = _injectEntry;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const isDictionaryEntry = _isDictionaryEntry;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const stripMetadataFromEntries = _stripMetadataFromEntries;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const injectHashes = _injectHashes;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const injectTranslations = _injectTranslations;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const injectFallbacks = _injectFallbacks;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const injectAndMerge = _injectAndMerge;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const collectUntranslatedEntries = _collectUntranslatedEntries;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const msg = _msg;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const decodeMsg = _decodeMsg;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const decodeOptions = _decodeOptions;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const derive = _derive;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const declareVar = _declareVar;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const decodeVars = _decodeVars;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const mFallback = _mFallback;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const gtFallback = _gtFallback;
-
-/**
- * @deprecated gt-react/internal is deprecated. Use public gt-react exports instead.
- */
-const getDefaultRenderSettings = _getDefaultRenderSettings;
-
-export type {
-  RenderMethod,
+  CustomLoader,
   Dictionary,
   DictionaryEntry,
-  FlattenedDictionary,
-  Metadata,
-  GTProp,
-  Entry,
-  TranslatedChildren,
+  RenderMethod,
   Translations,
-  ClientProviderProps,
-  GTProviderProps,
-  DictionaryTranslationOptions,
-  InlineTranslationOptions,
-  RuntimeTranslationOptions,
-  DictionaryContent,
-  DictionaryObject,
-  LocalesDictionary,
-  CustomLoader,
-  RenderVariable,
-  VariableProps,
-  MFunctionType,
-  GTFunctionType,
-  _Message,
-  _Messages,
-};
+} from '@generaltranslation/react-core/pure';
 
 export {
   defaultEnableI18nCookieName,
   defaultLocaleCookieName,
   defaultRegionCookieName,
-  reactHasUse,
-  Derive,
-  addGTIdentifier,
-  writeChildrenAsObjects,
-  isVariableObject,
-  flattenDictionary,
-  getDictionaryEntry,
-  isValidDictionaryEntry,
-  getVariableProps,
-  getPluralBranch,
-  getEntryAndMetadata,
-  getVariableName,
-  renderDefaultChildren,
-  renderTranslatedChildren,
-  renderSkeleton,
-  mergeDictionaries,
-  getSubtree,
-  getSubtreeWithCreation,
-  injectEntry,
-  isDictionaryEntry,
-  stripMetadataFromEntries,
-  injectHashes,
-  injectTranslations,
-  injectFallbacks,
-  injectAndMerge,
-  collectUntranslatedEntries,
-  msg,
-  decodeMsg,
-  decodeOptions,
-  derive,
-  declareVar,
-  decodeVars,
-  mFallback,
-  gtFallback,
-  getDefaultRenderSettings,
+} from './cookie-names';
+
+export type {
+  CustomLoader,
+  Dictionary,
+  DictionaryEntry,
+  RenderMethod,
+  Translations,
 };
+
+function get(dictionary: Dictionary, id: string | number) {
+  if (dictionary == null) {
+    throw new Error('Cannot index into an undefined dictionary');
+  }
+  if (Array.isArray(dictionary)) {
+    return dictionary[id as number];
+  }
+  return dictionary[id as string];
+}
+
+function isDictionaryEntry(value: unknown): value is DictionaryEntry {
+  if (typeof value === 'string') return true;
+  if (!Array.isArray(value) || typeof value[0] !== 'string') return false;
+
+  const metadata = value[1];
+  return typeof metadata === 'undefined' || typeof metadata === 'object';
+}
+
+const isPrimitiveOrArray = (value: unknown): boolean =>
+  typeof value === 'string' || Array.isArray(value);
+
+const isObjectDictionary = (value: unknown): boolean =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+export function getDefaultRenderSettings(
+  environment: 'development' | 'production' | 'test' = 'production'
+): {
+  method: RenderMethod;
+  timeout: number;
+} {
+  return {
+    method: 'default',
+    timeout: environment === 'development' ? 8000 : 12000,
+  };
+}
+
+export function getDictionaryEntry<T extends Dictionary>(
+  dictionary: T,
+  id: string
+): Dictionary | DictionaryEntry | undefined {
+  let current: Dictionary | DictionaryEntry = dictionary;
+  const dictionaryPath = id.split('.');
+  for (const key of dictionaryPath) {
+    if (typeof current !== 'object' && !Array.isArray(current)) {
+      return undefined;
+    }
+    current = get(current as Dictionary, key);
+  }
+  return current;
+}
+
+export function mergeDictionaries(
+  defaultLocaleDictionary: Dictionary,
+  localeDictionary: Dictionary
+): Dictionary {
+  if (Array.isArray(defaultLocaleDictionary)) {
+    return defaultLocaleDictionary.map((value, key) => {
+      if (isDictionaryEntry(value)) {
+        return (localeDictionary as (Dictionary | DictionaryEntry)[])[key];
+      }
+      return mergeDictionaries(
+        value as Dictionary,
+        (localeDictionary as (Dictionary | DictionaryEntry)[])[
+          key
+        ] as Dictionary
+      );
+    });
+  }
+
+  const mergedDictionary: Dictionary = {
+    ...Object.fromEntries(
+      Object.entries(defaultLocaleDictionary).filter(([, value]) =>
+        isPrimitiveOrArray(value)
+      )
+    ),
+    ...Object.fromEntries(
+      Object.entries(localeDictionary).filter(([, value]) =>
+        isPrimitiveOrArray(value)
+      )
+    ),
+  };
+
+  const defaultDictionaryKeys = Object.entries(defaultLocaleDictionary)
+    .filter(([, value]) => isObjectDictionary(value))
+    .map(([key]) => key);
+
+  const localeDictionaryKeys = Object.entries(localeDictionary)
+    .filter(([, value]) => isObjectDictionary(value))
+    .map(([key]) => key);
+
+  const allKeys = new Set([...defaultDictionaryKeys, ...localeDictionaryKeys]);
+  for (const key of allKeys) {
+    mergedDictionary[key] = mergeDictionaries(
+      (get(defaultLocaleDictionary, key) || {}) as Dictionary,
+      (get(localeDictionary, key) || {}) as Dictionary
+    );
+  }
+
+  return mergedDictionary;
+}


### PR DESCRIPTION
## Summary
- reduce `gt-react/internal` to the small compatibility surface used by `gt-next`
- expose the needed `gt-react` type exports publicly so downstream type-only imports no longer use `/internal`
- move `gt-next` helper imports off `/internal` where public exports are available

## Testing
- `pnpm --filter gt-react... build`
- `pnpm --filter gt-react test`
- `pnpm --filter gt-next typecheck`
- `pnpm --filter gt-next test:js`
- `pnpm lint`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1669"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785112709&installation_id=127936663&pr_number=1669&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1669&signature=62fb20d118ca4ec3797cb24c74a368b51d5ec5b1d3c23d4687dc6b37de306df9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reduces the `gt-react/internal` subpath to a minimal compatibility shim for `gt-next`, exposing the types that downstream consumers were importing via `/internal` as proper public exports instead. Runtime functions previously re-exported from `@generaltranslation/react-core/pure` are now inlined locally, and `gt-next` import sites are updated accordingly.

- `packages/react/src/internal.ts` is trimmed from ~451 lines to ~127 lines; `getDictionaryEntry`, `mergeDictionaries`, and `getDefaultRenderSettings` are locally reimplemented rather than re-exported from the upstream package.
- `packages/react/src/index.{client,server,rsc,types}.ts` each gain public type exports for `CustomLoader`, `Dictionary`, `DictionaryEntry`, `RenderMethod`, `Translations`, and `_Messages`.
- All `gt-next` files that imported types from `gt-react/internal` are updated to use the new public `gt-react` import paths.

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The gt-next import migration is clean and the type-surface additions are low-risk, but the mergeDictionaries array-recursion path can throw a TypeError at runtime when the locale dictionary is shorter than the default.

The vast majority of the diff is safe type-import cleanup. The risk is concentrated in internal.ts: the three locally-copied function implementations are no longer tied to their upstream source, and more concretely the mergeDictionaries array branch passes a potentially-undefined second argument recursively without the same || {} guard used elsewhere in the same function, which will throw a TypeError in production for any caller that supplies a shorter locale array dictionary.

packages/react/src/internal.ts — specifically the array branch of mergeDictionaries (lines 83–94) and the decision to inline rather than re-export the three functions from @generaltranslation/react-core/pure.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react/src/internal.ts | Radically pruned from 451 → 127 lines; three functions (getDictionaryEntry, mergeDictionaries, getDefaultRenderSettings) are now locally defined copies rather than re-exports from @generaltranslation/react-core/pure, creating a divergence risk. |
| packages/react/src/index.client.ts | Adds six type-only exports (CustomLoader, Dictionary, DictionaryEntry, RenderMethod, Translations, _Messages) to the public client surface; no runtime change. |
| packages/react/src/index.rsc.ts | Same type-only additions as index.client.ts, applied to the RSC entry point. |
| packages/react/src/index.server.ts | Same type-only additions as index.client.ts, applied to the server entry point. |
| packages/react/src/index.types.ts | Same type-only additions as index.client.ts, applied to the types-only entry point. |
| packages/next/src/i18n-cache/NextI18nCache.ts | Consolidates gt-react imports: ReactI18nCache, Dictionary, DictionaryEntry, ReactI18nCacheParams now come from gt-react public path; only mergeDictionaries stays on gt-react/internal. |
| packages/next/src/index.types.ts | Moves _Messages, derive, declareVar, decodeVars, mFallback, gtFallback imports from gt-react/internal to gt-react public; clean type-import change. |
| packages/react/src/__tests__/react-package.test.ts | Test updated to check for getDefaultRenderSettings (now exported from internal) instead of renderDefaultChildren (removed); reflects new internal surface correctly. |
| packages/next/src/config-dir/props/defaultWithGTConfigProps.ts | Splits import: RenderMethod now from gt-react public, getDefaultRenderSettings and defaultLocaleCookieName stay on gt-react/internal. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph gt-next ["gt-next (consumer)"]
        NT[index.types.ts] -->|import type _Messages, derive, declareVar...| GR
        NC[NextI18nCache.ts] -->|import ReactI18nCache, Dictionary, DictionaryEntry| GR
        NC -->|import mergeDictionaries| GRI
        DD[getDictionary.ts] -->|import getDictionaryEntry| GRI
        DWG[defaultWithGTConfigProps.ts] -->|import getDefaultRenderSettings, defaultLocaleCookieName| GRI
        DWG -->|import type RenderMethod| GR
    end

    subgraph gt-react ["gt-react (public exports)"]
        GR["gt-react (index.client/server/rsc/types)"]
        GRI["gt-react/internal"]
    end

    subgraph core ["@generaltranslation/react-core/pure"]
        CORE[react-core/pure]
    end

    GR -->|re-export types: CustomLoader, Dictionary, DictionaryEntry, RenderMethod, Translations, _Messages| CORE
    GRI -->|import types only| CORE
    GRI -->|local copies ⚠️| LOCAL["getDefaultRenderSettings\ngetDictionaryEntry\nmergeDictionaries"]
    GRI -->|re-export| CK["cookie-names\n(defaultLocaleCookieName etc.)"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    subgraph gt-next ["gt-next (consumer)"]
        NT[index.types.ts] -->|import type _Messages, derive, declareVar...| GR
        NC[NextI18nCache.ts] -->|import ReactI18nCache, Dictionary, DictionaryEntry| GR
        NC -->|import mergeDictionaries| GRI
        DD[getDictionary.ts] -->|import getDictionaryEntry| GRI
        DWG[defaultWithGTConfigProps.ts] -->|import getDefaultRenderSettings, defaultLocaleCookieName| GRI
        DWG -->|import type RenderMethod| GR
    end

    subgraph gt-react ["gt-react (public exports)"]
        GR["gt-react (index.client/server/rsc/types)"]
        GRI["gt-react/internal"]
    end

    subgraph core ["@generaltranslation/react-core/pure"]
        CORE[react-core/pure]
    end

    GR -->|re-export types: CustomLoader, Dictionary, DictionaryEntry, RenderMethod, Translations, _Messages| CORE
    GRI -->|import types only| CORE
    GRI -->|local copies ⚠️| LOCAL["getDefaultRenderSettings\ngetDictionaryEntry\nmergeDictionaries"]
    GRI -->|re-export| CK["cookie-names\n(defaultLocaleCookieName etc.)"]
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Freact%2Fsrc%2Finternal.ts%3A52-127%0A**Locally-copied%20implementations%20diverge%20from%20upstream%20source%20of%20truth**%0A%0A%60getDefaultRenderSettings%60%2C%20%60getDictionaryEntry%60%2C%20and%20%60mergeDictionaries%60%20were%20previously%20re-exported%20from%20%60%40generaltranslation%2Freact-core%2Fpure%60%3B%20they%20are%20now%20inlined%20verbatim%20in%20this%20file.%20Any%20future%20bug%20fix%20or%20behaviour%20change%20in%20the%20upstream%20package%20will%20silently%20not%20apply%20here%2C%20since%20there%20is%20no%20import%20relationship%20to%20pull%20updates%20through.%20Re-exporting%20from%20the%20package%20%28even%20if%20only%20for%20%60gt-next%60's%20benefit%29%20would%20keep%20the%20single%20source%20of%20truth%20intact.%20If%20the%20goal%20is%20specifically%20to%20avoid%20exposing%20more%20of%20%60%40generaltranslation%2Freact-core%2Fpure%60's%20surface%20via%20the%20internal%20shim%2C%20consider%20adding%20a%20brief%20comment%20explaining%20why%20the%20copy%20is%20intentional%20so%20future%20maintainers%20don't%20inadvertently%20patch%20one%20but%20not%20the%20other.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Freact%2Fsrc%2Finternal.ts%3A83-94%0A**Missing%20fallback%20guard%20in%20array-dictionary%20recursion**%0A%0AIn%20the%20array%20branch%20of%20%60mergeDictionaries%60%2C%20when%20a%20nested%20entry%20%28non-%60DictionaryEntry%60%29%20exists%20in%20%60defaultLocaleDictionary%60%20but%20the%20corresponding%20index%20is%20absent%20from%20%60localeDictionary%60%2C%20the%20recursive%20call%20receives%20%60undefined%60%20cast%20to%20%60Dictionary%60.%20The%20object-merge%20path%20that%20follows%20calls%20%60Object.entries%28localeDictionary%29%60%20on%20that%20%60undefined%60%2C%20which%20throws%20%60TypeError%3A%20Cannot%20convert%20undefined%20or%20null%20to%20object%60%20at%20runtime.%20The%20object-key%20loop%20at%20line%20120%E2%80%93123%20already%20applies%20a%20%60%7C%7C%20%7B%7D%60%20guard%20for%20exactly%20this%20reason%20%E2%80%94%20the%20array%20branch%20needs%20the%20same%20treatment.%20This%20would%20surface%20when%20%60localeDictionary%60%20is%20a%20sparse%20or%20shorter%20array%20than%20%60defaultLocaleDictionary%60.%0A%0A&repo=generaltranslation%2Fgt&pr=1669&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fodysseus%2Freduce-react-internal%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fodysseus%2Freduce-react-internal%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Freact%2Fsrc%2Finternal.ts%3A52-127%0A**Locally-copied%20implementations%20diverge%20from%20upstream%20source%20of%20truth**%0A%0A%60getDefaultRenderSettings%60%2C%20%60getDictionaryEntry%60%2C%20and%20%60mergeDictionaries%60%20were%20previously%20re-exported%20from%20%60%40generaltranslation%2Freact-core%2Fpure%60%3B%20they%20are%20now%20inlined%20verbatim%20in%20this%20file.%20Any%20future%20bug%20fix%20or%20behaviour%20change%20in%20the%20upstream%20package%20will%20silently%20not%20apply%20here%2C%20since%20there%20is%20no%20import%20relationship%20to%20pull%20updates%20through.%20Re-exporting%20from%20the%20package%20%28even%20if%20only%20for%20%60gt-next%60's%20benefit%29%20would%20keep%20the%20single%20source%20of%20truth%20intact.%20If%20the%20goal%20is%20specifically%20to%20avoid%20exposing%20more%20of%20%60%40generaltranslation%2Freact-core%2Fpure%60's%20surface%20via%20the%20internal%20shim%2C%20consider%20adding%20a%20brief%20comment%20explaining%20why%20the%20copy%20is%20intentional%20so%20future%20maintainers%20don't%20inadvertently%20patch%20one%20but%20not%20the%20other.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Freact%2Fsrc%2Finternal.ts%3A83-94%0A**Missing%20fallback%20guard%20in%20array-dictionary%20recursion**%0A%0AIn%20the%20array%20branch%20of%20%60mergeDictionaries%60%2C%20when%20a%20nested%20entry%20%28non-%60DictionaryEntry%60%29%20exists%20in%20%60defaultLocaleDictionary%60%20but%20the%20corresponding%20index%20is%20absent%20from%20%60localeDictionary%60%2C%20the%20recursive%20call%20receives%20%60undefined%60%20cast%20to%20%60Dictionary%60.%20The%20object-merge%20path%20that%20follows%20calls%20%60Object.entries%28localeDictionary%29%60%20on%20that%20%60undefined%60%2C%20which%20throws%20%60TypeError%3A%20Cannot%20convert%20undefined%20or%20null%20to%20object%60%20at%20runtime.%20The%20object-key%20loop%20at%20line%20120%E2%80%93123%20already%20applies%20a%20%60%7C%7C%20%7B%7D%60%20guard%20for%20exactly%20this%20reason%20%E2%80%94%20the%20array%20branch%20needs%20the%20same%20treatment.%20This%20would%20surface%20when%20%60localeDictionary%60%20is%20a%20sparse%20or%20shorter%20array%20than%20%60defaultLocaleDictionary%60.%0A%0A&repo=generaltranslation%2Fgt&pr=1669&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/react/src/internal.ts:52-127
**Locally-copied implementations diverge from upstream source of truth**

`getDefaultRenderSettings`, `getDictionaryEntry`, and `mergeDictionaries` were previously re-exported from `@generaltranslation/react-core/pure`; they are now inlined verbatim in this file. Any future bug fix or behaviour change in the upstream package will silently not apply here, since there is no import relationship to pull updates through. Re-exporting from the package (even if only for `gt-next`'s benefit) would keep the single source of truth intact. If the goal is specifically to avoid exposing more of `@generaltranslation/react-core/pure`'s surface via the internal shim, consider adding a brief comment explaining why the copy is intentional so future maintainers don't inadvertently patch one but not the other.

### Issue 2 of 2
packages/react/src/internal.ts:83-94
**Missing fallback guard in array-dictionary recursion**

In the array branch of `mergeDictionaries`, when a nested entry (non-`DictionaryEntry`) exists in `defaultLocaleDictionary` but the corresponding index is absent from `localeDictionary`, the recursive call receives `undefined` cast to `Dictionary`. The object-merge path that follows calls `Object.entries(localeDictionary)` on that `undefined`, which throws `TypeError: Cannot convert undefined or null to object` at runtime. The object-key loop at line 120–123 already applies a `|| {}` guard for exactly this reason — the array branch needs the same treatment. This would surface when `localeDictionary` is a sparse or shorter array than `defaultLocaleDictionary`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: reduce gt-react internal surface"](https://github.com/generaltranslation/gt/commit/68c4b333d141c0aefd62553cb378c5025c54daf8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40231395)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->