### PR TITLE
fix: preserve getgt preload format

### DIFF
--- a/.changeset/getgt-preload-format.md
+++ b/.changeset/getgt-preload-format.md
@@ -1,0 +1,5 @@
+---
+"@generaltranslation/compiler": patch
+---
+
+Preserve `$format` in compiler-injected `getGT` and `useGT` preload metadata so preloaded runtime lookups use the same hash format as the original translation call.

--- a/packages/compiler/src/passes/__tests__/runtimeTranslatePass.test.ts
+++ b/packages/compiler/src/passes/__tests__/runtimeTranslatePass.test.ts
@@ -853,7 +853,7 @@ describe('runtimeTranslatePass', () => {
         import { getGT } from 'gt-next/server';
         async function Page() {
           const gt = await getGT();
-          return gt("Hello", { $context: "nav", $id: "greet", $maxChars: 50 });
+          return gt("Hello", { $context: "nav", $id: "greet", $maxChars: 50, $format: "STRING" });
         }
       `,
         {
@@ -875,8 +875,9 @@ describe('runtimeTranslatePass', () => {
       expect(getObjectPropertyValue(message!, '$context')).toBe('nav');
       expect(getObjectPropertyValue(message!, '$id')).toBe('greet');
       expect(getObjectPropertyValue(message!, '$maxChars')).toBe(50);
+      expect(getObjectPropertyValue(message!, '$format')).toBe('STRING');
       expect(getObjectPropertyNames(message!)).not.toEqual(
-        expect.arrayContaining(['hash', 'context', 'id', 'maxChars'])
+        expect.arrayContaining(['hash', 'context', 'id', 'maxChars', 'format'])
       );
     });
 

--- a/packages/compiler/src/transform/injection/injectCallbackDeclaratorFunctionParameters.ts
+++ b/packages/compiler/src/transform/injection/injectCallbackDeclaratorFunctionParameters.ts
@@ -10,7 +10,7 @@ import { createErrorLocation } from '../../utils/errors';
 
 /**
  * inject parameters into invocation of translation function
- * - useGT(messages=[{$_hash, message, $id, $context, $maxChars}])
+ * - useGT(messages=[{$_hash, message, $id, $context, $maxChars, $format}])
  */
 export function injectCallbackDeclaratorFunctionParameters(
   varDeclarator: t.VariableDeclarator,
@@ -150,6 +150,14 @@ function injectUseGTParameters(
                 t.objectProperty(
                   t.identifier('$maxChars'),
                   t.numericLiteral(content.maxChars)
+                ),
+              ]
+            : []),
+          ...(content.format
+            ? [
+                t.objectProperty(
+                  t.identifier('$format'),
+                  t.stringLiteral(content.format)
                 ),
               ]
             : []),


### PR DESCRIPTION
## Summary
- Preserve compiler-collected format metadata on useGT/getGT preload entries.
- Add a regression test for await getGT() with $format: STRING.

## Testing
- pnpm --filter @generaltranslation/compiler test
- pnpm --filter @generaltranslation/compiler typecheck
- pnpm --filter @generaltranslation/compiler format

No changeset added per request.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where the `format` field was not being included in the preload metadata injected into `getGT`/`useGT` call expressions during the compiler's injection pass. It also adds a regression test and refactors shared test helper logic.

- **`injectCallbackDeclaratorFunctionParameters.ts`**: Adds a `format` property to the `objectExpression` built for each `translationContent` entry, matching the same conditional-spread pattern already used for `id`, `context`, and `maxChars`.
- **`runtimeTranslatePass.test.ts`**: Extracts a reusable `getObjectPropertyValue` helper, adds a `getPreloadMessageValue` helper for asserting into the preload array structure, and adds a dedicated test case verifying `format` is forwarded through the pipeline.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a minimal, well-tested addition of a missing field to the preload metadata injection.

The production change exactly mirrors the established pattern for other optional fields and the new test exercises the full compiler pipeline end-to-end. No existing behaviour is altered; only the previously dropped `format` field is now forwarded.

No files require special attention. The single style note in the test helper does not affect correctness.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/compiler/src/transform/injection/injectCallbackDeclaratorFunctionParameters.ts | Adds `format` property injection into the preload metadata object; follows the identical conditional-spread pattern used for other optional fields (`id`, `context`, `maxChars`) — correct and minimal. |
| packages/compiler/src/passes/__tests__/runtimeTranslatePass.test.ts | Adds test coverage for the format field in getGT preload metadata; uses `expect()` assertions inside a utility helper, which can produce harder-to-diagnose failure messages when assertions fail mid-helper. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Source as Source File
    participant Collection as collectionPass
    participant State as TransformState stringCollector
    participant Injection as injectionPass
    participant AST as Final AST getGT

    Source->>Collection: traverse AST
    Collection->>State: "store content {hash, message, format, ...}"
    Source->>Injection: traverse AST (varDeclarator for getGT)
    Injection->>State: getTranslationContent(id)
    State-->>Injection: "[{hash, message, format, ...}]"
    Injection->>AST: inject arguments as array of objects (now includes format field)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Source as Source File
    participant Collection as collectionPass
    participant State as TransformState stringCollector
    participant Injection as injectionPass
    participant AST as Final AST getGT

    Source->>Collection: traverse AST
    Collection->>State: "store content {hash, message, format, ...}"
    Source->>Injection: traverse AST (varDeclarator for getGT)
    Injection->>State: getTranslationContent(id)
    State-->>Injection: "[{hash, message, format, ...}]"
    Injection->>AST: inject arguments as array of objects (now includes format field)
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fcompiler%2Fsrc%2Fpasses%2F__tests__%2FruntimeTranslatePass.test.ts%3A160-169%0AUsing%20%60expect%28%29%60%20inside%20a%20non-test%20utility%20function%20can%20produce%20confusing%20failure%20output%20%E2%80%94%20when%20the%20assertion%20throws%2C%20Jest%2FVitest%20reports%20the%20failure%20site%20as%20being%20inside%20%60getPreloadMessageValue%60%2C%20making%20it%20hard%20to%20tell%20which%20test%20case%20failed%20or%20what%20the%20actual%20received%20value%20was.%20Prefer%20returning%20%60undefined%60%20on%20unexpected%20shapes%20and%20letting%20the%20call-site%20assertions%20fail%20with%20clear%20context.%0A%0A%60%60%60suggestion%0Afunction%20getPreloadMessageValue%28%0A%20%20call%3A%20t.CallExpression%2C%0A%20%20key%3A%20string%0A%29%3A%20string%20%7C%20number%20%7C%20undefined%20%7B%0A%20%20const%20arg%20%3D%20call.arguments%5B0%5D%3B%0A%20%20if%20%28!t.isArrayExpression%28arg%29%29%20return%20undefined%3B%0A%20%20const%20message%20%3D%20%28arg%20as%20t.ArrayExpression%29.elements%5B0%5D%3B%0A%20%20if%20%28!t.isObjectExpression%28message%29%29%20return%20undefined%3B%0A%20%20return%20getObjectPropertyValue%28message%20as%20t.ObjectExpression%2C%20key%29%3B%0A%7D%0A%60%60%60%0A%0A&repo=generaltranslation%2Fgt&pr=1743&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fodysseus%2Fgetgt-preload-format%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fodysseus%2Fgetgt-preload-format%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fcompiler%2Fsrc%2Fpasses%2F__tests__%2FruntimeTranslatePass.test.ts%3A160-169%0AUsing%20%60expect%28%29%60%20inside%20a%20non-test%20utility%20function%20can%20produce%20confusing%20failure%20output%20%E2%80%94%20when%20the%20assertion%20throws%2C%20Jest%2FVitest%20reports%20the%20failure%20site%20as%20being%20inside%20%60getPreloadMessageValue%60%2C%20making%20it%20hard%20to%20tell%20which%20test%20case%20failed%20or%20what%20the%20actual%20received%20value%20was.%20Prefer%20returning%20%60undefined%60%20on%20unexpected%20shapes%20and%20letting%20the%20call-site%20assertions%20fail%20with%20clear%20context.%0A%0A%60%60%60suggestion%0Afunction%20getPreloadMessageValue%28%0A%20%20call%3A%20t.CallExpression%2C%0A%20%20key%3A%20string%0A%29%3A%20string%20%7C%20number%20%7C%20undefined%20%7B%0A%20%20const%20arg%20%3D%20call.arguments%5B0%5D%3B%0A%20%20if%20%28!t.isArrayExpression%28arg%29%29%20return%20undefined%3B%0A%20%20const%20message%20%3D%20%28arg%20as%20t.ArrayExpression%29.elements%5B0%5D%3B%0A%20%20if%20%28!t.isObjectExpression%28message%29%29%20return%20undefined%3B%0A%20%20return%20getObjectPropertyValue%28message%20as%20t.ObjectExpression%2C%20key%29%3B%0A%7D%0A%60%60%60%0A%0A&repo=generaltranslation%2Fgt&pr=1743&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=4"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=4"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/compiler/src/passes/__tests__/runtimeTranslatePass.test.ts:160-169
Using `expect()` inside a non-test utility function can produce confusing failure output — when the assertion throws, Jest/Vitest reports the failure site as being inside `getPreloadMessageValue`, making it hard to tell which test case failed or what the actual received value was. Prefer returning `undefined` on unexpected shapes and letting the call-site assertions fail with clear context.

```suggestion
function getPreloadMessageValue(
  call: t.CallExpression,
  key: string
): string | number | undefined {
  const arg = call.arguments[0];
  if (!t.isArrayExpression(arg)) return undefined;
  const message = (arg as t.ArrayExpression).elements[0];
  if (!t.isObjectExpression(message)) return undefined;
  return getObjectPropertyValue(message as t.ObjectExpression, key);
}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: preserve getgt preload format"](https://github.com/generaltranslation/gt/commit/1b510b4c00e2cfa6c84af5378b20f96f04939895) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41002805)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->