### PR TITLE
fix(compiler): accept full gt config shapes

### DIFF
--- a/packages/compiler/src/config.ts
+++ b/packages/compiler/src/config.ts
@@ -7,18 +7,24 @@ export type LogLevel = 'silent' | 'error' | 'warn' | 'info' | 'debug';
 /**
  * The only relevant parts of the GT config that we are concerned with
  */
-type GTConfig = {
+export type GTConfigParsingFlags = {
+  enableAutoJsxInjection?: boolean;
+  autoderive?: boolean | { jsx?: boolean; strings?: boolean };
+  legacyGtReactImportSource?: boolean;
+  /** Dev hot reload: inject runtime translate calls and enable Suspense-based <T> */
+  devHotReload?: boolean | { strings?: boolean; jsx?: boolean };
+  [key: string]: unknown;
+};
+
+export type GTConfig = {
   files?: {
+    [key: string]: unknown;
     gt?: {
-      parsingFlags?: {
-        enableAutoJsxInjection?: boolean;
-        autoderive?: boolean | { jsx?: boolean; strings?: boolean };
-        legacyGtReactImportSource?: boolean;
-        /** Dev hot reload: inject runtime translate calls and enable Suspense-based <T> */
-        devHotReload?: boolean | { strings?: boolean; jsx?: boolean };
-      };
+      parsingFlags?: GTConfigParsingFlags;
+      [key: string]: unknown;
     };
   };
+  [key: string]: unknown;
 };
 
 /**


### PR DESCRIPTION
## Summary
- Export the compiler gt config type used by `gtConfig` plugin options.
- Allow normal `gt.config.json` fields alongside the compiler parsing flags.

## Testing
- `pnpm --filter @generaltranslation/compiler test src/__tests__/index.test.ts`
- `pnpm --filter @generaltranslation/compiler typecheck`
- `pnpm --filter @generaltranslation/compiler build`
- ad hoc `tsc --noEmit` check for an inline full `gt.config.json` shape passed as `GTUnpluginOptions.gtConfig`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes type-level improvements to the compiler's config module: it exports the `GTConfig` and `GTConfigParsingFlags` types from `config.ts` and broadens `GTConfig` to accept the full `gt.config.json` shape (e.g. `projectId`, `defaultLocale`, `locales`, `files.gt.output`) alongside the compiler-specific `parsingFlags`, removing TypeScript errors when users pass a complete project config inline.

- **Type broadening**: `GTConfig` is widened to accept all valid `gt.config.json` fields, not just `files.gt.parsingFlags`; runtime resolution in `initializeState.ts` is unaffected since it only reads the specific `parsingFlags` properties.
- **New exports**: `GTConfig` and `GTConfigParsingFlags` are marked `export type` in `config.ts`, enabling consumers to reference these types by name.
- **New test**: A test verifies that an auto-loaded `gt.config.json` with ordinary project-level fields (no `parsingFlags`) produces the correct default compiler behaviour.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the changes are confined to TypeScript type definitions and do not alter any runtime behaviour.

The diff touches only type declarations: broadening GTConfig and exporting new type aliases. All runtime resolution logic in initializeState.ts is unchanged and correctly reads parsingFlags through typed named-property access that remains valid under any reasonable broadening approach. The only open gap is test coverage for the inline full-config path, which is a testing concern rather than a correctness one.

packages/compiler/src/config.ts — verify the re-export situation in src/index.ts so consumers can import the new types by name.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/compiler/src/config.ts | Exports GTConfig and GTConfigParsingFlags types and broadens GTConfig to accept full gt.config.json shapes; type-only change with no runtime impact, though the re-export from index.ts needs attention per the previous review thread. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[GTUnpluginOptions.gtConfig] -->|provided inline| B{GTConfig type check}
    A -->|not provided| C[loadGTConfigFromCwd]
    C -->|reads gt.config.json| D[JSON.parse → cast to GTConfig]
    B --> E[initializeState.ts]
    D --> E
    E -->|extracts| F[files.gt.parsingFlags.enableAutoJsxInjection]
    E -->|extracts| G[files.gt.parsingFlags.autoderive]
    E -->|extracts| H[files.gt.parsingFlags.devHotReload]
    E -->|extracts| I[files.gt.parsingFlags.legacyGtReactImportSource]
    F & G & H & I --> J[PluginSettings resolved]
    B -->|extra fields accepted - PR fix| K[projectId / defaultLocale / locales / files.gt.output etc.]
    K --> E
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[GTUnpluginOptions.gtConfig] -->|provided inline| B{GTConfig type check}
    A -->|not provided| C[loadGTConfigFromCwd]
    C -->|reads gt.config.json| D[JSON.parse → cast to GTConfig]
    B --> E[initializeState.ts]
    D --> E
    E -->|extracts| F[files.gt.parsingFlags.enableAutoJsxInjection]
    E -->|extracts| G[files.gt.parsingFlags.autoderive]
    E -->|extracts| H[files.gt.parsingFlags.devHotReload]
    E -->|extracts| I[files.gt.parsingFlags.legacyGtReactImportSource]
    F & G & H & I --> J[PluginSettings resolved]
    B -->|extra fields accepted - PR fix| K[projectId / defaultLocale / locales / files.gt.output etc.]
    K --> E
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(compiler): accept full gt config sha..."](https://github.com/generaltranslation/gt/commit/be0a0c7df44e0908657dc6b0a200476f4c428a1e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41023441)</sub>

<!-- /greptile_comment -->