### PR TITLE
fix: clarify cache components request function warning

### DIFF
--- a/packages/next/src/errors/cacheComponents.ts
+++ b/packages/next/src/errors/cacheComponents.ts
@@ -20,7 +20,7 @@ export const createCacheComponentsMissingRequestFunctionsWarning = (
   return createGtNextDiagnostic({
     whatHappened: `cacheComponents is enabled, but custom ${functionNames} ${isPlural ? 'are' : 'is'} not configured`,
     wayOut:
-      'Automatic root parameter detection is deprecated because it relies on unsupported Next.js internals',
+      'cacheComponents requires explicit request functions because request values cannot be inferred safely during prerendering',
     fix: `Add ${fileNames} ${isPlural ? 'files' : 'file'}, or configure ${configKeys}`,
   });
 };


### PR DESCRIPTION
## Summary
- update the cacheComponents warning to say explicit request functions are required during prerendering
- remove stale wording about automatic root parameter detection

## Tests
- pnpm --filter gt-next test -- src/plugin/checks/__tests__/cacheComponentsChecks.test.ts
- git diff --check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates one error message string in the `cacheComponents` diagnostics module, replacing stale deprecation wording with a clearer explanation of why explicit request functions are required during prerendering.

- The `wayOut` field in `createCacheComponentsMissingRequestFunctionsWarning` now reads "cacheComponents requires explicit request functions because request values cannot be inferred safely during prerendering," making it more actionable than the previous reference to deprecated automatic root parameter detection.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This is a one-line string change in a diagnostic helper — no logic is altered and no runtime behavior changes.

The only change is the wayOut string inside an error-diagnostic factory. The new wording is more accurate and actionable than what it replaces, and no code path, type signature, or behavior is affected.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/next/src/errors/cacheComponents.ts | Single-line update to the `wayOut` field of the missing-request-functions diagnostic — replaces the stale "Automatic root parameter detection is deprecated" message with a clearer explanation about prerendering safety requirements. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[cacheComponents enabled] --> B{Explicit request functions configured?}
    B -- Yes --> C[Proceed with prerendering]
    B -- No --> D[createCacheComponentsMissingRequestFunctionsWarning]
    D --> E["whatHappened: cacheComponents enabled but getLocale()/getRegion() not configured"]
    D --> F["wayOut: explicit request functions required — values cannot be inferred during prerendering"]
    D --> G["fix: add getLocale.ts / getRegion.ts or configure getLocalePath / getRegionPath"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[cacheComponents enabled] --> B{Explicit request functions configured?}
    B -- Yes --> C[Proceed with prerendering]
    B -- No --> D[createCacheComponentsMissingRequestFunctionsWarning]
    D --> E["whatHappened: cacheComponents enabled but getLocale()/getRegion() not configured"]
    D --> F["wayOut: explicit request functions required — values cannot be inferred during prerendering"]
    D --> G["fix: add getLocale.ts / getRegion.ts or configure getLocalePath / getRegionPath"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: clarify cache components request fu..."](https://github.com/generaltranslation/gt/commit/41aa42bc593fdb5c092c24f911c223df38b70897) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40885818)</sub>

<!-- /greptile_comment -->