### PR TITLE
Use Next cache for Cache Components translations

### DIFF
--- a/.changeset/cache-components-disable-expiry.md
+++ b/.changeset/cache-components-disable-expiry.md
@@ -4,3 +4,5 @@
 ---
 
 Use Next.js caching semantics for Cache Components by disabling GT cache expiry and development hot reload runtime translation.
+
+Async translation and dictionary lookup boundaries now keep synchronous access to the loaded snapshot, so APIs like `getGT` and `getTranslations` can still resolve strings after cache expiry is delegated to Next.js.

--- a/.changeset/cache-components-disable-expiry.md
+++ b/.changeset/cache-components-disable-expiry.md
@@ -1,0 +1,6 @@
+---
+"gt-i18n": patch
+"gt-next": patch
+---
+
+Use Next.js caching semantics for Cache Components by disabling GT cache expiry and development hot reload runtime translation.

--- a/.changeset/cache-components-disable-expiry.md
+++ b/.changeset/cache-components-disable-expiry.md
@@ -6,3 +6,5 @@
 Use Next.js caching semantics for Cache Components by disabling GT cache expiry and development hot reload runtime translation.
 
 Async translation and dictionary lookup boundaries now keep synchronous access to the loaded snapshot, so APIs like `getGT` and `getTranslations` can still resolve strings after cache expiry is delegated to Next.js.
+
+The global i18n cache singleton now preserves the first initialized cache instead of replacing it on later initialization attempts.

--- a/.changeset/cache-components-disable-expiry.md
+++ b/.changeset/cache-components-disable-expiry.md
@@ -7,4 +7,4 @@ Use Next.js caching semantics for Cache Components by disabling GT cache expiry 
 
 Async translation and dictionary lookup boundaries now keep synchronous access to the loaded snapshot, so APIs like `getGT` and `getTranslations` can still resolve strings after cache expiry is delegated to Next.js.
 
-The global i18n cache singleton now preserves the first initialized cache instead of replacing it on later initialization attempts.
+Global singleton setup now preserves the first initialized instance instead of replacing it on later initialization attempts.

--- a/.changeset/compiler-getgt-preload-metadata.md
+++ b/.changeset/compiler-getgt-preload-metadata.md
@@ -1,0 +1,5 @@
+---
+'@generaltranslation/compiler': patch
+---
+
+Emit sugar metadata keys for injected getGT/useGT preload messages.

--- a/.changeset/compiler-getgt-preload-metadata.md
+++ b/.changeset/compiler-getgt-preload-metadata.md
@@ -1,5 +1,0 @@
----
-'@generaltranslation/compiler': patch
----
-
-Emit sugar metadata keys for injected getGT/useGT preload messages.

--- a/.changeset/dev-hot-reload-getgt.md
+++ b/.changeset/dev-hot-reload-getgt.md
@@ -1,0 +1,8 @@
+---
+"gt-i18n": patch
+"gt-next": patch
+---
+
+Support dev hot reload lookups for server `getGT` strings.
+
+`getGT` can now receive compiler-injected message metadata and prefetch missing translations through the runtime cache in development. `gt-next` forwards the server request conditions into this path so App Router server strings can participate in hot reload translation updates.

--- a/.changeset/dev-hot-reload-getgt.md
+++ b/.changeset/dev-hot-reload-getgt.md
@@ -1,4 +1,5 @@
 ---
+"@generaltranslation/compiler": patch
 "gt-i18n": patch
 "gt-next": patch
 ---
@@ -6,3 +7,5 @@
 Support dev hot reload lookups for server `getGT` strings.
 
 `getGT` can now receive compiler-injected message metadata and prefetch missing translations through the runtime cache in development. `gt-next` forwards the server request conditions into this path so App Router server strings can participate in hot reload translation updates.
+
+Compiler-injected `getGT` and `useGT` preload messages now emit the same sugar metadata keys used by runtime lookup options.

--- a/packages/compiler/src/passes/__tests__/runtimeTranslatePass.test.ts
+++ b/packages/compiler/src/passes/__tests__/runtimeTranslatePass.test.ts
@@ -135,7 +135,14 @@ function getOptionValue(
 ): string | number | undefined {
   const arg = call.arguments[1];
   if (!arg || !t.isObjectExpression(arg)) return undefined;
-  for (const prop of arg.properties) {
+  return getObjectPropertyValue(arg, key);
+}
+
+function getObjectPropertyValue(
+  object: t.ObjectExpression,
+  key: string
+): string | number | undefined {
+  for (const prop of object.properties) {
     if (!t.isObjectProperty(prop)) continue;
     const propKey = t.isStringLiteral(prop.key)
       ? prop.key.value
@@ -148,6 +155,40 @@ function getOptionValue(
     }
   }
   return undefined;
+}
+
+function getObjectPropertyNames(object: t.ObjectExpression): string[] {
+  return object.properties.flatMap((prop) => {
+    if (!t.isObjectProperty(prop)) return [];
+    if (t.isStringLiteral(prop.key)) return [prop.key.value];
+    if (t.isIdentifier(prop.key)) return [prop.key.name];
+    return [];
+  });
+}
+
+function getFirstArrayObjectArg(
+  call: t.CallExpression
+): t.ObjectExpression | undefined {
+  const arg = call.arguments[0];
+  if (!arg || !t.isArrayExpression(arg)) return undefined;
+  const firstElement = arg.elements[0];
+  if (!firstElement || !t.isObjectExpression(firstElement)) return undefined;
+  return firstElement;
+}
+
+function getCallExpressionsByName(
+  ast: t.File,
+  name: string
+): t.CallExpression[] {
+  const calls: t.CallExpression[] = [];
+  traverse(ast, {
+    CallExpression(path) {
+      if (t.isIdentifier(path.node.callee, { name })) {
+        calls.push(path.node);
+      }
+    },
+  });
+  return calls;
 }
 
 /** Check if code contains a Promise.all call */
@@ -803,6 +844,40 @@ describe('runtimeTranslatePass', () => {
       expect(calls).toHaveLength(1);
       expect(getOptionValue(calls[0], '$context')).toBe('greeting');
       expect(getOptionValue(calls[0], '$_hash')).toBeDefined();
+    });
+
+    it('injects getGT preload messages with TranslationMetadata keys', () => {
+      const state = initializeState({}, 'test.tsx');
+      const ast = parser.parse(
+        `
+        import { getGT } from 'gt-next/server';
+        async function Page() {
+          const gt = await getGT();
+          return gt("Hello", { $context: "nav", $id: "greet", $maxChars: 50 });
+        }
+      `,
+        {
+          sourceType: 'module',
+          plugins: ['jsx', 'typescript'],
+        }
+      );
+
+      traverse(ast, collectionPass(state));
+      traverse(ast, injectionPass(state));
+
+      const getGTCalls = getCallExpressionsByName(ast, 'getGT');
+      expect(getGTCalls).toHaveLength(1);
+
+      const message = getFirstArrayObjectArg(getGTCalls[0]);
+      expect(message).toBeDefined();
+      expect(getObjectPropertyValue(message!, 'message')).toBe('Hello');
+      expect(getObjectPropertyValue(message!, '$_hash')).toBeDefined();
+      expect(getObjectPropertyValue(message!, '$context')).toBe('nav');
+      expect(getObjectPropertyValue(message!, '$id')).toBe('greet');
+      expect(getObjectPropertyValue(message!, '$maxChars')).toBe(50);
+      expect(getObjectPropertyNames(message!)).not.toEqual(
+        expect.arrayContaining(['hash', 'context', 'id', 'maxChars'])
+      );
     });
 
     it('does not inject compile-time hash into msg() calls', () => {

--- a/packages/compiler/src/transform/injection/injectCallbackDeclaratorFunctionParameters.ts
+++ b/packages/compiler/src/transform/injection/injectCallbackDeclaratorFunctionParameters.ts
@@ -10,7 +10,7 @@ import { createErrorLocation } from '../../utils/errors';
 
 /**
  * inject parameters into invocation of translation function
- * - useGT(messages=[{hash, message, id, context, maxChars}])
+ * - useGT(messages=[{$_hash, message, $id, $context, $maxChars}])
  */
 export function injectCallbackDeclaratorFunctionParameters(
   varDeclarator: t.VariableDeclarator,
@@ -121,7 +121,10 @@ function injectUseGTParameters(
     t.arrayExpression(
       translationContent.map((content) =>
         t.objectExpression([
-          t.objectProperty(t.identifier('hash'), t.stringLiteral(content.hash)),
+          t.objectProperty(
+            t.identifier('$_hash'),
+            t.stringLiteral(content.hash)
+          ),
           t.objectProperty(
             t.identifier('message'),
             t.stringLiteral(content.message)
@@ -129,7 +132,7 @@ function injectUseGTParameters(
           ...(content.id
             ? [
                 t.objectProperty(
-                  t.identifier('id'),
+                  t.identifier('$id'),
                   t.stringLiteral(content.id)
                 ),
               ]
@@ -137,7 +140,7 @@ function injectUseGTParameters(
           ...(content.context
             ? [
                 t.objectProperty(
-                  t.identifier('context'),
+                  t.identifier('$context'),
                   t.stringLiteral(content.context)
                 ),
               ]
@@ -145,7 +148,7 @@ function injectUseGTParameters(
           ...(content.maxChars != null
             ? [
                 t.objectProperty(
-                  t.identifier('maxChars'),
+                  t.identifier('$maxChars'),
                   t.numericLiteral(content.maxChars)
                 ),
               ]

--- a/packages/i18n/src/condition-store/__tests__/createConditionStoreSingleton.test.ts
+++ b/packages/i18n/src/condition-store/__tests__/createConditionStoreSingleton.test.ts
@@ -57,13 +57,14 @@ describe('condition store singleton factory', () => {
     );
   });
 
-  it('warns when overwriting an existing global condition store', async () => {
+  it('warns and preserves an existing global condition store', async () => {
     const { createConditionStoreSingleton } =
       await import('../createConditionStoreSingleton');
     const singleton = createConditionStoreSingleton('not initialized');
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const conditionStore = createConditionStoreStub();
 
-    singleton.setConditionStore(createConditionStoreStub());
+    singleton.setConditionStore(conditionStore);
     singleton.setConditionStore(createConditionStoreStub());
 
     expect(warn).toHaveBeenCalledWith(
@@ -71,5 +72,6 @@ describe('condition store singleton factory', () => {
         'Overwriting global conditionStore singleton instance'
       )
     );
+    expect(singleton.getConditionStore()).toBe(conditionStore);
   });
 });

--- a/packages/i18n/src/config/types.ts
+++ b/packages/i18n/src/config/types.ts
@@ -44,6 +44,7 @@ export type GTConfig = {
   // remote translate config
   runtimeUrl?: string | null;
   modelProvider?: string;
+  _disableDevHotReload?: boolean;
 
   // other
   localeCookieName?: string;

--- a/packages/i18n/src/globals/__tests__/createGlobalSingleton.test.ts
+++ b/packages/i18n/src/globals/__tests__/createGlobalSingleton.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createGlobalSingleton } from '../createGlobalSingleton';
 
 type TestGlobal = typeof globalThis & {
@@ -41,5 +41,24 @@ describe('createGlobalSingleton', () => {
 
     expect(singleton.isInitialized()).toBe(false);
     expect(() => singleton.get()).toThrow('singleton missing');
+  });
+
+  it('warns and preserves an existing singleton instance', () => {
+    const singleton = createGlobalSingleton<{ id: string }>({
+      namespace: 'testGlobalSingleton',
+      key: 'singleton',
+      source: 'gt-i18n',
+      notInitialized: () => 'singleton missing',
+    });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const value = { id: 'first' };
+
+    singleton.set(value);
+    singleton.set({ id: 'second' });
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('Overwriting global singleton singleton instance')
+    );
+    expect(singleton.get()).toBe(value);
   });
 });

--- a/packages/i18n/src/globals/createGlobalSingleton.ts
+++ b/packages/i18n/src/globals/createGlobalSingleton.ts
@@ -62,10 +62,9 @@ export function createGlobalSingleton<T>({
         createDiagnosticMessage({
           source,
           severity: 'Warning',
-          whatHappened: `Global singleton ${key} is already initialized`,
+          whatHappened: `Overwriting global ${key} singleton instance`,
         })
       );
-      return;
     }
     ns[key] = next as unknown;
   }

--- a/packages/i18n/src/globals/createGlobalSingleton.ts
+++ b/packages/i18n/src/globals/createGlobalSingleton.ts
@@ -62,9 +62,10 @@ export function createGlobalSingleton<T>({
         createDiagnosticMessage({
           source,
           severity: 'Warning',
-          whatHappened: `Overwriting global ${key} singleton instance`,
+          whatHappened: `Global singleton ${key} is already initialized`,
         })
       );
+      return;
     }
     ns[key] = next as unknown;
   }

--- a/packages/i18n/src/globals/createGlobalSingleton.ts
+++ b/packages/i18n/src/globals/createGlobalSingleton.ts
@@ -65,6 +65,7 @@ export function createGlobalSingleton<T>({
           whatHappened: `Overwriting global ${key} singleton instance`,
         })
       );
+      return;
     }
     ns[key] = next as unknown;
   }

--- a/packages/i18n/src/i18n-cache/I18nCache.ts
+++ b/packages/i18n/src/i18n-cache/I18nCache.ts
@@ -43,6 +43,10 @@ type TranslationResolver<U extends Translation = Translation> = <
   options?: LookupOptions
 ) => T | undefined;
 
+type DictionaryResolver = (id: string) => DictionaryEntry | undefined;
+
+type DictionaryObjResolver = (id: string) => DictionaryObject | undefined;
+
 /**
  * A prefetch entry is an entry that we want to prefetch during the async period
  * @template TranslationType - The type of the translation
@@ -275,6 +279,34 @@ class I18nCache<
     } catch (error) {
       this.handleError(error);
       return undefined;
+    }
+  }
+
+  async getLookupDictionary(locale: string): Promise<DictionaryResolver> {
+    try {
+      const asyncBoundaryLocale = this._resolveCacheLocale(locale);
+      const asyncBoundaryDictionaryCache = asyncBoundaryLocale
+        ? await this.localesCache.getOrLoadDictionary(asyncBoundaryLocale)
+        : this.getDefaultDictionaryCache();
+
+      return (id) => asyncBoundaryDictionaryCache?.getEntry(id);
+    } catch (error) {
+      this.handleError(error);
+      return () => undefined;
+    }
+  }
+
+  async getLookupDictionaryObj(locale: string): Promise<DictionaryObjResolver> {
+    try {
+      const asyncBoundaryLocale = this._resolveCacheLocale(locale);
+      const asyncBoundaryDictionaryCache = asyncBoundaryLocale
+        ? await this.localesCache.getOrLoadDictionary(asyncBoundaryLocale)
+        : this.getDefaultDictionaryCache();
+
+      return (id) => asyncBoundaryDictionaryCache?.getValue(id);
+    } catch (error) {
+      this.handleError(error);
+      return () => undefined;
     }
   }
 

--- a/packages/i18n/src/i18n-cache/I18nCache.ts
+++ b/packages/i18n/src/i18n-cache/I18nCache.ts
@@ -47,6 +47,11 @@ type DictionaryResolver = (id: string) => DictionaryEntry | undefined;
 
 type DictionaryObjResolver = (id: string) => DictionaryObject | undefined;
 
+type DictionaryResolvers = {
+  lookupDictionary: DictionaryResolver;
+  lookupDictionaryObj: DictionaryObjResolver;
+};
+
 /**
  * A prefetch entry is an entry that we want to prefetch during the async period
  * @template TranslationType - The type of the translation
@@ -282,31 +287,23 @@ class I18nCache<
     }
   }
 
-  async getLookupDictionary(locale: string): Promise<DictionaryResolver> {
+  async getLookupDictionary(locale: string): Promise<DictionaryResolvers> {
     try {
       const asyncBoundaryLocale = this._resolveCacheLocale(locale);
       const asyncBoundaryDictionaryCache = asyncBoundaryLocale
         ? await this.localesCache.getOrLoadDictionary(asyncBoundaryLocale)
         : this.getDefaultDictionaryCache();
 
-      return (id) => asyncBoundaryDictionaryCache?.getEntry(id);
+      return {
+        lookupDictionary: (id) => asyncBoundaryDictionaryCache?.getEntry(id),
+        lookupDictionaryObj: (id) => asyncBoundaryDictionaryCache?.getValue(id),
+      };
     } catch (error) {
       this.handleError(error);
-      return () => undefined;
-    }
-  }
-
-  async getLookupDictionaryObj(locale: string): Promise<DictionaryObjResolver> {
-    try {
-      const asyncBoundaryLocale = this._resolveCacheLocale(locale);
-      const asyncBoundaryDictionaryCache = asyncBoundaryLocale
-        ? await this.localesCache.getOrLoadDictionary(asyncBoundaryLocale)
-        : this.getDefaultDictionaryCache();
-
-      return (id) => asyncBoundaryDictionaryCache?.getValue(id);
-    } catch (error) {
-      this.handleError(error);
-      return () => undefined;
+      return {
+        lookupDictionary: () => undefined,
+        lookupDictionaryObj: () => undefined,
+      };
     }
   }
 

--- a/packages/i18n/src/i18n-cache/I18nCache.ts
+++ b/packages/i18n/src/i18n-cache/I18nCache.ts
@@ -56,6 +56,12 @@ type PrefetchEntry<TranslationType extends Translation> = {
 };
 
 /**
+ * Callback function to prefetch entries during the async period
+ */
+type PrefetchEntriesType<TranslationType extends Translation> = (
+  prefetchEntries: PrefetchEntry<TranslationType>[]
+) => Promise<void>;
+/**
  * Class for managing translation functionality
  * @template TranslationValue - The type of the translation that will be cached
  */
@@ -403,9 +409,7 @@ class I18nCache<
         this.resolveLookupParams(locale, options);
 
       // Early return if in default locale
-      if (!translationLocale) {
-        return message;
-      }
+      if (!translationLocale) return message;
 
       // Get the locale cache
       const txCache = this.localesCache.getTranslations(translationLocale);
@@ -446,59 +450,94 @@ class I18nCache<
    * Saves a current lookup translation function immune to expiry
    * Useful for operations involving lookup callbacks like useGT()
    * @param locale - The locale to get the lookup translation for
-   * @param prefetchEntries - Any entries we want to prefetch during the async period
    * @returns A lookup translation function
    *
    * @important prefetchEntries must all be the same locale
    */
-  async getLookupTranslation(
-    locale: string,
-    prefetchEntries: {
-      message: TranslationValue;
-      options: LookupOptions;
-    }[] = []
-  ): Promise<TranslationResolver<TranslationValue>> {
+  async getLookupTranslation(locale: string): Promise<
+    TranslationResolver<TranslationValue> & {
+      prefetchEntries?: PrefetchEntriesType<TranslationValue>;
+    }
+  > {
     try {
-      // Validate
-      const translationLocale = this._resolveCacheLocale(locale);
+      // Locale used for the async load
+      const asyncBoundaryLocale = this._resolveCacheLocale(locale);
 
       // Early return if i18n is disabled or default locale
-      if (!translationLocale) {
+      if (!asyncBoundaryLocale) {
         return (message) => message;
       }
 
-      // Invariant: all prefetchEntries must be the same locale
-      const resolvedPrefetchEntries = resolvePrefetchEntriesByLocale(
-        prefetchEntries,
-        translationLocale,
-        (entryLocale) =>
-          this._resolveCacheLocale(entryLocale) ??
-          this._resolveLocale(entryLocale)
-      );
-      if (resolvedPrefetchEntries.length !== prefetchEntries.length) {
-        logger.warn(
-          `I18nCache: getLookupTranslation(): prefetchEntries must all be the same locale, ignoring all entries that are not for ${translationLocale}`
+      const asyncBoundaryTxCache =
+        await this.localesCache.getOrLoadTranslations(asyncBoundaryLocale);
+
+      // Prefetch any entries during async block (dev hot reload only)
+      const prefetchEntries = async (
+        prefetchEntries: {
+          message: TranslationValue;
+          options: LookupOptions;
+        }[] = []
+      ) => {
+        if (!getI18nConfig().isDevHotReloadEnabled()) return;
+
+        // Invariant: all prefetchEntries must be the same locale
+        // TODO: investigate why we have made this an invariant, we may be able to drop this requirement
+        const resolvedPrefetchEntries = resolvePrefetchEntriesByLocale(
+          prefetchEntries,
+          asyncBoundaryLocale,
+          (entryLocale) =>
+            this._resolveCacheLocale(entryLocale) ??
+            this._resolveLocale(entryLocale)
         );
-      }
+        if (resolvedPrefetchEntries.length !== prefetchEntries.length) {
+          logger.warn(
+            `I18nCache: getLookupTranslation(): prefetchEntries must all be the same locale, ignoring all entries that are not for ${asyncBoundaryLocale}`
+          );
+        }
 
-      const txCache =
-        await this.localesCache.getOrLoadTranslations(translationLocale);
-
-      // Prefetch any entries during async block
-      await Promise.all(
-        resolvedPrefetchEntries
-          .filter((entry) => txCache.get(entry) == null)
-          .map((entry) => txCache.miss(entry))
-      );
+        await Promise.allSettled(
+          resolvedPrefetchEntries
+            .filter((entry) => asyncBoundaryTxCache.get(entry) == null)
+            .map((entry) => asyncBoundaryTxCache.miss(entry))
+        );
+      };
 
       // Create translation resolver
-      return (message, options: LookupOptions = {} as LookupOptions) => {
-        // Calculate hash
-        return txCache.get({
-          message,
-          options: this.resolveLookupOptions(options),
-        });
+      const lookupTranslation: TranslationResolver<TranslationValue> = (
+        message,
+        lookupOptions: LookupOptions = {} as LookupOptions
+      ) => {
+        try {
+          const { translationLocale, options } = this.resolveLookupParams(
+            lookupOptions.$locale ?? asyncBoundaryLocale,
+            lookupOptions
+          );
+
+          // Default locale, return the message
+          if (!translationLocale) return message;
+
+          // Request locale overriden, to attempt a synchronous lookup if an alternate locale is requested
+          let txCache = asyncBoundaryTxCache;
+          if (translationLocale !== asyncBoundaryLocale) {
+            const syncBoundaryTxCache =
+              this.localesCache.getTranslations(translationLocale);
+            if (!syncBoundaryTxCache) return undefined;
+            txCache = syncBoundaryTxCache;
+          }
+
+          // Get the translation
+          return txCache.get({
+            message,
+            options,
+          });
+        } catch (error) {
+          this.handleError(error);
+          return undefined;
+        }
       };
+
+      Object.assign(lookupTranslation, { prefetchEntries });
+      return lookupTranslation;
     } catch (error) {
       this.handleError(error);
       return (message) => message;
@@ -571,7 +610,7 @@ class I18nCache<
   private resolveLookupOptions(
     options: LookupOptions = {} as LookupOptions,
     translationLocale?: string
-  ) {
+  ): LookupOptions {
     if (!options.$locale) {
       return options;
     }

--- a/packages/i18n/src/i18n-cache/__tests__/I18nCache.handleError.test.ts
+++ b/packages/i18n/src/i18n-cache/__tests__/I18nCache.handleError.test.ts
@@ -2,6 +2,14 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { I18nCache } from '../I18nCache';
 import { initializeI18nConfig } from '../../i18n-config/singleton-operations';
 
+type TestGlobal = typeof globalThis & {
+  __generaltranslation?: unknown;
+};
+
+function resetGTGlobals() {
+  Reflect.deleteProperty(globalThis as TestGlobal, '__generaltranslation');
+}
+
 // Mock createTranslateManyFactory so constructor doesn't need real GT
 vi.mock('../translations-manager/utils/createTranslateMany', () => ({
   createTranslateManyFactory: vi.fn().mockReturnValue(() => vi.fn()),
@@ -9,6 +17,7 @@ vi.mock('../translations-manager/utils/createTranslateMany', () => ({
 
 describe('I18nCache.handleError', () => {
   beforeEach(() => {
+    resetGTGlobals();
     initializeI18nConfig({
       defaultLocale: 'en',
       locales: ['en', 'fr'],
@@ -17,6 +26,7 @@ describe('I18nCache.handleError', () => {
   });
 
   afterEach(() => {
+    resetGTGlobals();
     vi.unstubAllEnvs();
   });
 

--- a/packages/i18n/src/i18n-cache/__tests__/I18nCache.test.ts
+++ b/packages/i18n/src/i18n-cache/__tests__/I18nCache.test.ts
@@ -1185,6 +1185,47 @@ describe('I18nCache', () => {
     );
   });
 
+  it('async lookup resolvers retain the loaded snapshot when cacheExpiryTime is 0', async () => {
+    const loadDictionary = vi.fn().mockResolvedValue({
+      greeting: 'Bonjour',
+      user: {
+        profile: {
+          name: 'Nom',
+        },
+      },
+    });
+    const cache = createCache({
+      cacheExpiryTime: 0,
+      dictionary: {
+        greeting: 'Hello',
+        user: {
+          profile: {
+            name: 'Name',
+          },
+        },
+      },
+      loadDictionary,
+    });
+
+    const lookupTranslation = await cache.getLookupTranslation('fr');
+    const lookupDictionary = await cache.getLookupDictionary('fr');
+    const lookupDictionaryObj = await cache.getLookupDictionaryObj('fr');
+
+    expect(
+      cache.lookupTranslation('fr', message, lookupOptions)
+    ).toBeUndefined();
+    expect(cache.lookupDictionary('fr', 'greeting')).toBeUndefined();
+    expect(cache.lookupDictionaryObj('fr', 'user.profile')).toBeUndefined();
+    expect(lookupTranslation(message, lookupOptions)).toBe(translatedString);
+    expect(lookupDictionary('greeting')).toEqual({
+      entry: 'Bonjour',
+      options: {},
+    });
+    expect(lookupDictionaryObj('user.profile')).toEqual({
+      name: 'Nom',
+    });
+  });
+
   it('does not clone leaf dictionary values on lookup', async () => {
     const cache = createCache({
       dictionary: {

--- a/packages/i18n/src/i18n-cache/__tests__/I18nCache.test.ts
+++ b/packages/i18n/src/i18n-cache/__tests__/I18nCache.test.ts
@@ -1208,8 +1208,8 @@ describe('I18nCache', () => {
     });
 
     const lookupTranslation = await cache.getLookupTranslation('fr');
-    const lookupDictionary = await cache.getLookupDictionary('fr');
-    const lookupDictionaryObj = await cache.getLookupDictionaryObj('fr');
+    const { lookupDictionary, lookupDictionaryObj } =
+      await cache.getLookupDictionary('fr');
 
     expect(
       cache.lookupTranslation('fr', message, lookupOptions)

--- a/packages/i18n/src/i18n-cache/__tests__/I18nCache.test.ts
+++ b/packages/i18n/src/i18n-cache/__tests__/I18nCache.test.ts
@@ -21,6 +21,14 @@ const lookupOptions: LookupOptions = {
 const expectedHash = hashMessage(message, lookupOptions);
 const translatedString = 'Bonjour {name} !';
 
+type TestGlobal = typeof globalThis & {
+  __generaltranslation?: unknown;
+};
+
+function resetGTGlobals() {
+  Reflect.deleteProperty(globalThis as TestGlobal, '__generaltranslation');
+}
+
 function createCache(overrides: Record<string, unknown> = {}) {
   const {
     defaultLocale = 'en',
@@ -28,6 +36,7 @@ function createCache(overrides: Record<string, unknown> = {}) {
     customMapping,
     ...cacheOverrides
   } = overrides;
+  resetGTGlobals();
   initializeI18nConfig({
     defaultLocale: defaultLocale as string,
     locales: locales as string[],
@@ -44,6 +53,7 @@ function createCache(overrides: Record<string, unknown> = {}) {
 
 describe('I18nCache', () => {
   beforeEach(() => {
+    resetGTGlobals();
     initializeI18nConfig({
       defaultLocale: 'en',
       locales: ['en', 'fr', 'es'],
@@ -53,6 +63,7 @@ describe('I18nCache', () => {
   });
 
   afterEach(() => {
+    resetGTGlobals();
     vi.useRealTimers();
     vi.unstubAllEnvs();
   });

--- a/packages/i18n/src/i18n-cache/__tests__/singleton-operations.test.ts
+++ b/packages/i18n/src/i18n-cache/__tests__/singleton-operations.test.ts
@@ -50,7 +50,7 @@ describe('i18n cache singleton operations', () => {
     expect(getI18nCache()).toBe(cache);
   });
 
-  it('does not overwrite an existing global cache', async () => {
+  it('warns and preserves an existing global cache', async () => {
     const { getI18nCache, setI18nCache } =
       await import('../singleton-operations');
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
@@ -60,6 +60,8 @@ describe('i18n cache singleton operations', () => {
     setI18nCache(createCacheStub());
 
     expect(getI18nCache()).toBe(cache);
-    expect(warn).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('Overwriting global i18nCache singleton instance')
+    );
   });
 });

--- a/packages/i18n/src/i18n-cache/__tests__/singleton-operations.test.ts
+++ b/packages/i18n/src/i18n-cache/__tests__/singleton-operations.test.ts
@@ -50,15 +50,16 @@ describe('i18n cache singleton operations', () => {
     expect(getI18nCache()).toBe(cache);
   });
 
-  it('warns when overwriting an existing global cache', async () => {
-    const { setI18nCache } = await import('../singleton-operations');
+  it('does not overwrite an existing global cache', async () => {
+    const { getI18nCache, setI18nCache } =
+      await import('../singleton-operations');
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const cache = createCacheStub();
 
-    setI18nCache(createCacheStub());
+    setI18nCache(cache);
     setI18nCache(createCacheStub());
 
-    expect(warn).toHaveBeenCalledWith(
-      expect.stringContaining('Overwriting global i18nCache singleton instance')
-    );
+    expect(getI18nCache()).toBe(cache);
+    expect(warn).not.toHaveBeenCalled();
   });
 });

--- a/packages/i18n/src/i18n-cache/singleton-operations.ts
+++ b/packages/i18n/src/i18n-cache/singleton-operations.ts
@@ -39,7 +39,11 @@ export function getI18nCache<U extends Translation = Translation>():
  * Note: should not be consumed by gt-react, consumers should use a wrapper
  */
 export function setI18nCache<TranslationValue extends Translation>(
-  i18nCacheInstance: I18nCache<TranslationValue>
+  i18nCacheInstance: I18nCache<TranslationValue>,
+  options?: { overwrite?: boolean }
 ): void {
+  if (options?.overwrite === false && i18nCacheSingleton.isInitialized()) {
+    return;
+  }
   i18nCacheSingleton.set(i18nCacheInstance as unknown as I18nCache);
 }

--- a/packages/i18n/src/i18n-cache/singleton-operations.ts
+++ b/packages/i18n/src/i18n-cache/singleton-operations.ts
@@ -41,8 +41,5 @@ export function getI18nCache<U extends Translation = Translation>():
 export function setI18nCache<TranslationValue extends Translation>(
   i18nCacheInstance: I18nCache<TranslationValue>
 ): void {
-  if (i18nCacheSingleton.isInitialized()) {
-    return;
-  }
   i18nCacheSingleton.set(i18nCacheInstance as unknown as I18nCache);
 }

--- a/packages/i18n/src/i18n-cache/singleton-operations.ts
+++ b/packages/i18n/src/i18n-cache/singleton-operations.ts
@@ -39,10 +39,9 @@ export function getI18nCache<U extends Translation = Translation>():
  * Note: should not be consumed by gt-react, consumers should use a wrapper
  */
 export function setI18nCache<TranslationValue extends Translation>(
-  i18nCacheInstance: I18nCache<TranslationValue>,
-  options?: { overwrite?: boolean }
+  i18nCacheInstance: I18nCache<TranslationValue>
 ): void {
-  if (options?.overwrite === false && i18nCacheSingleton.isInitialized()) {
+  if (i18nCacheSingleton.isInitialized()) {
     return;
   }
   i18nCacheSingleton.set(i18nCacheInstance as unknown as I18nCache);

--- a/packages/i18n/src/i18n-cache/translations-manager/ResourceCache.ts
+++ b/packages/i18n/src/i18n-cache/translations-manager/ResourceCache.ts
@@ -69,10 +69,13 @@ export class ResourceCache<Key extends string, Value> {
   }
 
   private getExpiresAt(): number {
-    return this.ttl < 0 ? this.ttl : Date.now() + this.ttl;
+    // Avoid Date.now() for Next.js Cache Components; Next handles caching.
+    return this.ttl <= 0 ? this.ttl : Date.now() + this.ttl;
   }
 
   private isExpired(entry: ResourceCacheEntry<Value>): boolean {
+    // Avoid Date.now() for Next.js Cache Components; Next handles caching.
+    if (entry.expiresAt === 0) return true;
     return entry.expiresAt > 0 && entry.expiresAt < Date.now();
   }
 }

--- a/packages/i18n/src/i18n-cache/translations-manager/__tests__/LocalesCache.test.ts
+++ b/packages/i18n/src/i18n-cache/translations-manager/__tests__/LocalesCache.test.ts
@@ -8,6 +8,14 @@ import type { LocalesTranslationsCacheMissCallback } from '../LocalesCache';
 import type { SafeTranslationsLoader } from '../translations-loaders/types';
 import { initializeI18nConfig } from '../../../i18n-config/singleton-operations';
 
+type TestGlobal = typeof globalThis & {
+  __generaltranslation?: unknown;
+};
+
+function resetGTGlobals() {
+  Reflect.deleteProperty(globalThis as TestGlobal, '__generaltranslation');
+}
+
 describe('LocalesCache', () => {
   let mockLoadTranslations: ReturnType<typeof vi.fn>;
   let mockLoadDictionary: ReturnType<typeof vi.fn>;
@@ -30,6 +38,7 @@ describe('LocalesCache', () => {
   };
 
   beforeEach(() => {
+    resetGTGlobals();
     vi.useFakeTimers();
     initializeI18nConfig({ defaultLocale: 'en', locales: ['en', 'fr'] });
     mockLoadTranslations = vi.fn().mockResolvedValue(frTranslations);
@@ -39,6 +48,7 @@ describe('LocalesCache', () => {
   });
 
   afterEach(() => {
+    resetGTGlobals();
     vi.useRealTimers();
   });
 

--- a/packages/i18n/src/i18n-cache/translations-manager/__tests__/ResourceCache.test.ts
+++ b/packages/i18n/src/i18n-cache/translations-manager/__tests__/ResourceCache.test.ts
@@ -1,0 +1,20 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ResourceCache } from '../ResourceCache';
+
+describe('ResourceCache', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('ttl 0 expires immediately without reading the current time', async () => {
+    const nowSpy = vi.spyOn(Date, 'now');
+    const cache = new ResourceCache({
+      ttl: 0,
+      load: async () => 'loaded',
+    });
+
+    await expect(cache.getOrLoad('key')).resolves.toBe('loaded');
+    expect(cache.get('key')).toBeUndefined();
+    expect(nowSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/i18n/src/i18n-config/I18nConfig.ts
+++ b/packages/i18n/src/i18n-config/I18nConfig.ts
@@ -27,11 +27,12 @@ export type I18nConfigParams = Pick<
   | 'apiKey'
   | 'cacheUrl'
   | 'runtimeUrl'
+  | '_disableDevHotReload'
 >;
 
 type RuntimeConfig = Pick<
   I18nConfigParams,
-  'projectId' | 'devApiKey' | 'apiKey' | 'runtimeUrl'
+  'projectId' | 'devApiKey' | 'apiKey' | 'runtimeUrl' | '_disableDevHotReload'
 >;
 
 export type LocaleCandidates = string | string[] | undefined;
@@ -48,6 +49,7 @@ export class I18nConfig extends LocaleConfig {
       devApiKey: params.devApiKey,
       apiKey: params.apiKey,
       runtimeUrl: params.runtimeUrl,
+      _disableDevHotReload: params._disableDevHotReload,
     };
     this.gtServicesEnabled = gtServicesEnabled;
   }
@@ -133,6 +135,7 @@ export class I18nConfig extends LocaleConfig {
    */
   isDevHotReloadEnabled(): boolean {
     return (
+      !this.runtimeConfig._disableDevHotReload &&
       !!this.runtimeConfig.devApiKey &&
       !!this.runtimeConfig.projectId &&
       this.runtimeConfig.runtimeUrl !== null &&

--- a/packages/i18n/src/i18n-config/__tests__/I18nConfig.test.ts
+++ b/packages/i18n/src/i18n-config/__tests__/I18nConfig.test.ts
@@ -110,6 +110,18 @@ describe('I18nConfig', () => {
     expect(config.isDevHotReloadEnabled()).toBe(true);
   });
 
+  it('disables dev hot reload when the config switch is set', () => {
+    vi.stubEnv('NODE_ENV', 'development');
+
+    const config = new I18nConfig({
+      devApiKey: 'dev-key',
+      projectId: 'project-id',
+      _disableDevHotReload: true,
+    });
+
+    expect(config.isDevHotReloadEnabled()).toBe(false);
+  });
+
   it.each([
     {
       name: 'missing dev API key',

--- a/packages/i18n/src/i18n-config/__tests__/singleton-operations.test.ts
+++ b/packages/i18n/src/i18n-config/__tests__/singleton-operations.test.ts
@@ -63,11 +63,12 @@ describe('i18n config singleton operations', () => {
     expect(getI18nConfig()).toBe(config);
   });
 
-  it('warns when overwriting an existing global config', async () => {
-    const { initializeI18nConfig } = await import('../singleton-operations');
+  it('warns and preserves an existing global config', async () => {
+    const { getI18nConfig, initializeI18nConfig } =
+      await import('../singleton-operations');
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-    initializeI18nConfig({
+    const config = initializeI18nConfig({
       defaultLocale: 'en',
     });
     initializeI18nConfig({
@@ -79,6 +80,7 @@ describe('i18n config singleton operations', () => {
         'Overwriting global i18nConfig singleton instance'
       )
     );
+    expect(getI18nConfig()).toBe(config);
   });
 
   it('preserves existing i18n global fields when setting config', async () => {

--- a/packages/i18n/src/translation-functions/__tests__/t.test.ts
+++ b/packages/i18n/src/translation-functions/__tests__/t.test.ts
@@ -14,6 +14,23 @@ import {
 import { hashMessage } from '../../utils/hashMessage';
 import { t } from '../t';
 
+type TestGlobal = typeof globalThis & {
+  __generaltranslation?: {
+    i18n?: {
+      i18nCache?: unknown;
+      [key: string]: unknown;
+    };
+    [key: string]: unknown;
+  };
+};
+
+function resetI18nCacheGlobal() {
+  const globalObj = globalThis as TestGlobal;
+  if (globalObj.__generaltranslation?.i18n) {
+    Reflect.deleteProperty(globalObj.__generaltranslation.i18n, 'i18nCache');
+  }
+}
+
 describe('t', () => {
   function createCache(
     i18nConfig: I18nConfigParams,
@@ -24,6 +41,7 @@ describe('t', () => {
   }
 
   afterEach(() => {
+    resetI18nCacheGlobal();
     setWritableConditionStore({ getLocale: () => 'en' });
   });
 

--- a/packages/i18n/src/translation-functions/__tests__/t.test.ts
+++ b/packages/i18n/src/translation-functions/__tests__/t.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { I18nCache } from '../../i18n-cache/I18nCache';
 import { setI18nCache } from '../../i18n-cache/singleton-operations';
 import type { I18nCacheConstructorParams } from '../../i18n-cache/types';
@@ -15,20 +15,11 @@ import { hashMessage } from '../../utils/hashMessage';
 import { t } from '../t';
 
 type TestGlobal = typeof globalThis & {
-  __generaltranslation?: {
-    i18n?: {
-      i18nCache?: unknown;
-      [key: string]: unknown;
-    };
-    [key: string]: unknown;
-  };
+  __generaltranslation?: unknown;
 };
 
-function resetI18nCacheGlobal() {
-  const globalObj = globalThis as TestGlobal;
-  if (globalObj.__generaltranslation?.i18n) {
-    Reflect.deleteProperty(globalObj.__generaltranslation.i18n, 'i18nCache');
-  }
+function resetGTGlobals() {
+  Reflect.deleteProperty(globalThis as TestGlobal, '__generaltranslation');
 }
 
 describe('t', () => {
@@ -40,10 +31,9 @@ describe('t', () => {
     return new I18nCache(cacheConfig);
   }
 
-  afterEach(() => {
-    resetI18nCacheGlobal();
-    setWritableConditionStore({ getLocale: () => 'en' });
-  });
+  beforeEach(resetGTGlobals);
+
+  afterEach(resetGTGlobals);
 
   it('works without an explicit locale', () => {
     setWritableConditionStore({ getLocale: () => 'en' });

--- a/packages/i18n/src/translation-functions/internal/__tests__/helpers.integration.test.ts
+++ b/packages/i18n/src/translation-functions/internal/__tests__/helpers.integration.test.ts
@@ -10,20 +10,11 @@ import {
 } from '../helpers';
 
 type TestGlobal = typeof globalThis & {
-  __generaltranslation?: {
-    i18n?: {
-      i18nCache?: unknown;
-      [key: string]: unknown;
-    };
-    [key: string]: unknown;
-  };
+  __generaltranslation?: unknown;
 };
 
-function resetI18nCacheGlobal() {
-  const globalObj = globalThis as TestGlobal;
-  if (globalObj.__generaltranslation?.i18n) {
-    Reflect.deleteProperty(globalObj.__generaltranslation.i18n, 'i18nCache');
-  }
+function resetGTGlobals() {
+  Reflect.deleteProperty(globalThis as TestGlobal, '__generaltranslation');
 }
 
 // Mock createTranslateManyFactory to inject controlled translateMany
@@ -39,13 +30,14 @@ vi.mock(
 
 describe('translation helpers (deep integration)', () => {
   beforeEach(() => {
+    resetGTGlobals();
     vi.useFakeTimers();
     vi.clearAllMocks();
     mockTranslateMany.mockReset();
   });
 
   afterEach(() => {
-    resetI18nCacheGlobal();
+    resetGTGlobals();
     vi.useRealTimers();
   });
 

--- a/packages/i18n/src/translation-functions/internal/__tests__/helpers.integration.test.ts
+++ b/packages/i18n/src/translation-functions/internal/__tests__/helpers.integration.test.ts
@@ -9,6 +9,23 @@ import {
   resolveJsxWithRuntimeFallback,
 } from '../helpers';
 
+type TestGlobal = typeof globalThis & {
+  __generaltranslation?: {
+    i18n?: {
+      i18nCache?: unknown;
+      [key: string]: unknown;
+    };
+    [key: string]: unknown;
+  };
+};
+
+function resetI18nCacheGlobal() {
+  const globalObj = globalThis as TestGlobal;
+  if (globalObj.__generaltranslation?.i18n) {
+    Reflect.deleteProperty(globalObj.__generaltranslation.i18n, 'i18nCache');
+  }
+}
+
 // Mock createTranslateManyFactory to inject controlled translateMany
 const mockTranslateMany = vi.fn();
 vi.mock(
@@ -28,6 +45,7 @@ describe('translation helpers (deep integration)', () => {
   });
 
   afterEach(() => {
+    resetI18nCacheGlobal();
     vi.useRealTimers();
   });
 

--- a/packages/i18n/src/translation-functions/internal/__tests__/helpers.test.ts
+++ b/packages/i18n/src/translation-functions/internal/__tests__/helpers.test.ts
@@ -8,11 +8,20 @@ import { initializeI18nConfig } from '../../../i18n-config/singleton-operations'
 import { getI18nCache } from '../../../i18n-cache/singleton-operations';
 import { interpolateMessage } from '../../utils/interpolation/interpolateMessage';
 
+type TestGlobal = typeof globalThis & {
+  __generaltranslation?: unknown;
+};
+
+function resetGTGlobals() {
+  Reflect.deleteProperty(globalThis as TestGlobal, '__generaltranslation');
+}
+
 vi.mock('../../../i18n-cache/singleton-operations');
 vi.mock('../../utils/interpolation/interpolateMessage');
 
 describe('translation helpers', () => {
   beforeEach(() => {
+    resetGTGlobals();
     vi.clearAllMocks();
     initializeI18nConfig({ defaultLocale: 'en' });
     vi.mocked(interpolateMessage).mockReturnValue('interpolated-result');

--- a/packages/i18n/src/translation-functions/internal/__tests__/locale-defaults.test.ts
+++ b/packages/i18n/src/translation-functions/internal/__tests__/locale-defaults.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { I18nCache } from '../../../i18n-cache/I18nCache';
 import type { I18nCacheConstructorParams } from '../../../i18n-cache/types';
 import { setI18nCache } from '../../../i18n-cache/singleton-operations';
@@ -13,26 +13,18 @@ import { getMessages } from '../getMessages';
 import { tx, txInternal } from '../tx';
 
 type TestGlobal = typeof globalThis & {
-  __generaltranslation?: {
-    i18n?: {
-      i18nCache?: unknown;
-      [key: string]: unknown;
-    };
-    [key: string]: unknown;
-  };
+  __generaltranslation?: unknown;
 };
 
-function resetI18nCacheGlobal() {
-  const globalObj = globalThis as TestGlobal;
-  if (globalObj.__generaltranslation?.i18n) {
-    Reflect.deleteProperty(globalObj.__generaltranslation.i18n, 'i18nCache');
-  }
+function resetGTGlobals() {
+  Reflect.deleteProperty(globalThis as TestGlobal, '__generaltranslation');
 }
 
 describe('translation function locale defaults', () => {
+  beforeEach(resetGTGlobals);
+
   afterEach(() => {
-    resetI18nCacheGlobal();
-    setWritableConditionStore(createConditionStore('en'));
+    resetGTGlobals();
     vi.unstubAllEnvs();
   });
 

--- a/packages/i18n/src/translation-functions/internal/__tests__/locale-defaults.test.ts
+++ b/packages/i18n/src/translation-functions/internal/__tests__/locale-defaults.test.ts
@@ -12,8 +12,26 @@ import { getTranslations } from '../getTranslations';
 import { getMessages } from '../getMessages';
 import { tx, txInternal } from '../tx';
 
+type TestGlobal = typeof globalThis & {
+  __generaltranslation?: {
+    i18n?: {
+      i18nCache?: unknown;
+      [key: string]: unknown;
+    };
+    [key: string]: unknown;
+  };
+};
+
+function resetI18nCacheGlobal() {
+  const globalObj = globalThis as TestGlobal;
+  if (globalObj.__generaltranslation?.i18n) {
+    Reflect.deleteProperty(globalObj.__generaltranslation.i18n, 'i18nCache');
+  }
+}
+
 describe('translation function locale defaults', () => {
   afterEach(() => {
+    resetI18nCacheGlobal();
     setWritableConditionStore(createConditionStore('en'));
     vi.unstubAllEnvs();
   });

--- a/packages/i18n/src/translation-functions/internal/__tests__/locale-defaults.test.ts
+++ b/packages/i18n/src/translation-functions/internal/__tests__/locale-defaults.test.ts
@@ -7,7 +7,7 @@ import { initializeI18nConfig } from '../../../i18n-config/singleton-operations'
 import type { I18nConfigParams } from '../../../i18n-config/I18nConfig';
 import { msg } from '../../msg/msg';
 import { hashMessage } from '../../../utils/hashMessage';
-import { getGT } from '../getGT';
+import { getGT, getGTInternal } from '../getGT';
 import { getTranslations } from '../getTranslations';
 import { getMessages } from '../getMessages';
 import { tx, txInternal } from '../tx';
@@ -15,6 +15,7 @@ import { tx, txInternal } from '../tx';
 describe('translation function locale defaults', () => {
   afterEach(() => {
     setWritableConditionStore(createConditionStore('en'));
+    vi.unstubAllEnvs();
   });
 
   function createConditionStore(locale: string) {
@@ -77,6 +78,89 @@ describe('translation function locale defaults', () => {
     await cache.loadTranslations('es');
 
     expect(gt(message, { $locale: 'es', name: 'Alice' })).toBe('Hola Alice!');
+  });
+
+  it('getGT preloads compiler messages when dev hot reload is enabled', async () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    const cache = createCache(
+      {
+        defaultLocale: 'en',
+        locales: ['en', 'fr'],
+        devApiKey: 'dev-key',
+        projectId: 'project-id',
+      },
+      {
+        loadTranslations: vi.fn().mockResolvedValue({}),
+      }
+    );
+    const lookupTranslationWithFallback = vi
+      .spyOn(cache, 'lookupTranslationWithFallback')
+      .mockResolvedValue('Bonjour Alice !');
+    setI18nCache(cache);
+
+    await getGTInternal({ locale: 'fr', enableI18n: true }, [
+      { message: 'Hello {name}!', $context: 'greeting' },
+    ]);
+
+    expect(lookupTranslationWithFallback).toHaveBeenCalledWith(
+      'fr',
+      'Hello {name}!',
+      expect.objectContaining({
+        $context: 'greeting',
+        $format: 'ICU',
+        $locale: 'fr',
+      })
+    );
+  });
+
+  it('getGT still returns a function when dev hot reload preload rejects', async () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    const cache = createCache(
+      {
+        defaultLocale: 'en',
+        locales: ['en', 'fr'],
+        devApiKey: 'dev-key',
+        projectId: 'project-id',
+      },
+      {
+        loadTranslations: vi.fn().mockResolvedValue({}),
+      }
+    );
+    vi.spyOn(cache, 'lookupTranslationWithFallback')
+      .mockRejectedValueOnce(new Error('offline'))
+      .mockResolvedValue(undefined);
+    setI18nCache(cache);
+
+    const gt = await getGTInternal({ locale: 'fr', enableI18n: true }, [
+      { message: 'Hello {name}!' },
+    ]);
+
+    expect(gt('Hello {name}!', { name: 'Alice' })).toBe('Hello Alice!');
+  });
+
+  it('getGT catches fire-and-forget dev hot reload lookup rejections', async () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    const cache = createCache(
+      {
+        defaultLocale: 'en',
+        locales: ['en', 'fr'],
+        devApiKey: 'dev-key',
+        projectId: 'project-id',
+      },
+      {
+        loadTranslations: vi.fn().mockResolvedValue({}),
+      }
+    );
+    const catchHandler = vi.fn();
+    vi.spyOn(cache, 'lookupTranslationWithFallback').mockReturnValue({
+      catch: catchHandler,
+    } as unknown as ReturnType<typeof cache.lookupTranslationWithFallback>);
+    setI18nCache(cache);
+
+    const gt = await getGTInternal({ locale: 'fr', enableI18n: true });
+
+    expect(gt('Hello {name}!', { name: 'Alice' })).toBe('Hello Alice!');
+    expect(catchHandler).toHaveBeenCalledWith(expect.any(Function));
   });
 
   it('getTranslations uses the current locale for dictionary entries', async () => {

--- a/packages/i18n/src/translation-functions/internal/__tests__/locale-defaults.test.ts
+++ b/packages/i18n/src/translation-functions/internal/__tests__/locale-defaults.test.ts
@@ -93,24 +93,27 @@ describe('translation function locale defaults', () => {
         loadTranslations: vi.fn().mockResolvedValue({}),
       }
     );
-    const lookupTranslationWithFallback = vi
-      .spyOn(cache, 'lookupTranslationWithFallback')
-      .mockResolvedValue('Bonjour Alice !');
+    const prefetchEntries = vi.fn();
+    vi.spyOn(cache, 'getLookupTranslation').mockResolvedValue(
+      Object.assign(vi.fn(), { prefetchEntries }) as Awaited<
+        ReturnType<typeof cache.getLookupTranslation>
+      >
+    );
     setI18nCache(cache);
 
     await getGTInternal({ locale: 'fr', enableI18n: true }, [
       { message: 'Hello {name}!', $context: 'greeting' },
     ]);
 
-    expect(lookupTranslationWithFallback).toHaveBeenCalledWith(
-      'fr',
-      'Hello {name}!',
-      expect.objectContaining({
-        $context: 'greeting',
-        $format: 'ICU',
-        $locale: 'fr',
-      })
-    );
+    expect(prefetchEntries).toHaveBeenCalledWith([
+      {
+        message: 'Hello {name}!',
+        options: {
+          $context: 'greeting',
+          $format: 'ICU',
+        },
+      },
+    ]);
   });
 
   it('getGT still returns a function when dev hot reload preload rejects', async () => {
@@ -224,6 +227,34 @@ describe('translation function locale defaults', () => {
 
     expect(t('greeting', { name: 'Alice' })).toBe('Bonjour Alice !');
     expect(loadTranslations).toHaveBeenCalledWith('fr');
+  });
+
+  it('getTranslations uses async lookup snapshots when cacheExpiryTime is 0', async () => {
+    const message = 'Hello {name}!';
+    const lookupOptions = { $format: 'ICU', $context: 'homepage' } as const;
+    const loadTranslations = vi.fn().mockResolvedValue({
+      [hashMessage(message, lookupOptions)]: 'Bonjour {name} !',
+    });
+    const cache = createCache(
+      { defaultLocale: 'en', locales: ['en', 'fr'] },
+      {
+        cacheExpiryTime: 0,
+        dictionary: {
+          greeting: [message, { $context: 'homepage' }],
+        },
+        loadDictionary: vi.fn().mockResolvedValue({}),
+        loadTranslations,
+      }
+    );
+    setI18nCache(cache);
+    setWritableConditionStore(createConditionStore('fr'));
+
+    const t = await getTranslations();
+
+    expect(
+      cache.lookupTranslation('fr', message, lookupOptions)
+    ).toBeUndefined();
+    expect(t('greeting', { name: 'Alice' })).toBe('Bonjour Alice !');
   });
 
   it('getTranslations throws when the source dictionary entry is missing', async () => {

--- a/packages/i18n/src/translation-functions/internal/getGT.ts
+++ b/packages/i18n/src/translation-functions/internal/getGT.ts
@@ -1,11 +1,19 @@
 import { getI18nCache } from '../../i18n-cache/singleton-operations';
 import { getI18nConfig } from '../../i18n-config/singleton-operations';
-import { GTTranslationOptions } from '../types/options';
+import {
+  GTTranslationOptions,
+  NormalizedLookupOptions,
+  TranslationMetadata,
+} from '../types/options';
 import { GTFunctionType } from '../types/functions';
 import { interpolateMessage } from '../utils/interpolation/interpolateMessage';
 import { createLookupOptions } from './helpers';
 import type { StringFormat } from '@generaltranslation/format/types';
 import { getWritableConditionStore } from '../../condition-store/singleton-operations';
+
+export type Message = TranslationMetadata & {
+  message: string;
+};
 
 /**
  * Returns the gt function that registers a string at build time and resolves its translation at runtime.
@@ -15,29 +23,75 @@ import { getWritableConditionStore } from '../../condition-store/singleton-opera
  * const gt = await getGT();
  * const greeting = gt('Hello, world!');
  */
-export async function getGT(): Promise<GTFunctionType> {
+export async function getGT(_messages?: Message[]): Promise<GTFunctionType> {
   const conditionStore = getWritableConditionStore();
   const locale = conditionStore.getLocale();
   const enableI18n = conditionStore.getEnableI18n();
-  return getGTInternal({ locale, enableI18n });
+  return getGTInternal({ locale, enableI18n }, _messages);
 }
 
 /**
  * Condition store agnostic getGT function
  */
-export async function getGTInternal({
-  locale,
-  enableI18n,
-}: {
-  locale: string;
-  enableI18n: boolean;
-}): Promise<GTFunctionType> {
+export async function getGTInternal(
+  {
+    locale,
+    enableI18n,
+  }: {
+    locale: string;
+    enableI18n: boolean;
+  },
+  _messages?: Message[]
+): Promise<GTFunctionType> {
   // Get the translation resolver
   const i18nCache = getI18nCache();
   await i18nCache.loadTranslations(locale);
   const sourceLocale = getI18nConfig().getDefaultLocale();
+  const devHotReloadEnabled = getI18nConfig().isDevHotReloadEnabled();
 
-  // TODO: dev hot reload translate compiler injected lookups
+  // dev hot reload translate compiler injected lookups
+  if (devHotReloadEnabled && _messages && _messages.length > 0) {
+    const lookups: {
+      message: string;
+      lookupOptions: NormalizedLookupOptions<StringFormat>;
+    }[] = _messages
+      .map(({ message, ...options }) => {
+        const targetLocale = enableI18n
+          ? (options.$locale ?? locale)
+          : getI18nConfig().getDefaultLocale();
+        const lookupOptions = createLookupOptions<StringFormat>(
+          targetLocale,
+          options,
+          'ICU'
+        );
+        return {
+          lookupOptions,
+          message,
+        };
+      })
+      .filter(({ lookupOptions, message }) => {
+        // Filter lookups that are already in the cache
+        return (
+          i18nCache.lookupTranslation(
+            lookupOptions.$locale,
+            message,
+            lookupOptions
+          ) == null
+        );
+      });
+
+    if (lookups.length > 0) {
+      await Promise.allSettled(
+        lookups.map(({ lookupOptions, message }) =>
+          i18nCache.lookupTranslationWithFallback(
+            lookupOptions.$locale,
+            message,
+            lookupOptions
+          )
+        )
+      );
+    }
+  }
 
   /**
    * Registers a message at build time and resolves its translation at runtime.
@@ -74,6 +128,17 @@ export async function getGTInternal({
       message,
       lookupOptions
     );
+
+    // Dev hot reload (fire and forget, will be available in a later lookup)
+    if (devHotReloadEnabled && translation == null) {
+      void i18nCache
+        .lookupTranslationWithFallback(
+          lookupOptions.$locale,
+          message,
+          lookupOptions
+        )
+        .catch(() => {});
+    }
 
     // Format result
     return interpolateMessage({

--- a/packages/i18n/src/translation-functions/internal/getGT.ts
+++ b/packages/i18n/src/translation-functions/internal/getGT.ts
@@ -1,10 +1,6 @@
 import { getI18nCache } from '../../i18n-cache/singleton-operations';
 import { getI18nConfig } from '../../i18n-config/singleton-operations';
-import {
-  GTTranslationOptions,
-  NormalizedLookupOptions,
-  TranslationMetadata,
-} from '../types/options';
+import { GTTranslationOptions, TranslationMetadata } from '../types/options';
 import { GTFunctionType } from '../types/functions';
 import { interpolateMessage } from '../utils/interpolation/interpolateMessage';
 import { createLookupOptions } from './helpers';
@@ -45,52 +41,21 @@ export async function getGTInternal(
 ): Promise<GTFunctionType> {
   // Get the translation resolver
   const i18nCache = getI18nCache();
-  await i18nCache.loadTranslations(locale);
   const sourceLocale = getI18nConfig().getDefaultLocale();
   const devHotReloadEnabled = getI18nConfig().isDevHotReloadEnabled();
+  const lookupTranslation = await i18nCache.getLookupTranslation(locale);
 
   // dev hot reload translate compiler injected lookups
-  if (devHotReloadEnabled && _messages && _messages.length > 0) {
-    const lookups: {
-      message: string;
-      lookupOptions: NormalizedLookupOptions<StringFormat>;
-    }[] = _messages
-      .map(({ message, ...options }) => {
-        const targetLocale = enableI18n
-          ? (options.$locale ?? locale)
-          : getI18nConfig().getDefaultLocale();
-        const lookupOptions = createLookupOptions<StringFormat>(
-          targetLocale,
-          options,
-          'ICU'
-        );
-        return {
-          lookupOptions,
-          message,
-        };
-      })
-      .filter(({ lookupOptions, message }) => {
-        // Filter lookups that are already in the cache
-        return (
-          i18nCache.lookupTranslation(
-            lookupOptions.$locale,
-            message,
-            lookupOptions
-          ) == null
-        );
-      });
-
-    if (lookups.length > 0) {
-      await Promise.allSettled(
-        lookups.map(({ lookupOptions, message }) =>
-          i18nCache.lookupTranslationWithFallback(
-            lookupOptions.$locale,
-            message,
-            lookupOptions
-          )
-        )
-      );
-    }
+  if (devHotReloadEnabled && lookupTranslation.prefetchEntries) {
+    await lookupTranslation.prefetchEntries(
+      _messages?.map(({ message, ...options }) => ({
+        message,
+        options: {
+          $format: 'ICU',
+          ...options,
+        },
+      })) ?? []
+    );
   }
 
   /**
@@ -123,11 +88,7 @@ export async function getGTInternal(
     );
 
     // Lookup translation
-    const translation = i18nCache.lookupTranslation(
-      lookupOptions.$locale,
-      message,
-      lookupOptions
-    );
+    const translation = lookupTranslation(message, lookupOptions);
 
     // Dev hot reload (fire and forget, will be available in a later lookup)
     if (devHotReloadEnabled && translation == null) {

--- a/packages/i18n/src/translation-functions/internal/getGT.ts
+++ b/packages/i18n/src/translation-functions/internal/getGT.ts
@@ -43,7 +43,9 @@ export async function getGTInternal(
   const i18nCache = getI18nCache();
   const sourceLocale = getI18nConfig().getDefaultLocale();
   const devHotReloadEnabled = getI18nConfig().isDevHotReloadEnabled();
-  const lookupTranslation = await i18nCache.getLookupTranslation(locale);
+  const lookupTranslation = await i18nCache.getLookupTranslation(
+    enableI18n ? locale : sourceLocale
+  );
 
   // dev hot reload translate compiler injected lookups
   if (devHotReloadEnabled && lookupTranslation.prefetchEntries) {

--- a/packages/i18n/src/translation-functions/internal/getTranslations.ts
+++ b/packages/i18n/src/translation-functions/internal/getTranslations.ts
@@ -37,9 +37,18 @@ export async function getTranslationsInternal({
   const i18nCache = getI18nCache();
   const sourceLocale = getI18nConfig().getDefaultLocale();
   const targetLocale = enableI18n ? locale : sourceLocale;
-  await Promise.all([
-    i18nCache.loadDictionary(targetLocale),
-    i18nCache.loadTranslations(targetLocale),
+  const [
+    lookupSourceDictionary,
+    lookupTargetDictionary,
+    lookupSourceDictionaryObj,
+    lookupTargetDictionaryObj,
+    lookupTranslation,
+  ] = await Promise.all([
+    i18nCache.getLookupDictionary(sourceLocale),
+    i18nCache.getLookupDictionary(targetLocale),
+    i18nCache.getLookupDictionaryObj(sourceLocale),
+    i18nCache.getLookupDictionaryObj(targetLocale),
+    i18nCache.getLookupTranslation(targetLocale),
   ]);
 
   /**
@@ -59,21 +68,17 @@ export async function getTranslationsInternal({
    * const greeting = t('user.greeting', { name: 'Bob' });
    */
   const t = ((id: string, options: TranslationVariables = {}): string => {
-    const sourceEntry = i18nCache.lookupDictionary(sourceLocale, id);
+    const sourceEntry = lookupSourceDictionary(id);
     if (sourceEntry === undefined) {
       throw new Error(`Dictionary entry ${id} cannot be found`);
     }
-    const targetEntry = i18nCache.lookupDictionary(targetLocale, id);
+    const targetEntry = lookupTargetDictionary(id);
     const dictionaryOptions = resolveDictionaryLookupOptions(
       sourceEntry.options
     );
     const target =
       targetEntry?.entry ??
-      i18nCache.lookupTranslation(
-        targetLocale,
-        sourceEntry.entry,
-        dictionaryOptions
-      );
+      lookupTranslation(sourceEntry.entry, dictionaryOptions);
     return renderDictionaryEntry({
       sourceLocale,
       targetLocale: targetLocale,
@@ -96,20 +101,16 @@ export async function getTranslationsInternal({
    * // { greeting1: 'Hello', greeting2: 'Hi' }
    */
   t.obj = (id: string): DictionaryObjectTranslation => {
-    const sourceObject = i18nCache.lookupDictionaryObj(sourceLocale, id);
+    const sourceObject = lookupSourceDictionaryObj(id);
     if (sourceObject === undefined) {
       throw new Error(`Dictionary entry ${id} cannot be found`);
     }
-    const targetObject = i18nCache.lookupDictionaryObj(targetLocale, id);
+    const targetObject = lookupTargetDictionaryObj(id);
     return renderDictionaryObject({
       sourceObject,
       targetObject,
       translate: (sourceEntry, dictionaryOptions) =>
-        i18nCache.lookupTranslation(
-          targetLocale,
-          sourceEntry.entry,
-          dictionaryOptions
-        ),
+        lookupTranslation(sourceEntry.entry, dictionaryOptions),
     });
   };
 

--- a/packages/i18n/src/translation-functions/internal/getTranslations.ts
+++ b/packages/i18n/src/translation-functions/internal/getTranslations.ts
@@ -37,19 +37,20 @@ export async function getTranslationsInternal({
   const i18nCache = getI18nCache();
   const sourceLocale = getI18nConfig().getDefaultLocale();
   const targetLocale = enableI18n ? locale : sourceLocale;
-  const [
-    lookupSourceDictionary,
-    lookupTargetDictionary,
-    lookupSourceDictionaryObj,
-    lookupTargetDictionaryObj,
-    lookupTranslation,
-  ] = await Promise.all([
-    i18nCache.getLookupDictionary(sourceLocale),
-    i18nCache.getLookupDictionary(targetLocale),
-    i18nCache.getLookupDictionaryObj(sourceLocale),
-    i18nCache.getLookupDictionaryObj(targetLocale),
-    i18nCache.getLookupTranslation(targetLocale),
-  ]);
+  const [sourceDictionary, targetDictionary, lookupTranslation] =
+    await Promise.all([
+      i18nCache.getLookupDictionary(sourceLocale),
+      i18nCache.getLookupDictionary(targetLocale),
+      i18nCache.getLookupTranslation(targetLocale),
+    ]);
+  const {
+    lookupDictionary: lookupSourceDictionary,
+    lookupDictionaryObj: lookupSourceDictionaryObj,
+  } = sourceDictionary;
+  const {
+    lookupDictionary: lookupTargetDictionary,
+    lookupDictionaryObj: lookupTargetDictionaryObj,
+  } = targetDictionary;
 
   /**
    * Dictionary resolution

--- a/packages/i18n/src/types.ts
+++ b/packages/i18n/src/types.ts
@@ -9,6 +9,7 @@ export type {
   ResolveJsxTranslationFunction,
 } from './translation-functions/types/functions';
 export type { RegisterableMessages } from './translation-functions/types/message';
+export type { Message } from './translation-functions/internal/getGT';
 export type {
   TranslationMetadata,
   TranslationOptions,

--- a/packages/next/src/__tests__/config.test.ts
+++ b/packages/next/src/__tests__/config.test.ts
@@ -1105,6 +1105,73 @@ describe('withGTConfig', () => {
       // loadTranslationsType is 'custom' so cacheExpiryTime should not be defaulted
       expect(params.cacheExpiryTime).toBeUndefined();
     });
+
+    it('0 when cacheComponents is enabled', async () => {
+      const withGTConfig = await getWithGTConfig();
+      const resolvedPath = require('path').resolve('./loadTranslations.ts');
+      vi.mocked(fs.existsSync).mockImplementation((p) => p === resolvedPath);
+
+      const result = withGTConfig(
+        { cacheComponents: true },
+        { loadTranslationsPath: './loadTranslations.ts' }
+      );
+      const params = parseConfigParams(result);
+
+      expect(params.cacheExpiryTime).toBe(0);
+      expect(params._cacheComponentsEnabled).toBe(true);
+      expect(params._disableDevHotReload).toBe(true);
+    });
+
+    it('overrides explicit cacheExpiryTime when cacheComponents is enabled', async () => {
+      const withGTConfig = await getWithGTConfig();
+      const resolvedPath = require('path').resolve('./loadTranslations.ts');
+      vi.mocked(fs.existsSync).mockImplementation((p) => p === resolvedPath);
+
+      const result = withGTConfig(
+        { cacheComponents: true },
+        {
+          cacheExpiryTime: 30000,
+          loadTranslationsPath: './loadTranslations.ts',
+        }
+      );
+      const params = parseConfigParams(result);
+
+      expect(params.cacheExpiryTime).toBe(0);
+    });
+
+    it('warns when cacheComponents disables active dev hot reload translation', async () => {
+      const withGTConfig = await getWithGTConfig();
+      process.env.GT_PROJECT_ID = 'project-id';
+      process.env.GT_DEV_API_KEY = 'dev-key';
+      const resolvedPath = require('path').resolve('./loadTranslations.ts');
+      vi.mocked(fs.existsSync).mockImplementation((p) => p === resolvedPath);
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const result = withGTConfig(
+        { cacheComponents: true },
+        {
+          loadTranslationsPath: './loadTranslations.ts',
+          getLocalePath: './getLocale.ts',
+          getRegionPath: './getRegion.ts',
+        }
+      );
+      const params = parseConfigParams(result);
+
+      expect(params._disableDevHotReload).toBe(true);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'development runtime translation hot reload has been disabled'
+        )
+      );
+    });
+
+    it('throws when cacheComponents is enabled without custom loadTranslations', async () => {
+      const withGTConfig = await getWithGTConfig();
+
+      expect(() => withGTConfig({ cacheComponents: true })).toThrow(
+        /custom loadTranslations\(\) is not configured/
+      );
+    });
   });
 
   // ==============================

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -40,6 +40,10 @@ import {
 } from './config-dir/utils/resolveRequestFunctionPaths';
 import { resolveConfigFilepath } from './config-dir/utils/resolveConfigFilepath';
 import { cacheComponentsChecks } from './plugin/checks/cacheComponentsChecks';
+import {
+  cacheComponentsDevHotReloadDisabledWarning,
+  cacheComponentsMissingLoadTranslationsError,
+} from './errors/cacheComponents';
 import { I18nConfigParams } from 'gt-i18n/internal/types';
 import { getRuntimeCredentials } from './setup/runtimeCredentials';
 
@@ -68,6 +72,8 @@ type InternalGTConfigProps = BaseWithGTConfigProps &
     loadDictionaryEnabled?: boolean;
     loadTranslationsType?: 'remote' | 'custom' | 'disabled';
     _dictionaryFileType?: string;
+    _cacheComponentsEnabled?: boolean;
+    _disableDevHotReload?: boolean;
   };
 
 type WithGTConfigResult<TNextConfig extends object> = TNextConfig & NextConfig;
@@ -449,6 +455,18 @@ export function withGTConfig<TNextConfig extends object = NextConfig>(
     mergedConfig.loadTranslationsType = 'remote';
   }
 
+  if (internalNextConfig.cacheComponents) {
+    if (mergedConfig.loadTranslationsType !== 'custom') {
+      throw new Error(cacheComponentsMissingLoadTranslationsError);
+    }
+    if (isDevHotReloadEnabled(mergedConfig)) {
+      console.warn(cacheComponentsDevHotReloadDisabledWarning);
+    }
+    mergedConfig._cacheComponentsEnabled = true;
+    mergedConfig._disableDevHotReload = true;
+    mergedConfig.cacheExpiryTime = 0;
+  }
+
   // Set default cache expiry if and only if no dev key
   if (
     mergedConfig.loadTranslationsType == 'remote' &&
@@ -725,6 +743,16 @@ export function withGTConfig<TNextConfig extends object = NextConfig>(
     },
   };
   return config as WithGTConfigResult<TNextConfig>;
+}
+
+function isDevHotReloadEnabled(config: InternalGTConfigProps): boolean {
+  return (
+    !!config.devApiKey &&
+    !!config.projectId &&
+    config.runtimeUrl !== null &&
+    config.runtimeUrl !== '' &&
+    process.env.NODE_ENV === 'development'
+  );
 }
 
 // Keep initGT for backward compatibility

--- a/packages/next/src/errors/cacheComponents.ts
+++ b/packages/next/src/errors/cacheComponents.ts
@@ -34,3 +34,22 @@ export const cacheComponentsNonLocalTranslationsWarning =
     fix: 'Store translations locally before building cached pages',
     docsUrl: 'https://generaltranslation.com/en-US/docs/next/guides/local-tx',
   });
+
+export const cacheComponentsMissingLoadTranslationsError =
+  createGtNextDiagnostic({
+    severity: 'Error',
+    whatHappened:
+      'cacheComponents is enabled, but custom loadTranslations() is not configured',
+    wayOut:
+      'gt-next cannot safely use the default remote translation loader with Cache Components',
+    fix: 'Add a loadTranslations.ts file, or configure loadTranslationsPath, and mark any dynamic loading with "use cache"',
+  });
+
+export const cacheComponentsDevHotReloadDisabledWarning =
+  createGtNextDiagnostic({
+    severity: 'Warning',
+    whatHappened:
+      'cacheComponents is enabled, so development runtime translation hot reload has been disabled',
+    why: 'development runtime translation performs dynamic requests that are not safe inside Cache Components',
+    fix: 'Use local translations, or disable cacheComponents while using development runtime translation hot reload',
+  });

--- a/packages/next/src/errors/cacheComponents.ts
+++ b/packages/next/src/errors/cacheComponents.ts
@@ -50,6 +50,6 @@ export const cacheComponentsDevHotReloadDisabledWarning =
     severity: 'Warning',
     whatHappened:
       'cacheComponents is enabled, so development runtime translation hot reload has been disabled',
-    why: 'development runtime translation performs dynamic requests that are not safe inside Cache Components',
+    why: 'development runtime translation performs dynamic requests that are not allowed with Cache Components',
     fix: 'Use local translations, or disable cacheComponents while using development runtime translation hot reload',
   });

--- a/packages/next/src/i18n-cache/NextI18nCache.ts
+++ b/packages/next/src/i18n-cache/NextI18nCache.ts
@@ -20,6 +20,14 @@ export function setNextI18nCache(i18nCache: NextI18nCache): void {
   setI18nCache(i18nCache as I18nCache<Translation>);
 }
 
+export function hasNextI18nCache(): boolean {
+  try {
+    return getI18nCache() instanceof NextI18nCache;
+  } catch {
+    return false;
+  }
+}
+
 export type NextI18nCacheParams = ReactI18nCacheParams;
 
 export class NextI18nCache extends ReactI18nCache {

--- a/packages/next/src/i18n-cache/NextI18nCache.ts
+++ b/packages/next/src/i18n-cache/NextI18nCache.ts
@@ -17,15 +17,7 @@ export function getNextI18nCache(): NextI18nCache {
 }
 
 export function setNextI18nCache(i18nCache: NextI18nCache): void {
-  setI18nCache(i18nCache as I18nCache<Translation>);
-}
-
-export function hasNextI18nCache(): boolean {
-  try {
-    return getI18nCache() instanceof NextI18nCache;
-  } catch {
-    return false;
-  }
+  setI18nCache(i18nCache as I18nCache<Translation>, { overwrite: false });
 }
 
 export type NextI18nCacheParams = ReactI18nCacheParams;

--- a/packages/next/src/i18n-cache/NextI18nCache.ts
+++ b/packages/next/src/i18n-cache/NextI18nCache.ts
@@ -17,7 +17,7 @@ export function getNextI18nCache(): NextI18nCache {
 }
 
 export function setNextI18nCache(i18nCache: NextI18nCache): void {
-  setI18nCache(i18nCache as I18nCache<Translation>, { overwrite: false });
+  setI18nCache(i18nCache as I18nCache<Translation>);
 }
 
 export type NextI18nCacheParams = ReactI18nCacheParams;

--- a/packages/next/src/index.client.ts
+++ b/packages/next/src/index.client.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { initializeGTClient } from './setup/initializeGTClient';
+import { initializeGTClient } from './setup/initGT.client';
 initializeGTClient();
 
 import type {

--- a/packages/next/src/pages-dir/__tests__/parseLocale.test.ts
+++ b/packages/next/src/pages-dir/__tests__/parseLocale.test.ts
@@ -3,6 +3,14 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { initializeI18nConfig } from 'gt-i18n/internal';
 import { parseLocale } from '../parseLocale';
 
+type TestGlobal = typeof globalThis & {
+  __generaltranslation?: unknown;
+};
+
+function resetGTGlobals() {
+  Reflect.deleteProperty(globalThis as TestGlobal, '__generaltranslation');
+}
+
 const localeConfig = {
   defaultLocale: 'en',
   locales: ['en', 'fr', 'es', 'brand-french'],
@@ -31,6 +39,7 @@ function createContext({
 
 describe('parseLocale', () => {
   beforeEach(() => {
+    resetGTGlobals();
     initializeI18nConfig(localeConfig);
     delete process.env._GENERALTRANSLATION_I18N_CONFIG_PARAMS;
   });

--- a/packages/next/src/server-dir/buildtime/__tests__/getTranslations.test.ts
+++ b/packages/next/src/server-dir/buildtime/__tests__/getTranslations.test.ts
@@ -44,10 +44,30 @@ describe('buildtime translation helpers', () => {
 
     await expect(getGT()).resolves.toBe(gt);
 
-    expect(mockGetGTInternal).toHaveBeenCalledWith({
-      locale: 'fr',
-      enableI18n: false,
-    });
+    expect(mockGetGTInternal).toHaveBeenCalledWith(
+      {
+        locale: 'fr',
+        enableI18n: false,
+      },
+      undefined
+    );
+  });
+
+  it('getGT forwards compiler messages to gt-i18n', async () => {
+    const gt = vi.fn();
+    const messages = [{ message: 'A server-translated string from getGT.' }];
+    mockGetGTInternal.mockReturnValue(gt);
+    const { getGT } = await import('../strings');
+
+    await expect(getGT(messages)).resolves.toBe(gt);
+
+    expect(mockGetGTInternal).toHaveBeenCalledWith(
+      {
+        locale: 'fr',
+        enableI18n: false,
+      },
+      messages
+    );
   });
 
   it('getMessages passes request conditions to gt-i18n', async () => {
@@ -94,4 +114,28 @@ describe('buildtime translation helpers', () => {
       expect(mockUse).toHaveBeenCalledWith(expect.any(Promise));
     }
   );
+
+  it('useGT forwards compiler messages through getGT', async () => {
+    const value = vi.fn();
+    const messages = [{ message: 'A server-translated string from useGT.' }];
+    mockGetGTInternal.mockReturnValue(value);
+    mockUse.mockReturnValue(value);
+    const { useGT } = await import('../strings');
+
+    const result = useGT(messages);
+
+    expect(result).toBe(value);
+    expect(mockUse).toHaveBeenCalledWith(expect.any(Promise));
+    expect(mockGetGTInternal).not.toHaveBeenCalled();
+
+    await expect(mockUse.mock.calls[0][0]).resolves.toBe(value);
+
+    expect(mockGetGTInternal).toHaveBeenCalledWith(
+      {
+        locale: 'fr',
+        enableI18n: false,
+      },
+      messages
+    );
+  });
 });

--- a/packages/next/src/server-dir/buildtime/strings.ts
+++ b/packages/next/src/server-dir/buildtime/strings.ts
@@ -4,14 +4,18 @@ import {
   getMessagesInternal,
   getTranslationsInternal,
 } from 'gt-i18n/internal';
+import type { Message } from 'gt-i18n/types';
 import { getRequestConditions } from '../../request/getRequestConditions';
 
-export async function getGT() {
+export async function getGT(_messages?: Message[]) {
   const conditions = await getRequestConditions();
-  return getGTInternal({
-    locale: conditions._locale,
-    enableI18n: conditions._enableI18n,
-  });
+  return getGTInternal(
+    {
+      locale: conditions._locale,
+      enableI18n: conditions._enableI18n,
+    },
+    _messages
+  );
 }
 
 export async function getMessages() {
@@ -30,8 +34,8 @@ export async function getTranslations() {
   });
 }
 
-export function useGT() {
-  return use(getGT());
+export function useGT(_messages?: Message[]) {
+  return use(getGT(_messages));
 }
 
 export function useMessages() {

--- a/packages/next/src/setup/__tests__/initGT.test.ts
+++ b/packages/next/src/setup/__tests__/initGT.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getNextI18nCache } from '../../i18n-cache/NextI18nCache';
+import { initializeGT } from '../initGT';
+
+type TestGlobal = typeof globalThis & {
+  __generaltranslation?: {
+    i18n?: Record<string, unknown>;
+    [key: string]: unknown;
+  };
+};
+
+function resetI18nGlobals() {
+  const globalObj = globalThis as TestGlobal;
+  if (globalObj.__generaltranslation?.i18n) {
+    Reflect.deleteProperty(globalObj.__generaltranslation.i18n, 'i18nConfig');
+    Reflect.deleteProperty(globalObj.__generaltranslation.i18n, 'i18nCache');
+    Reflect.deleteProperty(
+      globalObj.__generaltranslation.i18n,
+      'conditionStore'
+    );
+  }
+}
+
+describe('initializeGT', () => {
+  beforeEach(() => {
+    resetI18nGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('does not replace an existing NextI18nCache', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const params = {
+      i18nConfigParams: {
+        defaultLocale: 'en',
+        locales: ['en', 'fr'],
+      },
+      nextI18nCacheParams: {
+        defaultLocale: 'en',
+        locales: ['en', 'fr'],
+      },
+    };
+
+    initializeGT(params);
+    const cache = getNextI18nCache();
+
+    initializeGT(params);
+
+    expect(getNextI18nCache()).toBe(cache);
+    warn.mockRestore();
+  });
+});

--- a/packages/next/src/setup/__tests__/shared.test.ts
+++ b/packages/next/src/setup/__tests__/shared.test.ts
@@ -16,7 +16,15 @@ function setConfigEnv() {
     maxConcurrentRequests: 1,
     maxBatchSize: 2,
     batchInterval: 3,
+    cacheExpiryTime: 12345,
     _versionId: 'version-id',
+  });
+}
+
+function updatePrivateConfig(config: Record<string, unknown>) {
+  process.env._GENERALTRANSLATION_I18N_CONFIG_PARAMS = JSON.stringify({
+    ...JSON.parse(process.env._GENERALTRANSLATION_I18N_CONFIG_PARAMS || '{}'),
+    ...config,
   });
 }
 
@@ -48,6 +56,7 @@ describe('getParams', () => {
       projectId: 'project-id',
       apiKey: 'api-key',
       devApiKey: 'dev-key',
+      cacheExpiryTime: 12345,
     });
   });
 
@@ -61,5 +70,22 @@ describe('getParams', () => {
 
     expect(i18nConfigParams.projectId).toBe('public-project-id');
     expect(i18nConfigParams.devApiKey).toBe('public-dev-key');
+  });
+
+  it('keeps the default translation loader when cacheComponents is enabled', () => {
+    updatePrivateConfig({
+      _cacheComponentsEnabled: true,
+      _disableDevHotReload: true,
+      loadTranslationsType: 'remote',
+      cacheExpiryTime: 0,
+    });
+
+    const { i18nConfigParams, nextI18nCacheParams } = getParams();
+
+    expect(i18nConfigParams._disableDevHotReload).toBe(true);
+    expect(nextI18nCacheParams.cacheExpiryTime).toBe(0);
+    expect(nextI18nCacheParams.loadTranslations?.toString()).toContain(
+      'loadTranslations'
+    );
   });
 });

--- a/packages/next/src/setup/initGT.client.ts
+++ b/packages/next/src/setup/initGT.client.ts
@@ -10,8 +10,14 @@ export function initializeGTClient(): void {
   coreInitializeGT({
     ...params,
     nextI18nCacheParams: {
-      cacheExpiryTime: null,
       ...params.nextI18nCacheParams,
+      /**
+       * Always disable cache expiry for client-side lookups.
+       * Translations are exclusively passed from server to client, so
+       * if translations ever expire, then the client will have no way
+       * to fetch new translations.
+       */
+      cacheExpiryTime: null,
     },
   });
 }

--- a/packages/next/src/setup/initGT.ts
+++ b/packages/next/src/setup/initGT.ts
@@ -1,6 +1,5 @@
 import { initializeI18nConfig } from 'gt-i18n/internal';
 import {
-  hasNextI18nCache,
   NextI18nCache,
   NextI18nCacheParams,
   setNextI18nCache,
@@ -20,10 +19,6 @@ export function initializeGT(
   } = getParams()
 ): void {
   initializeI18nConfig(i18nConfigParams);
-
-  if (hasNextI18nCache()) {
-    return;
-  }
 
   const i18nCache = new NextI18nCache(nextI18nCacheParams);
   setNextI18nCache(i18nCache);

--- a/packages/next/src/setup/initGT.ts
+++ b/packages/next/src/setup/initGT.ts
@@ -1,5 +1,6 @@
 import { initializeI18nConfig } from 'gt-i18n/internal';
 import {
+  hasNextI18nCache,
   NextI18nCache,
   NextI18nCacheParams,
   setNextI18nCache,
@@ -19,6 +20,10 @@ export function initializeGT(
   } = getParams()
 ): void {
   initializeI18nConfig(i18nConfigParams);
+
+  if (hasNextI18nCache()) {
+    return;
+  }
 
   const i18nCache = new NextI18nCache(nextI18nCacheParams);
   setNextI18nCache(i18nCache);

--- a/packages/next/src/setup/shared.ts
+++ b/packages/next/src/setup/shared.ts
@@ -5,6 +5,7 @@ import { getRuntimeCredentials } from './runtimeCredentials';
 
 export type NextSetupI18nConfigParams = I18nConfigParams & {
   cacheUrl?: string | null;
+  _disableDevHotReload?: boolean;
 };
 
 // TODO: better way of communicating from build to runtime
@@ -31,6 +32,7 @@ export function getParams(): {
     devApiKey,
     apiKey,
     cacheUrl: privateConfig.cacheUrl,
+    _disableDevHotReload: privateConfig._disableDevHotReload,
   };
 
   // NextI18nCacheParams
@@ -41,6 +43,7 @@ export function getParams(): {
     projectId,
     runtimeUrl: publicConfig.runtimeUrl,
     cacheUrl: privateConfig.cacheUrl,
+    cacheExpiryTime: privateConfig.cacheExpiryTime,
     // batching config
     batchConfig: {
       maxConcurrentRequests: privateConfig.maxConcurrentRequests,
@@ -78,7 +81,7 @@ function createLoadTranslations({
   projectId,
   _versionId,
 }: {
-  cacheUrl: string | undefined;
+  cacheUrl: string | null | undefined;
   projectId: string | undefined;
   _versionId: string | undefined;
 }) {

--- a/packages/next/src/utils/client-boundary.tsx
+++ b/packages/next/src/utils/client-boundary.tsx
@@ -16,7 +16,7 @@ import { getI18nConfig, I18nConfig } from 'gt-i18n/internal';
 import { GTProvider, type SharedGTProviderProps } from 'gt-react';
 import { usePathname, useRouter } from 'next/navigation';
 import { useCallback, useEffect } from 'react';
-import { initializeGTClient } from '../setup/initializeGTClient';
+import { initializeGTClient } from '../setup/initGT.client';
 import {
   defaultLocaleRoutingEnabledCookieName,
   defaultReferrerLocaleCookieName,

--- a/packages/node/src/async-i18n-cache/__tests__/AsyncConditionStore.test.ts
+++ b/packages/node/src/async-i18n-cache/__tests__/AsyncConditionStore.test.ts
@@ -6,14 +6,23 @@ import {
 } from 'gt-i18n/internal';
 import { AsyncConditionStore } from '../AsyncConditionStore';
 
+type TestGlobal = typeof globalThis & {
+  __generaltranslation?: unknown;
+};
+
+function resetGTGlobals() {
+  Reflect.deleteProperty(globalThis as TestGlobal, '__generaltranslation');
+}
+
 describe('AsyncConditionStore', () => {
   afterEach(() => {
-    setTestCache();
+    resetGTGlobals();
     vi.unstubAllEnvs();
     vi.restoreAllMocks();
   });
 
   function setTestCache() {
+    resetGTGlobals();
     initializeI18nConfig({
       defaultLocale: 'en',
       locales: ['en', 'fr'],

--- a/packages/node/src/helpers/__tests__/getLocale.test.ts
+++ b/packages/node/src/helpers/__tests__/getLocale.test.ts
@@ -2,8 +2,17 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { initializeGT } from '../../setup/initializeGT';
 import { getRequestLocale } from '../getRequestLocale';
 
+type TestGlobal = typeof globalThis & {
+  __generaltranslation?: unknown;
+};
+
+function resetGTGlobals() {
+  Reflect.deleteProperty(globalThis as TestGlobal, '__generaltranslation');
+}
+
 describe('getLocale', () => {
   beforeEach(() => {
+    resetGTGlobals();
     initializeGT({
       defaultLocale: 'en-US',
       locales: ['en-US', 'es', 'fr', 'ja'],
@@ -53,6 +62,7 @@ describe('getLocale', () => {
   });
 
   it('resolves custom mapped request locales', () => {
+    resetGTGlobals();
     initializeGT({
       defaultLocale: 'en-US',
       locales: ['en-US', 'fr', 'brand-french'],

--- a/packages/node/src/setup/__tests__/withGT.test.ts
+++ b/packages/node/src/setup/__tests__/withGT.test.ts
@@ -5,8 +5,17 @@ import { withGT } from '../withGT';
 import { tx } from 'gt-i18n/internal';
 import { hashSource } from 'generaltranslation/id';
 
+type TestGlobal = typeof globalThis & {
+  __generaltranslation?: unknown;
+};
+
+function resetGTGlobals() {
+  Reflect.deleteProperty(globalThis as TestGlobal, '__generaltranslation');
+}
+
 describe.sequential('withGT', () => {
   beforeEach(() => {
+    resetGTGlobals();
     initializeGT({
       defaultLocale: 'en-US',
       locales: ['en-US', 'fr', 'es'],
@@ -29,6 +38,7 @@ describe.sequential('withGT', () => {
   });
 
   it('preserves same-language default locale dialects', () => {
+    resetGTGlobals();
     initializeGT({
       defaultLocale: 'pt-BR',
       locales: ['pt', 'fr'],
@@ -40,6 +50,7 @@ describe.sequential('withGT', () => {
   });
 
   it('allows explicit runtime locale to override the callback context', async () => {
+    resetGTGlobals();
     initializeGT({
       defaultLocale: 'en-US',
       locales: ['en-US', 'fr'],

--- a/packages/react-core/src/components/translation/__tests__/T.test.tsx
+++ b/packages/react-core/src/components/translation/__tests__/T.test.tsx
@@ -4,6 +4,14 @@ import { setReactI18nCache } from '../../../i18n-cache/singleton-operations';
 import { RscT } from '../T.rsc';
 import type { ReactI18nCache } from '../../../i18n-cache/ReactI18nCache';
 
+type TestGlobal = typeof globalThis & {
+  __generaltranslation?: unknown;
+};
+
+function resetGTGlobals() {
+  Reflect.deleteProperty(globalThis as TestGlobal, '__generaltranslation');
+}
+
 const getLookupTranslation = vi.fn();
 
 function setup() {
@@ -18,6 +26,7 @@ function setup() {
 
 describe('RscT', () => {
   beforeEach(() => {
+    resetGTGlobals();
     vi.clearAllMocks();
     setup();
   });

--- a/packages/react-core/src/hooks/__tests__/utils.test.ts
+++ b/packages/react-core/src/hooks/__tests__/utils.test.ts
@@ -1,8 +1,16 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { initializeI18nConfig } from 'gt-i18n/internal';
 import { setReadonlyConditionStore } from '../../condition-store/singleton-operations';
 import { getFormatLocales } from '../utils';
 import { getShouldTranslate } from '../utils/getShouldTranslate';
+
+type TestGlobal = typeof globalThis & {
+  __generaltranslation?: unknown;
+};
+
+function resetGTGlobals() {
+  Reflect.deleteProperty(globalThis as TestGlobal, '__generaltranslation');
+}
 
 function setup({
   locale,
@@ -27,6 +35,9 @@ function setup({
 }
 
 describe('getShouldTranslate', () => {
+  beforeEach(resetGTGlobals);
+  afterEach(resetGTGlobals);
+
   it('returns false for the default locale', () => {
     setup({ locale: 'en' });
 
@@ -62,6 +73,9 @@ describe('getShouldTranslate', () => {
 });
 
 describe('getFormatLocales', () => {
+  beforeEach(resetGTGlobals);
+  afterEach(resetGTGlobals);
+
   it('uses an explicit locale when translation is required', () => {
     setup({ locale: 'en' });
 

--- a/packages/react-core/src/i18n-store/__tests__/singleton-operations.test.ts
+++ b/packages/react-core/src/i18n-store/__tests__/singleton-operations.test.ts
@@ -50,16 +50,19 @@ describe('react-core i18n store singleton operations', () => {
     expect(getI18nStore()).toBe(store);
   });
 
-  it('warns when overwriting an existing global i18n store', async () => {
-    const { setI18nStore } = await import('../singleton-operations');
+  it('warns and preserves an existing global i18n store', async () => {
+    const { getI18nStore, setI18nStore } =
+      await import('../singleton-operations');
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const store = createI18nStoreStub();
 
-    setI18nStore(createI18nStoreStub());
+    setI18nStore(store);
     setI18nStore(createI18nStoreStub());
 
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining('Overwriting global i18nStore singleton instance')
     );
+    expect(getI18nStore()).toBe(store);
   });
 
   it('preserves existing package globals when setting the i18n store', async () => {

--- a/packages/react-core/src/setup/__tests__/i18nConfig.test.ts
+++ b/packages/react-core/src/setup/__tests__/i18nConfig.test.ts
@@ -1,9 +1,20 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type TestGlobal = typeof globalThis & {
+  __generaltranslation?: unknown;
+};
+
+function resetGTGlobals() {
+  Reflect.deleteProperty(globalThis as TestGlobal, '__generaltranslation');
+}
 
 describe('react i18n config', () => {
   beforeEach(() => {
+    resetGTGlobals();
     vi.resetModules();
   });
+
+  afterEach(resetGTGlobals);
 
   it('stores render strategy on the I18nConfig singleton', async () => {
     const { getI18nConfig: getBaseI18nConfig } =


### PR DESCRIPTION
## Summary
- Set translation cache expiry to 0 when Next.js Cache Components are enabled
- Treat gt-i18n cache entries with expiresAt 0 as immediately expired without calling Date.now()
- Use a file-level "use cache" remote translation loader for default Cache Components translation loading, while preserving custom loadTranslations()
- Add gt-i18n and gt-next patch changesets and focused tests

## Testing
- pnpm exec oxfmt --check packages/next/src/config.ts packages/next/src/config-dir/props/withGTConfigProps.ts packages/next/src/errors/cacheComponents.ts packages/next/src/setup/shared.ts packages/next/src/setup/__tests__/shared.test.ts packages/next/src/utils/createCacheComponentsLoadTranslations.ts packages/next/src/utils/loadCacheComponentsTranslations.ts packages/next/src/utils/__tests__/createCacheComponentsLoadTranslations.test.ts packages/i18n/src/i18n-cache/translations-manager/ResourceCache.ts packages/i18n/src/i18n-cache/translations-manager/__tests__/ResourceCache.test.ts .changeset/cache-components-disable-expiry.md
- pnpm --filter gt-next test:js -- src/__tests__/config.test.ts src/setup/__tests__/shared.test.ts src/utils/__tests__/createCacheComponentsLoadTranslations.test.ts
- pnpm --filter gt-i18n test -- src/i18n-cache/translations-manager/__tests__/ResourceCache.test.ts src/i18n-cache/__tests__/I18nCache.test.ts
- pnpm --filter gt-next typecheck
- pnpm --filter gt-i18n typecheck
- pnpm --filter gt-i18n build
- pnpm --filter gt-next build:no-swc-plugin
- pnpm build:next-app-router-locale-routing-use-cache