### PR TITLE
chore: add odysseus release trigger changeset

### DIFF
--- a/.changeset/odysseus-release-trigger.md
+++ b/.changeset/odysseus-release-trigger.md
@@ -1,0 +1,5 @@
+---
+"@generaltranslation/react-core": patch
+---
+
+Trigger a new Odysseus prerelease after updating the release workflow.


### PR DESCRIPTION
## Summary
- Add a patch changeset for `@generaltranslation/react-core` to trigger a new Odysseus prerelease path.
- Rely on the Odysseus fixed package group to include the related React/Next packages during versioning.

## Testing
- `pnpm changeset status --since=origin/odysseus`