### PR TITLE
refactor: remove deprecated context and $_locales options

### DIFF
--- a/.changeset/remove-deprecated-context-locales-options.md
+++ b/.changeset/remove-deprecated-context-locales-options.md
@@ -1,0 +1,5 @@
+---
+"gt-i18n": major
+---
+
+Remove deprecated translation options. The `context` dictionary option has been removed in favor of `$context`, and the `$_locales` inline option has been removed in favor of `$locale`.

--- a/packages/compiler/src/state/StringCollector.ts
+++ b/packages/compiler/src/state/StringCollector.ts
@@ -13,11 +13,11 @@ export interface TranslationContent {
   message: string;
   /** Pre-calculated hash for this content */
   hash: string;
-  /** Optional ID from options: t("text", {id: "greeting"}) → "greeting" */
+  /** Optional ID from options: t("text", {$id: "greeting"}) → "greeting" */
   id?: string;
-  /** Optional context from options: t("text", {context: "nav"}) → "nav" */
+  /** Optional context from options: t("text", {$context: "nav"}) → "nav" */
   context?: string;
-  /** Optional maxChars from options: t("text", {maxChars: 10}) → 10 */
+  /** Optional maxChars from options: t("text", {$maxChars: 10}) → 10 */
   maxChars?: number;
   /** Optional format from options: t("text", {$format: "STRING"}) → "STRING" */
   format?: string;

--- a/packages/i18n/src/i18n-cache/__tests__/I18nCache.test.ts
+++ b/packages/i18n/src/i18n-cache/__tests__/I18nCache.test.ts
@@ -324,7 +324,7 @@ describe('I18nCache', () => {
         greeting: ['Hello', { $context: 'homepage', $maxChars: 10 }],
       },
       loadDictionary: vi.fn().mockResolvedValue({
-        greeting: ['Bonjour', { context: 'homepage' }],
+        greeting: ['Bonjour', { $context: 'homepage' }],
       }),
     });
 
@@ -332,7 +332,7 @@ describe('I18nCache', () => {
 
     expect(cache.lookupDictionary('fr', 'greeting')).toEqual({
       entry: 'Bonjour',
-      options: { context: 'homepage' },
+      options: { $context: 'homepage' },
     });
   });
 
@@ -1092,7 +1092,7 @@ describe('I18nCache', () => {
     const sourceHash = hashMessage(source, sourceOptions);
     const cache = createCache({
       dictionary: {
-        greeting: [source, { $format: 'I18NEXT', context: 'homepage' }],
+        greeting: [source, { $format: 'I18NEXT', $context: 'homepage' }],
       },
       runtimeTranslation: {},
     });
@@ -1121,7 +1121,7 @@ describe('I18nCache', () => {
     const sourceHash = hashMessage(source, sourceOptions);
     const cache = createCache({
       dictionary: {
-        greeting: [source, { context: 'homepage' }],
+        greeting: [source, { $context: 'homepage' }],
       },
       runtimeTranslation: {},
     });

--- a/packages/i18n/src/i18n-cache/translations-manager/__tests__/DictionaryCache.test.ts
+++ b/packages/i18n/src/i18n-cache/translations-manager/__tests__/DictionaryCache.test.ts
@@ -8,7 +8,7 @@ describe('DictionaryCache', () => {
     greeting: 'Hello',
     cta: ['Click me'],
     header: ['Welcome', { $context: 'homepage', $maxChars: 12 }],
-    footer: ['Thanks', { context: 'homepage footer' }],
+    footer: ['Thanks', { $context: 'homepage footer' }],
     user: {
       profile: {
         name: 'Name',
@@ -57,7 +57,7 @@ describe('DictionaryCache', () => {
     });
     expect(cache.getEntry('footer')).toEqual({
       entry: 'Thanks',
-      options: { context: 'homepage footer' },
+      options: { $context: 'homepage footer' },
     });
   });
 

--- a/packages/i18n/src/i18n-cache/translations-manager/__tests__/LocalesCache.test.ts
+++ b/packages/i18n/src/i18n-cache/translations-manager/__tests__/LocalesCache.test.ts
@@ -23,7 +23,7 @@ describe('LocalesCache', () => {
   };
   const frDictionary: Dictionary = {
     greeting: 'Bonjour',
-    cta: ['Cliquez', { context: 'button' }],
+    cta: ['Cliquez', { $context: 'button' }],
     user: {
       name: 'Nom',
     },
@@ -278,7 +278,7 @@ describe('LocalesCache', () => {
 
       expect(dictionaryCache.getEntry('cta')).toEqual({
         entry: 'Cliquez',
-        options: { context: 'button' },
+        options: { $context: 'button' },
       });
     });
 
@@ -325,7 +325,7 @@ describe('LocalesCache', () => {
       });
       expect(cache.getDictionary('fr')?.getInternalCache()).toEqual({
         greeting: 'Salut',
-        cta: ['Cliquez', { context: 'button' }],
+        cta: ['Cliquez', { $context: 'button' }],
         user: {
           name: 'Nom',
           title: 'Titre',

--- a/packages/i18n/src/i18n-cache/translations-manager/__tests__/dictionary-helpers.test.ts
+++ b/packages/i18n/src/i18n-cache/translations-manager/__tests__/dictionary-helpers.test.ts
@@ -1,24 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import {
-  setDictionaryValueAtPath,
-  resolveDictionaryLookupOptions,
-} from '../utils/dictionary-helpers';
+import { setDictionaryValueAtPath } from '../utils/dictionary-helpers';
 import type { Dictionary } from '../DictionaryCache';
 
 describe('dictionary helpers', () => {
-  it('maps deprecated context metadata to $context without keeping context as a variable', () => {
-    expect(
-      resolveDictionaryLookupOptions({
-        context: 'homepage',
-        custom: 'value',
-      })
-    ).toEqual({
-      $format: 'ICU',
-      $context: 'homepage',
-      custom: 'value',
-    });
-  });
-
   it.each(['__proto__', 'constructor', 'prototype'])(
     'rejects unsafe dictionary path segment %s',
     (segment) => {

--- a/packages/i18n/src/i18n-cache/translations-manager/utils/dictionary-helpers.ts
+++ b/packages/i18n/src/i18n-cache/translations-manager/utils/dictionary-helpers.ts
@@ -145,8 +145,7 @@ function isDictionaryOptions(value: unknown): value is DictionaryOptions {
   return (
     (options.$context === undefined || typeof options.$context === 'string') &&
     (options.$format === undefined || isStringFormat(options.$format)) &&
-    (options.$maxChars === undefined ||
-      typeof options.$maxChars === 'number')
+    (options.$maxChars === undefined || typeof options.$maxChars === 'number')
   );
 }
 

--- a/packages/i18n/src/i18n-cache/translations-manager/utils/dictionary-helpers.ts
+++ b/packages/i18n/src/i18n-cache/translations-manager/utils/dictionary-helpers.ts
@@ -116,12 +116,10 @@ export function getDictionaryValue(value: DictionaryEntry): DictionaryValue {
 export function resolveDictionaryLookupOptions(
   options: DictionaryEntry['options']
 ): DictionaryLookupOptions {
-  const { $format, context, ...rest } = options;
+  const { $format, ...rest } = options;
   return {
     ...rest,
     $format: isStringFormat($format) ? $format : 'ICU',
-    ...(rest.$context === undefined &&
-      typeof context === 'string' && { $context: context }),
   };
 }
 
@@ -148,8 +146,7 @@ function isDictionaryOptions(value: unknown): value is DictionaryOptions {
     (options.$context === undefined || typeof options.$context === 'string') &&
     (options.$format === undefined || isStringFormat(options.$format)) &&
     (options.$maxChars === undefined ||
-      typeof options.$maxChars === 'number') &&
-    (options.context === undefined || typeof options.context === 'string')
+      typeof options.$maxChars === 'number')
   );
 }
 

--- a/packages/i18n/src/translation-functions/internal/__tests__/locale-defaults.test.ts
+++ b/packages/i18n/src/translation-functions/internal/__tests__/locale-defaults.test.ts
@@ -127,7 +127,7 @@ describe('translation function locale defaults', () => {
       { defaultLocale: 'en', locales: ['en', 'fr'] },
       {
         dictionary: {
-          greeting: [message, { context: 'homepage' }],
+          greeting: [message, { $context: 'homepage' }],
         },
         loadDictionary: vi.fn().mockResolvedValue({}),
         loadTranslations,
@@ -237,7 +237,7 @@ describe('translation function locale defaults', () => {
           user: {
             profile: {
               name: 'Name',
-              title: [title, { context: 'profile title' }],
+              title: [title, { $context: 'profile title' }],
             },
           },
         },

--- a/packages/i18n/src/translation-functions/types/options.ts
+++ b/packages/i18n/src/translation-functions/types/options.ts
@@ -15,8 +15,6 @@ export type DictionaryOptions = BaseTranslationOptions & {
   $format?: StringFormat;
   $context?: string;
   $maxChars?: number;
-  /** @deprecated use {@link $context} instead */
-  context?: string;
 };
 
 /**
@@ -30,10 +28,6 @@ export type InlineTranslationOptionsFields = {
   $format?: StringFormat;
   /** The locale to use for formatting the message. */
   $locale?: string;
-  /**
-   * @deprecated use {@link $locale} instead
-   */
-  $_locales?: string | string[];
   $_hash?: string;
   $maxChars?: number;
   /** @internal Used to carry the original source when rendering a translation */

--- a/packages/i18n/src/translation-functions/utils/interpolation/interpolateIcuMessage.ts
+++ b/packages/i18n/src/translation-functions/utils/interpolation/interpolateIcuMessage.ts
@@ -46,7 +46,7 @@ export function interpolateIcuMessage<T extends string | null | undefined>(
         ...declaredVars,
         [VAR_IDENTIFIER]: 'other',
       },
-      options.$locale ?? options.$_locales,
+      options.$locale,
       options.$format
     );
     // Apply cutoff formatting

--- a/packages/i18n/src/translation-functions/utils/interpolation/interpolateStringMessage.ts
+++ b/packages/i18n/src/translation-functions/utils/interpolation/interpolateStringMessage.ts
@@ -9,7 +9,7 @@ export function interpolateStringMessage(
   options: InlineTranslationOptions
 ): string {
   const cutoffMessage = formatCutoff(encodedMsg, {
-    locales: options.$locale ?? options.$_locales,
+    locales: options.$locale,
     maxChars: options.$maxChars,
   });
   return cutoffMessage;

--- a/packages/i18n/src/utils/extractVariables.ts
+++ b/packages/i18n/src/utils/extractVariables.ts
@@ -20,7 +20,6 @@ export function extractVariables<T extends BaseTranslationOptions>(
         key !== '$_source' &&
         key !== '$_fallback' &&
         key !== '$format' &&
-        key !== '$_locales' &&
         key !== '$locale'
     )
   );

--- a/packages/next/src/server-dir/runtime/tx.ts
+++ b/packages/next/src/server-dir/runtime/tx.ts
@@ -22,11 +22,10 @@ type TxOptions = FormatVariables & {
  *
  * @param {string} content - The content string that needs to be translated.
  * @param {Object} [options] - Translation options.
- * @param {string} [options.locale] - The target locale for translation. Defaults to the current locale if not provided.
- * @param {string} [options.context] - Additional context for the translation process, which may influence the translation's outcome.
- * @param {number} [options.maxChars] - The maximum number of characters to translate.
- * @param {Object} [options.variables] - An optional map of variables to be injected into the translated content.
- * @param {Object} [options.variableOptions] - Options for formatting numbers and dates using `Intl.NumberFormat` or `Intl.DateTimeFormat`.
+ * @param {string} [options.$locale] - The target locale for translation. Defaults to the current locale if not provided.
+ * @param {string} [options.$context] - Additional context for the translation process, which may influence the translation's outcome.
+ * @param {number} [options.$maxChars] - The maximum number of characters to translate.
+ * @param {string|number|boolean|Date} [options.<variable>] - Variables to interpolate into the message, passed as top-level keys (e.g. `{ price: 29.99 }`).
  * @param {StringFormat} [options.$format] - The data format for the message (e.g., 'ICU', 'STRING'). Defaults to 'ICU'.
  *
  * @returns {Promise<string>} - A promise that resolves to the translated content string, or the original content if no translation is needed.
@@ -39,11 +38,11 @@ type TxOptions = FormatVariables & {
  *
  * @example
  * // Providing specific translation options
- * const translation = await tx("Hello, world!", { locale: 'es', context: 'Translate informally' });
+ * const translation = await tx("Hello, world!", { $locale: 'es', $context: 'Translate informally' });
  *
  * @example
  * // Using variables in the content string
- * const translation = await tx("The price is {price}", { locale: 'es-MX', variables: { price: 29.99 } });
+ * const translation = await tx("The price is {price}", { $locale: 'es-MX', price: 29.99 });
  */
 export async function tx(
   message: string,

--- a/packages/next/swc-plugin/src/ast/string_collector.rs
+++ b/packages/next/swc-plugin/src/ast/string_collector.rs
@@ -8,11 +8,11 @@ pub struct TranslationContent {
   pub message: String,
   /// Pre-calculated hash for this content
   pub hash: String,
-  /// Optional ID from options: t("text", {id: "greeting"}) → Some("greeting")
+  /// Optional ID from options: t("text", {$id: "greeting"}) → Some("greeting")
   pub id: Option<String>,
-  /// Optional context from options: t("text", {context: "nav"}) → Some("nav")
+  /// Optional context from options: t("text", {$context: "nav"}) → Some("nav")
   pub context: Option<String>,
-  /// Optional max chars from options: t("text", {maxChars: 10}) → Some(10)
+  /// Optional max chars from options: t("text", {$maxChars: 10}) → Some(10)
   pub max_chars: Option<i32>,
 }
 

--- a/packages/next/swc-plugin/src/visitor/expr_utils.rs
+++ b/packages/next/swc-plugin/src/visitor/expr_utils.rs
@@ -130,7 +130,7 @@ pub fn contains_derive_call(expr: &Expr) -> bool {
   }
 }
 
-// Helper function to extract id, context, maxChars, and format from options
+// Helper function to extract $id, $context, $maxChars, and $format from options
 // Returns (id, context, maxChars, format, has_derive_context)
 pub fn extract_id_and_context_from_options(
   options: Option<&ExprOrSpread>,


### PR DESCRIPTION
## Summary

Removes deprecated translation options from `gt-i18n` as part of the Odysseus major-version cleanup:

- **`context` dictionary option** → use `$context`. Removed from `DictionaryOptions`, plus the fallback mapping in `resolveDictionaryLookupOptions` and the validation branch in `isDictionaryOptions`.
- **`$_locales` inline option** → use `$locale`. Removed from `InlineTranslationOptionsFields`, the `$locale ?? $_locales` fallbacks in ICU/string interpolation, and the exclusion list in `extractVariables`.

## Stale comment/doc cleanup

These reference the same options and were updated for consistency (no behavior change):

- `next/swc-plugin` comments now reference `$id`/`$context`/`$maxChars`.
- `@generaltranslation/compiler` `StringCollector` — `TranslationContent` (extracted from `t()` calls) comments now use `$`-prefixed keys. The parser already reads `$context`/`$id`/`$maxChars`.
- `next` `tx()` JSDoc corrected to the actual `TxOptions` shape (`$locale`/`$context`/`$maxChars`), and the `variables`/`variableOptions` docs fixed to flat top-level variables (`TxOptions extends FormatVariables`).

Left intentionally bare (not the i18n message-options form):
- JSX-prop `context` (`<T context="...">`, `TranslationJsx`).
- Backend translation-API request metadata `context` (`gt.translate` / `EntryMetadata`).

## Testing

- `pnpm --filter gt-i18n test` → 244/244 passing.

A changeset (`gt-i18n` major) is included documenting the breaking removal.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/generaltranslation/codesmith/gt/pr/1687"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785348313&installation_id=127936663&pr_number=1687&repository=generaltranslation%2Fgt&return_to=https%3A%2F%2Fgithub.com%2Fgeneraltranslation%2Fgt%2Fpull%2F1687&signature=ec3064c77242644ba9591dbed52aea3eadf4e7bb487ad4ed311b65d1c215e3c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes two deprecated translation options from `gt-i18n` as part of the Odysseus major-version cleanup: the `context` dictionary key (replaced by `$context`) and the `$_locales` inline option (replaced by `$locale`). Comment and JSDoc updates in `next/tx.ts`, the SWC plugin, and `@generaltranslation/compiler` are also included to align documentation with the already-live `$`-prefixed API.

- **`context` removal**: `DictionaryOptions` no longer carries `context`; `resolveDictionaryLookupOptions` no longer maps `context → $context`; `isDictionaryOptions` no longer validates the `context` string field. JS callers that still pass `context:` after upgrading will have it leak as an unknown key (and potentially a template variable) rather than being silently dropped — a silent regression for un-migrated users, but intentional at a major version boundary.
- **`$_locales` removal**: Dropped from `InlineTranslationOptionsFields`, both interpolation fallbacks, and the `extractVariables` exclusion list. Any un-migrated JS caller passing `$_locales` will now have that key treated as a user-defined template variable instead of being ignored.
- All 244 tests pass; a major-version changeset is included.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for the Odysseus major version — all breaking removals are intentional and the test suite passes cleanly.

The changes are a straightforward deprecation removal with 244 passing tests. The one subtlety worth noting is that un-migrated JS callers passing the old `context:` key will now have that value leak through `resolveDictionaryLookupOptions` as part of `rest` rather than being explicitly stripped. This means `context` could surface as a template variable name in messages that happen to contain a `{context}` placeholder — a quiet behavioral change rather than a hard error. The same applies to `$_locales` no longer being excluded from `extractVariables`. Both are expected consequences of a major-version break, but neither has a dedicated migration-path test to document the new runtime behavior for un-migrated callers.

`packages/i18n/src/i18n-cache/translations-manager/utils/dictionary-helpers.ts` — the `resolveDictionaryLookupOptions` change silently changes how old `context:` keys are handled at runtime.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/i18n/src/i18n-cache/translations-manager/utils/dictionary-helpers.ts | Removes deprecated `context`→`$context` mapping in `resolveDictionaryLookupOptions` and the `context` string validation in `isDictionaryOptions`. Old JS callers passing `context:` will now have it leak into `rest` as an unknown key instead of being silently dropped or mapped. |
| packages/i18n/src/translation-functions/types/options.ts | Removes deprecated `context` from `DictionaryOptions` and `$_locales` from `InlineTranslationOptionsFields`. Clean type-level enforcement of the new API surface. |
| packages/i18n/src/utils/extractVariables.ts | Removes `$_locales` from the GT-reserved key exclusion list. Any caller (JS runtime) still passing `$_locales` will now have that key treated as a user template variable rather than silently dropped. |
| packages/i18n/src/translation-functions/utils/interpolation/interpolateIcuMessage.ts | Drops `$_locales` fallback from locale resolution — `options.$locale` is now the only locale source passed to the ICU formatter. |
| packages/next/src/server-dir/runtime/tx.ts | JSDoc corrected to the actual `TxOptions` shape (`$locale`, `$context`, `$maxChars`) and variable interpolation docs updated to reflect flat top-level key passing. No logic changes. |
| packages/compiler/src/state/StringCollector.ts | JSDoc comments updated to use `$id`/`$context`/`$maxChars` in examples — no logic change. |
| .changeset/remove-deprecated-context-locales-options.md | Major-version changeset for `gt-i18n` documenting both breaking removals clearly. |

</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Dictionary entry\n['Hello', options]"] --> B{isDictionaryOptions?}
    B -- "pass" --> C[resolveDictionaryLookupOptions]
    C --> D["Destructure: { $format, ...rest }"]
    D --> E["Return: { ...rest, $format: ICU }"]

    E --> F{context key present\nin old JS dict?}
    F -- "yes (un-migrated)" --> G["context leaks into rest\n→ treated as template variable"]
    F -- "no" --> H["Clean lookup options\n$context/$format/$maxChars"]

    I["Inline call: gt(msg, options)"] --> J[extractVariables]
    J --> K{$_locales in options?}
    K -- "yes (un-migrated)" --> L["Included as template variable\n(no longer filtered)"]
    K -- "no" --> M["Only user variables returned"]

    N["interpolateIcuMessage / interpolateStringMessage"] --> O["options.$locale\n(no $_locales fallback)"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["Dictionary entry\n['Hello', options]"] --> B{isDictionaryOptions?}
    B -- "pass" --> C[resolveDictionaryLookupOptions]
    C --> D["Destructure: { $format, ...rest }"]
    D --> E["Return: { ...rest, $format: ICU }"]

    E --> F{context key present\nin old JS dict?}
    F -- "yes (un-migrated)" --> G["context leaks into rest\n→ treated as template variable"]
    F -- "no" --> H["Clean lookup options\n$context/$format/$maxChars"]

    I["Inline call: gt(msg, options)"] --> J[extractVariables]
    J --> K{$_locales in options?}
    K -- "yes (un-migrated)" --> L["Included as template variable\n(no longer filtered)"]
    K -- "no" --> M["Only user variables returned"]

    N["interpolateIcuMessage / interpolateStringMessage"] --> O["options.$locale\n(no $_locales fallback)"]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/i18n/src/utils/extractVariables.ts`, line 14-24 ([link](https://github.com/generaltranslation/gt/blob/ffc7be81dd257454414f23decdb048dae185ab83/packages/i18n/src/utils/extractVariables.ts#L14-L24)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`$_locales` no longer filtered — becomes a live template variable**

   `$_locales` was previously excluded from `extractVariables` so it could never accidentally appear as an interpolation variable. After this removal, any un-migrated JS caller that still passes `$_locales` will have it treated as a user-defined placeholder. If the message string contains `{$_locales}` (unlikely but possible), it would be interpolated with the locale value instead of raising a missing-variable error. This is consistent with the broader deprecation removal, but unlike the `$locale` key (which remains excluded), there is no longer any guard that prevents the old key from leaking into rendered output.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/i18n/src/utils/extractVariables.ts
   Line: 14-24

   Comment:
   **`$_locales` no longer filtered — becomes a live template variable**

   `$_locales` was previously excluded from `extractVariables` so it could never accidentally appear as an interpolation variable. After this removal, any un-migrated JS caller that still passes `$_locales` will have it treated as a user-defined placeholder. If the message string contains `{$_locales}` (unlikely but possible), it would be interpolated with the locale value instead of raising a missing-variable error. This is consistent with the broader deprecation removal, but unlike the `$locale` key (which remains excluded), there is no longer any guard that prevents the old key from leaking into rendered output.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fi18n%2Fsrc%2Futils%2FextractVariables.ts%0ALine%3A%2014-24%0A%0AComment%3A%0A**%60%24_locales%60%20no%20longer%20filtered%20%E2%80%94%20becomes%20a%20live%20template%20variable**%0A%0A%60%24_locales%60%20was%20previously%20excluded%20from%20%60extractVariables%60%20so%20it%20could%20never%20accidentally%20appear%20as%20an%20interpolation%20variable.%20After%20this%20removal%2C%20any%20un-migrated%20JS%20caller%20that%20still%20passes%20%60%24_locales%60%20will%20have%20it%20treated%20as%20a%20user-defined%20placeholder.%20If%20the%20message%20string%20contains%20%60%7B%24_locales%7D%60%20%28unlikely%20but%20possible%29%2C%20it%20would%20be%20interpolated%20with%20the%20locale%20value%20instead%20of%20raising%20a%20missing-variable%20error.%20This%20is%20consistent%20with%20the%20broader%20deprecation%20removal%2C%20but%20unlike%20the%20%60%24locale%60%20key%20%28which%20remains%20excluded%29%2C%20there%20is%20no%20longer%20any%20guard%20that%20prevents%20the%20old%20key%20from%20leaking%20into%20rendered%20output.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=generaltranslation%2Fgt&pr=1687&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22refactor%2Fremove-deprecated-i18n-options%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22refactor%2Fremove-deprecated-i18n-options%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fi18n%2Fsrc%2Futils%2FextractVariables.ts%0ALine%3A%2014-24%0A%0AComment%3A%0A**%60%24_locales%60%20no%20longer%20filtered%20%E2%80%94%20becomes%20a%20live%20template%20variable**%0A%0A%60%24_locales%60%20was%20previously%20excluded%20from%20%60extractVariables%60%20so%20it%20could%20never%20accidentally%20appear%20as%20an%20interpolation%20variable.%20After%20this%20removal%2C%20any%20un-migrated%20JS%20caller%20that%20still%20passes%20%60%24_locales%60%20will%20have%20it%20treated%20as%20a%20user-defined%20placeholder.%20If%20the%20message%20string%20contains%20%60%7B%24_locales%7D%60%20%28unlikely%20but%20possible%29%2C%20it%20would%20be%20interpolated%20with%20the%20locale%20value%20instead%20of%20raising%20a%20missing-variable%20error.%20This%20is%20consistent%20with%20the%20broader%20deprecation%20removal%2C%20but%20unlike%20the%20%60%24locale%60%20key%20%28which%20remains%20excluded%29%2C%20there%20is%20no%20longer%20any%20guard%20that%20prevents%20the%20old%20key%20from%20leaking%20into%20rendered%20output.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=generaltranslation%2Fgt&pr=1687&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fi18n%2Fsrc%2Fi18n-cache%2Ftranslations-manager%2Futils%2Fdictionary-helpers.ts%3A116-124%0A**Old%20%60context%60%20key%20now%20leaks%20into%20lookup%20options**%0A%0APreviously%2C%20%60context%60%20was%20explicitly%20destructured%20out%20of%20%60options%60%20before%20the%20spread%2C%20so%20it%20was%20always%20stripped%20from%20the%20returned%20object.%20After%20this%20change%2C%20any%20object%20that%20still%20carries%20a%20%60context%60%20property%20%28e.g.%20a%20JS%20dictionary%20written%20before%20the%20migration%29%20will%20have%20%60context%60%20included%20in%20%60rest%60%20and%20therefore%20spread%20verbatim%20into%20the%20%60DictionaryLookupOptions%60%20result.%20Downstream%20consumers%20that%20treat%20unknown%20keys%20as%20template%20variables%20will%20then%20expose%20%60context%60%20as%20an%20interpolation%20variable%20%E2%80%94%20if%20the%20message%20contains%20%60%7Bcontext%7D%60%2C%20it%20would%20be%20silently%20filled%20with%20the%20old%20metadata%20string%20rather%20than%20surfacing%20an%20error.%20A%20one-liner%20%60const%20%7B%20%24format%2C%20context%3A%20_context%2C%20...rest%20%7D%20%3D%20options%3B%60%20would%20preserve%20the%20old%20strip-and-discard%20behavior%20without%20resurrecting%20the%20compatibility%20mapping.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fi18n%2Fsrc%2Futils%2FextractVariables.ts%3A14-24%0A**%60%24_locales%60%20no%20longer%20filtered%20%E2%80%94%20becomes%20a%20live%20template%20variable**%0A%0A%60%24_locales%60%20was%20previously%20excluded%20from%20%60extractVariables%60%20so%20it%20could%20never%20accidentally%20appear%20as%20an%20interpolation%20variable.%20After%20this%20removal%2C%20any%20un-migrated%20JS%20caller%20that%20still%20passes%20%60%24_locales%60%20will%20have%20it%20treated%20as%20a%20user-defined%20placeholder.%20If%20the%20message%20string%20contains%20%60%7B%24_locales%7D%60%20%28unlikely%20but%20possible%29%2C%20it%20would%20be%20interpolated%20with%20the%20locale%20value%20instead%20of%20raising%20a%20missing-variable%20error.%20This%20is%20consistent%20with%20the%20broader%20deprecation%20removal%2C%20but%20unlike%20the%20%60%24locale%60%20key%20%28which%20remains%20excluded%29%2C%20there%20is%20no%20longer%20any%20guard%20that%20prevents%20the%20old%20key%20from%20leaking%20into%20rendered%20output.%0A%0A&repo=generaltranslation%2Fgt&pr=1687&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22refactor%2Fremove-deprecated-i18n-options%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22refactor%2Fremove-deprecated-i18n-options%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fi18n%2Fsrc%2Fi18n-cache%2Ftranslations-manager%2Futils%2Fdictionary-helpers.ts%3A116-124%0A**Old%20%60context%60%20key%20now%20leaks%20into%20lookup%20options**%0A%0APreviously%2C%20%60context%60%20was%20explicitly%20destructured%20out%20of%20%60options%60%20before%20the%20spread%2C%20so%20it%20was%20always%20stripped%20from%20the%20returned%20object.%20After%20this%20change%2C%20any%20object%20that%20still%20carries%20a%20%60context%60%20property%20%28e.g.%20a%20JS%20dictionary%20written%20before%20the%20migration%29%20will%20have%20%60context%60%20included%20in%20%60rest%60%20and%20therefore%20spread%20verbatim%20into%20the%20%60DictionaryLookupOptions%60%20result.%20Downstream%20consumers%20that%20treat%20unknown%20keys%20as%20template%20variables%20will%20then%20expose%20%60context%60%20as%20an%20interpolation%20variable%20%E2%80%94%20if%20the%20message%20contains%20%60%7Bcontext%7D%60%2C%20it%20would%20be%20silently%20filled%20with%20the%20old%20metadata%20string%20rather%20than%20surfacing%20an%20error.%20A%20one-liner%20%60const%20%7B%20%24format%2C%20context%3A%20_context%2C%20...rest%20%7D%20%3D%20options%3B%60%20would%20preserve%20the%20old%20strip-and-discard%20behavior%20without%20resurrecting%20the%20compatibility%20mapping.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fi18n%2Fsrc%2Futils%2FextractVariables.ts%3A14-24%0A**%60%24_locales%60%20no%20longer%20filtered%20%E2%80%94%20becomes%20a%20live%20template%20variable**%0A%0A%60%24_locales%60%20was%20previously%20excluded%20from%20%60extractVariables%60%20so%20it%20could%20never%20accidentally%20appear%20as%20an%20interpolation%20variable.%20After%20this%20removal%2C%20any%20un-migrated%20JS%20caller%20that%20still%20passes%20%60%24_locales%60%20will%20have%20it%20treated%20as%20a%20user-defined%20placeholder.%20If%20the%20message%20string%20contains%20%60%7B%24_locales%7D%60%20%28unlikely%20but%20possible%29%2C%20it%20would%20be%20interpolated%20with%20the%20locale%20value%20instead%20of%20raising%20a%20missing-variable%20error.%20This%20is%20consistent%20with%20the%20broader%20deprecation%20removal%2C%20but%20unlike%20the%20%60%24locale%60%20key%20%28which%20remains%20excluded%29%2C%20there%20is%20no%20longer%20any%20guard%20that%20prevents%20the%20old%20key%20from%20leaking%20into%20rendered%20output.%0A%0A&repo=generaltranslation%2Fgt&pr=1687&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/i18n/src/i18n-cache/translations-manager/utils/dictionary-helpers.ts:116-124
**Old `context` key now leaks into lookup options**

Previously, `context` was explicitly destructured out of `options` before the spread, so it was always stripped from the returned object. After this change, any object that still carries a `context` property (e.g. a JS dictionary written before the migration) will have `context` included in `rest` and therefore spread verbatim into the `DictionaryLookupOptions` result. Downstream consumers that treat unknown keys as template variables will then expose `context` as an interpolation variable — if the message contains `{context}`, it would be silently filled with the old metadata string rather than surfacing an error. A one-liner `const { $format, context: _context, ...rest } = options;` would preserve the old strip-and-discard behavior without resurrecting the compatibility mapping.

### Issue 2 of 2
packages/i18n/src/utils/extractVariables.ts:14-24
**`$_locales` no longer filtered — becomes a live template variable**

`$_locales` was previously excluded from `extractVariables` so it could never accidentally appear as an interpolation variable. After this removal, any un-migrated JS caller that still passes `$_locales` will have it treated as a user-defined placeholder. If the message string contains `{$_locales}` (unlikely but possible), it would be interpolated with the locale value instead of raising a missing-variable error. This is consistent with the broader deprecation removal, but unlike the `$locale` key (which remains excluded), there is no longer any guard that prevents the old key from leaking into rendered output.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: format issue"](https://github.com/generaltranslation/gt/commit/ffc7be81dd257454414f23decdb048dae185ab83) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40596073)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->