### PR TITLE
refactor: reuse default children renderer

### DIFF
--- a/packages/react-core/src/utils/rendering/createRenderPipeline.ts
+++ b/packages/react-core/src/utils/rendering/createRenderPipeline.ts
@@ -36,6 +36,7 @@ function createRenderPipeline(components: VariableComponents): RenderPipeline {
   const renderDefaultChildren = createRenderDefaultChildren({ renderVariable });
   const renderTranslatedChildren = createRenderTranslatedChildren({
     renderVariable,
+    renderDefaultChildren,
   });
   const renderPreparedT = createRenderPreparedT({
     renderDefaultChildren,

--- a/packages/react-core/src/utils/rendering/renderTranslatedChildren.shared.tsx
+++ b/packages/react-core/src/utils/rendering/renderTranslatedChildren.shared.tsx
@@ -10,7 +10,7 @@ import {
   getVariableProps,
   isVariableElementProps,
 } from '../variables/_getVariableProps';
-import { createRenderDefaultChildren } from './renderDefaultChildren.shared';
+import type { RenderDefaultChildrenArgs } from './renderDefaultChildren.shared';
 import { isVariable, libraryDefaultLocale } from 'generaltranslation/internal';
 import { getPluralBranch } from '../plurals/getPluralBranch';
 import {
@@ -34,11 +34,11 @@ type RenderTranslatedChildrenArgs = {
 
 function createRenderTranslatedChildren({
   renderVariable,
+  renderDefaultChildren,
 }: {
   renderVariable: RenderVariable;
+  renderDefaultChildren: (args: RenderDefaultChildrenArgs) => ReactNode;
 }): (args: RenderTranslatedChildrenArgs) => ReactNode {
-  const renderDefaultChildren = createRenderDefaultChildren({ renderVariable });
-
   function renderTranslatedElement({
     sourceElement,
     targetElement,


### PR DESCRIPTION
## Summary
- pass the existing default-children renderer into translated-children rendering
- avoid constructing duplicate renderDefaultChildren closures in the render pipeline

## Verification
- pnpm --filter @generaltranslation/react-core typecheck