### PR TITLE
fix: warn on tanstack custom cookie names

### DIFF
--- a/.changeset/tanstack-cookie-warning.md
+++ b/.changeset/tanstack-cookie-warning.md
@@ -1,0 +1,5 @@
+---
+"gt-tanstack-start": patch
+---
+
+Warn when custom cookie names are passed to initializeGT.

--- a/packages/tanstack-start/src/index.ts
+++ b/packages/tanstack-start/src/index.ts
@@ -1,4 +1,5 @@
 export { parseLocale } from './functions/parseLocale';
+export { initializeGT } from './setup/initializeGT';
 
 export {
   // ===== Components ===== //
@@ -37,6 +38,4 @@ export {
   gtFallback,
   getTranslationsSnapshot,
   t,
-  // ===== Setup ===== //
-  initializeGT,
 } from 'gt-react';

--- a/packages/tanstack-start/src/setup/__tests__/initializeGT.test.ts
+++ b/packages/tanstack-start/src/setup/__tests__/initializeGT.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockInitializeGT = vi.hoisted(() => vi.fn());
+
+vi.mock('gt-react', () => ({
+  initializeGT: (...args: unknown[]) => mockInitializeGT(...args),
+}));
+
+import { initializeGT } from '../initializeGT';
+
+describe('initializeGT warnings', () => {
+  beforeEach(() => {
+    mockInitializeGT.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  it('passes through configs without custom cookie names', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const config = {
+      defaultLocale: 'en',
+      locales: ['en', 'fr'],
+    };
+
+    initializeGT(config);
+
+    expect(mockInitializeGT).toHaveBeenCalledWith(config);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('warns and clears custom cookie names', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const config = {
+      defaultLocale: 'en',
+      localeCookieName: 'custom-locale',
+      regionCookieName: 'custom-region',
+      enableI18nCookieName: 'custom-enable-i18n',
+    };
+
+    initializeGT(config);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      'gt-tanstack-start Warning: Custom cookie names passed to initializeGT() are temporarily ignored because of a temporary regression. Use the default cookie names until the fix is available. This behavior will be restored in an upcoming patch. Details: localeCookieName, regionCookieName, enableI18nCookieName.'
+    );
+    expect(mockInitializeGT).toHaveBeenCalledWith({
+      ...config,
+      localeCookieName: undefined,
+      regionCookieName: undefined,
+      enableI18nCookieName: undefined,
+    });
+    expect(config.localeCookieName).toBe('custom-locale');
+    expect(config.regionCookieName).toBe('custom-region');
+    expect(config.enableI18nCookieName).toBe('custom-enable-i18n');
+  });
+});

--- a/packages/tanstack-start/src/setup/initializeGT.ts
+++ b/packages/tanstack-start/src/setup/initializeGT.ts
@@ -1,0 +1,35 @@
+import { initializeGT as initializeGTBase } from 'gt-react';
+import { createCustomCookieNamesWarning } from '../warnings/createWarnings';
+
+const COOKIE_CONFIG_KEYS = [
+  'localeCookieName',
+  'regionCookieName',
+  'enableI18nCookieName',
+] as const;
+
+type CookieConfigKey = (typeof COOKIE_CONFIG_KEYS)[number];
+type InitializeGTConfig = Parameters<typeof initializeGTBase>[0] &
+  Partial<Record<CookieConfigKey, unknown>>;
+
+export function initializeGT(
+  config: InitializeGTConfig
+): ReturnType<typeof initializeGTBase> {
+  const customCookieConfigKeys = COOKIE_CONFIG_KEYS.filter(
+    (key) => config[key] !== undefined
+  );
+
+  if (!customCookieConfigKeys.length) {
+    return initializeGTBase(config);
+  }
+
+  console.warn(createCustomCookieNamesWarning(customCookieConfigKeys));
+
+  const sanitizedConfig: InitializeGTConfig = {
+    ...config,
+    localeCookieName: undefined,
+    regionCookieName: undefined,
+    enableI18nCookieName: undefined,
+  };
+
+  return initializeGTBase(sanitizedConfig);
+}

--- a/packages/tanstack-start/src/warnings/createWarnings.ts
+++ b/packages/tanstack-start/src/warnings/createWarnings.ts
@@ -1,0 +1,13 @@
+import { createDiagnosticMessage } from 'generaltranslation/internal';
+
+export const createCustomCookieNamesWarning = (cookieConfigKeys: string[]) =>
+  createDiagnosticMessage({
+    source: 'gt-tanstack-start',
+    severity: 'Warning',
+    whatHappened:
+      'Custom cookie names passed to initializeGT() are temporarily ignored',
+    why: 'of a temporary regression',
+    fix: 'Use the default cookie names until the fix is available',
+    wayOut: 'This behavior will be restored in an upcoming patch',
+    details: cookieConfigKeys,
+  });


### PR DESCRIPTION
## Summary
- Wrap the gt-tanstack-start initializeGT export with a setup initializer that warns for custom cookie-name config.
- Format the warning with the shared diagnostic-message style.
- Temporarily clear locale, region, and enable-i18n cookie-name overrides before delegating to gt-react.
- Add a patch changeset for gt-tanstack-start.

## Testing
- pnpm --filter gt-tanstack-start test
- pnpm --filter gt-tanstack-start typecheck
- pnpm --filter gt-tanstack-start build
- pnpm exec oxfmt --check packages/tanstack-start/src/index.ts packages/tanstack-start/src/setup/initializeGT.ts packages/tanstack-start/src/setup/__tests__/initializeGT.test.ts packages/tanstack-start/src/warnings/createWarnings.ts
- pnpm exec oxlint packages/tanstack-start/src/index.ts packages/tanstack-start/src/setup/initializeGT.ts packages/tanstack-start/src/setup/__tests__/initializeGT.test.ts packages/tanstack-start/src/warnings/createWarnings.ts