### PR TITLE
refactor: share accept-language parsing

### DIFF
--- a/packages/i18n/src/internal.ts
+++ b/packages/i18n/src/internal.ts
@@ -44,6 +44,7 @@ export { getVersionId } from './helpers/versionId';
 export { interpolateMessage } from './translation-functions/utils/interpolation/interpolateMessage';
 export { isEncodedTranslationOptions } from './translation-functions/utils/isEncodedTranslationOptions';
 export { extractVariables } from './utils/extractVariables';
+export { parseAcceptLanguage } from './utils/parseAcceptLanguage';
 export {
   getDictionaryListenerKey,
   getTranslateListenerKey,

--- a/packages/i18n/src/utils/__tests__/parseAcceptLanguage.test.ts
+++ b/packages/i18n/src/utils/__tests__/parseAcceptLanguage.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { parseAcceptLanguage } from '../parseAcceptLanguage';
+
+describe('parseAcceptLanguage', () => {
+  it('preserves order when no q-values are present', () => {
+    expect(parseAcceptLanguage('fr-FR,fr,en')).toEqual(['fr-FR', 'fr', 'en']);
+  });
+
+  it('sorts by descending q-value', () => {
+    expect(parseAcceptLanguage('en;q=0.5, fr;q=0.9')).toEqual(['fr', 'en']);
+  });
+
+  it('treats a missing q-value as quality 1', () => {
+    expect(parseAcceptLanguage('fr-FR,fr;q=0.9,en;q=0.8')).toEqual([
+      'fr-FR',
+      'fr',
+      'en',
+    ]);
+  });
+
+  it('keeps original order for entries with equal quality (stable sort)', () => {
+    expect(parseAcceptLanguage('de;q=0.8,fr;q=0.8,en;q=0.8')).toEqual([
+      'de',
+      'fr',
+      'en',
+    ]);
+  });
+
+  it('drops empty entries', () => {
+    expect(parseAcceptLanguage('en,,fr')).toEqual(['en', 'fr']);
+  });
+
+  it('drops entries with q=0', () => {
+    expect(parseAcceptLanguage('fr;q=0,en;q=0.8')).toEqual(['en']);
+  });
+
+  it('falls back to quality 1 for malformed q-values', () => {
+    expect(parseAcceptLanguage('en;q=abc,fr;q=0.5')).toEqual(['en', 'fr']);
+  });
+});

--- a/packages/i18n/src/utils/parseAcceptLanguage.ts
+++ b/packages/i18n/src/utils/parseAcceptLanguage.ts
@@ -1,0 +1,28 @@
+/**
+ * Parse an `Accept-Language` header into locale candidates ordered by descending
+ * quality (q-value) per RFC 7231. Entries without an explicit `q=` default to a
+ * quality of 1, and empty entries or entries with `q=0` are dropped.
+ *
+ * @param header - The raw Accept-Language header value.
+ * @returns Locale candidates, highest quality first.
+ *
+ * @example
+ * parseAcceptLanguage('en;q=0.5, fr;q=0.9'); // ['fr', 'en']
+ * parseAcceptLanguage('fr-FR,fr;q=0.9,en;q=0.8'); // ['fr-FR', 'fr', 'en']
+ */
+export function parseAcceptLanguage(header: string): string[] {
+  return header
+    .split(',')
+    .map((entry) => {
+      const [locale, ...params] = entry.trim().split(';');
+      const qParam = params.find((param) => param.trim().startsWith('q='));
+      const quality = qParam ? parseFloat(qParam.split('=')[1]) : 1;
+      return {
+        locale: locale.trim(),
+        quality: Number.isNaN(quality) ? 1 : quality,
+      };
+    })
+    .filter((entry) => entry.locale !== '' && entry.quality > 0)
+    .sort((a, b) => b.quality - a.quality)
+    .map((entry) => entry.locale);
+}

--- a/packages/next/src/condition-store/AsyncConditionStore.ts
+++ b/packages/next/src/condition-store/AsyncConditionStore.ts
@@ -1,7 +1,7 @@
 import { AsyncReadonlyConditionStoreInterface } from 'gt-i18n/internal/types';
 import { cookies, headers } from 'next/headers';
 import { noLocalesCouldBeDeterminedWarning } from '../errors/ssg';
-import { getI18nConfig } from 'gt-i18n/internal';
+import { getI18nConfig, parseAcceptLanguage } from 'gt-i18n/internal';
 import { defaultLocaleHeaderName } from '../utils/headers';
 import {
   defaultLocaleCookieName,
@@ -106,13 +106,9 @@ function createDefaultGetLocale({
 
     // Preferred languages
     if (!ignorePreferredLanguages) {
-      const acceptedLocales = headersList
-        .get('accept-language')
-        ?.split(',')
-        .map((item: string) => item.split(';')?.[0].trim());
-
-      if (acceptedLocales) {
-        preferredLocales.push(...acceptedLocales);
+      const acceptLanguage = headersList.get('accept-language');
+      if (acceptLanguage) {
+        preferredLocales.push(...parseAcceptLanguage(acceptLanguage));
       }
     }
 

--- a/packages/next/src/middleware-dir/utils.ts
+++ b/packages/next/src/middleware-dir/utils.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { standardizeLocale } from '@generaltranslation/format';
 import { GT } from 'generaltranslation';
+import { parseAcceptLanguage } from 'gt-i18n/internal';
 import { NextURL } from 'next/dist/server/web/next-url';
 
 export type PathConfig = {
@@ -346,12 +347,10 @@ export function getLocaleFromRequest(
 
   // Get locales from accept-language header
   if (process.env._GENERALTRANSLATION_IGNORE_BROWSER_LOCALES === 'false') {
-    const acceptedLocales =
-      headerList
-        .get('accept-language')
-        ?.split(',')
-        .map((item) => item.split(';')?.[0].trim()) || [];
-    if (acceptedLocales) candidates.push(...acceptedLocales);
+    const acceptLanguage = headerList.get('accept-language');
+    if (acceptLanguage) {
+      candidates.push(...parseAcceptLanguage(acceptLanguage));
+    }
   }
 
   // Get default locale

--- a/packages/next/src/pages-dir/parseLocale.ts
+++ b/packages/next/src/pages-dir/parseLocale.ts
@@ -1,6 +1,6 @@
 import type { GetServerSidePropsContext, PreviewData } from 'next';
 import type { ParsedUrlQuery } from 'querystring';
-import { getI18nConfig } from 'gt-i18n/internal';
+import { getI18nConfig, parseAcceptLanguage } from 'gt-i18n/internal';
 import { noLocalesCouldBeDeterminedWarning } from '../errors/ssg';
 import { defaultLocaleHeaderName } from '../utils/headers';
 import { defaultLocaleCookieName } from '@generaltranslation/react-core/cookies';
@@ -74,11 +74,7 @@ function addHeaderCandidates(candidates: string[], headerValue: HeaderValue) {
 
 function getAcceptLanguageCandidates(headerValue: HeaderValue): string[] {
   const headerValues = Array.isArray(headerValue) ? headerValue : [headerValue];
-  return headerValues.flatMap(
-    (value) =>
-      value
-        ?.split(',')
-        .map((item) => item.split(';')?.[0].trim())
-        .filter(Boolean) || []
+  return headerValues.flatMap((value) =>
+    value ? parseAcceptLanguage(value) : []
   );
 }

--- a/packages/node/src/helpers/getRequestLocale.ts
+++ b/packages/node/src/helpers/getRequestLocale.ts
@@ -1,4 +1,4 @@
-import { getI18nConfig } from 'gt-i18n/internal';
+import { getI18nConfig, parseAcceptLanguage } from 'gt-i18n/internal';
 
 /**
  * A request object like interface
@@ -7,31 +7,6 @@ import { getI18nConfig } from 'gt-i18n/internal';
  */
 interface RequestLike {
   headers: Record<string, string | string[] | undefined>;
-}
-
-/**
- * Parse the Accept-Language header into an array of locales
- * @param header - The Accept-Language header
- * @returns An array of locales
- *
- * @example
- * const locales = parseAcceptLanguage('fr-FR,fr;q=0.9,en;q=0.8');
- * console.log(locales); // ['fr-FR', 'fr', 'en']
- */
-function parseAcceptLanguage(header: string): string[] {
-  return header
-    .split(',')
-    .map((entry) => {
-      const [locale, quality] = entry.trim().split(';');
-      const qPart = quality?.split('=')[1];
-      const q = qPart !== undefined ? parseFloat(qPart) : 1;
-      return {
-        locale: locale.trim(),
-        quality: isNaN(q) ? 1 : q,
-      };
-    })
-    .sort((a, b) => b.quality - a.quality)
-    .map((entry) => entry.locale);
 }
 
 /**

--- a/packages/tanstack-start/src/functions/parseLocale.ts
+++ b/packages/tanstack-start/src/functions/parseLocale.ts
@@ -5,8 +5,7 @@ import {
   getCookie,
   setCookie,
 } from '@tanstack/react-start/server';
-import { getI18nConfig } from 'gt-i18n/internal';
-import type { I18nConfigParams } from 'gt-i18n/internal/types';
+import { getI18nConfig, parseAcceptLanguage } from 'gt-i18n/internal';
 
 export const determineLocale = createIsomorphicFn()
   .server(determineLocaleServer)
@@ -16,29 +15,20 @@ export const determineLocale = createIsomorphicFn()
  * Resolve the user's locale for the current TanStack Start request or browser.
  */
 export function parseLocale(): string {
-  const i18nConfig = getI18nConfig();
-  return determineLocale({
-    defaultLocale: i18nConfig.getDefaultLocale(),
-    locales: i18nConfig.getLocales(),
-    customMapping: i18nConfig.getCustomMapping(),
-  });
+  return determineLocale();
 }
 
-function determineLocaleServer({
-  defaultLocale,
-  locales,
-  customMapping,
-}: I18nConfigParams) {
+// createIsomorphicFn is a build-time split (not an RPC), so the i18n config
+// singleton is available in both branches. There is no need to thread its
+// values through — resolveSupportedLocale() reads them off the singleton.
+function determineLocaleServer() {
   const candidates: string[] = [];
 
   const cookie = getCookie(defaultLocaleCookieName);
   if (cookie) candidates.push(cookie);
 
-  const headers =
-    getRequestHeader('accept-language')
-      ?.split(',')
-      .map((item) => item.split(';')?.[0].trim()) || [];
-  candidates.push(...headers);
+  const acceptLanguage = getRequestHeader('accept-language');
+  if (acceptLanguage) candidates.push(...parseAcceptLanguage(acceptLanguage));
 
   if (candidates.length === 0) {
     console.warn(
@@ -46,11 +36,7 @@ function determineLocaleServer({
     );
   }
 
-  const locale = getI18nConfig().resolveSupportedLocale(candidates, {
-    defaultLocale,
-    locales,
-    customMapping,
-  });
+  const locale = getI18nConfig().resolveSupportedLocale(candidates);
 
   setCookie(defaultLocaleCookieName, locale, {
     path: '/',
@@ -61,11 +47,7 @@ function determineLocaleServer({
   return locale;
 }
 
-function determineLocaleClient({
-  defaultLocale,
-  locales,
-  customMapping,
-}: I18nConfigParams) {
+function determineLocaleClient() {
   const candidates: string[] = [];
 
   const cookie = document.cookie
@@ -80,9 +62,5 @@ function determineLocaleClient({
     );
   }
 
-  return getI18nConfig().resolveSupportedLocale(candidates, {
-    defaultLocale,
-    locales,
-    customMapping,
-  });
+  return getI18nConfig().resolveSupportedLocale(candidates);
 }


### PR DESCRIPTION
## Summary
- add a shared gt-i18n Accept-Language parser and use it from Next, Node, and TanStack locale resolution
- sort by q-value consistently and drop q=0 entries
- keep the parser on the existing internal entrypoint used by these packages

## Verification
- pnpm --filter gt-i18n build
- pnpm --filter gt-i18n test -- parseAcceptLanguage
- pnpm --filter gt-i18n typecheck
- pnpm --filter gt-node typecheck
- pnpm --filter gt-tanstack-start typecheck
- pnpm --filter gt-next typecheck
- pnpm --filter gt-next test:js -- middleware.edge localeResolution.edge parseLocale