### PR TITLE
fix: correct global singleton warning

### DIFF
--- a/packages/i18n/src/condition-store/__tests__/createConditionStoreSingleton.test.ts
+++ b/packages/i18n/src/condition-store/__tests__/createConditionStoreSingleton.test.ts
@@ -69,7 +69,7 @@ describe('condition store singleton factory', () => {
 
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining(
-        'Overwriting global conditionStore singleton instance'
+        'Global conditionStore singleton instance was already initialized'
       )
     );
     expect(singleton.getConditionStore()).toBe(conditionStore);

--- a/packages/i18n/src/globals/__tests__/createGlobalSingleton.test.ts
+++ b/packages/i18n/src/globals/__tests__/createGlobalSingleton.test.ts
@@ -57,7 +57,9 @@ describe('createGlobalSingleton', () => {
     singleton.set({ id: 'second' });
 
     expect(warn).toHaveBeenCalledWith(
-      expect.stringContaining('Overwriting global singleton singleton instance')
+      expect.stringContaining(
+        'Global singleton singleton instance was already initialized'
+      )
     );
     expect(singleton.get()).toBe(value);
   });

--- a/packages/i18n/src/globals/createGlobalSingleton.ts
+++ b/packages/i18n/src/globals/createGlobalSingleton.ts
@@ -62,7 +62,7 @@ export function createGlobalSingleton<T>({
         createDiagnosticMessage({
           source,
           severity: 'Warning',
-          whatHappened: `Overwriting global ${key} singleton instance`,
+          whatHappened: `Global ${key} singleton instance was already initialized`,
         })
       );
       return;

--- a/packages/i18n/src/i18n-cache/__tests__/singleton-operations.test.ts
+++ b/packages/i18n/src/i18n-cache/__tests__/singleton-operations.test.ts
@@ -61,7 +61,9 @@ describe('i18n cache singleton operations', () => {
 
     expect(getI18nCache()).toBe(cache);
     expect(warn).toHaveBeenCalledWith(
-      expect.stringContaining('Overwriting global i18nCache singleton instance')
+      expect.stringContaining(
+        'Global i18nCache singleton instance was already initialized'
+      )
     );
   });
 });

--- a/packages/i18n/src/i18n-config/__tests__/singleton-operations.test.ts
+++ b/packages/i18n/src/i18n-config/__tests__/singleton-operations.test.ts
@@ -77,7 +77,7 @@ describe('i18n config singleton operations', () => {
 
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining(
-        'Overwriting global i18nConfig singleton instance'
+        'Global i18nConfig singleton instance was already initialized'
       )
     );
     expect(getI18nConfig()).toBe(config);

--- a/packages/react-core/src/i18n-store/__tests__/singleton-operations.test.ts
+++ b/packages/react-core/src/i18n-store/__tests__/singleton-operations.test.ts
@@ -60,7 +60,9 @@ describe('react-core i18n store singleton operations', () => {
     setI18nStore(createI18nStoreStub());
 
     expect(warn).toHaveBeenCalledWith(
-      expect.stringContaining('Overwriting global i18nStore singleton instance')
+      expect.stringContaining(
+        'Global i18nStore singleton instance was already initialized'
+      )
     );
     expect(getI18nStore()).toBe(store);
   });


### PR DESCRIPTION
## Summary
- Update the global singleton warning to state that the singleton was already initialized.
- Update singleton warning tests to match the preserved-instance behavior.

## Tests
- pnpm build
- pnpm --filter gt-i18n test
- pnpm --filter @generaltranslation/react-core test
- pnpm format
- pnpm lint

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a misleading warning message in the global singleton factory: the old message said "Overwriting global X singleton instance" but the code actually **preserves** the existing instance and returns early without overwriting. The new message "Global X singleton instance was already initialized" accurately reflects the preserved-instance behavior.

- `createGlobalSingleton.ts`: Changes the `whatHappened` string in the `set` guard from "Overwriting…" to "was already initialized" to match the actual no-op behavior when a duplicate `set` is detected.
- Five test files updated to assert the corrected warning text across `i18nConfig`, `i18nCache`, `i18nStore`, `conditionStore`, and the base singleton factory.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a single-line warning message correction with no behavioral impact; all affected tests were updated consistently.

The only production code change is the warning string in `createGlobalSingleton.ts`; the singleton's preserved-instance logic (`return` without overwriting) is unchanged. All five downstream test files were updated in lockstep to match the new message, and the tests continue to assert that the original value is retained after a duplicate `set`.

No files require special attention. The one minor follow-up is the stale "overwrite warning" phrasing left in the JSDoc comment of `createGlobalSingleton.ts`.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/i18n/src/globals/createGlobalSingleton.ts | Warning message corrected from "Overwriting" to "was already initialized" to accurately reflect the preserved-instance behavior; a minor JSDoc comment still uses the old "overwrite warning" phrasing. |
| packages/i18n/src/globals/__tests__/createGlobalSingleton.test.ts | Test assertion updated to match the new warning text; also verifies the original value is preserved after a duplicate set. |
| packages/i18n/src/i18n-config/__tests__/singleton-operations.test.ts | Warning assertion updated to match new message text; no other logic changes. |
| packages/i18n/src/i18n-cache/__tests__/singleton-operations.test.ts | Warning assertion updated to match new message text; no other logic changes. |
| packages/i18n/src/condition-store/__tests__/createConditionStoreSingleton.test.ts | Warning assertion updated to match new message text; no other logic changes. |
| packages/react-core/src/i18n-store/__tests__/singleton-operations.test.ts | Warning assertion updated to match new message text; no other logic changes. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["singleton.set(next)"] --> B{Is slot already\noccupied AND\nnext !== existing?}
    B -- Yes --> C["console.warn\n'Global X singleton instance\nwas already initialized'"]
    C --> D["return — existing\ninstance preserved"]
    B -- No --> E["ns[key] = next\nsingleton stored"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["singleton.set(next)"] --> B{Is slot already\noccupied AND\nnext !== existing?}
    B -- Yes --> C["console.warn\n'Global X singleton instance\nwas already initialized'"]
    C --> D["return — existing\ninstance preserved"]
    B -- No --> E["ns[key] = next\nsingleton stored"]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: correct global singleton warning"](https://github.com/generaltranslation/gt/commit/0464de0a103c4bb8e65afac7391fccf73db3b82c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41183771)</sub>

<!-- /greptile_comment -->