### PR TITLE
refactor: organize entrypoint exports

### DIFF
--- a/.changeset/organize-entrypoint-exports.md
+++ b/.changeset/organize-entrypoint-exports.md
@@ -1,0 +1,9 @@
+---
+"@generaltranslation/format": patch
+"generaltranslation": patch
+"gt-next": patch
+"gt-react-native": patch
+"gt-sanity": patch
+---
+
+Organize package entrypoint exports and replace re-export-only imports with direct export declarations.

--- a/packages/core/src/id.ts
+++ b/packages/core/src/id.ts
@@ -1,3 +1,2 @@
-import { hashSource, hashString } from './id/hashSource';
-import hashTemplate from './id/hashTemplate';
-export { hashSource, hashString, hashTemplate };
+export { hashSource, hashString } from './id/hashSource';
+export { default as hashTemplate } from './id/hashTemplate';

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -14,31 +14,21 @@ export type {
 export { libraryDefaultLocale } from './settings/settings';
 export type { RuntimeTranslateManyOptions } from './types-dir/api/entry';
 export { pluralForms, isAcceptedPluralForm } from './settings/plurals';
-import _getPluralForm from './locales/getPluralForm';
-import { defaultTimeout } from './settings/settings';
-import type { _Content, JsxChild, JsxChildren, JsxElement } from './types';
-import type { LocaleProperties } from './types';
-import isVariable from './utils/isVariable';
-import { minifyVariableType } from './utils/minify';
-import { encode, decode } from './utils/base64';
-import { isSupportedFileFormatTransform } from './utils/isSupportedFileFormatTransform';
-import { validateFileFormatTransforms } from './translate/utils/validateFileFormatTransform';
 
-export {
-  _getPluralForm as getPluralForm,
+export { default as getPluralForm } from './locales/getPluralForm';
+export { defaultTimeout } from './settings/settings';
+export type {
   JsxChildren,
   _Content,
   JsxChild,
   JsxElement,
   LocaleProperties,
-  isVariable,
-  minifyVariableType,
-  defaultTimeout,
-  encode,
-  decode,
-  isSupportedFileFormatTransform,
-  validateFileFormatTransforms,
-};
+} from './types';
+export { default as isVariable } from './utils/isVariable';
+export { minifyVariableType } from './utils/minify';
+export { encode, decode } from './utils/base64';
+export { isSupportedFileFormatTransform } from './utils/isSupportedFileFormatTransform';
+export { validateFileFormatTransforms } from './translate/utils/validateFileFormatTransform';
 
 // derive
 export { decodeVars } from './derive/decodeVars';

--- a/packages/format/src/types.ts
+++ b/packages/format/src/types.ts
@@ -1,32 +1,11 @@
-import type { LocaleProperties } from './locales/getLocaleProperties';
-import type { CustomRegionMapping } from './locales/getRegionProperties';
-import type { CustomMapping } from './locales/customLocaleMapping';
-import type { CutoffFormatOptions } from './formatting/custom-formats/CutoffFormat/types';
-import type { Variable, VariableType } from './types-dir/jsx/variables';
-import {
-  HTML_CONTENT_PROPS,
-  type Content,
-  type DataFormat,
-  type GTProp,
-  type HtmlContentPropKeysRecord,
-  type HtmlContentPropValuesRecord,
-  type I18nextMessage,
-  type IcuMessage,
-  type JsxChild,
-  type JsxChildren,
-  type JsxElement,
-  type StringContent,
-  type StringFormat,
-  type StringMessage,
-} from './types-dir/jsx/content';
-
-export { HTML_CONTENT_PROPS };
-
+export type { LocaleProperties } from './locales/getLocaleProperties';
+export type { CustomRegionMapping } from './locales/getRegionProperties';
+export type { CustomMapping } from './locales/customLocaleMapping';
+export type { CutoffFormatOptions } from './formatting/custom-formats/CutoffFormat/types';
+export type { Variable, VariableType } from './types-dir/jsx/variables';
+export { HTML_CONTENT_PROPS } from './types-dir/jsx/content';
 export type {
   Content,
-  CustomMapping,
-  CustomRegionMapping,
-  CutoffFormatOptions,
   DataFormat,
   GTProp,
   HtmlContentPropKeysRecord,
@@ -36,13 +15,10 @@ export type {
   JsxChild,
   JsxChildren,
   JsxElement,
-  LocaleProperties,
   StringContent,
   StringFormat,
   StringMessage,
-  Variable,
-  VariableType,
-};
+} from './types-dir/jsx/content';
 
 export type FormatVariables = Record<
   string,

--- a/packages/next/src/index.client.ts
+++ b/packages/next/src/index.client.ts
@@ -3,52 +3,6 @@
 import { initializeGT } from './setup/initGT';
 initializeGT();
 
-import {
-  Var,
-  Num,
-  Currency,
-  DateTime,
-  RelativeTime,
-  Derive,
-  T,
-  Branch,
-  Plural,
-  LocaleSelector,
-  RegionSelector,
-  GTProvider,
-  useSetLocale,
-  useLocaleSelector,
-  useGT,
-  useTranslations,
-  useLocale,
-  useRegion,
-  useLocales,
-  useDefaultLocale,
-  useMessages,
-  useGTClass,
-  useLocaleProperties,
-  useLocaleDirection,
-  useVersionId,
-  msg,
-  decodeMsg,
-  decodeOptions,
-  derive,
-  declareVar,
-  decodeVars,
-  mFallback,
-  gtFallback,
-  getTranslationsSnapshot,
-  getDefaultLocale,
-  getGTClass,
-  getLocaleProperties,
-  getLocales,
-  getVersionId,
-} from 'gt-react';
-import type {
-  DictionaryTranslationOptions,
-  InlineTranslationOptions,
-  RuntimeTranslationOptions,
-} from 'gt-react';
 import type {
   GetServerSideProps,
   GetServerSidePropsContext,
@@ -57,6 +11,7 @@ import type {
 import type { ParsedUrlQuery } from 'querystring';
 import type { WithGTServerSideProps } from './pages-dir/withGTServerSideProps';
 
+// ===== Unsupported Server APIs ===== //
 export function parseLocale<
   Params extends ParsedUrlQuery = ParsedUrlQuery,
   Preview extends PreviewData = PreviewData,
@@ -78,50 +33,61 @@ export function withGTServerSideProps<
   );
 }
 
+// ===== Components ===== //
 export {
-  T,
-  Var,
-  Num,
+  Branch,
   Currency,
   DateTime,
-  RelativeTime,
   Derive,
-  Branch,
-  Plural,
   GTProvider,
   LocaleSelector,
+  Num,
+  Plural,
   RegionSelector,
-  useSetLocale,
-  useLocaleSelector,
-  useGT,
-  useTranslations,
-  useLocale,
-  useRegion,
-  useLocales,
+  RelativeTime,
+  T,
+  Var,
+} from 'gt-react';
+
+// ===== Hooks ===== //
+export {
   useDefaultLocale,
+  useGT,
   useGTClass,
-  useLocaleProperties,
+  useLocale,
   useLocaleDirection,
-  useVersionId,
+  useLocaleProperties,
+  useLocales,
+  useLocaleSelector,
   useMessages,
-  msg,
+  useRegion,
+  useSetLocale,
+  useTranslations,
+  useVersionId,
+} from 'gt-react';
+
+// ===== Functions ===== //
+export {
   decodeMsg,
   decodeOptions,
-  derive,
-  declareVar,
   decodeVars,
-  mFallback,
-  gtFallback,
-  getTranslationsSnapshot,
+  declareVar,
+  derive,
   getDefaultLocale,
   getGTClass,
   getLocaleProperties,
   getLocales,
+  getTranslationsSnapshot,
   getVersionId,
-};
+  gtFallback,
+  mFallback,
+  msg,
+} from 'gt-react';
+
+// ===== Types ===== //
 export type {
   DictionaryTranslationOptions,
   InlineTranslationOptions,
   RuntimeTranslationOptions,
-  WithGTServerSideProps,
-};
+} from 'gt-react';
+export type { WithGTServerSideProps };

--- a/packages/next/src/index.rsc.ts
+++ b/packages/next/src/index.rsc.ts
@@ -7,23 +7,25 @@ import type {
   PreviewData,
 } from 'next';
 import type { ParsedUrlQuery } from 'querystring';
+import { getTranslationsSnapshotRscError } from './errors/createErrors';
 import type { WithGTServerSideProps } from './pages-dir/withGTServerSideProps';
 initializeGT();
 
-// ===== Overrides ===== //
-import { GTProvider } from './provider/GTProvider';
-import { Var } from './variables/Var';
-import { Num } from './variables/Num';
-import { Currency } from './variables/Currency';
-import { DateTime } from './variables/DateTime';
-import { RelativeTime } from './variables/RelativeTime';
-import { T } from './server-dir/buildtime/T';
-import { Branch } from './branches/Branch';
-import { Plural } from './branches/Plural';
-import { useLocale } from './request/getLocale';
-import { useRegion } from './request/getRegion';
-import { useLocaleDirection } from './request/getLocaleDirection';
+// ===== Components ===== //
+export { Branch } from './branches/Branch';
+export { Currency } from './variables/Currency';
+export { DateTime } from './variables/DateTime';
+export { GTProvider } from './provider/GTProvider';
+export { Num } from './variables/Num';
+export { Plural } from './branches/Plural';
+export { RelativeTime } from './variables/RelativeTime';
+export { T } from './server-dir/buildtime/T';
+export { Var } from './variables/Var';
 
+// ===== Hooks ===== //
+export { useLocale } from './request/getLocale';
+export { useRegion } from './request/getRegion';
+export { useLocaleDirection } from './request/getLocaleDirection';
 export {
   useTranslations,
   useMessages,
@@ -34,36 +36,6 @@ export {
 
 export { Client_LocaleSelector as LocaleSelector } from './utils/client-boundary';
 export { Client_RegionSelector as RegionSelector } from './utils/client-boundary';
-
-// ===== gt-react ===== //
-import {
-  msg,
-  decodeMsg,
-  decodeOptions,
-  declareVar,
-  decodeVars,
-  derive,
-  Derive,
-  mFallback,
-  gtFallback,
-  getDefaultLocale,
-  getGTClass,
-  getLocaleProperties,
-  getLocales,
-  getVersionId,
-  // ----- hooks ----- //
-  useGTClass,
-  useLocaleProperties,
-  useLocales,
-  useDefaultLocale,
-  useVersionId,
-} from 'gt-react';
-import type {
-  DictionaryTranslationOptions,
-  InlineTranslationOptions,
-  RuntimeTranslationOptions,
-} from 'gt-react';
-import { getTranslationsSnapshotRscError } from './errors/createErrors';
 
 // ===== other ===== //
 
@@ -102,42 +74,39 @@ export function withGTServerSideProps<
   );
 }
 
+// ===== gt-react Components ===== //
+export { Derive } from 'gt-react';
+
+// ===== gt-react Hooks ===== //
 export {
-  GTProvider,
-  T,
-  Var,
-  Num,
-  Currency,
-  DateTime,
-  RelativeTime,
-  Derive,
-  Branch,
-  Plural,
-  useLocale,
-  useRegion,
-  useLocaleDirection,
-  msg,
+  useDefaultLocale,
+  useGTClass,
+  useLocaleProperties,
+  useLocales,
+  useVersionId,
+} from 'gt-react';
+
+// ===== gt-react Functions ===== //
+export {
   decodeMsg,
   decodeOptions,
-  derive,
-  declareVar,
   decodeVars,
-  mFallback,
-  gtFallback,
+  declareVar,
+  derive,
   getDefaultLocale,
   getGTClass,
   getLocaleProperties,
   getLocales,
   getVersionId,
-  useGTClass,
-  useLocaleProperties,
-  useLocales,
-  useDefaultLocale,
-  useVersionId,
-};
+  gtFallback,
+  mFallback,
+  msg,
+} from 'gt-react';
+
+// ===== Types ===== //
 export type {
   DictionaryTranslationOptions,
   InlineTranslationOptions,
   RuntimeTranslationOptions,
-  WithGTServerSideProps,
-};
+} from 'gt-react';
+export type { WithGTServerSideProps };

--- a/packages/next/src/index.server.ts
+++ b/packages/next/src/index.server.ts
@@ -1,59 +1,65 @@
 'use client';
 
 import { initializeGT } from './setup/initGT';
-import { parseLocale } from './pages-dir/parseLocale';
-import { withGTServerSideProps } from './pages-dir/withGTServerSideProps';
 initializeGT();
 
-// ===== gt-react ===== //
-export { parseLocale, withGTServerSideProps };
+// ===== Pages Router ===== //
+export { parseLocale } from './pages-dir/parseLocale';
+export { withGTServerSideProps } from './pages-dir/withGTServerSideProps';
 export type { WithGTServerSideProps } from './pages-dir/withGTServerSideProps';
 
+// ===== Components ===== //
 export {
-  // ----- components ----- //
-  GTProvider,
-  Var,
-  Num,
+  Branch,
   Currency,
   DateTime,
-  RelativeTime,
   Derive,
-  Branch,
-  Plural,
+  GTProvider,
   T,
   LocaleSelector,
+  Num,
+  Plural,
   RegionSelector,
-  // ----- hooks ----- //
+  RelativeTime,
+  Var,
+} from 'gt-react';
+
+// ===== Hooks ===== //
+export {
+  useDefaultLocale,
   useGT,
-  useTranslations,
-  useMessages,
-  useSetLocale,
+  useGTClass,
+  useLocaleDirection,
+  useLocales,
+  useLocaleProperties,
   useLocaleSelector,
   useLocale,
+  useMessages,
   useRegion,
-  useLocaleDirection,
+  useSetLocale,
+  useTranslations,
   useVersionId,
-  useLocales,
-  useDefaultLocale,
-  useGTClass,
-  useLocaleProperties,
-  // ----- functions ----- //
-  msg,
+} from 'gt-react';
+
+// ===== Functions ===== //
+export {
   decodeMsg,
   decodeOptions,
-  declareVar,
   decodeVars,
+  declareVar,
   derive,
-  mFallback,
-  gtFallback,
-  getTranslationsSnapshot,
   getDefaultLocale,
   getGTClass,
   getLocaleProperties,
   getLocales,
+  getTranslationsSnapshot,
   getVersionId,
+  gtFallback,
+  mFallback,
+  msg,
 } from 'gt-react';
 
+// ===== Types ===== //
 export type {
   DictionaryTranslationOptions,
   InlineTranslationOptions,

--- a/packages/next/src/types.ts
+++ b/packages/next/src/types.ts
@@ -1,11 +1,5 @@
-import type {
-  DictionaryTranslationOptions,
-  InlineTranslationOptions,
-  RuntimeTranslationOptions,
-} from '@generaltranslation/react-core/pure';
-
 export type {
   DictionaryTranslationOptions,
   InlineTranslationOptions,
   RuntimeTranslationOptions,
-};
+} from '@generaltranslation/react-core/pure';

--- a/packages/react-native/src/index.tsx
+++ b/packages/react-native/src/index.tsx
@@ -1,98 +1,68 @@
-import { GTProvider } from './provider/GTProvider';
-import {
+// ===== Components ===== //
+export {
+  Branch,
+  Currency,
+  DateTime,
+  Derive,
+  Num,
+  Plural,
+  RelativeTime,
+  T,
+  Var,
+} from '@generaltranslation/react-core/components';
+export { GTProvider } from './provider/GTProvider';
+
+// ===== Hooks ===== //
+export {
+  useCustomMapping,
+  useDefaultLocale,
+  useEnableI18n,
+  useFormatLocales,
+  useGT,
+  useGTClass,
+  useLocale,
+  useLocaleProperties,
+  useLocales,
+  useMessages,
+  useRegion,
+  useTranslations,
+} from '@generaltranslation/react-core/hooks';
+export {
   useSetLocale,
   useSetRegion,
   useSetEnableI18n,
 } from './hooks/condition-store';
-import { useLocaleSelector, useRegionSelector } from './hooks/selectors';
-import { useLocaleDirection, useVersionId } from './hooks/utils';
-import { getLocaleFromNativeStore } from './utils/nativeStore';
-import { getLocale } from './utils/getLocale';
-import { initializeGT } from './setup/initializeGT';
-import type { GTProviderProps } from './provider/GTProvider';
-import type { GetLocaleParams } from './utils/getLocale';
-import type { InitializeGTParams } from './setup/initializeGT';
+export { useLocaleSelector, useRegionSelector } from './hooks/selectors';
+export { useLocaleDirection, useVersionId } from './hooks/utils';
 
-import type {
-  DictionaryTranslationOptions,
-  InlineTranslationOptions,
-  RuntimeTranslationOptions,
-} from '@generaltranslation/react-core/pure';
-import type {
-  RenderPipeline,
-  RenderPreparedT,
-} from '@generaltranslation/react-core/pure';
-
+// ===== Functions ===== //
 export {
-  // ===== Components ===== //
-  Branch,
-  Plural,
-  Derive,
-  T,
-  Currency,
-  DateTime,
-  RelativeTime,
-  Var,
-  Num,
-} from '@generaltranslation/react-core/components';
-
-export {
-  // ===== Hooks ===== //
-  useLocale,
-  useCustomMapping,
-  useDefaultLocale,
-  useEnableI18n,
-  useLocales,
-  useFormatLocales,
-  useGT,
-  useMessages,
-  useTranslations,
-} from '@generaltranslation/react-core/hooks';
-
-export {
-  // ===== Functions ===== //
-  msg,
+  createRenderPipeline,
   decodeMsg,
   decodeOptions,
-  derive,
-  declareVar,
   decodeVars,
-  mFallback,
-  gtFallback,
+  declareVar,
+  derive,
   getFormatLocales,
-  getTranslationsSnapshot,
   getReactI18nCache,
+  getTranslationsSnapshot,
+  gtFallback,
+  mFallback,
+  msg,
   setReactI18nCache,
-  createRenderPipeline,
 } from '@generaltranslation/react-core/pure';
+export { getLocaleFromNativeStore } from './utils/nativeStore';
+export { getLocale } from './utils/getLocale';
+export { initializeGT } from './setup/initializeGT';
 
-export {
-  useRegion,
-  useGTClass,
-  useLocaleProperties,
-} from '@generaltranslation/react-core/hooks';
-
-export {
-  GTProvider,
-  useSetLocale,
-  useSetRegion,
-  useSetEnableI18n,
-  useLocaleSelector,
-  useRegionSelector,
-  useLocaleDirection,
-  useVersionId,
-  getLocaleFromNativeStore,
-  getLocale,
-  initializeGT,
-};
-
+// ===== Types ===== //
 export type {
   DictionaryTranslationOptions,
   InlineTranslationOptions,
   RuntimeTranslationOptions,
   RenderPipeline,
   RenderPreparedT,
-  GTProviderProps,
-  GetLocaleParams,
-  InitializeGTParams,
-};
+} from '@generaltranslation/react-core/pure';
+export type { GTProviderProps } from './provider/GTProvider';
+export type { GetLocaleParams } from './utils/getLocale';
+export type { InitializeGTParams } from './setup/initializeGT';

--- a/packages/sanity/src/index.ts
+++ b/packages/sanity/src/index.ts
@@ -1,65 +1,10 @@
-export {
-  documentInternationalization,
-  useDocumentInternationalizationContext,
-  DocumentInternationalizationMenu,
-  useDeleteTranslationAction,
-  useDuplicateWithTranslationsAction,
-} from './documentInternationalization';
-export type {
-  DocumentInternationalizationConfig,
-  Language,
-  Metadata,
-  TranslationReference,
-} from './documentInternationalization';
-
-import TranslationsTab from './components/tab/TranslationsTab';
-import {
-  Secrets,
-  Adapter,
-  ExportForTranslation,
-  ImportTranslation,
-  TranslationFunctionContext,
-  TranslationsTabConfigOptions,
-} from './types';
-import { findLatestDraft } from './configuration/utils/findLatestDraft';
-import { BaseDocumentSerializer } from './serialization/serialize/index';
-import { BaseDocumentDeserializer } from './serialization/deserialize/BaseDocumentDeserializer';
-import { BaseDocumentMerger } from './serialization/BaseDocumentMerger';
-import {
-  defaultStopTypes,
-  customSerializers,
-} from './serialization/BaseSerializationConfig';
-import type { SerializedDocument } from './serialization/types';
-import { translateAction } from './actions/translateAction';
-
-export type {
-  Secrets,
-  Adapter,
-  ExportForTranslation,
-  ImportTranslation,
-  TranslationFunctionContext,
-  TranslationsTabConfigOptions,
-  SerializedDocument,
-};
-export {
-  TranslationsTab,
-  translateAction,
-  //helpers for end developers who may need to customize serialization
-  findLatestDraft,
-  BaseDocumentSerializer,
-  BaseDocumentDeserializer,
-  BaseDocumentMerger,
-  defaultStopTypes,
-  customSerializers,
-  attachGTData,
-  detachGTData,
-};
-
+import type { PortableTextHtmlComponents } from '@portabletext/to-html';
+import { getLocaleProperties } from 'generaltranslation';
+import { libraryDefaultLocale } from 'generaltranslation/internal';
 import { definePlugin } from 'sanity';
 import { route } from 'sanity/router';
+import { translateAction } from './actions/translateAction';
 import { gt, pluginConfig } from './adapter/core';
-import { libraryDefaultLocale } from 'generaltranslation/internal';
-import { getLocaleProperties } from 'generaltranslation';
 import type {
   DedupeFields,
   IgnoreFields,
@@ -67,11 +12,46 @@ import type {
   TranslateDocumentFilter,
 } from './adapter/types';
 import TranslationsTool from './components/page/TranslationsTool';
-import { SECRETS_NAMESPACE } from './utils/shared';
-import type { PortableTextHtmlComponents } from '@portabletext/to-html';
-import { attachGTData, detachGTData } from './serialization/data';
 import { documentInternationalization } from './documentInternationalization';
 import type { CustomDeserializers } from './serialization/types';
+import { SECRETS_NAMESPACE } from './utils/shared';
+
+// ===== Document Internationalization ===== //
+export {
+  useDocumentInternationalizationContext,
+  DocumentInternationalizationMenu,
+  useDeleteTranslationAction,
+  useDuplicateWithTranslationsAction,
+} from './documentInternationalization';
+export { documentInternationalization };
+export type {
+  DocumentInternationalizationConfig,
+  Language,
+  Metadata,
+  TranslationReference,
+} from './documentInternationalization';
+
+// ===== Serialization Helpers ===== //
+export { default as TranslationsTab } from './components/tab/TranslationsTab';
+export { findLatestDraft } from './configuration/utils/findLatestDraft';
+export { BaseDocumentSerializer } from './serialization/serialize/index';
+export { BaseDocumentDeserializer } from './serialization/deserialize/BaseDocumentDeserializer';
+export { BaseDocumentMerger } from './serialization/BaseDocumentMerger';
+export {
+  defaultStopTypes,
+  customSerializers,
+} from './serialization/BaseSerializationConfig';
+export { attachGTData, detachGTData } from './serialization/data';
+export { translateAction };
+export type {
+  Secrets,
+  Adapter,
+  ExportForTranslation,
+  ImportTranslation,
+  TranslationFunctionContext,
+  TranslationsTabConfigOptions,
+} from './types';
+export type { SerializedDocument } from './serialization/types';
 
 export type GTPluginConfig = Omit<
   Parameters<typeof gt.setConfig>[0],


### PR DESCRIPTION
## Summary
- Organize entrypoint exports into component, hook, function, type, and helper sections.
- Replace re-export-only imports with direct `export ... from` syntax where the binding is not needed locally.
- Preserve the existing export surface.
- Add patch changeset `.changeset/organize-entrypoint-exports.md`.

## Testing
- `pnpm build`
- `pnpm lint`
- `pnpm --filter generaltranslation test`
- `pnpm --filter gt-next test:js`
- `pnpm --filter gt-react-native test`
- `pnpm --filter gt-sanity test`
- export-name comparison against `origin/e/odysseus/remove-source-barrel-exports`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1678"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785120739&installation_id=127936663&pr_number=1678&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1678&signature=e72ed5832a40b17bd2c8b3f927104c075ca0d49cef814532bd4d3c26524ac592"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reorganizes the entrypoint exports across 9 packages by grouping them into labeled sections (Components, Hooks, Functions, Types) and converting the `import … + export {}` pattern to direct `export … from` syntax where no local binding is needed. No behavioral or API surface changes are intended.

- **`packages/core`** (`id.ts`, `internal.ts`) and **`packages/format`** (`types.ts`) now use `export { default as … }` for default-export re-exports and `export type {}` for pure type re-exports, which is semantically equivalent to the prior pattern.
- **`packages/next`** (`index.client.ts`, `index.rsc.ts`, `index.server.ts`), **`packages/react-native`**, and **`packages/sanity`** now have each entrypoint organized into clearly labeled sections; modules that are consumed locally *and* re-exported (e.g., `translateAction`, `documentInternationalization` in sanity) correctly keep their top-level `import` and use a bare `export { name }` re-export instead of `export … from`.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — purely organizational, no logic or API surface changes.

Every changed file is a package entrypoint barrel. The refactor converts local import+re-export pairs into direct export … from statements and groups the results into labeled sections. Default-export re-exports (getPluralForm, hashTemplate, isVariable, TranslationsTab) were verified against their source files and all have the expected default exports. Modules that are consumed locally inside the gtPlugin closure (translateAction, documentInternationalization) correctly retain their top-level imports alongside the bare re-export. The export surface was manually cross-checked against the base branch for all nine files and no additions or removals were found.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/id.ts | Converts import+re-export of hashSource/hashString/hashTemplate to direct export … from syntax; both source files have confirmed default/named exports. |
| packages/core/src/internal.ts | Switches to direct export … from for all re-exports; JsxChildren/_Content/JsxChild/JsxElement/LocaleProperties are now correctly marked export type (they are pure interfaces); runtime values (isVariable, encode/decode, etc.) keep value exports. |
| packages/format/src/types.ts | Each type now exports directly from its canonical source module; CustomMapping, CutoffFormatOptions, Variable, VariableType, LocaleProperties all preserved; HTML_CONTENT_PROPS value export unchanged. |
| packages/next/src/index.client.ts | Large gt-react import block replaced with three direct export sections; local type imports (GetServerSideProps, WithGTServerSideProps) still present for the parseLocale/withGTServerSideProps stub functions. |
| packages/next/src/index.rsc.ts | Individual per-component export lines replace a single combined block; getTranslationsSnapshotRscError import moved before initializeGT() in source order, but static imports are always hoisted in ESM so execution order is unchanged. |
| packages/next/src/index.server.ts | parseLocale and withGTServerSideProps converted from local import+export to direct export … from; all Components/Hooks/Functions from gt-react preserved with same names. |
| packages/react-native/src/index.tsx | Two separate hook export blocks from react-core/hooks consolidated into one alphabetical block; GTProvider, useSetLocale/Region/EnableI18n, useLocaleSelector/RegionSelector, useLocaleDirection/VersionId still exported from their original local modules. |
| packages/sanity/src/index.ts | Imports used locally in the gtPlugin closure (translateAction, documentInternationalization, TranslationsTool, SECRETS_NAMESPACE, etc.) are kept as top-level imports; items only re-exported are converted to direct export … from. |

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: organize entrypoint exports"](https://github.com/generaltranslation/gt/commit/f5c6c5afab1f5c8563782879e6be24890d0299ea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40242913)</sub>

<!-- /greptile_comment -->