### PR TITLE
fix: recover and retry flaky binary npm publishes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,13 +124,17 @@ jobs:
             }
 
       # gt (primary CLI package, lives in packages/cli/)
-      - name: Check if gt was published
+      - name: Check if gt binary release is needed
         id: check-gt
-        if: steps.changesets.outputs.published == 'true'
         run: |
           published_packages='${{ steps.changesets.outputs.publishedPackages }}'
+          version=$(jq -r .version packages/cli/package.json)
 
-          if echo "$published_packages" | jq -e 'any(.[]; .name == "gt")' > /dev/null; then
+          if [ -n "$published_packages" ] && echo "$published_packages" | jq -e 'any(.[]; .name == "gt")' > /dev/null; then
+            echo "should_release_bin=true" >> $GITHUB_OUTPUT
+          elif npm view "gt@${version}" version > /dev/null 2>&1 && ! npm view "gt@${version}-bin.0" version > /dev/null 2>&1; then
+            # A previous run published gt but failed before the binary
+            # release landed; finish it on this run.
             echo "should_release_bin=true" >> $GITHUB_OUTPUT
           else
             echo "should_release_bin=false" >> $GITHUB_OUTPUT
@@ -140,8 +144,7 @@ jobs:
         id: gt-version
         if: steps.check-gt.outputs.should_release_bin == 'true'
         run: |
-          published_packages='${{ steps.changesets.outputs.publishedPackages }}'
-          version=$(echo "$published_packages" | jq -er '.[] | select(.name == "gt") | .version')
+          version=$(jq -er .version packages/cli/package.json)
           echo "version=$version" >> $GITHUB_OUTPUT
 
       - name: Build gt binaries
@@ -189,16 +192,42 @@ jobs:
 
       - name: Release gt binary to npm
         if: steps.check-gt.outputs.should_release_bin == 'true'
-        run: pnpm --filter gt run bin:prep && pnpm --filter gt publish --tag bin --no-git-checks && pnpm --filter gt run bin:restore && pnpm --filter gt run build:clean
+        run: |
+          pnpm --filter gt run bin:prep
+          bin_version="${{ steps.gt-version.outputs.version }}-bin.0"
+          # The registry intermittently rejects the short-lived trusted
+          # publishing token partway through these large uploads; each retry
+          # is a fresh npm invocation and a fresh OIDC token exchange.
+          for attempt in 1 2 3 4 5; do
+            if pnpm --filter gt publish --tag bin --no-git-checks; then
+              break
+            fi
+            if npm view "gt@${bin_version}" version > /dev/null 2>&1; then
+              echo "gt@${bin_version} reached the registry despite the error"
+              break
+            fi
+            if [ "$attempt" = 5 ]; then
+              echo "Publishing gt@${bin_version} failed after ${attempt} attempts"
+              exit 1
+            fi
+            echo "Publish attempt ${attempt} failed, retrying in 30s"
+            sleep 30
+          done
+          pnpm --filter gt run bin:restore
+          pnpm --filter gt run build:clean
 
       # gtx-cli (backward-compat wrapper, lives in packages/gtx-cli/)
-      - name: Check if gtx-cli was published
+      - name: Check if gtx-cli binary release is needed
         id: check-gtx-cli
-        if: steps.changesets.outputs.published == 'true'
         run: |
           published_packages='${{ steps.changesets.outputs.publishedPackages }}'
+          version=$(jq -r .version packages/gtx-cli/package.json)
 
-          if echo "$published_packages" | jq -e 'any(.[]; .name == "gtx-cli")' > /dev/null; then
+          if [ -n "$published_packages" ] && echo "$published_packages" | jq -e 'any(.[]; .name == "gtx-cli")' > /dev/null; then
+            echo "should_release_bin=true" >> $GITHUB_OUTPUT
+          elif npm view "gtx-cli@${version}" version > /dev/null 2>&1 && ! npm view "gtx-cli@${version}-bin.0" version > /dev/null 2>&1; then
+            # A previous run published gtx-cli but failed before the binary
+            # release landed; finish it on this run.
             echo "should_release_bin=true" >> $GITHUB_OUTPUT
           else
             echo "should_release_bin=false" >> $GITHUB_OUTPUT
@@ -208,8 +237,7 @@ jobs:
         id: gtx-cli-version
         if: steps.check-gtx-cli.outputs.should_release_bin == 'true'
         run: |
-          published_packages='${{ steps.changesets.outputs.publishedPackages }}'
-          version=$(echo "$published_packages" | jq -er '.[] | select(.name == "gtx-cli") | .version')
+          version=$(jq -er .version packages/gtx-cli/package.json)
           echo "version=$version" >> $GITHUB_OUTPUT
 
       - name: Build gtx-cli binaries
@@ -240,4 +268,26 @@ jobs:
 
       - name: Release gtx-cli binary to npm
         if: steps.check-gtx-cli.outputs.should_release_bin == 'true'
-        run: pnpm --filter gtx-cli run bin:prep && pnpm --filter gtx-cli publish --tag bin --no-git-checks && pnpm --filter gtx-cli run bin:restore && pnpm --filter gtx-cli run build:clean
+        run: |
+          pnpm --filter gtx-cli run bin:prep
+          bin_version="${{ steps.gtx-cli-version.outputs.version }}-bin.0"
+          # The registry intermittently rejects the short-lived trusted
+          # publishing token partway through these large uploads; each retry
+          # is a fresh npm invocation and a fresh OIDC token exchange.
+          for attempt in 1 2 3 4 5; do
+            if pnpm --filter gtx-cli publish --tag bin --no-git-checks; then
+              break
+            fi
+            if npm view "gtx-cli@${bin_version}" version > /dev/null 2>&1; then
+              echo "gtx-cli@${bin_version} reached the registry despite the error"
+              break
+            fi
+            if [ "$attempt" = 5 ]; then
+              echo "Publishing gtx-cli@${bin_version} failed after ${attempt} attempts"
+              exit 1
+            fi
+            echo "Publish attempt ${attempt} failed, retrying in 30s"
+            sleep 30
+          done
+          pnpm --filter gtx-cli run bin:restore
+          pnpm --filter gtx-cli run build:clean


### PR DESCRIPTION
## Problem

Main releases are failing at the binary npm publish step ([failed run](https://github.com/generaltranslation/gt/actions/runs/28561796524/job/84680770458)):

```
npm error 401 Unauthorized - PUT https://registry.npmjs.org/gt - Failed to generate Web Auth URLs due to error: BadRequestError: token is invalid
```

Diagnosis from the run logs:

- Trusted publishing itself works: the same run published `gt@2.14.57` (and 4 other packages) via OIDC seconds earlier, and the failing bin publish signed a provenance statement (which only happens after a successful OIDC token exchange).
- The failure is intermittent and specific to the ~180 MB `-bin.0` tarballs: `gt@2.14.56-bin.0` (same size) published fine on 6/30 while `gtx-cli`'s equally large bin publish failed in that same run with the identical error. The registry appears to intermittently reject the short-lived OIDC-exchanged token partway through these large uploads.
- Once this happens, the release cannot be recovered by re-running the failed job: on rerun `changesets/action` reports nothing published (all packages already on npm), so `steps.changesets.outputs.published` is `false` and every bin step is silently skipped. `gt@2.14.57-bin.0` and `gtx-cli@2.14.57-bin.0` are currently missing from npm because of this (the `bin` dist-tags are stuck at 2.14.56-bin.0 / 2.14.55-bin.0).

## Fix

1. **Recovery**: the `check-gt` / `check-gtx-cli` steps no longer depend solely on the changesets output. If the plain version from `package.json` is on npm but `<version>-bin.0` is not, the bin release steps run. This makes any push to main self-heal a half-finished release — including the merge of this PR, which will publish the missing 2.14.57 binaries.
2. **Retry**: the bin publish is attempted up to 5 times with a 30s pause. Each attempt is a fresh npm invocation, i.e. a fresh OIDC token exchange. An `npm view` guard treats "version landed despite the error" as success so a retry can never double-publish.

The version extraction steps now read `package.json` directly (identical value to the changesets output at that commit) so they work on recovery runs too. R2 uploads overwrite idempotently and the PyPI publish already passes `--skip-existing`, so re-running those steps on a recovery run is safe.

## Notes

- Two of the other recent release failures (runs [28549372477](https://github.com/generaltranslation/gt/actions/runs/28549372477), [28556629391](https://github.com/generaltranslation/gt/actions/runs/28556629391)) are a different flake: `changeset version` dying on a transient `api.github.com/graphql` fetch error from `@changesets/changelog-github`. Not addressed here; worth a follow-up (retry or a changelog generator that doesn't call the GitHub API).

## Validation

- YAML lint on the workflow file passes.
- Verified against npm registry state: `gt@2.14.57` exists, `gt@2.14.57-bin.0` does not → gt bin steps will fire on the next main push; same for `gtx-cli@2.14.57`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes flaky binary npm publishes in the release workflow by adding a recovery mechanism and a retry loop. The recovery detects when a plain package version is on npm but its `-bin.0` counterpart is missing, and triggers the binary release steps on the next push to main. The retry loop attempts the publish up to 5 times with a 30-second back-off, using a fresh OIDC token exchange per attempt, and treats "version landed despite the error" as success to avoid double-publishing.

- **Recovery check**: `check-gt` and `check-gtx-cli` now run unconditionally; in addition to the changesets-output gate they add an `npm view` guard that catches half-finished releases from previous runs.
- **Retry loop**: Both binary publish steps loop up to 5 attempts; an `npm view` post-failure check prevents duplicate publishing if the upload actually succeeded before the 401 was returned.
- **Version source**: Both version-extraction steps now read directly from `package.json` instead of the changesets output, making them work on recovery runs where `publishedPackages` is empty.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge. The retry and recovery logic is well-guarded and the only gap — bin:restore not running on a complete 5-attempt failure — does not affect subsequent runs since the workspace is always freshly checked out.

The core retry and recovery logic is sound. The one cleanup gap leaves the workspace modified within the same failing run, but all downstream steps are already skipped and fresh checkouts on future runs are unaffected.

Only .github/workflows/release.yml changed. The retry and recovery sections in both the gt and gtx-cli publish steps warrant the most attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Adds recovery logic (npm view guard) and a 5-attempt retry loop with 30s back-off for both gt and gtx-cli binary npm publishes; version extraction switched from changesets output to package.json. One cleanup concern: bin:restore is never reached if all retries exhaust and exit 1 fires. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Push to main] --> B[changesets/action]
    B --> C{check-gt}
    C -->|changesets published gt| D[should_release_bin=true]
    C -->|gt version on npm but bin.0 missing| D
    C -->|neither| E[skip binary release]
    D --> F[Build gt binaries]
    F --> G[Upload to R2 and PyPI]
    G --> H[bin:prep]
    H --> J{Retry loop up to 5 attempts}
    J -->|publish succeeds| K[break - success]
    J -->|publish fails but version found on registry| K
    J -->|publish fails, not on registry, attempt lt 5| L[sleep 30s]
    L --> J
    J -->|attempt 5 fails, version not on registry| M[exit 1 - bin:restore skipped]
    K --> N[bin:restore and build:clean]
    N --> P[gtx-cli follows same pattern]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Push to main] --> B[changesets/action]
    B --> C{check-gt}
    C -->|changesets published gt| D[should_release_bin=true]
    C -->|gt version on npm but bin.0 missing| D
    C -->|neither| E[skip binary release]
    D --> F[Build gt binaries]
    F --> G[Upload to R2 and PyPI]
    G --> H[bin:prep]
    H --> J{Retry loop up to 5 attempts}
    J -->|publish succeeds| K[break - success]
    J -->|publish fails but version found on registry| K
    J -->|publish fails, not on registry, attempt lt 5| L[sleep 30s]
    L --> J
    J -->|attempt 5 fails, version not on registry| M[exit 1 - bin:restore skipped]
    K --> N[bin:restore and build:clean]
    N --> P[gtx-cli follows same pattern]
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Frelease.yml%3A193-217%0A%60bin%3Arestore%60%20and%20%60build%3Aclean%60%20are%20placed%20after%20the%20loop%2C%20so%20they%20are%20never%20called%20when%20%60exit%201%60%20fires%20on%20the%20fifth%20failed%20attempt.%20This%20leaves%20%60packages%2Fcli%2Fpackage.json%60%20in%20its%20%60bin%3Aprep%60-modified%20state%20for%20the%20remainder%20of%20the%20job%20run.%20While%20subsequent%20gtx-cli%20steps%20are%20skipped%20anyway%20%28GitHub%20Actions'%20implicit%20%60success%28%29%60%20check%29%2C%20and%20the%20workspace%20is%20fresh%20on%20the%20next%20push%2C%20a%20%60trap%60%20is%20the%20idiomatic%20way%20to%20guarantee%20the%20restore%20runs%20regardless%20of%20how%20the%20loop%20exits.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20-%20name%3A%20Release%20gt%20binary%20to%20npm%0A%20%20%20%20%20%20%20%20if%3A%20steps.check-gt.outputs.should_release_bin%20%3D%3D%20'true'%0A%20%20%20%20%20%20%20%20run%3A%20%7C%0A%20%20%20%20%20%20%20%20%20%20pnpm%20--filter%20gt%20run%20bin%3Aprep%0A%20%20%20%20%20%20%20%20%20%20trap%20'pnpm%20--filter%20gt%20run%20bin%3Arestore%3B%20pnpm%20--filter%20gt%20run%20build%3Aclean'%20EXIT%0A%20%20%20%20%20%20%20%20%20%20bin_version%3D%22%24%7B%7B%20steps.gt-version.outputs.version%20%7D%7D-bin.0%22%0A%20%20%20%20%20%20%20%20%20%20%23%20The%20registry%20intermittently%20rejects%20the%20short-lived%20trusted%0A%20%20%20%20%20%20%20%20%20%20%23%20publishing%20token%20partway%20through%20these%20large%20uploads%3B%20each%20retry%0A%20%20%20%20%20%20%20%20%20%20%23%20is%20a%20fresh%20npm%20invocation%20and%20a%20fresh%20OIDC%20token%20exchange.%0A%20%20%20%20%20%20%20%20%20%20for%20attempt%20in%201%202%203%204%205%3B%20do%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20pnpm%20--filter%20gt%20publish%20--tag%20bin%20--no-git-checks%3B%20then%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20break%0A%20%20%20%20%20%20%20%20%20%20%20%20fi%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20npm%20view%20%22gt%40%24%7Bbin_version%7D%22%20version%20%3E%20%2Fdev%2Fnull%202%3E%261%3B%20then%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20echo%20%22gt%40%24%7Bbin_version%7D%20reached%20the%20registry%20despite%20the%20error%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20break%0A%20%20%20%20%20%20%20%20%20%20%20%20fi%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20%5B%20%22%24attempt%22%20%3D%205%20%5D%3B%20then%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20echo%20%22Publishing%20gt%40%24%7Bbin_version%7D%20failed%20after%20%24%7Battempt%7D%20attempts%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20exit%201%0A%20%20%20%20%20%20%20%20%20%20%20%20fi%0A%20%20%20%20%20%20%20%20%20%20%20%20echo%20%22Publish%20attempt%20%24%7Battempt%7D%20failed%2C%20retrying%20in%2030s%22%0A%20%20%20%20%20%20%20%20%20%20%20%20sleep%2030%0A%20%20%20%20%20%20%20%20%20%20done%0A%60%60%60%0A%0A%281%20more%20issue%20omitted%20due%20to%20length%20limits.%20Use%20individual%20%22Fix%20in%20Claude%20Code%22%20links%20for%20remaining%20issues.%29%0A&repo=generaltranslation%2Fgt&pr=1785&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fci%2Ffix-bin-publish-retry%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fci%2Ffix-bin-publish-retry%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Frelease.yml%3A193-217%0A%60bin%3Arestore%60%20and%20%60build%3Aclean%60%20are%20placed%20after%20the%20loop%2C%20so%20they%20are%20never%20called%20when%20%60exit%201%60%20fires%20on%20the%20fifth%20failed%20attempt.%20This%20leaves%20%60packages%2Fcli%2Fpackage.json%60%20in%20its%20%60bin%3Aprep%60-modified%20state%20for%20the%20remainder%20of%20the%20job%20run.%20While%20subsequent%20gtx-cli%20steps%20are%20skipped%20anyway%20%28GitHub%20Actions'%20implicit%20%60success%28%29%60%20check%29%2C%20and%20the%20workspace%20is%20fresh%20on%20the%20next%20push%2C%20a%20%60trap%60%20is%20the%20idiomatic%20way%20to%20guarantee%20the%20restore%20runs%20regardless%20of%20how%20the%20loop%20exits.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20-%20name%3A%20Release%20gt%20binary%20to%20npm%0A%20%20%20%20%20%20%20%20if%3A%20steps.check-gt.outputs.should_release_bin%20%3D%3D%20'true'%0A%20%20%20%20%20%20%20%20run%3A%20%7C%0A%20%20%20%20%20%20%20%20%20%20pnpm%20--filter%20gt%20run%20bin%3Aprep%0A%20%20%20%20%20%20%20%20%20%20trap%20'pnpm%20--filter%20gt%20run%20bin%3Arestore%3B%20pnpm%20--filter%20gt%20run%20build%3Aclean'%20EXIT%0A%20%20%20%20%20%20%20%20%20%20bin_version%3D%22%24%7B%7B%20steps.gt-version.outputs.version%20%7D%7D-bin.0%22%0A%20%20%20%20%20%20%20%20%20%20%23%20The%20registry%20intermittently%20rejects%20the%20short-lived%20trusted%0A%20%20%20%20%20%20%20%20%20%20%23%20publishing%20token%20partway%20through%20these%20large%20uploads%3B%20each%20retry%0A%20%20%20%20%20%20%20%20%20%20%23%20is%20a%20fresh%20npm%20invocation%20and%20a%20fresh%20OIDC%20token%20exchange.%0A%20%20%20%20%20%20%20%20%20%20for%20attempt%20in%201%202%203%204%205%3B%20do%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20pnpm%20--filter%20gt%20publish%20--tag%20bin%20--no-git-checks%3B%20then%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20break%0A%20%20%20%20%20%20%20%20%20%20%20%20fi%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20npm%20view%20%22gt%40%24%7Bbin_version%7D%22%20version%20%3E%20%2Fdev%2Fnull%202%3E%261%3B%20then%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20echo%20%22gt%40%24%7Bbin_version%7D%20reached%20the%20registry%20despite%20the%20error%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20break%0A%20%20%20%20%20%20%20%20%20%20%20%20fi%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20%5B%20%22%24attempt%22%20%3D%205%20%5D%3B%20then%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20echo%20%22Publishing%20gt%40%24%7Bbin_version%7D%20failed%20after%20%24%7Battempt%7D%20attempts%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20exit%201%0A%20%20%20%20%20%20%20%20%20%20%20%20fi%0A%20%20%20%20%20%20%20%20%20%20%20%20echo%20%22Publish%20attempt%20%24%7Battempt%7D%20failed%2C%20retrying%20in%2030s%22%0A%20%20%20%20%20%20%20%20%20%20%20%20sleep%2030%0A%20%20%20%20%20%20%20%20%20%20done%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2Fworkflows%2Frelease.yml%3A269-293%0ASame%20%60bin%3Arestore%60%2F%60build%3Aclean%60%20cleanup%20gap%20applies%20to%20the%20gtx-cli%20block%3A%20if%20all%20five%20attempts%20fail%20and%20%60exit%201%60%20fires%2C%20%60packages%2Fgtx-cli%2Fpackage.json%60%20is%20left%20in%20its%20%60bin%3Aprep%60-modified%20state%20for%20the%20duration%20of%20the%20run.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20-%20name%3A%20Release%20gtx-cli%20binary%20to%20npm%0A%20%20%20%20%20%20%20%20if%3A%20steps.check-gtx-cli.outputs.should_release_bin%20%3D%3D%20'true'%0A%20%20%20%20%20%20%20%20run%3A%20%7C%0A%20%20%20%20%20%20%20%20%20%20pnpm%20--filter%20gtx-cli%20run%20bin%3Aprep%0A%20%20%20%20%20%20%20%20%20%20trap%20'pnpm%20--filter%20gtx-cli%20run%20bin%3Arestore%3B%20pnpm%20--filter%20gtx-cli%20run%20build%3Aclean'%20EXIT%0A%20%20%20%20%20%20%20%20%20%20bin_version%3D%22%24%7B%7B%20steps.gtx-cli-version.outputs.version%20%7D%7D-bin.0%22%0A%20%20%20%20%20%20%20%20%20%20%23%20The%20registry%20intermittently%20rejects%20the%20short-lived%20trusted%0A%20%20%20%20%20%20%20%20%20%20%23%20publishing%20token%20partway%20through%20these%20large%20uploads%3B%20each%20retry%0A%20%20%20%20%20%20%20%20%20%20%23%20is%20a%20fresh%20npm%20invocation%20and%20a%20fresh%20OIDC%20token%20exchange.%0A%20%20%20%20%20%20%20%20%20%20for%20attempt%20in%201%202%203%204%205%3B%20do%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20pnpm%20--filter%20gtx-cli%20publish%20--tag%20bin%20--no-git-checks%3B%20then%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20break%0A%20%20%20%20%20%20%20%20%20%20%20%20fi%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20npm%20view%20%22gtx-cli%40%24%7Bbin_version%7D%22%20version%20%3E%20%2Fdev%2Fnull%202%3E%261%3B%20then%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20echo%20%22gtx-cli%40%24%7Bbin_version%7D%20reached%20the%20registry%20despite%20the%20error%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20break%0A%20%20%20%20%20%20%20%20%20%20%20%20fi%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20%5B%20%22%24attempt%22%20%3D%205%20%5D%3B%20then%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20echo%20%22Publishing%20gtx-cli%40%24%7Bbin_version%7D%20failed%20after%20%24%7Battempt%7D%20attempts%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20exit%201%0A%20%20%20%20%20%20%20%20%20%20%20%20fi%0A%20%20%20%20%20%20%20%20%20%20%20%20echo%20%22Publish%20attempt%20%24%7Battempt%7D%20failed%2C%20retrying%20in%2030s%22%0A%20%20%20%20%20%20%20%20%20%20%20%20sleep%2030%0A%20%20%20%20%20%20%20%20%20%20done%0A%60%60%60%0A%0A&repo=generaltranslation%2Fgt&pr=1785&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=4"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=4"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
.github/workflows/release.yml:193-217
`bin:restore` and `build:clean` are placed after the loop, so they are never called when `exit 1` fires on the fifth failed attempt. This leaves `packages/cli/package.json` in its `bin:prep`-modified state for the remainder of the job run. While subsequent gtx-cli steps are skipped anyway (GitHub Actions' implicit `success()` check), and the workspace is fresh on the next push, a `trap` is the idiomatic way to guarantee the restore runs regardless of how the loop exits.

```suggestion
      - name: Release gt binary to npm
        if: steps.check-gt.outputs.should_release_bin == 'true'
        run: |
          pnpm --filter gt run bin:prep
          trap 'pnpm --filter gt run bin:restore; pnpm --filter gt run build:clean' EXIT
          bin_version="${{ steps.gt-version.outputs.version }}-bin.0"
          # The registry intermittently rejects the short-lived trusted
          # publishing token partway through these large uploads; each retry
          # is a fresh npm invocation and a fresh OIDC token exchange.
          for attempt in 1 2 3 4 5; do
            if pnpm --filter gt publish --tag bin --no-git-checks; then
              break
            fi
            if npm view "gt@${bin_version}" version > /dev/null 2>&1; then
              echo "gt@${bin_version} reached the registry despite the error"
              break
            fi
            if [ "$attempt" = 5 ]; then
              echo "Publishing gt@${bin_version} failed after ${attempt} attempts"
              exit 1
            fi
            echo "Publish attempt ${attempt} failed, retrying in 30s"
            sleep 30
          done
```

### Issue 2 of 2
.github/workflows/release.yml:269-293
Same `bin:restore`/`build:clean` cleanup gap applies to the gtx-cli block: if all five attempts fail and `exit 1` fires, `packages/gtx-cli/package.json` is left in its `bin:prep`-modified state for the duration of the run.

```suggestion
      - name: Release gtx-cli binary to npm
        if: steps.check-gtx-cli.outputs.should_release_bin == 'true'
        run: |
          pnpm --filter gtx-cli run bin:prep
          trap 'pnpm --filter gtx-cli run bin:restore; pnpm --filter gtx-cli run build:clean' EXIT
          bin_version="${{ steps.gtx-cli-version.outputs.version }}-bin.0"
          # The registry intermittently rejects the short-lived trusted
          # publishing token partway through these large uploads; each retry
          # is a fresh npm invocation and a fresh OIDC token exchange.
          for attempt in 1 2 3 4 5; do
            if pnpm --filter gtx-cli publish --tag bin --no-git-checks; then
              break
            fi
            if npm view "gtx-cli@${bin_version}" version > /dev/null 2>&1; then
              echo "gtx-cli@${bin_version} reached the registry despite the error"
              break
            fi
            if [ "$attempt" = 5 ]; then
              echo "Publishing gtx-cli@${bin_version} failed after ${attempt} attempts"
              exit 1
            fi
            echo "Publish attempt ${attempt} failed, retrying in 30s"
            sleep 30
          done
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: recover and retry flaky binary npm ..."](https://github.com/generaltranslation/gt/commit/b6eedcb2d3b21d3d9030d30d5d852c813ed50c29) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41290124)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->