### PR TITLE
fix: skip completed translation downloads

### DIFF
--- a/.changeset/skip-completed-translation-downloads.md
+++ b/.changeset/skip-completed-translation-downloads.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+Skip redundant download requests for translations that are already available locally.

--- a/packages/cli/src/api/__tests__/downloadFileBatch.test.ts
+++ b/packages/cli/src/api/__tests__/downloadFileBatch.test.ts
@@ -204,6 +204,122 @@ describe('downloadFileBatch', () => {
     expect(result.failed).toHaveLength(0);
   });
 
+  it('should skip the API request when the lockfile has the requested output', async () => {
+    const files = createBatchedFiles(1);
+    const fileTracker = createMockFileTracker(files);
+    const existingEntry: DownloadedVersionEntry = {
+      fileId: 'file-1',
+      versionId: 'version-1',
+      translations: {
+        en: {
+          updatedAt: '2026-01-01T00:00:00.000Z',
+          fileName: 'file1.json',
+        },
+      },
+    };
+
+    vi.mocked(readLockfile).mockReturnValue({
+      data: { version: 2, branchId: 'branch-1', entries: [existingEntry] },
+      entryMap: new Map([['file-1', existingEntry]]),
+      originalV1: null,
+    });
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+
+    const result = await downloadFileBatch(
+      fileTracker,
+      files,
+      createMockSettings()
+    );
+
+    expect(gt.downloadFileBatch).not.toHaveBeenCalled();
+    expect(fs.promises.writeFile).not.toHaveBeenCalled();
+    expect(result.skipped).toEqual(files);
+    expect(result.successful).toHaveLength(0);
+    expect(result.failed).toHaveLength(0);
+  });
+
+  it('should request only outputs that are not already current', async () => {
+    const files = createBatchedFiles();
+    const fileTracker = createMockFileTracker(files);
+    const existingEntry: DownloadedVersionEntry = {
+      fileId: 'file-1',
+      versionId: 'version-1',
+      translations: {
+        en: {
+          updatedAt: '2026-01-01T00:00:00.000Z',
+          fileName: 'file1.json',
+        },
+      },
+    };
+    vi.mocked(readLockfile).mockReturnValue({
+      data: { version: 2, branchId: 'branch-1', entries: [existingEntry] },
+      entryMap: new Map([['file-1', existingEntry]]),
+      originalV1: null,
+    });
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(gt.downloadFileBatch).mockResolvedValue({
+      files: [createMockResponseData().files[1]],
+      count: 1,
+    });
+
+    const result = await downloadFileBatch(
+      fileTracker,
+      files,
+      createMockSettings()
+    );
+
+    expect(gt.downloadFileBatch).toHaveBeenCalledWith([
+      {
+        branchId: 'branch-2',
+        fileId: 'file-2',
+        versionId: 'version-2',
+        locale: 'en',
+      },
+    ]);
+    expect(result.skipped).toEqual([files[0]]);
+    expect(result.successful).toEqual([files[1]]);
+    expect(result.failed).toEqual([]);
+  });
+
+  it('should keep an unreadable completed GTJSON output skipped', async () => {
+    const files = createBatchedFiles(1);
+    const fileTracker = createMockFileTracker(files);
+    const fileKey = 'branch-1:file-1:version-1:en';
+    const fileProperties = fileTracker.completed.get(fileKey);
+    if (!fileProperties) throw new Error('Missing test file properties');
+    fileProperties.componentCount = 2;
+    const existingEntry: DownloadedVersionEntry = {
+      fileId: 'file-1',
+      versionId: 'version-1',
+      translations: {
+        en: {
+          updatedAt: '2026-01-01T00:00:00.000Z',
+          fileName: 'file1.json',
+        },
+      },
+    };
+
+    vi.mocked(readLockfile).mockReturnValue({
+      data: { version: 2, branchId: 'branch-1', entries: [existingEntry] },
+      entryMap: new Map([['file-1', existingEntry]]),
+      originalV1: null,
+    });
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockImplementation(() => {
+      throw new Error('file disappeared');
+    });
+
+    const result = await downloadFileBatch(
+      fileTracker,
+      files,
+      createMockSettings()
+    );
+
+    expect(gt.downloadFileBatch).not.toHaveBeenCalled();
+    expect(result.skipped).toEqual(files);
+    expect(result.failed).toHaveLength(0);
+  });
+
   it('should sort JSON keys when writing JSON output files', async () => {
     const mockResponseData = createMockResponseData({
       files: [
@@ -265,7 +381,7 @@ describe('downloadFileBatch', () => {
 
     vi.mocked(gt.downloadFileBatch).mockResolvedValue(mockResponseData);
     vi.mocked(path.dirname).mockReturnValue('/output/dir');
-    vi.mocked(fs.existsSync).mockReturnValueOnce(false).mockReturnValue(true);
+    vi.mocked(fs.existsSync).mockReturnValue(false);
     vi.mocked(fs.promises.writeFile).mockResolvedValue(undefined);
 
     const result = await downloadFileBatch(
@@ -463,7 +579,7 @@ describe('downloadFileBatch', () => {
       createMockSettings()
     );
 
-    expect(gt.downloadFileBatch).toHaveBeenCalled();
+    expect(gt.downloadFileBatch).not.toHaveBeenCalled();
     expect(result.successful).toHaveLength(0);
     expect(result.failed).toHaveLength(0);
   });

--- a/packages/cli/src/api/downloadFileBatch.ts
+++ b/packages/cli/src/api/downloadFileBatch.ts
@@ -52,6 +52,25 @@ function reportWithheldGtJsonComponents(
   }
 }
 
+function reportWithheldGtJsonComponentsFromFile(
+  outputPath: string,
+  componentCount: number | undefined,
+  locale: string
+): void {
+  if (componentCount == null) return;
+  try {
+    reportWithheldGtJsonComponents(
+      'GTJSON',
+      fs.readFileSync(outputPath, 'utf8'),
+      componentCount,
+      locale
+    );
+  } catch {
+    // Warning metadata is advisory; an unreadable cached output should not
+    // turn an otherwise valid skipped download into a batch failure.
+  }
+}
+
 /**
  * Counts entries in downloaded GTJSON output, tolerating both the flat
  * public shape and a wrapped { type, data } shape.
@@ -178,6 +197,61 @@ export type DownloadFileBatchResult = {
   failed: BatchedFiles;
   skipped: BatchedFiles;
 };
+
+async function remergeExistingTranslation(
+  outputPath: string,
+  inputPath: string,
+  locale: string,
+  options: Settings
+): Promise<void> {
+  if (!options.options?.jsonSchema && !options.options?.yamlSchema) return;
+
+  try {
+    let existingContent = fs.readFileSync(outputPath, 'utf8');
+    if (shouldResolveRefs(outputPath, options.options)) {
+      try {
+        const json = JSON.parse(existingContent);
+        const { resolved } = resolveMintlifyRefs(json, outputPath);
+        existingContent = JSON.stringify(resolved, null, 2);
+      } catch {
+        // Fall through with original content.
+      }
+    }
+    const jsonExtracted = options.options.jsonSchema
+      ? extractJson(
+          existingContent,
+          inputPath,
+          options.options,
+          locale,
+          options.defaultLocale
+        )
+      : null;
+    const extracted =
+      jsonExtracted ??
+      (options.options.yamlSchema
+        ? extractYaml(existingContent, inputPath, options.options)
+        : null);
+    if (!extracted) return;
+
+    let remerged = mergeWithSource(extracted, locale, inputPath, options);
+    if (outputPath.endsWith('.json')) {
+      try {
+        remerged = sortJsonString(remerged);
+      } catch {
+        // Fall through with unsorted content.
+      }
+    }
+    if (remerged !== existingContent) {
+      await fs.promises.writeFile(outputPath, remerged);
+    }
+    recordRemerged(outputPath);
+  } catch (error) {
+    logger.warn(
+      `Failed to re-merge existing translation for ${outputPath} (${locale}): ${error}`
+    );
+  }
+}
+
 /**
  * Downloads multiple translation files in a single batch request
  * @param files - Array of files to download with their output paths
@@ -199,22 +273,58 @@ export async function downloadFileBatch(
   } = readLockfile(options);
   let didUpdateDownloadedLock = false;
 
-  // Create a map of requested file keys to the file object
-  const requestedFileMap = new Map(
-    files.map((file) => [
-      `${file.branchId}:${file.fileId}:${file.versionId}:${file.locale}`,
-      file,
-    ])
-  );
   const result: DownloadFileBatchResult = {
     successful: [],
     failed: [],
     skipped: [],
   };
+  const filesToDownload: BatchedFiles = [];
+  for (const file of files) {
+    const fileKey = `${file.branchId}:${file.fileId}:${file.versionId}:${file.locale}`;
+    const fileProperties = fileTracker.completed.get(fileKey);
+    const existingEntry = entryMap.get(file.fileId);
+    const isComposite = !!(
+      options.options?.jsonSchema &&
+      validateJsonSchema(options.options, file.inputPath)?.composite
+    );
+    if (
+      !forceDownload &&
+      fileProperties &&
+      fs.existsSync(file.outputPath) &&
+      existingEntry?.versionId === file.versionId &&
+      existingEntry.translations[file.locale] &&
+      !isComposite
+    ) {
+      await remergeExistingTranslation(
+        file.outputPath,
+        file.inputPath,
+        file.locale,
+        options
+      );
+      reportWithheldGtJsonComponentsFromFile(
+        file.outputPath,
+        fileProperties.componentCount,
+        file.locale
+      );
+      result.skipped.push(file);
+      continue;
+    }
+    filesToDownload.push(file);
+  }
+
+  if (filesToDownload.length === 0) return result;
+
+  // Create a map of requested file keys to the file object
+  const requestedFileMap = new Map(
+    filesToDownload.map((file) => [
+      `${file.branchId}:${file.fileId}:${file.versionId}:${file.locale}`,
+      file,
+    ])
+  );
 
   // Create a map of translationId to outputPath for easier lookup
   const outputPathMap = new Map(
-    files.map((file) => [
+    filesToDownload.map((file) => [
       `${file.branchId}:${file.fileId}:${file.versionId}:${file.locale}`,
       file.outputPath,
     ])
@@ -223,7 +333,7 @@ export async function downloadFileBatch(
   try {
     // Download the files
     const responseData = await gt.downloadFileBatch(
-      files.map((file) => ({
+      filesToDownload.map((file) => ({
         fileId: file.fileId,
         branchId: file.branchId,
         versionId: file.versionId,
@@ -338,62 +448,13 @@ export async function downloadFileBatch(
           !isInPlaceComposite
         ) {
           // For schema-based files, re-merge with current source in case
-          // non-translatable fields changed (skip the API download, not the merge)
-          try {
-            let existingContent = fs.readFileSync(outputPath, 'utf8');
-            // Resolve $ref before extraction if configured
-            if (shouldResolveRefs(outputPath, options.options)) {
-              try {
-                const json = JSON.parse(existingContent);
-                const { resolved } = resolveMintlifyRefs(json, outputPath);
-                existingContent = JSON.stringify(resolved, null, 2);
-              } catch {
-                // Fall through with original content
-              }
-            }
-            const jsonExtracted = options.options?.jsonSchema
-              ? extractJson(
-                  existingContent,
-                  inputPath,
-                  options.options,
-                  locale,
-                  options.defaultLocale
-                )
-              : null;
-            const extracted =
-              jsonExtracted ??
-              (options.options?.yamlSchema
-                ? extractYaml(existingContent, inputPath, options.options)
-                : null);
-            if (extracted) {
-              const remerged = mergeWithSource(
-                extracted,
-                locale,
-                inputPath,
-                options
-              );
-              let remergedData = remerged;
-              if (outputPath.endsWith('.json')) {
-                try {
-                  remergedData = sortJsonString(remergedData);
-                } catch {
-                  // Fall through with unsorted content
-                }
-              }
-              if (remergedData !== existingContent) {
-                await fs.promises.writeFile(outputPath, remergedData);
-              }
-              // Track for postprocessing (e.g. openapi path localization)
-              // even when the API download was skipped
-              recordRemerged(outputPath);
-            }
-          } catch (error) {
-            // If re-merge fails, still count as skipped — not worth failing
-            // the download, but surface it so missing output is diagnosable
-            logger.warn(
-              `Failed to re-merge existing translation for ${outputPath} (${locale}): ${error}`
-            );
-          }
+          // non-translatable fields changed (skip the API download, not the merge).
+          await remergeExistingTranslation(
+            outputPath,
+            inputPath,
+            locale,
+            options
+          );
           // Even when the local copy is current, the served content may
           // still be missing review-withheld components — keep reporting
           reportWithheldGtJsonComponents(


### PR DESCRIPTION
## Summary
- skip enqueue/download work for translations already completed on the server
- reuse completed translation status through stage, poll, and download workflow steps
- preserve schema re-merge behavior for existing up-to-date outputs

## Verification
- pnpm --filter gt typecheck
- pnpm --filter gt test -- --run packages/cli/src/api/__tests__/downloadFileBatch.test.ts packages/cli/src/workflows/__tests__/download.test.ts packages/cli/src/workflows/utils/__tests__/filterFilesForEnqueue.test.ts
- pnpm exec oxlint packages/cli/src/api/downloadFileBatch.ts packages/cli/src/workflows/download.ts packages/cli/src/workflows/stage.ts packages/cli/src/workflows/steps/DownloadStep.ts packages/cli/src/workflows/steps/PollJobsStep.ts packages/cli/src/workflows/utils/filterFilesForEnqueue.ts packages/cli/src/api/__tests__/downloadFileBatch.test.ts packages/cli/src/workflows/__tests__/download.test.ts
- pnpm exec oxfmt --check packages/cli/src/api/downloadFileBatch.ts packages/cli/src/workflows/download.ts packages/cli/src/workflows/stage.ts packages/cli/src/workflows/steps/DownloadStep.ts packages/cli/src/workflows/steps/PollJobsStep.ts packages/cli/src/workflows/utils/filterFilesForEnqueue.ts packages/cli/src/api/__tests__/downloadFileBatch.test.ts packages/cli/src/workflows/__tests__/download.test.ts

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR optimises the translation download workflow by skipping the API call entirely for files that are already up-to-date locally, checking the `fileTracker.completed` map, the lockfile `versionId`, and `fs.existsSync` before issuing any network request. It also extracts the schema re-merge logic into a reusable `remergeExistingTranslation` helper that is called from both the new pre-download skip path and the existing post-API skip path.

- **Pre-download filter**: each file is checked against three independent sources of truth (completed tracker, lockfile, disk) before it is added to `filesToDownload`; composite schema files are explicitly excluded from the skip to preserve their always-merge behaviour.
- **Early return**: when all files pass the skip check, `gt.downloadFileBatch` is never called; the empty-files path benefits from the same early return.
- **Test coverage**: three new tests cover full-batch skip, partial-batch skip, and graceful handling of an unreadable GTJSON output; the `existsSync` mock ordering in the sort-JSON test is correctly adjusted for the new call sequence.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- Safe to merge — the skip conditions are conservative (all three of completed-tracker entry, lockfile versionId match, and file presence on disk must agree) and composite schema files are explicitly excluded, preserving their always-fresh-merge behaviour.
- The change touches only the download path, adds no new network surface, and cannot cause data loss: a file is skipped only when three independent guards all confirm it is current. Composite files, force-download mode, missing lockfile entries, and absent output files all fall through to the existing download path unchanged. Test coverage for the new paths is thorough.
- No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/api/downloadFileBatch.ts | Core change: adds a pre-download filter loop that skips API calls for files whose lockfile version + translation entry + disk presence already match. Extracts remergeExistingTranslation into a shared helper called from both the new skip path and the existing post-API skip path. Logic is conservative (requires completed tracker entry AND lockfile versionId match AND existsSync), no path silently discards errors. |
| packages/cli/src/api/__tests__/downloadFileBatch.test.ts | Three new test cases cover: full-batch skip when all files are current, partial skip sending only the stale file to the API, and graceful handling of an unreadable GTJSON file. The existsSync mock for the sort-JSON test is correctly changed from mockReturnValueOnce(false).mockReturnValue(true) to mockReturnValue(false) because the new pre-download filter now issues existsSync before the directory check. The empty-files assertion flip to not.toHaveBeenCalled() accurately reflects the new early-return path. |
| .changeset/skip-completed-translation-downloads.md | Patch-level changeset entry for the gt package. Description accurately summarises the optimisation. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[downloadFileBatch called] --> B[readLockfile]
    B --> C{For each file}
    C --> D{forceDownload?}
    D -- No --> E{fileTracker.completed\nhas entry?}
    D -- Yes --> N[Add to filesToDownload]
    E -- No --> N
    E -- Yes --> F{outputPath exists\non disk?}
    F -- No --> N
    F -- Yes --> G{lockfile versionId\nmatches?}
    G -- No --> N
    G -- Yes --> H{locale present\nin lockfile?}
    H -- No --> N
    H -- Yes --> I{isComposite?}
    I -- Yes --> N
    I -- No --> J[remergeExistingTranslation]
    J --> K[reportWithheldGtJsonComponents\nFromFile]
    K --> L[result.skipped.push]
    L --> C
    N --> C
    C -- Done --> M{filesToDownload\nempty?}
    M -- Yes --> Z[Return result early]
    M -- No --> O[gt.downloadFileBatch API call]
    O --> P{For each API response file}
    P --> Q{local copy\nalready current?}
    Q -- Yes --> R[remergeExistingTranslation\nreportWithheldGtJsonComponents]
    R --> S[result.skipped.push]
    Q -- No --> T[mergeWithSource\nwrite to disk]
    T --> U[result.successful.push]
    S --> P
    U --> P
    P -- Done --> V[writeLockfile if updated]
    V --> W[Return result]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: skip completed translation download..."](https://github.com/generaltranslation/gt/commit/2cd814cb8ac261207c4269dfc0f17c7f94b3ae35) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46462674)</sub>

<!-- /greptile_comment -->