### PR TITLE
refactor(cli): dedupe locale path prefixing

### DIFF
--- a/packages/cli/src/utils/__tests__/localizePathSegment.test.ts
+++ b/packages/cli/src/utils/__tests__/localizePathSegment.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { localizePathSegment } from '../localizePathSegment.js';
+
+describe('localizePathSegment', () => {
+  const knownLocales = new Set(['en', 'es', 'fr']);
+
+  it('prefixes path-like values with the target locale', () => {
+    expect(localizePathSegment('/docs/api', 'es', knownLocales)).toBe(
+      '/es/docs/api'
+    );
+    expect(localizePathSegment('docs/api', 'es', knownLocales)).toBe(
+      'es/docs/api'
+    );
+  });
+
+  it('replaces existing known-locale prefixes', () => {
+    expect(localizePathSegment('/en/docs/api', 'es', knownLocales)).toBe(
+      '/es/docs/api'
+    );
+  });
+
+  it('preserves surrounding whitespace', () => {
+    expect(localizePathSegment('  /docs/api  ', 'es', knownLocales)).toBe(
+      '  /es/docs/api  '
+    );
+  });
+
+  it('returns null when the value is already normalized for the target locale', () => {
+    expect(localizePathSegment('/es/docs/api', 'es', knownLocales)).toBeNull();
+  });
+
+  it('skips external, anchor, and explicitly relative values', () => {
+    expect(
+      localizePathSegment('https://example.com/docs', 'es', knownLocales)
+    ).toBeNull();
+    expect(
+      localizePathSegment('//example.com/docs', 'es', knownLocales)
+    ).toBeNull();
+    expect(localizePathSegment('#docs', 'es', knownLocales)).toBeNull();
+    expect(localizePathSegment('./docs', 'es', knownLocales)).toBeNull();
+    expect(localizePathSegment('../docs', 'es', knownLocales)).toBeNull();
+  });
+
+  it('can emit a trailing slash for empty URL-style paths', () => {
+    expect(localizePathSegment('/', 'es', knownLocales)).toBe('/es');
+    expect(
+      localizePathSegment('/', 'es', knownLocales, {
+        trailingSlashWhenEmpty: true,
+      })
+    ).toBe('/es/');
+  });
+});

--- a/packages/cli/src/utils/__tests__/localizePathSegment.test.ts
+++ b/packages/cli/src/utils/__tests__/localizePathSegment.test.ts
@@ -17,6 +17,7 @@ describe('localizePathSegment', () => {
     expect(localizePathSegment('/en/docs/api', 'es', knownLocales)).toBe(
       '/es/docs/api'
     );
+    expect(localizePathSegment('/en', 'es', knownLocales)).toBe('/es');
   });
 
   it('preserves surrounding whitespace', () => {

--- a/packages/cli/src/utils/localizeMintlifyFrontmatterUrls.ts
+++ b/packages/cli/src/utils/localizeMintlifyFrontmatterUrls.ts
@@ -6,9 +6,8 @@ import remarkFrontmatter from 'remark-frontmatter';
 import YAML, { isMap, isScalar } from 'yaml';
 import type { Content, Root, Yaml } from 'mdast';
 import { createFileMapping } from '../formats/files/fileMapping.js';
+import { localizePathSegment } from './localizePathSegment.js';
 import type { Settings } from '../types/index.js';
-
-const SKIPPABLE_URL_REGEX = /^(?:[a-z][a-z0-9+.-]*:|\/\/|#|\.\/|\.\.\/)/i;
 
 function getYamlFrontmatter(content: string): Yaml | null {
   let tree: Root;
@@ -35,38 +34,6 @@ function getYamlFrontmatter(content: string): Yaml | null {
   return yamlNode;
 }
 
-function normalizeMintlifyFrontmatterUrl(
-  url: string,
-  targetLocale: string,
-  knownLocales: Set<string>
-): string | null {
-  const trimmed = url.trim();
-  if (!trimmed || SKIPPABLE_URL_REGEX.test(trimmed)) {
-    return null;
-  }
-
-  const leadingWhitespace = url.match(/^\s*/)?.[0] ?? '';
-  const trailingWhitespace = url.match(/\s*$/)?.[0] ?? '';
-  const leadingSlash = trimmed.startsWith('/') ? '/' : '';
-  const pathBody = trimmed.replace(/^\/+/, '');
-  const [firstSegment, ...restSegments] = pathBody.split('/');
-
-  if (firstSegment === targetLocale) {
-    const normalized = `${leadingWhitespace}${leadingSlash}${pathBody}${trailingWhitespace}`;
-    return normalized === url ? null : normalized;
-  }
-
-  const unprefixedPath = knownLocales.has(firstSegment)
-    ? restSegments.join('/')
-    : pathBody;
-  const localizedPath = unprefixedPath
-    ? `${targetLocale}/${unprefixedPath}`
-    : `${targetLocale}/`;
-  const normalized = `${leadingWhitespace}${leadingSlash}${localizedPath}${trailingWhitespace}`;
-
-  return normalized === url ? null : normalized;
-}
-
 export function localizeMintlifyFrontmatterUrlForContent(
   content: string,
   targetLocale: string,
@@ -91,10 +58,11 @@ export function localizeMintlifyFrontmatterUrlForContent(
     return { content, changed: false };
   }
 
-  const localizedUrl = normalizeMintlifyFrontmatterUrl(
+  const localizedUrl = localizePathSegment(
     urlNode.value,
     targetLocale,
-    new Set(knownLocaleValues)
+    new Set(knownLocaleValues),
+    { trailingSlashWhenEmpty: true }
   );
   if (!localizedUrl) {
     return { content, changed: false };

--- a/packages/cli/src/utils/localizePathSegment.ts
+++ b/packages/cli/src/utils/localizePathSegment.ts
@@ -1,0 +1,49 @@
+const SKIPPABLE_URL_REGEX = /^(?:[a-z][a-z0-9+.-]*:|\/\/|#|\.\/|\.\.\/)/i;
+
+/**
+ * Re-prefixes a path-like value with the target locale.
+ *
+ * Leaves external/relative/anchor values untouched, preserves surrounding
+ * whitespace and any leading slash, swaps out an existing known-locale prefix,
+ * and returns `null` when no change is needed.
+ *
+ * @param value - The raw path/URL value to localize.
+ * @param targetLocale - The locale to prefix with.
+ * @param knownLocales - Locales recognized as existing prefixes to replace.
+ * @param options.trailingSlashWhenEmpty - When the localized body is empty,
+ *   emit `"<locale>/"` (URLs) instead of `"<locale>"` (directories).
+ */
+export function localizePathSegment(
+  value: string,
+  targetLocale: string,
+  knownLocales: Set<string>,
+  options?: { trailingSlashWhenEmpty?: boolean }
+): string | null {
+  const trimmed = value.trim();
+  if (!trimmed || SKIPPABLE_URL_REGEX.test(trimmed)) {
+    return null;
+  }
+
+  const leadingWhitespace = value.match(/^\s*/)?.[0] ?? '';
+  const trailingWhitespace = value.match(/\s*$/)?.[0] ?? '';
+  const leadingSlash = trimmed.startsWith('/') ? '/' : '';
+  const pathBody = trimmed.replace(/^\/+/, '');
+  const [firstSegment, ...restSegments] = pathBody.split('/');
+
+  if (firstSegment === targetLocale) {
+    const normalized = `${leadingWhitespace}${leadingSlash}${pathBody}${trailingWhitespace}`;
+    return normalized === value ? null : normalized;
+  }
+
+  const unprefixedPath = knownLocales.has(firstSegment)
+    ? restSegments.join('/')
+    : pathBody;
+  const localizedPath = unprefixedPath
+    ? `${targetLocale}/${unprefixedPath}`
+    : options?.trailingSlashWhenEmpty
+      ? `${targetLocale}/`
+      : targetLocale;
+  const normalized = `${leadingWhitespace}${leadingSlash}${localizedPath}${trailingWhitespace}`;
+
+  return normalized === value ? null : normalized;
+}

--- a/packages/cli/src/utils/processOpenApi.ts
+++ b/packages/cli/src/utils/processOpenApi.ts
@@ -7,6 +7,7 @@ import YAML, { isMap, isScalar } from 'yaml';
 import type { Root, Content, Yaml } from 'mdast';
 import { logger } from '../console/logger.js';
 import { createFileMapping } from '../formats/files/fileMapping.js';
+import { localizePathSegment } from './localizePathSegment.js';
 import { Settings } from '../types/index.js';
 
 type SpecAnalysis = {
@@ -347,30 +348,7 @@ function localizeDocsJsonDirectory(
   knownLocales: Set<string>
 ): string | null {
   if (locale === defaultLocale) return null;
-
-  const trimmed = directory.trim();
-  if (!trimmed || /^(?:[a-z][a-z0-9+.-]*:|\/\/|#|\.\/|\.\.\/)/i.test(trimmed)) {
-    return null;
-  }
-
-  const leadingWhitespace = directory.match(/^\s*/)?.[0] ?? '';
-  const trailingWhitespace = directory.match(/\s*$/)?.[0] ?? '';
-  const leadingSlash = trimmed.startsWith('/') ? '/' : '';
-  const pathBody = trimmed.replace(/^\/+/, '');
-  const [firstSegment, ...restSegments] = pathBody.split('/');
-
-  if (firstSegment === locale) {
-    const normalized = `${leadingWhitespace}${leadingSlash}${pathBody}${trailingWhitespace}`;
-    return normalized === directory ? null : normalized;
-  }
-
-  const unprefixedPath = knownLocales.has(firstSegment)
-    ? restSegments.join('/')
-    : pathBody;
-  const localizedPath = unprefixedPath ? `${locale}/${unprefixedPath}` : locale;
-  const normalized = `${leadingWhitespace}${leadingSlash}${localizedPath}${trailingWhitespace}`;
-
-  return normalized === directory ? null : normalized;
+  return localizePathSegment(directory, locale, knownLocales);
 }
 
 function localizeDocsJsonSpecPath(


### PR DESCRIPTION
## Summary
- add a shared localizePathSegment helper for locale-prefixed path values
- reuse it for Mintlify frontmatter URLs and OpenAPI docs directory localization
- add focused helper coverage for prefixing, locale replacement, skips, whitespace, and empty paths

## Checks
- pnpm --filter gt test -- localizePathSegment localizeMintlifyFrontmatterUrls processOpenApi
- pnpm --filter gt typecheck
- pnpm format
- git diff --check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts the locale path-prefixing logic that was duplicated across `localizeMintlifyFrontmatterUrls.ts` and `processOpenApi.ts` into a single shared `localizePathSegment` helper, with a focused test suite covering its key branches.

- **`localizePathSegment.ts`**: New shared helper that handles locale prefix insertion/replacement, surrounding-whitespace preservation, skippable URL detection, and an opt-in `trailingSlashWhenEmpty` flag to thread the one behavioral difference between the two callers (Mintlify URLs emit `locale/`; OpenAPI directories emit `locale`).
- **`localizeMintlifyFrontmatterUrls.ts`**: Drops the now-redundant `normalizeMintlifyFrontmatterUrl` inline function and delegates to the shared helper with `trailingSlashWhenEmpty: true`, preserving the original behavior exactly.
- **`processOpenApi.ts`**: `localizeDocsJsonDirectory` is reduced to two lines by calling the shared helper without the trailing-slash option, again matching the old behavior.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- Safe to merge — the refactoring is a pure extraction with no behavior changes for either caller.
- Both callers are correctly threaded through the new helper: Mintlify passes `trailingSlashWhenEmpty: true` to reproduce its old `locale/` output, and the OpenAPI caller omits the option to keep the old `locale` output. All old code paths map 1-to-1 to the shared function, and the test suite covers the key branches including the previously noted bare-locale edge case.
- No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/utils/localizePathSegment.ts | New shared utility that extracts the locale path-prefixing logic previously duplicated in two callers; logic is correct, edge cases handled (root path, whitespace, SKIPPABLE_URL_REGEX), `trailingSlashWhenEmpty` option cleanly threads behavior difference between callers. |
| packages/cli/src/utils/__tests__/localizePathSegment.test.ts | Test suite covers prefixing, locale replacement (including the bare `/en` → `/es` case), whitespace preservation, already-normalized returns, skippable URLs, and the trailing-slash option; no gaps found that would hide a regression. |
| packages/cli/src/utils/localizeMintlifyFrontmatterUrls.ts | Drops the now-redundant `normalizeMintlifyFrontmatterUrl` and delegates to `localizePathSegment` with `trailingSlashWhenEmpty: true`, faithfully matching the old behavior where an empty path body produced `locale/` rather than `locale`. |
| packages/cli/src/utils/processOpenApi.ts | Delegates to `localizePathSegment` without `trailingSlashWhenEmpty`, correctly matching the old `localizeDocsJsonDirectory` behavior that emitted `locale` (no trailing slash) for an empty path body. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["localizeMintlifyFrontmatterUrls\n(trailingSlashWhenEmpty: true)"] --> C
    B["processOpenApi / localizeDocsJsonDirectory\n(no trailingSlashWhenEmpty)"] --> C

    C["localizePathSegment(value, targetLocale, knownLocales, options?)"]

    C --> D{trimmed empty\nor SKIPPABLE_URL_REGEX?}
    D -- yes --> E["return null"]
    D -- no --> F{firstSegment\n=== targetLocale?}
    F -- yes --> G["rebuild with whitespace\nreturn null if unchanged"]
    F -- no --> H{knownLocales.has\nfirstSegment?}
    H -- yes --> I["unprefixedPath = restSegments.join('/')"]
    H -- no --> J["unprefixedPath = pathBody"]
    I --> K{unprefixedPath\nempty?}
    J --> K
    K -- no --> L["localizedPath = targetLocale/unprefixedPath"]
    K -- yes --> M{trailingSlashWhenEmpty?}
    M -- yes --> N["localizedPath = targetLocale/"]
    M -- no --> O["localizedPath = targetLocale"]
    L --> P["return normalized (or null if unchanged)"]
    N --> P
    O --> P
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test(cli): cover bare locale path replac..."](https://github.com/generaltranslation/gt/commit/466e5ea5f951ec3f300653fbf29c662b369f0415) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40970458)</sub>

<!-- /greptile_comment -->