### PR TITLE
fix: pin release Node version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 24.18.0
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
 


### PR DESCRIPTION
## Summary
- Pin the release workflow's setup-node version to Node 24.18.0 instead of floating `24`.
- Keep `pnpm run version-packages` and `@changesets/changelog-github` intact, so main release changelogs still include PR/commit/user links.

## Diagnosis
The failing runs die inside `@changesets/changelog-github` / `@changesets/get-github-info` while `node-fetch@2` reads `https://api.github.com/graphql`:

`FetchError: Invalid response body while trying to fetch https://api.github.com/graphql: Premature close`

The pending changesets resolve to two commit lookups, and those exact lookups succeed locally, returning PR #1768 and PR #1729. This does not look like a bad repo/token/query config. The release runner selected Node 24.17.0 for `node-version: 24`; upstream reports tie this `node-fetch@2` false `ERR_STREAM_PREMATURE_CLOSE` behavior to Node 24.17.0, with Node 24.18.0 reported as fixed.

## Verification
- Exercised `@changesets/get-github-info` against the two release commits locally and confirmed it resolves PR #1768 and PR #1729.
- Confirmed final diff only pins `.github/workflows/release.yml` from `24` to `24.18.0`.

Fixes the release failure in https://github.com/generaltranslation/gt/actions/runs/28556629391/job/84665324175.