### PR TITLE
F/lock relative path fix

### DIFF
--- a/.changeset/quiet-donkeys-clap.md
+++ b/.changeset/quiet-donkeys-clap.md
@@ -1,0 +1,5 @@
+---
+"gt": patch
+---
+
+Fix translation file path in `gt-lock.json`

--- a/packages/cli/src/api/__tests__/downloadFileBatch.test.ts
+++ b/packages/cli/src/api/__tests__/downloadFileBatch.test.ts
@@ -3,13 +3,18 @@ import { BatchedFiles, downloadFileBatch } from '../downloadFileBatch.js';
 import { gt } from '../../utils/gt.js';
 import * as fs from 'fs';
 import * as path from 'path';
+import nodePath from 'node:path';
 import { logger } from '../../console/logger.js';
 import {
   DownloadFileBatchResult as CoreDownloadFileBatchResult,
   FileFormat,
 } from 'generaltranslation/types';
 import { createMockSettings } from '../__mocks__/settings.js';
-import { readLockfile } from '../../fs/config/downloadedVersions.js';
+import {
+  findOrCreateEntry,
+  readLockfile,
+} from '../../fs/config/downloadedVersions.js';
+import type { DownloadedVersionEntry } from '../../fs/config/downloadedVersions.js';
 import type { FileStatusTracker } from '../../workflow/PollJobsStep.js';
 
 // Mock dependencies
@@ -30,14 +35,19 @@ vi.mock('fs', () => ({
   },
 }));
 
-vi.mock('path', () => {
+vi.mock('path', async () => {
+  const actualPath =
+    await vi.importActual<typeof import('node:path')>('node:path');
   // Shared instances so default and named imports resolve to the same mocks
-  const dirname = vi.fn();
-  const relative = vi.fn();
+  const dirname = vi.fn(actualPath.dirname);
+  const relative = vi.fn(actualPath.relative);
+  const resolve = vi.fn(actualPath.resolve);
   return {
-    default: { dirname, relative },
+    ...actualPath,
+    default: { ...actualPath, dirname, relative, resolve },
     dirname,
     relative,
+    resolve,
   };
 });
 
@@ -490,6 +500,48 @@ describe('downloadFileBatch', () => {
 
     expect(result.successful).toHaveLength(1);
     expect(result.failed).toHaveLength(0);
+  });
+
+  it('stores relative output paths in the lockfile', async () => {
+    const outputPath = nodePath.resolve('public/gt/es.json');
+    const files = createBatchedFiles(1, {
+      locale: 'es',
+      outputPath,
+    });
+    const fileTracker = createMockFileTracker(files);
+    const lockEntry: DownloadedVersionEntry = {
+      fileId: 'file-1',
+      versionId: 'version-1',
+      translations: {},
+    };
+
+    vi.mocked(findOrCreateEntry).mockReturnValue(lockEntry);
+    vi.mocked(gt.downloadFileBatch).mockResolvedValue({
+      files: [
+        {
+          id: 'translation-1',
+          branchId: 'branch-1',
+          fileId: 'file-1',
+          versionId: 'version-1',
+          locale: 'es',
+          fileFormat: 'GTJSON' as FileFormat,
+          data: '{"hello":"Hola"}',
+          fileName: 'es.json',
+          metadata: {},
+        },
+      ],
+      count: 1,
+    });
+    setupFileSystemMocks();
+
+    const result = await downloadFileBatch(
+      fileTracker,
+      files,
+      createMockSettings()
+    );
+
+    expect(result.successful).toHaveLength(1);
+    expect(lockEntry.translations.es.fileName).toBe('public/gt/es.json');
   });
 
   it('should handle directory creation errors', async () => {

--- a/packages/cli/src/api/downloadFileBatch.ts
+++ b/packages/cli/src/api/downloadFileBatch.ts
@@ -335,7 +335,7 @@ export async function downloadFileBatch(
           entry.staged = false;
           entry.translations[locale] = {
             updatedAt: new Date().toISOString(),
-            fileName: outputPath,
+            fileName: getRelative(outputPath),
           };
           didUpdateDownloadedLock = true;
         }

--- a/packages/cli/src/formats/files/__tests__/fileMapping.test.ts
+++ b/packages/cli/src/formats/files/__tests__/fileMapping.test.ts
@@ -1,8 +1,24 @@
 import { describe, expect, it } from 'vitest';
 import path from 'node:path';
 import { createFileMapping } from '../fileMapping.js';
+import { TEMPLATE_FILE_NAME } from '../../../utils/constants.js';
 
 describe('createFileMapping', () => {
+  it('uses a relative output path for GTJSON template files', () => {
+    const outputPath = path.resolve('public/gt/[locale].json');
+
+    const mapping = createFileMapping(
+      {},
+      { gt: outputPath },
+      {},
+      {},
+      ['es'],
+      'en'
+    );
+
+    expect(mapping.es[TEMPLATE_FILE_NAME]).toBe('public/gt/es.json');
+  });
+
   // TODO: Re-enable when the API supports POT -> PO file format transforms.
   it.skip('uses the transformation format extension for mapped output files', () => {
     const sourcePath = path.resolve('locales/en/messages.pot');

--- a/packages/cli/src/formats/files/fileMapping.ts
+++ b/packages/cli/src/formats/files/fileMapping.ts
@@ -41,7 +41,7 @@ export function createFileMapping(
     // Start with GTJSON Template files
     if (translatedPaths.gt) {
       const filepath = translatedPaths.gt;
-      localeMapping[TEMPLATE_FILE_NAME] = filepath;
+      localeMapping[TEMPLATE_FILE_NAME] = getRelative(filepath);
     }
 
     for (const typeIndex of SUPPORTED_FILE_EXTENSIONS) {


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where absolute file paths were being stored in `gt-lock.json` instead of relative paths, causing portability issues when the lock file is shared across machines or CI environments.

- In `fileMapping.ts`, the GTJSON template file path assignment now passes through `getRelative()` before being stored in `localeMapping`, consistent with all other file-type entries already processed the same way.
- In `downloadFileBatch.ts`, the `fileName` field written to the lockfile's `translations` entry now uses `getRelative(outputPath)` instead of the raw (absolute) `outputPath`. The `path` mock in the test suite is also updated to wrap actual `path.resolve` so the new `getRelative` call can execute correctly in tests.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is small, focused, and covered by new regression tests in both affected packages.

Both source changes are single-line wraps of an existing utility (getRelative) that is already used consistently throughout the file-mapping logic. The fix closes an inconsistency where GTJSON template paths and lockfile output paths were the only entries written as absolute paths. New tests in both fileMapping.test.ts and downloadFileBatch.test.ts directly assert the relative-path behaviour, and the path mock was updated correctly to support the new resolve call inside getRelative.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/formats/files/fileMapping.ts | One-line fix: wraps the GTJSON template file path with getRelative() to match the treatment of all other file types already in this function. |
| packages/cli/src/api/downloadFileBatch.ts | Fixes lockfile storing absolute output paths by applying getRelative() before writing fileName into the translations entry. |
| packages/cli/src/api/__tests__/downloadFileBatch.test.ts | Upgrades the path mock to wrap actual implementations (adding resolve spy), imports findOrCreateEntry for direct control, and adds a test that asserts the lockfile stores the relative path. |
| packages/cli/src/formats/files/__tests__/fileMapping.test.ts | Adds a regression test confirming that an absolute input path yields a relative path in the GTJSON template mapping entry. |
| .changeset/quiet-donkeys-clap.md | Adds a patch-level changeset for the gt package documenting the lock file path fix. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[outputPath - absolute] --> B{Path storage site}
    B --> C[fileMapping.ts\nlocaleMapping TEMPLATE_FILE_NAME]
    B --> D[downloadFileBatch.ts\nentry.translations locale .fileName]
    C -->|before fix| E[store absolute path]
    C -->|after fix| F[getRelative outputPath\nstore relative path]
    D -->|before fix| G[store absolute path]
    D -->|after fix| H[getRelative outputPath\nstore relative path]
    F --> I[gt-lock.json\nportable relative paths]
    H --> I
    E --> J[gt-lock.json\nnon-portable absolute paths]
    G --> J
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[outputPath - absolute] --> B{Path storage site}
    B --> C[fileMapping.ts\nlocaleMapping TEMPLATE_FILE_NAME]
    B --> D[downloadFileBatch.ts\nentry.translations locale .fileName]
    C -->|before fix| E[store absolute path]
    C -->|after fix| F[getRelative outputPath\nstore relative path]
    D -->|before fix| G[store absolute path]
    D -->|after fix| H[getRelative outputPath\nstore relative path]
    F --> I[gt-lock.json\nportable relative paths]
    H --> I
    E --> J[gt-lock.json\nnon-portable absolute paths]
    G --> J
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: changeset"](https://github.com/generaltranslation/gt/commit/a1806620dad364d0418059206438a423213a4c72) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40893548)</sub>

<!-- /greptile_comment -->