### PR TITLE
fix: disable client i18n cache expiry

### DIFF
--- a/.changeset/client-i18n-cache-expiry.md
+++ b/.changeset/client-i18n-cache-expiry.md
@@ -1,0 +1,6 @@
+---
+"gt-react": patch
+"gt-next": patch
+---
+
+Allow client i18n cache expiry to default to no expiry while preserving explicit cache expiry configuration.

--- a/packages/next/src/index.client.ts
+++ b/packages/next/src/index.client.ts
@@ -1,7 +1,7 @@
 'use client';
 
-import { initializeGT } from './setup/initGT';
-initializeGT();
+import { initializeGTClient } from './setup/initializeGTClient';
+initializeGTClient();
 
 import type {
   GetServerSideProps,

--- a/packages/next/src/setup/initializeGTClient.ts
+++ b/packages/next/src/setup/initializeGTClient.ts
@@ -1,0 +1,17 @@
+import { initializeGT as coreInitializeGT } from './initGT';
+import { getParams } from './shared';
+
+/**
+ * Initialize GT for Next.js client entrypoints.
+ */
+export function initializeGTClient(): void {
+  const params = getParams();
+
+  coreInitializeGT({
+    ...params,
+    nextI18nCacheParams: {
+      cacheExpiryTime: null,
+      ...params.nextI18nCacheParams,
+    },
+  });
+}

--- a/packages/next/src/utils/client-boundary.tsx
+++ b/packages/next/src/utils/client-boundary.tsx
@@ -16,13 +16,13 @@ import { getI18nConfig, I18nConfig } from 'gt-i18n/internal';
 import { GTProvider, type SharedGTProviderProps } from 'gt-react';
 import { usePathname, useRouter } from 'next/navigation';
 import { useCallback, useEffect } from 'react';
-import { initializeGT } from '../setup/initGT';
+import { initializeGTClient } from '../setup/initializeGTClient';
 import {
   defaultLocaleRoutingEnabledCookieName,
   defaultReferrerLocaleCookieName,
 } from './cookies';
 
-initializeGT();
+initializeGTClient();
 
 /**
  * Small wrapper to embed nextjs app router behavior

--- a/packages/react/src/index.client.ts
+++ b/packages/react/src/index.client.ts
@@ -3,6 +3,7 @@
 import type { ReactNode } from 'react';
 
 export { initializeGTSPA } from './setup/initializeGTSPA';
+export { initializeGTSRAClient as initializeGT } from './setup/initializeGTSRAClient';
 export { useLocaleSelector } from './components/useLocaleSelector';
 export { useRegionSelector } from './components/useRegionSelector';
 export {
@@ -79,7 +80,6 @@ export {
   mFallback,
   gtFallback,
   getFormatLocales,
-  initializeGT,
   getDefaultLocale,
   getGTClass,
   getLocaleProperties,

--- a/packages/react/src/setup/initializeGTSRAClient.ts
+++ b/packages/react/src/setup/initializeGTSRAClient.ts
@@ -1,0 +1,20 @@
+import {
+  internalInitializeGTSRA,
+  type ReactI18nCacheParams,
+} from '@generaltranslation/react-core/pure';
+import type {
+  GTServicesEnabledParams,
+  I18nConfigParams,
+} from 'gt-i18n/internal/types';
+
+/**
+ * Initialize GT for client-side rendering.
+ */
+export function initializeGTSRAClient(
+  config: I18nConfigParams & GTServicesEnabledParams & ReactI18nCacheParams
+): void {
+  internalInitializeGTSRA({
+    cacheExpiryTime: null,
+    ...config,
+  });
+}


### PR DESCRIPTION
## Summary
- pass `cacheExpiryTime: null` when initializing client-side i18n caches in gt-react
- route gt-next browser/client-boundary initialization through a client initializer that disables cache expiry

## Testing
- `pnpm --filter gt-react... build`
- `pnpm --filter gt-next typecheck`
- `pnpm --filter gt-react test`
- `pnpm --filter gt-next test:js`
- `pnpm lint`

Note: `pnpm --filter gt-react typecheck` is still blocked by the existing `ImportMeta.env` typing issue in `BrowserI18nCache.ts`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1685"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785345577&installation_id=127936663&pr_number=1685&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1685&signature=5f4723f456084250913d0be547530fa50d6718fc9d3e22a2b2430b5b15ae684e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR disables client-side i18n cache expiry in both `gt-react` and `gt-next` by introducing thin wrapper initializers that force `cacheExpiryTime: null` on every client-side cache construction, preventing translations from being evicted while the browser session is alive.

- **`gt-react`**: A new `initializeGTClient.ts` wraps `internalInitializeGTSRA` with `cacheExpiryTime: null`, and `initializeGTSPA.ts` is updated to pass the same override to `BrowserI18nCache`. The public `initializeGT` export from `gt-react`'s client barrel now points to this new wrapper instead of re-exporting from `@generaltranslation/react-core/pure`.
- **`gt-next`**: A new `initGT.client.ts` wrapper calls `getParams()` and forwards the params to the core initializer with `nextI18nCacheParams.cacheExpiryTime` overridden to `null`. Both `index.client.ts` and `client-boundary.tsx` are updated to import from this new client-specific module.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the changes are small, mechanically consistent wrappers that apply a single override (cacheExpiryTime: null) to every client-side cache initialisation path.

All six changed files follow the same straightforward pattern: introduce a thin wrapper or change an import to route through a wrapper that forces cacheExpiryTime to null. No new logic branches, no altered data flow outside the cache, and the full test suite is reported green by the author.

No files require special attention. The pre-existing ImportMeta.env typing issue in BrowserI18nCache.ts (blocking gt-react typecheck) is explicitly acknowledged in the PR description and is unrelated to these changes.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/next/src/setup/initGT.client.ts | New wrapper that reads params via getParams() and forwards them to the core initializer with cacheExpiryTime forced to null; logic is correct and TypeScript-clean (gt-next typecheck passes). |
| packages/next/src/index.client.ts | One-line import path change from initGT to initGT.client; straightforward and correct. |
| packages/next/src/utils/client-boundary.tsx | Import path updated to use the new client-specific initializer so the boundary component now benefits from disabled cache expiry. |
| packages/react/src/setup/initializeGTClient.ts | New thin wrapper that hardcodes cacheExpiryTime: null on top of any caller-supplied config before delegating to internalInitializeGTSRA; correctly typed and appropriately scoped. |
| packages/react/src/index.client.ts | Swaps the initializeGT re-export from the react-core/pure barrel to the new initializeGTClient wrapper, ensuring all gt-react consumers get cache-expiry-disabled behaviour by default. |
| packages/react/src/setup/initializeGTSPA.ts | SPA initializer now passes cacheExpiryTime: null when constructing BrowserI18nCache, consistent with the broader client-side cache expiry fix. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CI as Client Entry (index.client.ts)
    participant CB as ClientBoundary (client-boundary.tsx)
    participant GTC as initGT.client.ts (new)
    participant GT as initGT.ts (core)
    participant NIC as NextI18nCache

    Note over CI,NIC: gt-next client initialization (after PR)

    CI->>GTC: initializeGT()
    CB->>GTC: initializeGT()
    GTC->>GTC: getParams()
    GTC->>GT: coreInitializeGT with cacheExpiryTime null
    GT->>NIC: new NextI18nCache(nextI18nCacheParams)
    Note right of NIC: cacheExpiryTime = null, no expiry

    participant GTCR as initializeGTClient.ts (new)
    participant SRA as internalInitializeGTSRA
    participant GSPA as initializeGTSPA.ts
    participant BIC as BrowserI18nCache

    Note over CI,BIC: gt-react client initialization (after PR)

    CI->>GTCR: initializeGT(config)
    GTCR->>SRA: internalInitializeGTSRA with cacheExpiryTime null
    Note right of SRA: cacheExpiryTime = null, no expiry

    CI->>GSPA: initializeGTSPA(config)
    GSPA->>BIC: new BrowserI18nCache with cacheExpiryTime null
    Note right of BIC: cacheExpiryTime = null, no expiry
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CI as Client Entry (index.client.ts)
    participant CB as ClientBoundary (client-boundary.tsx)
    participant GTC as initGT.client.ts (new)
    participant GT as initGT.ts (core)
    participant NIC as NextI18nCache

    Note over CI,NIC: gt-next client initialization (after PR)

    CI->>GTC: initializeGT()
    CB->>GTC: initializeGT()
    GTC->>GTC: getParams()
    GTC->>GT: coreInitializeGT with cacheExpiryTime null
    GT->>NIC: new NextI18nCache(nextI18nCacheParams)
    Note right of NIC: cacheExpiryTime = null, no expiry

    participant GTCR as initializeGTClient.ts (new)
    participant SRA as internalInitializeGTSRA
    participant GSPA as initializeGTSPA.ts
    participant BIC as BrowserI18nCache

    Note over CI,BIC: gt-react client initialization (after PR)

    CI->>GTCR: initializeGT(config)
    GTCR->>SRA: internalInitializeGTSRA with cacheExpiryTime null
    Note right of SRA: cacheExpiryTime = null, no expiry

    CI->>GSPA: initializeGTSPA(config)
    GSPA->>BIC: new BrowserI18nCache with cacheExpiryTime null
    Note right of BIC: cacheExpiryTime = null, no expiry
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: disable client i18n cache expiry"](https://github.com/generaltranslation/gt/commit/61df180c82b6fcca9173f050d1001f644fd96553) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40581150)</sub>

<!-- /greptile_comment -->