### PR TITLE
fix: avoid formatjs type subpath runtime import

### DIFF
--- a/.changeset/tanstack-formatjs-type-runtime.md
+++ b/.changeset/tanstack-formatjs-type-runtime.md
@@ -1,0 +1,5 @@
+---
+"generaltranslation": patch
+---
+
+Import the FormatJS `TYPE` runtime enum from the parser entrypoint so Vite dev does not request the CommonJS `types.js` subpath as a browser ESM module.

--- a/packages/core/src/__tests__/core-esm.test.ts
+++ b/packages/core/src/__tests__/core-esm.test.ts
@@ -91,6 +91,20 @@ describe('generaltranslation/core export', () => {
       expect(builtGraph).not.toContain(forbidden);
     }
   });
+
+  it('does not import FormatJS runtime values from the types subpath', () => {
+    const internalEsm = readFileSync(
+      join(process.cwd(), 'dist/internal.mjs'),
+      'utf8'
+    );
+
+    expect(internalEsm).not.toContain(
+      'from "@formatjs/icu-messageformat-parser/types.js"'
+    );
+    expect(internalEsm).not.toContain(
+      "from '@formatjs/icu-messageformat-parser/types.js'"
+    );
+  });
 });
 
 function readBuiltFileGraph(entryFileName: string) {

--- a/packages/core/src/derive/condenseVars.ts
+++ b/packages/core/src/derive/condenseVars.ts
@@ -1,7 +1,5 @@
-import {
-  type ArgumentElement,
-  TYPE,
-} from '@formatjs/icu-messageformat-parser/types.js';
+import { TYPE } from '@formatjs/icu-messageformat-parser';
+import type { ArgumentElement } from '@formatjs/icu-messageformat-parser/types.js';
 import { printAST } from '@formatjs/icu-messageformat-parser/printer.js';
 import { traverseIcu } from './utils/traverseIcu';
 import { VAR_IDENTIFIER } from './utils/constants';

--- a/packages/core/src/derive/utils/traverseHelpers.ts
+++ b/packages/core/src/derive/utils/traverseHelpers.ts
@@ -3,10 +3,8 @@ import {
   GT_UNINDEXED_IDENTIFIER_REGEX,
 } from './regex';
 import { GTIndexedSelectElement, GTUnindexedSelectElement } from './types';
-import {
-  type MessageFormatElement,
-  TYPE,
-} from '@formatjs/icu-messageformat-parser/types.js';
+import { TYPE } from '@formatjs/icu-messageformat-parser';
+import type { MessageFormatElement } from '@formatjs/icu-messageformat-parser/types.js';
 
 // Visit any _gt_# select
 export function isGTIndexedSelectElement(


### PR DESCRIPTION
## Summary
- Import the runtime FormatJS `TYPE` enum from `@formatjs/icu-messageformat-parser` instead of the `types.js` subpath.
- Keep FormatJS element shapes as type-only imports from `types.js`.

## Testing
- `pnpm --filter generaltranslation test`
- `pnpm exec turbo run build --filter=gt-tanstack-start... --ui stream`
- Linked `base/tanstack-start` from `gt-test-apps` to this GT worktree with `pnpm gt:link tanstack-start /Users/ernestmccarter/Documents/dev/gt-wt/e-odysseus-fix-tanstack-formatjs-type`
- `pnpm --dir base/tanstack-start build`
- Browser checked `http://localhost:5173/ssr` in dev: selected `fr`, verified provider locale `fr`, French GT strings, and zero captured browser runtime/log errors
- Browser checked `http://localhost:4173/ssr` in production preview: selected `fr`, verified provider locale `fr`, French GT strings, and zero captured browser runtime/log errors

No changeset added.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes an incorrect import path for the FormatJS `TYPE` runtime enum in two files. Previously, `TYPE` was imported from `@formatjs/icu-messageformat-parser/types.js`, a type-declaration-only subpath that carries no runtime value, causing bundler/runtime failures (observed in TanStack Start builds).

- **`condenseVars.ts`**: `TYPE` moved to the main `@formatjs/icu-messageformat-parser` entry; `ArgumentElement` stays as a `type`-only import from `types.js`.
- **`traverseHelpers.ts`**: Same split — `TYPE` from the main entry, `MessageFormatElement` as a `type`-only import from `types.js`.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a targeted two-line import split that directly fixes a bundler runtime failure with no logic changes.

Both files receive the identical, correct treatment: the runtime TYPE enum moves to the main package entry where it has an actual value export, while the TypeScript shape types stay as type-only imports from the declaration subpath. The rest of the codebase (utils/types.ts) was already using import type from types.js correctly and is untouched. No logic, no tests, and no public API are affected.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/derive/condenseVars.ts | TYPE import moved from types.js subpath to main package entry; ArgumentElement kept as type-only import. Change is correct. |
| packages/core/src/derive/utils/traverseHelpers.ts | TYPE import moved from types.js subpath to main package entry; MessageFormatElement kept as type-only import. Change is correct. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["@formatjs/icu-messageformat-parser\n(main entry)"] -->|"import { TYPE }"| B["condenseVars.ts"]
    A -->|"import { TYPE }"| C["traverseHelpers.ts"]
    D["@formatjs/icu-messageformat-parser/types.js\n(type declarations only)"] -->|"import type { ArgumentElement }"| B
    D -->|"import type { MessageFormatElement }"| C
    D -->|"import type { PluralOrSelectOption, LiteralElement, SelectElement }"| E["utils/types.ts"]

    style A fill:#22c55e,color:#fff
    style D fill:#64748b,color:#fff
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["@formatjs/icu-messageformat-parser\n(main entry)"] -->|"import { TYPE }"| B["condenseVars.ts"]
    A -->|"import { TYPE }"| C["traverseHelpers.ts"]
    D["@formatjs/icu-messageformat-parser/types.js\n(type declarations only)"] -->|"import type { ArgumentElement }"| B
    D -->|"import type { MessageFormatElement }"| C
    D -->|"import type { PluralOrSelectOption, LiteralElement, SelectElement }"| E["utils/types.ts"]

    style A fill:#22c55e,color:#fff
    style D fill:#64748b,color:#fff
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: avoid formatjs type subpath runtime..."](https://github.com/generaltranslation/gt/commit/59b2561e44b917de9b2e4fd91a57a2c5606900fe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40704066)</sub>

<!-- /greptile_comment -->