### PR TITLE
refactor: use shared singleton for react core context

### DIFF
--- a/packages/react-core/src/context/context.ts
+++ b/packages/react-core/src/context/context.ts
@@ -6,6 +6,7 @@ import {
 } from 'gt-i18n/internal/types';
 import { Translation } from 'gt-i18n/types';
 import { createDiagnosticMessage } from 'generaltranslation/internal';
+import { createGlobalSingleton } from 'gt-i18n/internal';
 import { createContext, useContext, type Context } from 'react';
 import { I18nStore } from '../i18n-store/I18nStore';
 import { getI18nConfig } from '../setup/i18nConfig';
@@ -42,34 +43,21 @@ export type GTContextType = {
   onMissingDictionaryObj?: OnMissingDictionaryObj;
 };
 
-type ReactCoreGlobals = {
-  gtContext?: Context<GTContextType | undefined>;
-  [key: string]: unknown;
-};
-
-type GeneralTranslationGlobal = {
-  reactCore?: ReactCoreGlobals;
-  [key: string]: unknown;
-};
-
-type GlobalWithGeneralTranslation = {
-  __generaltranslation?: GeneralTranslationGlobal;
-};
-
-function getReactCoreGlobals(): ReactCoreGlobals {
-  const globalObj = globalThis as unknown as GlobalWithGeneralTranslation;
-  globalObj.__generaltranslation ??= {};
-  // TODO: Consider checking package versions and using a compatibility matrix before sharing global singletons.
-  globalObj.__generaltranslation.reactCore ??= {};
-  return globalObj.__generaltranslation.reactCore;
-}
+const gtContextSingleton = createGlobalSingleton<
+  Context<GTContextType | undefined>
+>({
+  namespace: 'reactCore',
+  key: 'gtContext',
+  source: '@generaltranslation/react-core',
+  notInitialized: () => 'GTContext has not been initialized.',
+});
 
 export function getGTContext(): Context<GTContextType | undefined> {
-  const reactCoreGlobals = getReactCoreGlobals();
-  reactCoreGlobals.gtContext ??= createContext<GTContextType | undefined>(
-    undefined
-  );
-  return reactCoreGlobals.gtContext;
+  // Lazily create the React context once and share it across instances.
+  if (!gtContextSingleton.isInitialized()) {
+    gtContextSingleton.set(createContext<GTContextType | undefined>(undefined));
+  }
+  return gtContextSingleton.get();
 }
 
 export function useGTContext(): GTContextType | undefined {


### PR DESCRIPTION
## Summary
- replace the hand-rolled react-core context global registry with createGlobalSingleton
- preserve the existing reactCore/gtContext global slot and lazy creation behavior

## Testing
- pnpm exec oxlint packages/react-core/src/context/context.ts
- pnpm exec oxfmt --check packages/react-core/src/context/context.ts
- git diff --check
- pnpm --filter @generaltranslation/react-core test
- pnpm --filter @generaltranslation/react-core typecheck
- pnpm --filter gt-react test
- pnpm --filter gt-react typecheck

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors `packages/react-core/src/context/context.ts` to replace three hand-rolled TypeScript interfaces and the `getReactCoreGlobals()` helper with the shared `createGlobalSingleton` utility from `gt-i18n/internal`, reducing boilerplate while preserving the same `globalThis.__generaltranslation.reactCore.gtContext` slot.

- The module-level `gtContextSingleton` constant mirrors the old `getReactCoreGlobals()` plumbing exactly — same `namespace` (`reactCore`) and `key` (`gtContext`) — so the global slot is unchanged across package instances.
- `getGTContext()` preserves the lazy-creation pattern: it calls `isInitialized()` before `set()`, so `createContext` is still invoked at most once, and the new `set()` overwrite-warning path is never reached through normal usage.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the refactor is a direct mechanical substitution of equivalent logic with no functional change.

The global slot (__generaltranslation.reactCore.gtContext) is identical to what the old hand-rolled helper produced. The lazy-init guard (isInitialized() → set() → get()) matches the old ??= semantics precisely, and set() is only called when the slot is empty so the new overwrite-warning path is unreachable in normal use. The removed TypeScript types were internal implementation detail only. Nothing in the public API or runtime behavior changes.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react-core/src/context/context.ts | Replaces hand-rolled global-registry types and helper with createGlobalSingleton; namespace/key alignment is preserved, lazy-init behavior is equivalent. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant getGTContext
    participant gtContextSingleton
    participant globalThis

    Caller->>getGTContext: getGTContext()
    getGTContext->>gtContextSingleton: isInitialized()
    gtContextSingleton->>globalThis: globalThis.__generaltranslation["reactCore"]["gtContext"]
    globalThis-->>gtContextSingleton: undefined (first call)
    gtContextSingleton-->>getGTContext: false

    getGTContext->>getGTContext: createContext(undefined)
    getGTContext->>gtContextSingleton: set(ctx)
    gtContextSingleton->>globalThis: store ctx at ["reactCore"]["gtContext"]

    getGTContext->>gtContextSingleton: get()
    gtContextSingleton->>globalThis: read ["reactCore"]["gtContext"]
    globalThis-->>gtContextSingleton: ctx
    gtContextSingleton-->>getGTContext: ctx
    getGTContext-->>Caller: ctx

    Note over Caller,globalThis: Subsequent calls — slot already populated
    Caller->>getGTContext: getGTContext()
    getGTContext->>gtContextSingleton: isInitialized()
    gtContextSingleton->>globalThis: read ["reactCore"]["gtContext"]
    globalThis-->>gtContextSingleton: ctx
    gtContextSingleton-->>getGTContext: true
    getGTContext->>gtContextSingleton: get()
    gtContextSingleton-->>getGTContext: ctx
    getGTContext-->>Caller: ctx
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant getGTContext
    participant gtContextSingleton
    participant globalThis

    Caller->>getGTContext: getGTContext()
    getGTContext->>gtContextSingleton: isInitialized()
    gtContextSingleton->>globalThis: globalThis.__generaltranslation["reactCore"]["gtContext"]
    globalThis-->>gtContextSingleton: undefined (first call)
    gtContextSingleton-->>getGTContext: false

    getGTContext->>getGTContext: createContext(undefined)
    getGTContext->>gtContextSingleton: set(ctx)
    gtContextSingleton->>globalThis: store ctx at ["reactCore"]["gtContext"]

    getGTContext->>gtContextSingleton: get()
    gtContextSingleton->>globalThis: read ["reactCore"]["gtContext"]
    globalThis-->>gtContextSingleton: ctx
    gtContextSingleton-->>getGTContext: ctx
    getGTContext-->>Caller: ctx

    Note over Caller,globalThis: Subsequent calls — slot already populated
    Caller->>getGTContext: getGTContext()
    getGTContext->>gtContextSingleton: isInitialized()
    gtContextSingleton->>globalThis: read ["reactCore"]["gtContext"]
    globalThis-->>gtContextSingleton: ctx
    gtContextSingleton-->>getGTContext: true
    getGTContext->>gtContextSingleton: get()
    gtContextSingleton-->>getGTContext: ctx
    getGTContext-->>Caller: ctx
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: use shared singleton for react..."](https://github.com/generaltranslation/gt/commit/46bec0ec1376818724f768307d3b9daccf6e5953) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40949786)</sub>

<!-- /greptile_comment -->