### PR TITLE
fix: respect disabled i18n in t

### DIFF
--- a/packages/i18n/src/translation-functions/__tests__/t.test.ts
+++ b/packages/i18n/src/translation-functions/__tests__/t.test.ts
@@ -36,7 +36,10 @@ describe('t', () => {
   afterEach(resetGTGlobals);
 
   it('works without an explicit locale', () => {
-    setWritableConditionStore({ getLocale: () => 'en' });
+    setWritableConditionStore({
+      getLocale: () => 'en',
+      getEnableI18n: () => true,
+    });
     setI18nCache(
       createCache(
         { defaultLocale: 'en', locales: ['en', 'fr'] },
@@ -60,7 +63,10 @@ describe('t', () => {
         }),
       }
     );
-    const conditionStore = { getLocale: () => 'fr' };
+    const conditionStore = {
+      getLocale: () => 'fr',
+      getEnableI18n: () => true,
+    };
 
     setI18nCache(cache);
     setWritableConditionStore(conditionStore);
@@ -82,7 +88,10 @@ describe('t', () => {
     );
 
     setI18nCache(cache);
-    setWritableConditionStore({ getLocale: () => 'fr' });
+    setWritableConditionStore({
+      getLocale: () => 'fr',
+      getEnableI18n: () => true,
+    });
     await cache.loadTranslations('es');
 
     expect(t(message, { $locale: 'es', name: 'Alice' })).toBe('Hola Alice!');
@@ -101,7 +110,10 @@ describe('t', () => {
     );
 
     setI18nCache(cache);
-    setWritableConditionStore({ getLocale: () => 'fr' });
+    setWritableConditionStore({
+      getLocale: () => 'fr',
+      getEnableI18n: () => true,
+    });
     await cache.loadTranslations('fr');
 
     expect(t`Hello ${name}!`).toBe('Bonjour Alice !');
@@ -120,7 +132,10 @@ describe('t', () => {
     );
 
     setI18nCache(cache);
-    setWritableConditionStore({ getLocale: () => 'fr' });
+    setWritableConditionStore({
+      getLocale: () => 'fr',
+      getEnableI18n: () => true,
+    });
     await cache.loadTranslations('fr');
 
     expect(t`Hello ${name}!`).toBe('Bonjour Alice !');
@@ -142,6 +157,7 @@ describe('t', () => {
       getLocale: () => {
         throw new Error('current locale should not be read');
       },
+      getEnableI18n: () => true,
     });
     await cache.loadTranslations('fr');
 
@@ -150,8 +166,32 @@ describe('t', () => {
     );
   });
 
+  it('returns the source when i18n is disabled', async () => {
+    const message = 'Hello {name}!';
+    const cache = createCache(
+      { defaultLocale: 'en', locales: ['en', 'fr'] },
+      {
+        loadTranslations: vi.fn().mockResolvedValue({
+          [hashMessage(message, { $format: 'ICU' })]: 'Bonjour {name} !',
+        }),
+      }
+    );
+
+    setI18nCache(cache);
+    setWritableConditionStore({
+      getLocale: () => 'fr',
+      getEnableI18n: () => false,
+    });
+    await cache.loadTranslations('fr');
+
+    expect(t(message, { name: 'Alice' })).toBe('Hello Alice!');
+  });
+
   it('keeps the configured condition store when the singleton cache is replaced', () => {
-    setWritableConditionStore({ getLocale: () => 'fr' });
+    setWritableConditionStore({
+      getLocale: () => 'fr',
+      getEnableI18n: () => true,
+    });
 
     setI18nCache(
       createCache(

--- a/packages/i18n/src/translation-functions/t.ts
+++ b/packages/i18n/src/translation-functions/t.ts
@@ -3,7 +3,8 @@ import {
   resolveStringContentWithFallback,
 } from './internal/helpers';
 import { GTTranslationOptions } from './types/options';
-import { getLocale } from '../helpers/locale';
+import { getDefaultLocale } from '../helpers/locale';
+import { getWritableConditionStore } from '../condition-store/singleton-operations';
 
 /**
  * Translate a message
@@ -17,7 +18,10 @@ export const t: StringOrTemplateSyncResolutionFunction = (
 ) => {
   if (typeof messageOrStrings === 'string') {
     const options = values.at(0) as GTTranslationOptions | undefined;
-    const locale = options?.$locale ?? getLocale();
+    const conditionStore = getWritableConditionStore();
+    const locale = conditionStore.getEnableI18n()
+      ? (options?.$locale ?? conditionStore.getLocale())
+      : getDefaultLocale();
     return resolveStringContentWithFallback(locale, messageOrStrings, {
       $format: 'ICU',
       ...options,
@@ -31,7 +35,10 @@ function handleTaggedTemplateLiteralTranslation(
   messageOrStrings: TemplateStringsArray,
   values: unknown[]
 ): string {
-  const locale = getLocale();
+  const conditionStore = getWritableConditionStore();
+  const locale = conditionStore.getEnableI18n()
+    ? conditionStore.getLocale()
+    : getDefaultLocale();
   const interpolatedTemplate = messageOrStrings
     .map((string, index) => string + (values[index] ?? ''))
     .join('');


### PR DESCRIPTION
## Summary\n- make sync `t()` honor the writable condition store's `enableI18n` flag\n- return source/default-locale output when i18n is disabled\n- update `t` tests for the condition-store shape and disabled behavior\n\n## Checks\n- `pnpm --filter gt-i18n typecheck`\n- `pnpm --filter gt-i18n test -- --runInBand`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the synchronous `t()` function to honour the `enableI18n` flag from the writable condition store, mirroring the guard already present in async helpers like `getTranslations`, `getMessages`, and `getGT`. When i18n is disabled both the string-overload and tagged-template-literal code paths now fall back to `getDefaultLocale()`, returning source-language output instead of a translation.

- **`t.ts`**: The condition store is now fetched once per call; `getEnableI18n()` gates locale resolution in both `t()` and `handleTaggedTemplateLiteralTranslation()`, and the now-unused `getLocale` import is replaced with `getDefaultLocale`.
- **`t.test.ts`**: All existing mocks are updated to include `getEnableI18n`, and a new test asserts that source output is returned when i18n is disabled — though only for the string overload; the tagged-template-literal disabled branch has no dedicated test.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the core logic change is straightforward and consistent with how other translation helpers already handle the enableI18n flag.

Both code paths in t.ts are correctly guarded, and the implementation matches the existing pattern in the async helpers. The only gap is a missing test for the tagged-template-literal branch when i18n is disabled — the feature works, but a future regression there would go undetected by the suite.

t.test.ts — the tagged-template-literal disabled-i18n scenario has no test coverage.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/i18n/src/translation-functions/t.ts | Adds enableI18n guard to both the string and tagged-template-literal code paths; drops unused getLocale import and reads the condition store once per call. |
| packages/i18n/src/translation-functions/__tests__/t.test.ts | Updates all existing mocks to include getEnableI18n and adds a new test for the disabled-i18n string branch; the tagged-template-literal disabled case is untested. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[t called] --> B{string or template?}
    B -->|string| C[get conditionStore]
    B -->|template| D[get conditionStore]
    C --> E{enableI18n?}
    E -->|true| G[use explicit locale or conditionStore locale]
    E -->|false| H[use defaultLocale]
    D --> F{enableI18n?}
    F -->|true| I[use conditionStore locale]
    F -->|false| J[use defaultLocale]
    G --> K[resolveStringContentWithFallback]
    H --> K
    I --> L[resolveStringContent with fallback]
    J --> L
    K --> M[return string]
    L --> M
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[t called] --> B{string or template?}
    B -->|string| C[get conditionStore]
    B -->|template| D[get conditionStore]
    C --> E{enableI18n?}
    E -->|true| G[use explicit locale or conditionStore locale]
    E -->|false| H[use defaultLocale]
    D --> F{enableI18n?}
    F -->|true| I[use conditionStore locale]
    F -->|false| J[use defaultLocale]
    G --> K[resolveStringContentWithFallback]
    H --> K
    I --> L[resolveStringContent with fallback]
    J --> L
    K --> M[return string]
    L --> M
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fi18n%2Fsrc%2Ftranslation-functions%2F__tests__%2Ft.test.ts%3A164-183%0A**Missing%20disabled-i18n%20test%20for%20the%20tagged-template%20branch**%0A%0AThe%20new%20%60'returns%20the%20source%20when%20i18n%20is%20disabled'%60%20test%20only%20exercises%20the%20string%20overload%20%28%60t%28message%2C%20options%29%60%29.%20%60handleTaggedTemplateLiteralTranslation%60%20received%20the%20same%20%60getEnableI18n%28%29%60%20gate%2C%20but%20there%20is%20no%20corresponding%20test%20that%20calls%20%60%60%20t%60Hello%20%24%7Bname%7D!%60%20%60%60%20with%20%60getEnableI18n%3A%20%28%29%20%3D%3E%20false%60.%20If%20a%20regression%20is%20introduced%20in%20that%20branch%2C%20the%20suite%20will%20not%20catch%20it.%0A%0A&repo=generaltranslation%2Fgt&pr=1744&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22bg%2Fenable-i18n-t-disabled%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22bg%2Fenable-i18n-t-disabled%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fi18n%2Fsrc%2Ftranslation-functions%2F__tests__%2Ft.test.ts%3A164-183%0A**Missing%20disabled-i18n%20test%20for%20the%20tagged-template%20branch**%0A%0AThe%20new%20%60'returns%20the%20source%20when%20i18n%20is%20disabled'%60%20test%20only%20exercises%20the%20string%20overload%20%28%60t%28message%2C%20options%29%60%29.%20%60handleTaggedTemplateLiteralTranslation%60%20received%20the%20same%20%60getEnableI18n%28%29%60%20gate%2C%20but%20there%20is%20no%20corresponding%20test%20that%20calls%20%60%60%20t%60Hello%20%24%7Bname%7D!%60%20%60%60%20with%20%60getEnableI18n%3A%20%28%29%20%3D%3E%20false%60.%20If%20a%20regression%20is%20introduced%20in%20that%20branch%2C%20the%20suite%20will%20not%20catch%20it.%0A%0A&repo=generaltranslation%2Fgt&pr=1744&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=4"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=4"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/i18n/src/translation-functions/__tests__/t.test.ts:164-183
**Missing disabled-i18n test for the tagged-template branch**

The new `'returns the source when i18n is disabled'` test only exercises the string overload (`t(message, options)`). `handleTaggedTemplateLiteralTranslation` received the same `getEnableI18n()` gate, but there is no corresponding test that calls `` t`Hello ${name}!` `` with `getEnableI18n: () => false`. If a regression is introduced in that branch, the suite will not catch it.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: respect disabled i18n in t"](https://github.com/generaltranslation/gt/commit/8c7482618fb024a262d03eadf5a4ea6d439d49e6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41005495)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->