### PR TITLE
fix: cache i18n cache load promises

### DIFF
--- a/.changeset/quiet-i18n-promises.md
+++ b/.changeset/quiet-i18n-promises.md
@@ -1,0 +1,5 @@
+---
+'gt-i18n': patch
+---
+
+Cache i18n translation and dictionary load promises for repeated locale requests.

--- a/packages/i18n/src/i18n-cache/I18nCache.ts
+++ b/packages/i18n/src/i18n-cache/I18nCache.ts
@@ -248,25 +248,21 @@ class I18nCache<
    * Loads in translations for a given locale
    * Edge case usage: access the translations object directly
    */
-  async loadTranslations(
-    locale: string
-  ): Promise<Record<Hash, TranslationValue>> {
+  loadTranslations(locale: string): Promise<Record<Hash, TranslationValue>> {
     try {
       // Validate
       const translationLocale = this._resolveCacheLocale(locale);
       if (!translationLocale) {
-        return {};
+        return Promise.resolve({});
       }
 
-      const txCache =
-        await this.localesCache.getOrLoadTranslations(translationLocale);
-
-      // Get the translations
-      const translations = txCache.getInternalCache();
-      return translations;
+      return this.localesCache.getOrLoadTranslationsSnapshot(
+        translationLocale,
+        (error) => this.handleError(error)
+      );
     } catch (error) {
       this.handleError(error);
-      return {};
+      return Promise.resolve({});
     }
   }
 
@@ -274,21 +270,23 @@ class I18nCache<
    * Loads in the dictionary for a given locale
    * Edge case usage: access the dictionary object directly
    */
-  async loadDictionary(locale: string): Promise<Dictionary> {
+  loadDictionary(locale: string): Promise<Dictionary> {
     try {
       // Validate
       const dictionaryLocale = this._resolveCacheLocale(locale);
       if (!dictionaryLocale) {
-        return this.getDefaultDictionaryCache()?.getInternalCache() ?? {};
+        return Promise.resolve(
+          this.getDefaultDictionaryCache()?.getInternalCache() ?? {}
+        );
       }
 
-      const dictionaryCache =
-        await this.localesCache.getOrLoadDictionary(dictionaryLocale);
-
-      return dictionaryCache.getInternalCache();
+      return this.localesCache.getOrLoadDictionarySnapshot(
+        dictionaryLocale,
+        (error) => this.handleError(error)
+      );
     } catch (error) {
       this.handleError(error);
-      return {};
+      return Promise.resolve({});
     }
   }
 
@@ -581,14 +579,12 @@ class I18nCache<
    * Get the translations
    * @deprecated use loadTranslations instead
    */
-  async getTranslations(
-    locale: string
-  ): Promise<Record<Hash, TranslationValue>> {
+  getTranslations(locale: string): Promise<Record<Hash, TranslationValue>> {
     try {
       return this.loadTranslations(locale);
     } catch (error) {
       this.handleError(error);
-      return {};
+      return Promise.resolve({});
     }
   }
 

--- a/packages/i18n/src/i18n-cache/__tests__/I18nCache.test.ts
+++ b/packages/i18n/src/i18n-cache/__tests__/I18nCache.test.ts
@@ -5,6 +5,7 @@ import { hashMessage } from '../../utils/hashMessage';
 import { LookupOptions } from '../../translation-functions/types/options';
 import { initializeI18nConfig } from '../../i18n-config/singleton-operations';
 import type { CustomMapping } from '@generaltranslation/format/types';
+import type { Dictionary } from '../translations-manager/DictionaryCache';
 
 // Mock createTranslateManyFactory to inject a controlled translateMany
 const mockTranslateMany = vi.fn();
@@ -96,6 +97,46 @@ describe('I18nCache', () => {
     expect(translations[expectedHash]).toBe(translatedString);
   });
 
+  it('loadTranslations() returns the same promise for concurrent locale loads', async () => {
+    let resolveTranslations!: (translations: Record<Hash, string>) => void;
+    const loadTranslations = vi.fn().mockReturnValue(
+      new Promise((resolve) => {
+        resolveTranslations = resolve;
+      })
+    );
+    const cache = createCache({ loadTranslations });
+
+    const firstTranslations = cache.loadTranslations('fr');
+    const secondTranslations = cache.loadTranslations('fr');
+    expect(secondTranslations).toBe(firstTranslations);
+    expect(loadTranslations).toHaveBeenCalledTimes(1);
+
+    resolveTranslations({ [expectedHash]: translatedString });
+    await expect(firstTranslations).resolves.toEqual({
+      [expectedHash]: translatedString,
+    });
+  });
+
+  it('getTranslations() returns the same promise for concurrent locale loads', async () => {
+    let resolveTranslations!: (translations: Record<Hash, string>) => void;
+    const loadTranslations = vi.fn().mockReturnValue(
+      new Promise((resolve) => {
+        resolveTranslations = resolve;
+      })
+    );
+    const cache = createCache({ loadTranslations });
+
+    const firstTranslations = cache.getTranslations('fr');
+    const secondTranslations = cache.getTranslations('fr');
+    expect(secondTranslations).toBe(firstTranslations);
+    expect(loadTranslations).toHaveBeenCalledTimes(1);
+
+    resolveTranslations({ [expectedHash]: translatedString });
+    await expect(firstTranslations).resolves.toEqual({
+      [expectedHash]: translatedString,
+    });
+  });
+
   it('loadDictionary() returns source dictionary without loading when locale does not require translation', async () => {
     const loadDictionary = vi.fn().mockResolvedValue({ greeting: 'Bonjour' });
     const cache = createCache({
@@ -111,6 +152,31 @@ describe('I18nCache', () => {
       greeting: 'Hello',
     });
     expect(loadDictionary).not.toHaveBeenCalled();
+  });
+
+  it('loadDictionary() returns the same promise for concurrent locale loads', async () => {
+    let resolveDictionary!: (dictionary: Dictionary) => void;
+    const loadDictionary = vi.fn().mockReturnValue(
+      new Promise((resolve) => {
+        resolveDictionary = resolve;
+      })
+    );
+    const cache = createCache({
+      dictionary: {
+        greeting: 'Hello',
+      },
+      loadDictionary,
+    });
+
+    const firstDictionary = cache.loadDictionary('fr');
+    const secondDictionary = cache.loadDictionary('fr');
+    expect(secondDictionary).toBe(firstDictionary);
+    expect(loadDictionary).toHaveBeenCalledTimes(1);
+
+    resolveDictionary({ greeting: 'Bonjour' });
+    await expect(firstDictionary).resolves.toEqual({
+      greeting: 'Bonjour',
+    });
   });
 
   it('loadDictionary() loads and caches dictionary for requested locale', async () => {

--- a/packages/i18n/src/i18n-cache/translations-manager/LocalesCache.ts
+++ b/packages/i18n/src/i18n-cache/translations-manager/LocalesCache.ts
@@ -5,6 +5,7 @@ import type {
   DictionaryKey,
   DictionaryLoader,
 } from './DictionaryCache';
+import { PendingPromiseCache } from './PendingPromiseCache';
 import { ResourceCache } from './ResourceCache';
 import { TranslationsCache } from './TranslationsCache';
 import type {
@@ -50,6 +51,14 @@ export class LocalesCache<TranslationValue extends Translation> {
     TranslationsCache<TranslationValue>
   >;
   private readonly dictionaries: ResourceCache<Locale, DictionaryCache>;
+  private readonly translationSnapshots = new PendingPromiseCache<
+    Locale,
+    Record<Hash, TranslationValue>
+  >();
+  private readonly dictionarySnapshots = new PendingPromiseCache<
+    Locale,
+    Dictionary
+  >();
   private readonly createTranslationsCache: (
     locale: Locale,
     init: Record<Hash, TranslationValue>
@@ -121,12 +130,40 @@ export class LocalesCache<TranslationValue extends Translation> {
     return this.translations.getOrLoad(locale);
   }
 
+  public getOrLoadTranslationsSnapshot(
+    locale: Locale,
+    onError: (error: unknown) => void
+  ): Promise<Record<Hash, TranslationValue>> {
+    return this.translationSnapshots.getOrCreate(locale, () =>
+      this.getOrLoadTranslations(locale)
+        .then((txCache) => txCache.getInternalCache())
+        .catch((error) => {
+          onError(error);
+          return {};
+        })
+    );
+  }
+
   public getDictionary(locale: Locale): DictionaryCache | undefined {
     return this.dictionaries.get(locale);
   }
 
   public getOrLoadDictionary(locale: Locale): Promise<DictionaryCache> {
     return this.dictionaries.getOrLoad(locale);
+  }
+
+  public getOrLoadDictionarySnapshot(
+    locale: Locale,
+    onError: (error: unknown) => void
+  ): Promise<Dictionary> {
+    return this.dictionarySnapshots.getOrCreate(locale, () =>
+      this.getOrLoadDictionary(locale)
+        .then((dictionaryCache) => dictionaryCache.getInternalCache())
+        .catch((error) => {
+          onError(error);
+          return {};
+        })
+    );
   }
 
   public updateTranslations(

--- a/packages/i18n/src/i18n-cache/translations-manager/PendingPromiseCache.ts
+++ b/packages/i18n/src/i18n-cache/translations-manager/PendingPromiseCache.ts
@@ -1,0 +1,18 @@
+export class PendingPromiseCache<Key extends string, Value> {
+  private promises = new Map<Key, Promise<Value>>();
+
+  public getOrCreate(key: Key, create: () => Promise<Value>): Promise<Value> {
+    const cachedPromise = this.promises.get(key);
+    if (cachedPromise) {
+      return cachedPromise;
+    }
+
+    const promise = create().finally(() => {
+      if (this.promises.get(key) === promise) {
+        this.promises.delete(key);
+      }
+    });
+    this.promises.set(key, promise);
+    return promise;
+  }
+}

--- a/packages/i18n/src/i18n-cache/translations-manager/ResourceCache.ts
+++ b/packages/i18n/src/i18n-cache/translations-manager/ResourceCache.ts
@@ -15,7 +15,7 @@ type ResourceCacheLifecycle<Key extends string, Value> = LifecycleParam<
 
 export class ResourceCache<Key extends string, Value> {
   private cache = new Map<Key, ResourceCacheEntry<Value>>();
-  private pendingLoads = new Map<Key, Promise<ResourceCacheEntry<Value>>>();
+  private pendingLoads = new Map<Key, Promise<Value>>();
   private loadResource: (key: Key) => Promise<Value>;
   private lifecycle: ResourceCacheLifecycle<Key, Value>;
   private ttl: number;
@@ -61,11 +61,12 @@ export class ResourceCache<Key extends string, Value> {
     });
   }
 
-  public async getOrLoad(key: Key): Promise<Value> {
-    return this.get(key) ?? (await this.load(key));
+  public getOrLoad(key: Key): Promise<Value> {
+    const value = this.get(key);
+    return value === undefined ? this.load(key) : Promise.resolve(value);
   }
 
-  private async load(key: Key): Promise<Value> {
+  private load(key: Key): Promise<Value> {
     let loadPromise = this.pendingLoads.get(key);
     if (!loadPromise) {
       loadPromise = this.loadResource(key).then((value) => {
@@ -80,17 +81,17 @@ export class ResourceCache<Key extends string, Value> {
           cacheValue: entry,
           outputValue: entry.value,
         });
-        return entry;
+        return entry.value;
+      });
+      loadPromise = loadPromise.finally(() => {
+        if (this.pendingLoads.get(key) === loadPromise) {
+          this.pendingLoads.delete(key);
+        }
       });
       this.pendingLoads.set(key, loadPromise);
     }
 
-    try {
-      const entry = await loadPromise;
-      return entry.value;
-    } finally {
-      this.pendingLoads.delete(key);
-    }
+    return loadPromise;
   }
 
   private getExpiresAt(): number {

--- a/packages/i18n/src/i18n-cache/translations-manager/__tests__/LocalesCache.test.ts
+++ b/packages/i18n/src/i18n-cache/translations-manager/__tests__/LocalesCache.test.ts
@@ -77,6 +77,7 @@ describe('LocalesCache', () => {
 
       const firstCache = cache.getOrLoadTranslations('fr');
       const secondCache = cache.getOrLoadTranslations('fr');
+      expect(secondCache).toBe(firstCache);
       const [firstResult, secondResult] = await Promise.all([
         firstCache,
         secondCache,
@@ -205,6 +206,7 @@ describe('LocalesCache', () => {
 
       const firstCache = cache.getOrLoadDictionary('fr');
       const secondCache = cache.getOrLoadDictionary('fr');
+      expect(secondCache).toBe(firstCache);
       const [firstResult, secondResult] = await Promise.all([
         firstCache,
         secondCache,


### PR DESCRIPTION
## Summary
- cache same-locale translation and dictionary load promises in the lower cache layers used by `I18nCache`
- make `I18nCache.loadTranslations()`, `loadDictionary()`, and `getTranslations()` return those delegated cached promises directly
- add promise identity regression coverage for public and locale-cache loads
- add a patch changeset for `gt-i18n`

## Testing
- `pnpm --filter gt-i18n test`
- `pnpm --filter gt-i18n build`
- `pnpm format`
- `pnpm lint`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a request-stampede issue in the `gt-i18n` cache layer by deduplicating concurrent in-flight promises for the same locale. A new `PendingPromiseCache` utility stores pending promises by key and evicts them on settlement, while `ResourceCache` and `LocalesCache` are refactored to return `Promise<Value>` directly rather than using `async/await` wrappers that created new promise instances per caller.

- **`PendingPromiseCache`** (new): stores a promise per key only while it is pending; uses a `finally` + identity-check to avoid accidentally evicting a replacement promise started after the first settled.
- **`ResourceCache`**: `pendingLoads` now stores `Promise<Value>` (down from `Promise<ResourceCacheEntry<Value>>`); per-caller `try/finally` cleanup replaced with a single chained `finally`, eliminating redundant `Map.delete` calls.
- **`LocalesCache`**: adds `getOrLoadTranslationsSnapshot` / `getOrLoadDictionarySnapshot` that flatten the cache object to a plain record and deduplicate concurrent snapshot requests via `PendingPromiseCache`.
- **`I18nCache`**: `loadTranslations`, `loadDictionary`, and `getTranslations` drop `async`, delegating to the new snapshot methods and passing `handleError` as an `onError` callback.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the changes are additive and well-tested with promise-identity assertions at both the public and locale-cache layers.

The core logic is correct: PendingPromiseCache uses a finally with an identity guard to avoid evicting a replacement promise; ResourceCache cleanup is now done exactly once instead of once per caller; error handling is fully preserved via the onError callback. Regression tests directly verify promise identity under concurrent access for all three public methods.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/i18n/src/i18n-cache/translations-manager/PendingPromiseCache.ts | New utility class that deduplicates concurrent in-flight promises by key; correctly uses a `finally` with identity-check to evict only after settling. |
| packages/i18n/src/i18n-cache/translations-manager/ResourceCache.ts | Refactored `pendingLoads` from `Promise<ResourceCacheEntry<Value>>` to `Promise<Value>`, dropped `async/await` in `getOrLoad`/`load`, and moved cleanup from per-caller `try/finally` to a single `finally` chain with an identity guard. |
| packages/i18n/src/i18n-cache/translations-manager/LocalesCache.ts | Adds `translationSnapshots`/`dictionarySnapshots` PendingPromiseCaches and two new snapshot methods that flatten the cache-object into a plain record, deduplicating concurrent snapshot requests. |
| packages/i18n/src/i18n-cache/I18nCache.ts | `loadTranslations`, `loadDictionary`, and `getTranslations` drop `async` and delegate to the new snapshot methods; error handling is preserved via the `onError` callback passed to LocalesCache. |
| packages/i18n/src/i18n-cache/__tests__/I18nCache.test.ts | Adds promise-identity regression tests for `loadTranslations`, `getTranslations`, and `loadDictionary` to verify that concurrent calls return the same promise. |
| packages/i18n/src/i18n-cache/translations-manager/__tests__/LocalesCache.test.ts | Adds `expect(secondCache).toBe(firstCache)` assertions to the existing concurrent-load tests for both translations and dictionary, verifying promise identity at the `LocalesCache` layer. |
| .changeset/quiet-i18n-promises.md | Correct `patch` changeset for `gt-i18n` describing the promise-caching fix. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant C1 as Caller 1
    participant C2 as Caller 2
    participant I18n as I18nCache
    participant LC as LocalesCache
    participant PPC as PendingPromiseCache
    participant RC as ResourceCache
    participant Loader as loadTranslations fn

    C1->>I18n: "loadTranslations('fr')"
    I18n->>LC: "getOrLoadTranslationsSnapshot('fr', onError)"
    LC->>PPC: "getOrCreate('fr', create)"
    PPC->>RC: "getOrLoadTranslations('fr')"
    RC->>Loader: "loadResource('fr')"
    Note over PPC: promise stored, returned to C1

    C2->>I18n: "loadTranslations('fr')"
    I18n->>LC: "getOrLoadTranslationsSnapshot('fr', onError)"
    LC->>PPC: "getOrCreate('fr', create)"
    Note over PPC: same promise returned (dedup)
    PPC-->>C2: "same promise (no new load)"

    Loader-->>RC: "translations data"
    RC->>RC: "cache.set('fr', entry)"
    RC-->>PPC: "txCache resolved"
    PPC->>PPC: "txCache.getInternalCache()"
    Note over PPC: finally evicts 'fr' from map
    PPC-->>C1: "Record of translations"
    PPC-->>C2: "Record of translations"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant C1 as Caller 1
    participant C2 as Caller 2
    participant I18n as I18nCache
    participant LC as LocalesCache
    participant PPC as PendingPromiseCache
    participant RC as ResourceCache
    participant Loader as loadTranslations fn

    C1->>I18n: "loadTranslations('fr')"
    I18n->>LC: "getOrLoadTranslationsSnapshot('fr', onError)"
    LC->>PPC: "getOrCreate('fr', create)"
    PPC->>RC: "getOrLoadTranslations('fr')"
    RC->>Loader: "loadResource('fr')"
    Note over PPC: promise stored, returned to C1

    C2->>I18n: "loadTranslations('fr')"
    I18n->>LC: "getOrLoadTranslationsSnapshot('fr', onError)"
    LC->>PPC: "getOrCreate('fr', create)"
    Note over PPC: same promise returned (dedup)
    PPC-->>C2: "same promise (no new load)"

    Loader-->>RC: "translations data"
    RC->>RC: "cache.set('fr', entry)"
    RC-->>PPC: "txCache resolved"
    PPC->>PPC: "txCache.getInternalCache()"
    Note over PPC: finally evicts 'fr' from map
    PPC-->>C1: "Record of translations"
    PPC-->>C2: "Record of translations"
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: cache i18n cache load promises"](https://github.com/generaltranslation/gt/commit/1bb5a32ea0a871b3884ea750bf4ee4417ad2ef2a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40591967)</sub>

<!-- /greptile_comment -->