### PR TITLE
fix: key translations by content hash

### DIFF
--- a/packages/cli/src/cli/inline.ts
+++ b/packages/cli/src/cli/inline.ts
@@ -121,10 +121,8 @@ export class InlineCLI extends BaseCLI {
     const newData: Record<string, unknown> = {};
     for (const update of updates) {
       const { source, metadata } = update;
-      const { hash, id } = metadata;
-      if (id) {
-        newData[id] = source;
-      } else if (hash) {
+      const { hash } = metadata;
+      if (hash) {
         newData[hash] = source;
       }
     }

--- a/packages/cli/src/extraction/__tests__/postProcess.test.ts
+++ b/packages/cli/src/extraction/__tests__/postProcess.test.ts
@@ -32,6 +32,17 @@ describe('calculateHashes', () => {
 
     expect(updates[0].metadata.hash).not.toBe(updates[1].metadata.hash);
   });
+
+  it('does not include custom id in calculated hashes', async () => {
+    const updates: Updates = [
+      { dataFormat: 'ICU', source: 'hello', metadata: { id: 'first' } },
+      { dataFormat: 'ICU', source: 'hello', metadata: { id: 'second' } },
+    ];
+
+    await calculateHashes(updates);
+
+    expect(updates[0].metadata.hash).toBe(updates[1].metadata.hash);
+  });
 });
 
 describe('dedupeUpdates', () => {

--- a/packages/cli/src/extraction/postProcess.ts
+++ b/packages/cli/src/extraction/postProcess.ts
@@ -11,7 +11,6 @@ export async function calculateHashes(updates: Updates): Promise<void> {
       const hash = hashSource({
         source: update.source,
         ...(update.metadata.context && { context: update.metadata.context }),
-        ...(update.metadata.id && { id: update.metadata.id }),
         ...(update.metadata.maxChars != null && {
           maxChars: update.metadata.maxChars,
         }),

--- a/packages/cli/src/formats/files/__tests__/collectFiles.test.ts
+++ b/packages/cli/src/formats/files/__tests__/collectFiles.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { collectFiles } from '../collectFiles.js';
+import { aggregateInlineTranslations } from '../../../translation/stage.js';
+import type { Settings, TranslateFlags } from '../../../types/index.js';
+import { Libraries } from '../../../types/libraries.js';
+
+vi.mock('../aggregateFiles.js', () => ({
+  aggregateFiles: vi.fn(async () => ({
+    files: [],
+    publishMap: new Map<string, boolean>(),
+  })),
+}));
+
+vi.mock('../../../translation/stage.js', () => ({
+  aggregateInlineTranslations: vi.fn(),
+}));
+
+vi.mock('../../../utils/hash.js', () => ({
+  hashStringSync: vi.fn((value: string) => `hash_${value}`),
+}));
+
+vi.mock('../../../console/logging.js', () => ({
+  logErrorAndExit: vi.fn(),
+}));
+
+const settings = {
+  defaultLocale: 'en',
+  publish: true,
+  files: {
+    resolvedPaths: {},
+    placeholderPaths: {},
+    transformPaths: {},
+    transformFormats: {},
+    publishPaths: new Set<string>(),
+    unpublishPaths: new Set<string>(),
+    parsingFlags: {},
+    gtJson: {
+      parsingFlags: {},
+    },
+  },
+} as Settings;
+
+const options = {} as TranslateFlags;
+
+describe('collectFiles', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('keys inline GTJSON entries by hash while preserving custom id metadata', async () => {
+    vi.mocked(aggregateInlineTranslations).mockResolvedValue([
+      {
+        dataFormat: 'ICU',
+        source: 'Hello',
+        metadata: {
+          id: 'custom-id',
+          hash: 'content-hash',
+        },
+      },
+    ]);
+
+    const { files } = await collectFiles(options, settings, Libraries.GT_REACT);
+
+    expect(files).toHaveLength(1);
+    expect(JSON.parse(files[0].content)).toEqual({
+      'content-hash': 'Hello',
+    });
+    expect(files[0].formatMetadata).toEqual({
+      'content-hash': {
+        id: 'custom-id',
+        hash: 'content-hash',
+        dataFormat: 'ICU',
+      },
+    });
+  });
+});

--- a/packages/cli/src/formats/files/collectFiles.ts
+++ b/packages/cli/src/formats/files/collectFiles.ts
@@ -45,11 +45,8 @@ export async function collectFiles(
       for (const update of updates) {
         const { source, metadata, dataFormat } = update;
         metadata.dataFormat = dataFormat; // add the data format to the metadata
-        const { hash, id } = metadata;
-        if (id) {
-          fileData[id] = source;
-          fileMetadata[id] = metadata;
-        } else if (hash) {
+        const { hash } = metadata;
+        if (hash) {
           fileData[hash] = source;
           fileMetadata[hash] = metadata;
         }

--- a/packages/cli/src/react/jsx/utils/jsxParsing/__tests__/parseJsx.test.ts
+++ b/packages/cli/src/react/jsx/utils/jsxParsing/__tests__/parseJsx.test.ts
@@ -193,7 +193,6 @@ describe('parseTranslationComponent with cross-file resolution', () => {
       const hash = hashSource({
         source: update.source,
         ...(context && { context }),
-        ...(update.metadata.id && { id: update.metadata.id }),
         dataFormat: update.dataFormat,
       });
       return { hash, source: update.source };
@@ -1240,7 +1239,6 @@ describe('parseTranslationComponent with cross-file resolution', () => {
       const hash = hashSource({
         source: update.source,
         ...(context && { context }),
-        ...(update.metadata.id && { id: update.metadata.id }),
         dataFormat: update.dataFormat,
       });
       return { hash, source: update.source };

--- a/packages/cli/src/react/parse/__tests__/createInlineUpdates.test.ts
+++ b/packages/cli/src/react/parse/__tests__/createInlineUpdates.test.ts
@@ -97,7 +97,6 @@ async function createTest(dirPath: string) {
           const expectedHash = hashSource({
             source: update.source,
             ...(context && { context }),
-            ...(update.metadata.id && { id: update.metadata.id }),
             ...(update.metadata.maxChars && {
               maxChars: update.metadata.maxChars,
             }),

--- a/packages/cli/src/react/parse/createDictionaryUpdates.ts
+++ b/packages/cli/src/react/parse/createDictionaryUpdates.ts
@@ -103,7 +103,6 @@ export async function createDictionaryUpdates(
       hash: hashSource({
         source: entry,
         ...(context && { context }),
-        ...(id && { id }),
         ...(maxChars != null && { maxChars: Math.abs(maxChars) }),
         dataFormat: 'ICU',
       }),

--- a/packages/cli/src/translation/__tests__/parse.test.ts
+++ b/packages/cli/src/translation/__tests__/parse.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createUpdates } from '../parse.js';
+import { createInlineUpdates } from '../../react/parse/createInlineUpdates.js';
+import { Libraries } from '../../types/libraries.js';
+import type { ParsingConfigOptions } from '../../types/parsing.js';
+import type { TranslateFlags } from '../../types/index.js';
+
+vi.mock('../../react/parse/createInlineUpdates.js', () => ({
+  createInlineUpdates: vi.fn(),
+}));
+
+vi.mock('../../python/parse/createPythonInlineUpdates.js', () => ({
+  createPythonInlineUpdates: vi.fn(),
+}));
+
+describe('createUpdates', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not reject duplicate custom ids when entries have distinct hashes', async () => {
+    vi.mocked(createInlineUpdates).mockResolvedValue({
+      updates: [
+        {
+          dataFormat: 'ICU',
+          source: 'Hello',
+          metadata: { id: 'shared-id', hash: 'first-hash' },
+        },
+        {
+          dataFormat: 'ICU',
+          source: 'Goodbye',
+          metadata: { id: 'shared-id', hash: 'second-hash' },
+        },
+      ],
+      errors: [],
+      warnings: [],
+    });
+
+    const result = await createUpdates(
+      {} as TranslateFlags,
+      [],
+      undefined,
+      Libraries.GT_REACT,
+      false,
+      {},
+      {} as ParsingConfigOptions
+    );
+
+    expect(result.errors).toEqual([]);
+    expect(result.updates).toHaveLength(2);
+    expect(result.updates.map((update) => update.metadata.hash)).toEqual([
+      'first-hash',
+      'second-hash',
+    ]);
+  });
+});

--- a/packages/cli/src/translation/__tests__/parse.test.ts
+++ b/packages/cli/src/translation/__tests__/parse.test.ts
@@ -18,7 +18,7 @@ describe('createUpdates', () => {
     vi.clearAllMocks();
   });
 
-  it('does not reject duplicate custom ids when entries have distinct hashes', async () => {
+  it('rejects duplicate custom ids when entries have distinct hashes', async () => {
     vi.mocked(createInlineUpdates).mockResolvedValue({
       updates: [
         {
@@ -46,11 +46,45 @@ describe('createUpdates', () => {
       {} as ParsingConfigOptions
     );
 
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain('same id');
+    expect(result.errors[0]).toContain('shared-id');
+    expect(result.updates).toEqual([]);
+  });
+
+  it('allows duplicate custom ids when entries have matching hashes', async () => {
+    vi.mocked(createInlineUpdates).mockResolvedValue({
+      updates: [
+        {
+          dataFormat: 'ICU',
+          source: 'Hello',
+          metadata: { id: 'shared-id', hash: 'same-hash' },
+        },
+        {
+          dataFormat: 'ICU',
+          source: 'Hello',
+          metadata: { id: 'shared-id', hash: 'same-hash' },
+        },
+      ],
+      errors: [],
+      warnings: [],
+    });
+
+    const result = await createUpdates(
+      {} as TranslateFlags,
+      [],
+      undefined,
+      Libraries.GT_REACT,
+      false,
+      {},
+      {} as ParsingConfigOptions
+    );
+
     expect(result.errors).toEqual([]);
     expect(result.updates).toHaveLength(2);
-    expect(result.updates.map((update) => update.metadata.hash)).toEqual([
-      'first-hash',
-      'second-hash',
+    expect(result.updates.map((update) => update.metadata.id)).toEqual([
+      'shared-id',
+      'shared-id',
     ]);
   });
 });

--- a/packages/cli/src/translation/parse.ts
+++ b/packages/cli/src/translation/parse.ts
@@ -6,6 +6,7 @@ import { createDictionaryUpdates } from '../react/parse/createDictionaryUpdates.
 import { createInlineUpdates } from '../react/parse/createInlineUpdates.js';
 import { createPythonInlineUpdates } from '../python/parse/createPythonInlineUpdates.js';
 import createESBuildConfig from '../react/config/createESBuildConfig.js';
+import chalk from 'chalk';
 import type { ParsingConfigOptions, GTParsingFlags } from '../types/parsing.js';
 import { exitSync } from '../console/logging.js';
 import { InlineLibrary, isPythonLibrary } from '../types/libraries.js';
@@ -86,6 +87,59 @@ export async function createUpdates(
   errors = [...errors, ...newErrors];
   warnings = [...warnings, ...newWarnings];
   updates = [...updates, ...newUpdates];
+
+  // Validate user-supplied IDs without using them as translation lookup keys.
+  const idHashMap = new Map<string, string>();
+  const hashlessIds = new Set<string>();
+  const warnedHashlessDuplicateIds = new Set<string>();
+  const duplicateIds = new Set<string>();
+
+  const warnHashlessDuplicateId = (id: string) => {
+    if (warnedHashlessDuplicateIds.has(id)) return;
+    warnings.push(
+      `Duplicate id ${chalk.blue(
+        id
+      )} includes at least one entry without a hash. Hashless duplicate IDs cannot be compared, and later entries may overwrite earlier entries.`
+    );
+    warnedHashlessDuplicateIds.add(id);
+  };
+
+  updates = updates.map((update) => {
+    const { id, hash } = update.metadata;
+    if (!id) return update;
+    if (!hash) {
+      if (hashlessIds.has(id) || idHashMap.has(id)) {
+        warnHashlessDuplicateId(id);
+      }
+      hashlessIds.add(id);
+      return update;
+    }
+
+    if (hashlessIds.has(id)) {
+      warnHashlessDuplicateId(id);
+    }
+
+    const existingHash = idHashMap.get(id);
+    if (existingHash !== undefined) {
+      if (existingHash !== hash) {
+        errors.push(
+          `Hashes don't match on two components with the same id: ${chalk.blue(
+            id
+          )}. Check your ${chalk.green(
+            '<T>'
+          )} tags and dictionary entries and make sure you're not accidentally duplicating IDs.`
+        );
+        duplicateIds.add(id);
+      }
+    } else {
+      idHashMap.set(id, hash);
+    }
+    return update;
+  });
+
+  updates = updates.filter(
+    (update) => !update.metadata.id || !duplicateIds.has(update.metadata.id)
+  );
 
   return { updates, errors, warnings };
 }

--- a/packages/cli/src/translation/parse.ts
+++ b/packages/cli/src/translation/parse.ts
@@ -6,7 +6,6 @@ import { createDictionaryUpdates } from '../react/parse/createDictionaryUpdates.
 import { createInlineUpdates } from '../react/parse/createInlineUpdates.js';
 import { createPythonInlineUpdates } from '../python/parse/createPythonInlineUpdates.js';
 import createESBuildConfig from '../react/config/createESBuildConfig.js';
-import chalk from 'chalk';
 import type { ParsingConfigOptions, GTParsingFlags } from '../types/parsing.js';
 import { exitSync } from '../console/logging.js';
 import { InlineLibrary, isPythonLibrary } from '../types/libraries.js';
@@ -88,58 +87,5 @@ export async function createUpdates(
   warnings = [...warnings, ...newWarnings];
   updates = [...updates, ...newUpdates];
 
-  // Metadata addition and validation
-  const idHashMap = new Map<string, string>();
-  const hashlessIds = new Set<string>();
-  const warnedHashlessDuplicateIds = new Set<string>();
-  const duplicateIds = new Set<string>();
-
-  const warnHashlessDuplicateId = (id: string) => {
-    if (warnedHashlessDuplicateIds.has(id)) return;
-    warnings.push(
-      `Duplicate id ${chalk.blue(
-        id
-      )} includes at least one entry without a hash. Hashless duplicate IDs cannot be compared, and later entries may overwrite earlier entries.`
-    );
-    warnedHashlessDuplicateIds.add(id);
-  };
-
-  updates = updates.map((update) => {
-    const { id, hash } = update.metadata;
-    if (!id) return update;
-    if (!hash) {
-      if (hashlessIds.has(id) || idHashMap.has(id)) {
-        warnHashlessDuplicateId(id);
-      }
-      hashlessIds.add(id);
-      return update;
-    }
-
-    if (hashlessIds.has(id)) {
-      warnHashlessDuplicateId(id);
-    }
-
-    const existingHash = idHashMap.get(id);
-    if (existingHash !== undefined) {
-      if (existingHash !== hash) {
-        errors.push(
-          `Hashes don't match on two components with the same id: ${chalk.blue(
-            id
-          )}. Check your ${chalk.green(
-            '<T>'
-          )} tags and dictionary entries and make sure you're not accidentally duplicating IDs.`
-        );
-        duplicateIds.add(id);
-      }
-    } else {
-      idHashMap.set(id, hash);
-    }
-    return update;
-  });
-
-  // Filter out updates with duplicate IDs
-  updates = updates.filter(
-    (update) => !update.metadata.id || !duplicateIds.has(update.metadata.id)
-  );
   return { updates, errors, warnings };
 }

--- a/packages/compiler/src/processing/collection/processCallExpression.ts
+++ b/packages/compiler/src/processing/collection/processCallExpression.ts
@@ -278,7 +278,6 @@ function handleReactInvocation(
       hashSource({
         source: children!,
         ...(context && { context }),
-        ...(id && { id }),
         ...(maxChars != null && { maxChars }),
         dataFormat: 'JSX',
       });

--- a/packages/compiler/src/transform/registration/callbacks/registerUseGTCallback.ts
+++ b/packages/compiler/src/transform/registration/callbacks/registerUseGTCallback.ts
@@ -28,7 +28,6 @@ export function registerUseGTCallback({
   // Calculate hash for the call expression (skip if already set, including empty string for derive context)
   hash ??= hashSource({
     source: content,
-    id,
     context,
     maxChars,
     dataFormat: (format || 'ICU') as DataFormat,

--- a/packages/compiler/src/transform/registration/registerStandaloneTranslation.ts
+++ b/packages/compiler/src/transform/registration/registerStandaloneTranslation.ts
@@ -26,7 +26,6 @@ export function registerStandaloneTranslation({
 }): void {
   hash ??= hashSource({
     source: content,
-    ...(id && { id }),
     ...(context && { context }),
     ...(maxChars != null && { maxChars }),
     dataFormat: (format || 'ICU') as DataFormat,

--- a/packages/compiler/src/utils/__tests__/calculateHash.test.ts
+++ b/packages/compiler/src/utils/__tests__/calculateHash.test.ts
@@ -21,7 +21,6 @@ describe('calculateHash', () => {
       const params = {
         source: 'Hello world',
         context: 'greeting',
-        id: 'test-id',
         dataFormat: 'ICU' as DataFormat,
       };
 
@@ -39,7 +38,6 @@ describe('calculateHash', () => {
       const params = {
         source: 'Hello world',
         context: 'greeting',
-        id: 'test-id',
         dataFormat: 'I18NEXT' as DataFormat,
       };
 

--- a/packages/compiler/src/utils/__tests__/calculateHash.test.ts
+++ b/packages/compiler/src/utils/__tests__/calculateHash.test.ts
@@ -17,7 +17,7 @@ describe('calculateHash', () => {
   });
 
   describe('ICU and I18NEXT data formats', () => {
-    it('should delegate to original hashSource for ICU format', () => {
+    it('should delegate to original hashSource without id for ICU format', () => {
       const params = {
         source: 'Hello world',
         context: 'greeting',
@@ -27,11 +27,15 @@ describe('calculateHash', () => {
 
       const result = hashSource(params);
 
-      expect(mockHashSource).toHaveBeenCalledWith(params);
+      expect(mockHashSource).toHaveBeenCalledWith({
+        source: 'Hello world',
+        context: 'greeting',
+        dataFormat: 'ICU',
+      });
       expect(result).toBe('mocked-hash-ICU');
     });
 
-    it('should delegate to original hashSource for I18NEXT format', () => {
+    it('should delegate to original hashSource without id for I18NEXT format', () => {
       const params = {
         source: 'Hello world',
         context: 'greeting',
@@ -41,7 +45,11 @@ describe('calculateHash', () => {
 
       const result = hashSource(params);
 
-      expect(mockHashSource).toHaveBeenCalledWith(params);
+      expect(mockHashSource).toHaveBeenCalledWith({
+        source: 'Hello world',
+        context: 'greeting',
+        dataFormat: 'I18NEXT',
+      });
       expect(result).toBe('mocked-hash-I18NEXT');
     });
   });

--- a/packages/compiler/src/utils/calculateHash.ts
+++ b/packages/compiler/src/utils/calculateHash.ts
@@ -14,7 +14,6 @@ import { hashSource as _hashSource } from 'generaltranslation/id';
 export default function hashSource({
   source,
   context,
-  id,
   maxChars,
   dataFormat,
 }: {
@@ -24,15 +23,15 @@ export default function hashSource({
   maxChars?: number;
   dataFormat: DataFormat;
 }): string {
-  // No change needed for ICU or I18NEXT
+  // Delegate to the shared hasher without custom ids; ids are metadata only.
   if (dataFormat === 'ICU' || dataFormat === 'I18NEXT') {
-    return _hashSource({ source, context, id, maxChars, dataFormat });
+    return _hashSource({ source, context, maxChars, dataFormat });
   }
   // For Jsx, we set hash to empty string if it contains a static component
   if (containsStatic(source)) {
     return '';
   }
-  return _hashSource({ source, context, id, maxChars, dataFormat });
+  return _hashSource({ source, context, maxChars, dataFormat });
 }
 
 /* =============================================== */

--- a/packages/compiler/src/utils/calculateHash.ts
+++ b/packages/compiler/src/utils/calculateHash.ts
@@ -19,7 +19,6 @@ export default function hashSource({
 }: {
   source: JsxChildren | string;
   context?: string;
-  id?: string;
   maxChars?: number;
   dataFormat: DataFormat;
 }): string {

--- a/packages/core/src/translate/__tests__/translateMany.test.ts
+++ b/packages/core/src/translate/__tests__/translateMany.test.ts
@@ -115,6 +115,62 @@ describe.sequential('_translateMany', () => {
     expect(Array.isArray(result)).toBe(true);
   });
 
+  it('uses content hash keys while preserving custom id metadata', async () => {
+    vi.mocked(apiRequest).mockResolvedValue({});
+
+    const requests: TranslateManyEntry[] = [
+      {
+        source: 'Hello',
+        metadata: { id: 'custom-id', dataFormat: 'ICU' },
+      },
+    ];
+    const globalMetadata: {
+      targetLocale: string;
+      sourceLocale: string;
+    } & SharedMetadata = {
+      targetLocale: 'es',
+      sourceLocale: 'en',
+    };
+
+    await _translateMany(requests, globalMetadata, mockConfig);
+
+    const body = vi.mocked(apiRequest).mock.calls[0][2].body as {
+      requests: Record<
+        string,
+        { source: string; metadata?: { id?: string; hash?: string } }
+      >;
+    };
+    const key = Object.keys(body.requests)[0];
+    expect(key).not.toBe('custom-id');
+    expect(body.requests[key].source).toBe('Hello');
+    expect(body.requests[key].metadata).toMatchObject({ id: 'custom-id' });
+  });
+
+  it('uses explicit hash keys before calculating a hash', async () => {
+    vi.mocked(apiRequest).mockResolvedValue({});
+
+    const requests: TranslateManyEntry[] = [
+      {
+        source: 'Hello',
+        metadata: { id: 'custom-id', hash: 'precomputed-hash' },
+      },
+    ];
+    const globalMetadata: {
+      targetLocale: string;
+      sourceLocale: string;
+    } & SharedMetadata = {
+      targetLocale: 'es',
+      sourceLocale: 'en',
+    };
+
+    await _translateMany(requests, globalMetadata, mockConfig);
+
+    const body = vi.mocked(apiRequest).mock.calls[0][2].body as {
+      requests: Record<string, unknown>;
+    };
+    expect(Object.keys(body.requests)).toEqual(['precomputed-hash']);
+  });
+
   it('should use default timeout when not specified', async () => {
     vi.mocked(apiRequest).mockResolvedValue(mockResponseRecord);
 

--- a/packages/core/src/translate/translateMany.ts
+++ b/packages/core/src/translate/translateMany.ts
@@ -71,8 +71,9 @@ export async function _translateMany(
       metadata?.hash ??
       hashSource({
         source,
+        ...(metadata?.context && { context: metadata.context }),
+        ...(metadata?.maxChars != null && { maxChars: metadata.maxChars }),
         dataFormat: metadata?.dataFormat ?? 'STRING',
-        ...metadata,
       });
     hashOrder?.push(hash);
     requestsObject[hash] = {

--- a/packages/i18n/src/utils/__tests__/hashMessage.test.ts
+++ b/packages/i18n/src/utils/__tests__/hashMessage.test.ts
@@ -48,4 +48,17 @@ describe('hashMessage', () => {
       })
     ).toBe('');
   });
+
+  it('does not include custom id in calculated hashes', () => {
+    const hash1 = hashMessage('Hello {name}!', {
+      $format: 'ICU',
+      $id: 'first',
+    });
+    const hash2 = hashMessage('Hello {name}!', {
+      $format: 'ICU',
+      $id: 'second',
+    });
+
+    expect(hash1).toBe(hash2);
+  });
 });

--- a/packages/i18n/src/utils/hashMessage.ts
+++ b/packages/i18n/src/utils/hashMessage.ts
@@ -25,7 +25,6 @@ export function hashMessage<T extends Translation>(
     source:
       options.$format === 'ICU' ? indexVars(message as IcuMessage) : message,
     ...(metadataOptions.$context && { context: metadataOptions.$context }),
-    ...(metadataOptions.$id && { id: metadataOptions.$id }),
     ...(metadataOptions.$maxChars != null && {
       maxChars: Math.abs(metadataOptions.$maxChars),
     }),


### PR DESCRIPTION
## Summary
- key generated GTJSON/source entries by content hash instead of custom id
- keep custom ids as metadata while excluding them from calculated hashes
- remove id-based duplicate rejection now that ids are metadata-only

## Tests
- pnpm --filter gt test -- src/translation/__tests__/parse.test.ts src/extraction/__tests__/postProcess.test.ts src/formats/files/__tests__/collectFiles.test.ts
- pnpm --filter gt typecheck
- pnpm --filter @generaltranslation/compiler test -- src/utils/__tests__/calculateHash.test.ts
- pnpm --filter @generaltranslation/compiler typecheck
- pnpm --filter generaltranslation test -- src/translate/__tests__/translateMany.test.ts
- pnpm --filter generaltranslation typecheck
- pnpm --filter gt-i18n typecheck
- pnpm --filter @generaltranslation/react-core typecheck

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes how translation entries are keyed: from using a custom `id` (when present) as the primary lookup key to using a content-based hash that excludes the `id`. The `id` is now kept purely as metadata to aid debugging and duplicate validation, but it no longer participates in hash computation.

- All hash-computation call sites (`calculateHashes`, `createDictionaryUpdates`, `hashMessage`, `registerUseGTCallback`, `registerStandaloneTranslation`, `translateMany`) remove `id` from the fields passed to `hashSource`, making hashes stable across different user-supplied IDs.
- `collectFiles.ts` and `inline.ts` are updated to key data exclusively by hash rather than falling back to `id`; `parse.ts` retains ID validation but now only rejects entries whose IDs map to *different* hashes (conflicting content), rather than treating the ID itself as the storage key.
- New tests explicitly verify that two entries with different IDs but identical content produce identical hashes.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the change is consistently applied across all hash-computation sites and the ID validation in parse.ts correctly catches conflicting-id errors without relying on id as a storage key.

All six call sites that previously included `id` in hash computation have been updated in lockstep. Dictionary entries, inline entries, runtime translation, and the i18n utility all follow the same new contract. New tests explicitly verify the id-exclusion behavior and the conflicting-id error path still fires correctly.

No files require special attention.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/core/src/translate/translateMany.ts | Replaces the broad `...metadata` spread in the fallback hash computation with explicit `context` and `maxChars` fields, correctly excluding `id` and other irrelevant metadata fields from the hash. |
| packages/cli/src/translation/parse.ts | Retains ID-conflict validation (same id, different hashes → error + filter) while removing the id-as-primary-key role; the filter and error path remain semantically correct under the new scheme. |
| packages/compiler/src/utils/calculateHash.ts | Removes `id` from the parameter type and both `_hashSource` call sites; the previously noted stale `id?: string` in the type signature is now fully cleaned up. |
| packages/i18n/src/utils/hashMessage.ts | Removes `$id` from the `hashSource` call; the `$_hash` fast-path and `$context`/`$maxChars` handling are unchanged. |
| packages/cli/src/formats/files/collectFiles.ts | Now keys both `fileData` and `fileMetadata` exclusively by hash; entries without a computed hash are silently dropped, which is safe because all pipeline stages guarantee a hash before reaching this point. |
| packages/cli/src/extraction/postProcess.ts | Removes the `id` field from the `hashSource` call in `calculateHashes`, making this the canonical point where id-agnostic hashes are computed for inline updates. |
| packages/cli/src/cli/inline.ts | Removes the `id`-first keying branch in `handleGenerateSourceCommand`; safe because `aggregateInlineTranslations` always populates `metadata.hash` before this loop runs. |

</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Source entry\n(source, id?, context?, maxChars?)"] --> B["hashSource()\nexcludes id"]
    B --> C["content hash H"]
    C --> D{hash already\nprecomputed?}
    D -- "yes (metadata.hash)" --> E["use precomputed hash"]
    D -- "no" --> B
    E --> F["fileData[H] = source\nfileMetadata[H] = {id, hash, ...}"]
    F --> G["Upload to GT API\nkeyed by H"]
    G --> H["Translation result\nkeyed by H"]

    subgraph "ID Validation (parse.ts)"
        I["Same id, same hash"] --> J["Both pass through\n(deduplicated downstream by H)"]
        K["Same id, diff hash"] --> L["Error + filtered out"]
    end

    A --> I
    A --> K
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["Source entry\n(source, id?, context?, maxChars?)"] --> B["hashSource()\nexcludes id"]
    B --> C["content hash H"]
    C --> D{hash already\nprecomputed?}
    D -- "yes (metadata.hash)" --> E["use precomputed hash"]
    D -- "no" --> B
    E --> F["fileData[H] = source\nfileMetadata[H] = {id, hash, ...}"]
    F --> G["Upload to GT API\nkeyed by H"]
    G --> H["Translation result\nkeyed by H"]

    subgraph "ID Validation (parse.ts)"
        I["Same id, same hash"] --> J["Both pass through\n(deduplicated downstream by H)"]
        K["Same id, diff hash"] --> L["Error + filtered out"]
    end

    A --> I
    A --> K
```

</a>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/react-core/src/utils/dictionaries/injectHashes.ts`, line 13-40 ([link](https://github.com/generaltranslation/gt/blob/100b40afe648c7e2d60756415c1284d39e396b72/packages/react-core/src/utils/dictionaries/injectHashes.ts#L13-L40)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The `id` parameter and `wholeId` variable are now functionally dead code: `wholeId` is built on every iteration and passed to recursive calls, but nothing in the recursion chain uses it to affect the hash output. Passing `injectHashes(dict, 'custom.prefix')` produces identical hashes to `injectHashes(dict)` (confirmed by the updated test). The parameter and variable can be removed entirely to avoid confusion.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/react-core/src/utils/dictionaries/injectHashes.ts
   Line: 13-40

   Comment:
   The `id` parameter and `wholeId` variable are now functionally dead code: `wholeId` is built on every iteration and passed to recursive calls, but nothing in the recursion chain uses it to affect the hash output. Passing `injectHashes(dict, 'custom.prefix')` produces identical hashes to `injectHashes(dict)` (confirmed by the updated test). The parameter and variable can be removed entirely to avoid confusion.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Freact-core%2Fsrc%2Futils%2Fdictionaries%2FinjectHashes.ts%0ALine%3A%2013-40%0A%0AComment%3A%0AThe%20%60id%60%20parameter%20and%20%60wholeId%60%20variable%20are%20now%20functionally%20dead%20code%3A%20%60wholeId%60%20is%20built%20on%20every%20iteration%20and%20passed%20to%20recursive%20calls%2C%20but%20nothing%20in%20the%20recursion%20chain%20uses%20it%20to%20affect%20the%20hash%20output.%20Passing%20%60injectHashes%28dict%2C%20'custom.prefix'%29%60%20produces%20identical%20hashes%20to%20%60injectHashes%28dict%29%60%20%28confirmed%20by%20the%20updated%20test%29.%20The%20parameter%20and%20variable%20can%20be%20removed%20entirely%20to%20avoid%20confusion.%0A%0A%60%60%60suggestion%0Aexport%20function%20injectHashes%28%0A%20%20dictionary%3A%20Dictionary%0A%29%3A%20%7B%20dictionary%3A%20Dictionary%3B%20updateDictionary%3A%20boolean%20%7D%20%7B%0A%20%20let%20updateDictionary%20%3D%20false%3B%0A%20%20Object.entries%28dictionary%29.forEach%28%28%5Bkey%2C%20value%5D%29%20%3D%3E%20%7B%0A%20%20%20%20if%20%28isDictionaryEntry%28value%29%29%20%7B%0A%20%20%20%20%20%20%2F%2F%20eslint-disable-next-line%20prefer-const%0A%20%20%20%20%20%20let%20%7B%20entry%2C%20metadata%20%7D%20%3D%20getEntryAndMetadata%28value%29%3B%0A%20%20%20%20%20%20if%20%28!metadata%3F.%24_hash%29%20%7B%0A%20%20%20%20%20%20%20%20metadata%20%7C%7C%3D%20%7B%7D%3B%0A%20%20%20%20%20%20%20%20metadata.%24_hash%20%3D%20hashSource%28%7B%0A%20%20%20%20%20%20%20%20%20%20source%3A%20indexVars%28entry%29%2C%0A%20%20%20%20%20%20%20%20%20%20...%28metadata%3F.%24context%20%26%26%20%7B%20context%3A%20metadata.%24context%20%7D%29%2C%0A%20%20%20%20%20%20%20%20%20%20...%28metadata%3F.%24maxChars%20!%3D%20null%20%26%26%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20maxChars%3A%20Math.abs%28metadata.%24maxChars%29%2C%0A%20%20%20%20%20%20%20%20%20%20%7D%29%2C%0A%20%20%20%20%20%20%20%20%20%20dataFormat%3A%20'ICU'%2C%0A%20%20%20%20%20%20%20%20%7D%29%3B%0A%20%20%20%20%20%20%20%20set%28dictionary%2C%20key%2C%20%5Bentry%2C%20metadata%5D%29%3B%0A%20%20%20%20%20%20%20%20updateDictionary%20%3D%20true%3B%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20const%20%7B%20updateDictionary%3A%20updateFlag%20%7D%20%3D%20injectHashes%28value%29%3B%0A%20%20%20%20%20%20updateDictionary%20%3D%20updateDictionary%20%7C%7C%20updateFlag%3B%0A%20%20%20%20%7D%0A%20%20%7D%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=generaltranslation%2Fgt&pr=1696&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22bg%2Fhash-translation-keys%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22bg%2Fhash-translation-keys%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Freact-core%2Fsrc%2Futils%2Fdictionaries%2FinjectHashes.ts%0ALine%3A%2013-40%0A%0AComment%3A%0AThe%20%60id%60%20parameter%20and%20%60wholeId%60%20variable%20are%20now%20functionally%20dead%20code%3A%20%60wholeId%60%20is%20built%20on%20every%20iteration%20and%20passed%20to%20recursive%20calls%2C%20but%20nothing%20in%20the%20recursion%20chain%20uses%20it%20to%20affect%20the%20hash%20output.%20Passing%20%60injectHashes%28dict%2C%20'custom.prefix'%29%60%20produces%20identical%20hashes%20to%20%60injectHashes%28dict%29%60%20%28confirmed%20by%20the%20updated%20test%29.%20The%20parameter%20and%20variable%20can%20be%20removed%20entirely%20to%20avoid%20confusion.%0A%0A%60%60%60suggestion%0Aexport%20function%20injectHashes%28%0A%20%20dictionary%3A%20Dictionary%0A%29%3A%20%7B%20dictionary%3A%20Dictionary%3B%20updateDictionary%3A%20boolean%20%7D%20%7B%0A%20%20let%20updateDictionary%20%3D%20false%3B%0A%20%20Object.entries%28dictionary%29.forEach%28%28%5Bkey%2C%20value%5D%29%20%3D%3E%20%7B%0A%20%20%20%20if%20%28isDictionaryEntry%28value%29%29%20%7B%0A%20%20%20%20%20%20%2F%2F%20eslint-disable-next-line%20prefer-const%0A%20%20%20%20%20%20let%20%7B%20entry%2C%20metadata%20%7D%20%3D%20getEntryAndMetadata%28value%29%3B%0A%20%20%20%20%20%20if%20%28!metadata%3F.%24_hash%29%20%7B%0A%20%20%20%20%20%20%20%20metadata%20%7C%7C%3D%20%7B%7D%3B%0A%20%20%20%20%20%20%20%20metadata.%24_hash%20%3D%20hashSource%28%7B%0A%20%20%20%20%20%20%20%20%20%20source%3A%20indexVars%28entry%29%2C%0A%20%20%20%20%20%20%20%20%20%20...%28metadata%3F.%24context%20%26%26%20%7B%20context%3A%20metadata.%24context%20%7D%29%2C%0A%20%20%20%20%20%20%20%20%20%20...%28metadata%3F.%24maxChars%20!%3D%20null%20%26%26%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20maxChars%3A%20Math.abs%28metadata.%24maxChars%29%2C%0A%20%20%20%20%20%20%20%20%20%20%7D%29%2C%0A%20%20%20%20%20%20%20%20%20%20dataFormat%3A%20'ICU'%2C%0A%20%20%20%20%20%20%20%20%7D%29%3B%0A%20%20%20%20%20%20%20%20set%28dictionary%2C%20key%2C%20%5Bentry%2C%20metadata%5D%29%3B%0A%20%20%20%20%20%20%20%20updateDictionary%20%3D%20true%3B%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20const%20%7B%20updateDictionary%3A%20updateFlag%20%7D%20%3D%20injectHashes%28value%29%3B%0A%20%20%20%20%20%20updateDictionary%20%3D%20updateDictionary%20%7C%7C%20updateFlag%3B%0A%20%20%20%20%7D%0A%20%20%7D%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=generaltranslation%2Fgt&pr=1696&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["fix: remove ignored compiler hash id par..."](https://github.com/generaltranslation/gt/commit/b19306028dcb94f9bbd5b27b0232ac927ee8394d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40680642)</sub>

<!-- /greptile_comment -->