### PR TITLE
fix: read vite runtime credentials

### DIFF
--- a/.changeset/vite-runtime-credentials.md
+++ b/.changeset/vite-runtime-credentials.md
@@ -1,0 +1,6 @@
+---
+"gt-react": patch
+"gt-i18n": patch
+---
+
+Read Vite runtime credentials during React initialization while keeping dev API keys out of production bundles.

--- a/packages/i18n/src/utils/getRuntimeEnvironment.ts
+++ b/packages/i18n/src/utils/getRuntimeEnvironment.ts
@@ -11,17 +11,37 @@ export function getRuntimeEnvironment(): 'development' | 'production' {
     return 'development';
   }
 
-  const importMetaEnv = (
-    import.meta as ImportMeta & {
-      env?: RuntimeEnvironment;
-    }
-  ).env;
-  if (importMetaEnv?.MODE) {
-    return importMetaEnv.MODE === 'development' ? 'development' : 'production';
+  const importMetaMode = readImportMetaEnv(
+    () =>
+      (
+        import.meta as ImportMeta & {
+          env?: RuntimeEnvironment;
+        }
+      ).env?.MODE
+  );
+  if (importMetaMode) {
+    return importMetaMode === 'development' ? 'development' : 'production';
   }
-  if (importMetaEnv?.DEV === true) {
+  if (
+    readImportMetaEnv(
+      () =>
+        (
+          import.meta as ImportMeta & {
+            env?: RuntimeEnvironment;
+          }
+        ).env?.DEV
+    ) === true
+  ) {
     return 'development';
   }
 
   return 'production';
+}
+
+function readImportMetaEnv<T>(readValue: () => T | undefined): T | undefined {
+  try {
+    return readValue();
+  } catch {
+    return undefined;
+  }
 }

--- a/packages/react/src/__tests__/react-package.test.ts
+++ b/packages/react/src/__tests__/react-package.test.ts
@@ -76,6 +76,27 @@ describe('gt-react package exports', () => {
     ]);
   });
 
+  it('throws when initializeGTSPA is called from the server entrypoint', () => {
+    node([
+      '-e',
+      `
+          const assert = require('node:assert/strict');
+          const react = require('gt-react');
+
+          assert.equal(typeof react.initializeGTSPA, 'function');
+          (async () => {
+            await assert.rejects(
+              () => react.initializeGTSPA({}),
+              /server runtime entry point/
+            );
+          })().catch((error) => {
+            console.error(error);
+            process.exit(1);
+          });
+        `,
+    ]);
+  });
+
   it('loads named exports from built ESM entrypoints', () => {
     node([
       '--input-type=module',

--- a/packages/react/src/index.server.ts
+++ b/packages/react/src/index.server.ts
@@ -1,5 +1,6 @@
 'use client';
 
+import { createDiagnosticMessage } from 'generaltranslation/internal';
 import type { ReactNode } from 'react';
 import type { TxProps } from './utils/TxProps';
 
@@ -7,7 +8,7 @@ import type { TxProps } from './utils/TxProps';
 // providers, and context modules, so it must be consumed as a client boundary by
 // React Server Component frameworks.
 
-export { initializeGTSPA } from './setup/initializeGTSPA';
+export { initializeGTSRA as initializeGT } from './setup/initializeGTSRA';
 export { useLocaleSelector } from './components/useLocaleSelector';
 export { useRegionSelector } from './components/useRegionSelector';
 export {
@@ -20,6 +21,21 @@ export {
   defaultLocaleCookieName,
   defaultRegionCookieName,
 } from './cookie-names';
+
+type InitializeGTSPA = typeof import('./setup/initializeGTSPA').initializeGTSPA;
+
+export const initializeGTSPA: InitializeGTSPA = async () => {
+  throw new Error(
+    createDiagnosticMessage({
+      source: 'gt-react',
+      severity: 'Error',
+      whatHappened:
+        'initializeGTSPA() cannot be called from the server runtime entry point',
+      why: 'initializeGTSPA() initializes browser-only SPA state and translation cache behavior.',
+      fix: 'Use initializeGT() for server-rendered React runtimes or import initializeGTSPA from the browser entry point.',
+    })
+  );
+};
 
 // ===== Components ===== //
 export { ServerGTProvider as GTProvider } from './provider/ServerGTProvider';
@@ -82,7 +98,6 @@ export {
   getTranslationsSnapshot,
   getVersionId,
   createRenderPipeline,
-  internalInitializeGTSRA as initializeGT,
   setReactI18nCache,
   t,
 } from '@generaltranslation/react-core/pure';

--- a/packages/react/src/setup/__tests__/runtimeCredentials.test.ts
+++ b/packages/react/src/setup/__tests__/runtimeCredentials.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { addRuntimeCredentials } from '../runtimeCredentials';
+
+const originalNodeEnv = process.env.NODE_ENV;
+
+describe('runtime credentials', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  it('reads Vite runtime credentials in development', () => {
+    process.env.NODE_ENV = 'development';
+    vi.stubEnv('VITE_GT_PROJECT_ID', 'vite-project-id');
+    vi.stubEnv('VITE_GT_DEV_API_KEY', 'vite-dev-api-key');
+
+    expect(addRuntimeCredentials({})).toMatchObject({
+      projectId: 'vite-project-id',
+      devApiKey: 'vite-dev-api-key',
+    });
+  });
+
+  it('keeps explicitly supplied credentials', () => {
+    process.env.NODE_ENV = 'development';
+    vi.stubEnv('VITE_GT_PROJECT_ID', 'vite-project-id');
+    vi.stubEnv('VITE_GT_DEV_API_KEY', 'vite-dev-api-key');
+
+    expect(
+      addRuntimeCredentials({
+        projectId: 'explicit-project-id',
+        devApiKey: 'explicit-dev-api-key',
+      })
+    ).toMatchObject({
+      projectId: 'explicit-project-id',
+      devApiKey: 'explicit-dev-api-key',
+    });
+  });
+
+  it('does not read the dev api key outside development', () => {
+    process.env.NODE_ENV = 'production';
+    vi.stubEnv('VITE_GT_PROJECT_ID', 'vite-project-id');
+    vi.stubEnv('VITE_GT_DEV_API_KEY', 'vite-dev-api-key');
+
+    expect(addRuntimeCredentials({})).toMatchObject({
+      projectId: 'vite-project-id',
+      devApiKey: undefined,
+    });
+  });
+});

--- a/packages/react/src/setup/initializeGTSPA.ts
+++ b/packages/react/src/setup/initializeGTSPA.ts
@@ -13,6 +13,7 @@ import {
   createOrUpdateBrowserConditionStore,
   CreateBrowserConditionStoreParams,
 } from '../condition-store/createBrowserConditionStore';
+import { addRuntimeCredentials } from './runtimeCredentials';
 
 /**
  * Initialize GT for an SPA
@@ -27,12 +28,13 @@ export async function initializeGTSPA(
     BrowserI18nCacheParams &
     CreateBrowserConditionStoreParams
 ) {
-  initializeI18nConfig(config, 'SPA');
+  const runtimeConfig = addRuntimeCredentials(config);
+  initializeI18nConfig(runtimeConfig, 'SPA');
 
-  const i18nCache = new BrowserI18nCache(config);
+  const i18nCache = new BrowserI18nCache(runtimeConfig);
   setReactI18nCache(i18nCache);
 
-  createOrUpdateBrowserConditionStore(config);
+  createOrUpdateBrowserConditionStore(runtimeConfig);
 
   const i18nStore = new I18nStore();
   setI18nStore(i18nStore);

--- a/packages/react/src/setup/initializeGTSRA.ts
+++ b/packages/react/src/setup/initializeGTSRA.ts
@@ -6,15 +6,10 @@ import type { I18nConfigParams } from 'gt-i18n/internal/types';
 import { addRuntimeCredentials } from './runtimeCredentials';
 
 /**
- * Initialize GT for client-side rendering.
+ * Initialize GT for server-rendered React runtimes.
  */
-export function initializeGTSRAClient(
+export function initializeGTSRA(
   config: I18nConfigParams & ReactI18nCacheParams
 ): void {
-  internalInitializeGTSRA(
-    addRuntimeCredentials({
-      cacheExpiryTime: null,
-      ...config,
-    })
-  );
+  internalInitializeGTSRA(addRuntimeCredentials(config));
 }

--- a/packages/react/src/setup/runtimeCredentials.ts
+++ b/packages/react/src/setup/runtimeCredentials.ts
@@ -1,0 +1,73 @@
+import { getRuntimeEnvironment } from 'gt-i18n/internal';
+import type { I18nConfigParams } from 'gt-i18n/internal/types';
+
+type RuntimeCredentials = Pick<I18nConfigParams, 'projectId' | 'devApiKey'>;
+type RuntimeEnv = {
+  DEV?: boolean;
+  VITE_GT_PROJECT_ID?: string;
+  VITE_GT_DEV_API_KEY?: string;
+};
+
+export function addRuntimeCredentials<T extends RuntimeCredentials>(
+  config: T
+): T {
+  const credentials = getRuntimeCredentials();
+  return {
+    ...config,
+    projectId: config.projectId || credentials.projectId,
+    devApiKey: config.devApiKey || credentials.devApiKey,
+  };
+}
+
+function getRuntimeCredentials(): RuntimeCredentials {
+  return {
+    projectId:
+      readImportMetaVite(
+        () =>
+          (
+            import.meta as ImportMeta & {
+              env?: RuntimeEnv;
+            }
+          ).env?.VITE_GT_PROJECT_ID
+      ) || readProcessEnvViteProjectId(),
+    devApiKey:
+      getRuntimeEnvironment() === 'development'
+        ? readImportMetaVite(() =>
+            (import.meta as ImportMeta & { env?: RuntimeEnv }).env?.DEV
+              ? (import.meta as ImportMeta & { env?: RuntimeEnv }).env
+                  ?.VITE_GT_DEV_API_KEY
+              : undefined
+          ) || readProcessEnvViteDevApiKey()
+        : undefined,
+  };
+}
+
+function readImportMetaVite(
+  readValue: () => string | undefined
+): string | undefined {
+  try {
+    return normalizeEnvValue(readValue());
+  } catch {
+    return undefined;
+  }
+}
+
+function readProcessEnvViteProjectId(): string | undefined {
+  try {
+    return normalizeEnvValue(process.env.VITE_GT_PROJECT_ID);
+  } catch {
+    return undefined;
+  }
+}
+
+function readProcessEnvViteDevApiKey(): string | undefined {
+  try {
+    return normalizeEnvValue(process.env.VITE_GT_DEV_API_KEY);
+  } catch {
+    return undefined;
+  }
+}
+
+function normalizeEnvValue(value: string | undefined): string | undefined {
+  return value || undefined;
+}


### PR DESCRIPTION
## Summary
- Read VITE_GT_PROJECT_ID for Vite React initializers when credentials are not explicitly supplied.
- Read VITE_GT_DEV_API_KEY only in development and keep Vite env access static so production replacement behaves correctly.
- Avoid whole-object import.meta.env reads in runtime environment detection so production client bundles do not materialize dev-only VITE values.

## Tests
- pnpm --filter gt-i18n test -- getRuntimeEnvironment
- pnpm --filter gt-react test -- src/setup/__tests__/runtimeCredentials.test.ts
- pnpm --filter gt-i18n typecheck
- pnpm --filter gt-react typecheck
- pnpm --filter gt-react... build
- VITE_GT_PROJECT_ID=gt_project_probe_static_access VITE_GT_DEV_API_KEY=gt_dev_secret_should_not_ship pnpm build:vite-react
- rg confirmed the production Vite bundle includes the project ID sentinel and not the dev API key sentinel

## Changeset
- Patch changeset added for gt-react and gt-i18n.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes credential reading for Vite-based React initializers (`initializeGTSPA`, `initializeGTSRA`, `initializeGTSRAClient`) and refactors the server entry point to properly separate SPA and SRA initialization paths.

- **Vite credential injection**: `runtimeCredentials.ts` reads `VITE_GT_PROJECT_ID` in all environments; `VITE_GT_DEV_API_KEY` is guarded by both a runtime `getRuntimeEnvironment()` check and an inner `import.meta.env.DEV` ternary so the value is dead code in production Vite bundles and does not appear in the output.
- **Granular `import.meta.env` access**: `getRuntimeEnvironment.ts` now reads `.env?.MODE` and `.env?.DEV` as individual properties rather than materialising the whole `import.meta.env` object, preventing bundlers from pulling all env values into the production bundle.
- **Server entry point guard**: `index.server.ts` now exports a stub `initializeGTSPA` that throws a diagnostic error, replacing the previously live re-export, and routes server-rendered callers to `initializeGTSRA`/`initializeGT` instead.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the changes are narrowly scoped to credential injection and entry-point routing with no impact on translation or rendering logic.

The credential resolution strategy is correctly implemented: projectId flows through in all builds, devApiKey is excluded from production Vite bundles via the static DEV guard, and all three initializer paths (SPA, SRA, SRAClient) consistently apply the same logic. The server-entry stub throws a clear diagnostic rather than silently misbehaving. Tests cover the three key scenarios and the integration test validates the stub behaviour against the built package.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react/src/setup/runtimeCredentials.ts | New file implementing Vite credential resolution; correctly guards devApiKey behind both a runtime environment check and an import.meta.env.DEV guard to prevent the value from shipping in production bundles. |
| packages/i18n/src/utils/getRuntimeEnvironment.ts | Switches from reading import.meta.env as a whole object to per-property access via readImportMetaEnv helpers, preventing bundlers from materialising all env properties in production output. |
| packages/react/src/index.server.ts | Replaces the re-exported initializeGTSPA with a stub that throws a diagnostic error when called from the server entry point, and exports the new initializeGTSRA as initializeGT. |
| packages/react/src/setup/initializeGTSRA.ts | New thin wrapper around internalInitializeGTSRA that injects runtime credentials before delegating, consistent with the SPA and SRAClient paths. |
| packages/react/src/setup/initializeGTSRAClient.ts | Wraps the config spread (cacheExpiryTime: null, ...config) with addRuntimeCredentials before passing to internalInitializeGTSRA; spread order is preserved correctly. |
| packages/react/src/setup/__tests__/runtimeCredentials.test.ts | New tests covering development credential injection, explicit credential precedence, and production mode exclusion of devApiKey. |
| packages/react/src/__tests__/react-package.test.ts | Adds an integration test verifying that calling initializeGTSPA from the server entry point throws the expected diagnostic error. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[initializeGTSPA / initializeGTSRA / initializeGTSRAClient] --> B[addRuntimeCredentials]
    B --> C{config.projectId set?}
    C -- yes --> D[keep explicit projectId]
    C -- no --> E[readImportMetaVite\nimport.meta.env.VITE_GT_PROJECT_ID]
    E -- value --> D
    E -- undefined --> F[readProcessEnvViteProjectId\nprocess.env.VITE_GT_PROJECT_ID]
    F --> D
    B --> G{getRuntimeEnvironment\n=== development?}
    G -- no --> H[devApiKey = undefined]
    G -- yes --> I{import.meta.env.DEV?\nstatic: false in prod}
    I -- false/undefined --> J[readProcessEnvViteDevApiKey\nprocess.env.VITE_GT_DEV_API_KEY]
    I -- true --> K[readImportMetaVite\nimport.meta.env.VITE_GT_DEV_API_KEY]
    K -- value --> L[devApiKey resolved]
    K -- undefined --> J
    J --> L
    D --> M[merged config → internalInitialize*]
    L --> M
    H --> M
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[initializeGTSPA / initializeGTSRA / initializeGTSRAClient] --> B[addRuntimeCredentials]
    B --> C{config.projectId set?}
    C -- yes --> D[keep explicit projectId]
    C -- no --> E[readImportMetaVite\nimport.meta.env.VITE_GT_PROJECT_ID]
    E -- value --> D
    E -- undefined --> F[readProcessEnvViteProjectId\nprocess.env.VITE_GT_PROJECT_ID]
    F --> D
    B --> G{getRuntimeEnvironment\n=== development?}
    G -- no --> H[devApiKey = undefined]
    G -- yes --> I{import.meta.env.DEV?\nstatic: false in prod}
    I -- false/undefined --> J[readProcessEnvViteDevApiKey\nprocess.env.VITE_GT_DEV_API_KEY]
    I -- true --> K[readImportMetaVite\nimport.meta.env.VITE_GT_DEV_API_KEY]
    K -- value --> L[devApiKey resolved]
    K -- undefined --> J
    J --> L
    D --> M[merged config → internalInitialize*]
    L --> M
    H --> M
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: read vite runtime credentials"](https://github.com/generaltranslation/gt/commit/2b0845f936a378cb57c7609517f5063ed51980fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41159195)</sub>

<!-- /greptile_comment -->