### PR TITLE
fix: stop forwarding locale prop from next link

### DIFF
--- a/.changeset/fix-link-locale-false.md
+++ b/.changeset/fix-link-locale-false.md
@@ -1,0 +1,7 @@
+---
+"gt-next": patch
+---
+
+Stop forwarding `locale={false}` from `gt-next/link` to the underlying Next.js link after localizing the href.
+
+This avoids React DOM warnings in newer Next.js versions where the control prop can reach the rendered anchor.

--- a/packages/next/src/link/Link.tsx
+++ b/packages/next/src/link/Link.tsx
@@ -89,14 +89,7 @@ function renderLink(
   { href, locale, ...props }: ResolvedLinkProps,
   ref: ForwardedRef<LinkRef>
 ) {
-  return (
-    <NextLink
-      {...props}
-      href={localizeHref(href, locale)}
-      locale={false}
-      ref={ref}
-    />
-  );
+  return <NextLink {...props} href={localizeHref(href, locale)} ref={ref} />;
 }
 
 function localizeHref(href: LinkHref, locale: LinkProps['locale']): LinkHref {

--- a/packages/next/src/link/__tests__/Link.test.tsx
+++ b/packages/next/src/link/__tests__/Link.test.tsx
@@ -1,0 +1,62 @@
+import type React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockNextLink, mockUseLocale } = vi.hoisted(() => ({
+  mockNextLink: vi.fn(),
+  mockUseLocale: vi.fn(),
+}));
+
+vi.mock('gt-react', () => ({
+  useLocale: mockUseLocale,
+}));
+
+vi.mock('next/link', async () => {
+  const React = await import('react');
+
+  return {
+    default: React.forwardRef<HTMLAnchorElement, Record<string, unknown>>(
+      function MockNextLink({ children, href, ...props }, ref) {
+        mockNextLink({ ...props, href });
+        return (
+          <a href={href as string} ref={ref}>
+            {children as React.ReactNode}
+          </a>
+        );
+      }
+    ),
+  };
+});
+
+describe('Link', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseLocale.mockReturnValue('fr');
+  });
+
+  it('prefixes internal links with the current locale without forwarding locale', async () => {
+    const { Link } = await import('../Link');
+
+    renderToStaticMarkup(<Link href='/home'>Home</Link>);
+
+    expect(mockNextLink).toHaveBeenCalledWith({
+      href: '/fr/home',
+    });
+    expect(mockNextLink.mock.calls[0][0]).not.toHaveProperty('locale');
+  });
+
+  it('leaves href unchanged for locale=false without forwarding locale', async () => {
+    const { Link } = await import('../Link');
+
+    renderToStaticMarkup(
+      <Link href='/legal' locale={false}>
+        Legal
+      </Link>
+    );
+
+    expect(mockNextLink).toHaveBeenCalledWith({
+      href: '/legal',
+    });
+    expect(mockNextLink.mock.calls[0][0]).not.toHaveProperty('locale');
+  });
+});


### PR DESCRIPTION
## Summary

- Stop passing `locale={false}` through to `next/link` after `gt-next/link` localizes hrefs.
- Add regression coverage that verifies localized links do not forward `locale` to the underlying Link component.

## Testing

- `pnpm exec oxfmt --check packages/next/src/link/Link.tsx packages/next/src/link/__tests__/Link.test.tsx`
- `pnpm exec oxlint packages/next/src/link/Link.tsx packages/next/src/link/__tests__/Link.test.tsx`
- `pnpm --filter gt-next typecheck`
- `pnpm --filter gt-next exec vitest run src/link/__tests__/Link.test.tsx`
- `pnpm --filter gt-next test:js`
- `pnpm --filter gt-next build:no-swc-plugin`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the explicit `locale={false}` forwarding to `next/link` after `gt-next/link` has already localized the href, and adds a regression test to verify the behavior. The `locale` prop is a Pages Router i18n feature that is not supported (and could produce warnings) in the Next.js App Router.

- `renderLink` now omits `locale` entirely from the props passed to `NextLink`; since `locale` is already destructured out of `ResolvedLinkProps`, the fix is achieved by simply dropping the explicit `locale={false}` override.
- Two vitest cases are added: one for the default path (locale auto-detected from `useLocale`) and one for the opt-out path (`locale={false}`), both asserting that `locale` does not appear on the rendered `NextLink` props.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a one-line removal of a prop that was already redundant and could cause warnings in App Router.

The `locale` prop was already being destructured out of `ResolvedLinkProps` before `...props` was spread, so the explicit `locale={false}` override was the only way it reached `NextLink`. Removing it is a clean, correct fix. The new tests cover both the default-locale and opt-out paths and confirm `locale` does not appear on the rendered `NextLink` props.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/next/src/link/Link.tsx | Removes the explicit `locale={false}` prop forwarded to NextLink; locale is already destructured out and localizeHref handles all prefixing, so the fix is correct and minimal. |
| packages/next/src/link/__tests__/Link.test.tsx | New test file with two cases covering the default locale and locale=false paths; mock setup and assertions correctly validate that locale is not forwarded to NextLink. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User as User Code
    participant GTLink as gt-next Link
    participant renderLink as renderLink
    participant localizeHref as localizeHref
    participant NextLink as next/link

    User->>GTLink: "href="/home""
    GTLink->>GTLink: "locale = useLocale() returns "fr""
    GTLink->>renderLink: "href="/home", locale="fr", ...props"
    renderLink->>localizeHref: "/home", "fr"
    localizeHref-->>renderLink: "/fr/home"
    renderLink->>NextLink: "href="/fr/home", ...props (locale omitted)"

    User->>GTLink: "href="/legal", locale=false"
    GTLink->>renderLink: "href="/legal", locale=false, ...props"
    renderLink->>localizeHref: "/legal", false
    localizeHref-->>renderLink: "/legal" unchanged
    renderLink->>NextLink: "href="/legal", ...props (locale omitted)"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User as User Code
    participant GTLink as gt-next Link
    participant renderLink as renderLink
    participant localizeHref as localizeHref
    participant NextLink as next/link

    User->>GTLink: "href="/home""
    GTLink->>GTLink: "locale = useLocale() returns "fr""
    GTLink->>renderLink: "href="/home", locale="fr", ...props"
    renderLink->>localizeHref: "/home", "fr"
    localizeHref-->>renderLink: "/fr/home"
    renderLink->>NextLink: "href="/fr/home", ...props (locale omitted)"

    User->>GTLink: "href="/legal", locale=false"
    GTLink->>renderLink: "href="/legal", locale=false, ...props"
    renderLink->>localizeHref: "/legal", false
    localizeHref-->>renderLink: "/legal" unchanged
    renderLink->>NextLink: "href="/legal", ...props (locale omitted)"
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: stop forwarding locale prop from ne..."](https://github.com/generaltranslation/gt/commit/69b133ca8caeece797bf289e79a0b5137c8906e9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41022058)</sub>

<!-- /greptile_comment -->