### PR TITLE
fix(i18n): gate singleton warnings behind debug logging

### DIFF
--- a/.changeset/debug-log-level.md
+++ b/.changeset/debug-log-level.md
@@ -1,0 +1,5 @@
+---
+'gt-i18n': patch
+---
+
+Gate duplicate singleton initialization warnings behind `_GENERALTRANSLATION_LOG_LEVEL=DEBUG`.

--- a/packages/i18n/src/condition-store/__tests__/createConditionStoreSingleton.test.ts
+++ b/packages/i18n/src/condition-store/__tests__/createConditionStoreSingleton.test.ts
@@ -36,6 +36,7 @@ describe('condition store singleton factory', () => {
   beforeEach(() => {
     vi.resetModules();
     vi.restoreAllMocks();
+    vi.unstubAllEnvs();
     resetConditionStoreGlobal();
   });
 
@@ -57,7 +58,22 @@ describe('condition store singleton factory', () => {
     );
   });
 
-  it('warns and preserves an existing global condition store', async () => {
+  it('preserves an existing global condition store', async () => {
+    const { createConditionStoreSingleton } =
+      await import('../createConditionStoreSingleton');
+    const singleton = createConditionStoreSingleton('not initialized');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const conditionStore = createConditionStoreStub();
+
+    singleton.setConditionStore(conditionStore);
+    singleton.setConditionStore(createConditionStoreStub());
+
+    expect(warn).not.toHaveBeenCalled();
+    expect(singleton.getConditionStore()).toBe(conditionStore);
+  });
+
+  it('warns about an existing global condition store when debug logging is enabled', async () => {
+    vi.stubEnv('_GENERALTRANSLATION_LOG_LEVEL', 'DEBUG');
     const { createConditionStoreSingleton } =
       await import('../createConditionStoreSingleton');
     const singleton = createConditionStoreSingleton('not initialized');

--- a/packages/i18n/src/globals/__tests__/createGlobalSingleton.test.ts
+++ b/packages/i18n/src/globals/__tests__/createGlobalSingleton.test.ts
@@ -23,6 +23,7 @@ function resetTestGlobalSingleton() {
 
 describe('createGlobalSingleton', () => {
   beforeEach(() => {
+    vi.unstubAllEnvs();
     resetTestGlobalSingleton();
   });
 
@@ -43,7 +44,25 @@ describe('createGlobalSingleton', () => {
     expect(() => singleton.get()).toThrow('singleton missing');
   });
 
-  it('warns and preserves an existing singleton instance', () => {
+  it('preserves an existing singleton instance', () => {
+    const singleton = createGlobalSingleton<{ id: string }>({
+      namespace: 'testGlobalSingleton',
+      key: 'singleton',
+      source: 'gt-i18n',
+      notInitialized: () => 'singleton missing',
+    });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const value = { id: 'first' };
+
+    singleton.set(value);
+    singleton.set({ id: 'second' });
+
+    expect(warn).not.toHaveBeenCalled();
+    expect(singleton.get()).toBe(value);
+  });
+
+  it('warns about existing singleton instances when debug logging is enabled', () => {
+    vi.stubEnv('_GENERALTRANSLATION_LOG_LEVEL', 'DEBUG');
     const singleton = createGlobalSingleton<{ id: string }>({
       namespace: 'testGlobalSingleton',
       key: 'singleton',

--- a/packages/i18n/src/globals/createGlobalSingleton.ts
+++ b/packages/i18n/src/globals/createGlobalSingleton.ts
@@ -1,4 +1,8 @@
 import { createDiagnosticMessage } from 'generaltranslation/internal';
+import {
+  getGeneralTranslationLogLevel,
+  isDebugLogLevel,
+} from '../logs/logLevel';
 
 /**
  * Shared global registry stored on `globalThis.__generaltranslation`. Each
@@ -8,6 +12,10 @@ type SingletonRegistry = Record<string, Record<string, unknown> | undefined>;
 
 type GlobalWithRegistry = {
   __generaltranslation?: SingletonRegistry;
+};
+
+type DebugLoggingConfig = {
+  isDebugLoggingEnabled: () => boolean;
 };
 
 function getNamespace(namespace: string): Record<string, unknown> {
@@ -58,13 +66,15 @@ export function createGlobalSingleton<T>({
   function set(next: T): void {
     const ns = getNamespace(namespace);
     if (ns[key] !== undefined && ns[key] !== next) {
-      console.warn(
-        createDiagnosticMessage({
-          source,
-          severity: 'Warning',
-          whatHappened: `Global ${key} singleton instance was already initialized`,
-        })
-      );
+      if (shouldLogDebugWarnings(ns)) {
+        console.warn(
+          createDiagnosticMessage({
+            source,
+            severity: 'Warning',
+            whatHappened: `Global ${key} singleton instance was already initialized`,
+          })
+        );
+      }
       return;
     }
     ns[key] = next as unknown;
@@ -76,4 +86,21 @@ export function createGlobalSingleton<T>({
   }
 
   return { get, set, isInitialized };
+}
+
+function shouldLogDebugWarnings(namespace: Record<string, unknown>): boolean {
+  const config = namespace.i18nConfig;
+  if (hasDebugLoggingConfig(config)) {
+    return config.isDebugLoggingEnabled();
+  }
+  return isDebugLogLevel(getGeneralTranslationLogLevel());
+}
+
+function hasDebugLoggingConfig(value: unknown): value is DebugLoggingConfig {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as Partial<DebugLoggingConfig>).isDebugLoggingEnabled ===
+      'function'
+  );
 }

--- a/packages/i18n/src/globals/createGlobalSingleton.ts
+++ b/packages/i18n/src/globals/createGlobalSingleton.ts
@@ -26,6 +26,13 @@ function getNamespace(namespace: string): Record<string, unknown> {
   return globalObj.__generaltranslation[namespace]!;
 }
 
+function getExistingNamespace(
+  namespace: string
+): Record<string, unknown> | undefined {
+  const globalObj = globalThis as unknown as GlobalWithRegistry;
+  return globalObj.__generaltranslation?.[namespace];
+}
+
 export type GlobalSingleton<T> = {
   get: () => T;
   set: (next: T) => void;
@@ -66,7 +73,7 @@ export function createGlobalSingleton<T>({
   function set(next: T): void {
     const ns = getNamespace(namespace);
     if (ns[key] !== undefined && ns[key] !== next) {
-      if (shouldLogDebugWarnings(ns)) {
+      if (shouldLogDebugWarnings()) {
         console.warn(
           createDiagnosticMessage({
             source,
@@ -88,8 +95,8 @@ export function createGlobalSingleton<T>({
   return { get, set, isInitialized };
 }
 
-function shouldLogDebugWarnings(namespace: Record<string, unknown>): boolean {
-  const config = namespace.i18nConfig;
+function shouldLogDebugWarnings(): boolean {
+  const config = getExistingNamespace('i18n')?.i18nConfig;
   if (hasDebugLoggingConfig(config)) {
     return config.isDebugLoggingEnabled();
   }

--- a/packages/i18n/src/i18n-cache/__tests__/singleton-operations.test.ts
+++ b/packages/i18n/src/i18n-cache/__tests__/singleton-operations.test.ts
@@ -27,6 +27,7 @@ describe('i18n cache singleton operations', () => {
   beforeEach(() => {
     vi.resetModules();
     vi.restoreAllMocks();
+    vi.unstubAllEnvs();
     resetI18nCacheGlobal();
   });
 
@@ -50,7 +51,21 @@ describe('i18n cache singleton operations', () => {
     expect(getI18nCache()).toBe(cache);
   });
 
-  it('warns and preserves an existing global cache', async () => {
+  it('preserves an existing global cache', async () => {
+    const { getI18nCache, setI18nCache } =
+      await import('../singleton-operations');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const cache = createCacheStub();
+
+    setI18nCache(cache);
+    setI18nCache(createCacheStub());
+
+    expect(getI18nCache()).toBe(cache);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('warns about an existing global cache when debug logging is enabled', async () => {
+    vi.stubEnv('_GENERALTRANSLATION_LOG_LEVEL', 'DEBUG');
     const { getI18nCache, setI18nCache } =
       await import('../singleton-operations');
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});

--- a/packages/i18n/src/i18n-config/I18nConfig.ts
+++ b/packages/i18n/src/i18n-config/I18nConfig.ts
@@ -14,6 +14,11 @@ import {
   getTranslationApiType,
   TranslationApiType,
 } from '../i18n-cache/utils/getTranslationApiType';
+import {
+  getGeneralTranslationLogLevel,
+  isDebugLogLevel,
+  type GeneralTranslationLogLevel,
+} from '../logs/logLevel';
 import { getRuntimeEnvironment } from '../utils/getRuntimeEnvironment';
 import { validateI18nConfigParams } from './validation';
 
@@ -40,6 +45,7 @@ export type LocaleCandidates = string | string[] | undefined;
 export class I18nConfig extends LocaleConfig {
   private runtimeConfig: RuntimeConfig;
   private gtServicesEnabled: boolean;
+  private logLevel: GeneralTranslationLogLevel;
 
   constructor(params: I18nConfigParams = {}) {
     const gtServicesEnabled = resolveGTServicesEnabled(params);
@@ -52,6 +58,7 @@ export class I18nConfig extends LocaleConfig {
       _disableDevHotReload: params._disableDevHotReload,
     };
     this.gtServicesEnabled = gtServicesEnabled;
+    this.logLevel = getGeneralTranslationLogLevel();
   }
 
   getDefaultLocale(): string {
@@ -146,6 +153,14 @@ export class I18nConfig extends LocaleConfig {
 
   isGTServicesEnabled(): boolean {
     return this.gtServicesEnabled;
+  }
+
+  getLogLevel(): GeneralTranslationLogLevel {
+    return this.logLevel;
+  }
+
+  isDebugLoggingEnabled(): boolean {
+    return isDebugLogLevel(this.logLevel);
   }
 
   /**

--- a/packages/i18n/src/i18n-config/__tests__/I18nConfig.test.ts
+++ b/packages/i18n/src/i18n-config/__tests__/I18nConfig.test.ts
@@ -123,12 +123,12 @@ describe('I18nConfig', () => {
   });
 
   it('stores the configured log level at initialization', () => {
-    vi.stubEnv('_GENERALTRANSLATION_LOG_LEVEL', 'DEBUG');
+    vi.stubEnv('_GENERALTRANSLATION_LOG_LEVEL', 'debug');
 
     const config = new I18nConfig();
     vi.stubEnv('_GENERALTRANSLATION_LOG_LEVEL', '');
 
-    expect(config.getLogLevel()).toBe('DEBUG');
+    expect(config.getLogLevel()).toBe('debug');
     expect(config.isDebugLoggingEnabled()).toBe(true);
   });
 

--- a/packages/i18n/src/i18n-config/__tests__/I18nConfig.test.ts
+++ b/packages/i18n/src/i18n-config/__tests__/I18nConfig.test.ts
@@ -122,6 +122,16 @@ describe('I18nConfig', () => {
     expect(config.isDevHotReloadEnabled()).toBe(false);
   });
 
+  it('stores the configured log level at initialization', () => {
+    vi.stubEnv('_GENERALTRANSLATION_LOG_LEVEL', 'DEBUG');
+
+    const config = new I18nConfig();
+    vi.stubEnv('_GENERALTRANSLATION_LOG_LEVEL', '');
+
+    expect(config.getLogLevel()).toBe('DEBUG');
+    expect(config.isDebugLoggingEnabled()).toBe(true);
+  });
+
   it.each([
     {
       name: 'missing dev API key',

--- a/packages/i18n/src/i18n-config/__tests__/singleton-operations.test.ts
+++ b/packages/i18n/src/i18n-config/__tests__/singleton-operations.test.ts
@@ -21,6 +21,7 @@ describe('i18n config singleton operations', () => {
   beforeEach(() => {
     vi.resetModules();
     vi.restoreAllMocks();
+    vi.unstubAllEnvs();
     resetI18nConfigGlobal();
   });
 
@@ -63,7 +64,7 @@ describe('i18n config singleton operations', () => {
     expect(getI18nConfig()).toBe(config);
   });
 
-  it('warns and preserves an existing global config', async () => {
+  it('preserves an existing global config', async () => {
     const { getI18nConfig, initializeI18nConfig } =
       await import('../singleton-operations');
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
@@ -71,6 +72,24 @@ describe('i18n config singleton operations', () => {
     const config = initializeI18nConfig({
       defaultLocale: 'en',
     });
+    initializeI18nConfig({
+      defaultLocale: 'fr',
+    });
+
+    expect(warn).not.toHaveBeenCalled();
+    expect(getI18nConfig()).toBe(config);
+  });
+
+  it('warns about an existing global config when debug logging is enabled', async () => {
+    vi.stubEnv('_GENERALTRANSLATION_LOG_LEVEL', 'DEBUG');
+    const { getI18nConfig, initializeI18nConfig } =
+      await import('../singleton-operations');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const config = initializeI18nConfig({
+      defaultLocale: 'en',
+    });
+    vi.stubEnv('_GENERALTRANSLATION_LOG_LEVEL', '');
     initializeI18nConfig({
       defaultLocale: 'fr',
     });

--- a/packages/i18n/src/logs/logLevel.ts
+++ b/packages/i18n/src/logs/logLevel.ts
@@ -1,0 +1,42 @@
+export type GeneralTranslationLogLevel = string | undefined;
+
+type LogLevelEnvironment = {
+  _GENERALTRANSLATION_LOG_LEVEL?: string;
+};
+
+const debugLogLevel = 'DEBUG';
+
+export function getGeneralTranslationLogLevel(): GeneralTranslationLogLevel {
+  const processLogLevel = readProcessEnvLogLevel();
+  if (processLogLevel !== undefined) {
+    return processLogLevel;
+  }
+
+  return readImportMetaEnv(
+    () =>
+      (
+        import.meta as ImportMeta & {
+          env?: LogLevelEnvironment;
+        }
+      ).env?._GENERALTRANSLATION_LOG_LEVEL
+  );
+}
+
+export function isDebugLogLevel(logLevel: GeneralTranslationLogLevel): boolean {
+  return logLevel === debugLogLevel;
+}
+
+function readProcessEnvLogLevel(): GeneralTranslationLogLevel {
+  if (typeof process !== 'object') {
+    return undefined;
+  }
+  return process.env?._GENERALTRANSLATION_LOG_LEVEL;
+}
+
+function readImportMetaEnv<T>(readValue: () => T | undefined): T | undefined {
+  try {
+    return readValue();
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/i18n/src/logs/logLevel.ts
+++ b/packages/i18n/src/logs/logLevel.ts
@@ -23,7 +23,7 @@ export function getGeneralTranslationLogLevel(): GeneralTranslationLogLevel {
 }
 
 export function isDebugLogLevel(logLevel: GeneralTranslationLogLevel): boolean {
-  return logLevel === debugLogLevel;
+  return logLevel?.toUpperCase() === debugLogLevel;
 }
 
 function readProcessEnvLogLevel(): GeneralTranslationLogLevel {

--- a/packages/react-core/src/i18n-store/__tests__/singleton-operations.test.ts
+++ b/packages/react-core/src/i18n-store/__tests__/singleton-operations.test.ts
@@ -4,6 +4,7 @@ import type { I18nStore } from '../I18nStore';
 type TestGlobal = typeof globalThis & {
   __generaltranslation?: {
     i18n?: {
+      i18nConfig?: unknown;
       marker?: string;
       [key: string]: unknown;
     };
@@ -22,6 +23,9 @@ function resetI18nStoreGlobal() {
       globalObj.__generaltranslation.reactCore,
       'i18nStore'
     );
+  }
+  if (globalObj.__generaltranslation?.i18n) {
+    Reflect.deleteProperty(globalObj.__generaltranslation.i18n, 'i18nConfig');
   }
 }
 
@@ -66,6 +70,29 @@ describe('react-core i18n store singleton operations', () => {
 
   it('warns about an existing global i18n store when debug logging is enabled', async () => {
     vi.stubEnv('_GENERALTRANSLATION_LOG_LEVEL', 'DEBUG');
+    const { getI18nStore, setI18nStore } =
+      await import('../singleton-operations');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const store = createI18nStoreStub();
+
+    setI18nStore(store);
+    setI18nStore(createI18nStoreStub());
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Global i18nStore singleton instance was already initialized'
+      )
+    );
+    expect(getI18nStore()).toBe(store);
+  });
+
+  it('warns about an existing global i18n store when cached config enables debug logging', async () => {
+    vi.stubEnv('_GENERALTRANSLATION_LOG_LEVEL', 'DEBUG');
+    const { initializeI18nConfig } = await import('../../setup/i18nConfig');
+
+    initializeI18nConfig({ defaultLocale: 'en' });
+    vi.stubEnv('_GENERALTRANSLATION_LOG_LEVEL', '');
+
     const { getI18nStore, setI18nStore } =
       await import('../singleton-operations');
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});

--- a/packages/react-core/src/i18n-store/__tests__/singleton-operations.test.ts
+++ b/packages/react-core/src/i18n-store/__tests__/singleton-operations.test.ts
@@ -33,6 +33,7 @@ describe('react-core i18n store singleton operations', () => {
   beforeEach(() => {
     vi.resetModules();
     vi.restoreAllMocks();
+    vi.unstubAllEnvs();
     resetI18nStoreGlobal();
   });
 
@@ -50,7 +51,21 @@ describe('react-core i18n store singleton operations', () => {
     expect(getI18nStore()).toBe(store);
   });
 
-  it('warns and preserves an existing global i18n store', async () => {
+  it('preserves an existing global i18n store', async () => {
+    const { getI18nStore, setI18nStore } =
+      await import('../singleton-operations');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const store = createI18nStoreStub();
+
+    setI18nStore(store);
+    setI18nStore(createI18nStoreStub());
+
+    expect(warn).not.toHaveBeenCalled();
+    expect(getI18nStore()).toBe(store);
+  });
+
+  it('warns about an existing global i18n store when debug logging is enabled', async () => {
+    vi.stubEnv('_GENERALTRANSLATION_LOG_LEVEL', 'DEBUG');
     const { getI18nStore, setI18nStore } =
       await import('../singleton-operations');
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});


### PR DESCRIPTION
## Summary
- Store `_GENERALTRANSLATION_LOG_LEVEL` on `I18nConfig` at initialization.
- Suppress duplicate global singleton warnings unless debug logging is enabled with `_GENERALTRANSLATION_LOG_LEVEL=DEBUG`.
- Support reading the same debug flag from `process.env` and `import.meta.env` for Vite/browser-style builds.
- Add a patch changeset for `gt-i18n`.

## Testing
- `pnpm --filter gt-i18n test`
- `pnpm build`
- `pnpm format`
- `pnpm lint`