### PR TITLE
fix: clean up package metadata

### DIFF
--- a/.changeset/clean-package-config-metadata.md
+++ b/.changeset/clean-package-config-metadata.md
@@ -1,0 +1,7 @@
+---
+"gt-next": patch
+"gt-react": patch
+"gt-tanstack-start": patch
+---
+
+Clean up stale package metadata and align TanStack Start package entry points.

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -17,6 +17,8 @@
     "./dist/index.rsc.*",
     "./dist/index.client.*",
     "./dist/server.*",
+    "./dist/link.*",
+    "./dist/link/Link.*",
     "./dist/utils/client-boundary.*"
   ],
   "dependencies": {
@@ -121,16 +123,6 @@
       "import": "./dist/_load-dictionary.mjs",
       "default": "./dist/_load-dictionary.js"
     },
-    "./compiler": {
-      "types": "./dist/compiler/index.d.ts",
-      "import": "./dist/compiler/index.mjs",
-      "default": "./dist/compiler/index.js"
-    },
-    "./eslint-plugin": {
-      "types": "./dist/eslint-plugin/index.d.ts",
-      "import": "./dist/eslint-plugin/index.mjs",
-      "default": "./dist/eslint-plugin/index.js"
-    },
     "./internal/_getLocale": {
       "import": "./dist/internal/_getLocale.mjs",
       "default": "./dist/internal/_getLocale.js"
@@ -166,12 +158,6 @@
       "_load-dictionary": [
         "./dist/_load-dictionary.d.ts"
       ],
-      "compiler": [
-        "./dist/compiler/index.d.ts"
-      ],
-      "eslint-plugin": [
-        "./dist/eslint-plugin/index.d.ts"
-      ],
       "internal/_getLocale": [
         "./dist/internal/_getLocale.d.ts"
       ],
@@ -206,12 +192,6 @@
       ],
       "gt-next/_load-dictionary": [
         "/dist/_load-dictionary"
-      ],
-      "gt-next/compiler": [
-        "/dist/compiler"
-      ],
-      "gt-next/eslint-plugin": [
-        "/dist/eslint-plugin"
       ],
       "gt-next/internal/_getLocale": [
         "/dist/internal/_getLocale"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -101,9 +101,6 @@
   },
   "typesVersions": {
     "*": {
-      "setup": [
-        "./dist/setup.d.cts"
-      ],
       "macros": [
         "./dist/macros.d.cts"
       ]
@@ -112,9 +109,6 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "gt-react/setup": [
-        "./dist/setup.d.cts"
-      ],
       "gt-react/macros": [
         "./dist/macros.d.cts"
       ]

--- a/packages/tanstack-start/package.json
+++ b/packages/tanstack-start/package.json
@@ -2,8 +2,8 @@
   "name": "gt-tanstack-start",
   "version": "11.0.0-odysseus.9",
   "description": "TanStack Start integration for General Translation",
-  "main": "./dist/index.client.cjs",
-  "module": "./dist/index.client.mjs",
+  "main": "./dist/index.server.cjs",
+  "module": "./dist/index.server.mjs",
   "types": "./dist/index.types.d.cts",
   "files": [
     "dist",
@@ -84,24 +84,6 @@
         "default": "./dist/index.server.mjs"
       },
       "default": "./dist/index.server.mjs"
-    },
-    "./types": {
-      "types": "./dist/types.d.cts"
-    }
-  },
-  "typesVersions": {
-    "*": {
-      "types": [
-        "./dist/types.d.cts"
-      ]
-    }
-  },
-  "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "gt-tanstack-start/types": [
-        "./dist/types.d.cts"
-      ]
     }
   },
   "keywords": [

--- a/packages/tanstack-start/tsdown.config.mts
+++ b/packages/tanstack-start/tsdown.config.mts
@@ -24,7 +24,6 @@ const entries = [
   'src/index.client.ts',
   'src/index.server.ts',
   'src/index.types.ts',
-  'src/types.ts',
 ];
 
 export default defineConfig(


### PR DESCRIPTION
## Summary
- remove stale package metadata for non-emitted subpaths
- preserve gt-next link client-boundary files in sideEffects
- align gt-tanstack-start legacy main/module fields with the server export fallback
- add a patch changeset for gt-next, gt-react, and gt-tanstack-start

## Checks
- pnpm --filter gt-tanstack-start typecheck
- pnpm --filter gt-tanstack-start build
- pnpm --filter gt-next test -- packageExports
- pnpm --filter gt-react test -- react-package
- pnpm format
- git diff --check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR cleans up stale package metadata across three packages and fixes a `main`/`module` field misalignment in `gt-tanstack-start`.

- **`gt-next`**: Adds `./dist/link.*` and `./dist/link/Link.*` to `sideEffects` to prevent bundlers from tree-shaking client-boundary files; removes `./compiler` and `./eslint-plugin` subpath exports that had no emitted build output.
- **`gt-react`**: Removes the stale `./setup` entry from `typesVersions` and `compilerOptions.paths` — no corresponding `.d.cts` was emitted.
- **`gt-tanstack-start`**: Aligns legacy `main`/`module` fields to point at `index.server.*` (matching the `exports` default fallback), removes the empty `src/types.ts` file and its `./types` subpath export, and drops it from the tsdown build entries.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all changes are metadata cleanup and a legacy entry-point alignment with no runtime logic touched.

Every changed file is either a package.json, a build config, or an empty source file. The removed subpath exports (./compiler, ./eslint-plugin, ./setup, ./types) have no consumers anywhere in the repo. The gt-tanstack-start main/module alignment correctly matches what the exports default fallback already served, fixing a pre-existing mismatch rather than introducing a behavior change. The sideEffects additions protect client-boundary link files from being dropped by tree-shakers.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .changeset/clean-package-config-metadata.md | Patch changeset covering gt-next, gt-react, and gt-tanstack-start — correctly scoped as a patch for metadata-only and bug-fix alignment changes. |
| packages/next/package.json | Adds ./dist/link.* and ./dist/link/Link.* to sideEffects to prevent tree-shaking of client-boundary files; removes stale ./compiler and ./eslint-plugin subpath exports that had no corresponding build output. |
| packages/react/package.json | Removes the stale ./setup typesVersions and compilerOptions.paths entries that had no corresponding emitted output. |
| packages/tanstack-start/package.json | Aligns legacy main/module fields with the server export fallback; removes the stale ./types subpath export and its typesVersions/compilerOptions entries. |
| packages/tanstack-start/src/types.ts | Deleted empty file (zero-byte) whose corresponding build entry and package.json subpath export are removed in the same PR. |
| packages/tanstack-start/tsdown.config.mts | Removes src/types.ts from the build entry list, consistent with the file deletion and package.json cleanup. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph gt-next
        N1["sideEffects\n+ ./dist/link.*\n+ ./dist/link/Link.*"] --> N2["Client-boundary files\npreserved from tree-shaking"]
        N3["Remove ./compiler export"] --> N4["No emitted build output"]
        N5["Remove ./eslint-plugin export"] --> N4
    end
    subgraph gt-react
        R1["Remove ./setup from\ntypesVersions & paths"] --> R2["No emitted .d.cts"]
    end
    subgraph gt-tanstack-start
        T1["main/module: index.client.*\n→ index.server.*"] --> T2["Aligned with exports\ndefault fallback"]
        T3["Remove ./types subpath"] --> T4["src/types.ts deleted\n(was empty)"]
        T5["tsdown: remove\nsrc/types.ts entry"] --> T4
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    subgraph gt-next
        N1["sideEffects\n+ ./dist/link.*\n+ ./dist/link/Link.*"] --> N2["Client-boundary files\npreserved from tree-shaking"]
        N3["Remove ./compiler export"] --> N4["No emitted build output"]
        N5["Remove ./eslint-plugin export"] --> N4
    end
    subgraph gt-react
        R1["Remove ./setup from\ntypesVersions & paths"] --> R2["No emitted .d.cts"]
    end
    subgraph gt-tanstack-start
        T1["main/module: index.client.*\n→ index.server.*"] --> T2["Aligned with exports\ndefault fallback"]
        T3["Remove ./types subpath"] --> T4["src/types.ts deleted\n(was empty)"]
        T5["tsdown: remove\nsrc/types.ts entry"] --> T4
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: clean up package metadata"](https://github.com/generaltranslation/gt/commit/17799f3d99c1f47c97ee782211d93a28b886c8cf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40967115)</sub>

<!-- /greptile_comment -->