### PR TITLE
refactor: reuse react core initializeGT

### DIFF
--- a/packages/react-native/src/setup/initializeGT.ts
+++ b/packages/react-native/src/setup/initializeGT.ts
@@ -1,16 +1,9 @@
-import {
-  initializeI18nConfig,
-  setReactI18nCache,
-} from '@generaltranslation/react-core/pure';
-import { ReactI18nCache } from '@generaltranslation/react-core/pure';
 import type { ReactI18nCacheParams } from '@generaltranslation/react-core/pure';
 import type { I18nConfigParams } from 'gt-i18n/internal/types';
 
 export type InitializeGTParams = I18nConfigParams & ReactI18nCacheParams;
 
-export function initializeGT(config: InitializeGTParams): void {
-  initializeI18nConfig(config, 'server-render');
-
-  const i18nCache = new ReactI18nCache(config);
-  setReactI18nCache(i18nCache);
-}
+// Server-render initialization is identical to react-core's shared implementation
+// (there is no native-specific setup here), so re-export it directly instead of
+// maintaining a byte-for-byte copy.
+export { internalInitializeGTSRA as initializeGT } from '@generaltranslation/react-core/pure';


### PR DESCRIPTION
## Summary
- replace React Native server-render initializeGT implementation with the shared react-core implementation
- preserve the exported InitializeGTParams type

## Verification
- pnpm --filter gt-react-native typecheck

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the duplicated `initializeGT` implementation in the React Native package and replaces it with a re-export of `internalInitializeGTSRA` from `@generaltranslation/react-core/pure`, which is already exported from that module under both names. The public `InitializeGTParams` type and the `initializeGT` function name are fully preserved.

- The two implementations were byte-for-byte identical (`initializeI18nConfig(config, 'server-render')` + `new ReactI18nCache(config)` + `setReactI18nCache`), so the change is a pure deduplication with no behavioral difference.
- `InitializeGTParams` continues to be exported as `I18nConfigParams & ReactI18nCacheParams`, matching the parameter type of `internalInitializeGTSRA`, so the public API is unchanged.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a pure deduplication with no behavioral difference and the public API is fully preserved.

The deleted inline implementation and the re-exported internalInitializeGTSRA perform exactly the same two steps in the same order, and internalInitializeGTSRA is already a stable export of react-core/pure. The InitializeGTParams type and the initializeGT name are both preserved, so no downstream consumer needs to change.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react-native/src/setup/initializeGT.ts | Replaces the inline implementation of initializeGT with a direct re-export of internalInitializeGTSRA from react-core/pure; preserves the exported InitializeGTParams type; the two implementations are byte-for-byte identical so no behavior changes. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller as React Native caller
    participant File as initializeGT.ts (react-native)
    participant Core as react-core/pure (internalInitializeGTSRA)
    participant I18nConfig as initializeI18nConfig
    participant Cache as ReactI18nCache / setReactI18nCache

    Caller->>File: initializeGT(config)
    Note over File: re-export → delegates immediately
    File->>Core: internalInitializeGTSRA(config)
    Core->>I18nConfig: initializeI18nConfig(config, 'server-render')
    Core->>Cache: new ReactI18nCache(config)
    Core->>Cache: setReactI18nCache(i18nCache)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller as React Native caller
    participant File as initializeGT.ts (react-native)
    participant Core as react-core/pure (internalInitializeGTSRA)
    participant I18nConfig as initializeI18nConfig
    participant Cache as ReactI18nCache / setReactI18nCache

    Caller->>File: initializeGT(config)
    Note over File: re-export → delegates immediately
    File->>Core: internalInitializeGTSRA(config)
    Core->>I18nConfig: initializeI18nConfig(config, 'server-render')
    Core->>Cache: new ReactI18nCache(config)
    Core->>Cache: setReactI18nCache(i18nCache)
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: reuse react core initializeGT"](https://github.com/generaltranslation/gt/commit/4027d1cd5b20f40b8883487288aac0f1bca23c23) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41016618)</sub>

<!-- /greptile_comment -->