### PR TITLE
fix: avoid require in gt-next server initializer

### DIFF
--- a/.changeset/server-entrypoint-esm-import.md
+++ b/.changeset/server-entrypoint-esm-import.md
@@ -1,0 +1,5 @@
+---
+"gt-next": patch
+---
+
+Avoid requiring custom request functions while initializing the ESM server entrypoint.

--- a/packages/next/src/setup/__tests__/initGT.test.ts
+++ b/packages/next/src/setup/__tests__/initGT.test.ts
@@ -1,6 +1,7 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getNextI18nCache } from '../../i18n-cache/NextI18nCache';
 import { initializeGT } from '../initGT';
+import { initializeGTServer } from '../initGT.server';
 
 type TestGlobal = typeof globalThis & {
   __generaltranslation?: {
@@ -27,6 +28,10 @@ describe('initializeGT', () => {
     vi.restoreAllMocks();
   });
 
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it('does not replace an existing NextI18nCache', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const params = {
@@ -47,5 +52,22 @@ describe('initializeGT', () => {
 
     expect(getNextI18nCache()).toBe(cache);
     warn.mockRestore();
+  });
+
+  it('initializes server state with custom request functions enabled', () => {
+    vi.stubEnv('_GENERALTRANSLATION_CUSTOM_GET_LOCALE_ENABLED', 'true');
+    vi.stubEnv('_GENERALTRANSLATION_CUSTOM_GET_REGION_ENABLED', 'true');
+    const params = {
+      i18nConfigParams: {
+        defaultLocale: 'en',
+        locales: ['en', 'fr'],
+      },
+      nextI18nCacheParams: {
+        defaultLocale: 'en',
+        locales: ['en', 'fr'],
+      },
+    };
+
+    expect(() => initializeGTServer(params)).not.toThrow();
   });
 });

--- a/packages/next/src/setup/initGT.server.ts
+++ b/packages/next/src/setup/initGT.server.ts
@@ -12,6 +12,9 @@ import {
   customGetRegionUnresolvedWarning,
 } from '../errors/createErrors';
 
+const getLocaleModulePath = 'gt-next/internal/_getLocale';
+const getRegionModulePath = 'gt-next/internal/_getRegion';
+
 /**
  * Initialize GT for Next.js
  *
@@ -64,40 +67,42 @@ function resolveGetLocale(): (() => Promise<string>) | undefined {
   const isCustomGetLocaleEnabled =
     process.env._GENERALTRANSLATION_CUSTOM_GET_LOCALE_ENABLED === 'true';
   if (!isCustomGetLocaleEnabled) return undefined;
-  const module: unknown = require('gt-next/internal/_getLocale');
-
-  if (typeof module === 'function') {
-    return module as () => Promise<string>;
-  } else if (typeof module === 'object' && module !== null) {
-    if ('default' in module && typeof module.default === 'function') {
-      return module.default as () => Promise<string>;
-    } else if (
-      'getLocale' in module &&
-      typeof module.getLocale === 'function'
-    ) {
-      return module.getLocale as () => Promise<string>;
-    }
-  }
-  console.warn(customGetLocaleUnresolvedWarning);
+  return async () => {
+    const module = await import(getLocaleModulePath);
+    const getLocale = resolveRequestFunction<string>(module, 'getLocale');
+    if (getLocale) return getLocale();
+    console.warn(customGetLocaleUnresolvedWarning);
+    return undefined as never;
+  };
 }
 
 function resolveGetRegion(): (() => Promise<string | undefined>) | undefined {
   const isCustomGetRegionEnabled =
     process.env._GENERALTRANSLATION_CUSTOM_GET_REGION_ENABLED === 'true';
   if (!isCustomGetRegionEnabled) return undefined;
-  const module: unknown = require('gt-next/internal/_getRegion');
+  return async () => {
+    const module = await import(getRegionModulePath);
+    const getRegion = resolveRequestFunction<string | undefined>(
+      module,
+      'getRegion'
+    );
+    if (getRegion) return getRegion();
+    console.warn(customGetRegionUnresolvedWarning);
+  };
+}
 
+function resolveRequestFunction<T>(
+  module: unknown,
+  exportName: string
+): (() => Promise<T>) | undefined {
   if (typeof module === 'function') {
-    return module as () => Promise<string | undefined>;
+    return module as () => Promise<T>;
   } else if (typeof module === 'object' && module !== null) {
-    if ('default' in module && typeof module.default === 'function') {
-      return module.default as () => Promise<string | undefined>;
-    } else if (
-      'getRegion' in module &&
-      typeof module.getRegion === 'function'
-    ) {
-      return module.getRegion as () => Promise<string | undefined>;
+    const record = module as Record<string, unknown>;
+    if (typeof record.default === 'function') {
+      return record.default as () => Promise<T>;
+    } else if (typeof record[exportName] === 'function') {
+      return record[exportName] as () => Promise<T>;
     }
   }
-  console.warn(customGetRegionUnresolvedWarning);
 }


### PR DESCRIPTION
## Summary
- Load custom getLocale/getRegion modules lazily with dynamic import from the server condition store resolver.
- Add a regression test for initializing server state with custom request functions enabled.

## Testing
- pnpm --filter gt-next test:js
- pnpm --filter gt-next build:no-swc-plugin
- _GENERALTRANSLATION_CUSTOM_GET_LOCALE_ENABLED=true node --input-type=module -e "await import('gt-next')" from packages/next
- pnpm lint

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces eager `require()` calls with lazy `dynamic import()` in the server initializer so that `gt-next` can be loaded as an ESM entry point without triggering a synchronous CJS `require` at module evaluation time. A new `resolveRequestFunction` helper de-duplicates the export-shape detection logic that was previously copy-pasted between `resolveGetLocale` and `resolveGetRegion`.

- **Lazy loading via dynamic import**: `resolveGetLocale` and `resolveGetRegion` now return async wrapper functions that call `import()` on the first (and every subsequent) request instead of loading the module once at startup.
- **Shared helper**: `resolveRequestFunction<T>` consolidates the `default` / named-export resolution logic that was duplicated in both resolver functions.
- **Regression test**: A new test stubs both custom-function env vars and asserts that `initializeGTServer` no longer throws during ESM initialization.

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The core ESM fix is correct, but the changed fallback behavior in the unresolvable-module path could silently break locale detection at runtime for misconfigured deployments.

When custom locale is enabled and the user-supplied module exports the wrong shape, the old code fell back transparently to header/cookie locale detection. The new code returns a function that resolves to `undefined as never`, so `AsyncConditionStore.getLocale()` returns `undefined` to every caller that expects a `string`. This edge case only triggers on misconfiguration, but the degradation changed from silent fallback to potential runtime crash, and the regression test does not exercise the lazy-loaded functions after initialization.

packages/next/src/setup/initGT.server.ts — specifically the `resolveGetLocale` wrapper's `undefined as never` return when module resolution fails.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/next/src/setup/initGT.server.ts | Replaces eager require() with lazy dynamic import() to fix ESM init issue; extracts resolveRequestFunction helper. A type-lie (undefined as never) removes the prior fallback to default locale detection when a custom module is present but exports the wrong shape. |
| packages/next/src/setup/__tests__/initGT.test.ts | Adds a regression test for custom-request-function env vars and an afterEach unstubAllEnvs cleanup. The new test only asserts that initializeGTServer doesn't throw; it does not exercise the lazy-loaded getLocale/getRegion callables. |
| .changeset/server-entrypoint-esm-import.md | Changeset entry for the patch release; no logic changes. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant App as Next.js App (ESM)
    participant Init as initializeGTServer()
    participant Resolve as resolveGetLocale/Region()
    participant Store as AsyncConditionStore
    participant Mod as gt-next/internal/_getLocale

    App->>Init: startup
    Init->>Resolve: resolveGetLocale()
    Note over Resolve: env var enabled?
    alt "env var = true"
        Resolve-->>Init: return async wrapper fn
    else "env var = false"
        Resolve-->>Init: return undefined
    end
    Init->>Store: "new AsyncConditionStore({ getLocale: wrapper })"
    Note over Store: stores wrapper as getLocaleFn

    App->>Store: getLocale() [per request]
    Store->>Resolve: wrapper()
    Resolve->>Mod: await import(getLocaleModulePath)
    Mod-->>Resolve: module (cached after first call)
    Resolve->>Resolve: resolveRequestFunction(module, 'getLocale')
    alt function resolved
        Resolve-->>Store: return getLocale()
    else not resolved
        Resolve-->>Store: warn + return undefined as never
        Note over Store: no fallback to default header/cookie detection
    end
    Store-->>App: locale (or undefined if unresolved)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant App as Next.js App (ESM)
    participant Init as initializeGTServer()
    participant Resolve as resolveGetLocale/Region()
    participant Store as AsyncConditionStore
    participant Mod as gt-next/internal/_getLocale

    App->>Init: startup
    Init->>Resolve: resolveGetLocale()
    Note over Resolve: env var enabled?
    alt "env var = true"
        Resolve-->>Init: return async wrapper fn
    else "env var = false"
        Resolve-->>Init: return undefined
    end
    Init->>Store: "new AsyncConditionStore({ getLocale: wrapper })"
    Note over Store: stores wrapper as getLocaleFn

    App->>Store: getLocale() [per request]
    Store->>Resolve: wrapper()
    Resolve->>Mod: await import(getLocaleModulePath)
    Mod-->>Resolve: module (cached after first call)
    Resolve->>Resolve: resolveRequestFunction(module, 'getLocale')
    alt function resolved
        Resolve-->>Store: return getLocale()
    else not resolved
        Resolve-->>Store: warn + return undefined as never
        Note over Store: no fallback to default header/cookie detection
    end
    Store-->>App: locale (or undefined if unresolved)
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fnext%2Fsrc%2Fsetup%2FinitGT.server.ts%3A70-76%0A**Loss%20of%20fallback%20when%20module%20export%20is%20unresolvable**%0A%0AWhen%20%60resolveRequestFunction%60%20returns%20%60undefined%60%20%28e.g.%2C%20the%20module%20exists%20but%20exports%20neither%20a%20%60default%60%20function%20nor%20a%20%60getLocale%60%20function%29%2C%20the%20wrapper%20logs%20a%20warning%20and%20then%20returns%20%60undefined%20as%20never%60.%20This%20is%20a%20type%20lie%3A%20at%20runtime%20the%20%60Promise%60%20resolves%20to%20%60undefined%60%2C%20but%20%60AsyncConditionStore%60%20assigns%20the%20wrapper%20to%20%60getLocaleFn%60%20%28typed%20%60%28%29%20%3D%3E%20Promise%3Cstring%3E%60%29%20and%20returns%20its%20result%20directly%20to%20callers.%0A%0AIn%20the%20previous%20%60require%28%29%60-based%20implementation%2C%20%60resolveGetLocale%28%29%60%20returned%20%60undefined%60%20when%20the%20module%20was%20unresolvable%2C%20so%20%60AsyncConditionStore%60%20fell%20back%20to%20%60createDefaultGetLocale%28%29%60%20%28header%2Fcookie%20detection%29.%20With%20this%20change%2C%20the%20fallback%20is%20silently%20bypassed%20and%20every%20call%20to%20%60getLocale%28%29%60%20resolves%20to%20%60undefined%60%2C%20which%20could%20cause%20downstream%20crashes%20for%20any%20code%20that%20treats%20the%20locale%20as%20a%20%60string%60.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fnext%2Fsrc%2Fsetup%2FinitGT.server.ts%3A71-76%0A**Module%20and%20function%20resolution%20repeated%20on%20every%20request**%0A%0A%60resolveRequestFunction%60%20is%20now%20called%20on%20every%20invocation%20of%20%60getLocale%28%29%60%20or%20%60getRegion%28%29%60%20instead%20of%20once%20at%20startup.%20Node.js%20module%20caching%20makes%20the%20%60import%28%29%60%20call%20cheap%20after%20the%20first%20hit%2C%20but%20the%20per-call%20overhead%20of%20%60import%28%29%60%20%2B%20object%20inspection%20in%20%60resolveRequestFunction%60%20is%20unnecessary.%20Consider%20resolving%20the%20target%20function%20once%20%28e.g.%2C%20memoizing%20inside%20the%20closure%20on%20first%20call%29%20and%20caching%20it%20for%20subsequent%20requests.%0A%0A&repo=generaltranslation%2Fgt&pr=1765&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fodysseus%2Ffix-server-entrypoint-esm-require%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fodysseus%2Ffix-server-entrypoint-esm-require%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fnext%2Fsrc%2Fsetup%2FinitGT.server.ts%3A70-76%0A**Loss%20of%20fallback%20when%20module%20export%20is%20unresolvable**%0A%0AWhen%20%60resolveRequestFunction%60%20returns%20%60undefined%60%20%28e.g.%2C%20the%20module%20exists%20but%20exports%20neither%20a%20%60default%60%20function%20nor%20a%20%60getLocale%60%20function%29%2C%20the%20wrapper%20logs%20a%20warning%20and%20then%20returns%20%60undefined%20as%20never%60.%20This%20is%20a%20type%20lie%3A%20at%20runtime%20the%20%60Promise%60%20resolves%20to%20%60undefined%60%2C%20but%20%60AsyncConditionStore%60%20assigns%20the%20wrapper%20to%20%60getLocaleFn%60%20%28typed%20%60%28%29%20%3D%3E%20Promise%3Cstring%3E%60%29%20and%20returns%20its%20result%20directly%20to%20callers.%0A%0AIn%20the%20previous%20%60require%28%29%60-based%20implementation%2C%20%60resolveGetLocale%28%29%60%20returned%20%60undefined%60%20when%20the%20module%20was%20unresolvable%2C%20so%20%60AsyncConditionStore%60%20fell%20back%20to%20%60createDefaultGetLocale%28%29%60%20%28header%2Fcookie%20detection%29.%20With%20this%20change%2C%20the%20fallback%20is%20silently%20bypassed%20and%20every%20call%20to%20%60getLocale%28%29%60%20resolves%20to%20%60undefined%60%2C%20which%20could%20cause%20downstream%20crashes%20for%20any%20code%20that%20treats%20the%20locale%20as%20a%20%60string%60.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fnext%2Fsrc%2Fsetup%2FinitGT.server.ts%3A71-76%0A**Module%20and%20function%20resolution%20repeated%20on%20every%20request**%0A%0A%60resolveRequestFunction%60%20is%20now%20called%20on%20every%20invocation%20of%20%60getLocale%28%29%60%20or%20%60getRegion%28%29%60%20instead%20of%20once%20at%20startup.%20Node.js%20module%20caching%20makes%20the%20%60import%28%29%60%20call%20cheap%20after%20the%20first%20hit%2C%20but%20the%20per-call%20overhead%20of%20%60import%28%29%60%20%2B%20object%20inspection%20in%20%60resolveRequestFunction%60%20is%20unnecessary.%20Consider%20resolving%20the%20target%20function%20once%20%28e.g.%2C%20memoizing%20inside%20the%20closure%20on%20first%20call%29%20and%20caching%20it%20for%20subsequent%20requests.%0A%0A&repo=generaltranslation%2Fgt&pr=1765&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=4"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=4"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/next/src/setup/initGT.server.ts:70-76
**Loss of fallback when module export is unresolvable**

When `resolveRequestFunction` returns `undefined` (e.g., the module exists but exports neither a `default` function nor a `getLocale` function), the wrapper logs a warning and then returns `undefined as never`. This is a type lie: at runtime the `Promise` resolves to `undefined`, but `AsyncConditionStore` assigns the wrapper to `getLocaleFn` (typed `() => Promise<string>`) and returns its result directly to callers.

In the previous `require()`-based implementation, `resolveGetLocale()` returned `undefined` when the module was unresolvable, so `AsyncConditionStore` fell back to `createDefaultGetLocale()` (header/cookie detection). With this change, the fallback is silently bypassed and every call to `getLocale()` resolves to `undefined`, which could cause downstream crashes for any code that treats the locale as a `string`.

### Issue 2 of 2
packages/next/src/setup/initGT.server.ts:71-76
**Module and function resolution repeated on every request**

`resolveRequestFunction` is now called on every invocation of `getLocale()` or `getRegion()` instead of once at startup. Node.js module caching makes the `import()` call cheap after the first hit, but the per-call overhead of `import()` + object inspection in `resolveRequestFunction` is unnecessary. Consider resolving the target function once (e.g., memoizing inside the closure on first call) and caching it for subsequent requests.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: avoid require in gt-next server ini..."](https://github.com/generaltranslation/gt/commit/cb12d26300324f359141cd84fd847d4cfaa0baa0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41198670)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->