### PR TITLE
ci: apply odysseus changelog config during version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -288,17 +288,11 @@ jobs:
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
-      - name: Configure Changesets for Odysseus
-        run: |
-          jq '.baseBranch = "odysseus" | .changelog = "@changesets/cli/changelog"' .changeset/config.json > .changeset/config.tmp.json
-          mv .changeset/config.tmp.json .changeset/config.json
-          git update-index --assume-unchanged .changeset/config.json
-
       - name: Create Odysseus Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1
         with:
-          version: pnpm run version-packages
+          version: bash scripts/version-packages-odysseus.sh
           publish: pnpm run release
           commit: '[ci] odysseus release'
           title: '[ci] odysseus release'

--- a/scripts/version-packages-odysseus.sh
+++ b/scripts/version-packages-odysseus.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+jq '.baseBranch = "odysseus" | .changelog = "@changesets/cli/changelog"' .changeset/config.json > .changeset/config.tmp.json
+mv .changeset/config.tmp.json .changeset/config.json
+git update-index --assume-unchanged .changeset/config.json
+
+pnpm run version-packages


### PR DESCRIPTION
## Summary
- Add `scripts/version-packages-odysseus.sh` for the Odysseus release action.
- The script rewrites `.changeset/config.json` to use `baseBranch: odysseus` and `@changesets/cli/changelog`, marks the config file assume-unchanged, then runs `pnpm run version-packages`.
- Configure `changesets/action` to call the script via `version: bash scripts/version-packages-odysseus.sh`, so the rewrite happens after the action resets the release branch.

## Testing
- `bash -n scripts/version-packages-odysseus.sh`
- `pnpm exec oxfmt --check .github/workflows/release.yml scripts/version-packages-odysseus.sh`
- In a temp worktree at this PR head, ran `bash scripts/version-packages-odysseus.sh`; it completed successfully, generated the expected release files, and `.changeset/config.json` had no diff.

## Notes
The previous workflow step did run, but `changesets/action` then performed `git reset --hard <headSha>` before invoking `version`, which discarded the config rewrite. The script is called from `version`, after that reset.