### PR TITLE
fix: align react-core locale lookups

### DIFF
--- a/packages/react-core/src/functions/translation/__tests__/t.test.ts
+++ b/packages/react-core/src/functions/translation/__tests__/t.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { initializeI18nConfig } from '../../../setup/i18nConfig';
+import { setReactI18nCache } from '../../../i18n-cache/singleton-operations';
+import { setReadonlyConditionStore } from '../../../condition-store/singleton-operations';
+import type { ReactI18nCache } from '../../../i18n-cache/ReactI18nCache';
+import type { ReadonlyConditionStoreInterface } from 'gt-i18n/internal/types';
+import { t } from '../t';
+
+const lookupTranslation = vi.fn();
+
+function setup() {
+  initializeI18nConfig(
+    {
+      defaultLocale: 'en',
+      locales: ['en', 'fr'],
+    },
+    'SPA'
+  );
+  setReactI18nCache({
+    lookupTranslation,
+  } as unknown as ReactI18nCache);
+  setReadonlyConditionStore({
+    getLocale: () => 'fr',
+    getEnableI18n: () => true,
+  } as unknown as ReadonlyConditionStoreInterface);
+}
+
+describe('t (tagged template)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setup();
+  });
+
+  // Regression: the interpolated "derived message" lookup must use the ICU
+  // data format so its hash matches the ICU-registered entry (compiler + the
+  // gt-i18n sibling both register these as ICU). Using 'STRING' silently
+  // misses and falls through to the less-specific uninterpolated message.
+  it('looks up the interpolated derived message with the ICU format', () => {
+    const name = 'Alice';
+    lookupTranslation.mockReturnValue('Bonjour Alice !');
+
+    expect(t`Hello ${name}!`).toBe('Bonjour Alice !');
+    expect(lookupTranslation).toHaveBeenCalledWith('fr', 'Hello Alice!', {
+      $format: 'ICU',
+    });
+  });
+});

--- a/packages/react-core/src/functions/translation/t.ts
+++ b/packages/react-core/src/functions/translation/t.ts
@@ -105,7 +105,7 @@ function handleTaggedTemplateLiteralTranslation(
   const translatedInterpolatedTemplate = i18nCache.lookupTranslation(
     locale,
     interpolatedTemplate,
-    { $format: 'STRING' }
+    { $format: 'ICU' }
   );
   if (translatedInterpolatedTemplate) return translatedInterpolatedTemplate;
 

--- a/packages/react-core/src/hooks/useInternalLocaleSelector.ts
+++ b/packages/react-core/src/hooks/useInternalLocaleSelector.ts
@@ -37,8 +37,8 @@ export function useInternalLocaleSelector(
 
   // create getLocaleProperties callback
   const getLocalePropertiesCallback = useCallback(
-    (locale: string) => {
-      return getLocaleProperties(locale, locale, customMapping);
+    (targetLocale: string) => {
+      return getLocaleProperties(targetLocale, locale, customMapping);
     },
     [locale, customMapping]
   );


### PR DESCRIPTION
## Summary\n- use ICU lookup options for React-core tagged-template derived messages\n- add a regression test for the tagged-template lookup format\n- localize locale selector properties relative to the current locale\n\n## Checks\n- `pnpm --filter @generaltranslation/react-core typecheck`\n- `pnpm --filter @generaltranslation/react-core test`\n- `pnpm lint`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two locale lookup bugs in `@generaltranslation/react-core` and adds a regression test for one of them.

- **`t.ts`**: Corrects the format key passed to `lookupTranslation` in the tagged-template path from `'STRING'` to `'ICU'`, aligning it with the format registered by the compiler plugin and `gt-i18n`, so interpolated derived-message lookups no longer silently miss.
- **`useInternalLocaleSelector.ts`**: Fixes `getLocalePropertiesCallback` which was passing the current locale as the first (target) argument, causing it to always return the current locale's own properties instead of the requested locale's properties.
- **`t.test.ts`**: Adds a regression test that pins the exact `lookupTranslation` call shape produced by the tagged-template path.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Both fixes are narrow, targeted corrections to existing bugs with no new surface area introduced.

The tagged-template format change is a one-liner that directly matches what the compiler and gt-i18n already register, and the new test pins the exact call shape to guard against regression. The locale-selector callback fix is equally minimal — it restores the intended argument order that the surrounding sortedLocales memo already had correct. No logic branches are added, no APIs are changed, and the PR description confirms the relevant typecheck and test commands pass.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react-core/src/functions/translation/t.ts | Single-line fix: changes lookup format from 'STRING' to 'ICU' in handleTaggedTemplateLiteralTranslation, matching how the compiler and gt-i18n register these entries. |
| packages/react-core/src/hooks/useInternalLocaleSelector.ts | Bug fix: getLocalePropertiesCallback now correctly passes targetLocale as the first arg and locale (the display locale) as the second, consistent with how sortedLocales already used getLocaleProperties. |
| packages/react-core/src/functions/translation/__tests__/t.test.ts | New regression test pinning the ICU lookup shape for tagged-template literals; setup/teardown pattern is consistent with vitest expectations. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["t`Hello ${name}!`"] --> B[handleTaggedTemplateLiteralTranslation]
    B --> C[interpolateTemplateLiteral\n→ 'Hello Alice!']
    C --> D["lookupTranslation(locale, 'Hello Alice!', { $format: 'ICU' })\n✅ was STRING, now ICU"]
    D -->|hit| E[Return translated string]
    D -->|miss| F[extractInterpolatableValues\n→ message + variables]
    F --> G[resolveStringContent\nwith ICU lookup options]
    G --> E

    H[useInternalLocaleSelector] --> I[getLocalePropertiesCallback]
    I --> J["getLocaleProperties(targetLocale, locale, customMapping)\n✅ was locale, locale — now targetLocale, locale"]
    J --> K[Returns properties of targetLocale\ndisplayed in current locale]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["t`Hello ${name}!`"] --> B[handleTaggedTemplateLiteralTranslation]
    B --> C[interpolateTemplateLiteral\n→ 'Hello Alice!']
    C --> D["lookupTranslation(locale, 'Hello Alice!', { $format: 'ICU' })\n✅ was STRING, now ICU"]
    D -->|hit| E[Return translated string]
    D -->|miss| F[extractInterpolatableValues\n→ message + variables]
    F --> G[resolveStringContent\nwith ICU lookup options]
    G --> E

    H[useInternalLocaleSelector] --> I[getLocalePropertiesCallback]
    I --> J["getLocaleProperties(targetLocale, locale, customMapping)\n✅ was locale, locale — now targetLocale, locale"]
    J --> K[Returns properties of targetLocale\ndisplayed in current locale]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: align react-core locale lookups"](https://github.com/generaltranslation/gt/commit/e3ae46a8a617bca8377bf9f67fbb3f83c51a6190) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41007932)</sub>

<!-- /greptile_comment -->