### PR TITLE
fix: preserve undefined plural fallbacks

### DIFF
--- a/packages/react-core/src/components/branches/Plural.shared.ts
+++ b/packages/react-core/src/components/branches/Plural.shared.ts
@@ -36,7 +36,8 @@ function renderPlural({
   if (typeof n !== 'number') {
     return children;
   }
-  return getPluralBranch(n, locales, branches) || children;
+  const resolvedBranch = getPluralBranch(n, locales, branches);
+  return resolvedBranch != null ? resolvedBranch : children;
 }
 
 export { renderPlural };

--- a/packages/react-core/src/utils/rendering/__tests__/branchRendering.test.tsx
+++ b/packages/react-core/src/utils/rendering/__tests__/branchRendering.test.tsx
@@ -1,0 +1,178 @@
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { initializeI18nConfig } from 'gt-i18n/internal';
+import {
+  renderDefaultChildren,
+  renderTranslatedChildren,
+} from '../renderPipeline';
+import { renderPlural } from '../../../components/branches/Plural.shared';
+import type {
+  TaggedElement,
+  TaggedElementProps,
+  TranslatedChildren,
+} from '../../types';
+
+const renderArgs = {
+  defaultLocale: 'en',
+  enableI18n: true,
+};
+
+type TestGlobal = typeof globalThis & {
+  __generaltranslation?: unknown;
+};
+
+function resetGTGlobals() {
+  Reflect.deleteProperty(globalThis as TestGlobal, '__generaltranslation');
+}
+
+function createBranchElement(
+  branch: string | number | boolean,
+  branches: Record<string, string>
+): TaggedElement {
+  const props = {
+    'data-_gt': {
+      id: 1,
+      injectionType: 'manual',
+      transformation: 'branch',
+      branches,
+    },
+    branch,
+    children: 'Fallback',
+  } as unknown as TaggedElementProps;
+  return React.createElement('span', props) as TaggedElement;
+}
+
+function createPluralElement(
+  n: number,
+  branches: Record<string, string | number | boolean | undefined>
+): TaggedElement {
+  const props = {
+    'data-_gt': {
+      id: 1,
+      injectionType: 'manual',
+      transformation: 'plural',
+      branches,
+    },
+    n,
+    children: 'Fallback',
+  } as unknown as TaggedElementProps;
+  return React.createElement('span', props) as TaggedElement;
+}
+
+function createTranslatedPluralTarget(
+  branch: string | number | boolean | undefined
+): TranslatedChildren {
+  return {
+    d: { b: { other: branch } },
+    c: 'Fallback translation',
+  } as unknown as TranslatedChildren;
+}
+
+describe('branch rendering', () => {
+  it('selects numeric branch keys when rendering default children', () => {
+    const result = renderDefaultChildren({
+      ...renderArgs,
+      children: createBranchElement(0, { '0': 'Zero' }),
+    });
+
+    expect(result).toBe('Zero');
+  });
+
+  it('selects boolean branch keys when rendering translated children', () => {
+    const result = renderTranslatedChildren({
+      source: createBranchElement(false, { false: 'Off' }),
+      target: {
+        d: { b: { false: 'Apagado' } },
+        c: 'Fallback translation',
+      },
+      locales: ['es'],
+      enableI18n: true,
+    });
+
+    expect(result).toBe('Apagado');
+  });
+});
+
+describe('plural rendering', () => {
+  it('preserves numeric zero branch content when rendering default children', () => {
+    const result = renderDefaultChildren({
+      ...renderArgs,
+      children: createPluralElement(2, { other: 0 }),
+    });
+
+    expect(result).toBe(0);
+  });
+
+  it('preserves boolean branch content when rendering translated children', () => {
+    const result = renderTranslatedChildren({
+      source: createPluralElement(2, { other: false }),
+      target: createTranslatedPluralTarget(false),
+      locales: ['en'],
+      enableI18n: true,
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('falls back for undefined branch content when rendering default children', () => {
+    const result = renderDefaultChildren({
+      ...renderArgs,
+      children: createPluralElement(2, { other: undefined }),
+    });
+
+    expect(result).toBe('Fallback');
+  });
+
+  it('falls back for undefined branch content when rendering translated children', () => {
+    const result = renderTranslatedChildren({
+      source: createPluralElement(2, { other: undefined }),
+      target: createTranslatedPluralTarget(undefined),
+      locales: ['en'],
+      enableI18n: true,
+    });
+
+    expect(result).toBe('Fallback translation');
+  });
+});
+
+describe('shared plural component renderer', () => {
+  beforeEach(() => {
+    resetGTGlobals();
+    initializeI18nConfig({ defaultLocale: 'en' });
+  });
+
+  afterEach(resetGTGlobals);
+
+  it('preserves falsy content in the shared plural component renderer', () => {
+    expect(
+      renderPlural({
+        _enableI18n: true,
+        _locale: 'en',
+        children: 'Fallback',
+        n: 2,
+        other: 0,
+      })
+    ).toBe(0);
+    expect(
+      renderPlural({
+        _enableI18n: true,
+        _locale: 'en',
+        children: 'Fallback',
+        n: 2,
+        other: false,
+      })
+    ).toBe(false);
+  });
+
+  it('falls back for undefined content in the shared plural component renderer', () => {
+    expect(
+      renderPlural({
+        _enableI18n: true,
+        _locale: 'en',
+        children: 'Fallback',
+        n: 2,
+        other: undefined,
+      })
+    ).toBe('Fallback');
+  });
+});

--- a/packages/react-core/src/utils/rendering/renderDefaultChildren.shared.ts
+++ b/packages/react-core/src/utils/rendering/renderDefaultChildren.shared.ts
@@ -63,7 +63,7 @@ function createRenderDefaultChildren({
           branches
         );
         return handleChildren(
-          (resolvedBranch !== null
+          (resolvedBranch != null
             ? resolvedBranch
             : child.props.children) as TaggedChildren
         );

--- a/packages/react-core/src/utils/rendering/renderTranslatedChildren.shared.tsx
+++ b/packages/react-core/src/utils/rendering/renderTranslatedChildren.shared.tsx
@@ -83,13 +83,13 @@ function createRenderTranslatedChildren({
       const sourceBranches = sourceGT.branches || {};
       const resolvedSourceBranch = getPluralBranch(n, locales, sourceBranches);
       const sourceBranch =
-        resolvedSourceBranch !== null
+        resolvedSourceBranch != null
           ? resolvedSourceBranch
           : sourceElement.props.children;
       const targetBranches = targetElement.d?.b || {};
       const resolvedTargetBranch = getPluralBranch(n, locales, targetBranches);
       const targetBranch =
-        resolvedTargetBranch !== null ? resolvedTargetBranch : targetElement.c;
+        resolvedTargetBranch != null ? resolvedTargetBranch : targetElement.c;
       return renderTranslatedChildren({
         source: sourceBranch as TaggedChildren,
         target: targetBranch as TranslatedChildren,


### PR DESCRIPTION
## TL;DR

Preserve valid falsy plural branch content while treating `undefined` plural branches as missing so renderers fall back correctly.

## Code Changes

- Use nullish checks when resolving plural branches in the shared render pipeline.
- Apply the same fallback behavior to the shared `Plural` component renderer.
- Add React Core regression coverage for numeric/boolean branch keys, falsy plural branch content, and undefined plural fallbacks.

## Notes / Flags

- Rewritten cleanly on current `odysseus`; the stale reference-branch changes were removed.
- Verified with `pnpm --filter @generaltranslation/react-core test -- src/utils/rendering/__tests__/branchRendering.test.tsx`, `pnpm --filter @generaltranslation/react-core typecheck`, `pnpm format`, `pnpm lint`, and `git diff --check`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a two-part bug in the plural branch rendering pipeline: the `||` operator in `Plural.shared.ts` was silently discarding valid falsy branch values (`0`, `false`), and the strict `!== null` guard in the two render utilities missed `undefined` returns from `getPluralBranch` (which occur when a branch key exists with an explicit `undefined` value), preventing the expected fallback to children.

- **`Plural.shared.ts`**: replaces `getPluralBranch(...) || children` with a nullish ternary so that `0` and `false` branch content is returned as-is rather than falling through to the fallback.
- **`renderDefaultChildren.shared.ts` / `renderTranslatedChildren.shared.tsx`**: widens the null guard from `!== null` to `!= null` so that an explicitly `undefined` branch value also triggers the children fallback.
- **`branchRendering.test.tsx`**: new regression test suite covering numeric/boolean branch keys, falsy plural branch content (`0`, `false`), and `undefined` plural branch fallback in both the default and translated render paths as well as the shared `Plural` component renderer.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the changes are narrowly scoped null/falsy guard fixes in the plural branch resolution path with no side effects on other transformations.

All three changed sites have a clear, verifiable bug and a minimal correct fix. The new test suite directly exercises every edge case: falsy values preserved, undefined values falling back, both in default and translated render paths and in the shared Plural renderer. No pre-existing behaviour outside the plural path is touched.

No files require special attention. The getPluralBranch utility (unchanged) contains a redundant !branch guard that is always true at evaluation time, but this is pre-existing and does not affect correctness.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react-core/src/components/branches/Plural.shared.ts | Fixes the || falsy-coercion bug by switching to a nullish (!= null) ternary; the fix is minimal and correct. |
| packages/react-core/src/utils/rendering/renderDefaultChildren.shared.ts | Widens the null-guard from !== null to != null so that an explicit undefined branch value also falls back to children; the single-character change is correct. |
| packages/react-core/src/utils/rendering/renderTranslatedChildren.shared.tsx | Applies the same != null guard to both the source-branch and target-branch resolution paths; correct and symmetric with the default-children fix. |
| packages/react-core/src/utils/rendering/__tests__/branchRendering.test.tsx | Adds comprehensive regression tests for all three fixed sites; covers numeric/boolean branch keys, falsy plural branch content, and undefined fallback paths. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[getPluralBranch called] --> B{branchName found?}
    B -- No --> C[return null]
    B -- Yes --> D["branch = branches[branchName]"]
    D --> E{branch value?}
    E -- null --> C
    E -- undefined --> F[return undefined]
    E -- "0 / false / ReactNode" --> G[return branch value]
    C --> H{Caller null-check}
    F --> H
    G --> I{Caller null-check}
    H -- "undefined !== null OLD BUG" --> J[use undefined as branch]
    H -- "undefined != null NEW FIX" --> K[fall back to children]
    I -- "0 !== null" --> L[use 0 as branch]
    I -- "false !== null" --> L
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[getPluralBranch called] --> B{branchName found?}
    B -- No --> C[return null]
    B -- Yes --> D["branch = branches[branchName]"]
    D --> E{branch value?}
    E -- null --> C
    E -- undefined --> F[return undefined]
    E -- "0 / false / ReactNode" --> G[return branch value]
    C --> H{Caller null-check}
    F --> H
    G --> I{Caller null-check}
    H -- "undefined !== null OLD BUG" --> J[use undefined as branch]
    H -- "undefined != null NEW FIX" --> K[fall back to children]
    I -- "0 !== null" --> L[use 0 as branch]
    I -- "false !== null" --> L
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: preserve undefined plural fallbacks"](https://github.com/generaltranslation/gt/commit/adf990444bc2390b44bec66cfc70683919188601) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41511360)</sub>

<!-- /greptile_comment -->