### PR TITLE
ci: avoid github changelog for odysseus release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -290,7 +290,7 @@ jobs:
 
       - name: Configure Changesets for Odysseus
         run: |
-          jq '.baseBranch = "odysseus"' .changeset/config.json > .changeset/config.tmp.json
+          jq '.baseBranch = "odysseus" | .changelog = "@changesets/cli/changelog"' .changeset/config.json > .changeset/config.tmp.json
           mv .changeset/config.tmp.json .changeset/config.json
           git update-index --assume-unchanged .changeset/config.json
 


### PR DESCRIPTION
## Summary
- Configure the Odysseus release job to use Changesets' built-in git changelog instead of `@changesets/changelog-github`.
- Keep the normal `main` release path unchanged.
- Avoid GitHub GraphQL calls during Odysseus `changeset version`, which is the failing path in the release action.

## Testing
- `pnpm exec oxfmt --check .github/workflows/release.yml`
- In a temporary worktree at current `origin/odysseus`, rewrote `.changeset/config.json` with the same `jq` expression and ran `pnpm run version-packages`; it completed successfully.

## Notes
- Odysseus prerelease changelog entries will use local git commit references instead of GitHub-enriched PR/user links.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1670"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785114309&installation_id=127936663&pr_number=1670&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1670&signature=a48f10e5a5e62e66a055f1ea51d296d0093e8ab4c64d542c46ea1e7707006787"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This CI-only PR patches the Odysseus prerelease job in `release.yml` to swap out `@changesets/changelog-github` (which makes GitHub GraphQL API calls during `changeset version`) for the built-in `@changesets/cli/changelog` module. The main `release` job targeting `main` is untouched.

- The `jq` expression now chains `.baseBranch = "odysseus" | .changelog = "@changesets/cli/changelog"`, correctly replacing both fields in the temporary `config.json` mutation. The built-in changelog is the default generated by `changeset init` and is confirmed valid when the package is locally installed (as it is via `pnpm install` earlier in the job).
- Odysseus changelog entries will use local git commit references instead of enriched GitHub PR/user links, which is an acceptable trade-off for unblocking the prerelease pipeline.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the change is limited to a one-line CI config mutation in the Odysseus prerelease job and does not touch any production code or the main release path.

The jq expression is correct chained syntax, `@changesets/cli/changelog` is the confirmed default built-in module (installed locally via `pnpm install` earlier in the job), the temporary config mutation pattern is unchanged from before, and the main release job is completely unaffected.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Single-line change to the Odysseus jq config mutation; adds `.changelog = "@changesets/cli/changelog"` alongside the existing `.baseBranch = "odysseus"` assignment. No issues found. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant GHA as GitHub Actions
    participant JQ as jq (config patch)
    participant CS as changesets/action@v1
    participant CLI as @changesets/cli
    participant CL as @changesets/cli/changelog
    participant NPM as npm registry

    GHA->>JQ: "set baseBranch=odysseus + changelog=@changesets/cli/changelog"
    JQ-->>GHA: patched config.json (temp)
    GHA->>CS: version: pnpm run version-packages
    CS->>CLI: changeset version
    CLI->>CL: getReleaseLine() (git-only, no GraphQL)
    CL-->>CLI: commit-based changelog entries
    CLI-->>CS: CHANGELOGs + bumped versions
    CS->>GHA: open/update release PR
    GHA->>CS: publish: pnpm run release
    CS->>NPM: publish odysseus prerelease packages
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant GHA as GitHub Actions
    participant JQ as jq (config patch)
    participant CS as changesets/action@v1
    participant CLI as @changesets/cli
    participant CL as @changesets/cli/changelog
    participant NPM as npm registry

    GHA->>JQ: "set baseBranch=odysseus + changelog=@changesets/cli/changelog"
    JQ-->>GHA: patched config.json (temp)
    GHA->>CS: version: pnpm run version-packages
    CS->>CLI: changeset version
    CLI->>CL: getReleaseLine() (git-only, no GraphQL)
    CL-->>CLI: commit-based changelog entries
    CLI-->>CS: CHANGELOGs + bumped versions
    CS->>GHA: open/update release PR
    GHA->>CS: publish: pnpm run release
    CS->>NPM: publish odysseus prerelease packages
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["ci: avoid github changelog for odysseus ..."](https://github.com/generaltranslation/gt/commit/5bd34b27ba58ed20058f9768bf22f75ce4b7b9d3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40235893)</sub>

<!-- /greptile_comment -->