### PR TITLE
refactor: remove default source exports

### DIFF
--- a/.changeset/remove-default-source-exports.md
+++ b/.changeset/remove-default-source-exports.md
@@ -1,0 +1,11 @@
+---
+'generaltranslation': patch
+'gt-next': patch
+'@generaltranslation/react-core': patch
+'gt-react': patch
+'gt-react-native': patch
+---
+
+Remove default exports from package entrypoints and internal source modules.
+
+Use named imports for affected public entrypoints, including `import { Link } from 'gt-next/link'` and `import { plugin } from 'gt-react-native/plugin'`.

--- a/.changeset/remove-default-source-exports.md
+++ b/.changeset/remove-default-source-exports.md
@@ -8,4 +8,4 @@
 
 Remove default exports from package entrypoints and internal source modules.
 
-Use named imports for affected public entrypoints, including `import { Link } from 'gt-next/link'` and `import { plugin } from 'gt-react-native/plugin'`.
+Use named imports for affected public entrypoints, including `import { plugin } from 'gt-react-native/plugin'`. The `gt-next/link` entrypoint keeps its default export to match `next/link`.

--- a/packages/core/src/__tests__/index.test.ts
+++ b/packages/core/src/__tests__/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { GT, LocaleConfig } from '../index';
-import _translateMany from '../translate/translateMany';
+import { _translateMany } from '../translate/translateMany';
 import {
   TranslationResult,
   TranslateManyResult,
@@ -11,7 +11,7 @@ import {
 
 // Mock the internal translate function
 vi.mock('../translate/translateMany', () => ({
-  default: vi.fn(),
+  _translateMany: vi.fn(),
 }));
 
 const numberValue = 1234.56;

--- a/packages/core/src/id.ts
+++ b/packages/core/src/id.ts
@@ -1,2 +1,2 @@
 export { hashSource, hashString } from './id/hashSource';
-export { default as hashTemplate } from './id/hashTemplate';
+export { hashTemplate } from './id/hashTemplate';

--- a/packages/core/src/id/hashSource.ts
+++ b/packages/core/src/id/hashSource.ts
@@ -4,7 +4,7 @@ import { JsxChild, JsxChildren, Variable } from '../types';
 import { stableStringify as stringify } from '../utils/stableStringify';
 import { sha256 } from '@noble/hashes/sha2.js';
 import { bytesToHex, utf8ToBytes } from '@noble/hashes/utils.js';
-import isVariable from '../utils/isVariable';
+import { isVariable } from '../utils/isVariable';
 import { HashMetadata } from './types';
 
 // ----- FUNCTIONS ----- //

--- a/packages/core/src/id/hashTemplate.ts
+++ b/packages/core/src/id/hashTemplate.ts
@@ -1,7 +1,7 @@
 import { hashString } from './hashSource';
 import { stableStringify as stringify } from '../utils/stableStringify';
 
-export default function hashTemplate(
+export function hashTemplate(
   template: {
     [key: string]: string;
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -43,64 +43,71 @@ import {
   noApiKeyProvidedError,
 } from './logging/errors';
 import { gtInstanceLogger } from './logging/logger';
-import _translateMany from './translate/translateMany';
-import _setupProject, {
+import { _translateMany } from './translate/translateMany';
+import {
+  _setupProject,
   SetupProjectResult,
   SetupProjectOptions,
 } from './translate/setupProject';
-import _enqueueFiles, { EnqueueOptions } from './translate/enqueueFiles';
-import _createTag, {
+import { _enqueueFiles, EnqueueOptions } from './translate/enqueueFiles';
+import {
+  _createTag,
   CreateTagOptions,
   CreateTagResult,
 } from './translate/createTag';
-import _downloadFileBatch from './translate/downloadFileBatch';
+import { _downloadFileBatch } from './translate/downloadFileBatch';
 import {
   FileQuery,
   FileQueryResult,
 } from './types-dir/api/checkFileTranslations';
-import _submitUserEditDiffs, {
+import {
+  _submitUserEditDiffs,
   SubmitUserEditDiffsPayload,
 } from './translate/submitUserEditDiffs';
-import _uploadSourceFiles from './translate/uploadSourceFiles';
-import _uploadTranslations from './translate/uploadTranslations';
+import { _uploadSourceFiles } from './translate/uploadSourceFiles';
+import { _uploadTranslations } from './translate/uploadTranslations';
 import {
   FileUpload,
   RequiredUploadFilesOptions,
   UploadFilesOptions,
   UploadFilesResponse,
 } from './types-dir/api/uploadFiles';
-import _querySourceFile from './translate/querySourceFile';
+import { _querySourceFile } from './translate/querySourceFile';
 import { ProjectData } from './types-dir/api/project';
-import _getProjectData from './projects/getProjectData';
+import { _getProjectData } from './projects/getProjectData';
 import { DownloadFileBatchRequest } from './types-dir/api/downloadFileBatch';
 import {
   _checkJobStatus,
   CheckJobStatusResult,
 } from './translate/checkJobStatus';
-import _awaitJobs, {
+import {
+  _awaitJobs,
   AwaitJobsOptions,
   AwaitJobsResult,
 } from './translate/awaitJobs';
 import type { FileDataQuery, FileDataResult } from './translate/queryFileData';
-import _queryFileData from './translate/queryFileData';
+import { _queryFileData } from './translate/queryFileData';
 import type { BranchQuery } from './translate/queryBranchData';
 import type { BranchDataResult } from './types-dir/api/branch';
-import _queryBranchData from './translate/queryBranchData';
+import { _queryBranchData } from './translate/queryBranchData';
 import type {
   CreateBranchQuery,
   CreateBranchResult,
 } from './translate/createBranch';
-import _createBranch from './translate/createBranch';
+import { _createBranch } from './translate/createBranch';
 import type { FileReference, FileReferenceIds } from './types-dir/api/file';
-import _processFileMoves, {
+import {
+  _processFileMoves,
   type MoveMapping,
   type ProcessMovesResponse,
   type ProcessMovesOptions,
 } from './translate/processFileMoves';
-import _getOrphanedFiles, {
+import {
+  _getOrphanedFiles,
   type GetOrphanedFilesResult,
 } from './translate/getOrphanedFiles';
-import _publishFiles, {
+import {
+  _publishFiles,
   type PublishFileEntry,
   type PublishFilesResult,
 } from './translate/publishFiles';

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -15,7 +15,7 @@ export { libraryDefaultLocale } from './settings/settings';
 export type { RuntimeTranslateManyOptions } from './types-dir/api/entry';
 export { pluralForms, isAcceptedPluralForm } from './settings/plurals';
 
-export { default as getPluralForm } from './locales/getPluralForm';
+export { _getPluralForm as getPluralForm } from './locales/getPluralForm';
 export { defaultTimeout } from './settings/settings';
 export type {
   JsxChildren,
@@ -24,7 +24,7 @@ export type {
   JsxElement,
   LocaleProperties,
 } from './types';
-export { default as isVariable } from './utils/isVariable';
+export { isVariable } from './utils/isVariable';
 export { minifyVariableType } from './utils/minify';
 export { encode, decode } from './utils/base64';
 export { isSupportedFileFormatTransform } from './utils/isSupportedFileFormatTransform';

--- a/packages/core/src/locales/getPluralForm.ts
+++ b/packages/core/src/locales/getPluralForm.ts
@@ -10,7 +10,7 @@ import { libraryDefaultLocale } from '../settings/settings';
  * @param {PluralType[]} forms - The allowed plural forms.
  * @returns {PluralType} The determined plural form, or an empty string if none fit.
  */
-export default function _getPluralForm(
+export function _getPluralForm(
   n: number,
   forms: readonly PluralType[] = pluralForms,
   locales: string[] = [libraryDefaultLocale]

--- a/packages/core/src/projects/__tests__/getProjectData.test.ts
+++ b/packages/core/src/projects/__tests__/getProjectData.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import _getProjectData from '../getProjectData';
-import fetchWithTimeout from '../../translate/utils/fetchWithTimeout';
-import validateResponse from '../../translate/utils/validateResponse';
-import handleFetchError from '../../translate/utils/handleFetchError';
-import generateRequestHeaders from '../../translate/utils/generateRequestHeaders';
+import { _getProjectData } from '../getProjectData';
+import { fetchWithTimeout } from '../../translate/utils/fetchWithTimeout';
+import { validateResponse } from '../../translate/utils/validateResponse';
+import { handleFetchError } from '../../translate/utils/handleFetchError';
+import { generateRequestHeaders } from '../../translate/utils/generateRequestHeaders';
 import { TranslationRequestConfig } from '../../types';
 import { ProjectData } from '../../types-dir/api/project';
 

--- a/packages/core/src/projects/getProjectData.ts
+++ b/packages/core/src/projects/getProjectData.ts
@@ -1,10 +1,10 @@
 import { defaultBaseUrl } from '../settings/settingsUrls';
-import fetchWithTimeout from '../translate/utils/fetchWithTimeout';
+import { fetchWithTimeout } from '../translate/utils/fetchWithTimeout';
 import { defaultTimeout } from '../settings/settings';
-import validateResponse from '../translate/utils/validateResponse';
-import handleFetchError from '../translate/utils/handleFetchError';
+import { validateResponse } from '../translate/utils/validateResponse';
+import { handleFetchError } from '../translate/utils/handleFetchError';
 import { TranslationRequestConfig } from '../types';
-import generateRequestHeaders from '../translate/utils/generateRequestHeaders';
+import { generateRequestHeaders } from '../translate/utils/generateRequestHeaders';
 import { ProjectData } from '../types-dir/api/project';
 
 /**
@@ -15,7 +15,7 @@ import { ProjectData } from '../types-dir/api/project';
  * @param config - The configuration for the request.
  * @returns The project data for the given project ID.
  */
-export default async function _getProjectData(
+export async function _getProjectData(
   projectId: string,
   options: { timeout?: number },
   config: TranslationRequestConfig

--- a/packages/core/src/translate/__tests__/awaitJobs.test.ts
+++ b/packages/core/src/translate/__tests__/awaitJobs.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import _awaitJobs from '../awaitJobs';
+import { _awaitJobs } from '../awaitJobs';
 import { _checkJobStatus } from '../checkJobStatus';
 import { TranslationRequestConfig } from '../../types';
 import { EnqueueFilesResult } from '../../types-dir/api/enqueueFiles';

--- a/packages/core/src/translate/__tests__/checkJobStatus.test.ts
+++ b/packages/core/src/translate/__tests__/checkJobStatus.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { TranslationRequestConfig } from '../../types';
-import apiRequest from '../utils/apiRequest';
+import { apiRequest } from '../utils/apiRequest';
 import { _checkJobStatus, CheckJobStatusResult } from '../checkJobStatus';
 
 vi.mock('../utils/apiRequest');

--- a/packages/core/src/translate/__tests__/createTag.test.ts
+++ b/packages/core/src/translate/__tests__/createTag.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import _createTag, {
+import {
+  _createTag,
   CreateTagOptions,
   CreateTagResult,
   CreateTagFileReference,
 } from '../createTag';
 import { TranslationRequestConfig } from '../../types';
-import apiRequest from '../utils/apiRequest';
+import { apiRequest } from '../utils/apiRequest';
 
 vi.mock('../utils/apiRequest');
 

--- a/packages/core/src/translate/__tests__/downloadFileBatch.test.ts
+++ b/packages/core/src/translate/__tests__/downloadFileBatch.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import _downloadFileBatch from '../downloadFileBatch';
-import apiRequest from '../utils/apiRequest';
+import { _downloadFileBatch } from '../downloadFileBatch';
+import { apiRequest } from '../utils/apiRequest';
 import { TranslationRequestConfig } from '../../types';
 import {
   DownloadFileBatchOptions,

--- a/packages/core/src/translate/__tests__/enqueueFiles.test.ts
+++ b/packages/core/src/translate/__tests__/enqueueFiles.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import _enqueueFiles, { EnqueueOptions } from '../enqueueFiles';
+import { _enqueueFiles, EnqueueOptions } from '../enqueueFiles';
 import { TranslationRequestConfig, EnqueueFilesResult } from '../../types';
 import { FileReference } from '../../types-dir/api/file';
-import apiRequest from '../utils/apiRequest';
+import { apiRequest } from '../utils/apiRequest';
 
 vi.mock('../utils/apiRequest');
 

--- a/packages/core/src/translate/__tests__/querySourceFile.test.ts
+++ b/packages/core/src/translate/__tests__/querySourceFile.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import _querySourceFile from '../querySourceFile';
-import apiRequest from '../utils/apiRequest';
+import { _querySourceFile } from '../querySourceFile';
+import { apiRequest } from '../utils/apiRequest';
 import { TranslationRequestConfig } from '../../types';
 import {
   FileQuery,

--- a/packages/core/src/translate/__tests__/setupProject.test.ts
+++ b/packages/core/src/translate/__tests__/setupProject.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import _setupProject, { SetupProjectResult } from '../setupProject';
+import { _setupProject, SetupProjectResult } from '../setupProject';
 import { TranslationRequestConfig } from '../../types';
 import { FileReference } from '../../types-dir/api/file';
-import apiRequest from '../utils/apiRequest';
+import { apiRequest } from '../utils/apiRequest';
 
 vi.mock('../utils/apiRequest');
 

--- a/packages/core/src/translate/__tests__/translate.test.ts
+++ b/packages/core/src/translate/__tests__/translate.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import _translateMany from '../translateMany';
-import apiRequest from '../utils/apiRequest';
+import { _translateMany } from '../translateMany';
+import { apiRequest } from '../utils/apiRequest';
 import { TranslationRequestConfig, TranslationResult } from '../../types';
 import type { Content } from '@generaltranslation/format/types';
 import { SharedMetadata } from '../../types-dir/api/entry';

--- a/packages/core/src/translate/__tests__/translateMany.test.ts
+++ b/packages/core/src/translate/__tests__/translateMany.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import _translateMany from '../translateMany';
-import apiRequest from '../utils/apiRequest';
+import { _translateMany } from '../translateMany';
+import { apiRequest } from '../utils/apiRequest';
 import { TranslationRequestConfig, TranslationResult } from '../../types';
 import { TranslateManyEntry, SharedMetadata } from '../../types-dir/api/entry';
 

--- a/packages/core/src/translate/__tests__/uploadSourceFiles.test.ts
+++ b/packages/core/src/translate/__tests__/uploadSourceFiles.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import _uploadSourceFiles from '../uploadSourceFiles';
+import { _uploadSourceFiles } from '../uploadSourceFiles';
 import { TranslationRequestConfig } from '../../types';
 import {
   FileUpload,
   RequiredUploadFilesOptions,
 } from '../../types-dir/api/uploadFiles';
-import apiRequest from '../utils/apiRequest';
+import { apiRequest } from '../utils/apiRequest';
 
 vi.mock('../utils/apiRequest');
 

--- a/packages/core/src/translate/__tests__/uploadTranslations.test.ts
+++ b/packages/core/src/translate/__tests__/uploadTranslations.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import _uploadTranslations from '../uploadTranslations';
+import { _uploadTranslations } from '../uploadTranslations';
 import { TranslationRequestConfig } from '../../types';
 import {
   FileUpload,
   RequiredUploadFilesOptions,
 } from '../../types-dir/api/uploadFiles';
-import apiRequest from '../utils/apiRequest';
+import { apiRequest } from '../utils/apiRequest';
 
 vi.mock('../utils/apiRequest');
 

--- a/packages/core/src/translate/awaitJobs.ts
+++ b/packages/core/src/translate/awaitJobs.ts
@@ -29,7 +29,7 @@ export type AwaitJobsResult = {
  * @param config - API credentials and configuration.
  * @returns The final status of all jobs.
  */
-export default async function _awaitJobs(
+export async function _awaitJobs(
   enqueueResult: EnqueueFilesResult,
   options: AwaitJobsOptions | undefined,
   config: TranslationRequestConfig

--- a/packages/core/src/translate/checkJobStatus.ts
+++ b/packages/core/src/translate/checkJobStatus.ts
@@ -1,5 +1,5 @@
 import { TranslationRequestConfig } from '../types';
-import apiRequest from './utils/apiRequest';
+import { apiRequest } from './utils/apiRequest';
 
 export type JobStatus =
   | 'queued'

--- a/packages/core/src/translate/createBranch.ts
+++ b/packages/core/src/translate/createBranch.ts
@@ -1,5 +1,5 @@
 import { TranslationRequestConfig } from '../types';
-import apiRequest from './utils/apiRequest';
+import { apiRequest } from './utils/apiRequest';
 
 export type CreateBranchQuery = {
   branchName: string;
@@ -17,7 +17,7 @@ export type CreateBranchResult = {
  * @param config - The configuration for the API call.
  * @returns The created branch information.
  */
-export default async function _createBranch(
+export async function _createBranch(
   query: CreateBranchQuery,
   config: TranslationRequestConfig
 ): Promise<CreateBranchResult> {

--- a/packages/core/src/translate/createTag.ts
+++ b/packages/core/src/translate/createTag.ts
@@ -1,5 +1,5 @@
 import { TranslationRequestConfig } from '../types';
-import apiRequest from './utils/apiRequest';
+import { apiRequest } from './utils/apiRequest';
 
 export type CreateTagFileReference = {
   fileId: string;
@@ -30,7 +30,7 @@ export type CreateTagResult = {
  * @param config - The configuration for the API call.
  * @returns The created or updated tag.
  */
-export default async function _createTag(
+export async function _createTag(
   options: CreateTagOptions,
   config: TranslationRequestConfig
 ): Promise<CreateTagResult> {

--- a/packages/core/src/translate/downloadFileBatch.ts
+++ b/packages/core/src/translate/downloadFileBatch.ts
@@ -4,7 +4,7 @@ import {
   DownloadFileBatchRequest,
   DownloadFileBatchResult,
 } from '../types-dir/api/downloadFileBatch';
-import apiRequest from './utils/apiRequest';
+import { apiRequest } from './utils/apiRequest';
 import { decode } from '../utils/base64';
 import { processBatches } from './utils/batch';
 
@@ -16,7 +16,7 @@ import { processBatches } from './utils/batch';
  * @param config - The configuration for the request.
  * @returns Promise resolving to a BatchList with all downloaded files
  */
-export default async function _downloadFileBatch(
+export async function _downloadFileBatch(
   requests: DownloadFileBatchRequest,
   options: DownloadFileBatchOptions,
   config: TranslationRequestConfig

--- a/packages/core/src/translate/enqueueFiles.ts
+++ b/packages/core/src/translate/enqueueFiles.ts
@@ -1,5 +1,5 @@
 import { TranslationRequestConfig, EnqueueFilesResult } from '../types';
-import apiRequest from './utils/apiRequest';
+import { apiRequest } from './utils/apiRequest';
 import type { FileReferenceIds } from '../types-dir/api/file';
 import { processBatches } from './utils/batch';
 import { validateFileFormatTransforms } from './utils/validateFileFormatTransform';
@@ -21,7 +21,7 @@ export type EnqueueOptions = {
  * @param config - The configuration for the API call.
  * @returns The result of the API call.
  */
-export default async function _enqueueFiles(
+export async function _enqueueFiles(
   files: FileReferenceIds[],
   options: EnqueueOptions,
   config: TranslationRequestConfig

--- a/packages/core/src/translate/getOrphanedFiles.ts
+++ b/packages/core/src/translate/getOrphanedFiles.ts
@@ -1,5 +1,5 @@
 import { TranslationRequestConfig } from '../types';
-import apiRequest from './utils/apiRequest';
+import { apiRequest } from './utils/apiRequest';
 import { createBatches } from './utils/batch';
 
 export type OrphanedFile = {
@@ -23,7 +23,7 @@ export type GetOrphanedFilesResult = {
  * @param config - The configuration for the API call
  * @returns The orphaned files
  */
-export default async function _getOrphanedFiles(
+export async function _getOrphanedFiles(
   branchId: string,
   fileIds: string[],
   options: { timeout?: number } = {},

--- a/packages/core/src/translate/processFileMoves.ts
+++ b/packages/core/src/translate/processFileMoves.ts
@@ -1,5 +1,5 @@
 import { TranslationRequestConfig } from '../types';
-import apiRequest from './utils/apiRequest';
+import { apiRequest } from './utils/apiRequest';
 import { processBatches } from './utils/batch';
 
 export type MoveMapping = {
@@ -40,7 +40,7 @@ export type ProcessMovesOptions = {
  * @param config - The configuration for the API call.
  * @returns Promise resolving to the move results
  */
-export default async function _processFileMoves(
+export async function _processFileMoves(
   moves: MoveMapping[],
   options: ProcessMovesOptions,
   config: TranslationRequestConfig

--- a/packages/core/src/translate/publishFiles.ts
+++ b/packages/core/src/translate/publishFiles.ts
@@ -1,5 +1,5 @@
 import { TranslationRequestConfig } from '../types';
-import apiRequest from './utils/apiRequest';
+import { apiRequest } from './utils/apiRequest';
 
 export type PublishFileEntry = {
   fileId: string;
@@ -27,7 +27,7 @@ export type PublishFilesResult = {
  * @param config - The configuration for the API call.
  * @returns The result of the API call.
  */
-export default async function _publishFiles(
+export async function _publishFiles(
   files: PublishFileEntry[],
   config: TranslationRequestConfig
 ): Promise<PublishFilesResult> {

--- a/packages/core/src/translate/queryBranchData.ts
+++ b/packages/core/src/translate/queryBranchData.ts
@@ -1,5 +1,5 @@
 import { TranslationRequestConfig } from '../types';
-import apiRequest from './utils/apiRequest';
+import { apiRequest } from './utils/apiRequest';
 import type { BranchDataResult } from '../types-dir/api/branch';
 
 export type BranchQuery = {
@@ -13,7 +13,7 @@ export type BranchQuery = {
  * @param config - The configuration for the API call.
  * @returns The branch information.
  */
-export default async function _queryBranchData(
+export async function _queryBranchData(
   query: BranchQuery,
   config: TranslationRequestConfig
 ): Promise<BranchDataResult> {

--- a/packages/core/src/translate/queryFileData.ts
+++ b/packages/core/src/translate/queryFileData.ts
@@ -1,6 +1,6 @@
 import { TranslationRequestConfig } from '../types';
 import { CheckFileTranslationsOptions } from '../types-dir/api/checkFileTranslations';
-import apiRequest from './utils/apiRequest';
+import { apiRequest } from './utils/apiRequest';
 
 export type FileDataQuery = {
   sourceFiles?: {
@@ -54,7 +54,7 @@ export type FileDataResult = {
  * @param config - The configuration for the API call.
  * @returns The file data.
  */
-export default async function _queryFileData(
+export async function _queryFileData(
   data: FileDataQuery,
   options: CheckFileTranslationsOptions = {},
   config: TranslationRequestConfig

--- a/packages/core/src/translate/querySourceFile.ts
+++ b/packages/core/src/translate/querySourceFile.ts
@@ -4,7 +4,7 @@ import {
   FileQueryResult,
 } from '../types-dir/api/checkFileTranslations';
 import { FileQuery } from '../types-dir/api/checkFileTranslations';
-import apiRequest from './utils/apiRequest';
+import { apiRequest } from './utils/apiRequest';
 
 /**
  * @internal
@@ -14,7 +14,7 @@ import apiRequest from './utils/apiRequest';
  * @param config - The configuration for the request.
  * @returns The source file and translation information for the given file ID and version ID
  */
-export default async function _querySourceFile(
+export async function _querySourceFile(
   query: FileQuery,
   options: CheckFileTranslationsOptions,
   config: TranslationRequestConfig

--- a/packages/core/src/translate/setupProject.ts
+++ b/packages/core/src/translate/setupProject.ts
@@ -1,5 +1,5 @@
 import { TranslationRequestConfig } from '../types';
-import apiRequest from './utils/apiRequest';
+import { apiRequest } from './utils/apiRequest';
 import type { FileReference } from '../types-dir/api/file';
 
 export type SetupProjectResult =
@@ -20,7 +20,7 @@ export type SetupProjectOptions = {
  * @param timeoutMS - The timeout in milliseconds
  * @returns The result of the API call.
  */
-export default async function _setupProject(
+export async function _setupProject(
   files: FileReference[],
   config: TranslationRequestConfig,
   options?: SetupProjectOptions

--- a/packages/core/src/translate/submitUserEditDiffs.ts
+++ b/packages/core/src/translate/submitUserEditDiffs.ts
@@ -1,5 +1,5 @@
 import { TranslationRequestConfig } from '../types';
-import apiRequest from './utils/apiRequest';
+import { apiRequest } from './utils/apiRequest';
 import { processBatches } from './utils/batch';
 
 export type SubmitUserEditDiff = {
@@ -20,7 +20,7 @@ export type SubmitUserEditDiffsPayload = {
  * @internal
  * Submits user edit diffs so the service can learn/persist user-intended rules.
  */
-export default async function _submitUserEditDiffs(
+export async function _submitUserEditDiffs(
   payload: SubmitUserEditDiffsPayload,
   config: TranslationRequestConfig,
   options: { timeout?: number } = {}

--- a/packages/core/src/translate/translateMany.ts
+++ b/packages/core/src/translate/translateMany.ts
@@ -9,7 +9,7 @@ import {
   TranslateOptions,
   EntryMetadata,
 } from '../types-dir/api/entry';
-import apiRequest from './utils/apiRequest';
+import { apiRequest } from './utils/apiRequest';
 import type { Content } from '@generaltranslation/format/types';
 import { hashSource } from '../id';
 
@@ -25,7 +25,7 @@ import { hashSource } from '../id';
  * @param config - The configuration for the translation.
  * @returns The results of the translation. An array if requests was an array, a record if requests was a record.
  */
-export default async function _translateMany<
+export async function _translateMany<
   T extends TranslateManyEntry[] | Record<string, TranslateManyEntry>,
 >(
   requests: T,
@@ -40,7 +40,7 @@ export default async function _translateMany<
     ? TranslateManyResult
     : Record<string, TranslationResult>
 >;
-export default async function _translateMany(
+export async function _translateMany(
   requests: TranslateManyEntry[] | Record<string, TranslateManyEntry>,
   globalMetadata: {
     targetLocale: string;

--- a/packages/core/src/translate/uploadSourceFiles.ts
+++ b/packages/core/src/translate/uploadSourceFiles.ts
@@ -1,5 +1,5 @@
 import { TranslationRequestConfig } from '../types';
-import apiRequest from './utils/apiRequest';
+import { apiRequest } from './utils/apiRequest';
 import { encode } from '../utils/base64';
 import { processBatches } from './utils/batch';
 
@@ -17,7 +17,7 @@ import {
  * @param config - The configuration for the API call.
  * @returns Promise resolving to a BatchList with all uploaded files
  */
-export default async function _uploadSourceFiles(
+export async function _uploadSourceFiles(
   files: { source: FileUpload }[],
   options: RequiredUploadFilesOptions,
   config: TranslationRequestConfig

--- a/packages/core/src/translate/uploadTranslations.ts
+++ b/packages/core/src/translate/uploadTranslations.ts
@@ -1,5 +1,5 @@
 import { TranslationRequestConfig } from '../types';
-import apiRequest from './utils/apiRequest';
+import { apiRequest } from './utils/apiRequest';
 import { processBatches } from './utils/batch';
 
 import {
@@ -18,7 +18,7 @@ import { validateFileFormatTransforms } from './utils/validateFileFormatTransfor
  * @param config - The configuration for the API call.
  * @returns Promise resolving to a BatchList with all uploaded files
  */
-export default async function _uploadTranslations(
+export async function _uploadTranslations(
   files: {
     source: FileUpload;
     translations: FileUpload[];

--- a/packages/core/src/translate/utils/__tests__/apiRequest.test.ts
+++ b/packages/core/src/translate/utils/__tests__/apiRequest.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import apiRequest from '../apiRequest';
-import fetchWithTimeout from '../fetchWithTimeout';
-import validateResponse from '../validateResponse';
+import { apiRequest } from '../apiRequest';
+import { fetchWithTimeout } from '../fetchWithTimeout';
+import { validateResponse } from '../validateResponse';
 
 vi.mock('../fetchWithTimeout');
 vi.mock('../validateResponse');

--- a/packages/core/src/translate/utils/__tests__/fetchWithTimeout.test.ts
+++ b/packages/core/src/translate/utils/__tests__/fetchWithTimeout.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import fetchWithTimeout from '../fetchWithTimeout.js';
+import { fetchWithTimeout } from '../fetchWithTimeout.js';
 import { defaultTimeout } from '../../../settings/settings.js';
 
 // Mock dependencies

--- a/packages/core/src/translate/utils/__tests__/generateRequestHeaders.test.ts
+++ b/packages/core/src/translate/utils/__tests__/generateRequestHeaders.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import generateRequestHeaders from '../generateRequestHeaders';
+import { generateRequestHeaders } from '../generateRequestHeaders';
 import { TranslationRequestConfig } from '../../../types';
 import { API_VERSION } from '../../api';
 

--- a/packages/core/src/translate/utils/__tests__/handleFetchError.test.ts
+++ b/packages/core/src/translate/utils/__tests__/handleFetchError.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import handleFetchError from '../handleFetchError';
+import { handleFetchError } from '../handleFetchError';
 import { fetchLogger } from '../../../logging/logger';
 import {
   translationRequestFailedError,

--- a/packages/core/src/translate/utils/__tests__/validateResponse.test.ts
+++ b/packages/core/src/translate/utils/__tests__/validateResponse.test.ts
@@ -7,7 +7,7 @@ vi.mock('../../../logging/errors', () => ({
   ),
 }));
 
-import validateResponse from '../validateResponse';
+import { validateResponse } from '../validateResponse';
 import { apiError } from '../../../logging/errors';
 import { ApiError } from '../../../errors/ApiError';
 

--- a/packages/core/src/translate/utils/apiRequest.ts
+++ b/packages/core/src/translate/utils/apiRequest.ts
@@ -1,10 +1,10 @@
 import { TranslationRequestConfig } from '../../types';
 import { defaultBaseUrl } from '../../settings/settingsUrls';
 import { defaultTimeout } from '../../settings/settings';
-import fetchWithTimeout from './fetchWithTimeout';
-import validateResponse from './validateResponse';
-import handleFetchError from './handleFetchError';
-import generateRequestHeaders from './generateRequestHeaders';
+import { fetchWithTimeout } from './fetchWithTimeout';
+import { validateResponse } from './validateResponse';
+import { handleFetchError } from './handleFetchError';
+import { generateRequestHeaders } from './generateRequestHeaders';
 
 const MAX_RETRIES = 3;
 const INITIAL_DELAY_MS = 500;
@@ -92,7 +92,7 @@ function getResponseRetryDelay(
  * @param options - Optional request options.
  * @returns The parsed JSON response.
  */
-export default async function apiRequest<T>(
+export async function apiRequest<T>(
   config: TranslationRequestConfig,
   endpoint: string,
   options?: {

--- a/packages/core/src/translate/utils/fetchWithTimeout.ts
+++ b/packages/core/src/translate/utils/fetchWithTimeout.ts
@@ -11,7 +11,7 @@ import { defaultTimeout } from '../../settings/settings';
  * @param timeout - The timeout in milliseconds.
  * @returns The response from the fetch function.
  */
-export default async function fetchWithTimeout(
+export async function fetchWithTimeout(
   url: string | URL | globalThis.Request,
   options: RequestInit,
   timeout?: number

--- a/packages/core/src/translate/utils/generateRequestHeaders.ts
+++ b/packages/core/src/translate/utils/generateRequestHeaders.ts
@@ -1,7 +1,7 @@
 import { TranslationRequestConfig } from '../../types';
 import { API_VERSION } from '../api';
 
-export default function generateRequestHeaders(
+export function generateRequestHeaders(
   config: TranslationRequestConfig,
   excludeContentType = false
 ) {

--- a/packages/core/src/translate/utils/handleFetchError.ts
+++ b/packages/core/src/translate/utils/handleFetchError.ts
@@ -4,10 +4,7 @@ import {
   translationTimeoutError,
 } from '../../logging/errors';
 
-export default function handleFetchError(
-  error: unknown,
-  timeout: number
-): never {
+export function handleFetchError(error: unknown, timeout: number): never {
   if (error instanceof Error && error.name === 'AbortError') {
     const errorMessage = translationTimeoutError(timeout);
     fetchLogger.error(errorMessage);

--- a/packages/core/src/translate/utils/validateResponse.ts
+++ b/packages/core/src/translate/utils/validateResponse.ts
@@ -1,7 +1,7 @@
 import { apiError } from '../../logging/errors';
 import { ApiError } from '../../errors/ApiError';
 
-export default async function validateResponse(response: Response) {
+export async function validateResponse(response: Response) {
   if (!response.ok) {
     let errorMsg = 'Unknown error';
     try {

--- a/packages/core/src/utils/isVariable.ts
+++ b/packages/core/src/utils/isVariable.ts
@@ -1,6 +1,6 @@
 import { Variable } from '../types';
 
-export default function isVariable(obj: unknown): obj is Variable {
+export function isVariable(obj: unknown): obj is Variable {
   const variableObj = obj as Variable;
   if (
     variableObj &&

--- a/packages/next/src/_dictionary.ts
+++ b/packages/next/src/_dictionary.ts
@@ -1,5 +1,5 @@
 // hidden internal route
-export default {};
+export const dictionary = {};
 throw new Error(
   `Something has gone seriously wrong if you're seeing this error message. Check docs.generaltranslation.com for the latest documentation and make sure you've got the library configured properly.`
 );

--- a/packages/next/src/_load-dictionary.ts
+++ b/packages/next/src/_load-dictionary.ts
@@ -1,5 +1,5 @@
 // hidden internal route
-export default {};
+export const loadDictionary = undefined;
 throw new Error(
   `Something has gone seriously wrong if you're seeing this error message. Check docs.generaltranslation.com for the latest documentation and make sure you've got the library configured properly.`
 );

--- a/packages/next/src/_load-translations.ts
+++ b/packages/next/src/_load-translations.ts
@@ -1,5 +1,5 @@
 // hidden internal route
-export default {};
+export const loadTranslations = undefined;
 throw new Error(
   `Something has gone seriously wrong if you're seeing this error message. Check docs.generaltranslation.com for the latest documentation and make sure you've got the library configured properly.`
 );

--- a/packages/next/src/dictionary/getDictionary.ts
+++ b/packages/next/src/dictionary/getDictionary.ts
@@ -23,7 +23,9 @@ export async function getDictionary(): Promise<Dictionary | undefined> {
     if (dictionaryFileType === '.json') {
       internalDictionary = require('gt-next/_dictionary');
     } else if (dictionaryFileType === '.ts' || dictionaryFileType === '.js') {
-      internalDictionary = require('gt-next/_dictionary').default;
+      const bundledDictionary = require('gt-next/_dictionary');
+      internalDictionary =
+        bundledDictionary.default || bundledDictionary.dictionary;
     }
   } catch {
     // No bundled dictionary module was generated.

--- a/packages/next/src/internal/_getDomain.ts
+++ b/packages/next/src/internal/_getDomain.ts
@@ -1,6 +1,6 @@
 // Internal route for getDomain() function
 
-export default function getDomain(): string | undefined {
+export function getDomain(): string | undefined {
   throw new Error(
     `Unable to import custom getDomain(). Check docs.generaltranslation.com for the latest documentation.`
   );

--- a/packages/next/src/internal/_getLocale.ts
+++ b/packages/next/src/internal/_getLocale.ts
@@ -1,5 +1,5 @@
 // Internal route
-export default async function getLocale(): Promise<string> {
+export async function getLocale(): Promise<string> {
   throw new Error(
     `Unable to import custom getLocale(). Check docs.generaltranslation.com for the latest documentation.`
   );

--- a/packages/next/src/internal/_getRegion.ts
+++ b/packages/next/src/internal/_getRegion.ts
@@ -1,7 +1,7 @@
 // Internal route for getRegion() function
 import { RequestFunctionReturnType } from '../request/types';
 
-export default async function getRegion(): Promise<RequestFunctionReturnType> {
+export async function getRegion(): Promise<RequestFunctionReturnType> {
   throw new Error(
     `Unable to import custom getRegion(). Check docs.generaltranslation.com for the latest documentation.`
   );

--- a/packages/next/src/link.ts
+++ b/packages/next/src/link.ts
@@ -1,4 +1,4 @@
 'use client';
 
-export { Link, default } from './link/Link';
+export { Link } from './link/Link';
 export type { LinkProps } from './link/Link';

--- a/packages/next/src/link.ts
+++ b/packages/next/src/link.ts
@@ -1,4 +1,5 @@
 'use client';
 
-export { Link } from './link/Link';
+// Match `next/link` so switching to `gt-next/link` only changes the package.
+export { Link as default } from './link/Link';
 export type { LinkProps } from './link/Link';

--- a/packages/next/src/link/Link.tsx
+++ b/packages/next/src/link/Link.tsx
@@ -35,7 +35,7 @@ const LinkWithLocale = forwardRef<LinkRef, Omit<LinkProps, 'locale'>>(
  *
  * @example
  * ```tsx
- * import { Link } from 'gt-next/link';
+ * import Link from 'gt-next/link';
  *
  * export function Navigation() {
  *   return <Link href="/home">Home</Link>; // /en/home
@@ -44,7 +44,7 @@ const LinkWithLocale = forwardRef<LinkRef, Omit<LinkProps, 'locale'>>(
  *
  * @example
  * ```tsx
- * import { Link } from 'gt-next/link';
+ * import Link from 'gt-next/link';
  *
  * export function LocaleSwitcher() {
  *   return <Link href="/home" locale="fr">French</Link>; // /fr/home
@@ -53,7 +53,7 @@ const LinkWithLocale = forwardRef<LinkRef, Omit<LinkProps, 'locale'>>(
  *
  * @example
  * ```tsx
- * import { Link } from 'gt-next/link';
+ * import Link from 'gt-next/link';
  *
  * export function UnlocalizedLink() {
  *   return <Link href="/legal" locale={false}>Legal</Link>; // /legal
@@ -62,7 +62,7 @@ const LinkWithLocale = forwardRef<LinkRef, Omit<LinkProps, 'locale'>>(
  *
  * @example
  * ```tsx
- * import { Link } from 'gt-next/link';
+ * import Link from 'gt-next/link';
  *
  * export function ExternalLink() {
  *   return <Link href="https://example.com">Example</Link>; // https://example.com

--- a/packages/next/src/link/Link.tsx
+++ b/packages/next/src/link/Link.tsx
@@ -35,7 +35,7 @@ const LinkWithLocale = forwardRef<LinkRef, Omit<LinkProps, 'locale'>>(
  *
  * @example
  * ```tsx
- * import Link from 'gt-next/link';
+ * import { Link } from 'gt-next/link';
  *
  * export function Navigation() {
  *   return <Link href="/home">Home</Link>; // /en/home
@@ -44,7 +44,7 @@ const LinkWithLocale = forwardRef<LinkRef, Omit<LinkProps, 'locale'>>(
  *
  * @example
  * ```tsx
- * import Link from 'gt-next/link';
+ * import { Link } from 'gt-next/link';
  *
  * export function LocaleSwitcher() {
  *   return <Link href="/home" locale="fr">French</Link>; // /fr/home
@@ -53,7 +53,7 @@ const LinkWithLocale = forwardRef<LinkRef, Omit<LinkProps, 'locale'>>(
  *
  * @example
  * ```tsx
- * import Link from 'gt-next/link';
+ * import { Link } from 'gt-next/link';
  *
  * export function UnlocalizedLink() {
  *   return <Link href="/legal" locale={false}>Legal</Link>; // /legal
@@ -62,7 +62,7 @@ const LinkWithLocale = forwardRef<LinkRef, Omit<LinkProps, 'locale'>>(
  *
  * @example
  * ```tsx
- * import Link from 'gt-next/link';
+ * import { Link } from 'gt-next/link';
  *
  * export function ExternalLink() {
  *   return <Link href="https://example.com">Example</Link>; // https://example.com
@@ -128,5 +128,3 @@ function localizePath(href: string, locale: string): string {
 
   return `${url.pathname}${url.search}${url.hash}`;
 }
-
-export default Link;

--- a/packages/react-core/src/components/branches/Plural.shared.ts
+++ b/packages/react-core/src/components/branches/Plural.shared.ts
@@ -1,4 +1,4 @@
-import getPluralBranch from '../../utils/plurals/getPluralBranch';
+import { getPluralBranch } from '../../utils/plurals/getPluralBranch';
 import type { ReactNode } from 'react';
 import { getFormatLocales } from '../../hooks/utils/getFormatLocales';
 

--- a/packages/react-core/src/pure.ts
+++ b/packages/react-core/src/pure.ts
@@ -13,12 +13,12 @@ export {
   gtFallback,
 } from 'gt-i18n';
 
-export { default as getPluralBranch } from './utils/plurals/getPluralBranch';
-export { default as addGTIdentifier } from './utils/internal/addGTIdentifier';
-export { default as writeChildrenAsObjects } from './utils/internal/writeChildrenAsObjects';
-export { default as flattenDictionary } from './utils/dictionaries/flattenDictionary';
-export { default as getVariableProps } from './utils/variables/_getVariableProps';
-export { default as getVariableName } from './utils/variables/getVariableName';
+export { getPluralBranch } from './utils/plurals/getPluralBranch';
+export { addGTIdentifier } from './utils/internal/addGTIdentifier';
+export { writeChildrenAsObjects } from './utils/internal/writeChildrenAsObjects';
+export { flattenDictionary } from './utils/dictionaries/flattenDictionary';
+export { getVariableProps } from './utils/variables/_getVariableProps';
+export { getVariableName } from './utils/variables/getVariableName';
 export { getFormatLocales } from './hooks/utils/getFormatLocales';
 export { getTranslationsSnapshot } from './functions/helpers/getTranslationsSnapshot';
 export { t } from './functions/translation/t';
@@ -38,10 +38,10 @@ export {
   getDictionaryEntry,
   isValidDictionaryEntry,
 } from './utils/dictionaries/getDictionaryEntry';
-export { default as getEntryAndMetadata } from './utils/dictionaries/getEntryAndMetadata';
-export { default as isVariableObject } from './utils/rendering/isVariableObject';
-export { default as renderSkeleton } from './utils/rendering/renderSkeleton';
-export { default as mergeDictionaries } from './utils/dictionaries/mergeDictionaries';
+export { getEntryAndMetadata } from './utils/dictionaries/getEntryAndMetadata';
+export { isVariableObject } from './utils/rendering/isVariableObject';
+export { renderSkeleton } from './utils/rendering/renderSkeleton';
+export { mergeDictionaries } from './utils/dictionaries/mergeDictionaries';
 export { getDefaultRenderSettings } from './utils/rendering/getDefaultRenderSettings';
 export { reactHasUse } from './utils/promises/reactHasUse';
 export {

--- a/packages/react-core/src/utils/dictionaries/__tests__/getEntryAndMetadata.test.ts
+++ b/packages/react-core/src/utils/dictionaries/__tests__/getEntryAndMetadata.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import getEntryAndMetadata from '../getEntryAndMetadata';
+import { getEntryAndMetadata } from '../getEntryAndMetadata';
 import { DictionaryEntry } from '../../types';
 
 describe('getEntryAndMetadata', () => {

--- a/packages/react-core/src/utils/dictionaries/__tests__/mergeDictionaries.test.ts
+++ b/packages/react-core/src/utils/dictionaries/__tests__/mergeDictionaries.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import mergeDictionaries from '../mergeDictionaries';
+import { mergeDictionaries } from '../mergeDictionaries';
 import { Dictionary } from '../../types';
 
 describe('mergeDictionaries', () => {

--- a/packages/react-core/src/utils/dictionaries/collectUntranslatedEntries.ts
+++ b/packages/react-core/src/utils/dictionaries/collectUntranslatedEntries.ts
@@ -1,5 +1,5 @@
 import type { Dictionary } from '../types';
-import getEntryAndMetadata from './getEntryAndMetadata';
+import { getEntryAndMetadata } from './getEntryAndMetadata';
 import { get } from './indexDict';
 import { isDictionaryEntry } from './isDictionaryEntry';
 

--- a/packages/react-core/src/utils/dictionaries/flattenDictionary.ts
+++ b/packages/react-core/src/utils/dictionaries/flattenDictionary.ts
@@ -16,7 +16,7 @@ const createDuplicateKeyError = (key: string) =>
  * @returns {Record<string, React.ReactNode>} The flattened dictionary object.
  * @throws {Error} If two keys result in the same flattened key.
  */
-export default function flattenDictionary(
+export function flattenDictionary(
   dictionary: Dictionary,
   prefix: string = ''
 ): FlattenedDictionary {

--- a/packages/react-core/src/utils/dictionaries/getEntryAndMetadata.ts
+++ b/packages/react-core/src/utils/dictionaries/getEntryAndMetadata.ts
@@ -1,6 +1,6 @@
 import type { DictionaryEntry, MetaEntry } from '../types';
 
-export default function getEntryAndMetadata(value: DictionaryEntry): {
+export function getEntryAndMetadata(value: DictionaryEntry): {
   entry: string;
   metadata?: MetaEntry;
 } {

--- a/packages/react-core/src/utils/dictionaries/injectAndMerge.ts
+++ b/packages/react-core/src/utils/dictionaries/injectAndMerge.ts
@@ -3,7 +3,7 @@ import { getDictionaryEntry } from './getDictionaryEntry';
 import { getSubtree } from './getSubtree';
 import { get, set } from './indexDict';
 import { isDictionaryEntry } from './isDictionaryEntry';
-import mergeDictionaries from './mergeDictionaries';
+import { mergeDictionaries } from './mergeDictionaries';
 
 const createSubtreeNotFoundError = (id: string) =>
   `Dictionary subtree "${id}" could not be found`;

--- a/packages/react-core/src/utils/dictionaries/injectFallbacks.ts
+++ b/packages/react-core/src/utils/dictionaries/injectFallbacks.ts
@@ -1,6 +1,6 @@
 import type { Dictionary } from '../types';
 import { getDictionaryEntry } from './getDictionaryEntry';
-import getEntryAndMetadata from './getEntryAndMetadata';
+import { getEntryAndMetadata } from './getEntryAndMetadata';
 import { injectEntry } from './injectEntry';
 import { isDictionaryEntry } from './isDictionaryEntry';
 

--- a/packages/react-core/src/utils/dictionaries/injectHashes.ts
+++ b/packages/react-core/src/utils/dictionaries/injectHashes.ts
@@ -1,7 +1,7 @@
 import { hashSource } from 'generaltranslation/id';
 import { indexVars } from 'generaltranslation/internal';
 import type { Dictionary } from '../types';
-import getEntryAndMetadata from './getEntryAndMetadata';
+import { getEntryAndMetadata } from './getEntryAndMetadata';
 import { isDictionaryEntry } from './isDictionaryEntry';
 import { set } from './indexDict';
 

--- a/packages/react-core/src/utils/dictionaries/injectTranslations.ts
+++ b/packages/react-core/src/utils/dictionaries/injectTranslations.ts
@@ -1,6 +1,6 @@
 import type { Dictionary, Translations } from '../types';
 import { getDictionaryEntry } from './getDictionaryEntry';
-import getEntryAndMetadata from './getEntryAndMetadata';
+import { getEntryAndMetadata } from './getEntryAndMetadata';
 import { injectEntry } from './injectEntry';
 import { isDictionaryEntry } from './isDictionaryEntry';
 

--- a/packages/react-core/src/utils/dictionaries/mergeDictionaries.ts
+++ b/packages/react-core/src/utils/dictionaries/mergeDictionaries.ts
@@ -8,7 +8,7 @@ const isPrimitiveOrArray = (value: unknown): boolean =>
 const isObjectDictionary = (value: unknown): boolean =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
 
-export default function mergeDictionaries(
+export function mergeDictionaries(
   defaultLocaleDictionary: Dictionary,
   localeDictionary: Dictionary
 ): Dictionary {

--- a/packages/react-core/src/utils/dictionaries/stripMetadataFromEntries.ts
+++ b/packages/react-core/src/utils/dictionaries/stripMetadataFromEntries.ts
@@ -1,5 +1,5 @@
 import type { Dictionary } from '../types';
-import getEntryAndMetadata from './getEntryAndMetadata';
+import { getEntryAndMetadata } from './getEntryAndMetadata';
 import { isDictionaryEntry } from './isDictionaryEntry';
 import { set } from './indexDict';
 

--- a/packages/react-core/src/utils/internal/addGTIdentifier.ts
+++ b/packages/react-core/src/utils/internal/addGTIdentifier.ts
@@ -17,7 +17,7 @@ type GTComponentType = {
   _gtt?: Transformation;
 };
 
-export default function addGTIdentifier(
+export function addGTIdentifier(
   children: ReactNode,
   startingIndex: number = 0
 ): TaggedChildren {

--- a/packages/react-core/src/utils/internal/writeChildrenAsObjects.ts
+++ b/packages/react-core/src/utils/internal/writeChildrenAsObjects.ts
@@ -1,4 +1,4 @@
-import getVariableName from '../variables/getVariableName';
+import { getVariableName } from '../variables/getVariableName';
 import { TaggedChild, TaggedChildren, TaggedElement } from '../../utils/types';
 import { isValidTaggedElement } from '../../utils/utils';
 import { minifyVariableType } from 'generaltranslation/internal';
@@ -169,9 +169,7 @@ const handleSingleChild = (child: TaggedChild): JsxChild => {
  * @param {Children} children - The children to process.
  * @returns {object} The processed children as objects.
  */
-export default function writeChildrenAsObjects(
-  children: TaggedChildren
-): JsxChildren {
+export function writeChildrenAsObjects(children: TaggedChildren): JsxChildren {
   const result = Array.isArray(children)
     ? children.map(handleSingleChild)
     : handleSingleChild(children);

--- a/packages/react-core/src/utils/plurals/getPluralBranch.ts
+++ b/packages/react-core/src/utils/plurals/getPluralBranch.ts
@@ -10,7 +10,7 @@ import {
  * @param {any} branches - The object containing possible branches.
  * @returns {any} The determined branch.
  */
-export default function getPluralBranch<T>(
+export function getPluralBranch<T>(
   n: number,
   locales: string[],
   branches: Record<string, T>

--- a/packages/react-core/src/utils/rendering/getGTTag.ts
+++ b/packages/react-core/src/utils/rendering/getGTTag.ts
@@ -1,6 +1,6 @@
 import { TaggedElement, GTTag } from '../types';
 
-export default function getGTTag(child: TaggedElement): GTTag | null {
+export function getGTTag(child: TaggedElement): GTTag | null {
   if (child && child.props && child.props['data-_gt']) {
     return child.props['data-_gt'];
   }

--- a/packages/react-core/src/utils/rendering/isVariableObject.ts
+++ b/packages/react-core/src/utils/rendering/isVariableObject.ts
@@ -1,6 +1,6 @@
 import type { Variable } from '@generaltranslation/format/types';
 
-export default function isVariableObject(obj: unknown): obj is Variable {
+export function isVariableObject(obj: unknown): obj is Variable {
   const variableObj = obj as Variable;
   if (
     variableObj &&

--- a/packages/react-core/src/utils/rendering/renderDefaultChildren.shared.ts
+++ b/packages/react-core/src/utils/rendering/renderDefaultChildren.shared.ts
@@ -1,11 +1,12 @@
 import React, { ReactNode } from 'react';
-import getVariableProps, {
+import {
+  getVariableProps,
   isVariableElementProps,
 } from '../variables/_getVariableProps';
 import { libraryDefaultLocale } from 'generaltranslation/internal';
 import { TaggedChild, TaggedChildren, TaggedElement } from '../types';
-import getGTTag from './getGTTag';
-import getPluralBranch from '../plurals/getPluralBranch';
+import { getGTTag } from './getGTTag';
+import { getPluralBranch } from '../plurals/getPluralBranch';
 import type { RenderVariable } from '../types';
 
 // Shared implementation: the variable renderer is dependency-injected by a

--- a/packages/react-core/src/utils/rendering/renderSkeleton.tsx
+++ b/packages/react-core/src/utils/rendering/renderSkeleton.tsx
@@ -5,6 +5,6 @@ import React from 'react';
  * It replaces all content with empty strings
  * @returns an empty string
  */
-export default function renderSkeleton(): React.ReactNode {
+export function renderSkeleton(): React.ReactNode {
   return '';
 }

--- a/packages/react-core/src/utils/rendering/renderTranslatedChildren.shared.tsx
+++ b/packages/react-core/src/utils/rendering/renderTranslatedChildren.shared.tsx
@@ -6,17 +6,18 @@ import {
   TranslatedElement,
   VariableProps,
 } from '../types';
-import getVariableProps, {
+import {
+  getVariableProps,
   isVariableElementProps,
 } from '../variables/_getVariableProps';
 import { createRenderDefaultChildren } from './renderDefaultChildren.shared';
 import { isVariable, libraryDefaultLocale } from 'generaltranslation/internal';
-import getPluralBranch from '../plurals/getPluralBranch';
+import { getPluralBranch } from '../plurals/getPluralBranch';
 import {
   HTML_CONTENT_PROPS,
   HtmlContentPropValuesRecord,
 } from '@generaltranslation/format/types';
-import getGTTag from './getGTTag';
+import { getGTTag } from './getGTTag';
 import type { RenderVariable } from '../types';
 
 // Shared implementation: the variable renderer is dependency-injected by a

--- a/packages/react-core/src/utils/translation/prepareT.shared.ts
+++ b/packages/react-core/src/utils/translation/prepareT.shared.ts
@@ -1,6 +1,6 @@
-import addGTIdentifier from '../internal/addGTIdentifier';
+import { addGTIdentifier } from '../internal/addGTIdentifier';
 import { removeInjectedT } from '../internal/removeInjectedT';
-import writeChildrenAsObjects from '../internal/writeChildrenAsObjects';
+import { writeChildrenAsObjects } from '../internal/writeChildrenAsObjects';
 import type { JsxTranslationOptions as JsxTranslationOptionsWithSugar } from 'gt-i18n/types';
 import type { JsxChildren } from 'generaltranslation/types';
 import type { ReactNode } from 'react';

--- a/packages/react-core/src/utils/variables/_getVariableProps.ts
+++ b/packages/react-core/src/utils/variables/_getVariableProps.ts
@@ -1,6 +1,6 @@
 import { VariableTransformationSuffix } from 'generaltranslation/types';
 import { GTTag, VariableProps } from '../types';
-import getVariableName from './getVariableName';
+import { getVariableName } from './getVariableName';
 import { minifyVariableType } from 'generaltranslation/internal';
 
 type VariableElementProps = {
@@ -24,9 +24,7 @@ export function isVariableElementProps(
   );
 }
 
-export default function getVariableProps(
-  props: VariableElementProps
-): VariableProps {
+export function getVariableProps(props: VariableElementProps): VariableProps {
   const variableType: VariableTransformationSuffix =
     props['data-_gt']?.variableType || 'variable';
 

--- a/packages/react-core/src/utils/variables/getVariableName.ts
+++ b/packages/react-core/src/utils/variables/getVariableName.ts
@@ -8,7 +8,7 @@ const defaultVariableNames = {
 
 export const baseVariablePrefix = '_gt_';
 
-export default function getVariableName(
+export function getVariableName(
   props: Record<string, unknown> = {},
   variableType: keyof typeof defaultVariableNames
 ): string {

--- a/packages/react-native/src/NativeGtReactNative.ts
+++ b/packages/react-native/src/NativeGtReactNative.ts
@@ -7,4 +7,5 @@ export interface Spec extends TurboModule {
   nativeStoreSet(key: string, value: string): void;
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('GtReactNative');
+export const GtReactNative =
+  TurboModuleRegistry.getEnforcing<Spec>('GtReactNative');

--- a/packages/react-native/src/plugin-dir/index.ts
+++ b/packages/react-native/src/plugin-dir/index.ts
@@ -3,7 +3,7 @@ import type { PluginObj, types } from '@babel/core';
 import { LOCALE_POLYFILLS, POLYFILLS, type PluginOptions } from './types';
 import { resolveLocales } from './utils/resolveLocales';
 
-export default function (
+export function plugin(
   babel: { types: typeof types },
   {
     locales,

--- a/packages/react-native/src/plugin.ts
+++ b/packages/react-native/src/plugin.ts
@@ -1,1 +1,1 @@
-export { default } from './plugin-dir';
+export { plugin } from './plugin-dir';

--- a/packages/react-native/src/utils/getNativeLocales.ts
+++ b/packages/react-native/src/utils/getNativeLocales.ts
@@ -1,5 +1,5 @@
 import { Platform } from 'react-native';
-import GtReactNative from '../NativeGtReactNative';
+import { GtReactNative } from '../NativeGtReactNative';
 
 /**
  * Get native device locales in preference order

--- a/packages/react-native/src/utils/nativeStore.ts
+++ b/packages/react-native/src/utils/nativeStore.ts
@@ -1,6 +1,6 @@
 import { defaultLocaleCookieName as defaultLocaleStoreKey } from '@generaltranslation/react-core/pure';
 import { Platform } from 'react-native';
-import GtReactNative from '../NativeGtReactNative';
+import { GtReactNative } from '../NativeGtReactNative';
 import { ssrUnsupportedWarning } from '../errors-dir/warnings';
 
 /**


### PR DESCRIPTION
## Summary
- Convert default source exports to named exports in core, next, react-core, and react-native source files
- Update internal imports, re-exports, and Vitest mocks to use named exports
- Keep `gt-next/link` default-only to match `next/link`, so swapping imports only changes the package path
- Keep Next generated fallback modules compatible with both default and named dictionary/loader exports
- Change `gt-react-native/plugin` to expose the named `plugin` export

## Testing
- pnpm lint
- pnpm build
- pnpm --filter generaltranslation typecheck
- pnpm --filter @generaltranslation/react-core typecheck
- pnpm --filter gt-react build
- pnpm --filter gt-next typecheck
- pnpm --filter gt-react-native typecheck
- pnpm --filter gt-node typecheck
- pnpm --filter gt-tanstack-start typecheck
- pnpm --filter generaltranslation test
- pnpm --filter @generaltranslation/react-core test
- pnpm --filter gt-next test:js
- pnpm --filter gt-react-native test

Note: `pnpm typecheck` currently fails on `packages/react/src/i18n-cache/BrowserI18nCache.ts` because `ImportMeta.env` is not typed on this branch; focused typechecks above pass after building `gt-react`.

Changeset added: `.changeset/remove-default-source-exports.md`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR mechanically converts `export default` to named exports across `packages/core`, `packages/next`, `packages/react-core`, and `packages/react-native`. All internal imports are updated to match, and consumer code that dynamically `require()`s these modules already has backward-compatible resolution (`?.default || ?.namedExport`).

- **Internal source modules** (`translate/`, `utils/`, `react-core/utils/`) are pure refactors with no behavior change — every call site is updated in the same PR.
- **`gt-next/link`** keeps a default export (to match `next/link`) but drops the re-exported named `Link`; all in-repo consumers use `import Link from 'gt-next/link'` (default), so no breakage.
- **`gt-react-native/plugin`** moves from a default export to a named `plugin` export, which is a breaking public-API change documented in the changeset.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — this is a mechanical export style refactor with no behavior changes in internal logic and explicit backward-compatible fallbacks in every dynamic consumer.

Every changed file follows the same pattern: export default function/const → export function/const. All internal call sites are updated in the same PR. Dynamic consumers (getDictionary.ts, resolveDictionaryLoader.ts, resolveTranslationLoader.ts, initGT.rsc.ts) already resolve both .default and the new named export. The two public-API breaks (gt-react-native/plugin default→named, gt-next/link dropping named Link) are intentional, pre-release, and documented in the changeset.

No files require special attention. The most externally visible changes are in packages/react-native/src/plugin.ts (public API) and packages/next/src/link.ts (drops named re-export), both of which are intentional and documented.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/next/src/link.ts | Drops the named `Link` re-export; only default export remains to mirror `next/link`. All in-repo usages use the default import. |
| packages/react-native/src/plugin.ts | Public entrypoint `gt-react-native/plugin` now exports named `plugin` instead of default; breaking change documented in the changeset. |
| packages/react-native/src/plugin-dir/index.ts | Babel plugin function renamed from anonymous default to named `plugin` export; re-exported cleanly from `plugin.ts`. |
| packages/next/src/dictionary/getDictionary.ts | Backward-compatible resolution: tries `.default` first then `.dictionary` for TS/JS dictionaries; handles both old and new generated module shapes. |
| packages/next/src/_dictionary.ts | Fallback sentinel changed from `export default {}` to `export const dictionary = {}`; still throws on evaluation so the catch block in getDictionary handles it identically. |
| packages/next/src/_load-dictionary.ts | Fallback sentinel changed to `export const loadDictionary = undefined`; `resolveDictionaryLoader.ts` already checks `?.default || ?.loadDictionary` for compatibility. |
| packages/next/src/_load-translations.ts | Identical pattern to `_load-dictionary.ts`; `resolveTranslationLoader.ts` handles both `.default` and `.loadTranslations`. |
| packages/react-native/src/NativeGtReactNative.ts | TurboModule instance moved from default export to named `GtReactNative`; both consumer files (`getNativeLocales.ts`, `nativeStore.ts`) updated in the same PR. |
| packages/core/src/translate/translateMany.ts | Function overload pair correctly converted from `export default` to named `export`; both overload signature and implementation updated consistently. |
| packages/core/src/index.ts | All default-import callers updated to named-import destructuring; no missed imports found. |
| packages/react-core/src/pure.ts | All `export { default as X }` re-exports converted to `export { X }`; consistent with updated source files. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["gt-next/link\n(public entrypoint)"] -->|"export { Link as default }"| B["link/Link.tsx\nnamed export only"]
    C["gt-react-native/plugin\n(public entrypoint)"] -->|"export { plugin }"| D["plugin-dir/index.ts\nexport function plugin()"]
    E["gt-next/_dictionary\n(webpack alias / fallback)"] -->|"bundledDictionary.default\n|| bundledDictionary.dictionary"| F["getDictionary.ts\nbackward-compatible resolution"]
    G["gt-next/_load-dictionary\n(webpack alias / fallback)"] -->|"?.default || ?.loadDictionary"| H["resolveDictionaryLoader.ts\nbackward-compatible resolution"]
    I["gt-next/_load-translations\n(webpack alias / fallback)"] -->|"?.default || ?.loadTranslations"| J["resolveTranslationLoader.ts\nbackward-compatible resolution"]
    K["gt-next/internal/_getLocale\ngt-next/internal/_getRegion"] -->|"?.default || ?.getLocale/.getRegion"| L["initGT.rsc.ts\nbackward-compatible resolution"]

    style A fill:#ffd700,color:#000
    style C fill:#ffd700,color:#000
    style F fill:#90ee90,color:#000
    style H fill:#90ee90,color:#000
    style J fill:#90ee90,color:#000
    style L fill:#90ee90,color:#000
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["gt-next/link\n(public entrypoint)"] -->|"export { Link as default }"| B["link/Link.tsx\nnamed export only"]
    C["gt-react-native/plugin\n(public entrypoint)"] -->|"export { plugin }"| D["plugin-dir/index.ts\nexport function plugin()"]
    E["gt-next/_dictionary\n(webpack alias / fallback)"] -->|"bundledDictionary.default\n|| bundledDictionary.dictionary"| F["getDictionary.ts\nbackward-compatible resolution"]
    G["gt-next/_load-dictionary\n(webpack alias / fallback)"] -->|"?.default || ?.loadDictionary"| H["resolveDictionaryLoader.ts\nbackward-compatible resolution"]
    I["gt-next/_load-translations\n(webpack alias / fallback)"] -->|"?.default || ?.loadTranslations"| J["resolveTranslationLoader.ts\nbackward-compatible resolution"]
    K["gt-next/internal/_getLocale\ngt-next/internal/_getRegion"] -->|"?.default || ?.getLocale/.getRegion"| L["initGT.rsc.ts\nbackward-compatible resolution"]

    style A fill:#ffd700,color:#000
    style C fill:#ffd700,color:#000
    style F fill:#90ee90,color:#000
    style H fill:#90ee90,color:#000
    style J fill:#90ee90,color:#000
    style L fill:#90ee90,color:#000
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: preserve default link export"](https://github.com/generaltranslation/gt/commit/b55b9c41c75e4f90b1422f12bca14ea2007ad1ce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40241802)</sub>

<!-- /greptile_comment -->