### PR TITLE
fix: respect pages locale cookie header

### DIFF
--- a/packages/next/src/pages-dir/__tests__/parseLocale.test.ts
+++ b/packages/next/src/pages-dir/__tests__/parseLocale.test.ts
@@ -78,4 +78,15 @@ describe('parseLocale', () => {
 
     expect(parseLocale(context)).toBe('es');
   });
+
+  it('uses the raw cookie header when parsed cookies are unavailable', () => {
+    const context = createContext({
+      headers: {
+        cookie: 'other=value; generaltranslation.locale=fr',
+        'accept-language': 'en-US,en;q=0.8',
+      },
+    });
+
+    expect(parseLocale(context)).toBe('fr');
+  });
 });

--- a/packages/next/src/pages-dir/parseLocale.ts
+++ b/packages/next/src/pages-dir/parseLocale.ts
@@ -20,7 +20,9 @@ export function parseLocale<
 
   addHeaderCandidates(preferredLocales, context.req.headers[headerName]);
 
-  const cookieLocale = context.req.cookies?.[cookieName];
+  const cookieLocale =
+    context.req.cookies?.[cookieName] ||
+    getCookieHeaderValue(context.req.headers.cookie, cookieName);
   if (cookieLocale) {
     preferredLocales.push(cookieLocale);
   }
@@ -81,4 +83,26 @@ function getAcceptLanguageCandidates(headerValue: HeaderValue): string[] {
         .map((item) => item.split(';')?.[0].trim())
         .filter(Boolean) || []
   );
+}
+
+function getCookieHeaderValue(
+  headerValue: HeaderValue,
+  cookieName: string
+): string | undefined {
+  const headerValues = Array.isArray(headerValue) ? headerValue : [headerValue];
+  for (const value of headerValues) {
+    const cookies = value?.split(';') || [];
+    for (const cookie of cookies) {
+      const [name, ...rawValue] = cookie.trim().split('=');
+      if (name === cookieName && rawValue.length > 0) {
+        const value = rawValue.join('=');
+        try {
+          return decodeURIComponent(value);
+        } catch {
+          return value;
+        }
+      }
+    }
+  }
+  return undefined;
 }

--- a/packages/next/src/pages-dir/parseLocale.ts
+++ b/packages/next/src/pages-dir/parseLocale.ts
@@ -95,11 +95,11 @@ function getCookieHeaderValue(
     for (const cookie of cookies) {
       const [name, ...rawValue] = cookie.trim().split('=');
       if (name === cookieName && rawValue.length > 0) {
-        const value = rawValue.join('=');
+        const cookieValue = rawValue.join('=');
         try {
-          return decodeURIComponent(value);
+          return decodeURIComponent(cookieValue);
         } catch {
-          return value;
+          return cookieValue;
         }
       }
     }


### PR DESCRIPTION
## Summary
- Read the raw `Cookie` header as a fallback when Pages Router SSR does not expose parsed cookies.
- Add coverage for resolving the GT locale cookie before `Accept-Language` in that request shape.

## Testing
- `pnpm --filter gt-next test:js`
- `pnpm --filter gt-next build`
- `pnpm --dir base/next-pages-router build`
- Browser validation in linked `gt-test-apps` worktree:
  - dev: `next dev -p 3101`, clear GT cookies, select French, verify `Client locale: fr` and `Cookie locale (SSR): fr`, no fresh page errors
  - prod: `next start -p 4101`, clear GT cookies, select French, verify `Client locale: fr` and `Cookie locale (SSR): fr`, no fresh page errors

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes locale resolution in the Next.js Pages Router by adding a fallback that parses the raw `Cookie` header when `req.cookies` is not populated (a known gap in Pages Router SSR). A new `getCookieHeaderValue` helper handles URL-decoding, multi-value headers, and cookie values that contain `=` characters.

- Adds `getCookieHeaderValue` to parse the raw `Cookie` header as a fallback after `req.cookies?.[cookieName]`, preserving the existing priority order (middleware header → cookie → Accept-Language).
- Adds a focused test exercising the fallback path when `req.cookies` is empty but the `cookie` header carries the GT locale.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a narrowly scoped fallback that only activates when req.cookies is absent, with no impact on the existing parsed-cookies path.

The new helper correctly handles all cookie-header edge cases (URL-encoded values, multi-value headers, values containing =), the fallback is gated by the || operator so the existing parsed-cookies path is unchanged, and the added test directly exercises the new code path.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/next/src/pages-dir/parseLocale.ts | Adds getCookieHeaderValue helper and wires it as a fallback for req.cookies; logic handles edge cases (multi-value headers, URL-encoding, = in values) correctly. |
| packages/next/src/pages-dir/__tests__/parseLocale.test.ts | New test covers the raw-cookie-header fallback path when req.cookies is empty; test structure is consistent with the existing suite. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[parseLocale called] --> B[Add middleware header candidates]
    B --> C{req.cookies cookieName defined?}
    C -- Yes --> D[cookieLocale = req.cookies value]
    C -- No --> E[getCookieHeaderValue raw header]
    E --> F{Found in raw Cookie header?}
    F -- Yes --> G[Parse + decodeURIComponent]
    F -- No --> H[cookieLocale = undefined]
    D --> I{cookieLocale truthy?}
    G --> I
    H --> I
    I -- Yes --> J[Push to preferredLocales]
    I -- No --> K[Skip]
    J --> L{ignorePreferredLanguages?}
    K --> L
    L -- No --> M[Add Accept-Language candidates]
    L -- Yes --> N[determineLocale]
    M --> N
    N --> O[Return resolved locale]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[parseLocale called] --> B[Add middleware header candidates]
    B --> C{req.cookies cookieName defined?}
    C -- Yes --> D[cookieLocale = req.cookies value]
    C -- No --> E[getCookieHeaderValue raw header]
    E --> F{Found in raw Cookie header?}
    F -- Yes --> G[Parse + decodeURIComponent]
    F -- No --> H[cookieLocale = undefined]
    D --> I{cookieLocale truthy?}
    G --> I
    H --> I
    I -- Yes --> J[Push to preferredLocales]
    I -- No --> K[Skip]
    J --> L{ignorePreferredLanguages?}
    K --> L
    L -- No --> M[Add Accept-Language candidates]
    L -- Yes --> N[determineLocale]
    M --> N
    N --> O[Return resolved locale]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["chore: avoid shadowed cookie value"](https://github.com/generaltranslation/gt/commit/2870daeda3fff3f3ef7f78f764b0d9093e711c1f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40698541)</sub>

<!-- /greptile_comment -->