### PR TITLE
refactor: reuse next private config for rsc init

### DIFF
--- a/packages/next/src/setup/__tests__/initGT.rsc.test.ts
+++ b/packages/next/src/setup/__tests__/initGT.rsc.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AsyncConditionStoreParams } from '../../condition-store/AsyncConditionStore';
+import { initializeGT } from '../initGT.rsc';
+
+const mocks = vi.hoisted(() => ({
+  coreInitializeGT: vi.fn(),
+  setAsyncConditionStore: vi.fn(),
+  conditionStoreParams: [] as AsyncConditionStoreParams[],
+}));
+
+vi.mock('../initGT', () => ({
+  initializeGT: mocks.coreInitializeGT,
+}));
+
+vi.mock('../../condition-store/AsyncConditionStore', () => ({
+  AsyncConditionStore: class MockAsyncConditionStore {
+    constructor(params: AsyncConditionStoreParams) {
+      mocks.conditionStoreParams.push(params);
+    }
+  },
+  setAsyncConditionStore: mocks.setAsyncConditionStore,
+}));
+
+function createParams() {
+  return {
+    i18nConfigParams: {
+      defaultLocale: 'en',
+      locales: ['en', 'fr'],
+    },
+    nextI18nCacheParams: {
+      defaultLocale: 'en',
+      locales: ['en', 'fr'],
+    },
+    privateConfig: {
+      headersAndCookies: {
+        localeHeaderName: 'x-gt-locale',
+        localeCookieName: 'gt-locale',
+      },
+      ignoreBrowserLocales: true,
+    },
+  };
+}
+
+describe('initializeGT RSC', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mocks.conditionStoreParams.length = 0;
+    Reflect.deleteProperty(
+      process.env,
+      '_GENERALTRANSLATION_CUSTOM_GET_LOCALE_ENABLED'
+    );
+    Reflect.deleteProperty(
+      process.env,
+      '_GENERALTRANSLATION_CUSTOM_GET_REGION_ENABLED'
+    );
+  });
+
+  it('threads private config into the async condition store', () => {
+    const params = createParams();
+
+    initializeGT(params);
+
+    expect(mocks.coreInitializeGT).toHaveBeenCalledWith({
+      i18nConfigParams: params.i18nConfigParams,
+      nextI18nCacheParams: params.nextI18nCacheParams,
+    });
+    expect(mocks.conditionStoreParams).toEqual([
+      {
+        headerName: 'x-gt-locale',
+        cookieName: 'gt-locale',
+        ignorePreferredLanguages: true,
+        getLocale: undefined,
+        getRegion: undefined,
+      },
+    ]);
+    expect(mocks.setAsyncConditionStore).toHaveBeenCalledTimes(1);
+  });
+
+  it('wires configured custom locale and region getters', () => {
+    process.env._GENERALTRANSLATION_CUSTOM_GET_LOCALE_ENABLED = 'true';
+    process.env._GENERALTRANSLATION_CUSTOM_GET_REGION_ENABLED = 'true';
+
+    initializeGT(createParams());
+
+    const [conditionStoreParams] = mocks.conditionStoreParams;
+    expect(conditionStoreParams.getLocale).toEqual(expect.any(Function));
+    expect(conditionStoreParams.getRegion).toEqual(expect.any(Function));
+  });
+});

--- a/packages/next/src/setup/__tests__/shared.test.ts
+++ b/packages/next/src/setup/__tests__/shared.test.ts
@@ -44,7 +44,8 @@ describe('getParams', () => {
     process.env.GT_API_KEY = 'api-key';
     process.env.GT_DEV_API_KEY = 'dev-key';
 
-    const { i18nConfigParams, nextI18nCacheParams } = getParams();
+    const { i18nConfigParams, nextI18nCacheParams, privateConfig } =
+      getParams();
 
     expect(i18nConfigParams).toMatchObject({
       projectId: 'project-id',
@@ -57,6 +58,11 @@ describe('getParams', () => {
       apiKey: 'api-key',
       devApiKey: 'dev-key',
       cacheExpiryTime: 12345,
+    });
+    expect(privateConfig).toMatchObject({
+      cacheUrl: 'https://cache.example.com',
+      cacheExpiryTime: 12345,
+      _versionId: 'version-id',
     });
   });
 

--- a/packages/next/src/setup/initGT.rsc.ts
+++ b/packages/next/src/setup/initGT.rsc.ts
@@ -1,5 +1,8 @@
 import { getParams } from './shared';
-import type { NextSetupI18nConfigParams } from './shared';
+import type {
+  NextSetupI18nConfigParams,
+  PrivateI18nConfigParams,
+} from './shared';
 import type { NextI18nCacheParams } from '../i18n-cache/NextI18nCache';
 import { initializeGT as coreInitializeGT } from './initGT';
 import {
@@ -19,9 +22,11 @@ export function initializeGT(
   {
     i18nConfigParams,
     nextI18nCacheParams,
+    privateConfig,
   }: {
     i18nConfigParams: NextSetupI18nConfigParams;
     nextI18nCacheParams: NextI18nCacheParams;
+    privateConfig: PrivateI18nConfigParams;
   } = getParams()
 ): void {
   coreInitializeGT({
@@ -29,7 +34,7 @@ export function initializeGT(
     nextI18nCacheParams,
   });
 
-  const asyncConditionStoreParams = getAsyncConditionStoreParams();
+  const asyncConditionStoreParams = getAsyncConditionStoreParams(privateConfig);
 
   // Note that this gets used by RSC, but SSR (aka 'use client' bondary on server)
   // uses context to access this condition store
@@ -37,58 +42,52 @@ export function initializeGT(
   setAsyncConditionStore(conditionStore);
 }
 
-function getAsyncConditionStoreParams(): AsyncConditionStoreParams {
-  // TODO: we are parsing this twice, address in separate PR
-  const privateConfig = JSON.parse(
-    process.env._GENERALTRANSLATION_I18N_CONFIG_PARAMS || '{}'
-  );
+function getAsyncConditionStoreParams(
+  privateConfig: PrivateI18nConfigParams
+): AsyncConditionStoreParams {
   return {
     headerName: privateConfig.headersAndCookies?.localeHeaderName,
     cookieName: privateConfig.headersAndCookies?.localeCookieName,
     ignorePreferredLanguages: privateConfig.ignoreBrowserLocales,
-    getLocale: resolveGetLocale(),
-    getRegion: resolveGetRegion(),
+    getLocale: resolveCustomGetter<string>(
+      process.env._GENERALTRANSLATION_CUSTOM_GET_LOCALE_ENABLED === 'true',
+      // Keep require paths static string literals so the bundler can resolve them.
+      () => require('gt-next/internal/_getLocale'),
+      'getLocale',
+      customGetLocaleUnresolvedWarning
+    ),
+    getRegion: resolveCustomGetter<string | undefined>(
+      process.env._GENERALTRANSLATION_CUSTOM_GET_REGION_ENABLED === 'true',
+      () => require('gt-next/internal/_getRegion'),
+      'getRegion',
+      customGetRegionUnresolvedWarning
+    ),
   };
 }
 
-function resolveGetLocale(): (() => Promise<string>) | undefined {
-  const isCustomGetLocaleEnabled =
-    process.env._GENERALTRANSLATION_CUSTOM_GET_LOCALE_ENABLED === 'true';
-  if (!isCustomGetLocaleEnabled) return undefined;
-  const module: unknown = require('gt-next/internal/_getLocale');
+/**
+ * Resolve a user-provided custom getter (getLocale / getRegion) from its module,
+ * accepting either a bare function export, a default export, or a named export.
+ */
+function resolveCustomGetter<T>(
+  isEnabled: boolean,
+  loadModule: () => unknown,
+  memberName: string,
+  unresolvedWarning: string
+): (() => Promise<T>) | undefined {
+  if (!isEnabled) return undefined;
+  const module = loadModule();
 
   if (typeof module === 'function') {
-    return module as () => Promise<string>;
+    return module as () => Promise<T>;
   } else if (typeof module === 'object' && module !== null) {
     if ('default' in module && typeof module.default === 'function') {
-      return module.default as () => Promise<string>;
-    } else if (
-      'getLocale' in module &&
-      typeof module.getLocale === 'function'
-    ) {
-      return module.getLocale as () => Promise<string>;
+      return module.default as () => Promise<T>;
+    }
+    const namedExport = (module as Record<string, unknown>)[memberName];
+    if (typeof namedExport === 'function') {
+      return namedExport as () => Promise<T>;
     }
   }
-  console.warn(customGetLocaleUnresolvedWarning);
-}
-
-function resolveGetRegion(): (() => Promise<string | undefined>) | undefined {
-  const isCustomGetRegionEnabled =
-    process.env._GENERALTRANSLATION_CUSTOM_GET_REGION_ENABLED === 'true';
-  if (!isCustomGetRegionEnabled) return undefined;
-  const module: unknown = require('gt-next/internal/_getRegion');
-
-  if (typeof module === 'function') {
-    return module as () => Promise<string | undefined>;
-  } else if (typeof module === 'object' && module !== null) {
-    if ('default' in module && typeof module.default === 'function') {
-      return module.default as () => Promise<string | undefined>;
-    } else if (
-      'getRegion' in module &&
-      typeof module.getRegion === 'function'
-    ) {
-      return module.getRegion as () => Promise<string | undefined>;
-    }
-  }
-  console.warn(customGetRegionUnresolvedWarning);
+  console.warn(unresolvedWarning);
 }

--- a/packages/next/src/setup/shared.ts
+++ b/packages/next/src/setup/shared.ts
@@ -8,16 +8,38 @@ export type NextSetupI18nConfigParams = I18nConfigParams & {
   _disableDevHotReload?: boolean;
 };
 
+/**
+ * Shape of the private build-time config serialized into
+ * `_GENERALTRANSLATION_I18N_CONFIG_PARAMS`. Only the fields consumed at runtime
+ * are typed here.
+ */
+export type PrivateI18nConfigParams = {
+  cacheUrl?: string;
+  cacheExpiryTime?: number | null;
+  _versionId?: string;
+  _disableDevHotReload?: boolean;
+  ignoreBrowserLocales?: boolean;
+  maxConcurrentRequests?: number;
+  maxBatchSize?: number;
+  batchInterval?: number;
+  renderSettings?: { timeout?: number };
+  headersAndCookies?: {
+    localeHeaderName?: string;
+    localeCookieName?: string;
+  };
+};
+
 // TODO: better way of communicating from build to runtime
 export function getParams(): {
   i18nConfigParams: NextSetupI18nConfigParams;
   nextI18nCacheParams: NextI18nCacheParams;
+  privateConfig: PrivateI18nConfigParams;
 } {
   // Read from build output
   const publicConfig = JSON.parse(
     process.env.NEXT_PUBLIC_GENERALTRANSLATION_I18N_CONFIG_PARAMS || '{}'
   );
-  const privateConfig = JSON.parse(
+  const privateConfig: PrivateI18nConfigParams = JSON.parse(
     process.env._GENERALTRANSLATION_I18N_CONFIG_PARAMS || '{}'
   );
   const { projectId, devApiKey, apiKey } = getRuntimeCredentials();
@@ -73,6 +95,7 @@ export function getParams(): {
   return {
     i18nConfigParams,
     nextI18nCacheParams,
+    privateConfig,
   };
 }
 


### PR DESCRIPTION
## Summary
- pass private build-time config from getParams into RSC initializeGT instead of reparsing env JSON
- consolidate custom getLocale/getRegion module resolution
- add focused RSC initializer tests for private config and custom getter wiring

## Verification
- pnpm --filter gt-next typecheck
- pnpm --filter gt-next test:js -- initGT.rsc shared