### PR TITLE
fix: use RSC declarations for gt-next react-server export

### DIFF
--- a/.changeset/gt-next-react-server-types.md
+++ b/.changeset/gt-next-react-server-types.md
@@ -1,0 +1,5 @@
+---
+"gt-next": patch
+---
+
+Point the `react-server` export condition at the RSC-specific declaration file so TypeScript no longer exposes client-only hooks in React Server Components.

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -72,6 +72,7 @@
   "exports": {
     ".": {
       "react-server": {
+        "types": "./dist/index.rsc.d.ts",
         "import": "./dist/index.rsc.mjs",
         "default": "./dist/index.rsc.js"
       },

--- a/packages/next/src/__tests__/packageExports.test.ts
+++ b/packages/next/src/__tests__/packageExports.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const packageRoot = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
+
+describe('gt-next package exports', () => {
+  it('uses RSC-specific declarations for the react-server condition', () => {
+    const packageJson = JSON.parse(
+      readFileSync(join(packageRoot, 'package.json'), 'utf8')
+    ) as {
+      exports: {
+        '.': {
+          'react-server': {
+            types?: string;
+          };
+          types: string;
+        };
+      };
+    };
+
+    expect(packageJson.exports['.']['react-server'].types).toBe(
+      './dist/index.rsc.d.ts'
+    );
+    expect(packageJson.exports['.'].types).toBe('./dist/index.types.d.ts');
+  });
+});


### PR DESCRIPTION
## Summary
- add a react-server-specific types condition for gt-next's root export
- point the condition at `dist/index.rsc.d.ts` so RSC imports no longer see client-only hooks from `index.types.d.ts`
- add a package export regression test
- add a gt-next patch changeset

## Tests
- pnpm --filter gt-next test -- src/__tests__/packageExports.test.ts
- pnpm --filter gt-next typecheck
- pnpm exec oxlint packages/next/src/__tests__/packageExports.test.ts
- pnpm exec oxfmt --check .changeset/gt-next-react-server-types.md packages/next/package.json packages/next/src/__tests__/packageExports.test.ts
- git diff --check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes incorrect TypeScript types being exposed when `gt-next` is imported under the `react-server` export condition. By adding a `"types"` field pointing at `dist/index.rsc.d.ts` inside the `react-server` export block, TypeScript will now resolve RSC-specific declarations instead of the general `index.types.d.ts` which includes client-only hooks.

- **`packages/next/package.json`**: Inserts `"types": "./dist/index.rsc.d.ts"` as the first key in the `react-server` condition block, consistent with how other named conditions (e.g. `./config`, `./server`) order their `types` field ahead of the runtime entries.
- **`packages/next/src/__tests__/packageExports.test.ts`**: Adds a regression test that reads `package.json` at test time and asserts both the RSC-condition `types` path and the fallback `types` path, preventing silent rollback of this fix.
- **`.changeset/gt-next-react-server-types.md`**: Records a `patch` changeset describing the fix.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a single-line addition to the exports map that wires up an already-emitted declaration file, accompanied by a targeted regression test.

The fix is minimal and mechanical: one new field in `package.json`, a matching test, and a changeset. `src/index.rsc.ts` already exists and `tsc --emitDeclarationOnly` will produce `dist/index.rsc.d.ts` as part of the normal build, so the pointed-at file is not invented. The `types` key is correctly placed before `import`/`default` inside the `react-server` condition block, matching the ordering convention used elsewhere in the exports map. No runtime behavior changes — only TypeScript's view of the package changes for RSC consumers.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/next/package.json | Adds `"types": "./dist/index.rsc.d.ts"` as the first entry in the `react-server` export condition; ordering is correct (types before import/default). The corresponding source `src/index.rsc.ts` exists and the `tsc --emitDeclarationOnly` step will produce `dist/index.rsc.d.ts` at build time. |
| packages/next/src/__tests__/packageExports.test.ts | New regression test that reads `package.json` directly and asserts both the RSC-specific `types` path and the general `types` fallback. The `packageRoot` path traversal (3× `dirname`) correctly resolves to `packages/next`. |
| .changeset/gt-next-react-server-types.md | Correct patch-level changeset for `gt-next` describing the RSC types fix. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["TypeScript imports 'gt-next'"] --> B{Which condition?}
    B -->|react-server condition active| C["types: ./dist/index.rsc.d.ts NEW"]
    B -->|browser condition active| D["(no types field — pre-existing)"]
    B -->|default| E["types: ./dist/index.types.d.ts"]
    C --> F["RSC-safe declarations\n(no client-only hooks)"]
    E --> G["General declarations\n(includes client hooks)"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["TypeScript imports 'gt-next'"] --> B{Which condition?}
    B -->|react-server condition active| C["types: ./dist/index.rsc.d.ts NEW"]
    B -->|browser condition active| D["(no types field — pre-existing)"]
    B -->|default| E["types: ./dist/index.types.d.ts"]
    C --> F["RSC-safe declarations\n(no client-only hooks)"]
    E --> G["General declarations\n(includes client hooks)"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: use rsc types for gt-next react-ser..."](https://github.com/generaltranslation/gt/commit/15f4c24626866b97054004cab0320748f3849658) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40945802)</sub>

<!-- /greptile_comment -->