### PR TITLE
refactor: share locale reset cookie constant

### DIFF
--- a/packages/next/src/config-dir/props/defaultWithGTConfigProps.ts
+++ b/packages/next/src/config-dir/props/defaultWithGTConfigProps.ts
@@ -3,7 +3,10 @@ import {
   defaultCacheUrl,
   defaultRuntimeApiUrl,
 } from 'generaltranslation/internal';
-import { defaultLocaleCookieName } from '@generaltranslation/react-core/cookies';
+import {
+  defaultLocaleCookieName,
+  defaultResetLocaleCookieName,
+} from '@generaltranslation/react-core/cookies';
 import {
   getDefaultRenderSettings,
   type RenderMethod,
@@ -12,7 +15,6 @@ import { defaultLocaleHeaderName } from '../../utils/headers';
 import {
   defaultLocaleRoutingEnabledCookieName,
   defaultReferrerLocaleCookieName,
-  defaultResetLocaleCookieName,
 } from '../../utils/cookies';
 import { CompilerOptions } from './withGTConfigProps';
 

--- a/packages/next/src/middleware-dir/__tests__/localeResolution.edge.test.ts
+++ b/packages/next/src/middleware-dir/__tests__/localeResolution.edge.test.ts
@@ -7,6 +7,7 @@ import { getLocaleFromRequest } from '../utils';
 // Mock react-core/cookies — only provides a constant, avoids deep react-core build chain
 vi.mock('@generaltranslation/react-core/cookies', () => ({
   defaultLocaleCookieName: 'generaltranslation.locale',
+  defaultResetLocaleCookieName: 'generaltranslation.locale-reset',
 }));
 
 // ---- Cookie Constants ----

--- a/packages/next/src/middleware-dir/__tests__/middleware.edge.test.ts
+++ b/packages/next/src/middleware-dir/__tests__/middleware.edge.test.ts
@@ -8,6 +8,7 @@ import type { CustomMapping } from '@generaltranslation/format/types';
 // Mock react-core/cookies — only provides a constant, avoids deep react-core build chain
 vi.mock('@generaltranslation/react-core/cookies', () => ({
   defaultLocaleCookieName: 'generaltranslation.locale',
+  defaultResetLocaleCookieName: 'generaltranslation.locale-reset',
 }));
 
 // ---- Cookie Constants (must match the real defaults) ----

--- a/packages/next/src/middleware-dir/createNextMiddleware.ts
+++ b/packages/next/src/middleware-dir/createNextMiddleware.ts
@@ -6,9 +6,11 @@ import { NextRequest, NextResponse } from 'next/server';
 import {
   defaultLocaleRoutingEnabledCookieName,
   defaultReferrerLocaleCookieName,
-  defaultResetLocaleCookieName,
 } from '../utils/cookies';
-import { defaultLocaleCookieName } from '@generaltranslation/react-core/cookies';
+import {
+  defaultLocaleCookieName,
+  defaultResetLocaleCookieName,
+} from '@generaltranslation/react-core/cookies';
 import {
   PathConfig,
   getSharedPath,

--- a/packages/next/src/utils/cookies.ts
+++ b/packages/next/src/utils/cookies.ts
@@ -9,8 +9,3 @@ export const defaultLocaleRoutingEnabledCookieName =
  */
 export const defaultReferrerLocaleCookieName =
   'generaltranslation.referrer-locale';
-
-/**
- * Cookie name for tracking the locale reset
- */
-export const defaultResetLocaleCookieName = 'generaltranslation.locale-reset';

--- a/packages/react-core/src/cookies.ts
+++ b/packages/react-core/src/cookies.ts
@@ -5,4 +5,5 @@ export {
   defaultLocaleCookieName,
   defaultRegionCookieName,
   defaultEnableI18nCookieName,
+  defaultResetLocaleCookieName,
 } from './utils/cookies';

--- a/packages/react-core/src/pure.ts
+++ b/packages/react-core/src/pure.ts
@@ -33,6 +33,7 @@ export {
   defaultEnableI18nCookieName,
   defaultLocaleCookieName,
   defaultRegionCookieName,
+  defaultResetLocaleCookieName,
 } from './utils/cookies';
 export {
   getDictionaryEntry,

--- a/packages/react-core/src/utils/cookies.ts
+++ b/packages/react-core/src/utils/cookies.ts
@@ -12,3 +12,11 @@ export const defaultRegionCookieName = 'generaltranslation.region';
  * Cookie name for persisting the enableI18n feature flag.
  */
 export const defaultEnableI18nCookieName = 'generaltranslation.enable-i18n';
+
+/**
+ * Cookie name for tracking the locale reset.
+ * Used by gt-react's BrowserConditionStore and gt-next's middleware.
+ *
+ * TODO: remove this cookie when we come up with a better solution.
+ */
+export const defaultResetLocaleCookieName = 'generaltranslation.locale-reset';

--- a/packages/react/src/cookie-names.ts
+++ b/packages/react/src/cookie-names.ts
@@ -1,22 +1,9 @@
-/**
- * Cookie name for tracking the user's selected locale.
- */
-export const defaultLocaleCookieName = 'generaltranslation.locale';
-
-/**
- * Cookie name for tracking the user's selected region.
- */
-export const defaultRegionCookieName = 'generaltranslation.region';
-
-/**
- * Cookie name for persisting the enableI18n feature flag.
- */
-export const defaultEnableI18nCookieName = 'generaltranslation.enable-i18n';
-
-/**
- * Cookie name for tracking the locale reset
- * Used by gt-next middleware
- *
- * TODO: remove this cookie when come up with better solution
- */
-export const defaultResetLocaleCookieName = 'generaltranslation.locale-reset';
+// Re-export the shared default cookie-name constants from react-core so there
+// is a single source of truth for these on-the-wire keys. Divergence here would
+// silently break locale/region/enable-i18n persistence with no compile error.
+export {
+  defaultLocaleCookieName,
+  defaultRegionCookieName,
+  defaultEnableI18nCookieName,
+  defaultResetLocaleCookieName,
+} from '@generaltranslation/react-core/cookies';


### PR DESCRIPTION
## Summary
- move the locale reset cookie name to the shared react-core cookie constants entrypoint
- update React and Next consumers to avoid duplicate on-the-wire cookie constants

## Verification
- pnpm --filter @generaltranslation/react-core typecheck
- pnpm --filter gt-react typecheck
- pnpm --filter gt-next test:js -- middleware.edge localeResolution.edge