### PR TITLE
refactor: share render pipeline child renderers

### DIFF
--- a/.changeset/react-core-render-pipeline-dedup.md
+++ b/.changeset/react-core-render-pipeline-dedup.md
@@ -1,0 +1,5 @@
+---
+"@generaltranslation/react-core": patch
+---
+
+Share render pipeline child renderers with prepared translation rendering.

--- a/packages/react-core/src/utils/rendering/createRenderPipeline.ts
+++ b/packages/react-core/src/utils/rendering/createRenderPipeline.ts
@@ -37,7 +37,10 @@ function createRenderPipeline(components: VariableComponents): RenderPipeline {
   const renderTranslatedChildren = createRenderTranslatedChildren({
     renderVariable,
   });
-  const renderPreparedT = createRenderPreparedT({ renderVariable });
+  const renderPreparedT = createRenderPreparedT({
+    renderDefaultChildren,
+    renderTranslatedChildren,
+  });
 
   return {
     renderVariable,

--- a/packages/react-core/src/utils/rendering/renderPreparedT.shared.ts
+++ b/packages/react-core/src/utils/rendering/renderPreparedT.shared.ts
@@ -1,13 +1,13 @@
-import { createRenderDefaultChildren } from './renderDefaultChildren.shared';
-import { createRenderTranslatedChildren } from './renderTranslatedChildren.shared';
+import type { RenderDefaultChildrenArgs } from './renderDefaultChildren.shared';
+import type { RenderTranslatedChildrenArgs } from './renderTranslatedChildren.shared';
 import type { JsxChildren } from 'generaltranslation/types';
 import type { ReactNode } from 'react';
-import type { RenderVariable, TaggedChildren } from '../types';
+import type { TaggedChildren } from '../types';
 
-// Shared rendering logic. The variable renderer is injected through a factory
-// so the RSC code path never statically imports the hook-based variable
-// components. This module must stay free of hook/context imports so it can be
-// reached from the components-rsc entrypoint.
+// Shared rendering logic. The child renderers are injected so the RSC code path
+// never statically imports the hook-based variable components, and so the
+// pipeline can build them once and share them. This module must stay free of
+// hook/context imports so it can be reached from the components-rsc entrypoint.
 
 type RenderPreparedTParams = {
   taggedSourceChildren: TaggedChildren;
@@ -19,15 +19,12 @@ type RenderPreparedTParams = {
 };
 
 function createRenderPreparedT({
-  renderVariable,
+  renderDefaultChildren,
+  renderTranslatedChildren,
 }: {
-  renderVariable: RenderVariable;
+  renderDefaultChildren: (args: RenderDefaultChildrenArgs) => ReactNode;
+  renderTranslatedChildren: (args: RenderTranslatedChildrenArgs) => ReactNode;
 }): (args: RenderPreparedTParams) => ReactNode {
-  const renderDefaultChildren = createRenderDefaultChildren({ renderVariable });
-  const renderTranslatedChildren = createRenderTranslatedChildren({
-    renderVariable,
-  });
-
   function renderPreparedT({
     taggedSourceChildren,
     targetJsxChildren,


### PR DESCRIPTION
## Summary
- pass prebuilt child renderers into createRenderPreparedT
- keep renderPreparedT shared logic free of child renderer construction
- add a patch changeset for react-core

## Checks
- pnpm --filter @generaltranslation/react-core typecheck
- pnpm --filter @generaltranslation/react-core test
- pnpm format
- git diff --check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors the render pipeline so that `createRenderPreparedT` receives already-constructed `renderDefaultChildren` and `renderTranslatedChildren` instances rather than re-creating them internally from `renderVariable`. The result is one fewer `createRenderTranslatedChildren` call per pipeline instantiation and a cleaner separation of concerns inside `renderPreparedT.shared.ts`.

- `createRenderPipeline.ts` now passes the already-built child renderers to `createRenderPreparedT`, eliminating the internal construction that previously happened inside the factory.
- `renderPreparedT.shared.ts` drops its factory imports and accepts the pre-built renderer functions directly, keeping the module free of any renderer-construction logic.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — purely structural refactor with no behavioral changes to the rendering logic.

The refactor correctly wires the shared child renderers through createRenderPipeline and the updated createRenderPreparedT signature. createRenderTranslatedChildren still constructs its own private renderDefaultChildren internally (unchanged file), so deduplication is only partial — the PR achieves its stated goal for renderPreparedT but leaves one duplicate in renderTranslatedChildren.

renderTranslatedChildren.shared.tsx still builds a private renderDefaultChildren internally; a follow-up could pass the pre-built instance in if full sharing is desired.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react-core/src/utils/rendering/createRenderPipeline.ts | Updated to pass pre-built renderDefaultChildren and renderTranslatedChildren to createRenderPreparedT instead of renderVariable; logic is straightforward and all four pipeline members are correctly wired. |
| packages/react-core/src/utils/rendering/renderPreparedT.shared.ts | Factory signature changed from { renderVariable } to { renderDefaultChildren, renderTranslatedChildren }; now type-imports the arg types rather than the constructors, and removes internal child-renderer construction — no logic changes. |
| .changeset/react-core-render-pipeline-dedup.md | Adds a patch changeset for @generaltranslation/react-core describing the deduplication of child renderer construction. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[createRenderPipeline] --> B[createRenderVariable\nrenderVariable]
    B --> C[createRenderDefaultChildren\nrenderDefaultChildren ①]
    B --> D[createRenderTranslatedChildren\nrenderTranslatedChildren]
    D --> E[createRenderDefaultChildren\nrenderDefaultChildren ② internal]
    C --> F[createRenderPreparedT\nrenderPreparedT]
    D --> F
    F --> G[RenderPipeline\n renderVariable\n renderDefaultChildren ①\n renderTranslatedChildren\n renderPreparedT]

    style E fill:#ffe0b2,stroke:#f57c00
    style C fill:#c8e6c9,stroke:#388e3c
    style F fill:#c8e6c9,stroke:#388e3c
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[createRenderPipeline] --> B[createRenderVariable\nrenderVariable]
    B --> C[createRenderDefaultChildren\nrenderDefaultChildren ①]
    B --> D[createRenderTranslatedChildren\nrenderTranslatedChildren]
    D --> E[createRenderDefaultChildren\nrenderDefaultChildren ② internal]
    C --> F[createRenderPreparedT\nrenderPreparedT]
    D --> F
    F --> G[RenderPipeline\n renderVariable\n renderDefaultChildren ①\n renderTranslatedChildren\n renderPreparedT]

    style E fill:#ffe0b2,stroke:#f57c00
    style C fill:#c8e6c9,stroke:#388e3c
    style F fill:#c8e6c9,stroke:#388e3c
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: share render pipeline child re..."](https://github.com/generaltranslation/gt/commit/142f62697b7dd043acd31a75553c14cef1a5187a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40971275)</sub>

<!-- /greptile_comment -->