### PR TITLE
refactor: remove dead internal exports

### DIFF
--- a/.changeset/remove-dead-internal-exports.md
+++ b/.changeset/remove-dead-internal-exports.md
@@ -1,0 +1,7 @@
+---
+"gt": patch
+"gt-i18n": patch
+"@generaltranslation/react-core": patch
+---
+
+Remove unused internal exports and dead utility code.

--- a/packages/cli/src/console/index.ts
+++ b/packages/cli/src/console/index.ts
@@ -402,7 +402,6 @@ export const noLocalesError = `No target locales were found. Add locales to gt.c
 export const noDefaultLocaleError = `No default locale was found. Add defaultLocale to gt.config.json or pass it with --default-locale.`;
 export const noFilesError = `The files configuration is missing or invalid. Check the files section in gt.config.json and try again.`;
 export const noSourceFileError = `No source translation file was found. Check your translations directory and default locale configuration.`;
-export const noSupportedFormatError = `The translation file format is not supported. Use a supported file extension in translationsDir.`;
 export const noApiKeyError = `No API key was found. Pass --api-key or set the GT_API_KEY environment variable.`;
 export const devApiKeyError = `Development API keys cannot be used with the General Translation API. Use a production API key instead.\nGenerate a production API key with: npx gt auth -t production`;
 export const noProjectIdError = `No project ID was found. Pass --project-id, add projectId to gt.config.json, or set the GT_PROJECT_ID environment variable.`;

--- a/packages/cli/src/formats/files/aggregateFiles.ts
+++ b/packages/cli/src/formats/files/aggregateFiles.ts
@@ -44,7 +44,6 @@ function isCompanionMetadataFile(
   );
   return allFilePaths.includes(sourceFilePath);
 }
-export const SUPPORTED_DATA_FORMATS = ['JSX', 'ICU', 'I18NEXT'];
 
 export async function aggregateFiles(
   settings: Settings

--- a/packages/cli/src/utils/headers.ts
+++ b/packages/cli/src/utils/headers.ts
@@ -1,9 +1,0 @@
-export function getAuthHeaders(projectId: string, apiKey: string) {
-  const authHeaders: Record<string, string> = {
-    'gt-project-id': projectId,
-  };
-  if (apiKey) {
-    authHeaders['Authorization'] = `Bearer ${apiKey}`;
-  }
-  return authHeaders;
-}

--- a/packages/i18n/src/internal-types.ts
+++ b/packages/i18n/src/internal-types.ts
@@ -27,7 +27,6 @@ export type { WritableConditionStoreParams } from './condition-store/WritableCon
 
 // Translation Options (Function types exported by /types)
 export type * from './translation-functions/types/options';
-export type { TranslationMetadata } from './translation-functions/types/options';
 
 // Config
 export type * from './config/types';

--- a/packages/react-core/src/condition-store/singleton-operations.ts
+++ b/packages/react-core/src/condition-store/singleton-operations.ts
@@ -69,7 +69,6 @@ function getReadonlyConditionStoreWithFallback(): ReadonlyConditionStoreInterfac
 }
 
 export {
-  getConditionStore as getReadonlyConditionStore,
   getReadonlyConditionStoreWithFallback,
   setConditionStore as setReadonlyConditionStore,
   isConditionStoreInitialized as isReadonlyConditionStoreInitialized,

--- a/packages/react-core/src/pure.ts
+++ b/packages/react-core/src/pure.ts
@@ -44,8 +44,6 @@ export { getDefaultRenderSettings } from './utils/rendering/getDefaultRenderSett
 export { isDictionaryEntry } from './utils/dictionaries/isDictionaryEntry';
 
 export type {
-  AuthFromEnvParams,
-  AuthFromEnvReturn,
   CustomLoader,
   Dictionary,
   DictionaryContent,

--- a/packages/react-core/src/utils/types.ts
+++ b/packages/react-core/src/utils/types.ts
@@ -124,11 +124,3 @@ export type _Message = {
   $_hash?: string;
 };
 export type _Messages = _Message[];
-export type AuthFromEnvParams = {
-  projectId?: string;
-  devApiKey?: string;
-};
-export type AuthFromEnvReturn = {
-  projectId: string;
-  devApiKey?: string;
-};


### PR DESCRIPTION
## Summary
- remove unused CLI console/format exports and an unused auth header utility
- remove redundant gt-i18n internal type re-export
- remove unused react-core pure/condition-store exports and auth env types

## Tests
- pnpm --filter gt typecheck
- pnpm --filter gt-i18n typecheck
- pnpm --filter @generaltranslation/react-core typecheck
- git diff --check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes dead internal exports across three packages (`gt`, `gt-i18n`, `@generaltranslation/react-core`) — string constants, a utility function, type definitions, and re-export aliases that have no remaining consumers in the codebase.

- **CLI (`gt`)**: Removes unused `noSupportedFormatError` string, the `SUPPORTED_DATA_FORMATS` array, and deletes the entire `headers.ts` utility file containing `getAuthHeaders`.
- **i18n**: Removes a redundant named re-export of `TranslationMetadata` that was already covered by the preceding `export type *` wildcard.
- **react-core**: Removes the `getConditionStore as getReadonlyConditionStore` alias (all consumers use the `WithFallback` variant) and the `AuthFromEnvParams`/`AuthFromEnvReturn` type definitions and their public re-exports.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

All removals are confirmed dead code with no remaining consumers — safe to merge.

Every removed export was verified against the full codebase: no remaining imports of `noSupportedFormatError`, `SUPPORTED_DATA_FORMATS`, `getAuthHeaders`, `getReadonlyConditionStore` (bare alias), `AuthFromEnvParams`, or `AuthFromEnvReturn`. The `TranslationMetadata` named re-export was redundant due to the existing `export type *` wildcard. The accompanying typecheck CI steps cover each affected package.

No files require special attention — all changes are straightforward dead-code removals.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/console/index.ts | Removes `noSupportedFormatError` constant — confirmed unused across the codebase. |
| packages/cli/src/formats/files/aggregateFiles.ts | Removes `SUPPORTED_DATA_FORMATS` exported constant — confirmed unused across the codebase. |
| packages/cli/src/utils/headers.ts | Deletes entire file containing `getAuthHeaders` utility — confirmed no imports of this file or function remain anywhere. |
| packages/i18n/src/internal-types.ts | Removes redundant explicit re-export of `TranslationMetadata`, which is already covered by the preceding `export type *` wildcard from the same source file. |
| packages/react-core/src/condition-store/singleton-operations.ts | Removes `getConditionStore as getReadonlyConditionStore` alias from the export block; all consumers in the codebase use the `WithFallback` variant, so this alias had zero consumers. |
| packages/react-core/src/pure.ts | Removes `AuthFromEnvParams` and `AuthFromEnvReturn` type re-exports — both types are being deleted at source and have no remaining consumers. |
| packages/react-core/src/utils/types.ts | Deletes `AuthFromEnvParams` and `AuthFromEnvReturn` type definitions — confirmed unused across the entire codebase. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Dead Export Removal PR] --> B[packages/cli]
    A --> C[packages/i18n]
    A --> D[packages/react-core]

    B --> B1["console/index.ts\n- noSupportedFormatError ❌"]
    B --> B2["formats/files/aggregateFiles.ts\n- SUPPORTED_DATA_FORMATS ❌"]
    B --> B3["utils/headers.ts\n- getAuthHeaders() ❌ (file deleted)"]

    C --> C1["internal-types.ts\n- TranslationMetadata (redundant re-export) ❌\n  already covered by export type *"]

    D --> D1["condition-store/singleton-operations.ts\n- getConditionStore as getReadonlyConditionStore ❌\n  all callers use WithFallback variant"]
    D --> D2["pure.ts\n- AuthFromEnvParams ❌\n- AuthFromEnvReturn ❌"]
    D --> D3["utils/types.ts\n- AuthFromEnvParams type def ❌\n- AuthFromEnvReturn type def ❌"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Dead Export Removal PR] --> B[packages/cli]
    A --> C[packages/i18n]
    A --> D[packages/react-core]

    B --> B1["console/index.ts\n- noSupportedFormatError ❌"]
    B --> B2["formats/files/aggregateFiles.ts\n- SUPPORTED_DATA_FORMATS ❌"]
    B --> B3["utils/headers.ts\n- getAuthHeaders() ❌ (file deleted)"]

    C --> C1["internal-types.ts\n- TranslationMetadata (redundant re-export) ❌\n  already covered by export type *"]

    D --> D1["condition-store/singleton-operations.ts\n- getConditionStore as getReadonlyConditionStore ❌\n  all callers use WithFallback variant"]
    D --> D2["pure.ts\n- AuthFromEnvParams ❌\n- AuthFromEnvReturn ❌"]
    D --> D3["utils/types.ts\n- AuthFromEnvParams type def ❌\n- AuthFromEnvReturn type def ❌"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: remove dead internal exports"](https://github.com/generaltranslation/gt/commit/d5576f63f5169a31c5b8e53198bcd3b0561bd8aa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40963643)</sub>

<!-- /greptile_comment -->