### PR TITLE
fix: add portable selector return types

### DIFF
--- a/.changeset/react-native-selector-return-types.md
+++ b/.changeset/react-native-selector-return-types.md
@@ -1,0 +1,6 @@
+---
+"@generaltranslation/react-core": patch
+"gt-react-native": patch
+---
+
+Add portable selector hook return types for React Native declarations.

--- a/packages/react-core/src/hooks.ts
+++ b/packages/react-core/src/hooks.ts
@@ -24,8 +24,10 @@ export {
   useVersionId,
 } from './hooks/utils';
 export { useInternalLocaleSelector } from './hooks/useInternalLocaleSelector';
+export type { InternalLocaleSelectorResult } from './hooks/useInternalLocaleSelector';
 export { useInternalRegionSelector } from './hooks/useInternalRegionSelector';
 export type {
   InternalRegionSelectorOptions,
+  InternalRegionSelectorResult,
   RegionData,
 } from './hooks/useInternalRegionSelector';

--- a/packages/react-core/src/hooks/useInternalLocaleSelector.ts
+++ b/packages/react-core/src/hooks/useInternalLocaleSelector.ts
@@ -1,9 +1,21 @@
 import { useCallback, useMemo } from 'react';
+import type { LocaleProperties } from '@generaltranslation/format/types';
 import { useCustomMapping, useLocales } from './i18n-config';
 import { useLocale } from './condition-store';
 import { getLocaleProperties } from 'generaltranslation';
 
-export function useInternalLocaleSelector(locales?: string[]) {
+// Explicit return type so the inferred type stays portable for downstream
+// packages (e.g. gt-react-native), otherwise the getLocaleProperties callback
+// pulls in generaltranslation's bundled, non-nameable type (TS2742).
+export type InternalLocaleSelectorResult = {
+  locale: string;
+  locales: string[];
+  getLocaleProperties: (locale: string) => LocaleProperties;
+};
+
+export function useInternalLocaleSelector(
+  locales?: string[]
+): InternalLocaleSelectorResult {
   // Retrieve the locale, locales, and setLocale function
   const contextLocales = useLocales();
   const customMapping = useCustomMapping();

--- a/packages/react-core/src/hooks/useInternalRegionSelector.ts
+++ b/packages/react-core/src/hooks/useInternalRegionSelector.ts
@@ -22,6 +22,14 @@ export type InternalRegionSelectorOptions = {
   sortRegionsAlphabetically?: boolean;
 };
 
+export type InternalRegionSelectorResult = {
+  region: string | undefined;
+  regions: string[];
+  regionData: Map<string, RegionData>;
+  locale: string;
+  localeRegion: string;
+};
+
 /**
  * Internal logic for region selection in applications supporting multiple regions.
  *
@@ -34,7 +42,7 @@ export function useInternalRegionSelector({
   customMapping,
   prioritizeCurrentLocaleRegion = true,
   sortRegionsAlphabetically = true,
-}: InternalRegionSelectorOptions = {}) {
+}: InternalRegionSelectorOptions = {}): InternalRegionSelectorResult {
   // Retrieve the locale, locales, and region
   const contextLocales = useLocales();
   const localeCustomMapping = useCustomMapping();

--- a/packages/react-native/src/hooks/selectors.ts
+++ b/packages/react-native/src/hooks/selectors.ts
@@ -3,14 +3,28 @@ import {
   useInternalLocaleSelector,
   useInternalRegionSelector,
 } from '@generaltranslation/react-core/hooks';
-import type { InternalRegionSelectorOptions } from '@generaltranslation/react-core/hooks';
+import type {
+  InternalLocaleSelectorResult,
+  InternalRegionSelectorOptions,
+  InternalRegionSelectorResult,
+} from '@generaltranslation/react-core/hooks';
 
-export function useLocaleSelector(locales?: string[]) {
+// Explicit return types are required: project references make TypeScript try to
+// name the inferred selector types, which otherwise reach into
+// generaltranslation's non-portable bundled declarations (TS2742).
+export function useLocaleSelector(
+  locales?: string[]
+): InternalLocaleSelectorResult & { setLocale: (locale: string) => void } {
   const setLocale = useSetLocale();
   return { setLocale, ...useInternalLocaleSelector(locales) };
 }
 
-export function useRegionSelector(options?: InternalRegionSelectorOptions) {
+export function useRegionSelector(
+  options?: InternalRegionSelectorOptions
+): InternalRegionSelectorResult & {
+  setLocale: (locale: string) => void;
+  setRegion: (region: string | undefined) => void;
+} {
   const setLocale = useSetLocale();
   const setRegion = useSetRegion();
   return { setLocale, setRegion, ...useInternalRegionSelector(options) };


### PR DESCRIPTION
## Summary
- add explicit portable selector hook result types in react-core
- reuse those types in gt-react-native selector hooks to avoid non-nameable declaration output
- add a patch changeset for react-core and gt-react-native

## Checks
- pnpm --filter @generaltranslation/react-core typecheck
- pnpm --filter gt-react typecheck
- pnpm --filter gt-react-native typecheck
- pnpm format
- git diff --check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds explicit TypeScript return types to the `useInternalLocaleSelector` and `useInternalRegionSelector` hooks in `react-core`, then reuses those exported types in the `gt-react-native` selector wrappers to fix TS2742 errors that occur in project-reference builds when TypeScript tries to name inferred types that reach into non-portable bundled declarations from `generaltranslation`.

- **`react-core`**: Introduces `InternalLocaleSelectorResult` and `InternalRegionSelectorResult` types, annotates the hook functions with those types, and re-exports them from the hooks barrel (`hooks.ts`).
- **`gt-react-native`**: Updates `useLocaleSelector` and `useRegionSelector` to declare explicit return types as intersections of the newly exported core result types with their respective setter signatures.
- **Changeset**: A patch bump for both `@generaltranslation/react-core` and `gt-react-native` is included.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Pure TypeScript type-annotation additions with no runtime behavior changes; safe to merge.

All changes are additive type exports and explicit return-type annotations. The declared types accurately reflect the objects each hook already returned. No logic, runtime paths, or public APIs are altered.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react-core/src/hooks/useInternalLocaleSelector.ts | Adds explicit InternalLocaleSelectorResult type and annotates the function's return type; types accurately match the actual returned shape. |
| packages/react-core/src/hooks/useInternalRegionSelector.ts | Adds InternalRegionSelectorResult type and annotates the function's return; all five fields match the returned object exactly. |
| packages/react-core/src/hooks.ts | Re-exports the two new result types from the hooks barrel; no functional changes. |
| packages/react-native/src/hooks/selectors.ts | Annotates useLocaleSelector and useRegionSelector with explicit intersection return types reusing the newly exported core types; resolves TS2742 for project-reference builds. |
| .changeset/react-native-selector-return-types.md | Correct patch changeset targeting both @generaltranslation/react-core and gt-react-native. |

</details>

<details><summary><h3>Class Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
classDiagram
    class InternalLocaleSelectorResult {
        +string locale
        +string[] locales
        +getLocaleProperties(locale: string) LocaleProperties
    }

    class InternalRegionSelectorResult {
        +string|undefined region
        +string[] regions
        +Map~string,RegionData~ regionData
        +string locale
        +string localeRegion
    }

    class useLocaleSelector {
        +InternalLocaleSelectorResult & setLocale
    }

    class useRegionSelector {
        +InternalRegionSelectorResult & setLocale & setRegion
    }

    useLocaleSelector --|> InternalLocaleSelectorResult : extends
    useRegionSelector --|> InternalRegionSelectorResult : extends
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
classDiagram
    class InternalLocaleSelectorResult {
        +string locale
        +string[] locales
        +getLocaleProperties(locale: string) LocaleProperties
    }

    class InternalRegionSelectorResult {
        +string|undefined region
        +string[] regions
        +Map~string,RegionData~ regionData
        +string locale
        +string localeRegion
    }

    class useLocaleSelector {
        +InternalLocaleSelectorResult & setLocale
    }

    class useRegionSelector {
        +InternalRegionSelectorResult & setLocale & setRegion
    }

    useLocaleSelector --|> InternalLocaleSelectorResult : extends
    useRegionSelector --|> InternalRegionSelectorResult : extends
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: add portable selector return types"](https://github.com/generaltranslation/gt/commit/b5303b19f81926477fd293ddb7bfefcda7bef28a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40965389)</sub>

<!-- /greptile_comment -->