### PR TITLE
fix: use trusted publishing for binary releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,8 +190,6 @@ jobs:
       - name: Release gt binary to npm
         if: steps.check-gt.outputs.should_release_bin == 'true'
         run: pnpm --filter gt run bin:prep && pnpm --filter gt publish --tag bin --no-git-checks && pnpm --filter gt run bin:restore && pnpm --filter gt run build:clean
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       # gtx-cli (backward-compat wrapper, lives in packages/gtx-cli/)
       - name: Check if gtx-cli was published
@@ -243,5 +241,3 @@ jobs:
       - name: Release gtx-cli binary to npm
         if: steps.check-gtx-cli.outputs.should_release_bin == 'true'
         run: pnpm --filter gtx-cli run bin:prep && pnpm --filter gtx-cli publish --tag bin --no-git-checks && pnpm --filter gtx-cli run bin:restore && pnpm --filter gtx-cli run build:clean
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- remove the stale npm token env from the gt and gtx-cli binary publish steps
- let npm use the workflow OIDC trusted publisher configuration for those publishes

## Validation
- git diff --check
- pnpm --filter gtx-cli run bin:prep
- pnpm --filter gtx-cli publish --dry-run --tag bin --no-git-checks
- pnpm --filter gtx-cli run bin:restore
- pnpm --filter gt run bin:prep
- pnpm --filter gt publish --dry-run --tag bin --no-git-checks (skipped because the binary prerelease already exists)
- pnpm --filter gt run bin:restore

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the explicit `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` environment variable from the `gt` and `gtx-cli` binary npm publish steps, aligning them with the rest of the workflow (including the `changesets/action` publish step) which already relies on npm OIDC trusted publishing.

- The workflow-level `id-token: write` permission and `actions/setup-node@v4` with `registry-url: 'https://registry.npmjs.org'` are the required infrastructure for OIDC; both are already in place.
- The two removed `env` blocks are the only diff — no logic, conditions, or other publish parameters are changed.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge assuming OIDC trusted publishing is already configured on npmjs.com for both `gt` and `gtx-cli`; the workflow infrastructure (`id-token: write`, `registry-url`) is correctly in place.

The change is a two-line removal that aligns the binary publish steps with the rest of the workflow. The only practical risk is that npm's OIDC trusted-publisher configuration on npmjs.com may not yet cover these packages — if that's missing, the first live binary release will fail. The dry-run validation in the PR description does not exercise actual authentication, so that gap remains unconfirmed.

`.github/workflows/release.yml` — verify the npm trusted-publisher or granular access token (OIDC) configuration on npmjs.com covers both `gt` and `gtx-cli` for this repo/workflow before the next binary release fires.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Removes explicit NODE_AUTH_TOKEN from the gt and gtx-cli binary publish steps, relying on OIDC trusted publishing; workflow already has id-token: write and registry-url configured. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant GHA as GitHub Actions
    participant NPM_OIDC as npm Registry (OIDC)
    participant NPM as npm Registry

    Note over GHA: id-token: write + registry-url set

    GHA->>GHA: changesets/action publishes packages (no NODE_AUTH_TOKEN)
    GHA->>NPM_OIDC: OIDC token exchange (automatic)
    NPM_OIDC-->>GHA: short-lived npm token
    NPM-->>GHA: publish success

    Note over GHA: Binary publish steps (after this PR)
    GHA->>GHA: bin:prep → pnpm publish --tag bin
    GHA->>NPM_OIDC: OIDC token exchange (no explicit NODE_AUTH_TOKEN)
    NPM_OIDC-->>GHA: short-lived npm token
    NPM-->>GHA: binary publish success

    Note over GHA: Before this PR — binary steps used NPM_TOKEN secret (now removed)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant GHA as GitHub Actions
    participant NPM_OIDC as npm Registry (OIDC)
    participant NPM as npm Registry

    Note over GHA: id-token: write + registry-url set

    GHA->>GHA: changesets/action publishes packages (no NODE_AUTH_TOKEN)
    GHA->>NPM_OIDC: OIDC token exchange (automatic)
    NPM_OIDC-->>GHA: short-lived npm token
    NPM-->>GHA: publish success

    Note over GHA: Binary publish steps (after this PR)
    GHA->>GHA: bin:prep → pnpm publish --tag bin
    GHA->>NPM_OIDC: OIDC token exchange (no explicit NODE_AUTH_TOKEN)
    NPM_OIDC-->>GHA: short-lived npm token
    NPM-->>GHA: binary publish success

    Note over GHA: Before this PR — binary steps used NPM_TOKEN secret (now removed)
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Frelease.yml%3A192%0A**Dry-run%20validation%20doesn't%20exercise%20OIDC%20authentication**%0A%0AThe%20PR%20description%20uses%20%60pnpm%20publish%20--dry-run%60%20to%20validate%20both%20binary%20steps%2C%20but%20%60--dry-run%60%20skips%20the%20actual%20registry%20call%20entirely%20%E2%80%94%20it%20only%20resolves%20what%20would%20be%20published.%20This%20means%20the%20OIDC%20token%20exchange%20hasn't%20been%20tested%20end-to-end%20for%20these%20steps.%20If%20the%20npm%20OIDC%20trusted-publisher%20configuration%20on%20npmjs.com%20isn't%20set%20up%20for%20the%20%60gt%60%20%28and%20%60gtx-cli%60%29%20packages%20under%20the%20%60generaltranslation%2Fgt%60%20repo%2Fworkflow%20path%2C%20the%20first%20live%20binary%20release%20after%20this%20merge%20will%20fail%20at%20the%20auth%20step.%20Confirming%20the%20npmjs.com%20%22Granular%20Access%20Tokens%20%E2%86%92%20OIDC%22%20or%20%22Trusted%20Publisher%22%20configuration%20exists%20for%20both%20packages%20before%20merging%20would%20eliminate%20this%20gap.%0A%0A&repo=generaltranslation%2Fgt&pr=1767&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22fix%2Fnpm-trusted-publishing-binaries%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fnpm-trusted-publishing-binaries%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Frelease.yml%3A192%0A**Dry-run%20validation%20doesn't%20exercise%20OIDC%20authentication**%0A%0AThe%20PR%20description%20uses%20%60pnpm%20publish%20--dry-run%60%20to%20validate%20both%20binary%20steps%2C%20but%20%60--dry-run%60%20skips%20the%20actual%20registry%20call%20entirely%20%E2%80%94%20it%20only%20resolves%20what%20would%20be%20published.%20This%20means%20the%20OIDC%20token%20exchange%20hasn't%20been%20tested%20end-to-end%20for%20these%20steps.%20If%20the%20npm%20OIDC%20trusted-publisher%20configuration%20on%20npmjs.com%20isn't%20set%20up%20for%20the%20%60gt%60%20%28and%20%60gtx-cli%60%29%20packages%20under%20the%20%60generaltranslation%2Fgt%60%20repo%2Fworkflow%20path%2C%20the%20first%20live%20binary%20release%20after%20this%20merge%20will%20fail%20at%20the%20auth%20step.%20Confirming%20the%20npmjs.com%20%22Granular%20Access%20Tokens%20%E2%86%92%20OIDC%22%20or%20%22Trusted%20Publisher%22%20configuration%20exists%20for%20both%20packages%20before%20merging%20would%20eliminate%20this%20gap.%0A%0A&repo=generaltranslation%2Fgt&pr=1767&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=4"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=4"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/workflows/release.yml:192
**Dry-run validation doesn't exercise OIDC authentication**

The PR description uses `pnpm publish --dry-run` to validate both binary steps, but `--dry-run` skips the actual registry call entirely — it only resolves what would be published. This means the OIDC token exchange hasn't been tested end-to-end for these steps. If the npm OIDC trusted-publisher configuration on npmjs.com isn't set up for the `gt` (and `gtx-cli`) packages under the `generaltranslation/gt` repo/workflow path, the first live binary release after this merge will fail at the auth step. Confirming the npmjs.com "Granular Access Tokens → OIDC" or "Trusted Publisher" configuration exists for both packages before merging would eliminate this gap.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: use trusted publishing for binary r..."](https://github.com/generaltranslation/gt/commit/5d6d4b036250fbc7c9fc5be46fb708f97fb60070) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41217052)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->