### PR TITLE
perf: reuse cached hashed translations

### DIFF
--- a/packages/react-core/src/hooks/external-store.ts
+++ b/packages/react-core/src/hooks/external-store.ts
@@ -31,7 +31,10 @@ export function useTranslate<T extends Translation>(
     () => i18nStore.getTranslateSnapshot(lookup, translationsSnapshot)
   );
 
-  if (storeTranslation == null && getI18nConfig().isDevHotReloadEnabled()) {
+  if (
+    storeTranslation === undefined &&
+    getI18nConfig().isDevHotReloadEnabled()
+  ) {
     // TODO: (separate PR): add configuration for a use() + suspense strategy
     // TODO: consider moving this to a useEffect
     onMissingTranslation(lookup);

--- a/packages/react-core/src/hooks/external-store/useTrackedTranslationResolver.ts
+++ b/packages/react-core/src/hooks/external-store/useTrackedTranslationResolver.ts
@@ -92,7 +92,7 @@ export function useTrackedTranslationResolver(
       );
 
       // Trigger a hot reload if the translation is not found
-      if (translation == null && devHotReloadEnabled) {
+      if (translation === undefined && devHotReloadEnabled) {
         onMissingTranslation(lookup);
       }
       return translation;
@@ -162,7 +162,8 @@ function usePreloadCompilerLookups(
     lookups
       .filter(
         ([lookup]) =>
-          i18nStore.getTranslateSnapshot(lookup, translationsSnapshot) == null
+          i18nStore.getTranslateSnapshot(lookup, translationsSnapshot) ===
+          undefined
       )
       .forEach(([lookup]) => i18nStore.translate(lookup));
   }, [txHotReloadEnabled, i18nStore, lookups, translationsSnapshot]);

--- a/packages/react-core/src/hooks/useGT.ts
+++ b/packages/react-core/src/hooks/useGT.ts
@@ -44,7 +44,7 @@ export function useGT(_messages?: Message[]): GTFunctionType {
 
       return interpolateMessage({
         source: message,
-        target: translation,
+        target: translation ?? undefined,
         options: lookupOptions,
         sourceLocale: defaultLocale,
       });

--- a/packages/react-core/src/i18n-store/I18nStore.ts
+++ b/packages/react-core/src/i18n-store/I18nStore.ts
@@ -138,13 +138,14 @@ export class I18nStore {
     lookup: TranslateLookup<T>,
     translationsSnapshot: Record<Locale, Record<Hash, Translation>> = {}
   ): TranslateSnapshot<T> => {
-    return (
-      lookupTranslation(translationsSnapshot, lookup) ??
-      getReactI18nCache().lookupTranslation<T>(
-        lookup.locale,
-        lookup.message,
-        lookup.options
-      )
+    const snapshotTranslation = lookupTranslation(translationsSnapshot, lookup);
+    if (snapshotTranslation !== undefined) {
+      return snapshotTranslation;
+    }
+    return getReactI18nCache().lookupTranslation<T>(
+      lookup.locale,
+      lookup.message,
+      lookup.options
     );
   };
 

--- a/packages/react-core/src/i18n-store/__tests__/translations.test.ts
+++ b/packages/react-core/src/i18n-store/__tests__/translations.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { setReactI18nCache } from '../../i18n-cache/singleton-operations';
+import { I18nStore } from '../I18nStore';
+import type { ReactI18nCache } from '../../i18n-cache/ReactI18nCache';
+import type { Translation } from 'gt-i18n/types';
+
+type TestGlobal = typeof globalThis & {
+  __generaltranslation?: unknown;
+};
+
+function resetGTGlobals() {
+  Reflect.deleteProperty(globalThis as TestGlobal, '__generaltranslation');
+}
+
+describe('translation snapshots', () => {
+  beforeEach(() => {
+    resetGTGlobals();
+  });
+
+  it('treats cached null translations as known snapshot results', () => {
+    const lookupTranslation = vi.fn(() => 'cache fallback');
+    setReactI18nCache({
+      lookupTranslation,
+    } as unknown as ReactI18nCache);
+
+    const store = new I18nStore();
+    const result = store.getTranslateSnapshot(
+      {
+        locale: 'fr',
+        message: 'Source',
+        options: {
+          $format: 'JSX',
+          $_hash: 'known-null',
+        },
+      },
+      {
+        fr: {
+          'known-null': null as unknown as Translation,
+        },
+      }
+    );
+
+    expect(result).toBeNull();
+    expect(lookupTranslation).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react-core/src/i18n-store/storeTypes.ts
+++ b/packages/react-core/src/i18n-store/storeTypes.ts
@@ -27,6 +27,7 @@ export type DictionaryLookup = {
 
 export type TranslateSnapshot<T extends Translation = Translation> =
   | T
+  | null
   | undefined;
 export type TranslateManySnapshot<T extends Translation = Translation> =
   readonly TranslateSnapshot<T>[];

--- a/packages/react-core/src/utils/translation/__tests__/prepareT.test.tsx
+++ b/packages/react-core/src/utils/translation/__tests__/prepareT.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { prepareT } from '../prepareT.shared';
+import type { JsxChildren } from 'generaltranslation/types';
+
+describe('prepareT', () => {
+  it('uses a provided source JSX payload for hashed cache lookups', () => {
+    const sourceJsxChildren = '' as JsxChildren;
+    const prepared = prepareT({
+      sourceChildren: <span>Source</span>,
+      params: { _hash: 'cached-hash' },
+      locale: 'fr',
+      sourceJsxChildren,
+    });
+
+    expect(prepared.sourceJsxChildren).toBe(sourceJsxChildren);
+    expect(prepared.targetOptions).toMatchObject({
+      $format: 'JSX',
+      $locale: 'fr',
+      $_hash: 'cached-hash',
+    });
+  });
+});

--- a/packages/react-core/src/utils/translation/prepareT.shared.ts
+++ b/packages/react-core/src/utils/translation/prepareT.shared.ts
@@ -45,19 +45,21 @@ function prepareT({
   sourceChildren,
   params,
   locale,
+  sourceJsxChildren,
 }: {
   sourceChildren: ReactNode;
   params: JsxTranslationOptions;
   locale: string;
+  sourceJsxChildren?: JsxChildren;
 }): PreparedT {
   const taggedSourceChildren = prepareTaggedSourceChildren(sourceChildren);
-  const sourceJsxChildren = prepareSourceJsxChildren(taggedSourceChildren);
-  const options = normalizeParameters(params);
-  const targetOptions = prepareTargetOptions({ options, locale });
+  const preparedSourceJsxChildren =
+    sourceJsxChildren ?? prepareSourceJsxChildren(taggedSourceChildren);
+  const targetOptions = prepareTTargetOptions({ params, locale });
 
   return {
     taggedSourceChildren,
-    sourceJsxChildren,
+    sourceJsxChildren: preparedSourceJsxChildren,
     targetOptions,
   };
 }
@@ -87,6 +89,22 @@ function prepareTargetOptions({
   return { ...options, $locale: locale };
 }
 
+function prepareTTargetOptions({
+  params,
+  locale,
+}: {
+  params: JsxTranslationOptions;
+  locale: string;
+}): JsxTranslationOptionsWithSugar & {
+  $format: 'JSX';
+  $locale: string;
+} {
+  return prepareTargetOptions({
+    options: normalizeParameters(params),
+    locale,
+  });
+}
+
 function normalizeParameters(
   parameters: {
     context?: string;
@@ -103,7 +121,7 @@ function normalizeParameters(
   };
 }
 
-export { prepareT };
+export { prepareT, prepareTTargetOptions };
 export type {
   JsxTranslationOptions,
   PreparedT,

--- a/packages/react-core/src/utils/translation/usePrepareT.ts
+++ b/packages/react-core/src/utils/translation/usePrepareT.ts
@@ -4,10 +4,16 @@ import { useDefaultLocale } from '../../hooks/i18n-config';
 import { getI18nConfig } from 'gt-i18n/internal';
 import {
   prepareT,
+  prepareTTargetOptions,
   type JsxTranslationOptions,
   type PreparedT,
 } from './prepareT.shared';
 import type { ReactNode } from 'react';
+import type { JsxChildren } from 'generaltranslation/types';
+import { useTranslationsSnapshot } from '../../i18n-store/useI18nStore';
+import { lookupTranslation } from '../../i18n-store/utils/translations';
+
+const HASHED_SOURCE_PLACEHOLDER = '' as JsxChildren;
 
 function usePrepareT({
   sourceChildren,
@@ -28,18 +34,37 @@ function usePrepareT({
   const contextLocale = useLocale();
   const contextEnableI18n = useEnableI18n();
   const defaultLocale = useDefaultLocale();
+  const translationsSnapshot = useTranslationsSnapshot();
   const locale = _locale ?? contextLocale;
   const enableI18n = _enableI18n ?? contextEnableI18n;
   const shouldTranslate =
     enableI18n && getI18nConfig().requiresTranslation(locale);
+  const targetOptions = useMemo(
+    () => prepareTTargetOptions({ params, locale }),
+    [locale, params]
+  );
+  const sourceJsxChildren = useMemo(() => {
+    if (!shouldTranslate || targetOptions.$_hash == null) {
+      return undefined;
+    }
+    const cachedTranslation = lookupTranslation(translationsSnapshot, {
+      locale,
+      message: HASHED_SOURCE_PLACEHOLDER,
+      options: targetOptions,
+    });
+    return cachedTranslation !== undefined
+      ? HASHED_SOURCE_PLACEHOLDER
+      : undefined;
+  }, [locale, shouldTranslate, targetOptions, translationsSnapshot]);
   const prepared = useMemo(
     () =>
       prepareT({
         sourceChildren,
         params,
         locale,
+        sourceJsxChildren,
       }),
-    [locale, params, sourceChildren]
+    [locale, params, sourceChildren, sourceJsxChildren]
   );
 
   return {


### PR DESCRIPTION
## TL;DR

Reuse existing hashed JSX translation cache entries without rebuilding the source JSX object, and treat cached `null` translation snapshots as known fallback results instead of missing translations.

## Code Changes

- Skip source JSX serialization for client `<T>` when `$_hash` points at an existing translation snapshot.
- Preserve cached `null` translation snapshots through the external-store lookup path so dev hot reload does not retry known fallback results.
- Add focused React Core coverage for cached null snapshots and hashed source JSX preparation.

## Notes / Flags

- Rewritten cleanly on current `odysseus`; the stale reference-branch changes were removed.
- This is still worthwhile, but much narrower than the original stale PR because content-hash keying is already on `odysseus`.
- Verified with `pnpm --filter @generaltranslation/react-core test -- src/i18n-store/__tests__/translations.test.ts src/utils/translation/__tests__/prepareT.test.tsx`, `pnpm --filter @generaltranslation/react-core typecheck`, `pnpm format`, `pnpm lint`, and `git diff --check`.