### PR TITLE
fix: avoid vite import meta env types

### DIFF
--- a/.changeset/fix-react-import-meta-env.md
+++ b/.changeset/fix-react-import-meta-env.md
@@ -1,0 +1,5 @@
+---
+"gt-react": patch
+---
+
+Use the shared runtime environment helper for browser cache dev-mode checks so `gt-react` typechecks without Vite ambient types.

--- a/packages/react/src/i18n-cache/BrowserI18nCache.ts
+++ b/packages/react/src/i18n-cache/BrowserI18nCache.ts
@@ -2,7 +2,11 @@ import type {
   I18nCacheConstructorParams,
   TranslationsLoader,
 } from 'gt-i18n/internal/types';
-import { getI18nConfig, I18nCache } from 'gt-i18n/internal';
+import {
+  getI18nConfig,
+  getRuntimeEnvironment,
+  I18nCache,
+} from 'gt-i18n/internal';
 import type { HtmlTagOptions } from './types';
 import type { Translation } from 'gt-i18n/types';
 import { DEFAULT_HTML_TAG_OPTIONS } from './constants';
@@ -95,7 +99,7 @@ export class BrowserI18nCache extends I18nCache<Translation> {
     locale: string,
     init?: Record<string, Translation>
   ): LocalStorageTranslationCache | undefined {
-    if (!import.meta.env?.DEV) return undefined;
+    if (getRuntimeEnvironment() !== 'development') return undefined;
 
     if (!this._localStorageCaches[locale]) {
       this._localStorageCaches[locale] = new LocalStorageTranslationCache({


### PR DESCRIPTION
## Summary
- replace direct `import.meta.env` access in `BrowserI18nCache` with the shared runtime environment helper
- add a `gt-react` patch changeset

## Tests
- pnpm --filter @generaltranslation/react-core build
- pnpm --filter gt-react typecheck
- pnpm --filter gt-react test
- git diff --check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the direct `import.meta.env?.DEV` access from `BrowserI18nCache.getLocalStorageTranslationCache` and replaces it with the shared `getRuntimeEnvironment()` helper from `gt-i18n/internal`, fixing TypeScript errors that occur when Vite's ambient types are not present in the project.

- **`BrowserI18nCache.ts`**: The single-line guard `!import.meta.env?.DEV` is replaced with `getRuntimeEnvironment() !== 'development'`. The helper checks `process.env.NODE_ENV` first (for webpack/CRA/Node environments), then `import.meta.env.MODE`, then `import.meta.env.DEV`, defaulting to `'production'` — behavior is equivalent for Vite and slightly broader for non-Vite bundlers.
- **`.changeset/fix-react-import-meta-env.md`**: A `patch` changeset is added for `gt-react` to track the release.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — a one-line guard swap with no altered control flow in normal usage.

The change is minimal and the replacement helper consolidates the same import.meta.env.DEV check alongside additional process.env.NODE_ENV support. For Vite users the behavior is identical; for non-Vite bundlers it is strictly more correct. No new runtime paths or error conditions are introduced.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .changeset/fix-react-import-meta-env.md | Adds a patch changeset entry for gt-react, documenting the import.meta.env type fix. |
| packages/react/src/i18n-cache/BrowserI18nCache.ts | Replaces the bare `import.meta.env?.DEV` guard in `getLocalStorageTranslationCache` with the shared `getRuntimeEnvironment()` helper; imports updated accordingly. Behavior is equivalent for Vite and improves coverage for webpack/Node environments. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[getLocalStorageTranslationCache called] --> B{getRuntimeEnvironment}
    B --> C{process.env.NODE_ENV === 'development'?}
    C -- Yes --> D[return 'development']
    C -- No --> E{import.meta.env.MODE exists?}
    E -- Yes --> F{MODE === 'development'?}
    F -- Yes --> D
    F -- No --> G[return 'production']
    E -- No --> H{import.meta.env.DEV === true?}
    H -- Yes --> D
    H -- No --> G
    D --> I[env === 'development' → create/return LocalStorageTranslationCache]
    G --> J[env !== 'development' → return undefined]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[getLocalStorageTranslationCache called] --> B{getRuntimeEnvironment}
    B --> C{process.env.NODE_ENV === 'development'?}
    C -- Yes --> D[return 'development']
    C -- No --> E{import.meta.env.MODE exists?}
    E -- Yes --> F{MODE === 'development'?}
    F -- Yes --> D
    F -- No --> G[return 'production']
    E -- No --> H{import.meta.env.DEV === true?}
    H -- Yes --> D
    H -- No --> G
    D --> I[env === 'development' → create/return LocalStorageTranslationCache]
    G --> J[env !== 'development' → return undefined]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: avoid vite import meta env types"](https://github.com/generaltranslation/gt/commit/c3ac32dfde00c6e568f65be5e735268ebe7a6b18) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40888010)</sub>

<!-- /greptile_comment -->