### PR TITLE
fix: preserve route handler locale registration

### DIFF
--- a/.changeset/fix-next-route-handler-locale-store.md
+++ b/.changeset/fix-next-route-handler-locale-store.md
@@ -1,0 +1,5 @@
+---
+'gt-next': patch
+---
+
+Fix route handler locale registration so `getGT()` honors locales registered with `registerLocale()` before falling back to request locale resolution.

--- a/packages/next/src/__tests__/server.test.ts
+++ b/packages/next/src/__tests__/server.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('server-only', () => ({}));
+
+type TestGlobal = typeof globalThis & {
+  __generaltranslation?: {
+    i18n?: Record<string, unknown>;
+    next?: Record<string, unknown>;
+    [key: string]: unknown;
+  };
+};
+
+function resetGTGlobals() {
+  const globalObj = globalThis as TestGlobal;
+  if (globalObj.__generaltranslation?.i18n) {
+    Reflect.deleteProperty(globalObj.__generaltranslation.i18n, 'i18nConfig');
+    Reflect.deleteProperty(globalObj.__generaltranslation.i18n, 'i18nCache');
+    Reflect.deleteProperty(
+      globalObj.__generaltranslation.i18n,
+      'conditionStore'
+    );
+  }
+  if (globalObj.__generaltranslation?.next) {
+    Reflect.deleteProperty(globalObj.__generaltranslation.next, 'localeStore');
+  }
+}
+
+describe('server entrypoint', () => {
+  beforeEach(() => {
+    resetGTGlobals();
+    vi.resetModules();
+  });
+
+  it('initializes request globals when imported directly', async () => {
+    const { isI18nConfigInitialized } = await import('gt-i18n/internal');
+
+    expect(isI18nConfigInitialized()).toBe(false);
+
+    await import('../server');
+
+    const { getAsyncConditionStore } =
+      await import('../condition-store/AsyncConditionStore');
+
+    expect(isI18nConfigInitialized()).toBe(true);
+    expect(() => getAsyncConditionStore()).not.toThrow();
+  });
+
+  it('initializes a missing condition store without replacing the i18n config', async () => {
+    const { getI18nConfig, initializeI18nConfig } =
+      await import('gt-i18n/internal');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const config = initializeI18nConfig({ defaultLocale: 'en' });
+
+    await import('../server');
+
+    const { getAsyncConditionStore } =
+      await import('../condition-store/AsyncConditionStore');
+
+    expect(getI18nConfig()).toBe(config);
+    expect(() => getAsyncConditionStore()).not.toThrow();
+    expect(warn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/next/src/condition-store/AsyncConditionStore.ts
+++ b/packages/next/src/condition-store/AsyncConditionStore.ts
@@ -23,6 +23,7 @@ export type AsyncConditionStoreParams = {
 export const {
   getConditionStore: getAsyncConditionStore,
   setConditionStore: setAsyncConditionStore,
+  isConditionStoreInitialized: isAsyncConditionStoreInitialized,
 } = createConditionStoreSingleton<AsyncConditionStore>(
   'AsyncConditionStore not initialized. Invoke initializeGT() to initialize.'
 );

--- a/packages/next/src/request/__tests__/localeStore.test.ts
+++ b/packages/next/src/request/__tests__/localeStore.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type TestGlobal = typeof globalThis & {
+  __generaltranslation?: {
+    next?: Record<string, unknown>;
+    [key: string]: unknown;
+  };
+};
+
+function resetNextGlobals() {
+  const globalObj = globalThis as TestGlobal;
+  if (globalObj.__generaltranslation?.next) {
+    Reflect.deleteProperty(globalObj.__generaltranslation.next, 'localeStore');
+  }
+}
+
+describe('localeStore', () => {
+  beforeEach(() => {
+    resetNextGlobals();
+    vi.resetModules();
+  });
+
+  it('reuses the same store after the module is loaded again', async () => {
+    const firstModule = await import('../localeStore');
+
+    vi.resetModules();
+
+    const secondModule = await import('../localeStore');
+
+    expect(secondModule.localeStore).toBe(firstModule.localeStore);
+  });
+});

--- a/packages/next/src/request/localeStore.ts
+++ b/packages/next/src/request/localeStore.ts
@@ -1,3 +1,15 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
+import { createGlobalSingleton } from 'gt-i18n/internal';
 
-export const localeStore = new AsyncLocalStorage<string>();
+const localeStoreSingleton = createGlobalSingleton<AsyncLocalStorage<string>>({
+  namespace: 'next',
+  key: 'localeStore',
+  source: 'gt-next',
+  notInitialized: () => 'Locale store has not been initialized.',
+});
+
+if (!localeStoreSingleton.isInitialized()) {
+  localeStoreSingleton.set(new AsyncLocalStorage<string>());
+}
+
+export const localeStore = localeStoreSingleton.get();

--- a/packages/next/src/server.ts
+++ b/packages/next/src/server.ts
@@ -1,8 +1,23 @@
 import 'server-only';
+import { isI18nConfigInitialized } from 'gt-i18n/internal';
+import { isAsyncConditionStoreInitialized } from './condition-store/AsyncConditionStore';
+import {
+  initializeAsyncConditionStore,
+  initializeGT,
+} from './setup/initGT.rsc';
 
 /**
  * Rule: have to throw an error if called in a "use client" context
  */
+
+const hasI18nConfig = isI18nConfigInitialized();
+const hasAsyncConditionStore = isAsyncConditionStoreInitialized();
+
+if (!hasI18nConfig && !hasAsyncConditionStore) {
+  initializeGT();
+} else if (!hasAsyncConditionStore) {
+  initializeAsyncConditionStore();
+}
 
 // Locale management
 export { getLocale } from './request/getLocale';

--- a/packages/next/src/setup/initGT.rsc.ts
+++ b/packages/next/src/setup/initGT.rsc.ts
@@ -29,8 +29,11 @@ export function initializeGT(
     nextI18nCacheParams,
   });
 
-  const asyncConditionStoreParams = getAsyncConditionStoreParams();
+  initializeAsyncConditionStore();
+}
 
+export function initializeAsyncConditionStore(): void {
+  const asyncConditionStoreParams = getAsyncConditionStoreParams();
   // Note that this gets used by RSC, but SSR (aka 'use client' bondary on server)
   // uses context to access this condition store
   const conditionStore = new AsyncConditionStore(asyncConditionStoreParams);


### PR DESCRIPTION
## Summary
- store `gt-next` route-handler locale registration in the shared GT global registry so split Next/Turbopack module graphs read the same `AsyncLocalStorage`
- initialize GT request globals when `gt-next/server` is imported directly by a cold route handler
- add regression coverage for shared locale store reuse and direct server-entry initialization
- add a patch changeset for `gt-next`

## Tests
- `pnpm --filter gt-next test:js src/request/__tests__/localeStore.test.ts src/__tests__/server.test.ts src/__tests__/rscLeaks.test.ts`
- `pnpm --filter gt-next build:no-swc-plugin`
- `git diff --check`
- packed local `gt-next`, installed it into `~/code/bengubler.com`, restored the RSS route to `getGT()` + `registerLocale(locale)`, and verified cold `GET /rss.xml` and `GET /en/rss.xml` both returned `200 application/xml` without the `next/root-params` route-handler error

## Notes
- `build:no-swc-plugin` still emits the existing unresolved dynamic import warnings for `gt-next/internal/_getLocale` and `gt-next/internal/_getRegion`; the build exits successfully.
- Raw `pnpm link` was not usable for the app smoke test because Turbopack could not resolve `gt-next/server` and `gt-next/middleware` from the symlinked package, so the smoke test used a packed local tarball instead.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a locale registration bug in `gt-next` where split Next.js/Turbopack module graphs could end up with different `AsyncLocalStorage` instances for the locale store, causing `registerLocale()` to be invisible to `getGT()`. It also ensures that a cold import of `gt-next/server` directly by a route handler self-initializes request globals.

- **`localeStore.ts`** migrates the `AsyncLocalStorage` instance into the shared GT global registry (`createGlobalSingleton`) so any module graph instance retrieves the same store object.
- **`server.ts`** adds module-level guard logic to call `initializeGT()` (neither singleton exists) or the lighter `initializeAsyncConditionStore()` (only the condition store is missing), avoiding the spurious i18n-config overwrite warning from the previous approach.
- **`initGT.rsc.ts`** extracts `initializeAsyncConditionStore` into a standalone export so `server.ts` can call it without re-running the full `initializeGT` path.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a targeted, well-tested fix that stores the locale AsyncLocalStorage in the shared global registry and adds self-initialization for cold route-handler imports.

The fix is narrow and well-reasoned: the localeStore migration to the global registry correctly ensures one AsyncLocalStorage instance across split module graphs, the three-branch guard in server.ts avoids both uninitialized-access and spurious singleton-overwrite warnings, and new regression tests cover both the shared-store and partial-initialization scenarios.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/next/src/request/localeStore.ts | Core fix: moves AsyncLocalStorage into the GT global registry via createGlobalSingleton so split module graphs share one instance. |
| packages/next/src/server.ts | Adds module-level auto-initialization guarded by isI18nConfigInitialized / isAsyncConditionStoreInitialized; the three-branch logic correctly avoids overwriting an existing i18n config. |
| packages/next/src/setup/initGT.rsc.ts | Extracts initializeAsyncConditionStore as a named export; initializeGT now delegates to it. Clean refactor with no behavior change for the normal setup path. |
| packages/next/src/condition-store/AsyncConditionStore.ts | Exports the new isAsyncConditionStoreInitialized predicate from the existing singleton; minimal, correct change. |
| packages/next/src/__tests__/server.test.ts | New tests cover cold-import initialization and partial-initialization without spurious warnings. |
| packages/next/src/request/__tests__/localeStore.test.ts | Regression test confirms that re-importing the module after vi.resetModules still returns the same AsyncLocalStorage reference from the global registry. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Route Handler imports gt-next/server] --> B{isI18nConfigInitialized?}
    B -- No --> C{isAsyncConditionStoreInitialized?}
    C -- No --> D[initializeGT\ncreates I18nConfig + AsyncConditionStore]
    C -- Yes --> E[No-op\nboth already set]
    B -- Yes --> F{isAsyncConditionStoreInitialized?}
    F -- No --> G[initializeAsyncConditionStore\ncreates AsyncConditionStore only]
    F -- Yes --> E
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Route Handler imports gt-next/server] --> B{isI18nConfigInitialized?}
    B -- No --> C{isAsyncConditionStoreInitialized?}
    C -- No --> D[initializeGT\ncreates I18nConfig + AsyncConditionStore]
    C -- Yes --> E[No-op\nboth already set]
    B -- Yes --> F{isAsyncConditionStoreInitialized?}
    F -- No --> G[initializeAsyncConditionStore\ncreates AsyncConditionStore only]
    F -- Yes --> E
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: preserve route handler locale regis..."](https://github.com/generaltranslation/gt/commit/d4f36d7ec0d2c85242d251764e3571c015812044) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41029738)</sub>

<!-- /greptile_comment -->