### PR TITLE
fix: initialize gt-next server standalone helpers

### DIFF
--- a/.changeset/server-standalone-init.md
+++ b/.changeset/server-standalone-init.md
@@ -1,0 +1,5 @@
+---
+"gt-next": patch
+---
+
+Initialize Next server singletons lazily when using the `gt-next/server` subpath in standalone route handlers and server utilities.

--- a/packages/next/src/__tests__/server-standalone.test.ts
+++ b/packages/next/src/__tests__/server-standalone.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockCookies, mockHeaders } = vi.hoisted(() => ({
+  mockCookies: vi.fn(),
+  mockHeaders: vi.fn(),
+}));
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('next/headers', () => ({
+  cookies: mockCookies,
+  headers: mockHeaders,
+}));
+
+type GlobalWithGT = typeof globalThis & {
+  __generaltranslation?: Record<string, Record<string, unknown> | undefined>;
+};
+
+let savedEnv: NodeJS.ProcessEnv;
+let savedGeneralTranslation: GlobalWithGT['__generaltranslation'];
+let savedFetch: typeof globalThis.fetch;
+
+function setConfigEnv() {
+  process.env.GT_PROJECT_ID = 'project-id';
+  process.env.NEXT_PUBLIC_GENERALTRANSLATION_I18N_CONFIG_PARAMS =
+    JSON.stringify({
+      defaultLocale: 'en',
+      locales: ['en', 'fr', 'ar'],
+    });
+  process.env._GENERALTRANSLATION_I18N_CONFIG_PARAMS = JSON.stringify({
+    cacheUrl: 'https://cache.example.com',
+    headersAndCookies: {
+      localeHeaderName: 'x-generaltranslation-locale',
+      localeCookieName: 'generaltranslation.locale',
+    },
+    ignoreBrowserLocales: false,
+  });
+}
+
+function resetGTGlobals() {
+  delete (globalThis as GlobalWithGT).__generaltranslation;
+  vi.resetModules();
+}
+
+describe('gt-next/server standalone entrypoint', () => {
+  beforeEach(() => {
+    savedEnv = { ...process.env };
+    savedGeneralTranslation = (globalThis as GlobalWithGT).__generaltranslation;
+    savedFetch = globalThis.fetch;
+    process.env = {};
+    setConfigEnv();
+    resetGTGlobals();
+    vi.clearAllMocks();
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      json: vi.fn().mockResolvedValue({}),
+    }) as unknown as typeof globalThis.fetch;
+    mockHeaders.mockResolvedValue({
+      get: (name: string) =>
+        name === 'x-generaltranslation-locale' ? 'fr' : null,
+    });
+    mockCookies.mockResolvedValue({
+      get: () => undefined,
+    });
+  });
+
+  afterEach(() => {
+    process.env = savedEnv;
+    (globalThis as GlobalWithGT).__generaltranslation = savedGeneralTranslation;
+    globalThis.fetch = savedFetch;
+    vi.resetModules();
+  });
+
+  it('initializes global singletons before request helpers run', async () => {
+    const { getLocale, getLocaleDirection, getRegion } =
+      await import('../server');
+
+    await expect(getLocale()).resolves.toBe('fr');
+    await expect(getRegion()).resolves.toBeUndefined();
+    expect(getLocaleDirection('ar')).toBe('rtl');
+  });
+
+  it('initializes global singletons before registerLocale runs', async () => {
+    const { getLocale, registerLocale } = await import('../server');
+
+    registerLocale('ar');
+
+    await expect(getLocale()).resolves.toBe('ar');
+  });
+
+  it('initializes global singletons before translation helpers run', async () => {
+    const { getGT } = await import('../server');
+
+    const gt = await getGT();
+
+    expect(gt('Hello')).toBe('Hello');
+  });
+});

--- a/packages/next/src/condition-store/AsyncConditionStore.ts
+++ b/packages/next/src/condition-store/AsyncConditionStore.ts
@@ -20,12 +20,15 @@ export type AsyncConditionStoreParams = {
   ignorePreferredLanguages?: boolean;
 };
 
-export const {
+const {
   getConditionStore: getAsyncConditionStore,
   setConditionStore: setAsyncConditionStore,
+  isConditionStoreInitialized,
 } = createConditionStoreSingleton<AsyncConditionStore>(
   'AsyncConditionStore not initialized. Invoke initializeGT() to initialize.'
 );
+
+export { getAsyncConditionStore, setAsyncConditionStore };
 
 /**
  * Server-side (app router) condition store
@@ -75,6 +78,15 @@ export class AsyncConditionStore implements AsyncReadonlyConditionStoreInterface
     // Technically does not need async, but good for parity
     return this.enableI18n;
   }
+}
+
+export function isAsyncConditionStoreInitialized(): boolean {
+  // The i18n condition-store singleton is shared across packages; make sure
+  // gt-next/server sees the async Next store, not another implementation.
+  return (
+    isConditionStoreInitialized() &&
+    getAsyncConditionStore() instanceof AsyncConditionStore
+  );
 }
 
 /**

--- a/packages/next/src/request/getEnableI18n.ts
+++ b/packages/next/src/request/getEnableI18n.ts
@@ -1,7 +1,9 @@
 import { getAsyncConditionStore } from '../condition-store/AsyncConditionStore';
+import { ensureGTServerInitialized } from '../setup/ensureGTServerInitialized';
 import { use } from '../utils/use';
 
 export function getEnableI18n(): Promise<boolean> {
+  ensureGTServerInitialized();
   return getAsyncConditionStore().getEnableI18n();
 }
 

--- a/packages/next/src/request/getLocale.ts
+++ b/packages/next/src/request/getLocale.ts
@@ -1,5 +1,6 @@
 import { use } from '../utils/use';
 import { getAsyncConditionStore } from '../condition-store/AsyncConditionStore';
+import { ensureGTServerInitialized } from '../setup/ensureGTServerInitialized';
 
 /**
  * Gets the user's current locale.
@@ -11,6 +12,7 @@ import { getAsyncConditionStore } from '../condition-store/AsyncConditionStore';
  * console.log(locale); // 'en-US'
  */
 export function getLocale(): Promise<string> {
+  ensureGTServerInitialized();
   return getAsyncConditionStore().getLocale();
 }
 

--- a/packages/next/src/request/getLocaleDirection.ts
+++ b/packages/next/src/request/getLocaleDirection.ts
@@ -1,5 +1,6 @@
 import { getI18nConfig } from 'gt-i18n/internal';
 import { getLocale, useLocale } from './getLocale';
+import { ensureGTServerInitialized } from '../setup/ensureGTServerInitialized';
 
 /**
  * Retrieves the text direction ('ltr' or 'rtl') for the current or specified locale.
@@ -18,6 +19,7 @@ export function getLocaleDirection(locale: string): 'ltr' | 'rtl';
 export function getLocaleDirection(): Promise<'ltr' | 'rtl'>;
 // Implementation
 export function getLocaleDirection(locale?: string) {
+  ensureGTServerInitialized();
   const gtInstance = getI18nConfig().getGTClass();
   if (typeof locale === 'string') {
     // Synchronous result when locale is given
@@ -42,6 +44,7 @@ export function getLocaleDirection(locale?: string) {
  * const arabicDir = useLocaleDirection('ar'); // 'rtl'
  */
 export function useLocaleDirection(locale?: string): 'ltr' | 'rtl' {
+  ensureGTServerInitialized();
   locale = locale || useLocale();
   return getI18nConfig().getGTClass().getLocaleDirection(locale);
 }

--- a/packages/next/src/request/getRegion.ts
+++ b/packages/next/src/request/getRegion.ts
@@ -1,5 +1,6 @@
 import { use } from '../utils/use';
 import { getAsyncConditionStore } from '../condition-store/AsyncConditionStore';
+import { ensureGTServerInitialized } from '../setup/ensureGTServerInitialized';
 
 /**
  * Gets the user's current region code.
@@ -11,6 +12,7 @@ import { getAsyncConditionStore } from '../condition-store/AsyncConditionStore';
  * console.log(region); // 'US' or undefined
  */
 export function getRegion(): Promise<string | undefined> {
+  ensureGTServerInitialized();
   return getAsyncConditionStore().getRegion();
 }
 

--- a/packages/next/src/request/registerLocale.ts
+++ b/packages/next/src/request/registerLocale.ts
@@ -1,5 +1,6 @@
 import { getI18nConfig } from 'gt-i18n/internal';
 import { localeStore } from './localeStore';
+import { ensureGTServerInitialized } from '../setup/ensureGTServerInitialized';
 
 /**
  * Set the locale for the current request context.
@@ -9,6 +10,7 @@ import { localeStore } from './localeStore';
  * @param locale - A BCP-47 locale tag (e.g., 'en-US', 'de', 'fr')
  */
 export function registerLocale(locale: string): void {
+  ensureGTServerInitialized();
   const gt = getI18nConfig().getGTClass();
   localeStore.enterWith(gt.resolveAliasLocale(locale));
 }

--- a/packages/next/src/setup/ensureGTServerInitialized.ts
+++ b/packages/next/src/setup/ensureGTServerInitialized.ts
@@ -1,0 +1,11 @@
+import { isI18nConfigInitialized } from 'gt-i18n/internal';
+import { isAsyncConditionStoreInitialized } from '../condition-store/AsyncConditionStore';
+import { initializeGT } from './initGT.rsc';
+
+export function ensureGTServerInitialized(): void {
+  if (isI18nConfigInitialized() && isAsyncConditionStoreInitialized()) {
+    return;
+  }
+
+  initializeGT();
+}


### PR DESCRIPTION
## Summary
- lazily initialize gt-next server singletons before `gt-next/server` request helpers access config or condition stores
- verify the condition-store singleton is actually the Next async store before treating it as initialized
- add a standalone `gt-next/server` regression test for route-handler style isolation
- add a gt-next patch changeset

## Tests
- pnpm --filter gt-next typecheck
- pnpm --filter gt-next test -- src/__tests__/server-standalone.test.ts
- pnpm exec oxfmt --check .changeset/server-standalone-init.md packages/next/src/condition-store/AsyncConditionStore.ts packages/next/src/request/getEnableI18n.ts packages/next/src/request/getLocale.ts packages/next/src/request/getLocaleDirection.ts packages/next/src/request/getRegion.ts packages/next/src/request/registerLocale.ts packages/next/src/setup/ensureGTServerInitialized.ts packages/next/src/__tests__/server-standalone.test.ts
- pnpm exec oxlint packages/next/src/condition-store/AsyncConditionStore.ts packages/next/src/request/getEnableI18n.ts packages/next/src/request/getLocale.ts packages/next/src/request/getLocaleDirection.ts packages/next/src/request/getRegion.ts packages/next/src/request/registerLocale.ts packages/next/src/setup/ensureGTServerInitialized.ts packages/next/src/__tests__/server-standalone.test.ts
- git diff --check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a cold-start bug where `gt-next/server` request helpers (`getLocale`, `getRegion`, `registerLocale`, etc.) would throw if the GT singletons had not been initialized by a prior `initGT` call (e.g. in standalone route handlers). The fix inserts a lightweight `ensureGTServerInitialized()` guard at the top of each helper and adds an `instanceof AsyncConditionStore` check to detect cross-package singleton sharing.

- **Lazy init guard** (`ensureGTServerInitialized.ts`): checks both `isI18nConfigInitialized()` and `isAsyncConditionStoreInitialized()` before calling `initializeGT()`; if either is missing the full RSC init path runs.
- **`isAsyncConditionStoreInitialized()`** (`AsyncConditionStore.ts`): wraps the generic singleton check with an `instanceof` test so a foreign store set by another package won't be treated as valid.
- **Regression test** (`server-standalone.test.ts`): wipes module registry and globals between tests to simulate a first-access cold start, then asserts locale/direction/region/registerLocale all resolve correctly.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the lazy-init guard is purely additive and the fast path is a cheap global-property check on every request.

The changes are focused and mechanically straightforward: each helper gains a synchronous guard at the top that exits immediately when both singletons are already set. The `instanceof AsyncConditionStore` cross-package check is a deliberate safety net with a clear code comment. No new issues were identified beyond what was already surfaced in earlier review rounds.

The only file worth a second look is `ensureGTServerInitialized.ts`, where the AND condition means a partially-initialized state triggers a full re-initialization — a known trade-off discussed in prior review threads.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/next/src/setup/ensureGTServerInitialized.ts | New lazy-init guard that calls full initializeGT() whenever either singleton is uninitialized; the AND check can re-initialize an already-set config (flagged in previous threads). |
| packages/next/src/condition-store/AsyncConditionStore.ts | Adds `isAsyncConditionStoreInitialized()` with an `instanceof AsyncConditionStore` guard to detect cross-package store sharing; exports restructured to expose the check internally only. |
| packages/next/src/request/getLocale.ts | Adds `ensureGTServerInitialized()` call before delegating to the condition store; straightforward guard addition. |
| packages/next/src/request/getEnableI18n.ts | Adds `ensureGTServerInitialized()` guard; the function is not re-exported from `server.ts`, so the regression test suite doesn't cover this path directly (flagged in previous threads). |
| packages/next/src/__tests__/server-standalone.test.ts | New regression test using `vi.resetModules()` and env-var mocking; covers `getLocale`, `getLocaleDirection`, `getRegion`, `registerLocale`, and `getGT` paths but not `getEnableI18n` directly (flagged in previous threads). |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Request helper called\n(getLocale / getRegion /\nregisterLocale / getLocaleDirection /\ngetEnableI18n)"] --> B["ensureGTServerInitialized()"]
    B --> C{"isI18nConfigInitialized()\n&&\nisAsyncConditionStoreInitialized()"}
    C -- "both true" --> D["Return early (fast path)"]
    C -- "either false" --> E["initializeGT() from initGT.rsc"]
    E --> F["coreInitializeGT()\ninitializeI18nConfig() + setNextI18nCache()"]
    E --> G["new AsyncConditionStore(env params)\nsetAsyncConditionStore()"]
    F --> H["Singletons ready"]
    G --> H
    H --> I["Helper reads from condition store / i18n config"]

    subgraph isAsyncConditionStoreInitialized
        J["isConditionStoreInitialized()"] --> K{"non-null\nin globalThis?"}
        K -- "no" --> L["false"]
        K -- "yes" --> M{"instanceof\nAsyncConditionStore?"}
        M -- "no" --> L
        M -- "yes" --> N["true"]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["Request helper called\n(getLocale / getRegion /\nregisterLocale / getLocaleDirection /\ngetEnableI18n)"] --> B["ensureGTServerInitialized()"]
    B --> C{"isI18nConfigInitialized()\n&&\nisAsyncConditionStoreInitialized()"}
    C -- "both true" --> D["Return early (fast path)"]
    C -- "either false" --> E["initializeGT() from initGT.rsc"]
    E --> F["coreInitializeGT()\ninitializeI18nConfig() + setNextI18nCache()"]
    E --> G["new AsyncConditionStore(env params)\nsetAsyncConditionStore()"]
    F --> H["Singletons ready"]
    G --> H
    H --> I["Helper reads from condition store / i18n config"]

    subgraph isAsyncConditionStoreInitialized
        J["isConditionStoreInitialized()"] --> K{"non-null\nin globalThis?"}
        K -- "no" --> L["false"]
        K -- "yes" --> M{"instanceof\nAsyncConditionStore?"}
        M -- "no" --> L
        M -- "yes" --> N["true"]
    end
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: initialize gt-next server standalon..."](https://github.com/generaltranslation/gt/commit/57af464e8d28b467ba3d0c59999370f4860e96f3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40913080)</sub>

<!-- /greptile_comment -->