### PR TITLE
refactor: use supported locale resolver

### DIFF
--- a/packages/i18n/src/condition-store/ReadonlyConditionStore.ts
+++ b/packages/i18n/src/condition-store/ReadonlyConditionStore.ts
@@ -18,9 +18,7 @@ export class ReadonlyConditionStore implements ReadonlyConditionStoreContract {
     region,
     enableI18n = true,
   }: ReadonlyConditionStoreParams) {
-    const i18nConfig = getI18nConfig();
-    this.locale =
-      i18nConfig.determineLocale(locale) || i18nConfig.getDefaultLocale();
+    this.locale = getI18nConfig().resolveSupportedLocale(locale);
     this.region = region;
     this.enableI18n = enableI18n;
   }

--- a/packages/i18n/src/condition-store/WritableConditionStore.ts
+++ b/packages/i18n/src/condition-store/WritableConditionStore.ts
@@ -13,9 +13,7 @@ export class WritableConditionStore
   implements WritableConditionStoreInterface
 {
   setLocale = (locale: LocaleCandidates): void => {
-    const i18nConfig = getI18nConfig();
-    this.locale =
-      i18nConfig.determineLocale(locale) || i18nConfig.getDefaultLocale();
+    this.locale = getI18nConfig().resolveSupportedLocale(locale);
   };
 
   setRegion = (region: string | undefined): void => {

--- a/packages/node/src/async-i18n-cache/AsyncConditionStore.ts
+++ b/packages/node/src/async-i18n-cache/AsyncConditionStore.ts
@@ -85,6 +85,5 @@ export class AsyncConditionStore implements ScopedConditionStoreInterface {
 }
 
 function resolveLocale(locale?: string): string {
-  const i18nConfig = getI18nConfig();
-  return i18nConfig.determineLocale(locale) || i18nConfig.getDefaultLocale();
+  return getI18nConfig().resolveSupportedLocale(locale);
 }

--- a/packages/react-native/src/utils/resolveLocale.ts
+++ b/packages/react-native/src/utils/resolveLocale.ts
@@ -2,9 +2,5 @@ import { getI18nConfig } from 'gt-i18n/internal';
 import type { LocaleCandidates } from 'gt-i18n/internal/types';
 
 export function resolveLocale(candidates?: LocaleCandidates | null): string {
-  const i18nConfig = getI18nConfig();
-  return (
-    i18nConfig.determineLocale(candidates ?? undefined) ||
-    i18nConfig.getDefaultLocale()
-  );
+  return getI18nConfig().resolveSupportedLocale(candidates ?? undefined);
 }

--- a/packages/react/src/condition-store/BrowserConditionStore.ts
+++ b/packages/react/src/condition-store/BrowserConditionStore.ts
@@ -60,12 +60,9 @@ export class BrowserConditionStore implements WritableConditionStoreInterface {
     this.regionCookieName = config.regionCookieName ?? defaultRegionCookieName;
     this.enableI18nCookieName =
       config.enableI18nCookieName ?? defaultEnableI18nCookieName;
-    const i18nConfig = getI18nConfig();
     setCookieValue({
       cookieName: this.localeCookieName,
-      value:
-        i18nConfig.determineLocale(config.locale) ||
-        i18nConfig.getDefaultLocale(),
+      value: getI18nConfig().resolveSupportedLocale(config.locale),
     });
     if (config.region !== undefined) {
       setCookieValue({
@@ -121,11 +118,9 @@ export class BrowserConditionStore implements WritableConditionStoreInterface {
    * Soft locale update
    */
   updateLocale = (locale: LocaleCandidates): void => {
-    const i18nConfig = getI18nConfig();
     setCookieValue({
       cookieName: this.localeCookieName,
-      value:
-        i18nConfig.determineLocale(locale) || i18nConfig.getDefaultLocale(),
+      value: getI18nConfig().resolveSupportedLocale(locale),
     });
   };
 
@@ -167,8 +162,5 @@ export class BrowserConditionStore implements WritableConditionStoreInterface {
 function getBrowserLocale(cookieName: string, getLocale?: GetLocale): string {
   const candidates = readBrowserLocale(cookieName);
   if (getLocale) candidates.push(getLocale());
-  const i18nConfig = getI18nConfig();
-  return (
-    i18nConfig.determineLocale(candidates) || i18nConfig.getDefaultLocale()
-  );
+  return getI18nConfig().resolveSupportedLocale(candidates);
 }

--- a/packages/react/src/condition-store/__tests__/BrowserConditionStore.test.ts
+++ b/packages/react/src/condition-store/__tests__/BrowserConditionStore.test.ts
@@ -13,6 +13,10 @@ vi.mock('gt-i18n/internal', () => ({
       return Array.isArray(locale) ? locale[0] : locale;
     },
     getDefaultLocale: () => 'en',
+    resolveSupportedLocale: (locale?: string | string[]) => {
+      const resolved = Array.isArray(locale) ? locale[0] : locale;
+      return resolved || 'en';
+    },
   }),
 }));
 

--- a/packages/react/src/condition-store/createBrowserConditionStore.ts
+++ b/packages/react/src/condition-store/createBrowserConditionStore.ts
@@ -80,14 +80,7 @@ function determineLocale({
   }
   if (getLocale) candidates.push(getLocale());
   candidates.push(...readBrowserLocale(localeCookieName));
-  return resolveLocale(candidates);
-}
-
-function resolveLocale(candidates?: LocaleCandidates): string {
-  const i18nConfig = getI18nConfig();
-  return (
-    i18nConfig.determineLocale(candidates) || i18nConfig.getDefaultLocale()
-  );
+  return getI18nConfig().resolveSupportedLocale(candidates);
 }
 
 function determineRegion({


### PR DESCRIPTION
## Summary
- replace repeated determineLocale/defaultLocale fallback code with resolveSupportedLocale
- keep behavior equivalent while reducing repeated locale resolution logic

## Verification
- pnpm --filter gt-react test -- BrowserConditionStore
- pnpm --filter gt-react typecheck
- pnpm --filter gt-react-native typecheck
- pnpm --filter gt-node typecheck
- pnpm --filter gt-i18n typecheck

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR consolidates the repeated `determineLocale(x) || getDefaultLocale()` two-step fallback pattern into a single call to `resolveSupportedLocale`, which encapsulates the same logic inside `I18nConfig`. The change touches six production files across the `gt-i18n`, `gt-node`, `gt-react`, and `gt-react-native` packages plus the matching test mock.

- The refactor is behaviorally equivalent: `resolveSupportedLocale` delegates to `determineSupportedLocaleWithConfig` (which calls the same `determineLocale` path) and falls back to `defaultLocale`, mirroring the old pattern exactly.
- The `resolveLocale` private helper in `createBrowserConditionStore.ts` is correctly inlined away since it was a one-liner wrapping the old pattern.
- The test mock retains the now-unused `determineLocale` and `getDefaultLocale` stubs; trimming them would keep the mock in sync with what the code actually exercises.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the refactor is a mechanical substitution of an equivalent one-liner across six files with no logic changes.

Every changed call site replaces a two-step fallback with resolveSupportedLocale, which internally performs the same determineLocale-then-defaultLocale logic, confirmed by reading I18nConfig. The only finding is dead stubs in the test mock.

The test mock in BrowserConditionStore.test.ts retains stubs that are no longer called; worth tidying but not a blocker.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/i18n/src/condition-store/ReadonlyConditionStore.ts | Replaces two-step determineLocale+getDefaultLocale fallback with resolveSupportedLocale; behaviorally equivalent. |
| packages/i18n/src/condition-store/WritableConditionStore.ts | Same single-line refactor in setLocale; no behavioral change. |
| packages/node/src/async-i18n-cache/AsyncConditionStore.ts | Local resolveLocale helper simplified to one line using resolveSupportedLocale; equivalent logic. |
| packages/react-native/src/utils/resolveLocale.ts | resolveLocale utility simplified; null coalescing to undefined preserved, behavior unchanged. |
| packages/react/src/condition-store/BrowserConditionStore.ts | Three call sites updated in constructor, updateLocale, and getBrowserLocale; all equivalent to prior pattern. |
| packages/react/src/condition-store/__tests__/BrowserConditionStore.test.ts | Adds resolveSupportedLocale to the mock; retains now-unused determineLocale and getDefaultLocale stubs. |
| packages/react/src/condition-store/createBrowserConditionStore.ts | Removes the now-redundant resolveLocale private helper; determineLocale inlines the call directly. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant ConditionStore
    participant I18nConfig

    Note over Caller,I18nConfig: Before (old pattern)
    Caller->>ConditionStore: setLocale(locale)
    ConditionStore->>I18nConfig: determineLocale(locale)
    I18nConfig-->>ConditionStore: "string | undefined"
    alt undefined
        ConditionStore->>I18nConfig: getDefaultLocale()
        I18nConfig-->>ConditionStore: defaultLocale
    end
    ConditionStore-->>Caller: resolved locale

    Note over Caller,I18nConfig: After (new pattern)
    Caller->>ConditionStore: setLocale(locale)
    ConditionStore->>I18nConfig: resolveSupportedLocale(locale)
    I18nConfig->>I18nConfig: determineSupportedLocaleWithConfig(candidates, this)
    I18nConfig->>I18nConfig: determineLocale(candidates) OR defaultLocale
    I18nConfig-->>ConditionStore: string (never undefined)
    ConditionStore-->>Caller: resolved locale
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant ConditionStore
    participant I18nConfig

    Note over Caller,I18nConfig: Before (old pattern)
    Caller->>ConditionStore: setLocale(locale)
    ConditionStore->>I18nConfig: determineLocale(locale)
    I18nConfig-->>ConditionStore: "string | undefined"
    alt undefined
        ConditionStore->>I18nConfig: getDefaultLocale()
        I18nConfig-->>ConditionStore: defaultLocale
    end
    ConditionStore-->>Caller: resolved locale

    Note over Caller,I18nConfig: After (new pattern)
    Caller->>ConditionStore: setLocale(locale)
    ConditionStore->>I18nConfig: resolveSupportedLocale(locale)
    I18nConfig->>I18nConfig: determineSupportedLocaleWithConfig(candidates, this)
    I18nConfig->>I18nConfig: determineLocale(candidates) OR defaultLocale
    I18nConfig-->>ConditionStore: string (never undefined)
    ConditionStore-->>Caller: resolved locale
```

</a>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/react/src/condition-store/__tests__/BrowserConditionStore.test.ts`, line 10-21 ([link](https://github.com/generaltranslation/gt/blob/602339b6c47568cbb07904df5fbe6c894344e091/packages/react/src/condition-store/__tests__/BrowserConditionStore.test.ts#L10-L21)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> After the refactor, `BrowserConditionStore` no longer calls `determineLocale` or `getDefaultLocale` — only `resolveSupportedLocale` is invoked. Leaving the unused stubs in the mock is harmless but creates noise for future readers who may expect these methods to be exercised.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/react/src/condition-store/__tests__/BrowserConditionStore.test.ts
   Line: 10-21

   Comment:
   After the refactor, `BrowserConditionStore` no longer calls `determineLocale` or `getDefaultLocale` — only `resolveSupportedLocale` is invoked. Leaving the unused stubs in the mock is harmless but creates noise for future readers who may expect these methods to be exercised.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Freact%2Fsrc%2Fcondition-store%2F__tests__%2FBrowserConditionStore.test.ts%0ALine%3A%2010-21%0A%0AComment%3A%0AAfter%20the%20refactor%2C%20%60BrowserConditionStore%60%20no%20longer%20calls%20%60determineLocale%60%20or%20%60getDefaultLocale%60%20%E2%80%94%20only%20%60resolveSupportedLocale%60%20is%20invoked.%20Leaving%20the%20unused%20stubs%20in%20the%20mock%20is%20harmless%20but%20creates%20noise%20for%20future%20readers%20who%20may%20expect%20these%20methods%20to%20be%20exercised.%0A%0A%60%60%60suggestion%0Avi.mock%28'gt-i18n%2Finternal'%2C%20%28%29%20%3D%3E%20%28%7B%0A%20%20getI18nConfig%3A%20%28%29%20%3D%3E%20%28%7B%0A%20%20%20%20resolveSupportedLocale%3A%20%28locale%3F%3A%20string%20%7C%20string%5B%5D%29%20%3D%3E%20%7B%0A%20%20%20%20%20%20const%20resolved%20%3D%20Array.isArray%28locale%29%20%3F%20locale%5B0%5D%20%3A%20locale%3B%0A%20%20%20%20%20%20return%20resolved%20%7C%7C%20'en'%3B%0A%20%20%20%20%7D%2C%0A%20%20%7D%29%2C%0A%7D%29%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=generaltranslation%2Fgt&pr=1750&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=4"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=4"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22bg%2Fodysseus-resolve-supported-locale%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22bg%2Fodysseus-resolve-supported-locale%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Freact%2Fsrc%2Fcondition-store%2F__tests__%2FBrowserConditionStore.test.ts%0ALine%3A%2010-21%0A%0AComment%3A%0AAfter%20the%20refactor%2C%20%60BrowserConditionStore%60%20no%20longer%20calls%20%60determineLocale%60%20or%20%60getDefaultLocale%60%20%E2%80%94%20only%20%60resolveSupportedLocale%60%20is%20invoked.%20Leaving%20the%20unused%20stubs%20in%20the%20mock%20is%20harmless%20but%20creates%20noise%20for%20future%20readers%20who%20may%20expect%20these%20methods%20to%20be%20exercised.%0A%0A%60%60%60suggestion%0Avi.mock%28'gt-i18n%2Finternal'%2C%20%28%29%20%3D%3E%20%28%7B%0A%20%20getI18nConfig%3A%20%28%29%20%3D%3E%20%28%7B%0A%20%20%20%20resolveSupportedLocale%3A%20%28locale%3F%3A%20string%20%7C%20string%5B%5D%29%20%3D%3E%20%7B%0A%20%20%20%20%20%20const%20resolved%20%3D%20Array.isArray%28locale%29%20%3F%20locale%5B0%5D%20%3A%20locale%3B%0A%20%20%20%20%20%20return%20resolved%20%7C%7C%20'en'%3B%0A%20%20%20%20%7D%2C%0A%20%20%7D%29%2C%0A%7D%29%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=generaltranslation%2Fgt&pr=1750&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=4"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=4"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Freact%2Fsrc%2Fcondition-store%2F__tests__%2FBrowserConditionStore.test.ts%3A10-21%0AAfter%20the%20refactor%2C%20%60BrowserConditionStore%60%20no%20longer%20calls%20%60determineLocale%60%20or%20%60getDefaultLocale%60%20%E2%80%94%20only%20%60resolveSupportedLocale%60%20is%20invoked.%20Leaving%20the%20unused%20stubs%20in%20the%20mock%20is%20harmless%20but%20creates%20noise%20for%20future%20readers%20who%20may%20expect%20these%20methods%20to%20be%20exercised.%0A%0A%60%60%60suggestion%0Avi.mock%28'gt-i18n%2Finternal'%2C%20%28%29%20%3D%3E%20%28%7B%0A%20%20getI18nConfig%3A%20%28%29%20%3D%3E%20%28%7B%0A%20%20%20%20resolveSupportedLocale%3A%20%28locale%3F%3A%20string%20%7C%20string%5B%5D%29%20%3D%3E%20%7B%0A%20%20%20%20%20%20const%20resolved%20%3D%20Array.isArray%28locale%29%20%3F%20locale%5B0%5D%20%3A%20locale%3B%0A%20%20%20%20%20%20return%20resolved%20%7C%7C%20'en'%3B%0A%20%20%20%20%7D%2C%0A%20%20%7D%29%2C%0A%7D%29%29%3B%0A%60%60%60%0A%0A&repo=generaltranslation%2Fgt&pr=1750&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22bg%2Fodysseus-resolve-supported-locale%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22bg%2Fodysseus-resolve-supported-locale%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Freact%2Fsrc%2Fcondition-store%2F__tests__%2FBrowserConditionStore.test.ts%3A10-21%0AAfter%20the%20refactor%2C%20%60BrowserConditionStore%60%20no%20longer%20calls%20%60determineLocale%60%20or%20%60getDefaultLocale%60%20%E2%80%94%20only%20%60resolveSupportedLocale%60%20is%20invoked.%20Leaving%20the%20unused%20stubs%20in%20the%20mock%20is%20harmless%20but%20creates%20noise%20for%20future%20readers%20who%20may%20expect%20these%20methods%20to%20be%20exercised.%0A%0A%60%60%60suggestion%0Avi.mock%28'gt-i18n%2Finternal'%2C%20%28%29%20%3D%3E%20%28%7B%0A%20%20getI18nConfig%3A%20%28%29%20%3D%3E%20%28%7B%0A%20%20%20%20resolveSupportedLocale%3A%20%28locale%3F%3A%20string%20%7C%20string%5B%5D%29%20%3D%3E%20%7B%0A%20%20%20%20%20%20const%20resolved%20%3D%20Array.isArray%28locale%29%20%3F%20locale%5B0%5D%20%3A%20locale%3B%0A%20%20%20%20%20%20return%20resolved%20%7C%7C%20'en'%3B%0A%20%20%20%20%7D%2C%0A%20%20%7D%29%2C%0A%7D%29%29%3B%0A%60%60%60%0A%0A&repo=generaltranslation%2Fgt&pr=1750&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=4"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=4"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/react/src/condition-store/__tests__/BrowserConditionStore.test.ts:10-21
After the refactor, `BrowserConditionStore` no longer calls `determineLocale` or `getDefaultLocale` — only `resolveSupportedLocale` is invoked. Leaving the unused stubs in the mock is harmless but creates noise for future readers who may expect these methods to be exercised.

```suggestion
vi.mock('gt-i18n/internal', () => ({
  getI18nConfig: () => ({
    resolveSupportedLocale: (locale?: string | string[]) => {
      const resolved = Array.isArray(locale) ? locale[0] : locale;
      return resolved || 'en';
    },
  }),
}));
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: use supported locale resolver"](https://github.com/generaltranslation/gt/commit/602339b6c47568cbb07904df5fbe6c894344e091) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41016695)</sub>

<!-- /greptile_comment -->