### PR TITLE
Support getGT dev hot reload lookups

### DIFF
--- a/.changeset/compiler-getgt-preload-metadata.md
+++ b/.changeset/compiler-getgt-preload-metadata.md
@@ -1,0 +1,5 @@
+---
+'@generaltranslation/compiler': patch
+---
+
+Emit sugar metadata keys for injected getGT/useGT preload messages.

--- a/.changeset/compiler-getgt-preload-metadata.md
+++ b/.changeset/compiler-getgt-preload-metadata.md
@@ -1,5 +1,0 @@
----
-'@generaltranslation/compiler': patch
----
-
-Emit sugar metadata keys for injected getGT/useGT preload messages.

--- a/.changeset/dev-hot-reload-getgt.md
+++ b/.changeset/dev-hot-reload-getgt.md
@@ -1,0 +1,8 @@
+---
+"gt-i18n": patch
+"gt-next": patch
+---
+
+Support dev hot reload lookups for server `getGT` strings.
+
+`getGT` can now receive compiler-injected message metadata and prefetch missing translations through the runtime cache in development. `gt-next` forwards the server request conditions into this path so App Router server strings can participate in hot reload translation updates.

--- a/.changeset/dev-hot-reload-getgt.md
+++ b/.changeset/dev-hot-reload-getgt.md
@@ -1,4 +1,5 @@
 ---
+"@generaltranslation/compiler": patch
 "gt-i18n": patch
 "gt-next": patch
 ---
@@ -6,3 +7,5 @@
 Support dev hot reload lookups for server `getGT` strings.
 
 `getGT` can now receive compiler-injected message metadata and prefetch missing translations through the runtime cache in development. `gt-next` forwards the server request conditions into this path so App Router server strings can participate in hot reload translation updates.
+
+Compiler-injected `getGT` and `useGT` preload messages now emit the same sugar metadata keys used by runtime lookup options.

--- a/packages/compiler/src/passes/__tests__/runtimeTranslatePass.test.ts
+++ b/packages/compiler/src/passes/__tests__/runtimeTranslatePass.test.ts
@@ -135,7 +135,14 @@ function getOptionValue(
 ): string | number | undefined {
   const arg = call.arguments[1];
   if (!arg || !t.isObjectExpression(arg)) return undefined;
-  for (const prop of arg.properties) {
+  return getObjectPropertyValue(arg, key);
+}
+
+function getObjectPropertyValue(
+  object: t.ObjectExpression,
+  key: string
+): string | number | undefined {
+  for (const prop of object.properties) {
     if (!t.isObjectProperty(prop)) continue;
     const propKey = t.isStringLiteral(prop.key)
       ? prop.key.value
@@ -148,6 +155,40 @@ function getOptionValue(
     }
   }
   return undefined;
+}
+
+function getObjectPropertyNames(object: t.ObjectExpression): string[] {
+  return object.properties.flatMap((prop) => {
+    if (!t.isObjectProperty(prop)) return [];
+    if (t.isStringLiteral(prop.key)) return [prop.key.value];
+    if (t.isIdentifier(prop.key)) return [prop.key.name];
+    return [];
+  });
+}
+
+function getFirstArrayObjectArg(
+  call: t.CallExpression
+): t.ObjectExpression | undefined {
+  const arg = call.arguments[0];
+  if (!arg || !t.isArrayExpression(arg)) return undefined;
+  const firstElement = arg.elements[0];
+  if (!firstElement || !t.isObjectExpression(firstElement)) return undefined;
+  return firstElement;
+}
+
+function getCallExpressionsByName(
+  ast: t.File,
+  name: string
+): t.CallExpression[] {
+  const calls: t.CallExpression[] = [];
+  traverse(ast, {
+    CallExpression(path) {
+      if (t.isIdentifier(path.node.callee, { name })) {
+        calls.push(path.node);
+      }
+    },
+  });
+  return calls;
 }
 
 /** Check if code contains a Promise.all call */
@@ -803,6 +844,40 @@ describe('runtimeTranslatePass', () => {
       expect(calls).toHaveLength(1);
       expect(getOptionValue(calls[0], '$context')).toBe('greeting');
       expect(getOptionValue(calls[0], '$_hash')).toBeDefined();
+    });
+
+    it('injects getGT preload messages with TranslationMetadata keys', () => {
+      const state = initializeState({}, 'test.tsx');
+      const ast = parser.parse(
+        `
+        import { getGT } from 'gt-next/server';
+        async function Page() {
+          const gt = await getGT();
+          return gt("Hello", { $context: "nav", $id: "greet", $maxChars: 50 });
+        }
+      `,
+        {
+          sourceType: 'module',
+          plugins: ['jsx', 'typescript'],
+        }
+      );
+
+      traverse(ast, collectionPass(state));
+      traverse(ast, injectionPass(state));
+
+      const getGTCalls = getCallExpressionsByName(ast, 'getGT');
+      expect(getGTCalls).toHaveLength(1);
+
+      const message = getFirstArrayObjectArg(getGTCalls[0]);
+      expect(message).toBeDefined();
+      expect(getObjectPropertyValue(message!, 'message')).toBe('Hello');
+      expect(getObjectPropertyValue(message!, '$_hash')).toBeDefined();
+      expect(getObjectPropertyValue(message!, '$context')).toBe('nav');
+      expect(getObjectPropertyValue(message!, '$id')).toBe('greet');
+      expect(getObjectPropertyValue(message!, '$maxChars')).toBe(50);
+      expect(getObjectPropertyNames(message!)).not.toEqual(
+        expect.arrayContaining(['hash', 'context', 'id', 'maxChars'])
+      );
     });
 
     it('does not inject compile-time hash into msg() calls', () => {

--- a/packages/compiler/src/transform/injection/injectCallbackDeclaratorFunctionParameters.ts
+++ b/packages/compiler/src/transform/injection/injectCallbackDeclaratorFunctionParameters.ts
@@ -10,7 +10,7 @@ import { createErrorLocation } from '../../utils/errors';
 
 /**
  * inject parameters into invocation of translation function
- * - useGT(messages=[{hash, message, id, context, maxChars}])
+ * - useGT(messages=[{$_hash, message, $id, $context, $maxChars}])
  */
 export function injectCallbackDeclaratorFunctionParameters(
   varDeclarator: t.VariableDeclarator,
@@ -121,7 +121,10 @@ function injectUseGTParameters(
     t.arrayExpression(
       translationContent.map((content) =>
         t.objectExpression([
-          t.objectProperty(t.identifier('hash'), t.stringLiteral(content.hash)),
+          t.objectProperty(
+            t.identifier('$_hash'),
+            t.stringLiteral(content.hash)
+          ),
           t.objectProperty(
             t.identifier('message'),
             t.stringLiteral(content.message)
@@ -129,7 +132,7 @@ function injectUseGTParameters(
           ...(content.id
             ? [
                 t.objectProperty(
-                  t.identifier('id'),
+                  t.identifier('$id'),
                   t.stringLiteral(content.id)
                 ),
               ]
@@ -137,7 +140,7 @@ function injectUseGTParameters(
           ...(content.context
             ? [
                 t.objectProperty(
-                  t.identifier('context'),
+                  t.identifier('$context'),
                   t.stringLiteral(content.context)
                 ),
               ]
@@ -145,7 +148,7 @@ function injectUseGTParameters(
           ...(content.maxChars != null
             ? [
                 t.objectProperty(
-                  t.identifier('maxChars'),
+                  t.identifier('$maxChars'),
                   t.numericLiteral(content.maxChars)
                 ),
               ]

--- a/packages/i18n/src/translation-functions/internal/__tests__/locale-defaults.test.ts
+++ b/packages/i18n/src/translation-functions/internal/__tests__/locale-defaults.test.ts
@@ -7,7 +7,7 @@ import { initializeI18nConfig } from '../../../i18n-config/singleton-operations'
 import type { I18nConfigParams } from '../../../i18n-config/I18nConfig';
 import { msg } from '../../msg/msg';
 import { hashMessage } from '../../../utils/hashMessage';
-import { getGT } from '../getGT';
+import { getGT, getGTInternal } from '../getGT';
 import { getTranslations } from '../getTranslations';
 import { getMessages } from '../getMessages';
 import { tx, txInternal } from '../tx';
@@ -15,6 +15,7 @@ import { tx, txInternal } from '../tx';
 describe('translation function locale defaults', () => {
   afterEach(() => {
     setWritableConditionStore(createConditionStore('en'));
+    vi.unstubAllEnvs();
   });
 
   function createConditionStore(locale: string) {
@@ -77,6 +78,89 @@ describe('translation function locale defaults', () => {
     await cache.loadTranslations('es');
 
     expect(gt(message, { $locale: 'es', name: 'Alice' })).toBe('Hola Alice!');
+  });
+
+  it('getGT preloads compiler messages when dev hot reload is enabled', async () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    const cache = createCache(
+      {
+        defaultLocale: 'en',
+        locales: ['en', 'fr'],
+        devApiKey: 'dev-key',
+        projectId: 'project-id',
+      },
+      {
+        loadTranslations: vi.fn().mockResolvedValue({}),
+      }
+    );
+    const lookupTranslationWithFallback = vi
+      .spyOn(cache, 'lookupTranslationWithFallback')
+      .mockResolvedValue('Bonjour Alice !');
+    setI18nCache(cache);
+
+    await getGTInternal({ locale: 'fr', enableI18n: true }, [
+      { message: 'Hello {name}!', $context: 'greeting' },
+    ]);
+
+    expect(lookupTranslationWithFallback).toHaveBeenCalledWith(
+      'fr',
+      'Hello {name}!',
+      expect.objectContaining({
+        $context: 'greeting',
+        $format: 'ICU',
+        $locale: 'fr',
+      })
+    );
+  });
+
+  it('getGT still returns a function when dev hot reload preload rejects', async () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    const cache = createCache(
+      {
+        defaultLocale: 'en',
+        locales: ['en', 'fr'],
+        devApiKey: 'dev-key',
+        projectId: 'project-id',
+      },
+      {
+        loadTranslations: vi.fn().mockResolvedValue({}),
+      }
+    );
+    vi.spyOn(cache, 'lookupTranslationWithFallback')
+      .mockRejectedValueOnce(new Error('offline'))
+      .mockResolvedValue(undefined);
+    setI18nCache(cache);
+
+    const gt = await getGTInternal({ locale: 'fr', enableI18n: true }, [
+      { message: 'Hello {name}!' },
+    ]);
+
+    expect(gt('Hello {name}!', { name: 'Alice' })).toBe('Hello Alice!');
+  });
+
+  it('getGT catches fire-and-forget dev hot reload lookup rejections', async () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    const cache = createCache(
+      {
+        defaultLocale: 'en',
+        locales: ['en', 'fr'],
+        devApiKey: 'dev-key',
+        projectId: 'project-id',
+      },
+      {
+        loadTranslations: vi.fn().mockResolvedValue({}),
+      }
+    );
+    const catchHandler = vi.fn();
+    vi.spyOn(cache, 'lookupTranslationWithFallback').mockReturnValue({
+      catch: catchHandler,
+    } as unknown as ReturnType<typeof cache.lookupTranslationWithFallback>);
+    setI18nCache(cache);
+
+    const gt = await getGTInternal({ locale: 'fr', enableI18n: true });
+
+    expect(gt('Hello {name}!', { name: 'Alice' })).toBe('Hello Alice!');
+    expect(catchHandler).toHaveBeenCalledWith(expect.any(Function));
   });
 
   it('getTranslations uses the current locale for dictionary entries', async () => {

--- a/packages/i18n/src/translation-functions/internal/getGT.ts
+++ b/packages/i18n/src/translation-functions/internal/getGT.ts
@@ -1,11 +1,19 @@
 import { getI18nCache } from '../../i18n-cache/singleton-operations';
 import { getI18nConfig } from '../../i18n-config/singleton-operations';
-import { GTTranslationOptions } from '../types/options';
+import {
+  GTTranslationOptions,
+  NormalizedLookupOptions,
+  TranslationMetadata,
+} from '../types/options';
 import { GTFunctionType } from '../types/functions';
 import { interpolateMessage } from '../utils/interpolation/interpolateMessage';
 import { createLookupOptions } from './helpers';
 import type { StringFormat } from '@generaltranslation/format/types';
 import { getWritableConditionStore } from '../../condition-store/singleton-operations';
+
+export type Message = TranslationMetadata & {
+  message: string;
+};
 
 /**
  * Returns the gt function that registers a string at build time and resolves its translation at runtime.
@@ -15,29 +23,75 @@ import { getWritableConditionStore } from '../../condition-store/singleton-opera
  * const gt = await getGT();
  * const greeting = gt('Hello, world!');
  */
-export async function getGT(): Promise<GTFunctionType> {
+export async function getGT(_messages?: Message[]): Promise<GTFunctionType> {
   const conditionStore = getWritableConditionStore();
   const locale = conditionStore.getLocale();
   const enableI18n = conditionStore.getEnableI18n();
-  return getGTInternal({ locale, enableI18n });
+  return getGTInternal({ locale, enableI18n }, _messages);
 }
 
 /**
  * Condition store agnostic getGT function
  */
-export async function getGTInternal({
-  locale,
-  enableI18n,
-}: {
-  locale: string;
-  enableI18n: boolean;
-}): Promise<GTFunctionType> {
+export async function getGTInternal(
+  {
+    locale,
+    enableI18n,
+  }: {
+    locale: string;
+    enableI18n: boolean;
+  },
+  _messages?: Message[]
+): Promise<GTFunctionType> {
   // Get the translation resolver
   const i18nCache = getI18nCache();
   await i18nCache.loadTranslations(locale);
   const sourceLocale = getI18nConfig().getDefaultLocale();
+  const devHotReloadEnabled = getI18nConfig().isDevHotReloadEnabled();
 
-  // TODO: dev hot reload translate compiler injected lookups
+  // dev hot reload translate compiler injected lookups
+  if (devHotReloadEnabled && _messages && _messages.length > 0) {
+    const lookups: {
+      message: string;
+      lookupOptions: NormalizedLookupOptions<StringFormat>;
+    }[] = _messages
+      .map(({ message, ...options }) => {
+        const targetLocale = enableI18n
+          ? (options.$locale ?? locale)
+          : getI18nConfig().getDefaultLocale();
+        const lookupOptions = createLookupOptions<StringFormat>(
+          targetLocale,
+          options,
+          'ICU'
+        );
+        return {
+          lookupOptions,
+          message,
+        };
+      })
+      .filter(({ lookupOptions, message }) => {
+        // Filter lookups that are already in the cache
+        return (
+          i18nCache.lookupTranslation(
+            lookupOptions.$locale,
+            message,
+            lookupOptions
+          ) == null
+        );
+      });
+
+    if (lookups.length > 0) {
+      await Promise.allSettled(
+        lookups.map(({ lookupOptions, message }) =>
+          i18nCache.lookupTranslationWithFallback(
+            lookupOptions.$locale,
+            message,
+            lookupOptions
+          )
+        )
+      );
+    }
+  }
 
   /**
    * Registers a message at build time and resolves its translation at runtime.
@@ -74,6 +128,17 @@ export async function getGTInternal({
       message,
       lookupOptions
     );
+
+    // Dev hot reload (fire and forget, will be available in a later lookup)
+    if (devHotReloadEnabled && translation == null) {
+      void i18nCache
+        .lookupTranslationWithFallback(
+          lookupOptions.$locale,
+          message,
+          lookupOptions
+        )
+        .catch(() => {});
+    }
 
     // Format result
     return interpolateMessage({

--- a/packages/i18n/src/types.ts
+++ b/packages/i18n/src/types.ts
@@ -9,6 +9,7 @@ export type {
   ResolveJsxTranslationFunction,
 } from './translation-functions/types/functions';
 export type { RegisterableMessages } from './translation-functions/types/message';
+export type { Message } from './translation-functions/internal/getGT';
 export type {
   TranslationMetadata,
   TranslationOptions,

--- a/packages/next/src/server-dir/buildtime/__tests__/getTranslations.test.ts
+++ b/packages/next/src/server-dir/buildtime/__tests__/getTranslations.test.ts
@@ -44,10 +44,30 @@ describe('buildtime translation helpers', () => {
 
     await expect(getGT()).resolves.toBe(gt);
 
-    expect(mockGetGTInternal).toHaveBeenCalledWith({
-      locale: 'fr',
-      enableI18n: false,
-    });
+    expect(mockGetGTInternal).toHaveBeenCalledWith(
+      {
+        locale: 'fr',
+        enableI18n: false,
+      },
+      undefined
+    );
+  });
+
+  it('getGT forwards compiler messages to gt-i18n', async () => {
+    const gt = vi.fn();
+    const messages = [{ message: 'A server-translated string from getGT.' }];
+    mockGetGTInternal.mockReturnValue(gt);
+    const { getGT } = await import('../strings');
+
+    await expect(getGT(messages)).resolves.toBe(gt);
+
+    expect(mockGetGTInternal).toHaveBeenCalledWith(
+      {
+        locale: 'fr',
+        enableI18n: false,
+      },
+      messages
+    );
   });
 
   it('getMessages passes request conditions to gt-i18n', async () => {
@@ -94,4 +114,28 @@ describe('buildtime translation helpers', () => {
       expect(mockUse).toHaveBeenCalledWith(expect.any(Promise));
     }
   );
+
+  it('useGT forwards compiler messages through getGT', async () => {
+    const value = vi.fn();
+    const messages = [{ message: 'A server-translated string from useGT.' }];
+    mockGetGTInternal.mockReturnValue(value);
+    mockUse.mockReturnValue(value);
+    const { useGT } = await import('../strings');
+
+    const result = useGT(messages);
+
+    expect(result).toBe(value);
+    expect(mockUse).toHaveBeenCalledWith(expect.any(Promise));
+    expect(mockGetGTInternal).not.toHaveBeenCalled();
+
+    await expect(mockUse.mock.calls[0][0]).resolves.toBe(value);
+
+    expect(mockGetGTInternal).toHaveBeenCalledWith(
+      {
+        locale: 'fr',
+        enableI18n: false,
+      },
+      messages
+    );
+  });
 });

--- a/packages/next/src/server-dir/buildtime/strings.ts
+++ b/packages/next/src/server-dir/buildtime/strings.ts
@@ -4,14 +4,18 @@ import {
   getMessagesInternal,
   getTranslationsInternal,
 } from 'gt-i18n/internal';
+import type { Message } from 'gt-i18n/types';
 import { getRequestConditions } from '../../request/getRequestConditions';
 
-export async function getGT() {
+export async function getGT(_messages?: Message[]) {
   const conditions = await getRequestConditions();
-  return getGTInternal({
-    locale: conditions._locale,
-    enableI18n: conditions._enableI18n,
-  });
+  return getGTInternal(
+    {
+      locale: conditions._locale,
+      enableI18n: conditions._enableI18n,
+    },
+    _messages
+  );
 }
 
 export async function getMessages() {
@@ -30,8 +34,8 @@ export async function getTranslations() {
   });
 }
 
-export function useGT() {
-  return use(getGT());
+export function useGT(_messages?: Message[]) {
+  return use(getGT(_messages));
 }
 
 export function useMessages() {


### PR DESCRIPTION
## Summary

- add dev hot reload prefetch support for server `getGT` lookups in `gt-i18n`
- forward compiler-injected server message metadata through `gt-next` App Router `getGT`
- add patch changeset entries for `gt-i18n` and `gt-next`

## Testing

- `pnpm --filter gt-i18n typecheck`
- `pnpm --filter gt-i18n build`
- `pnpm --filter gt-next build:no-swc-plugin`

`pnpm --filter gt-next typecheck` currently fails on existing workspace resolution/type errors around `gt-react` and `NextI18nCache`, unrelated to this diff.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds dev hot reload prefetch support for server-side `getGT` string lookups in `gt-i18n`, and threads compiler-injected message metadata through the `gt-next` App Router's `getGT`/`useGT` functions so server strings can participate in hot-reload translation updates.

- **`gt-i18n` (`getGT.ts`)**: `getGTInternal` now accepts an optional `_messages[]` array; when dev hot reload is enabled, it maps the messages to lookup options, filters out cache hits, and issues a `Promise.allSettled` batch prefetch before returning the `gt` function. A secondary fire-and-forget call is also added inside `gt()` itself for messages missed by the batch.
- **`gt-next` (`strings.ts`)**: `getGT` and `useGT` accept and forward the same `_messages[]` to the underlying `getGTInternal`, and the `Message` type is re-exported publicly via `gt-i18n/types`.
- Tests cover the happy-path prefetch call signature and the resilience of `getGTInternal` when the batch promise rejects.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge after fixing the unhandled rejection in the fire-and-forget path inside gt().

The batch prefetch is correctly guarded by Promise.allSettled, but the inline fire-and-forget inside gt() at line 132 has no .catch(). I18nCache.handleError re-throws in dev mode, so a failed API call from that fire-and-forget produces a dangling rejected Promise that Node.js treats as a fatal unhandledRejection. Since devHotReloadEnabled is only true in dev mode, this won't affect production, but it can terminate or destabilize the dev server whenever the translation API is unavailable.

packages/i18n/src/translation-functions/internal/getGT.ts — specifically the fire-and-forget lookupTranslationWithFallback call inside the returned gt() closure.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/i18n/src/translation-functions/internal/getGT.ts | Adds dev hot reload prefetch loop (safe, uses Promise.allSettled) and fire-and-forget fallback inside gt() — the fire-and-forget lacks a .catch() handler, creating an unhandled rejection in dev mode when the API call fails. |
| packages/next/src/server-dir/buildtime/strings.ts | Threads the optional _messages parameter through getGT and useGT to the underlying getGTInternal call; straightforward delegation with no logic changes. |
| packages/i18n/src/types.ts | Adds public re-export of the new Message type from its internal definition site; no logic changes. |
| packages/i18n/src/translation-functions/internal/__tests__/locale-defaults.test.ts | Adds two new tests: one verifying compiler messages are prefetched via lookupTranslationWithFallback, one verifying gt() is still returned when the prefetch rejects. The rejection test uses mockRejectedValueOnce on the batch path and does not cover the fire-and-forget path inside gt(). |
| packages/next/src/server-dir/buildtime/__tests__/getTranslations.test.ts | Extends existing test suite to verify getGT and useGT forward compiler messages to getGTInternal; test coverage is appropriate for the new forwarding logic. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Compiler
    participant getGT (gt-next)
    participant getGTInternal (gt-i18n)
    participant i18nCache

    Compiler->>getGT (gt-next): getGT(_messages[])
    getGT (gt-next)->>getGT (gt-next): getRequestConditions()
    getGT (gt-next)->>getGTInternal (gt-i18n): getGTInternal({locale, enableI18n}, _messages[])
    getGTInternal (gt-i18n)->>i18nCache: loadTranslations(locale)
    getGTInternal (gt-i18n)->>getGTInternal (gt-i18n): isDevHotReloadEnabled()?
    alt "devHotReloadEnabled and _messages.length > 0"
        loop for each message
            getGTInternal (gt-i18n)->>i18nCache: lookupTranslation() [cache hit?]
            alt not in cache
                getGTInternal (gt-i18n)->>i18nCache: lookupTranslationWithFallback()
            end
        end
        note over getGTInternal (gt-i18n): Promise.allSettled — rejects are swallowed
    end
    getGTInternal (gt-i18n)-->>getGT (gt-next): gt() function
    getGT (gt-next)-->>Compiler: gt()

    note over Compiler: Later, at render time...
    Compiler->>getGT (gt-next): gt('Hello {name}!', {name:'Alice'})
    getGT (gt-next)->>i18nCache: lookupTranslation()
    alt "translation == null and devHotReloadEnabled"
        getGT (gt-next)->>i18nCache: lookupTranslationWithFallback() [fire and forget, no .catch()]
    end
    getGT (gt-next)-->>Compiler: interpolated string
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Compiler
    participant getGT (gt-next)
    participant getGTInternal (gt-i18n)
    participant i18nCache

    Compiler->>getGT (gt-next): getGT(_messages[])
    getGT (gt-next)->>getGT (gt-next): getRequestConditions()
    getGT (gt-next)->>getGTInternal (gt-i18n): getGTInternal({locale, enableI18n}, _messages[])
    getGTInternal (gt-i18n)->>i18nCache: loadTranslations(locale)
    getGTInternal (gt-i18n)->>getGTInternal (gt-i18n): isDevHotReloadEnabled()?
    alt "devHotReloadEnabled and _messages.length > 0"
        loop for each message
            getGTInternal (gt-i18n)->>i18nCache: lookupTranslation() [cache hit?]
            alt not in cache
                getGTInternal (gt-i18n)->>i18nCache: lookupTranslationWithFallback()
            end
        end
        note over getGTInternal (gt-i18n): Promise.allSettled — rejects are swallowed
    end
    getGTInternal (gt-i18n)-->>getGT (gt-next): gt() function
    getGT (gt-next)-->>Compiler: gt()

    note over Compiler: Later, at render time...
    Compiler->>getGT (gt-next): gt('Hello {name}!', {name:'Alice'})
    getGT (gt-next)->>i18nCache: lookupTranslation()
    alt "translation == null and devHotReloadEnabled"
        getGT (gt-next)->>i18nCache: lookupTranslationWithFallback() [fire and forget, no .catch()]
    end
    getGT (gt-next)-->>Compiler: interpolated string
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fi18n%2Fsrc%2Ftranslation-functions%2Finternal%2FgetGT.ts%3A130-137%0A**Unhandled%20rejection%20from%20fire-and-forget%20in%20dev%20mode**%0A%0A%60I18nCache.handleError%60%20re-throws%20errors%20when%20%60getRuntimeEnvironment%28%29%20%3D%3D%3D%20'development'%60%2C%20so%20%60lookupTranslationWithFallback%60%20itself%20rejects%20%28not%20resolves%29%20whenever%20the%20underlying%20API%20call%20fails%20in%20dev%20mode.%20The%20unguarded%20fire-and-forget%20here%20therefore%20creates%20a%20dangling%20rejected%20Promise%20that%20Node.js%20will%20surface%20as%20an%20unhandled%20rejection%20%E2%80%94%20in%20Node.js%20%E2%89%A5%2015%20this%20terminates%20the%20process%20by%20default.%20The%20batch%20path%20above%20this%20correctly%20uses%20%60Promise.allSettled%60%2C%20but%20this%20inline%20call%20inside%20%60gt%28%29%60%20has%20no%20%60.catch%28%29%60.%20Adding%20%60.catch%28%28%29%20%3D%3E%20%7B%7D%29%60%20mirrors%20the%20client-side%20fire-and-forget%20pattern%20and%20silences%20the%20rejection%20safely.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%20Dev%20hot%20reload%20%28fire%20and%20forget%2C%20will%20be%20available%20in%20a%20later%20lookup%29%0A%20%20%20%20if%20%28devHotReloadEnabled%20%26%26%20translation%20%3D%3D%20null%29%20%7B%0A%20%20%20%20%20%20i18nCache%0A%20%20%20%20%20%20%20%20.lookupTranslationWithFallback%28%0A%20%20%20%20%20%20%20%20%20%20lookupOptions.%24locale%2C%0A%20%20%20%20%20%20%20%20%20%20message%2C%0A%20%20%20%20%20%20%20%20%20%20lookupOptions%0A%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20.catch%28%28%29%20%3D%3E%20%7B%7D%29%3B%0A%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=generaltranslation%2Fgt&pr=1728&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fodysseus%2Fnext-app-router-testing%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fodysseus%2Fnext-app-router-testing%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fi18n%2Fsrc%2Ftranslation-functions%2Finternal%2FgetGT.ts%3A130-137%0A**Unhandled%20rejection%20from%20fire-and-forget%20in%20dev%20mode**%0A%0A%60I18nCache.handleError%60%20re-throws%20errors%20when%20%60getRuntimeEnvironment%28%29%20%3D%3D%3D%20'development'%60%2C%20so%20%60lookupTranslationWithFallback%60%20itself%20rejects%20%28not%20resolves%29%20whenever%20the%20underlying%20API%20call%20fails%20in%20dev%20mode.%20The%20unguarded%20fire-and-forget%20here%20therefore%20creates%20a%20dangling%20rejected%20Promise%20that%20Node.js%20will%20surface%20as%20an%20unhandled%20rejection%20%E2%80%94%20in%20Node.js%20%E2%89%A5%2015%20this%20terminates%20the%20process%20by%20default.%20The%20batch%20path%20above%20this%20correctly%20uses%20%60Promise.allSettled%60%2C%20but%20this%20inline%20call%20inside%20%60gt%28%29%60%20has%20no%20%60.catch%28%29%60.%20Adding%20%60.catch%28%28%29%20%3D%3E%20%7B%7D%29%60%20mirrors%20the%20client-side%20fire-and-forget%20pattern%20and%20silences%20the%20rejection%20safely.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%20Dev%20hot%20reload%20%28fire%20and%20forget%2C%20will%20be%20available%20in%20a%20later%20lookup%29%0A%20%20%20%20if%20%28devHotReloadEnabled%20%26%26%20translation%20%3D%3D%20null%29%20%7B%0A%20%20%20%20%20%20i18nCache%0A%20%20%20%20%20%20%20%20.lookupTranslationWithFallback%28%0A%20%20%20%20%20%20%20%20%20%20lookupOptions.%24locale%2C%0A%20%20%20%20%20%20%20%20%20%20message%2C%0A%20%20%20%20%20%20%20%20%20%20lookupOptions%0A%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20.catch%28%28%29%20%3D%3E%20%7B%7D%29%3B%0A%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=generaltranslation%2Fgt&pr=1728&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=4"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=4"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/i18n/src/translation-functions/internal/getGT.ts:130-137
**Unhandled rejection from fire-and-forget in dev mode**

`I18nCache.handleError` re-throws errors when `getRuntimeEnvironment() === 'development'`, so `lookupTranslationWithFallback` itself rejects (not resolves) whenever the underlying API call fails in dev mode. The unguarded fire-and-forget here therefore creates a dangling rejected Promise that Node.js will surface as an unhandled rejection — in Node.js ≥ 15 this terminates the process by default. The batch path above this correctly uses `Promise.allSettled`, but this inline call inside `gt()` has no `.catch()`. Adding `.catch(() => {})` mirrors the client-side fire-and-forget pattern and silences the rejection safely.

```suggestion
    // Dev hot reload (fire and forget, will be available in a later lookup)
    if (devHotReloadEnabled && translation == null) {
      i18nCache
        .lookupTranslationWithFallback(
          lookupOptions.$locale,
          message,
          lookupOptions
        )
        .catch(() => {});
    }
```

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["Support getGT dev hot reload lookups"](https://github.com/generaltranslation/gt/commit/0a015cb4aa22ae092695042b56b1062c621165fe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40916719)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->