### PR TITLE
fix(next): keep locale cookie when middleware clears the setLocale reset cookie

### DIFF
--- a/.changeset/keep-locale-cookie-on-reset.md
+++ b/.changeset/keep-locale-cookie-on-reset.md
@@ -1,0 +1,5 @@
+---
+'gt-next': patch
+---
+
+Keep the locale cookie when the middleware clears the setLocale reset cookie. Deleting it raced with concurrent prefetch responses after a locale switch in production builds, causing client components to fall back to the browser's default locale while server components rendered the selected locale.

--- a/packages/next/src/middleware-dir/__tests__/middleware.edge.test.ts
+++ b/packages/next/src/middleware-dir/__tests__/middleware.edge.test.ts
@@ -457,5 +457,28 @@ describe('Middleware Integration Tests', () => {
       // This should be a next() since the locale and path now match
       expect(getResponseType(nextRes)).toBe('next');
     });
+
+    it('keeps the locale cookie when clearing the reset cookie', () => {
+      setEnvConfig();
+      const middleware = createNextMiddleware({
+        prefixDefaultLocale: true,
+      });
+
+      const res = middleware(
+        createRequest('/fr/about', {
+          cookies: {
+            [LOCALE_COOKIE]: 'fr',
+            [RESET_COOKIE]: 'true',
+          },
+        })
+      );
+      expect(getResponseType(res)).toBe('next');
+      const setCookie = res.headers.get('set-cookie') || '';
+      expect(setCookie).toContain(`${RESET_COOKIE}=;`);
+      // The locale cookie must survive: the client re-reads it on every
+      // render, and deleting it races with concurrent prefetch responses
+      // after a locale switch.
+      expect(setCookie).not.toContain(`${LOCALE_COOKIE}=;`);
+    });
   });
 });

--- a/packages/next/src/middleware-dir/createNextMiddleware.ts
+++ b/packages/next/src/middleware-dir/createNextMiddleware.ts
@@ -200,7 +200,6 @@ export function createNextMiddleware({
       clearResetCookie,
       localeRouting,
       localeRoutingEnabledCookieName,
-      localeCookieName,
       resetLocaleCookieName,
       localeHeaderName,
     };

--- a/packages/next/src/middleware-dir/utils.ts
+++ b/packages/next/src/middleware-dir/utils.ts
@@ -16,7 +16,6 @@ export type ResponseConfig = {
   headerList: Headers;
   localeRouting: boolean;
   localeRoutingEnabledCookieName: string;
-  localeCookieName: string;
   resetLocaleCookieName: string;
   localeHeaderName: string;
 };
@@ -30,7 +29,6 @@ export function getResponse({
   headerList,
   localeRouting,
   localeRoutingEnabledCookieName,
-  localeCookieName,
   resetLocaleCookieName,
   localeHeaderName,
 }: ResponseConfig): NextResponse<unknown> {
@@ -61,10 +59,12 @@ export function getResponse({
     localeRoutingEnabledCookieName,
     localeRouting.toString()
   );
-  // Clear setLocale cookies
+  // Clear the setLocale reset cookie once it has been processed. The locale
+  // cookie must be kept: the client re-reads it on every render, and deleting
+  // it here races with concurrent prefetch responses after a locale switch,
+  // dropping client components back to the browser's default locale.
   if (clearResetCookie && type !== 'redirect') {
     response.cookies.delete(resetLocaleCookieName);
-    response.cookies.delete(localeCookieName);
   }
   return response;
 }


### PR DESCRIPTION
## Problem

On production builds of gt-next v11 (odysseus) apps with middleware locale routing, switching locales in the browser intermittently left **client-rendered content in the default locale** while RSC content rendered the selected locale correctly. It appeared locale-dependent, but the failing locales changed between runs — it's a race. Reproduced on `gt-cloud/apps/landing` and `cursor-sh-landing/apps/docs` (both `gt-next@11.0.0-odysseus.12`).

## Root cause

`setLocale()` writes `generaltranslation.locale` + `generaltranslation.locale-reset` cookies, then calls `router.refresh()`. The middleware's `getResponse` deleted **both** the reset cookie **and the locale cookie** on every non-redirect response whose request carried the reset cookie.

In production, Next.js link prefetches fire concurrently with the refresh, all carrying the reset cookie, so several responses come back with `Set-Cookie` deletions. If any of them lands **after** the client provider re-writes the locale cookie from the new server props, the cookie ends up deleted. Since the v11 client resolves `useLocale()` from the cookie + `navigator.languages` on every render (no in-memory locale), the next client re-render falls back to the browser language — the default locale. Server requests stay on the selected locale via the referrer-locale cookie, which is why RSC content remained correct.

Dev builds don't prefetch (single in-flight request, deterministic ordering) and dev hot-reload refetches missing translations, which is why this was production-only and unreproducible in minimal apps (too few links to trigger the prefetch storm).

Deterministic proof against a prod build:

```
$ curl -D - -H 'Cookie: generaltranslation.locale=fr; generaltranslation.locale-reset=true' localhost:3000/fr/docs
set-cookie: generaltranslation.locale-reset=; Expires=Thu, 01 Jan 1970 ...
set-cookie: generaltranslation.locale=; Expires=Thu, 01 Jan 1970 ...   <-- deletes the user's locale
```

## Fix

Only delete the reset cookie once processed; keep the locale cookie. The client re-writes the locale cookie on every provider init anyway, so deleting it never had an effect other than this race. Removed the now-unused `localeCookieName` from `ResponseConfig`.

## Verification

- Playwright sweep over all 12 locales of the cursor docs app (prod build), switching via the real language dropdown: before the fix ~30% of switches failed (different locales each run); with the patched middleware, 36/36 switches rendered client content in the selected locale.
- New regression test: middleware response clearing the reset cookie must not delete the locale cookie.
- `pnpm --filter gt-next test`: 212 JS + 295 Rust tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a production-only race condition in `gt-next` where concurrent Next.js prefetch responses carrying the `locale-reset` cookie caused the middleware to delete the locale cookie, leaving client components momentarily falling back to the browser's default locale after a `setLocale()` call.

- **`utils.ts` / `createNextMiddleware.ts`**: Removed the `response.cookies.delete(localeCookieName)` call from the reset-cookie cleanup path in `getResponse`. Only the reset cookie is now cleared once processed; the locale cookie is left intact since the client provider re-writes it on every render and the middleware never needs to delete it.
- **Test**: Adds a regression test confirming the reset cookie is deleted and the locale cookie is preserved on `next`-type responses when both cookies are present.
- **Changeset**: Adds a patch entry for `gt-next`.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a minimal, targeted removal of one redundant cookie deletion that was causing a race condition in production builds.

The middleware was deleting the locale cookie on every non-redirect response that carried the reset cookie, which was both unnecessary (the client re-writes it on every provider init) and harmful (concurrent prefetch responses could wipe it after the client had already set the new locale). Removing that single deletion line is low risk. The fix is confined to one branch in getResponse, is covered by a new regression test, and leaves all other routing logic untouched. The localeCookieName variable removal from ResponseConfig is clean — the variable is still present and used in createNextMiddleware.ts for reading the cookie via getLocaleFromRequest.

No files require special attention; all changes are straightforward and well-covered by the new regression test.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/next/src/middleware-dir/utils.ts | Removed localeCookieName from ResponseConfig type and getResponse parameters; the reset-cookie clearing block now only deletes the reset cookie, fixing the race condition. |
| packages/next/src/middleware-dir/createNextMiddleware.ts | Removed the now-unused localeCookieName field from the responseConfig object passed to getResponse; localeCookieName is still correctly used locally for reading the locale cookie in getLocaleFromRequest. |
| packages/next/src/middleware-dir/__tests__/middleware.edge.test.ts | Adds a targeted regression test asserting the reset cookie is cleared while the locale cookie is preserved when both cookies are present on a next-type response. |
| .changeset/keep-locale-cookie-on-reset.md | Patch-level changeset entry for gt-next describing the locale-cookie race fix. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client as Browser Client
    participant MW as Next.js Middleware

    Note over Client,MW: setLocale("fr") called
    Client->>Client: "writes locale=fr cookie"
    Client->>Client: "writes locale-reset=true cookie"
    Client->>MW: router.refresh() + concurrent prefetches

    par Refresh request
        Client->>MW: "GET /fr/page (locale=fr, reset=true)"
        MW->>MW: "clearResetCookie=true, userLocale=fr"
        MW-->>Client: Set-Cookie: locale-reset deleted
    and Prefetch A
        Client->>MW: "GET /fr/other (locale=fr, reset=true)"
        MW-->>Client: Set-Cookie: locale-reset deleted
    and Prefetch B
        Client->>MW: "GET /fr/link (locale=fr, reset=true)"
        MW-->>Client: Set-Cookie: locale-reset deleted
    end

    Note over Client,MW: AFTER fix - locale cookie never touched by middleware
    Client->>Client: "useLocale() reads locale=fr cookie correctly"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client as Browser Client
    participant MW as Next.js Middleware

    Note over Client,MW: setLocale("fr") called
    Client->>Client: "writes locale=fr cookie"
    Client->>Client: "writes locale-reset=true cookie"
    Client->>MW: router.refresh() + concurrent prefetches

    par Refresh request
        Client->>MW: "GET /fr/page (locale=fr, reset=true)"
        MW->>MW: "clearResetCookie=true, userLocale=fr"
        MW-->>Client: Set-Cookie: locale-reset deleted
    and Prefetch A
        Client->>MW: "GET /fr/other (locale=fr, reset=true)"
        MW-->>Client: Set-Cookie: locale-reset deleted
    and Prefetch B
        Client->>MW: "GET /fr/link (locale=fr, reset=true)"
        MW-->>Client: Set-Cookie: locale-reset deleted
    end

    Note over Client,MW: AFTER fix - locale cookie never touched by middleware
    Client->>Client: "useLocale() reads locale=fr cookie correctly"
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(next): keep locale cookie when middl..."](https://github.com/generaltranslation/gt/commit/522f4af103d2990d3d9f1dea815fadbc74ab5353) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41282472)</sub>

<!-- /greptile_comment -->