### PR TITLE
perf(i18n): unbundle build output for tree-shaking

### DIFF
--- a/.changeset/i18n-unbundle.md
+++ b/.changeset/i18n-unbundle.md
@@ -1,0 +1,7 @@
+---
+"gt-i18n": patch
+---
+
+Build `gt-i18n` with unbundled, tree-shakeable implementation modules.
+
+The package now keeps the existing public entrypoints (`.`, `types`, `fallbacks`, `internal`, and `internal/types`) while emitting their internal implementation graph as separate CJS and ESM files, matching the package shape used by `@generaltranslation/react-core`. The package export paths and declaration filenames are unchanged, but downstream bundlers can now analyze the smaller module graph instead of treating each entrypoint as one bundled file.

--- a/packages/i18n/tsdown.config.mts
+++ b/packages/i18n/tsdown.config.mts
@@ -1,12 +1,28 @@
 import { defineConfig } from 'tsdown';
-import { createTsdownConfig } from '../../tsdown.preset.mts';
+import { createTsdownUnbundleConfig } from '../../tsdown.preset.mts';
 
-export default defineConfig(
-  createTsdownConfig([
-    'src/index.ts',
-    'src/types.ts',
-    'src/fallbacks.ts',
-    'src/internal.ts',
-    'src/internal-types.ts',
-  ])
-);
+const entries = [
+  'src/index.ts',
+  'src/types.ts',
+  'src/fallbacks.ts',
+  'src/internal.ts',
+  'src/internal-types.ts',
+];
+
+const cjs = createTsdownUnbundleConfig({
+  format: 'cjs',
+  entry: entries,
+  outExtensions: () => ({ js: '.cjs', dts: '.d.cts' }),
+});
+
+const esm = createTsdownUnbundleConfig({
+  format: 'esm',
+  entry: entries,
+  clean: false,
+  outExtensions: () => ({ js: '.mjs', dts: '.d.mts' }),
+});
+
+export default defineConfig([
+  { ...cjs, minify: true, dts: true },
+  { ...esm, minify: true, dts: true },
+]);


### PR DESCRIPTION
## Summary

- Switch `gt-i18n` to unbundled tsdown output for CJS and ESM.
- Keep the existing public export paths and declaration filenames unchanged while emitting the internal implementation graph as separate files, matching the `@generaltranslation/react-core` package shape.
- Add a patch changeset for `gt-i18n`.

## Validation

- `pnpm --filter gt-i18n test`
- `pnpm build`
- `pnpm format -- packages/i18n/tsdown.config.mts`
- CJS and ESM import smoke checks for `gt-i18n`, `gt-i18n/internal`, and `gt-i18n/fallbacks`
- `next-app-router` analyzer before/after comparison with published `odysseus` packages vs a `gt-i18n` tarball from this branch

## Analyzer Notes

- Before (`odysseus`): `459.05 KB` compressed estimated, `1.23 MB` uncompressed, `312` modules.
- After (`gt-i18n` tarball): `471.43 KB` compressed estimated, `1.22 MB` uncompressed, `360` modules.
- The visible `gt-i18n` analyzer block changes from a few bundled files into smaller internal module groups. In this app the compressed estimate increases, so this should be reviewed as a tree-shaking enabler rather than a proven app-size reduction.