### PR TITLE
fix: prioritize root dictionary defaults

### DIFF
--- a/.changeset/default-dictionary-priority.md
+++ b/.changeset/default-dictionary-priority.md
@@ -1,0 +1,5 @@
+---
+'gt-next': patch
+---
+
+Prefer the root dictionary file over custom dictionary loaders for the default locale.

--- a/packages/next/src/i18n-cache/NextI18nCache.ts
+++ b/packages/next/src/i18n-cache/NextI18nCache.ts
@@ -1,4 +1,9 @@
-import { getI18nCache, setI18nCache, type I18nCache } from 'gt-i18n/internal';
+import {
+  getI18nCache,
+  getI18nConfig,
+  setI18nCache,
+  type I18nCache,
+} from 'gt-i18n/internal';
 import type { Locale } from 'gt-i18n/internal/types';
 import type { Dictionary, Translation } from 'gt-i18n/types';
 import { isValidElement } from 'react';
@@ -30,7 +35,9 @@ export class NextI18nCache extends ReactI18nCache {
       ...(loadDictionary && {
         dictionary: params.dictionary ?? {},
         loadDictionary: async (locale: string) =>
-          ((await loadDictionary(locale)) || {}) as Dictionary,
+          locale === getI18nConfig().getDefaultLocale()
+            ? (((await getDictionary()) || {}) as Dictionary)
+            : (((await loadDictionary(locale)) || {}) as Dictionary),
       }),
     });
   }
@@ -66,5 +73,12 @@ export class NextI18nCache extends ReactI18nCache {
     return {
       [locale]: dictionary as unknown as Dictionary,
     };
+  }
+
+  override async getLookupDictionary(
+    locale: string
+  ): Promise<Awaited<ReturnType<ReactI18nCache['getLookupDictionary']>>> {
+    this.updateDictionaries(await this.loadDictionaries(locale));
+    return super.getLookupDictionary(locale);
   }
 }

--- a/packages/next/src/i18n-cache/__tests__/NextI18nCache.test.ts
+++ b/packages/next/src/i18n-cache/__tests__/NextI18nCache.test.ts
@@ -5,24 +5,31 @@ const {
   mockGetDictionary,
   mockGetDictionaryEntry,
   mockGetI18nCache,
+  mockGetI18nConfig,
   mockLoadDictionary,
   mockMergeDictionaries,
+  mockReactGetLookupDictionary,
   mockReactI18nCacheConstructor,
+  mockReactUpdateDictionaries,
   mockResolveDictionaryLoader,
   mockSetI18nCache,
 } = vi.hoisted(() => ({
   mockGetDictionary: vi.fn(),
   mockGetDictionaryEntry: vi.fn(),
   mockGetI18nCache: vi.fn(),
+  mockGetI18nConfig: vi.fn(),
   mockLoadDictionary: vi.fn(),
   mockMergeDictionaries: vi.fn(),
+  mockReactGetLookupDictionary: vi.fn(),
   mockReactI18nCacheConstructor: vi.fn(),
+  mockReactUpdateDictionaries: vi.fn(),
   mockResolveDictionaryLoader: vi.fn(),
   mockSetI18nCache: vi.fn(),
 }));
 
 vi.mock('gt-i18n/internal', () => ({
   getI18nCache: mockGetI18nCache,
+  getI18nConfig: mockGetI18nConfig,
   setI18nCache: mockSetI18nCache,
   I18nCache: class {},
 }));
@@ -35,6 +42,14 @@ vi.mock('gt-react', () => ({
 
     loadDictionary(locale: string) {
       return mockLoadDictionary(locale);
+    }
+
+    updateDictionaries(dictionaries: unknown) {
+      mockReactUpdateDictionaries(dictionaries);
+    }
+
+    getLookupDictionary(locale: string) {
+      return mockReactGetLookupDictionary(locale);
     }
   },
 }));
@@ -69,9 +84,50 @@ describe('NextI18nCache', () => {
     mockGetDictionaryEntry.mockReturnValue({
       title: 'Title',
     });
+    mockGetI18nConfig.mockReturnValue({
+      getDefaultLocale: () => 'en',
+    });
     mockMergeDictionaries.mockReturnValue({
       greeting: 'Bonjour',
     });
+    mockReactGetLookupDictionary.mockResolvedValue({
+      lookupDictionary: vi.fn(),
+      lookupDictionaryObj: vi.fn(),
+    });
+  });
+
+  it('uses the root dictionary instead of the loader for the default locale', async () => {
+    const { NextI18nCache } = await import('../NextI18nCache');
+    new NextI18nCache({
+      loadDictionary: mockLoadDictionary,
+    });
+    const params = mockReactI18nCacheConstructor.mock.calls[0][0] as {
+      loadDictionary: (locale: string) => Promise<unknown>;
+    };
+
+    await expect(params.loadDictionary('en')).resolves.toEqual({
+      greeting: 'Hello',
+    });
+
+    expect(mockGetDictionary).toHaveBeenCalled();
+    expect(mockLoadDictionary).not.toHaveBeenCalled();
+  });
+
+  it('uses the loader for non-default locales', async () => {
+    const { NextI18nCache } = await import('../NextI18nCache');
+    new NextI18nCache({
+      loadDictionary: mockLoadDictionary,
+    });
+    const params = mockReactI18nCacheConstructor.mock.calls[0][0] as {
+      loadDictionary: (locale: string) => Promise<unknown>;
+    };
+
+    await expect(params.loadDictionary('fr')).resolves.toEqual({
+      greeting: 'Bonjour',
+    });
+
+    expect(mockGetDictionary).not.toHaveBeenCalled();
+    expect(mockLoadDictionary).toHaveBeenCalledWith('fr');
   });
 
   it('loads a locale-scoped dictionaries snapshot', async () => {
@@ -118,6 +174,29 @@ describe('NextI18nCache', () => {
         greeting: 'Bonjour',
       }
     );
+  });
+
+  it('updates dictionaries before delegating lookup dictionary resolution', async () => {
+    const lookupDictionary = {
+      lookupDictionary: vi.fn(),
+      lookupDictionaryObj: vi.fn(),
+    };
+    mockLoadDictionary.mockResolvedValue({});
+    mockMergeDictionaries.mockReturnValue({
+      greeting: 'Hello',
+    });
+    mockReactGetLookupDictionary.mockResolvedValue(lookupDictionary);
+    const { NextI18nCache } = await import('../NextI18nCache');
+    const cache = new NextI18nCache({});
+
+    await expect(cache.getLookupDictionary('en')).resolves.toBe(
+      lookupDictionary
+    );
+
+    expect(mockReactUpdateDictionaries).toHaveBeenCalledWith({
+      en: { greeting: 'Hello' },
+    });
+    expect(mockReactGetLookupDictionary).toHaveBeenCalledWith('en');
   });
 
   it('throws when a prefixed dictionary subtree is not an object', async () => {

--- a/packages/next/src/server-dir/buildtime/__tests__/getTranslations.test.ts
+++ b/packages/next/src/server-dir/buildtime/__tests__/getTranslations.test.ts
@@ -2,17 +2,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const {
   mockGetGTInternal,
-  mockGetI18nConfig,
   mockGetMessagesInternal,
-  mockGetNextI18nCache,
   mockGetRequestConditions,
   mockGetTranslationsInternal,
   mockUse,
 } = vi.hoisted(() => ({
   mockGetGTInternal: vi.fn(),
-  mockGetI18nConfig: vi.fn(),
   mockGetMessagesInternal: vi.fn(),
-  mockGetNextI18nCache: vi.fn(),
   mockGetRequestConditions: vi.fn(),
   mockGetTranslationsInternal: vi.fn(),
   mockUse: vi.fn(),
@@ -20,13 +16,8 @@ const {
 
 vi.mock('gt-i18n/internal', () => ({
   getGTInternal: mockGetGTInternal,
-  getI18nConfig: mockGetI18nConfig,
   getMessagesInternal: mockGetMessagesInternal,
   getTranslationsInternal: mockGetTranslationsInternal,
-}));
-
-vi.mock('../../../i18n-cache/NextI18nCache', () => ({
-  getNextI18nCache: mockGetNextI18nCache,
 }));
 
 vi.mock('../../../request/getRequestConditions', () => ({
@@ -43,16 +34,6 @@ describe('buildtime translation helpers', () => {
     mockGetRequestConditions.mockResolvedValue({
       _locale: 'fr',
       _enableI18n: false,
-    });
-    mockGetI18nConfig.mockReturnValue({
-      getDefaultLocale: () => 'en',
-    });
-    mockGetNextI18nCache.mockReturnValue({
-      loadDictionaries: vi
-        .fn()
-        .mockResolvedValueOnce({ en: { greeting: 'Hello' } })
-        .mockResolvedValueOnce({ fr: { greeting: 'Bonjour' } }),
-      updateDictionaries: vi.fn(),
     });
   });
 
@@ -114,19 +95,10 @@ describe('buildtime translation helpers', () => {
       enableI18n: false,
       rootId: undefined,
     });
-    expect(mockGetNextI18nCache().loadDictionaries).toHaveBeenCalledTimes(1);
-    expect(mockGetNextI18nCache().loadDictionaries).toHaveBeenCalledWith('en');
-    expect(mockGetNextI18nCache().updateDictionaries).toHaveBeenCalledWith({
-      en: { greeting: 'Hello' },
-    });
   });
 
   it('getTranslations forwards root id to gt-i18n', async () => {
     const translations = vi.fn();
-    mockGetRequestConditions.mockResolvedValue({
-      _locale: 'fr',
-      _enableI18n: true,
-    });
     mockGetTranslationsInternal.mockReturnValue(translations);
     const { getTranslations } = await import('../strings');
 
@@ -134,37 +106,8 @@ describe('buildtime translation helpers', () => {
 
     expect(mockGetTranslationsInternal).toHaveBeenCalledWith({
       locale: 'fr',
-      enableI18n: true,
+      enableI18n: false,
       rootId: 'metadata',
-    });
-    expect(mockGetNextI18nCache().loadDictionaries).toHaveBeenCalledWith('en');
-    expect(mockGetNextI18nCache().loadDictionaries).toHaveBeenCalledWith('fr');
-    expect(mockGetNextI18nCache().updateDictionaries).toHaveBeenCalledWith({
-      en: { greeting: 'Hello' },
-      fr: { greeting: 'Bonjour' },
-    });
-  });
-
-  it('getTranslations loads one dictionary when request locale matches source locale', async () => {
-    const translations = vi.fn();
-    mockGetRequestConditions.mockResolvedValue({
-      _locale: 'en',
-      _enableI18n: true,
-    });
-    mockGetTranslationsInternal.mockReturnValue(translations);
-    const { getTranslations } = await import('../strings');
-
-    await expect(getTranslations()).resolves.toBe(translations);
-
-    expect(mockGetNextI18nCache().loadDictionaries).toHaveBeenCalledTimes(1);
-    expect(mockGetNextI18nCache().loadDictionaries).toHaveBeenCalledWith('en');
-    expect(mockGetNextI18nCache().updateDictionaries).toHaveBeenCalledWith({
-      en: { greeting: 'Hello' },
-    });
-    expect(mockGetTranslationsInternal).toHaveBeenCalledWith({
-      locale: 'en',
-      enableI18n: true,
-      rootId: undefined,
     });
   });
 

--- a/packages/next/src/server-dir/buildtime/strings.ts
+++ b/packages/next/src/server-dir/buildtime/strings.ts
@@ -1,13 +1,11 @@
 import { use } from '../../utils/use';
 import {
   getGTInternal,
-  getI18nConfig,
   getMessagesInternal,
   getTranslationsInternal,
 } from 'gt-i18n/internal';
 import type { Message } from 'gt-i18n/types';
 import { getRequestConditions } from '../../request/getRequestConditions';
-import { getNextI18nCache } from '../../i18n-cache/NextI18nCache';
 
 export async function getGT(_messages?: Message[]) {
   const conditions = await getRequestConditions();
@@ -30,17 +28,6 @@ export async function getMessages() {
 
 export async function getTranslations(rootId?: string) {
   const conditions = await getRequestConditions();
-  const cache = getNextI18nCache();
-  const sourceLocale = getI18nConfig().getDefaultLocale();
-  const targetLocale = conditions._enableI18n
-    ? conditions._locale
-    : sourceLocale;
-  const dictionariesToLoad = [cache.loadDictionaries(sourceLocale)];
-  if (targetLocale !== sourceLocale) {
-    dictionariesToLoad.push(cache.loadDictionaries(targetLocale));
-  }
-  const dictionaries = await Promise.all(dictionariesToLoad);
-  cache.updateDictionaries(Object.assign({}, ...dictionaries));
   return getTranslationsInternal({
     locale: conditions._locale,
     enableI18n: conditions._enableI18n,


### PR DESCRIPTION
## Summary
- prefer the root dictionary file over custom dictionary loaders for the default locale
- move dictionary lookup priming into NextI18nCache so gt-next/server helpers can rely on getTranslationsInternal
- add coverage for default-locale loader precedence and lookup cache priming

## Testing
- pnpm --dir packages/next exec vitest run src/i18n-cache/__tests__/NextI18nCache.test.ts src/server-dir/buildtime/__tests__/getTranslations.test.ts
- pnpm --filter gt-next typecheck
- pnpm format
- pnpm --filter gt-next build:no-swc-plugin
- pnpm build:next-app-router in linked gt-test-apps worktree
- T3 preview default render with both dictionary.ts and loadDictionary.ts present showed `English from root dictionary file.`
- `curl -H "x-generaltranslation-locale: fr" http://localhost:46849/` showed `French from loadDictionary override.`

Stacked on #1775.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes how the default locale's dictionary is resolved when a custom `loadDictionary` is provided: the root dictionary file now takes precedence over the custom loader. Dictionary cache priming is moved out of `getTranslations` in `strings.ts` and into a new `getLookupDictionary` override on `NextI18nCache`, so that any call to `getTranslationsInternal` will automatically prime the cache.

- **`NextI18nCache`**: Wraps `params.loadDictionary` to call `getDictionary()` for the default locale and adds a `getLookupDictionary` override that calls `loadDictionaries` + `updateDictionaries` before delegating to the base implementation.
- **`strings.ts`**: Removes explicit `loadDictionaries` / `updateDictionaries` calls from `getTranslations`, relying on the new cache override instead.
- **Tests**: Adds coverage for the default-locale loader precedence and the lookup-dictionary priming path; simplifies `getTranslations` tests to match the leaner implementation.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the core priming logic through `getLookupDictionary` is sound and well-tested, with no correctness regressions.

The constructor's `params.loadDictionary` wrapper for the default locale is dead code in normal operation (the base class never invokes the loader for the default locale), and the `getLookupDictionary` override calls `loadDictionaries` on every render without a "already loaded" guard. Neither is a blocker, but both warrant a second look before the next major refactor of the cache layer.

packages/next/src/i18n-cache/NextI18nCache.ts — the constructor wrapper and the unconditional `loadDictionaries` call in `getLookupDictionary`.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/next/src/i18n-cache/NextI18nCache.ts | Adds default-locale override to the `loadDictionary` wrapper and a `getLookupDictionary` override that primes the cache; the wrapper change is functionally dead for the default locale because `I18nCache` never invokes `params.loadDictionary` when `_resolveCacheLocale` returns undefined. |
| packages/next/src/server-dir/buildtime/strings.ts | Removes explicit dictionary-loading logic from `getTranslations`; now delegates entirely to `getTranslationsInternal` which triggers the `NextI18nCache.getLookupDictionary` override. |
| packages/next/src/i18n-cache/__tests__/NextI18nCache.test.ts | Adds three new tests covering default-locale loader precedence and `getLookupDictionary` priming; mocks extended cleanly. |
| packages/next/src/server-dir/buildtime/__tests__/getTranslations.test.ts | Removes cache-loading assertions and the `enableI18n: true` scenario from `getTranslations` tests; the `rootId` forwarding test now only exercises the `enableI18n: false` path. |
| .changeset/default-dictionary-priority.md | Patch changeset for `gt-next`; description matches the behaviour change. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant GT as getTranslations (strings.ts)
    participant GTI as getTranslationsInternal (gt-i18n)
    participant NIC as NextI18nCache.getLookupDictionary
    participant LD as loadDictionaries
    participant GD as getDictionary (root file)
    participant CL as customLoadDictionary
    participant Base as I18nCache.getLookupDictionary

    GT->>GTI: "getTranslationsInternal({ locale, enableI18n, rootId })"
    GTI->>NIC: getLookupDictionary(sourceLocale)
    NIC->>LD: loadDictionaries(sourceLocale)
    LD->>GD: getDictionary() — root dict
    GD-->>LD: rootDict
    LD-->>NIC: "{ sourceLocale: mergedDict }"
    NIC->>NIC: "updateDictionaries({ sourceLocale: mergedDict })"
    NIC->>Base: super.getLookupDictionary(sourceLocale)
    Base-->>NIC: "{ lookupDictionary, lookupDictionaryObj }"
    NIC-->>GTI: resolvers for sourceLocale

    GTI->>NIC: getLookupDictionary(targetLocale)
    alt "targetLocale === defaultLocale"
        NIC->>LD: loadDictionaries(defaultLocale)
        LD->>GD: getDictionary()
        GD-->>LD: rootDict
        LD-->>NIC: "{ defaultLocale: rootDict }"
    else targetLocale is non-default
        NIC->>LD: loadDictionaries(targetLocale)
        LD->>GD: getDictionary()
        GD-->>LD: rootDict (base)
        LD->>CL: customLoader(targetLocale) via I18nCache.loadDictionary
        CL-->>LD: targetTranslations
        LD-->>NIC: "{ targetLocale: merged(rootDict, targetTranslations) }"
    end
    NIC->>NIC: "updateDictionaries({ targetLocale: ... })"
    NIC->>Base: super.getLookupDictionary(targetLocale)
    Base-->>NIC: "{ lookupDictionary, lookupDictionaryObj }"
    NIC-->>GTI: resolvers for targetLocale

    GTI-->>GT: t() function
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant GT as getTranslations (strings.ts)
    participant GTI as getTranslationsInternal (gt-i18n)
    participant NIC as NextI18nCache.getLookupDictionary
    participant LD as loadDictionaries
    participant GD as getDictionary (root file)
    participant CL as customLoadDictionary
    participant Base as I18nCache.getLookupDictionary

    GT->>GTI: "getTranslationsInternal({ locale, enableI18n, rootId })"
    GTI->>NIC: getLookupDictionary(sourceLocale)
    NIC->>LD: loadDictionaries(sourceLocale)
    LD->>GD: getDictionary() — root dict
    GD-->>LD: rootDict
    LD-->>NIC: "{ sourceLocale: mergedDict }"
    NIC->>NIC: "updateDictionaries({ sourceLocale: mergedDict })"
    NIC->>Base: super.getLookupDictionary(sourceLocale)
    Base-->>NIC: "{ lookupDictionary, lookupDictionaryObj }"
    NIC-->>GTI: resolvers for sourceLocale

    GTI->>NIC: getLookupDictionary(targetLocale)
    alt "targetLocale === defaultLocale"
        NIC->>LD: loadDictionaries(defaultLocale)
        LD->>GD: getDictionary()
        GD-->>LD: rootDict
        LD-->>NIC: "{ defaultLocale: rootDict }"
    else targetLocale is non-default
        NIC->>LD: loadDictionaries(targetLocale)
        LD->>GD: getDictionary()
        GD-->>LD: rootDict (base)
        LD->>CL: customLoader(targetLocale) via I18nCache.loadDictionary
        CL-->>LD: targetTranslations
        LD-->>NIC: "{ targetLocale: merged(rootDict, targetTranslations) }"
    end
    NIC->>NIC: "updateDictionaries({ targetLocale: ... })"
    NIC->>Base: super.getLookupDictionary(targetLocale)
    Base-->>NIC: "{ lookupDictionary, lookupDictionaryObj }"
    NIC-->>GTI: resolvers for targetLocale

    GTI-->>GT: t() function
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Apackages%2Fnext%2Fsrc%2Fi18n-cache%2FNextI18nCache.ts%3A37-40%0A**Default-locale%20branch%20in%20%60params.loadDictionary%60%20is%20dead%20code%20in%20practice.**%0A%0A%60I18nCache%60%20only%20calls%20%60params.loadDictionary%60%20%28internally%2C%20via%20%60LocalesCache.getOrLoadDictionary%60%29%20when%20%60_resolveCacheLocale%28locale%29%60%20returns%20a%20non-null%20value.%20For%20the%20default%20locale%2C%20%60_resolveCacheLocale%60%20always%20returns%20%60undefined%60%20%28because%20%60requiresTranslation%28defaultLocale%29%60%20is%20false%29%2C%20so%20the%20early-return%20in%20%60I18nCache.loadDictionary%60%20fires%20before%20the%20loader%20is%20ever%20invoked.%20The%20actual%20root-dictionary%20priming%20for%20the%20default%20locale%20happens%20through%20the%20%60loadDictionaries%60%20%E2%86%92%20%60await%20getDictionary%28%29%60%20%E2%86%92%20%60updateDictionaries%60%20path%20inside%20the%20new%20%60getLookupDictionary%60%20override%2C%20not%20through%20this%20wrapper.%0A%0AThe%20branch%20is%20harmless%2C%20but%20it%20silently%20diverges%20from%20how%20the%20cache%20is%20actually%20populated%20for%20the%20default%20locale%2C%20which%20may%20cause%20confusion%20when%20tracing%20the%20data%20flow%20later.%20Consider%20adding%20a%20comment%20that%20explains%20this%20is%20a%20guard%20for%20locale-alias%20edge%20cases%20%28e.g.%20when%20an%20alias%20locale%20resolves%20to%20the%20default%20locale%20string%20and%20%60requiresTranslation%60%20returns%20true%20for%20that%20alias%29%2C%20rather%20than%20the%20primary%20priming%20mechanism.%0A%0A%23%23%23%20Issue%202%20of%203%0Apackages%2Fnext%2Fsrc%2Fserver-dir%2Fbuildtime%2F__tests__%2FgetTranslations.test.ts%3A100-112%0A**%60rootId%60%20forwarding%20test%20no%20longer%20covers%20the%20i18n-enabled%20path.**%0A%0AThe%20previous%20version%20of%20this%20test%20set%20%60_enableI18n%3A%20true%60%20with%20a%20non-default%20locale%20%28%60'fr'%60%29%2C%20exercising%20the%20case%20where%20%60getTranslations%60%20forwards%20a%20%60rootId%60%20while%20i18n%20is%20active.%20The%20%60mockGetRequestConditions%60%20override%20was%20removed%20here%2C%20so%20the%20test%20now%20falls%20through%20to%20the%20%60beforeEach%60%20default%20of%20%60%7B%20_locale%3A%20'fr'%2C%20_enableI18n%3A%20false%20%7D%60.%20There%20is%20no%20remaining%20test%20in%20%60getTranslations.test.ts%60%20that%20calls%20%60getTranslations%28rootId%29%60%20with%20%60enableI18n%3A%20true%60.%20The%20dictionary-priming%20side%20of%20that%20scenario%20is%20now%20covered%20by%20%60NextI18nCache.test.ts%60%2C%20but%20the%20argument-forwarding%20contract%20of%20%60getTranslations%60%20itself%20when%20i18n%20is%20enabled%20%2B%20a%20%60rootId%60%20is%20present%20goes%20untested.%0A%0A%23%23%23%20Issue%203%20of%203%0Apackages%2Fnext%2Fsrc%2Fi18n-cache%2FNextI18nCache.ts%3A78-83%0A**%60loadDictionaries%60%20is%20called%20unconditionally%20on%20every%20%60getLookupDictionary%60%20invocation.**%0A%0A%60getTranslationsInternal%60%20calls%20%60getLookupDictionary%28sourceLocale%29%60%20and%20%60getLookupDictionary%28targetLocale%29%60%20concurrently%20via%20%60Promise.all%60%20on%20every%20request.%20Each%20call%20now%20triggers%20%60loadDictionaries%60%20which%20calls%20%60getDictionary%28%29%60%20%28file%20read%29%20and%20%60mergeDictionaries%60%20even%20when%20the%20cache%20was%20already%20primed%20on%20a%20previous%20request.%20If%20%60getDictionary%28%29%60%20is%20not%20memoised%20at%20the%20module%20level%20or%20per%20request%2C%20this%20adds%20file-read%20overhead%20on%20every%20server%20render.%20It%20may%20be%20worth%20checking%20whether%20a%20%22dictionary%20already%20loaded%20for%20this%20locale%22%20guard%20is%20needed%2C%20or%20confirming%20that%20%60getDictionary%28%29%60's%20memoisation%20is%20sufficient.%0A%0A&repo=generaltranslation%2Fgt&pr=1779&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fodysseus%2Fdefault-dictionary-priority%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fodysseus%2Fdefault-dictionary-priority%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Apackages%2Fnext%2Fsrc%2Fi18n-cache%2FNextI18nCache.ts%3A37-40%0A**Default-locale%20branch%20in%20%60params.loadDictionary%60%20is%20dead%20code%20in%20practice.**%0A%0A%60I18nCache%60%20only%20calls%20%60params.loadDictionary%60%20%28internally%2C%20via%20%60LocalesCache.getOrLoadDictionary%60%29%20when%20%60_resolveCacheLocale%28locale%29%60%20returns%20a%20non-null%20value.%20For%20the%20default%20locale%2C%20%60_resolveCacheLocale%60%20always%20returns%20%60undefined%60%20%28because%20%60requiresTranslation%28defaultLocale%29%60%20is%20false%29%2C%20so%20the%20early-return%20in%20%60I18nCache.loadDictionary%60%20fires%20before%20the%20loader%20is%20ever%20invoked.%20The%20actual%20root-dictionary%20priming%20for%20the%20default%20locale%20happens%20through%20the%20%60loadDictionaries%60%20%E2%86%92%20%60await%20getDictionary%28%29%60%20%E2%86%92%20%60updateDictionaries%60%20path%20inside%20the%20new%20%60getLookupDictionary%60%20override%2C%20not%20through%20this%20wrapper.%0A%0AThe%20branch%20is%20harmless%2C%20but%20it%20silently%20diverges%20from%20how%20the%20cache%20is%20actually%20populated%20for%20the%20default%20locale%2C%20which%20may%20cause%20confusion%20when%20tracing%20the%20data%20flow%20later.%20Consider%20adding%20a%20comment%20that%20explains%20this%20is%20a%20guard%20for%20locale-alias%20edge%20cases%20%28e.g.%20when%20an%20alias%20locale%20resolves%20to%20the%20default%20locale%20string%20and%20%60requiresTranslation%60%20returns%20true%20for%20that%20alias%29%2C%20rather%20than%20the%20primary%20priming%20mechanism.%0A%0A%23%23%23%20Issue%202%20of%203%0Apackages%2Fnext%2Fsrc%2Fserver-dir%2Fbuildtime%2F__tests__%2FgetTranslations.test.ts%3A100-112%0A**%60rootId%60%20forwarding%20test%20no%20longer%20covers%20the%20i18n-enabled%20path.**%0A%0AThe%20previous%20version%20of%20this%20test%20set%20%60_enableI18n%3A%20true%60%20with%20a%20non-default%20locale%20%28%60'fr'%60%29%2C%20exercising%20the%20case%20where%20%60getTranslations%60%20forwards%20a%20%60rootId%60%20while%20i18n%20is%20active.%20The%20%60mockGetRequestConditions%60%20override%20was%20removed%20here%2C%20so%20the%20test%20now%20falls%20through%20to%20the%20%60beforeEach%60%20default%20of%20%60%7B%20_locale%3A%20'fr'%2C%20_enableI18n%3A%20false%20%7D%60.%20There%20is%20no%20remaining%20test%20in%20%60getTranslations.test.ts%60%20that%20calls%20%60getTranslations%28rootId%29%60%20with%20%60enableI18n%3A%20true%60.%20The%20dictionary-priming%20side%20of%20that%20scenario%20is%20now%20covered%20by%20%60NextI18nCache.test.ts%60%2C%20but%20the%20argument-forwarding%20contract%20of%20%60getTranslations%60%20itself%20when%20i18n%20is%20enabled%20%2B%20a%20%60rootId%60%20is%20present%20goes%20untested.%0A%0A%23%23%23%20Issue%203%20of%203%0Apackages%2Fnext%2Fsrc%2Fi18n-cache%2FNextI18nCache.ts%3A78-83%0A**%60loadDictionaries%60%20is%20called%20unconditionally%20on%20every%20%60getLookupDictionary%60%20invocation.**%0A%0A%60getTranslationsInternal%60%20calls%20%60getLookupDictionary%28sourceLocale%29%60%20and%20%60getLookupDictionary%28targetLocale%29%60%20concurrently%20via%20%60Promise.all%60%20on%20every%20request.%20Each%20call%20now%20triggers%20%60loadDictionaries%60%20which%20calls%20%60getDictionary%28%29%60%20%28file%20read%29%20and%20%60mergeDictionaries%60%20even%20when%20the%20cache%20was%20already%20primed%20on%20a%20previous%20request.%20If%20%60getDictionary%28%29%60%20is%20not%20memoised%20at%20the%20module%20level%20or%20per%20request%2C%20this%20adds%20file-read%20overhead%20on%20every%20server%20render.%20It%20may%20be%20worth%20checking%20whether%20a%20%22dictionary%20already%20loaded%20for%20this%20locale%22%20guard%20is%20needed%2C%20or%20confirming%20that%20%60getDictionary%28%29%60's%20memoisation%20is%20sufficient.%0A%0A&repo=generaltranslation%2Fgt&pr=1779&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=4"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=4"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
packages/next/src/i18n-cache/NextI18nCache.ts:37-40
**Default-locale branch in `params.loadDictionary` is dead code in practice.**

`I18nCache` only calls `params.loadDictionary` (internally, via `LocalesCache.getOrLoadDictionary`) when `_resolveCacheLocale(locale)` returns a non-null value. For the default locale, `_resolveCacheLocale` always returns `undefined` (because `requiresTranslation(defaultLocale)` is false), so the early-return in `I18nCache.loadDictionary` fires before the loader is ever invoked. The actual root-dictionary priming for the default locale happens through the `loadDictionaries` → `await getDictionary()` → `updateDictionaries` path inside the new `getLookupDictionary` override, not through this wrapper.

The branch is harmless, but it silently diverges from how the cache is actually populated for the default locale, which may cause confusion when tracing the data flow later. Consider adding a comment that explains this is a guard for locale-alias edge cases (e.g. when an alias locale resolves to the default locale string and `requiresTranslation` returns true for that alias), rather than the primary priming mechanism.

### Issue 2 of 3
packages/next/src/server-dir/buildtime/__tests__/getTranslations.test.ts:100-112
**`rootId` forwarding test no longer covers the i18n-enabled path.**

The previous version of this test set `_enableI18n: true` with a non-default locale (`'fr'`), exercising the case where `getTranslations` forwards a `rootId` while i18n is active. The `mockGetRequestConditions` override was removed here, so the test now falls through to the `beforeEach` default of `{ _locale: 'fr', _enableI18n: false }`. There is no remaining test in `getTranslations.test.ts` that calls `getTranslations(rootId)` with `enableI18n: true`. The dictionary-priming side of that scenario is now covered by `NextI18nCache.test.ts`, but the argument-forwarding contract of `getTranslations` itself when i18n is enabled + a `rootId` is present goes untested.

### Issue 3 of 3
packages/next/src/i18n-cache/NextI18nCache.ts:78-83
**`loadDictionaries` is called unconditionally on every `getLookupDictionary` invocation.**

`getTranslationsInternal` calls `getLookupDictionary(sourceLocale)` and `getLookupDictionary(targetLocale)` concurrently via `Promise.all` on every request. Each call now triggers `loadDictionaries` which calls `getDictionary()` (file read) and `mergeDictionaries` even when the cache was already primed on a previous request. If `getDictionary()` is not memoised at the module level or per request, this adds file-read overhead on every server render. It may be worth checking whether a "dictionary already loaded for this locale" guard is needed, or confirming that `getDictionary()`'s memoisation is sufficient.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: prioritize root dictionary defaults"](https://github.com/generaltranslation/gt/commit/3377b96dda5190523b68f61a9e6fa4dc3a3ee4fd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41259406)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->