### PR TITLE
refactor: store gt services flag in global singleton

### DIFF
--- a/.changeset/gt-services-enabled-singleton.md
+++ b/.changeset/gt-services-enabled-singleton.md
@@ -2,4 +2,4 @@
 "gt-i18n": patch
 ---
 
-Store the GT services enabled flag through the shared global singleton registry.
+Store the GT services enabled flag on the i18n config singleton.

--- a/.changeset/gt-services-enabled-singleton.md
+++ b/.changeset/gt-services-enabled-singleton.md
@@ -1,0 +1,5 @@
+---
+"gt-i18n": patch
+---
+
+Store the GT services enabled flag through the shared global singleton registry.

--- a/packages/i18n/src/globals/__tests__/getGTServicesEnabled.test.ts
+++ b/packages/i18n/src/globals/__tests__/getGTServicesEnabled.test.ts
@@ -1,8 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import {
-  getGTServicesEnabled,
-  setupGTServicesEnabled,
-} from '../getGTServicesEnabled';
+import { getGTServicesEnabled } from '../getGTServicesEnabled';
+import { initializeI18nConfig } from '../../i18n-config/singleton-operations';
 
 type TestGlobal = typeof globalThis & {
   __generaltranslation?: Record<string, unknown>;
@@ -14,13 +12,13 @@ describe('getGTServicesEnabled', () => {
   });
 
   it('stores true when GT remote translations are enabled', () => {
-    setupGTServicesEnabled({ projectId: 'test-project' });
+    initializeI18nConfig({ projectId: 'test-project' });
 
     expect(getGTServicesEnabled()).toBe(true);
   });
 
   it('stores true when the GT runtime API is enabled', () => {
-    setupGTServicesEnabled({
+    initializeI18nConfig({
       projectId: 'test-project',
       devApiKey: 'test-key',
       cacheUrl: null,
@@ -30,11 +28,15 @@ describe('getGTServicesEnabled', () => {
   });
 
   it('stores false when GT services are disabled', () => {
-    setupGTServicesEnabled({
+    initializeI18nConfig({
       cacheUrl: null,
       runtimeUrl: null,
     });
 
+    expect(getGTServicesEnabled()).toBe(false);
+  });
+
+  it('returns false before config is initialized', () => {
     expect(getGTServicesEnabled()).toBe(false);
   });
 });

--- a/packages/i18n/src/globals/__tests__/getGTServicesEnabled.test.ts
+++ b/packages/i18n/src/globals/__tests__/getGTServicesEnabled.test.ts
@@ -4,9 +4,13 @@ import {
   setupGTServicesEnabled,
 } from '../getGTServicesEnabled';
 
+type TestGlobal = typeof globalThis & {
+  __generaltranslation?: Record<string, unknown>;
+};
+
 describe('getGTServicesEnabled', () => {
   afterEach(() => {
-    globalThis.__generaltranslation = undefined;
+    (globalThis as TestGlobal).__generaltranslation = undefined;
   });
 
   it('stores true when GT remote translations are enabled', () => {

--- a/packages/i18n/src/globals/getGTServicesEnabled.ts
+++ b/packages/i18n/src/globals/getGTServicesEnabled.ts
@@ -1,53 +1,13 @@
 import {
-  getLoadTranslationsType,
-  LoadTranslationsType,
-} from '../i18n-cache/utils/getLoadTranslationsType';
-import {
-  getTranslationApiType,
-  TranslationApiType,
-} from '../i18n-cache/utils/getTranslationApiType';
-import { createGlobalSingleton } from './createGlobalSingleton';
-
-export type GTServicesEnabledParams = {
-  projectId?: string;
-  devApiKey?: string;
-  apiKey?: string;
-  cacheUrl?: string | null;
-  runtimeUrl?: string | null;
-};
-
-const gtServicesEnabledSingleton = createGlobalSingleton<boolean>({
-  namespace: 'i18n',
-  key: 'gtServicesEnabled',
-  source: 'gt-i18n',
-  notInitialized: () => 'GT services enabled flag has not been initialized.',
-});
-
-function resolveGTServicesEnabled(config: GTServicesEnabledParams): boolean {
-  return (
-    getLoadTranslationsType(config) === LoadTranslationsType.GT_REMOTE ||
-    getTranslationApiType(config) === TranslationApiType.GT
-  );
-}
+  getI18nConfig,
+  isI18nConfigInitialized,
+} from '../i18n-config/singleton-operations';
 
 /**
  * Returns true if GT services are enabled.
  */
 export function getGTServicesEnabled(): boolean {
-  return gtServicesEnabledSingleton.isInitialized()
-    ? gtServicesEnabledSingleton.get()
+  return isI18nConfigInitialized()
+    ? getI18nConfig().isGTServicesEnabled()
     : false;
-}
-
-/**
- * Evaluates and stores whether GT services are enabled.
- * @param config - The configuration
- * @returns True if GT services are enabled
- */
-export function setupGTServicesEnabled(
-  config: GTServicesEnabledParams = {}
-): boolean {
-  const gtServicesEnabled = resolveGTServicesEnabled(config);
-  gtServicesEnabledSingleton.set(gtServicesEnabled);
-  return gtServicesEnabled;
 }

--- a/packages/i18n/src/globals/getGTServicesEnabled.ts
+++ b/packages/i18n/src/globals/getGTServicesEnabled.ts
@@ -6,6 +6,7 @@ import {
   getTranslationApiType,
   TranslationApiType,
 } from '../i18n-cache/utils/getTranslationApiType';
+import { createGlobalSingleton } from './createGlobalSingleton';
 
 export type GTServicesEnabledParams = {
   projectId?: string;
@@ -15,24 +16,12 @@ export type GTServicesEnabledParams = {
   runtimeUrl?: string | null;
 };
 
-declare global {
-  interface GeneralTranslationGlobal {
-    i18n?: {
-      gtServicesEnabled: boolean | undefined;
-    };
-  }
-
-  var __generaltranslation: GeneralTranslationGlobal | undefined;
-}
-
-function getI18nGlobals() {
-  globalThis.__generaltranslation ??= {};
-  // Add new gt-i18n globals here so this module owns the i18n namespace shape.
-  globalThis.__generaltranslation.i18n ??= {
-    gtServicesEnabled: undefined,
-  };
-  return globalThis.__generaltranslation.i18n;
-}
+const gtServicesEnabledSingleton = createGlobalSingleton<boolean>({
+  namespace: 'i18n',
+  key: 'gtServicesEnabled',
+  source: 'gt-i18n',
+  notInitialized: () => 'GT services enabled flag has not been initialized.',
+});
 
 function resolveGTServicesEnabled(config: GTServicesEnabledParams): boolean {
   return (
@@ -45,7 +34,9 @@ function resolveGTServicesEnabled(config: GTServicesEnabledParams): boolean {
  * Returns true if GT services are enabled.
  */
 export function getGTServicesEnabled(): boolean {
-  return getI18nGlobals().gtServicesEnabled ?? false;
+  return gtServicesEnabledSingleton.isInitialized()
+    ? gtServicesEnabledSingleton.get()
+    : false;
 }
 
 /**
@@ -57,6 +48,6 @@ export function setupGTServicesEnabled(
   config: GTServicesEnabledParams = {}
 ): boolean {
   const gtServicesEnabled = resolveGTServicesEnabled(config);
-  getI18nGlobals().gtServicesEnabled = gtServicesEnabled;
+  gtServicesEnabledSingleton.set(gtServicesEnabled);
   return gtServicesEnabled;
 }

--- a/packages/i18n/src/i18n-config/I18nConfig.ts
+++ b/packages/i18n/src/i18n-config/I18nConfig.ts
@@ -4,11 +4,16 @@ import {
 } from '@generaltranslation/format';
 import type { CustomMapping } from '@generaltranslation/format/types';
 import { GT } from 'generaltranslation';
-import {
-  defaultRuntimeApiUrl,
-  libraryDefaultLocale,
-} from 'generaltranslation/internal';
+import { libraryDefaultLocale } from 'generaltranslation/internal';
 import type { GTConfig } from '../config/types';
+import {
+  getLoadTranslationsType,
+  LoadTranslationsType,
+} from '../i18n-cache/utils/getLoadTranslationsType';
+import {
+  getTranslationApiType,
+  TranslationApiType,
+} from '../i18n-cache/utils/getTranslationApiType';
 import { getRuntimeEnvironment } from '../utils/getRuntimeEnvironment';
 import { validateI18nConfigParams } from './validation';
 
@@ -20,6 +25,7 @@ export type I18nConfigParams = Pick<
   | 'projectId'
   | 'devApiKey'
   | 'apiKey'
+  | 'cacheUrl'
   | 'runtimeUrl'
 >;
 
@@ -32,15 +38,18 @@ export type LocaleCandidates = string | string[] | undefined;
 
 export class I18nConfig extends LocaleConfig {
   private runtimeConfig: RuntimeConfig;
+  private gtServicesEnabled: boolean;
 
   constructor(params: I18nConfigParams = {}) {
-    super(getLocaleConfigParams(params));
+    const gtServicesEnabled = resolveGTServicesEnabled(params);
+    super(getLocaleConfigParams(params, gtServicesEnabled));
     this.runtimeConfig = {
       projectId: params.projectId,
       devApiKey: params.devApiKey,
       apiKey: params.apiKey,
       runtimeUrl: params.runtimeUrl,
     };
+    this.gtServicesEnabled = gtServicesEnabled;
   }
 
   getDefaultLocale(): string {
@@ -132,15 +141,8 @@ export class I18nConfig extends LocaleConfig {
     );
   }
 
-  /**
-   * TODO: also check the cache url too, really this can be more specific
-   */
   isGTServicesEnabled(): boolean {
-    return (
-      !!this.runtimeConfig.projectId &&
-      (this.runtimeConfig.runtimeUrl === undefined ||
-        this.runtimeConfig.runtimeUrl === defaultRuntimeApiUrl)
-    );
+    return this.gtServicesEnabled;
   }
 
   /**
@@ -187,7 +189,8 @@ export class I18nConfig extends LocaleConfig {
 }
 
 function getLocaleConfigParams(
-  params: I18nConfigParams = {}
+  params: I18nConfigParams,
+  gtServicesEnabled: boolean
 ): LocaleConfigConstructorParams {
   const {
     defaultLocale = libraryDefaultLocale,
@@ -195,12 +198,15 @@ function getLocaleConfigParams(
     customMapping,
   } = params;
 
-  validateI18nConfigParams({
-    ...params,
-    defaultLocale,
-    locales,
-    customMapping,
-  });
+  validateI18nConfigParams(
+    {
+      ...params,
+      defaultLocale,
+      locales,
+      customMapping,
+    },
+    gtServicesEnabled
+  );
 
   return {
     defaultLocale,
@@ -226,5 +232,12 @@ function hasI18nConfigParams(config: I18nConfigParams): boolean {
     config.defaultLocale !== undefined ||
     config.locales !== undefined ||
     config.customMapping !== undefined
+  );
+}
+
+function resolveGTServicesEnabled(config: I18nConfigParams): boolean {
+  return (
+    getLoadTranslationsType(config) === LoadTranslationsType.GT_REMOTE ||
+    getTranslationApiType(config) === TranslationApiType.GT
   );
 }

--- a/packages/i18n/src/i18n-config/__tests__/I18nConfig.test.ts
+++ b/packages/i18n/src/i18n-config/__tests__/I18nConfig.test.ts
@@ -1,13 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { setupGTServicesEnabled } from '../../globals/getGTServicesEnabled';
 import { I18nConfig } from '../I18nConfig';
 
 describe('I18nConfig', () => {
   beforeEach(() => {
-    setupGTServicesEnabled({
-      cacheUrl: null,
-      runtimeUrl: null,
-    });
+    vi.restoreAllMocks();
   });
 
   afterEach(() => {
@@ -23,19 +19,21 @@ describe('I18nConfig', () => {
   it('skips locale validation when GT services are disabled', () => {
     const config = new I18nConfig({
       defaultLocale: 'invalid-locale',
+      cacheUrl: null,
+      runtimeUrl: null,
     });
 
     expect(config.getDefaultLocale()).toBe('invalid-locale');
   });
 
   it('validates configured locales when GT services are enabled', () => {
-    setupGTServicesEnabled({ projectId: 'test-project' });
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     expect(
       () =>
         new I18nConfig({
           defaultLocale: 'invalid-locale',
+          projectId: 'test-project',
         })
     ).toThrow('Invalid I18nConfig locale configuration');
     expect(errorSpy).toHaveBeenCalledWith(
@@ -46,13 +44,13 @@ describe('I18nConfig', () => {
   });
 
   it('validates custom mapping locales when GT services are enabled', () => {
-    setupGTServicesEnabled({ projectId: 'test-project' });
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     expect(
       () =>
         new I18nConfig({
           defaultLocale: 'en',
+          projectId: 'test-project',
           customMapping: {
             invalidStringMapping: 'invalid-locale',
             invalidObjectMapping: {

--- a/packages/i18n/src/i18n-config/__tests__/singleton-operations.test.ts
+++ b/packages/i18n/src/i18n-config/__tests__/singleton-operations.test.ts
@@ -4,7 +4,6 @@ type TestGlobal = typeof globalThis & {
   __generaltranslation?: {
     i18n?: {
       i18nConfig?: unknown;
-      gtServicesEnabled?: boolean | undefined;
       [key: string]: unknown;
     };
     [key: string]: unknown;
@@ -86,7 +85,7 @@ describe('i18n config singleton operations', () => {
     const globalObj = globalThis as TestGlobal;
     globalObj.__generaltranslation ??= {};
     globalObj.__generaltranslation.i18n = {
-      gtServicesEnabled: true,
+      marker: true,
     };
     const { initializeI18nConfig } = await import('../singleton-operations');
 
@@ -94,6 +93,18 @@ describe('i18n config singleton operations', () => {
       defaultLocale: 'en',
     });
 
-    expect(globalObj.__generaltranslation.i18n.gtServicesEnabled).toBe(true);
+    expect(globalObj.__generaltranslation.i18n.marker).toBe(true);
+  });
+
+  it('stores the GT services enabled flag on the config singleton', async () => {
+    const { getI18nConfig, initializeI18nConfig } =
+      await import('../singleton-operations');
+
+    const config = initializeI18nConfig({
+      projectId: 'test-project',
+    });
+
+    expect(config.isGTServicesEnabled()).toBe(true);
+    expect(getI18nConfig().isGTServicesEnabled()).toBe(true);
   });
 });

--- a/packages/i18n/src/i18n-config/validation.ts
+++ b/packages/i18n/src/i18n-config/validation.ts
@@ -1,11 +1,13 @@
 import { isValidLocale } from '@generaltranslation/format';
 import { createDiagnosticMessage } from 'generaltranslation/internal';
-import { getGTServicesEnabled } from '../globals/getGTServicesEnabled';
 import logger from '../logs/logger';
 import type { I18nConfigParams } from './I18nConfig';
 
-export function validateI18nConfigParams(params: I18nConfigParams): void {
-  if (!getGTServicesEnabled()) {
+export function validateI18nConfigParams(
+  params: I18nConfigParams,
+  gtServicesEnabled: boolean
+): void {
+  if (!gtServicesEnabled) {
     return;
   }
 

--- a/packages/i18n/src/internal-types.ts
+++ b/packages/i18n/src/internal-types.ts
@@ -24,7 +24,6 @@ export type {
 } from './i18n-cache/translations-manager/DictionaryCache';
 export type { ReadonlyConditionStoreParams } from './condition-store/ReadonlyConditionStore';
 export type { WritableConditionStoreParams } from './condition-store/WritableConditionStore';
-export type { GTServicesEnabledParams } from './globals/getGTServicesEnabled';
 
 // Translation Options (Function types exported by /types)
 export type * from './translation-functions/types/options';

--- a/packages/i18n/src/internal.ts
+++ b/packages/i18n/src/internal.ts
@@ -58,10 +58,7 @@ export {
   getDictionaryValue,
   resolveDictionaryLookupOptions,
 } from './i18n-cache/translations-manager/utils/dictionary-helpers';
-export {
-  getGTServicesEnabled,
-  setupGTServicesEnabled,
-} from './globals/getGTServicesEnabled';
+export { getGTServicesEnabled } from './globals/getGTServicesEnabled';
 
 export {
   getI18nConfig,

--- a/packages/next/src/setup/__tests__/shared.test.ts
+++ b/packages/next/src/setup/__tests__/shared.test.ts
@@ -36,18 +36,13 @@ describe('getParams', () => {
     process.env.GT_API_KEY = 'api-key';
     process.env.GT_DEV_API_KEY = 'dev-key';
 
-    const { i18nConfigParams, gtservicesEnabledParams, nextI18nCacheParams } =
-      getParams();
+    const { i18nConfigParams, nextI18nCacheParams } = getParams();
 
     expect(i18nConfigParams).toMatchObject({
       projectId: 'project-id',
       apiKey: 'api-key',
       devApiKey: 'dev-key',
-    });
-    expect(gtservicesEnabledParams).toMatchObject({
-      projectId: 'project-id',
-      apiKey: 'api-key',
-      devApiKey: 'dev-key',
+      cacheUrl: 'https://cache.example.com',
     });
     expect(nextI18nCacheParams).toMatchObject({
       projectId: 'project-id',

--- a/packages/next/src/setup/initGT.rsc.ts
+++ b/packages/next/src/setup/initGT.rsc.ts
@@ -1,8 +1,5 @@
 import { getParams } from './shared';
-import type {
-  I18nConfigParams,
-  GTServicesEnabledParams,
-} from 'gt-i18n/internal/types';
+import type { NextSetupI18nConfigParams } from './shared';
 import type { NextI18nCacheParams } from '../i18n-cache/NextI18nCache';
 import { initializeGT as coreInitializeGT } from './initGT';
 import {
@@ -21,17 +18,14 @@ import {
 export function initializeGT(
   {
     i18nConfigParams,
-    gtservicesEnabledParams,
     nextI18nCacheParams,
   }: {
-    i18nConfigParams: I18nConfigParams;
-    gtservicesEnabledParams: GTServicesEnabledParams;
+    i18nConfigParams: NextSetupI18nConfigParams;
     nextI18nCacheParams: NextI18nCacheParams;
   } = getParams()
 ): void {
   coreInitializeGT({
     i18nConfigParams,
-    gtservicesEnabledParams,
     nextI18nCacheParams,
   });
 

--- a/packages/next/src/setup/initGT.ts
+++ b/packages/next/src/setup/initGT.ts
@@ -1,15 +1,10 @@
-import {
-  I18nConfigParams,
-  initializeI18nConfig,
-  setupGTServicesEnabled,
-} from 'gt-i18n/internal';
+import { initializeI18nConfig } from 'gt-i18n/internal';
 import {
   NextI18nCache,
   NextI18nCacheParams,
   setNextI18nCache,
 } from '../i18n-cache/NextI18nCache';
-import { getParams } from './shared';
-import { GTServicesEnabledParams } from 'gt-i18n/internal/types';
+import { getParams, type NextSetupI18nConfigParams } from './shared';
 
 /**
  * Initialize GT for Next.js
@@ -17,15 +12,12 @@ import { GTServicesEnabledParams } from 'gt-i18n/internal/types';
 export function initializeGT(
   {
     i18nConfigParams,
-    gtservicesEnabledParams,
     nextI18nCacheParams,
   }: {
-    i18nConfigParams: I18nConfigParams;
-    gtservicesEnabledParams: GTServicesEnabledParams;
+    i18nConfigParams: NextSetupI18nConfigParams;
     nextI18nCacheParams: NextI18nCacheParams;
   } = getParams()
 ): void {
-  setupGTServicesEnabled(gtservicesEnabledParams);
   initializeI18nConfig(i18nConfigParams);
 
   const i18nCache = new NextI18nCache(nextI18nCacheParams);

--- a/packages/next/src/setup/shared.ts
+++ b/packages/next/src/setup/shared.ts
@@ -1,13 +1,15 @@
 import { type I18nConfigParams } from 'gt-i18n/internal';
 import { type NextI18nCacheParams } from '../i18n-cache/NextI18nCache';
-import type { GTServicesEnabledParams } from 'gt-i18n/internal/types';
 import { loadTranslations } from '../config-dir/loadTranslation';
 import { getRuntimeCredentials } from './runtimeCredentials';
 
+export type NextSetupI18nConfigParams = I18nConfigParams & {
+  cacheUrl?: string | null;
+};
+
 // TODO: better way of communicating from build to runtime
 export function getParams(): {
-  i18nConfigParams: I18nConfigParams;
-  gtservicesEnabledParams: GTServicesEnabledParams;
+  i18nConfigParams: NextSetupI18nConfigParams;
   nextI18nCacheParams: NextI18nCacheParams;
 } {
   // Read from build output
@@ -20,7 +22,7 @@ export function getParams(): {
   const { projectId, devApiKey, apiKey } = getRuntimeCredentials();
 
   // I18nConfigParams
-  const i18nConfigParams: I18nConfigParams = {
+  const i18nConfigParams: NextSetupI18nConfigParams = {
     defaultLocale: publicConfig.defaultLocale,
     locales: publicConfig.locales,
     customMapping: publicConfig.customMapping,
@@ -28,14 +30,6 @@ export function getParams(): {
     projectId,
     devApiKey,
     apiKey,
-  };
-
-  // GTServicesEnabledParams
-  const gtservicesEnabledParams: GTServicesEnabledParams = {
-    projectId,
-    devApiKey,
-    apiKey,
-    runtimeUrl: publicConfig.runtimeUrl,
     cacheUrl: privateConfig.cacheUrl,
   };
 
@@ -75,7 +69,6 @@ export function getParams(): {
 
   return {
     i18nConfigParams,
-    gtservicesEnabledParams,
     nextI18nCacheParams,
   };
 }

--- a/packages/node/src/setup/initializeGT.ts
+++ b/packages/node/src/setup/initializeGT.ts
@@ -3,7 +3,6 @@ import type { InitializeGTParams } from './types';
 import {
   I18nCache,
   initializeI18nConfig,
-  setupGTServicesEnabled,
   setI18nCache,
 } from 'gt-i18n/internal';
 import { AsyncConditionStore } from '../async-i18n-cache/AsyncConditionStore';
@@ -14,7 +13,6 @@ import { AsyncConditionStore } from '../async-i18n-cache/AsyncConditionStore';
  * TODO: auto detect if can find gt.config.json files
  */
 export function initializeGT(params: InitializeGTParams): void {
-  setupGTServicesEnabled(params);
   initializeI18nConfig(params);
 
   const i18nCache = new I18nCache<string>(params);

--- a/packages/node/src/setup/types.ts
+++ b/packages/node/src/setup/types.ts
@@ -1,5 +1,4 @@
 import type {
-  GTServicesEnabledParams,
   I18nCacheConstructorParams,
   I18nConfigParams,
 } from 'gt-i18n/internal/types';
@@ -10,9 +9,7 @@ import type {
  * @param {string[]} params.locales - The locales to support
  * @param {object} params.loadTranslations - The custom translation loader to use
  */
-export type InitializeGTParams = I18nConfigParams &
-  GTServicesEnabledParams &
-  I18nCacheConstructorParams;
+export type InitializeGTParams = I18nConfigParams & I18nCacheConstructorParams;
 
 // Other Reexports
 export type { GTConfig, TranslationsLoader } from 'gt-i18n/internal/types';

--- a/packages/react-core/src/setup/initializeGTSRA.ts
+++ b/packages/react-core/src/setup/initializeGTSRA.ts
@@ -1,8 +1,4 @@
-import { setupGTServicesEnabled } from 'gt-i18n/internal';
-import type {
-  GTServicesEnabledParams,
-  I18nConfigParams,
-} from 'gt-i18n/internal/types';
+import type { I18nConfigParams } from 'gt-i18n/internal/types';
 import type { ReactI18nCacheParams } from '../i18n-cache/ReactI18nCache';
 import { setReactI18nCache } from '../i18n-cache/singleton-operations';
 import { ReactI18nCache } from '../i18n-cache/ReactI18nCache';
@@ -12,9 +8,8 @@ import { initializeI18nConfig } from './i18nConfig';
  * Validation and setup for read only properties
  */
 export function internalInitializeGTSRA(
-  config: I18nConfigParams & GTServicesEnabledParams & ReactI18nCacheParams
+  config: I18nConfigParams & ReactI18nCacheParams
 ): void {
-  setupGTServicesEnabled(config);
   initializeI18nConfig(config, 'server-render');
 
   const i18nCache = new ReactI18nCache(config);

--- a/packages/react-native/src/setup/initializeGT.ts
+++ b/packages/react-native/src/setup/initializeGT.ts
@@ -4,18 +4,11 @@ import {
 } from '@generaltranslation/react-core/pure';
 import { ReactI18nCache } from '@generaltranslation/react-core/pure';
 import type { ReactI18nCacheParams } from '@generaltranslation/react-core/pure';
-import { setupGTServicesEnabled } from 'gt-i18n/internal';
-import type {
-  GTServicesEnabledParams,
-  I18nConfigParams,
-} from 'gt-i18n/internal/types';
+import type { I18nConfigParams } from 'gt-i18n/internal/types';
 
-export type InitializeGTParams = I18nConfigParams &
-  GTServicesEnabledParams &
-  ReactI18nCacheParams;
+export type InitializeGTParams = I18nConfigParams & ReactI18nCacheParams;
 
 export function initializeGT(config: InitializeGTParams): void {
-  setupGTServicesEnabled(config);
   initializeI18nConfig(config, 'server-render');
 
   const i18nCache = new ReactI18nCache(config);

--- a/packages/react/src/setup/initializeGTSPA.ts
+++ b/packages/react/src/setup/initializeGTSPA.ts
@@ -7,8 +7,6 @@ import {
   initializeI18nConfig,
 } from '@generaltranslation/react-core/pure';
 import type { I18nConfigParams } from '@generaltranslation/react-core/pure';
-import { setupGTServicesEnabled } from 'gt-i18n/internal';
-import type { GTServicesEnabledParams } from 'gt-i18n/internal/types';
 import { BrowserI18nCache } from '../i18n-cache/BrowserI18nCache';
 import type { BrowserI18nCacheParams } from '../i18n-cache/BrowserI18nCache';
 import {
@@ -26,11 +24,9 @@ import {
  */
 export async function initializeGTSPA(
   config: I18nConfigParams &
-    GTServicesEnabledParams &
     BrowserI18nCacheParams &
     CreateBrowserConditionStoreParams
 ) {
-  setupGTServicesEnabled(config);
   initializeI18nConfig(config, 'SPA');
 
   const i18nCache = new BrowserI18nCache(config);

--- a/packages/react/src/setup/initializeGTSRAClient.ts
+++ b/packages/react/src/setup/initializeGTSRAClient.ts
@@ -2,16 +2,13 @@ import {
   internalInitializeGTSRA,
   type ReactI18nCacheParams,
 } from '@generaltranslation/react-core/pure';
-import type {
-  GTServicesEnabledParams,
-  I18nConfigParams,
-} from 'gt-i18n/internal/types';
+import type { I18nConfigParams } from 'gt-i18n/internal/types';
 
 /**
  * Initialize GT for client-side rendering.
  */
 export function initializeGTSRAClient(
-  config: I18nConfigParams & GTServicesEnabledParams & ReactI18nCacheParams
+  config: I18nConfigParams & ReactI18nCacheParams
 ): void {
   internalInitializeGTSRA({
     cacheExpiryTime: null,


### PR DESCRIPTION
## Summary
- move `gtServicesEnabled` onto the shared `createGlobalSingleton` registry
- preserve the existing `globalThis.__generaltranslation.i18n.gtServicesEnabled` namespace/key
- keep uninitialized reads defaulting to `false`
- add a gt-i18n patch changeset

## Notes
- Repeated setup with the same resolved boolean remains quiet.
- The shared singleton warning now fires if setup flips the flag between enabled and disabled in the same JS realm, which should indicate a meaningful config change rather than normal runtime behavior.

## Tests
- pnpm --filter gt-i18n test -- src/globals/__tests__/getGTServicesEnabled.test.ts src/i18n-config/__tests__/singleton-operations.test.ts
- pnpm --filter gt-i18n typecheck
- pnpm exec oxlint packages/i18n/src/globals/getGTServicesEnabled.ts packages/i18n/src/globals/__tests__/getGTServicesEnabled.test.ts
- pnpm exec oxfmt --check .changeset/gt-services-enabled-singleton.md packages/i18n/src/globals/getGTServicesEnabled.ts packages/i18n/src/globals/__tests__/getGTServicesEnabled.test.ts
- git diff --check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the standalone `setupGTServicesEnabled` global and folds the `gtServicesEnabled` flag directly into the `I18nConfig` class, which is already managed via the shared `createGlobalSingleton` registry. All downstream callers (Next, Node, React, React Native) drop their separate `setupGTServicesEnabled` call and now rely solely on `initializeI18nConfig`.

- `cacheUrl` is promoted into `I18nConfigParams` so the `resolveGTServicesEnabled` logic (which needs it) can live entirely inside `I18nConfig`'s constructor without a separate parameter bag.
- `validateI18nConfigParams` is updated to accept the already-resolved `gtServicesEnabled` boolean as an explicit argument instead of reading the old global, eliminating the circular dependency between the validator and the global setter.
- All tests pass and a new case pins the "returns false before config is initialized" contract.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the refactoring correctly consolidates a previously split-brain flag into a single, already-tested singleton.

The change removes a parallel global write and re-homes the flag computation inside I18nConfig's constructor, which is the natural owner. All call sites are updated, the validation function is now testable in isolation, and the uninitialized-default contract is now verified by a test. No behavioral regressions identified.

packages/next/src/setup/shared.ts — the NextSetupI18nConfigParams alias can be simplified now that cacheUrl is part of I18nConfigParams, but this has no runtime impact.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/i18n/src/globals/getGTServicesEnabled.ts | Simplified to a thin wrapper over the I18nConfig singleton; correctly returns false before initialization. setupGTServicesEnabled removed. |
| packages/i18n/src/i18n-config/I18nConfig.ts | Adds cacheUrl to I18nConfigParams, moves resolveGTServicesEnabled logic here, stores result as a private field. Clean consolidation. |
| packages/i18n/src/i18n-config/validation.ts | Eliminates the global read in favor of an explicit parameter; no logic change, avoids the need to read the global singleton during construction. |
| packages/next/src/setup/shared.ts | Removes the separate gtservicesEnabledParams block; adds cacheUrl directly to i18nConfigParams. Introduces NextSetupI18nConfigParams which is now redundant given cacheUrl is already in I18nConfigParams. |
| packages/i18n/src/globals/__tests__/getGTServicesEnabled.test.ts | Updated to use initializeI18nConfig; adds the previously-missing test for the uninitialized default (false). Addresses prior review comment. |
| packages/i18n/src/i18n-config/__tests__/singleton-operations.test.ts | Removes the gtServicesEnabled field from the singleton shape type and adds a dedicated test verifying the flag is stored and retrievable via the config singleton. |
| packages/next/src/setup/initGT.ts | Drops the separate setupGTServicesEnabled call; initializeI18nConfig now owns the full setup. Correctly uses NextSetupI18nConfigParams. |
| packages/node/src/setup/initializeGT.ts | Removes setupGTServicesEnabled call; initializeI18nConfig takes full responsibility. Clean one-line removal. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["initializeGT() / initializeI18nConfig()"] --> B["new I18nConfig(params)"]
    B --> C["resolveGTServicesEnabled(params)\n(getLoadTranslationsType | getTranslationApiType)"]
    C --> D["gtServicesEnabled: boolean"]
    D --> E["validateI18nConfigParams(params, gtServicesEnabled)"]
    D --> F["this.gtServicesEnabled = gtServicesEnabled"]
    B --> G["setI18nConfig(instance)\ncreateGlobalSingleton registry"]
    G --> H["globalThis.__generaltranslation.i18n.i18nConfig"]
    H --> I["getGTServicesEnabled()\n-> isI18nConfigInitialized()\n  ? getI18nConfig().isGTServicesEnabled()\n  : false"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["initializeGT() / initializeI18nConfig()"] --> B["new I18nConfig(params)"]
    B --> C["resolveGTServicesEnabled(params)\n(getLoadTranslationsType | getTranslationApiType)"]
    C --> D["gtServicesEnabled: boolean"]
    D --> E["validateI18nConfigParams(params, gtServicesEnabled)"]
    D --> F["this.gtServicesEnabled = gtServicesEnabled"]
    B --> G["setI18nConfig(instance)\ncreateGlobalSingleton registry"]
    G --> H["globalThis.__generaltranslation.i18n.i18nConfig"]
    H --> I["getGTServicesEnabled()\n-> isI18nConfigInitialized()\n  ? getI18nConfig().isGTServicesEnabled()\n  : false"]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["refactor: store gt services flag on i18n..."](https://github.com/generaltranslation/gt/commit/eeb2452503dd75b42a323f6bbf60be337bd23cab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40948338)</sub>

<!-- /greptile_comment -->