### PR TITLE
chore: sync related package versioning

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,7 +7,13 @@
   "commit": false,
   "fixed": [
     ["gt", "gtx-cli"],
-    ["gt-react", "gt-react-native"]
+    [
+      "@generaltranslation/react-core",
+      "gt-next",
+      "gt-react",
+      "gt-react-native",
+      "gt-tanstack-start"
+    ]
   ],
   "linked": [],
   "access": "public",


### PR DESCRIPTION
## Summary
- Expand the Changesets fixed version group to include react-core, next, react, react-native, and tanstack-start.
- Keep the existing CLI fixed group unchanged.

## Testing
- `pnpm format -- .changeset/config.json`
- Verified with a temporary local Changesets version run that a future patch to one package syncs all five related packages to the same prerelease version.

No changeset added.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1680"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785120952&installation_id=127936663&pr_number=1680&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1680&signature=1b2e4cdc281afeb25ea4aa19521cda7dd14fc7b3beec917330a29793fcdb8315"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->