### PR TITLE
refactor: consolidate global singleton handling

### DIFF
--- a/packages/i18n/src/condition-store/createConditionStoreSingleton.ts
+++ b/packages/i18n/src/condition-store/createConditionStoreSingleton.ts
@@ -1,75 +1,24 @@
-import { createDiagnosticMessage } from 'generaltranslation/internal';
+import { createGlobalSingleton } from '../globals/createGlobalSingleton';
 import type {
   AsyncReadonlyConditionStoreInterface,
   ReadonlyConditionStoreInterface,
 } from '../i18n-cache/types';
-
-type I18nGlobals = {
-  conditionStore?: ReadonlyConditionStoreInterface;
-  gtServicesEnabled?: boolean | undefined;
-  [key: string]: unknown;
-};
-
-type GeneralTranslationGlobal = {
-  i18n?: I18nGlobals;
-  [key: string]: unknown;
-};
-
-type GlobalWithGeneralTranslation = {
-  __generaltranslation?: GeneralTranslationGlobal;
-};
-
-function getI18nGlobals(): I18nGlobals {
-  const globalObj = globalThis as unknown as GlobalWithGeneralTranslation;
-  globalObj.__generaltranslation ??= {};
-  // TODO: Consider checking package versions and using a compatibility matrix before sharing global singletons.
-  globalObj.__generaltranslation.i18n ??= {};
-  return globalObj.__generaltranslation.i18n;
-}
 
 export function createConditionStoreSingleton<
   T extends
     | ReadonlyConditionStoreInterface
     | AsyncReadonlyConditionStoreInterface,
 >(notInitializedMessage: string) {
-  function getConditionStore(): T {
-    /**
-     * TODO: each package throws a different error message
-     */
-    const conditionStore = getI18nGlobals().conditionStore;
-    if (!conditionStore) {
-      throw new Error(notInitializedMessage);
-    }
-    return conditionStore as T;
-  }
-
-  function setConditionStore(nextConditionStore: T): void {
-    const i18nGlobals = getI18nGlobals();
-    if (
-      i18nGlobals.conditionStore &&
-      i18nGlobals.conditionStore !== nextConditionStore
-    ) {
-      console.warn(createSingletonOverwriteWarning('conditionStore'));
-    }
-    i18nGlobals.conditionStore =
-      nextConditionStore as ReadonlyConditionStoreInterface;
-  }
-
-  function isConditionStoreInitialized(): boolean {
-    return getI18nGlobals().conditionStore !== undefined;
-  }
+  const singleton = createGlobalSingleton<T>({
+    namespace: 'i18n',
+    key: 'conditionStore',
+    source: 'gt-i18n',
+    notInitialized: () => notInitializedMessage,
+  });
 
   return {
-    getConditionStore,
-    setConditionStore,
-    isConditionStoreInitialized,
+    getConditionStore: singleton.get,
+    setConditionStore: singleton.set,
+    isConditionStoreInitialized: singleton.isInitialized,
   };
-}
-
-function createSingletonOverwriteWarning(name: string): string {
-  return createDiagnosticMessage({
-    source: 'gt-i18n',
-    severity: 'Warning',
-    whatHappened: `Overwriting global ${name} singleton instance`,
-  });
 }

--- a/packages/i18n/src/globals/__tests__/createGlobalSingleton.test.ts
+++ b/packages/i18n/src/globals/__tests__/createGlobalSingleton.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createGlobalSingleton } from '../createGlobalSingleton';
+
+type TestGlobal = typeof globalThis & {
+  __generaltranslation?: {
+    testGlobalSingleton?: {
+      singleton?: unknown;
+      [key: string]: unknown;
+    };
+    [key: string]: unknown;
+  };
+};
+
+function resetTestGlobalSingleton() {
+  const globalObj = globalThis as TestGlobal;
+  if (globalObj.__generaltranslation?.testGlobalSingleton) {
+    Reflect.deleteProperty(
+      globalObj.__generaltranslation.testGlobalSingleton,
+      'singleton'
+    );
+  }
+}
+
+describe('createGlobalSingleton', () => {
+  beforeEach(() => {
+    resetTestGlobalSingleton();
+  });
+
+  it('treats null registry slots as uninitialized', () => {
+    const singleton = createGlobalSingleton<{ id: string }>({
+      namespace: 'testGlobalSingleton',
+      key: 'singleton',
+      source: 'gt-i18n',
+      notInitialized: () => 'singleton missing',
+    });
+    const globalObj = globalThis as TestGlobal;
+    globalObj.__generaltranslation ??= {};
+    globalObj.__generaltranslation.testGlobalSingleton = {
+      singleton: null,
+    };
+
+    expect(singleton.isInitialized()).toBe(false);
+    expect(() => singleton.get()).toThrow('singleton missing');
+  });
+});

--- a/packages/i18n/src/globals/createGlobalSingleton.ts
+++ b/packages/i18n/src/globals/createGlobalSingleton.ts
@@ -70,7 +70,8 @@ export function createGlobalSingleton<T>({
   }
 
   function isInitialized(): boolean {
-    return getNamespace(namespace)[key] !== undefined;
+    const value = getNamespace(namespace)[key];
+    return value !== undefined && value !== null;
   }
 
   return { get, set, isInitialized };

--- a/packages/i18n/src/globals/createGlobalSingleton.ts
+++ b/packages/i18n/src/globals/createGlobalSingleton.ts
@@ -1,0 +1,77 @@
+import { createDiagnosticMessage } from 'generaltranslation/internal';
+
+/**
+ * Shared global registry stored on `globalThis.__generaltranslation`. Each
+ * package namespace (e.g. `i18n`, `reactCore`) owns a bag of singleton slots.
+ */
+type SingletonRegistry = Record<string, Record<string, unknown> | undefined>;
+
+type GlobalWithRegistry = {
+  __generaltranslation?: SingletonRegistry;
+};
+
+function getNamespace(namespace: string): Record<string, unknown> {
+  const globalObj = globalThis as unknown as GlobalWithRegistry;
+  globalObj.__generaltranslation ??= {};
+  // TODO: Consider checking package versions and using a compatibility matrix before sharing global singletons.
+  globalObj.__generaltranslation[namespace] ??= {};
+  return globalObj.__generaltranslation[namespace]!;
+}
+
+export type GlobalSingleton<T> = {
+  get: () => T;
+  set: (next: T) => void;
+  isInitialized: () => boolean;
+};
+
+/**
+ * Creates a global singleton backed by `globalThis.__generaltranslation`.
+ *
+ * Centralizes the global-registry plumbing and overwrite warning shared by the
+ * i18nConfig, i18nCache, i18nStore, and conditionStore singletons.
+ *
+ * @param namespace - The package namespace bag (e.g. `i18n`, `reactCore`).
+ * @param key - The slot within the namespace and the name used in the warning.
+ * @param source - Diagnostic source for the overwrite warning.
+ * @param notInitialized - Lazily builds the error thrown when read before set.
+ */
+export function createGlobalSingleton<T>({
+  namespace,
+  key,
+  source,
+  notInitialized,
+}: {
+  namespace: string;
+  key: string;
+  source: string;
+  notInitialized: () => string | Error;
+}): GlobalSingleton<T> {
+  function get(): T {
+    const value = getNamespace(namespace)[key];
+    if (value === undefined || value === null) {
+      const error = notInitialized();
+      throw typeof error === 'string' ? new Error(error) : error;
+    }
+    return value as T;
+  }
+
+  function set(next: T): void {
+    const ns = getNamespace(namespace);
+    if (ns[key] !== undefined && ns[key] !== next) {
+      console.warn(
+        createDiagnosticMessage({
+          source,
+          severity: 'Warning',
+          whatHappened: `Overwriting global ${key} singleton instance`,
+        })
+      );
+    }
+    ns[key] = next as unknown;
+  }
+
+  function isInitialized(): boolean {
+    return getNamespace(namespace)[key] !== undefined;
+  }
+
+  return { get, set, isInitialized };
+}

--- a/packages/i18n/src/i18n-cache/singleton-operations.ts
+++ b/packages/i18n/src/i18n-cache/singleton-operations.ts
@@ -1,29 +1,21 @@
 import { createDiagnosticMessage } from 'generaltranslation/internal';
+import { createGlobalSingleton } from '../globals/createGlobalSingleton';
 import { I18nCache } from './I18nCache';
 import { Translation } from './translations-manager/utils/types/translation-data';
 
-type I18nGlobals = {
-  i18nCache?: I18nCache;
-  gtServicesEnabled?: boolean | undefined;
-  [key: string]: unknown;
-};
-
-type GeneralTranslationGlobal = {
-  i18n?: I18nGlobals;
-  [key: string]: unknown;
-};
-
-type GlobalWithGeneralTranslation = {
-  __generaltranslation?: GeneralTranslationGlobal;
-};
-
-function getI18nGlobals(): I18nGlobals {
-  const globalObj = globalThis as unknown as GlobalWithGeneralTranslation;
-  globalObj.__generaltranslation ??= {};
-  // TODO: Consider checking package versions and using a compatibility matrix before sharing global singletons.
-  globalObj.__generaltranslation.i18n ??= {};
-  return globalObj.__generaltranslation.i18n;
-}
+const i18nCacheSingleton = createGlobalSingleton<I18nCache>({
+  namespace: 'i18n',
+  key: 'i18nCache',
+  source: 'gt-i18n',
+  notInitialized: () =>
+    createDiagnosticMessage({
+      source: 'gt-i18n',
+      severity: 'Error',
+      whatHappened: 'Cannot read I18nCache before it has been initialized',
+      why: 'the internal I18nCache singleton is unavailable',
+      fix: 'Call initializeGT() before accessing I18nCache.',
+    }),
+});
 
 /**
  * Get the singleton instance of I18nCache
@@ -35,11 +27,7 @@ function getI18nGlobals(): I18nGlobals {
 export function getI18nCache<U extends Translation = Translation>():
   | I18nCache<U>
   | I18nCache<Translation> {
-  const i18nCache = getI18nGlobals().i18nCache;
-  if (!i18nCache) {
-    throw new Error(getI18nCacheNotInitializedError());
-  }
-  return i18nCache;
+  return i18nCacheSingleton.get();
 }
 
 /**
@@ -53,28 +41,5 @@ export function getI18nCache<U extends Translation = Translation>():
 export function setI18nCache<TranslationValue extends Translation>(
   i18nCacheInstance: I18nCache<TranslationValue>
 ): void {
-  const i18nGlobals = getI18nGlobals();
-  const nextI18nCache = i18nCacheInstance as unknown as I18nCache;
-  if (i18nGlobals.i18nCache && i18nGlobals.i18nCache !== nextI18nCache) {
-    console.warn(createSingletonOverwriteWarning('i18nCache'));
-  }
-  i18nGlobals.i18nCache = nextI18nCache;
-}
-
-function getI18nCacheNotInitializedError(): string {
-  return createDiagnosticMessage({
-    source: 'gt-i18n',
-    severity: 'Error',
-    whatHappened: 'Cannot read I18nCache before it has been initialized',
-    why: 'the internal I18nCache singleton is unavailable',
-    fix: 'Call initializeGT() before accessing I18nCache.',
-  });
-}
-
-function createSingletonOverwriteWarning(name: string): string {
-  return createDiagnosticMessage({
-    source: 'gt-i18n',
-    severity: 'Warning',
-    whatHappened: `Overwriting global ${name} singleton instance`,
-  });
+  i18nCacheSingleton.set(i18nCacheInstance as unknown as I18nCache);
 }

--- a/packages/i18n/src/i18n-config/singleton-operations.ts
+++ b/packages/i18n/src/i18n-config/singleton-operations.ts
@@ -1,44 +1,24 @@
 import { createDiagnosticMessage } from 'generaltranslation/internal';
+import { createGlobalSingleton } from '../globals/createGlobalSingleton';
 import { I18nConfig, type I18nConfigParams } from './I18nConfig';
 
-type I18nGlobals = {
-  i18nConfig?: I18nConfig;
-  gtServicesEnabled?: boolean | undefined;
-  [key: string]: unknown;
-};
+const i18nConfigSingleton = createGlobalSingleton<I18nConfig>({
+  namespace: 'i18n',
+  key: 'i18nConfig',
+  source: 'gt-i18n',
+  notInitialized: () =>
+    createDiagnosticMessage({
+      source: 'gt-i18n',
+      severity: 'Error',
+      whatHappened: 'Cannot read I18nConfig before it has been initialized',
+      why: 'the internal I18nConfig singleton is unavailable',
+      fix: 'Call initializeGT() before reading locale config.',
+    }),
+});
 
-type GeneralTranslationGlobal = {
-  i18n?: I18nGlobals;
-  [key: string]: unknown;
-};
-
-type GlobalWithGeneralTranslation = {
-  __generaltranslation?: GeneralTranslationGlobal;
-};
-
-function getI18nGlobals(): I18nGlobals {
-  const globalObj = globalThis as unknown as GlobalWithGeneralTranslation;
-  globalObj.__generaltranslation ??= {};
-  // TODO: Consider checking package versions and using a compatibility matrix before sharing global singletons.
-  globalObj.__generaltranslation.i18n ??= {};
-  return globalObj.__generaltranslation.i18n;
-}
-
-export function getI18nConfig(): I18nConfig {
-  const i18nConfig = getI18nGlobals().i18nConfig;
-  if (!i18nConfig) {
-    throw new Error(getI18nConfigNotInitializedError());
-  }
-  return i18nConfig;
-}
-
-export function setI18nConfig(nextI18nConfig: I18nConfig): void {
-  const i18nGlobals = getI18nGlobals();
-  if (i18nGlobals.i18nConfig && i18nGlobals.i18nConfig !== nextI18nConfig) {
-    console.warn(createSingletonOverwriteWarning('i18nConfig'));
-  }
-  i18nGlobals.i18nConfig = nextI18nConfig;
-}
+export const getI18nConfig = i18nConfigSingleton.get;
+export const setI18nConfig = i18nConfigSingleton.set;
+export const isI18nConfigInitialized = i18nConfigSingleton.isInitialized;
 
 export function initializeI18nConfig(
   params: I18nConfigParams = {}
@@ -46,26 +26,4 @@ export function initializeI18nConfig(
   const nextI18nConfig = new I18nConfig(params);
   setI18nConfig(nextI18nConfig);
   return nextI18nConfig;
-}
-
-export function isI18nConfigInitialized(): boolean {
-  return getI18nGlobals().i18nConfig !== undefined;
-}
-
-function getI18nConfigNotInitializedError(): string {
-  return createDiagnosticMessage({
-    source: 'gt-i18n',
-    severity: 'Error',
-    whatHappened: 'Cannot read I18nConfig before it has been initialized',
-    why: 'the internal I18nConfig singleton is unavailable',
-    fix: 'Call initializeGT() before reading locale config.',
-  });
-}
-
-function createSingletonOverwriteWarning(name: string): string {
-  return createDiagnosticMessage({
-    source: 'gt-i18n',
-    severity: 'Warning',
-    whatHappened: `Overwriting global ${name} singleton instance`,
-  });
 }

--- a/packages/i18n/src/internal.ts
+++ b/packages/i18n/src/internal.ts
@@ -72,5 +72,7 @@ export {
 export { I18nConfig } from './i18n-config/I18nConfig';
 export type { I18nConfigParams } from './i18n-config/I18nConfig';
 export { createConditionStoreSingleton } from './condition-store/createConditionStoreSingleton';
+export { createGlobalSingleton } from './globals/createGlobalSingleton';
+export type { GlobalSingleton } from './globals/createGlobalSingleton';
 export { getRuntimeEnvironment } from './utils/getRuntimeEnvironment';
 export { hashMessage } from './utils/hashMessage';

--- a/packages/react-core/src/i18n-store/singleton-operations.ts
+++ b/packages/react-core/src/i18n-store/singleton-operations.ts
@@ -1,50 +1,20 @@
 import { createDiagnosticMessage } from 'generaltranslation/internal';
+import { createGlobalSingleton } from 'gt-i18n/internal';
 import { I18nStore } from './I18nStore';
 import { getI18nConfig } from '../setup/i18nConfig';
 
 // ===== I18n Store ===== //
 
-type ReactCoreGlobals = {
-  i18nStore?: I18nStore;
-  [key: string]: unknown;
-};
+const i18nStoreSingleton = createGlobalSingleton<I18nStore>({
+  namespace: 'reactCore',
+  key: 'i18nStore',
+  source: '@generaltranslation/react-core',
+  notInitialized: () => createI18nStoreNotInitializedError(),
+});
 
-type GeneralTranslationGlobal = {
-  reactCore?: ReactCoreGlobals;
-  [key: string]: unknown;
-};
-
-type GlobalWithGeneralTranslation = {
-  __generaltranslation?: GeneralTranslationGlobal;
-};
-
-function getReactCoreGlobals(): ReactCoreGlobals {
-  const globalObj = globalThis as unknown as GlobalWithGeneralTranslation;
-  globalObj.__generaltranslation ??= {};
-  // TODO: Consider checking package versions and using a compatibility matrix before sharing global singletons.
-  globalObj.__generaltranslation.reactCore ??= {};
-  return globalObj.__generaltranslation.reactCore;
-}
-
-export function getI18nStore(): I18nStore {
-  const i18nStore = getReactCoreGlobals().i18nStore;
-  if (!i18nStore) {
-    throw createI18nStoreNotInitializedError();
-  }
-  return i18nStore;
-}
-
-export function setI18nStore(nextStore: I18nStore): void {
-  const reactCoreGlobals = getReactCoreGlobals();
-  if (reactCoreGlobals.i18nStore && reactCoreGlobals.i18nStore !== nextStore) {
-    console.warn(createI18nStoreOverwriteWarning());
-  }
-  reactCoreGlobals.i18nStore = nextStore;
-}
-
-export function isI18nStoreInitialized(): boolean {
-  return getReactCoreGlobals().i18nStore !== undefined;
-}
+export const getI18nStore = i18nStoreSingleton.get;
+export const setI18nStore = i18nStoreSingleton.set;
+export const isI18nStoreInitialized = i18nStoreSingleton.isInitialized;
 
 function createI18nStoreNotInitializedError(): Error {
   const renderStrategy = getI18nConfig().getRenderStrategy();
@@ -59,12 +29,4 @@ function createI18nStoreNotInitializedError(): Error {
   });
 
   return new Error(errorMessage);
-}
-
-function createI18nStoreOverwriteWarning(): string {
-  return createDiagnosticMessage({
-    source: '@generaltranslation/react-core',
-    severity: 'Warning',
-    whatHappened: 'Overwriting global i18nStore singleton instance',
-  });
 }


### PR DESCRIPTION
## Summary
- add a shared gt-i18n global singleton helper
- refactor i18n config/cache/condition-store and react-core store singletons to use it
- preserve internal exports for cross-package singleton sharing

## Tests
- pnpm --filter gt-i18n test
- pnpm --filter @generaltranslation/react-core test
- pnpm --filter gt-i18n typecheck
- pnpm --filter @generaltranslation/react-core typecheck
- git diff --check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Introduces a shared `createGlobalSingleton` factory in `gt-i18n` that centralises the `globalThis.__generaltranslation` registry plumbing previously duplicated across `i18nConfig`, `i18nCache`, `conditionStore`, and `react-core`'s `i18nStore`. All four singletons are refactored to delegate to the new helper, and it is re-exported from `gt-i18n/internal` so downstream packages can adopt it directly.

- **New factory** (`packages/i18n/src/globals/createGlobalSingleton.ts`): exposes a uniform `{ get, set, isInitialized }` interface backed by a namespaced slot in `globalThis.__generaltranslation`; `get()` and `isInitialized()` both treat `null` and `undefined` as "not initialized", addressing a previous inconsistency raised in review.
- **Refactored singletons**: `i18nConfig`, `i18nCache`, `conditionStore`, and `i18nStore` each replace ~30–50 lines of near-identical boilerplate with a two-line `createGlobalSingleton` call; error messages and overwrite warnings are preserved.
- **Internal export**: `createGlobalSingleton` and the `GlobalSingleton` type are added to `packages/i18n/src/internal.ts`, enabling cross-package singleton sharing without duplicating the registry logic.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — a clean deduplication with no changes to public API surface or runtime behaviour on the normal path.

All four singletons delegate to the new factory through thin wrappers; get/set/isInitialized semantics are unchanged for callers. The null-slot handling in isInitialized() is now correctly addressed (with a matching test). The only finding is a minor inconsistency in the set() overwrite-warning guard that only manifests under external registry tampering.

packages/i18n/src/globals/createGlobalSingleton.ts — the set() overwrite guard should also exclude null to stay consistent with isInitialized().
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/i18n/src/globals/createGlobalSingleton.ts | New shared utility that consolidates the globalThis.__generaltranslation registry plumbing. Minor inconsistency: the set() overwrite-warning guard checks !== undefined while isInitialized() also excludes null. |
| packages/i18n/src/globals/__tests__/createGlobalSingleton.test.ts | Unit test covering the null-slot edge case; verifies isInitialized() returns false and get() throws when the registry slot holds null. |
| packages/react-core/src/i18n-store/singleton-operations.ts | Switches to importing createGlobalSingleton from gt-i18n/internal; createI18nStoreNotInitializedError() still calls getI18nConfig() which is the same cascading behavior as before. |
| packages/i18n/src/internal.ts | Exports createGlobalSingleton and GlobalSingleton type so react-core (and future packages) can import from gt-i18n/internal. |
| packages/i18n/src/condition-store/createConditionStoreSingleton.ts | Inline boilerplate replaced by createGlobalSingleton delegation; no behavioral changes for the normal path. |
| packages/i18n/src/i18n-cache/singleton-operations.ts | Replaced custom registry boilerplate with createGlobalSingleton; error message preserved via the notInitialized factory. |
| packages/i18n/src/i18n-config/singleton-operations.ts | Direct method exports now forward to i18nConfigSingleton; isI18nConfigInitialized is now exported (was previously present as a named function). |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Consumer calls get / set / isInitialized] --> B[createGlobalSingleton factory]
    B --> C[getNamespace reads globalThis.__generaltranslation namespace bag]
    C --> D{Operation}
    D -->|get| E{slot is undefined or null?}
    E -->|yes| F[invoke notInitialized callback and throw Error]
    E -->|no| G[return value as T]
    D -->|set| H{slot is not undefined AND not equal to next?}
    H -->|yes| I[console.warn overwrite via createDiagnosticMessage]
    H -->|no| J[write next to slot]
    I --> J
    D -->|isInitialized| K{slot is not undefined AND not null?}
    K -->|true| L[return true]
    K -->|false| M[return false]

    subgraph Callers
      N[gt-i18n i18nConfig]
      O[gt-i18n i18nCache]
      P[gt-i18n conditionStore]
      Q[react-core i18nStore]
    end
    Callers --> B
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Consumer calls get / set / isInitialized] --> B[createGlobalSingleton factory]
    B --> C[getNamespace reads globalThis.__generaltranslation namespace bag]
    C --> D{Operation}
    D -->|get| E{slot is undefined or null?}
    E -->|yes| F[invoke notInitialized callback and throw Error]
    E -->|no| G[return value as T]
    D -->|set| H{slot is not undefined AND not equal to next?}
    H -->|yes| I[console.warn overwrite via createDiagnosticMessage]
    H -->|no| J[write next to slot]
    I --> J
    D -->|isInitialized| K{slot is not undefined AND not null?}
    K -->|true| L[return true]
    K -->|false| M[return false]

    subgraph Callers
      N[gt-i18n i18nConfig]
      O[gt-i18n i18nCache]
      P[gt-i18n conditionStore]
      Q[react-core i18nStore]
    end
    Callers --> B
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: treat null singleton slots as unini..."](https://github.com/generaltranslation/gt/commit/d0f66660effebb8d7eda6daf90ef60f4b1236e72) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40882016)</sub>

<!-- /greptile_comment -->