### PR TITLE
refactor(gt-next): remove 21 unused error/warning builders

### DIFF
--- a/.changeset/trim-next-createerrors.md
+++ b/.changeset/trim-next-createerrors.md
@@ -1,0 +1,7 @@
+---
+"gt-next": patch
+---
+
+Remove 21 unused error/warning builders from `gt-next`'s `errors/createErrors.ts`.
+
+The following had no consumers anywhere: `createDictionaryTranslationError`, `createInvalidDictionaryEntryWarning`, `createInvalidDictionaryTranslationEntryWarning`, `createInvalidIcuDictionaryEntryError`, `createInvalidIcuDictionaryEntryWarning`, `createMismatchingHashWarning`, `createNoEntryFoundWarning`, `createRequiredPrefixError`, `createStringRenderError`, `createStringRenderWarning`, `createStringTranslationError`, `createTranslationLoadingWarning`, `dictionaryDisabledError`, `dictionaryNotFoundWarning`, `gtProviderUseClientError`, `missingVariablesError`, `noInitGTWarn`, `runtimeTranslationTimeoutWarning`, `txUseClientError`, `unresolvedGetLocaleBuildError`, `usingDefaultsWarning`. ~155 LOC of dead error-string code removed.

--- a/packages/next/src/errors/createErrors.ts
+++ b/packages/next/src/errors/createErrors.ts
@@ -45,32 +45,6 @@ export const createUnresolvedReactVersionError = (error: Error) =>
     details: error.message,
   });
 
-export const createStringTranslationError = (
-  string: string,
-  id?: string,
-  functionName = 'tx'
-) =>
-  createGtNextDiagnostic({
-    severity: 'Error',
-    whatHappened: `${functionName}("${string}")${id ? ` with id "${id}"` : ''} could not find a translation`,
-    wayOut: 'Source content will render as a fallback',
-    fix: 'Push translations again or check your dictionary/runtime translation configuration',
-  });
-
-export const createDictionaryTranslationError = (id: string) =>
-  createGtNextDiagnostic({
-    severity: 'Error',
-    whatHappened: `Dictionary translation entry "${id}" could not be found`,
-    fix: 'Check that the id exists in your dictionary or push translations again',
-  });
-
-export const createRequiredPrefixError = (id: string, requiredPrefix: string) =>
-  createGtNextDiagnostic({
-    severity: 'Error',
-    whatHappened: `<GTProvider> is scoped to prefix "${requiredPrefix}", but a child uses id "${id}"`,
-    fix: 'Change the <GTProvider> id prop or move the child under the matching dictionary subtree',
-  });
-
 export const devApiKeyIncludedInProductionError = createGtNextDiagnostic({
   severity: 'Error',
   whatHappened: 'Production builds cannot use a development API key',
@@ -83,13 +57,6 @@ export const createDictionarySubsetError = (id: string, functionName: string) =>
     whatHappened: `${functionName} with id "${id}" could not read a valid dictionary subtree`,
     fix: 'Make sure the id maps to the correct subroute of the dictionary',
   });
-
-export const dictionaryDisabledError = createGtNextDiagnostic({
-  severity: 'Error',
-  whatHappened: 'Dictionaries are not enabled',
-  fix: 'Add the withGTConfig() plugin to your Next.js config before using dictionary translations',
-  docsUrl: 'https://generaltranslation.com/docs',
-});
 
 export const unresolvedCustomLoadDictionaryError = createGtNextDiagnostic({
   severity: 'Error',
@@ -119,13 +86,6 @@ export const unresolvedLoadTranslationsBuildError = (path: string) =>
     fix: 'Check the configured path and try again',
   });
 
-export const unresolvedGetLocaleBuildError = (path: string) =>
-  createGtNextDiagnostic({
-    severity: 'Error',
-    whatHappened: `The file defining custom getLocale() could not be resolved at ${path}`,
-    fix: 'Check the configured path and try again',
-  });
-
 export const conflictingConfigurationBuildError = (conflicts: string[]) =>
   `gt-next Error: Conflicting configuration${
     conflicts.length > 1 ? 's' : ''
@@ -146,33 +106,6 @@ export const getTranslationsSnapshotRscError = createGtNextDiagnostic({
   fix: 'Use gt-next build-time translation helpers in the App Router, or call getTranslationsSnapshot() from a Pages Router entry point',
 });
 
-export const gtProviderUseClientError =
-  `The Next.js <GTProvider> was imported in a client component. This prevents gt-next from fetching translations on the server. ` +
-  `Move <GTProvider> to a file without 'use client'.`;
-
-export const txUseClientError =
-  `The <Tx> runtime translation component was rendered in a client component, which is not supported. ` +
-  `Use <T> with variables, or render <Tx> from a server component.`;
-
-export const missingVariablesError = (variables: string[], message: string) =>
-  createGtNextDiagnostic({
-    severity: 'Error',
-    whatHappened: `The message "${message}" is missing variables: "${variables.join('", "')}"`,
-    fix: 'Provide values for these variables before rendering the translation',
-  });
-
-export const createStringRenderError = (
-  message: string,
-  id: string | undefined,
-  error?: unknown
-) =>
-  createGtNextDiagnostic({
-    severity: 'Error',
-    whatHappened: `The string ${id ? `for id "${id}" ` : ''}could not be rendered`,
-    fix: `Check the message syntax and variables for: "${message}"`,
-    details: formatDiagnosticErrorDetails(error),
-  });
-
 export const invalidLocalesError = (locales: string[]) =>
   createGtNextDiagnostic({
     severity: 'Error',
@@ -189,49 +122,12 @@ export const invalidCanonicalLocalesError = (locales: string[]) =>
     details: locales,
   });
 
-export const createInvalidIcuDictionaryEntryError = (id: string) =>
-  createGtNextDiagnostic({
-    severity: 'Error',
-    whatHappened: `Dictionary entry "${id}" contains invalid ICU syntax`,
-    fix: 'Fix the ICU message before rendering this translation',
-  });
-
 // ---- WARNINGS ---- //
-
-export const createInvalidIcuDictionaryEntryWarning = (id: string) =>
-  createGtNextDiagnostic({
-    whatHappened: `Dictionary entry "${id}" contains invalid ICU syntax`,
-    wayOut: 'Source content will render as a fallback until the entry is fixed',
-  });
 
 export const createBadFilepathWarning = (filename: string, dir: string[]) =>
   createGtNextDiagnostic({
     whatHappened: `${filename} was found in ${dir.join(' or ')}, which is not supported`,
     fix: 'Move it to your project root so gt-next can load it',
-  });
-
-export const usingDefaultsWarning = createGtNextDiagnostic({
-  whatHappened: 'The gt-next configuration could not be loaded',
-  wayOut: 'Defaults will be used',
-  fix: 'Check your config path if this was unexpected',
-});
-
-export const createNoEntryFoundWarning = (id: string) =>
-  createGtNextDiagnostic({
-    whatHappened: `No valid dictionary entry was found for id "${id}"`,
-    wayOut: 'Source content will render as a fallback',
-  });
-
-export const createInvalidDictionaryEntryWarning = (id: string) =>
-  createGtNextDiagnostic({
-    whatHappened: `Dictionary entry "${id}" is invalid`,
-    wayOut: 'Source content will render as a fallback until the entry is fixed',
-  });
-
-export const createInvalidDictionaryTranslationEntryWarning = (id: string) =>
-  createGtNextDiagnostic({
-    whatHappened: `Dictionary translation entry "${id}" is invalid`,
-    wayOut: 'Source content will render as a fallback until the entry is fixed',
   });
 
 export const createUnsupportedLocalesWarning = (locales: string[]) =>
@@ -242,56 +138,15 @@ export const createUnsupportedLocalesWarning = (locales: string[]) =>
     })
     .join(', ')}`;
 
-export const createMismatchingHashWarning = (
-  expectedHash: string,
-  receivedHash: string
-) =>
-  createGtNextDiagnostic({
-    whatHappened: 'Translation hashes do not match',
-    reassurance: 'The translation will still render',
-    fix: 'Update your translations to the newest version to avoid stale content',
-    details: [`expected ${expectedHash}`, `received ${receivedHash}`],
-  });
-
 export const projectIdMissingWarn = createGtNextDiagnostic({
   whatHappened: 'Runtime translation needs a project ID',
   fix: 'Set GT_PROJECT_ID in your environment or pass projectId to withGTConfig()',
   docsUrl: 'https://generaltranslation.com/dashboard',
 });
 
-export const noInitGTWarn =
-  `gt-next: You are running General Translation without the withGTConfig() plugin. ` +
-  `This means that you are not translating your app. To activate translation, add the withGTConfig() plugin to your app, ` +
-  `and set the projectId and apiKey in your environment. ` +
-  `For more information, visit https://generaltranslation.com/docs/next/tutorials/quickstart`;
-
 export const APIKeyMissingWarn = createGtNextPluginDiagnostic({
   whatHappened: 'Runtime translation needs a development API key',
   fix: 'Find your development API key at generaltranslation.com/dashboard, or set runtimeUrl to an empty string to disable runtime translation',
-});
-
-export const createTranslationLoadingWarning = ({
-  source,
-  translation,
-  id,
-}: {
-  source: string;
-  translation: string;
-  id?: string;
-}) =>
-  `[DEV ONLY] Warning: gt-next created translation "${source}" -> "${translation}"` +
-  (id ? ` for id "${id}"` : '') +
-  `. ` +
-  `In development, hot-reloaded translations may not be be displayed until the page is refreshed. ` +
-  `In production, translations will be preloaded and there won't be a warning.`;
-
-export const runtimeTranslationTimeoutWarning = createGtNextDiagnostic({
-  whatHappened: 'Runtime translation timed out',
-});
-
-export const dictionaryNotFoundWarning = createGtNextDiagnostic({
-  whatHappened: 'No dictionary was found',
-  fix: 'Add dictionary.js or [defaultLocale].json to your project, and make sure withGTConfig() is enabled',
 });
 
 export const standardizedLocalesWarning = (locales: string[]) =>
@@ -325,17 +180,5 @@ export const babelCompilerTurbopackUnavailableWarning =
   `To use compiler optimizations with Turbopack, set experimentalCompilerOptions: { type: 'swc' }.`;
 
 export const disablingCompileTimeHashWarning = `gt-next (plugin): Compile-time hash is disabled. Compiler optimizations are inactive.`;
-
-export const createStringRenderWarning = (
-  message: string,
-  id: string | undefined,
-  error?: unknown
-) =>
-  createGtNextDiagnostic({
-    whatHappened: `The string ${id ? `for id "${id}" ` : ''}could not be rendered`,
-    wayOut: 'Source content will render as a fallback',
-    fix: `Check the message syntax and variables for: "${message}"`,
-    details: formatDiagnosticErrorDetails(error),
-  });
 
 export const swcPluginCompatibilityChangeWarning = `gt-next (plugin): As of gt-next@6.12.4, SWC plugin support is disabled for Next.js versions prior to ${SWC_PLUGIN_SUPPORT}. Update to the latest version of Next.js.`;

--- a/packages/next/src/errors/createErrors.ts
+++ b/packages/next/src/errors/createErrors.ts
@@ -4,7 +4,6 @@ import { getLocaleProperties } from '@generaltranslation/format';
 import {
   createGtNextDiagnostic,
   createGtNextPluginDiagnostic,
-  formatDiagnosticErrorDetails,
 } from './diagnostics';
 import { BABEL_PLUGIN_SUPPORT, SWC_PLUGIN_SUPPORT } from '../plugin/constants';
 


### PR DESCRIPTION
Removes 21 error/warning builders from `errors/createErrors.ts` that have **zero consumers** anywhere (grep-verified each). ~155 LOC of dead error-string code, some of which shipped to bundles. The 29 still-used builders are unchanged. gt-next builds; 191 tests pass. Part of the odysseus dead-code sweep.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes 21 dead error/warning builder functions from `packages/next/src/errors/createErrors.ts` (~155 LOC), along with the now-unused `formatDiagnosticErrorDetails` import. The 29 remaining builders are untouched and the changeset is correctly scoped as a patch.

- **Dead code removed**: 21 exported functions (`createDictionaryTranslationError`, `gtProviderUseClientError`, `noInitGTWarn`, `runtimeTranslationTimeoutWarning`, and 17 others) that had zero consumers in the repo were deleted.
- **Import cleaned up**: `formatDiagnosticErrorDetails` was the only import whose sole callers (`createStringRenderError` / `createStringRenderWarning`) were among the deleted functions; it was correctly removed in the same commit.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Pure dead-code removal with no changes to active error paths; safe to merge.

Every deleted symbol was confirmed to have zero consumers, the unused import was correctly cleaned up in the same commit, and the 29 still-used builders are untouched.

No files require special attention.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/next/src/errors/createErrors.ts | Removes 21 unused exported error/warning builders and the now-orphaned `formatDiagnosticErrorDetails` import; all 29 remaining builders and their consumers are unchanged. |
| .changeset/trim-next-createerrors.md | Correct patch-level changeset enumerating all 21 removed symbols; no issues. |

</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[createErrors.ts\n29 remaining builders] --> B[createGtNextDiagnostic]
    A --> C[createGtNextPluginDiagnostic]
    B --> D[diagnostics.ts]
    C --> D

    DEL["❌ Removed — 21 unused builders\n(createStringRenderError, gtProviderUseClientError,\nnoInitGTWarn, runtimeTranslationTimeoutWarning,\ncreateStringRenderWarning, dictionaryDisabledError,\ncreateTranslationLoadingWarning, … +14 more)"]
    DEL -. was calling .-> FMT["❌ formatDiagnosticErrorDetails\n(import also removed)"]
    FMT -. was imported from .-> D
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[createErrors.ts\n29 remaining builders] --> B[createGtNextDiagnostic]
    A --> C[createGtNextPluginDiagnostic]
    B --> D[diagnostics.ts]
    C --> D

    DEL["❌ Removed — 21 unused builders\n(createStringRenderError, gtProviderUseClientError,\nnoInitGTWarn, runtimeTranslationTimeoutWarning,\ncreateStringRenderWarning, dictionaryDisabledError,\ncreateTranslationLoadingWarning, … +14 more)"]
    DEL -. was calling .-> FMT["❌ formatDiagnosticErrorDetails\n(import also removed)"]
    FMT -. was imported from .-> D
```

</a>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/next/src/errors/createErrors.ts`, line 4-8 ([link](https://github.com/generaltranslation/gt/blob/3d7fd6cda7f5364f90381634aa4975fa717c1616/packages/next/src/errors/createErrors.ts#L4-L8)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The `formatDiagnosticErrorDetails` import is now unused. The only two callers — `createStringRenderError` and `createStringRenderWarning` — were both removed in this PR, leaving the import as dead code. TypeScript (and any lint rule for `no-unused-vars`) will flag this.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/next/src/errors/createErrors.ts
   Line: 4-8

   Comment:
   The `formatDiagnosticErrorDetails` import is now unused. The only two callers — `createStringRenderError` and `createStringRenderWarning` — were both removed in this PR, leaving the import as dead code. TypeScript (and any lint rule for `no-unused-vars`) will flag this.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fnext%2Fsrc%2Ferrors%2FcreateErrors.ts%0ALine%3A%204-8%0A%0AComment%3A%0AThe%20%60formatDiagnosticErrorDetails%60%20import%20is%20now%20unused.%20The%20only%20two%20callers%20%E2%80%94%20%60createStringRenderError%60%20and%20%60createStringRenderWarning%60%20%E2%80%94%20were%20both%20removed%20in%20this%20PR%2C%20leaving%20the%20import%20as%20dead%20code.%20TypeScript%20%28and%20any%20lint%20rule%20for%20%60no-unused-vars%60%29%20will%20flag%20this.%0A%0A%60%60%60suggestion%0Aimport%20%7B%0A%20%20createGtNextDiagnostic%2C%0A%20%20createGtNextPluginDiagnostic%2C%0A%7D%20from%20'.%2Fdiagnostics'%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=generaltranslation%2Fgt&pr=1707&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22bg%2Fodysseus-trim-next-createerrors%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22bg%2Fodysseus-trim-next-createerrors%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fnext%2Fsrc%2Ferrors%2FcreateErrors.ts%0ALine%3A%204-8%0A%0AComment%3A%0AThe%20%60formatDiagnosticErrorDetails%60%20import%20is%20now%20unused.%20The%20only%20two%20callers%20%E2%80%94%20%60createStringRenderError%60%20and%20%60createStringRenderWarning%60%20%E2%80%94%20were%20both%20removed%20in%20this%20PR%2C%20leaving%20the%20import%20as%20dead%20code.%20TypeScript%20%28and%20any%20lint%20rule%20for%20%60no-unused-vars%60%29%20will%20flag%20this.%0A%0A%60%60%60suggestion%0Aimport%20%7B%0A%20%20createGtNextDiagnostic%2C%0A%20%20createGtNextPluginDiagnostic%2C%0A%7D%20from%20'.%2Fdiagnostics'%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=generaltranslation%2Fgt&pr=1707&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["refactor(gt-next): drop now-unused forma..."](https://github.com/generaltranslation/gt/commit/646c8b8ee3bab4e6b50e9eadc85c8f515a8fd016) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40687204)</sub>

<!-- /greptile_comment -->