### PR TITLE
perf(react-core): unbundle build output for tree-shaking

### DIFF
--- a/.changeset/react-core-unbundle.md
+++ b/.changeset/react-core-unbundle.md
@@ -1,0 +1,11 @@
+---
+"@generaltranslation/react-core": patch
+---
+
+Build `@generaltranslation/react-core` as unbundled, tree-shakeable modules.
+
+Each entrypoint (`pure`, `hooks`, `components`, `components-rsc`, `cookies`) was previously emitted as a single pre-bundled, minified file, so a consumer importing one component pulled the entire entry. The package now builds unbundled (per-module) output in both ESM and CJS: entrypoints are thin re-export barrels over granular sibling modules, allowing a downstream bundler to drop unused components and hooks.
+
+The build also stops inlining `generaltranslation`/`@generaltranslation/format` into react-core's output, so they resolve to their single shared copy instead of being duplicated in react-core (they are already loaded standalone). This removes the duplication and keeps the per-module declarations referencing the dependency packages directly, so inferred types stay portable for downstream packages.
+
+When consumed via ESM (see the companion `gt-next` ESM change), tree-shaking plus de-duplication cuts react-core's client footprint substantially. Output filenames change from `*.cjs.min.cjs`/`*.esm.min.mjs` to `*.cjs`/`*.mjs` (resolved through the `exports` map, so no consumer-facing API change). The package-shape test is updated to assert the new unbundled layout.

--- a/.size-limit.cjs
+++ b/.size-limit.cjs
@@ -29,7 +29,7 @@ const i18n = (name, file) =>
   entry(name, `packages/i18n/dist/${file}.mjs`, '35 kB');
 
 const reactCore = (name, file) =>
-  entry(name, `packages/react-core/dist/${file}.esm.min.mjs`, '48 kB', {
+  entry(name, `packages/react-core/dist/${file}.mjs`, '48 kB', {
     ignore: ['react'],
   });
 

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -49,28 +49,28 @@
   "exports": {
     "./pure": {
       "types": "./dist/pure.d.ts",
-      "require": "./dist/pure.cjs.min.cjs",
-      "import": "./dist/pure.esm.min.mjs"
+      "require": "./dist/pure.cjs",
+      "import": "./dist/pure.mjs"
     },
     "./hooks": {
       "types": "./dist/hooks.d.ts",
-      "require": "./dist/hooks.cjs.min.cjs",
-      "import": "./dist/hooks.esm.min.mjs"
+      "require": "./dist/hooks.cjs",
+      "import": "./dist/hooks.mjs"
     },
     "./components": {
       "types": "./dist/components.d.ts",
-      "require": "./dist/components.cjs.min.cjs",
-      "import": "./dist/components.esm.min.mjs"
+      "require": "./dist/components.cjs",
+      "import": "./dist/components.mjs"
     },
     "./components-rsc": {
       "types": "./dist/components-rsc.d.ts",
-      "require": "./dist/components-rsc.cjs.min.cjs",
-      "import": "./dist/components-rsc.esm.min.mjs"
+      "require": "./dist/components-rsc.cjs",
+      "import": "./dist/components-rsc.mjs"
     },
     "./cookies": {
       "types": "./dist/cookies.d.ts",
-      "require": "./dist/cookies.cjs.min.cjs",
-      "import": "./dist/cookies.esm.min.mjs"
+      "require": "./dist/cookies.cjs",
+      "import": "./dist/cookies.mjs"
     }
   },
   "typesVersions": {

--- a/packages/react-core/src/__tests__/react-core-package.test.ts
+++ b/packages/react-core/src/__tests__/react-core-package.test.ts
@@ -1,20 +1,8 @@
 import { execFileSync } from 'node:child_process';
-import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { existsSync, readdirSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import {
-  createSourceFile,
-  forEachChild,
-  isCallExpression,
-  isExportDeclaration,
-  isIdentifier,
-  isImportDeclaration,
-  isStringLiteralLike,
-  type Node,
-  ScriptKind,
-  ScriptTarget,
-} from 'typescript';
 import { beforeAll, describe, expect, it } from 'vitest';
 
 const packageRoot = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
@@ -25,31 +13,20 @@ const runtimeEntryNames = [
   'hooks',
   'pure',
 ];
-const runtimeArtifactNames = runtimeEntryNames
+// Each public entrypoint is emitted as a thin re-export barrel in both module
+// formats, plus its type declaration.
+const entryArtifacts = runtimeEntryNames
   .flatMap((entryName) => [
-    `${entryName}.cjs.min.cjs`,
-    `${entryName}.esm.min.mjs`,
-  ])
-  .sort();
-const builtArtifacts = runtimeEntryNames
-  .flatMap((entryName) => [
-    `${entryName}.cjs.min.cjs`,
-    `${entryName}.esm.min.mjs`,
+    `${entryName}.cjs`,
+    `${entryName}.mjs`,
     `${entryName}.d.ts`,
   ])
   .map((artifact) => join(packageRoot, 'dist', artifact));
-const workspaceSubpathPackages = [
-  '@generaltranslation/format',
-  '@generaltranslation/react-core',
-  'generaltranslation',
-  'gt-i18n',
-];
 
 function hasBuiltArtifacts(): boolean {
   return (
     existsSync(join(packageRoot, 'dist')) &&
-    builtArtifacts.every((artifact) => existsSync(artifact)) &&
-    getRuntimeArtifactNames().join('\0') === runtimeArtifactNames.join('\0')
+    entryArtifacts.every((artifact) => existsSync(artifact))
   );
 }
 
@@ -69,63 +46,10 @@ function node(args: string[]): void {
   execFileSync(process.execPath, args, { cwd: packageRoot, stdio: 'pipe' });
 }
 
-function getRuntimeArtifactNames(): string[] {
-  return readdirSync(join(packageRoot, 'dist'))
-    .filter((file) => /\.(cjs|mjs)$/.test(file))
-    .sort();
-}
-
-function isWorkspaceSubpath(specifier: string): boolean {
-  return workspaceSubpathPackages.some((packageName) =>
-    specifier.startsWith(`${packageName}/`)
-  );
-}
-
-function isAllowedExternalizedSubpath(
-  file: string,
-  specifier: string
-): boolean {
-  return (
-    runtimeEntryNames.some((entryName) => file.startsWith(`${entryName}.`)) &&
-    specifier.startsWith('gt-i18n/')
-  );
-}
-
-function getModuleSpecifiers(file: string): string[] {
-  const code = readFileSync(join(packageRoot, 'dist', file), 'utf8');
-  const sourceFile = createSourceFile(
-    file,
-    code,
-    ScriptTarget.Latest,
-    false,
-    ScriptKind.JS
-  );
-  const specifiers: string[] = [];
-
-  function visit(node: Node): void {
-    if (
-      (isImportDeclaration(node) || isExportDeclaration(node)) &&
-      node.moduleSpecifier &&
-      isStringLiteralLike(node.moduleSpecifier)
-    ) {
-      specifiers.push(node.moduleSpecifier.text);
-    }
-
-    if (
-      isCallExpression(node) &&
-      isIdentifier(node.expression) &&
-      node.expression.text === 'require' &&
-      node.arguments.length === 1 &&
-      isStringLiteralLike(node.arguments[0])
-    ) {
-      specifiers.push(node.arguments[0].text);
-    }
-
-    forEachChild(node, visit);
-  }
-
-  visit(sourceFile);
-  return specifiers;
+function getRuntimeModuleFiles(): string[] {
+  return readdirSync(join(packageRoot, 'dist'), { recursive: true })
+    .map((entry) => String(entry))
+    .filter((file) => /\.(cjs|mjs)$/.test(file) && !file.endsWith('.map'));
 }
 
 describe('@generaltranslation/react-core package exports', () => {
@@ -171,22 +95,21 @@ describe('@generaltranslation/react-core package exports', () => {
     ]);
   });
 
-  it('emits independent runtime entrypoints without shared chunks', () => {
-    expect(getRuntimeArtifactNames()).toEqual(runtimeArtifactNames);
+  it('emits each entrypoint as a barrel in both module formats', () => {
+    const runtimeFiles = getRuntimeModuleFiles();
+    for (const entryName of runtimeEntryNames) {
+      expect(runtimeFiles).toContain(`${entryName}.cjs`);
+      expect(runtimeFiles).toContain(`${entryName}.mjs`);
+    }
   });
 
-  it(
-    'bundles workspace subpath imports in runtime artifacts',
-    { timeout: 15000 },
-    () => {
-      const externalizedSubpaths = getRuntimeArtifactNames().flatMap((file) => {
-        return getModuleSpecifiers(file)
-          .filter(isWorkspaceSubpath)
-          .filter((specifier) => !isAllowedExternalizedSubpath(file, specifier))
-          .map((specifier) => `${file}: ${specifier}`);
-      });
-
-      expect(externalizedSubpaths).toEqual([]);
-    }
-  );
+  it('emits unbundled runtime modules so consumers can tree-shake', () => {
+    // The build is intentionally unbundled: entrypoints are thin re-export
+    // barrels and the implementation lives in granular sibling modules that
+    // can be shared and individually dropped by a downstream bundler. This is
+    // the opposite of the previous per-entry bundled artifacts, so the dist
+    // tree contains far more runtime modules than there are entrypoints.
+    const runtimeFiles = getRuntimeModuleFiles();
+    expect(runtimeFiles.length).toBeGreaterThan(runtimeEntryNames.length * 2);
+  });
 });

--- a/packages/react-core/tsdown.config.mts
+++ b/packages/react-core/tsdown.config.mts
@@ -1,36 +1,28 @@
 import { defineConfig } from 'tsdown';
-import { createTsdownMinifiedDualFormatConfig } from '../../tsdown.preset.mts';
+import { createTsdownUnbundleConfig } from '../../tsdown.preset.mts';
 
-const deps = {
-  neverBundle: [
-    /^react$/,
-    /^react\//,
-    /^@generaltranslation\/format$/,
-    /^@generaltranslation\/supported-locales$/,
-    /^generaltranslation$/,
-  ],
-  alwaysBundle: [
-    /^@generaltranslation\/format\//,
-    /^generaltranslation\//,
-    /^gt-i18n(?:\/.*)?$/,
-  ],
-};
+const entries = [
+  'src/pure.ts',
+  'src/hooks.ts',
+  'src/components.ts',
+  'src/components-rsc.ts',
+  'src/cookies.ts',
+];
 
-const contextDeps = {
-  neverBundle: [...deps.neverBundle, /^gt-i18n$/, /^gt-i18n\//],
-  alwaysBundle: [/^@generaltranslation\/format\//, /^generaltranslation\//],
-};
+const cjs = createTsdownUnbundleConfig({
+  format: 'cjs',
+  entry: entries,
+  outExtensions: () => ({ js: '.cjs', dts: '.d.ts' }),
+});
 
-export default defineConfig(
-  createTsdownMinifiedDualFormatConfig({
-    entries: [
-      'src/pure.ts',
-      'src/hooks.ts',
-      'src/components.ts',
-      'src/components-rsc.ts',
-      'src/cookies.ts',
-    ],
-    deps: contextDeps,
-    typeEntry: false,
-  })
-);
+const esm = createTsdownUnbundleConfig({
+  format: 'esm',
+  entry: entries,
+  clean: false,
+  outExtensions: () => ({ js: '.mjs', dts: '.d.ts' }),
+});
+
+export default defineConfig([
+  { ...cjs, minify: true, dts: true },
+  { ...esm, minify: true },
+]);


### PR DESCRIPTION
## Summary

Each `@generaltranslation/react-core` entrypoint (`pure`, `hooks`, `components`, `components-rsc`, `cookies`) was built as a **single pre-bundled, minified file**, so importing one component pulled the whole entry and a downstream bundler couldn't drop unused code.

This PR switches react-core to an **unbundled** build (per-module output, ESM + CJS): entrypoints become thin re-export barrels over granular sibling modules. Output filenames change from `*.cjs.min.cjs`/`*.esm.min.mjs` to `*.cjs`/`*.mjs`, resolved through the `exports` map — no consumer-facing API change.

## Measured impact

When react-core is consumed via ESM, this lets the bundler tree-shake the unused half of `pure`/`components`. react-core's **client** footprint (real Next.js app, `next experimental-analyze`):

| | react-core client raw | react-core client gz |
|---|---|---|
| bundled (before) | 158.2 kB | 49.1 kB |
| unbundled (after) | **82.0 kB** | **33.0 kB** |

> ⚠️ This reduction only materializes when react-core is resolved as **ESM**. CJS can't be tree-shaken, so on its own this PR barely moves gzip (it just de-duplicates raw text). It pays off layered on #1688 (`gt-next` ESM build); together the two cut gt's total client bundle ~40% gzip.

## Reviewer note — intentional architecture reversal

This reverses the previous "independent entrypoints **without shared chunks**" design. The `react-core-package.test.ts` guard that enforced per-entry bundling is rewritten to assert the new unbundled layout (entrypoints present in both formats; many granular runtime modules emitted). The two behavioral export-loading tests are unchanged. All 267 react-core tests pass.

## Validation

- `pnpm --filter @generaltranslation/react-core test` → 267 passing
- Full app build (this + #1688) compiles and runs; gt-react/gt-next consume the unbundled subpaths via the `exports` map with no changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR switches `@generaltranslation/react-core` from a per-entrypoint pre-bundled build to an unbundled (per-module) ESM + CJS output, enabling downstream bundlers to tree-shake unused components and hooks. The measured client footprint drops from 158 kB → 82 kB raw (49 kB → 33 kB gzip) when consumed as ESM.

- **Build config** (`tsdown.config.mts`): replaces `createTsdownMinifiedDualFormatConfig` with two `createTsdownUnbundleConfig` calls (CJS with `dts:true`, ESM with `clean:false`); `@generaltranslation/format` and `generaltranslation` subpath imports are intentionally externalized instead of inlined.
- **Package exports** (`package.json`): filename extensions updated from `*.cjs.min.cjs`/`*.esm.min.mjs` to `*.cjs`/`*.mjs`; `sideEffects: false` is already set, which is required for tree-shaking to work.
- **Tests**: TypeScript AST-based bundling assertion removed and replaced with a file-count heuristic asserting the unbundled layout; the two behavioral load tests (CJS and ESM named-export checks) are kept unchanged.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a pure build-output restructuring with no runtime logic changes and no public API surface modifications.

The only changes are to the build configuration, the exports map filename extensions, the size-limit path, and the test assertions. The two behavioral load tests that verify named exports from both CJS and ESM entrypoints are unchanged and confirmed passing (267 tests). The `sideEffects: false` flag that makes tree-shaking effective was already present. The dependency externalization (`@generaltranslation/format`, `generaltranslation` subpaths) is intentional and documented in the changeset, and both packages remain listed as `dependencies` in `package.json` so they are guaranteed to be installed.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react-core/tsdown.config.mts | Switches from createTsdownMinifiedDualFormatConfig to createTsdownUnbundleConfig; CJS gets dts:true, ESM gets clean:false; both get minify:true spread in. No alwaysBundle overrides needed since generaltranslation/format subpaths are now intentionally externalized. |
| packages/react-core/package.json | Exports map updated from *.cjs.min.cjs/esm.min.mjs to *.cjs/*.mjs; all five entrypoints updated consistently; no other consumer-facing changes. |
| packages/react-core/src/__tests__/react-core-package.test.ts | Test rewritten to assert unbundled layout: barrel presence in both formats plus a file-count check; TypeScript AST-based bundling check removed; two behavioral load tests are unchanged. |
| .size-limit.cjs | Path updated from *.esm.min.mjs to *.mjs to match new output extensions; 48 kB limit preserved. |
| .changeset/react-core-unbundle.md | New patch-level changeset describing the unbundled build, removed format sub-dependency inlining, and filename extension changes. |

</details>

<sub>Reviews (2): Last reviewed commit: ["perf(react-core): unbundle build output ..."](https://github.com/generaltranslation/gt/commit/c6441dfcd4a450749fce99f2b504586abd230465) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40606757)</sub>

<!-- /greptile_comment -->