### PR TITLE
refactor: share tracked lookup subscriptions

### DIFF
--- a/.changeset/tracked-lookup-subscriptions.md
+++ b/.changeset/tracked-lookup-subscriptions.md
@@ -1,0 +1,5 @@
+---
+"@generaltranslation/react-core": patch
+---
+
+Share tracked lookup subscription handling across resolver hooks.

--- a/packages/react-core/src/hooks/external-store/useSubscribeToTrackedLookups.ts
+++ b/packages/react-core/src/hooks/external-store/useSubscribeToTrackedLookups.ts
@@ -1,0 +1,38 @@
+import {
+  type RefObject,
+  useCallback,
+  useRef,
+  useSyncExternalStore,
+} from 'react';
+import type { StoreListener, Unsubscribe } from '../../i18n-store/storeTypes';
+
+/**
+ * Subscribe to store events, but only trigger re-renders when the event's
+ * lookup is in the tracked keys set. Shared by the tracked translation and
+ * dictionary resolvers, which differ only in the store subscribe method and the
+ * listener-key function.
+ *
+ * Remember that we can make no assumptions about when the tracked set gets
+ * updated. This is technically not pure, but it is an acceptable trade since it
+ * only drives dev translation hot reload.
+ */
+export function useSubscribeToTrackedLookups<L>(
+  trackedKeysRef: RefObject<Set<string> | null>,
+  subscribeToEvents: (onEvent: (lookup: L) => void) => Unsubscribe,
+  getListenerKey: (lookup: L) => string
+) {
+  // invalidation counter for triggering updates
+  const versionRef = useRef(0);
+  const subscribe = useCallback(
+    (listener: StoreListener) =>
+      subscribeToEvents((lookup) => {
+        if (!trackedKeysRef.current!.has(getListenerKey(lookup))) return;
+        versionRef.current++;
+        listener();
+      }),
+    [subscribeToEvents, getListenerKey, trackedKeysRef]
+  );
+  const getSnapshot = useCallback(() => versionRef.current, []);
+
+  useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}

--- a/packages/react-core/src/hooks/external-store/useTrackedDictionaryObjResolver.ts
+++ b/packages/react-core/src/hooks/external-store/useTrackedDictionaryObjResolver.ts
@@ -2,19 +2,14 @@ import { getDictionaryListenerKey, getI18nConfig } from 'gt-i18n/internal';
 import type {
   DictionaryLookup,
   DictionaryObjectSnapshot,
-  StoreListener,
 } from '../../i18n-store/storeTypes';
 import {
   useDictionariesSnapshot,
   useI18nStore,
 } from '../../i18n-store/useI18nStore';
-import {
-  type RefObject,
-  useCallback,
-  useRef,
-  useSyncExternalStore,
-} from 'react';
+import { useCallback, useRef } from 'react';
 import { useHandleMissingDictionaryObject } from '../utils/missing-translation';
+import { useSubscribeToTrackedLookups } from './useSubscribeToTrackedLookups';
 
 export type TrackedDictionaryObjResolver = (
   lookup: DictionaryLookup
@@ -32,8 +27,12 @@ export function useTrackedDictionaryObjResolver(): TrackedDictionaryObjResolver 
     trackedKeysRef.current = new Set();
   }
 
-  // subscribe to dictionary entry updates
-  useSubscribeToLookups(trackedKeysRef);
+  // subscribe to dictionary object updates
+  useSubscribeToTrackedLookups(
+    trackedKeysRef,
+    i18nStore.subscribeToDictionaryObjectEvents,
+    getDictionaryListenerKey
+  );
 
   // Resolution callback
   return useCallback(
@@ -64,26 +63,4 @@ export function useTrackedDictionaryObjResolver(): TrackedDictionaryObjResolver 
       onMissingDictionaryObj,
     ]
   );
-}
-
-function useSubscribeToLookups(trackedKeysRef: RefObject<Set<string> | null>) {
-  // invalidation counter for triggering updates
-  const versionRef = useRef(0);
-  const i18nStore = useI18nStore();
-  const subscribe = useCallback(
-    (listener: StoreListener) => {
-      return i18nStore.subscribeToDictionaryObjectEvents((lookup) => {
-        const key = getDictionaryListenerKey(lookup);
-        if (!trackedKeysRef.current!.has(key)) return;
-        versionRef.current++;
-        listener();
-      });
-    },
-    [i18nStore]
-  );
-  const getSnapshot = useCallback(() => {
-    return versionRef.current;
-  }, []);
-
-  useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 }

--- a/packages/react-core/src/hooks/external-store/useTrackedDictionaryResolver.ts
+++ b/packages/react-core/src/hooks/external-store/useTrackedDictionaryResolver.ts
@@ -6,12 +6,10 @@ import {
 import type {
   DictionaryEntrySnapshot,
   DictionaryLookup,
-  StoreListener,
 } from '../../i18n-store/storeTypes';
 import { getDictionaryListenerKey, getI18nConfig } from 'gt-i18n/internal';
-import { useSyncExternalStore } from 'react';
-import type { RefObject } from 'react';
 import { useHandleMissingDictionaryEntry } from '../utils/missing-translation';
+import { useSubscribeToTrackedLookups } from './useSubscribeToTrackedLookups';
 
 export type TrackedDictionaryEntryResolver = (
   lookup: DictionaryLookup
@@ -30,7 +28,11 @@ export function useTrackedDictionaryResolver(): TrackedDictionaryEntryResolver {
   }
 
   // subscribe to dictionary entry updates
-  useSubscribeToLookups(trackedKeysRef);
+  useSubscribeToTrackedLookups(
+    trackedKeysRef,
+    i18nStore.subscribeToDictionaryEntryEvents,
+    getDictionaryListenerKey
+  );
 
   // Resolution callback
   return useCallback(
@@ -61,26 +63,4 @@ export function useTrackedDictionaryResolver(): TrackedDictionaryEntryResolver {
       onMissingDictionaryEntry,
     ]
   );
-}
-
-function useSubscribeToLookups(trackedKeysRef: RefObject<Set<string> | null>) {
-  // invalidation counter for triggering updates
-  const versionRef = useRef(0);
-  const i18nStore = useI18nStore();
-  const subscribe = useCallback(
-    (listener: StoreListener) => {
-      return i18nStore.subscribeToDictionaryEntryEvents((lookup) => {
-        const key = getDictionaryListenerKey(lookup);
-        if (!trackedKeysRef.current!.has(key)) return;
-        versionRef.current++;
-        listener();
-      });
-    },
-    [i18nStore]
-  );
-  const getSnapshot = useCallback(() => {
-    return versionRef.current;
-  }, []);
-
-  useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 }

--- a/packages/react-core/src/hooks/external-store/useTrackedTranslationResolver.ts
+++ b/packages/react-core/src/hooks/external-store/useTrackedTranslationResolver.ts
@@ -1,11 +1,4 @@
-import {
-  type RefObject,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useSyncExternalStore,
-} from 'react';
+import { type RefObject, useCallback, useEffect, useMemo, useRef } from 'react';
 import {
   createLookupOptions,
   getI18nConfig,
@@ -13,7 +6,6 @@ import {
 } from 'gt-i18n/internal';
 import type { Translation } from 'gt-i18n/types';
 import type {
-  StoreListener,
   TranslateLookup,
   TranslateSnapshot,
 } from '../../i18n-store/storeTypes';
@@ -26,6 +18,7 @@ import {
   useTranslationsSnapshot,
 } from '../../i18n-store/useI18nStore';
 import { useHandleMissingTranslation } from '../utils/missing-translation';
+import { useSubscribeToTrackedLookups } from './useSubscribeToTrackedLookups';
 
 /**
  * Returns the translation, but also triggers a translation if it is not found
@@ -71,7 +64,11 @@ export function useTrackedTranslationResolver(
   usePreloadCompilerLookups(messages, trackedKeysRef);
 
   // (tx hot reload) Subscribe to translation updates
-  useSubscribeToLookups(trackedKeysRef);
+  useSubscribeToTrackedLookups(
+    trackedKeysRef,
+    i18nStore.subscribeToTranslationEvents,
+    getTranslateListenerKey
+  );
 
   /**
    * Remember that we can make no assumptions about when this cb gets invoked
@@ -102,38 +99,6 @@ export function useTrackedTranslationResolver(
     },
     [i18nStore, translationsSnapshot, onMissingTranslation, devHotReloadEnabled]
   );
-}
-
-/**
- * Subscribe to translation updates, but only trigger re-renders
- * if the lookup is in the tracked keys. Remember that we can make
- * no assumptions about when this list gets updated. Technically,
- * not pure, but this is an acceptable trade since this is
- * really just for translation hot reload.
- *
- * TODO: (separate PR) we can probably do better filtering for adding to the set since this is primarily dev only
- * TODO: reduce code duplication with the other two useSubscribeToLookups functions
- */
-function useSubscribeToLookups(trackedKeysRef: RefObject<Set<string> | null>) {
-  // invalidation counter for triggering updates
-  const versionRef = useRef(0);
-  const i18nStore = useI18nStore();
-  const subscribe = useCallback(
-    (listener: StoreListener) => {
-      return i18nStore.subscribeToTranslationEvents((lookup) => {
-        const key = getTranslateListenerKey(lookup);
-        if (!trackedKeysRef.current!.has(key)) return;
-        versionRef.current++;
-        listener();
-      });
-    },
-    [i18nStore]
-  );
-  const getSnapshot = useCallback(() => {
-    return versionRef.current;
-  }, []);
-
-  useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 }
 
 /**

--- a/packages/react-core/src/i18n-store/I18nStore.ts
+++ b/packages/react-core/src/i18n-store/I18nStore.ts
@@ -99,6 +99,8 @@ export class I18nStore {
 
   // ----- Subscriptions ----- //
 
+  // Keep subscription methods as arrow fields so hooks can pass them by
+  // reference without losing access to this store instance.
   subscribeToTranslate = <T extends Translation>(
     lookup: TranslateLookup<T>,
     listener: StoreListener


### PR DESCRIPTION
## Summary
- extract duplicated useSyncExternalStore subscription filtering for tracked translation and dictionary lookups
- leave missing-translation queue behavior unchanged

## Verification
- pnpm --filter @generaltranslation/react-core typecheck

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts the duplicated `useSyncExternalStore` subscription logic across three tracked-lookup resolver hooks into a single shared hook, `useSubscribeToTrackedLookups`. The three callers now pass their store subscribe method and key function as arguments instead of each embedding identical inline helpers.

- **New shared hook** (`useSubscribeToTrackedLookups.ts`): generic over the lookup type `L`, accepts the subscribe method and key extractor as parameters, and owns the `versionRef` / `subscribe` / `getSnapshot` wiring that was previously copy-pasted in each file.
- **Three callers updated** (`useTrackedTranslationResolver`, `useTrackedDictionaryResolver`, `useTrackedDictionaryObjResolver`): their local `useSubscribeToLookups` functions are deleted and replaced with a call to the shared hook; imports are trimmed accordingly.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Pure deduplication refactor — no behavioral change, only the shared subscription logic is extracted into a single hook.

The store subscribe methods are arrow function class fields, making them stable references per store instance. getDictionaryListenerKey and getTranslateListenerKey are module-level functions and also stable. The versionRef is scoped inside the shared hook so each call site gets its own counter, preserving independent invalidation. No logic was altered — only location and structure changed.

No files require special attention. The new useSubscribeToTrackedLookups.ts is the only net-new code and it is a straightforward extraction.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react-core/src/hooks/external-store/useSubscribeToTrackedLookups.ts | New shared hook extracting the tracked-lookup subscription pattern; generic, correctly wired with stable deps, and own versionRef per call site. |
| packages/react-core/src/hooks/external-store/useTrackedTranslationResolver.ts | Local useSubscribeToLookups helper removed; now delegates to the shared hook with i18nStore.subscribeToTranslationEvents (stable arrow-field) and module-level getTranslateListenerKey. |
| packages/react-core/src/hooks/external-store/useTrackedDictionaryResolver.ts | Duplicate useSubscribeToLookups removed; delegates to shared hook with subscribeToDictionaryEntryEvents and getDictionaryListenerKey. |
| packages/react-core/src/hooks/external-store/useTrackedDictionaryObjResolver.ts | Duplicate useSubscribeToLookups removed; delegates to shared hook with subscribeToDictionaryObjectEvents and getDictionaryListenerKey. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller as Resolver Hook
    participant Shared as useSubscribeToTrackedLookups
    participant Store as I18nStore
    participant React as useSyncExternalStore

    Caller->>Caller: init trackedKeysRef (Set)
    Caller->>Shared: (trackedKeysRef, subscribeToEvents, getListenerKey)
    Shared->>Shared: create versionRef
    Shared->>React: useSyncExternalStore(subscribe, getSnapshot)
    React->>Store: subscribe(listener)
    Store-->>React: Unsubscribe fn

    note over Store,Shared: On store event
    Store->>Shared: onEvent(lookup)
    Shared->>Shared: getListenerKey(lookup) in trackedKeysRef?
    alt key tracked
        Shared->>Shared: versionRef++
        Shared->>React: listener() re-render
    else key not tracked
        Shared-->>Store: skip
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller as Resolver Hook
    participant Shared as useSubscribeToTrackedLookups
    participant Store as I18nStore
    participant React as useSyncExternalStore

    Caller->>Caller: init trackedKeysRef (Set)
    Caller->>Shared: (trackedKeysRef, subscribeToEvents, getListenerKey)
    Shared->>Shared: create versionRef
    Shared->>React: useSyncExternalStore(subscribe, getSnapshot)
    React->>Store: subscribe(listener)
    Store-->>React: Unsubscribe fn

    note over Store,Shared: On store event
    Store->>Shared: onEvent(lookup)
    Shared->>Shared: getListenerKey(lookup) in trackedKeysRef?
    alt key tracked
        Shared->>Shared: versionRef++
        Shared->>React: listener() re-render
    else key not tracked
        Shared-->>Store: skip
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: share tracked lookup subscript..."](https://github.com/generaltranslation/gt/commit/69f8f0809b475d46e1519fa69bd7a602c3d1911d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41016405)</sub>

<!-- /greptile_comment -->