### PR TITLE
fix: skip Next.js static middleware routes

### DIFF
--- a/.changeset/cool-tips-sleep.md
+++ b/.changeset/cool-tips-sleep.md
@@ -1,0 +1,5 @@
+---
+'gt-next': patch
+---
+
+Skip Next.js static and file-like routes in locale routing middleware.

--- a/packages/next/src/middleware-dir/__tests__/middleware.edge.test.ts
+++ b/packages/next/src/middleware-dir/__tests__/middleware.edge.test.ts
@@ -242,6 +242,23 @@ describe('Middleware Integration Tests', () => {
       expect(res.headers.get(LOCALE_HEADER)).toBeNull();
       expect(res.cookies.get(ROUTING_COOKIE)).toBeUndefined();
     });
+
+    it.each(['/release-notes/v1.5', '/pricing/plan.pro', '/blog/2024.01.15'])(
+      '2.9: dotted app route %s → rewrite with locale',
+      (pathname) => {
+        setEnvConfig();
+        const middleware = createNextMiddleware({
+          prefixDefaultLocale: false,
+        });
+
+        const res = middleware(createRequest(pathname));
+
+        expect(getResponseType(res)).toBe('rewrite');
+        expect(getResponsePath(res)).toBe(`/en${pathname}`);
+        expect(res.headers.get(LOCALE_HEADER)).toBe('en');
+        expect(res.cookies.get(ROUTING_COOKIE)?.value).toBe('true');
+      }
+    );
   });
 
   // ================================================================

--- a/packages/next/src/middleware-dir/__tests__/middleware.edge.test.ts
+++ b/packages/next/src/middleware-dir/__tests__/middleware.edge.test.ts
@@ -223,6 +223,25 @@ describe('Middleware Integration Tests', () => {
       // Source map next() is bare — no locale header or routing cookie
       expect(res.headers.get(LOCALE_HEADER)).toBeNull();
     });
+
+    it.each([
+      '/llms.txt',
+      '/llms-full.txt',
+      '/favicon-light.ico',
+      '/apple-touch-icon.png',
+      '/apple-touch-icon-precomposed.png',
+      '/_next/image',
+      '/_next/static/chunks/app.js',
+    ])('2.8: Next.js static route %s → bare next()', (pathname) => {
+      setEnvConfig();
+      const middleware = createNextMiddleware();
+
+      const res = middleware(createRequest(pathname));
+
+      expect(getResponseType(res)).toBe('next');
+      expect(res.headers.get(LOCALE_HEADER)).toBeNull();
+      expect(res.cookies.get(ROUTING_COOKIE)).toBeUndefined();
+    });
   });
 
   // ================================================================

--- a/packages/next/src/middleware-dir/__tests__/middleware.edge.test.ts
+++ b/packages/next/src/middleware-dir/__tests__/middleware.edge.test.ts
@@ -224,6 +224,25 @@ describe('Middleware Integration Tests', () => {
       expect(res.headers.get(LOCALE_HEADER)).toBeNull();
     });
 
+    it('2.7.1: ignoreSourceMaps=false, /__nextjs_source-map/* → rewrite with locale', () => {
+      setEnvConfig();
+      const middleware = createNextMiddleware({
+        ignoreSourceMaps: false,
+        prefixDefaultLocale: false,
+      });
+
+      const res = middleware(
+        createRequest('/__nextjs_source-map/main.chunk.js')
+      );
+
+      expect(getResponseType(res)).toBe('rewrite');
+      expect(getResponsePath(res)).toBe(
+        '/en/__nextjs_source-map/main.chunk.js'
+      );
+      expect(res.headers.get(LOCALE_HEADER)).toBe('en');
+      expect(res.cookies.get(ROUTING_COOKIE)?.value).toBe('true');
+    });
+
     it.each([
       '/llms.txt',
       '/llms-full.txt',

--- a/packages/next/src/middleware-dir/createNextMiddleware.ts
+++ b/packages/next/src/middleware-dir/createNextMiddleware.ts
@@ -28,7 +28,16 @@ const NEXT_JS_INTERNAL_PATH = '/_next';
 const STATIC_FILE_PATH_REGEX =
   /\.(?:avif|css|eot|gif|gz|ico|jpe?g|js|json|map|mjs|otf|pdf|png|svg|tar|ttf|txt|wasm|webmanifest|webp|woff2?|xml|zip)$/i;
 
-function isNextJsPath(pathname: string): boolean {
+function isNextJsSourceMapPath(pathname: string): boolean {
+  return pathname.startsWith(NEXT_JS_SOURCE_MAP_PATH);
+}
+
+function shouldBypassNextJsPath(
+  pathname: string,
+  ignoreSourceMaps: boolean
+): boolean {
+  if (isNextJsSourceMapPath(pathname)) return ignoreSourceMaps;
+
   return (
     pathname === NEXT_JS_INTERNAL_PATH ||
     pathname.startsWith(`${NEXT_JS_INTERNAL_PATH}/`) ||
@@ -173,15 +182,7 @@ export function createNextMiddleware({
    * @returns {NextResponse} - The Next.js response, either continuing the request or redirecting to the localized URL.
    */
   function middleware(req: NextRequest) {
-    if (isNextJsPath(req.nextUrl.pathname)) {
-      return NextResponse.next();
-    }
-
-    // Ignore source maps
-    if (
-      ignoreSourceMaps &&
-      req.nextUrl.pathname.startsWith(NEXT_JS_SOURCE_MAP_PATH)
-    ) {
+    if (shouldBypassNextJsPath(req.nextUrl.pathname, ignoreSourceMaps)) {
       return NextResponse.next();
     }
 

--- a/packages/next/src/middleware-dir/createNextMiddleware.ts
+++ b/packages/next/src/middleware-dir/createNextMiddleware.ts
@@ -25,13 +25,14 @@ import type { HeadersAndCookies } from '../config-dir/props/withGTConfigProps';
 
 const NEXT_JS_SOURCE_MAP_PATH = '/__nextjs_source-map';
 const NEXT_JS_INTERNAL_PATH = '/_next';
-const FILE_PATH_REGEX = /(?:^|\/)[^/]+\.[^/]+$/;
+const STATIC_FILE_PATH_REGEX =
+  /\.(?:avif|css|eot|gif|gz|ico|jpe?g|js|json|map|mjs|otf|pdf|png|svg|tar|ttf|txt|wasm|webmanifest|webp|woff2?|xml|zip)$/i;
 
 function isNextJsPath(pathname: string): boolean {
   return (
     pathname === NEXT_JS_INTERNAL_PATH ||
     pathname.startsWith(`${NEXT_JS_INTERNAL_PATH}/`) ||
-    FILE_PATH_REGEX.test(pathname)
+    STATIC_FILE_PATH_REGEX.test(pathname)
   );
 }
 

--- a/packages/next/src/middleware-dir/createNextMiddleware.ts
+++ b/packages/next/src/middleware-dir/createNextMiddleware.ts
@@ -24,6 +24,16 @@ import type { CustomMapping } from '@generaltranslation/format/types';
 import type { HeadersAndCookies } from '../config-dir/props/withGTConfigProps';
 
 const NEXT_JS_SOURCE_MAP_PATH = '/__nextjs_source-map';
+const NEXT_JS_INTERNAL_PATH = '/_next';
+const FILE_PATH_REGEX = /(?:^|\/)[^/]+\.[^/]+$/;
+
+function isNextJsPath(pathname: string): boolean {
+  return (
+    pathname === NEXT_JS_INTERNAL_PATH ||
+    pathname.startsWith(`${NEXT_JS_INTERNAL_PATH}/`) ||
+    FILE_PATH_REGEX.test(pathname)
+  );
+}
 
 type MiddlewareEnvConfig = {
   customMapping?: CustomMapping;
@@ -162,6 +172,10 @@ export function createNextMiddleware({
    * @returns {NextResponse} - The Next.js response, either continuing the request or redirecting to the localized URL.
    */
   function middleware(req: NextRequest) {
+    if (isNextJsPath(req.nextUrl.pathname)) {
+      return NextResponse.next();
+    }
+
     // Ignore source maps
     if (
       ignoreSourceMaps &&


### PR DESCRIPTION
## Summary
- Bypass file-like static routes and Next.js internal paths before locale routing runs.
- Add middleware edge coverage for llms files, favicons, touch icons, and /_next paths.
- Add a patch changeset for gt-next.

## Testing
- pnpm --filter 'gt-next^...' build
- pnpm --filter gt-next exec vitest run src/middleware-dir/__tests__/middleware.edge.test.ts
- pnpm --filter gt-next test:js
- pnpm --filter gt-next typecheck
- pnpm format
- pnpm lint
- pnpm --filter gt-next build:no-swc-plugin

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors the source-map early-exit in `createNextMiddleware` into a unified `shouldBypassNextJsPath` helper that also skips `/_next/*` paths and any request whose pathname ends in a known static file extension, preventing unnecessary locale routing for assets.

- Replaces the old overly-broad dot-segment regex with a specific extension allowlist (`STATIC_FILE_PATH_REGEX`), so dotted app routes like `/release-notes/v1.5` are no longer incorrectly bypassed.
- Preserves the `ignoreSourceMaps` opt-in by checking `isNextJsSourceMapPath` before falling through to the extension regex, ensuring `/__nextjs_source-map/*.js` with `ignoreSourceMaps: false` still receives locale processing.
- Adds three new test groups (2.7.1, 2.8, 2.9) covering the `ignoreSourceMaps=false` edge case, new static-bypass paths, and dotted app-route regression.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change narrows the bypass surface compared to previous behavior and the new test suite validates all the edge cases introduced.

The refactoring is logically sound: the isNextJsSourceMapPath early return correctly takes priority over the extension regex, so ignoreSourceMaps: false still works for .js-suffixed source-map URLs. The extension allowlist in STATIC_FILE_PATH_REGEX is specific and avoids the previous overly-broad dot-segment match. The new tests (2.7.1, 2.8, 2.9) directly cover the key scenarios, including the regression case for dotted app routes that must not be bypassed.

No files require special attention.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .changeset/cool-tips-sleep.md | Adds a patch changeset entry for gt-next describing the new static/file-like route bypass in locale middleware. |
| packages/next/src/middleware-dir/createNextMiddleware.ts | Refactors the source-map early-return into a broader shouldBypassNextJsPath helper that also skips /_next/* paths and any URL ending in a known static file extension. The priority ordering (source-map checked first) correctly preserves the ignoreSourceMaps=false opt-in path. |
| packages/next/src/middleware-dir/__tests__/middleware.edge.test.ts | Adds three new test groups: the ignoreSourceMaps=false edge case for .js-suffixed source-map URLs (2.7.1), bare-next() assertions for the new static-bypass paths (2.8), and regression tests confirming that dotted-segment app routes still receive locale rewrites (2.9). |

</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Incoming Request] --> B{isNextJsSourceMapPath?}
    B -->|yes| C{ignoreSourceMaps?}
    C -->|true| D[Return bare NextResponse.next]
    C -->|false| E[Continue to locale routing]
    B -->|no| F{pathname starts with /_next?}
    F -->|yes| D
    F -->|no| G{STATIC_FILE_PATH_REGEX matches?}
    G -->|yes| D
    G -->|no| E
    E --> H[Locale detection and routing]
    H --> I[Rewrite / Redirect / Next with locale headers]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Incoming Request] --> B{isNextJsSourceMapPath?}
    B -->|yes| C{ignoreSourceMaps?}
    C -->|true| D[Return bare NextResponse.next]
    C -->|false| E[Continue to locale routing]
    B -->|no| F{pathname starts with /_next?}
    F -->|yes| D
    F -->|no| G{STATIC_FILE_PATH_REGEX matches?}
    G -->|yes| D
    G -->|no| E
    E --> H[Locale detection and routing]
    H --> I[Rewrite / Redirect / Next with locale headers]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/next/src/middleware-dir/createNextMiddleware.ts`, line 175-184 ([link](https://github.com/generaltranslation/gt/blob/b71321e77da918adc9d4bb5b0af5b4a994622fc9/packages/next/src/middleware-dir/createNextMiddleware.ts#L175-L184)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`isNextJsPath` supersedes the `ignoreSourceMaps` option for file-extension source-map URLs**

   `isNextJsPath` is evaluated before the `ignoreSourceMaps` guard. Any source-map path that carries a file extension — e.g. `/__nextjs_source-map/main.chunk.js` — will match `FILE_PATH_REGEX` and return a bare `NextResponse.next()` regardless of `ignoreSourceMaps`. A developer who explicitly passes `ignoreSourceMaps: false` to let those requests flow into normal locale processing will silently get the same short-circuit as with `ignoreSourceMaps: true`. Consider placing the `isNextJsPath` guard after the `ignoreSourceMaps` check, or excluding the `/__nextjs_source-map` prefix from `isNextJsPath`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/next/src/middleware-dir/createNextMiddleware.ts
   Line: 175-184

   Comment:
   **`isNextJsPath` supersedes the `ignoreSourceMaps` option for file-extension source-map URLs**

   `isNextJsPath` is evaluated before the `ignoreSourceMaps` guard. Any source-map path that carries a file extension — e.g. `/__nextjs_source-map/main.chunk.js` — will match `FILE_PATH_REGEX` and return a bare `NextResponse.next()` regardless of `ignoreSourceMaps`. A developer who explicitly passes `ignoreSourceMaps: false` to let those requests flow into normal locale processing will silently get the same short-circuit as with `ignoreSourceMaps: true`. Consider placing the `isNextJsPath` guard after the `ignoreSourceMaps` check, or excluding the `/__nextjs_source-map` prefix from `isNextJsPath`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fnext%2Fsrc%2Fmiddleware-dir%2FcreateNextMiddleware.ts%0ALine%3A%20175-184%0A%0AComment%3A%0A**%60isNextJsPath%60%20supersedes%20the%20%60ignoreSourceMaps%60%20option%20for%20file-extension%20source-map%20URLs**%0A%0A%60isNextJsPath%60%20is%20evaluated%20before%20the%20%60ignoreSourceMaps%60%20guard.%20Any%20source-map%20path%20that%20carries%20a%20file%20extension%20%E2%80%94%20e.g.%20%60%2F__nextjs_source-map%2Fmain.chunk.js%60%20%E2%80%94%20will%20match%20%60FILE_PATH_REGEX%60%20and%20return%20a%20bare%20%60NextResponse.next%28%29%60%20regardless%20of%20%60ignoreSourceMaps%60.%20A%20developer%20who%20explicitly%20passes%20%60ignoreSourceMaps%3A%20false%60%20to%20let%20those%20requests%20flow%20into%20normal%20locale%20processing%20will%20silently%20get%20the%20same%20short-circuit%20as%20with%20%60ignoreSourceMaps%3A%20true%60.%20Consider%20placing%20the%20%60isNextJsPath%60%20guard%20after%20the%20%60ignoreSourceMaps%60%20check%2C%20or%20excluding%20the%20%60%2F__nextjs_source-map%60%20prefix%20from%20%60isNextJsPath%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=generaltranslation%2Fgt&pr=1695&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fnext%2Fexclude-nextjs-endpoints%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fnext%2Fexclude-nextjs-endpoints%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fnext%2Fsrc%2Fmiddleware-dir%2FcreateNextMiddleware.ts%0ALine%3A%20175-184%0A%0AComment%3A%0A**%60isNextJsPath%60%20supersedes%20the%20%60ignoreSourceMaps%60%20option%20for%20file-extension%20source-map%20URLs**%0A%0A%60isNextJsPath%60%20is%20evaluated%20before%20the%20%60ignoreSourceMaps%60%20guard.%20Any%20source-map%20path%20that%20carries%20a%20file%20extension%20%E2%80%94%20e.g.%20%60%2F__nextjs_source-map%2Fmain.chunk.js%60%20%E2%80%94%20will%20match%20%60FILE_PATH_REGEX%60%20and%20return%20a%20bare%20%60NextResponse.next%28%29%60%20regardless%20of%20%60ignoreSourceMaps%60.%20A%20developer%20who%20explicitly%20passes%20%60ignoreSourceMaps%3A%20false%60%20to%20let%20those%20requests%20flow%20into%20normal%20locale%20processing%20will%20silently%20get%20the%20same%20short-circuit%20as%20with%20%60ignoreSourceMaps%3A%20true%60.%20Consider%20placing%20the%20%60isNextJsPath%60%20guard%20after%20the%20%60ignoreSourceMaps%60%20check%2C%20or%20excluding%20the%20%60%2F__nextjs_source-map%60%20prefix%20from%20%60isNextJsPath%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=generaltranslation%2Fgt&pr=1695&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["fix: preserve source map routing option"](https://github.com/generaltranslation/gt/commit/37e3327efb1e8b9ce71d60465a4642445dcf9cf1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40680276)</sub>

<!-- /greptile_comment -->