### PR TITLE
fix: allow disabling invalid locale warnings

### DIFF
--- a/.changeset/sharp-flags-dream.md
+++ b/.changeset/sharp-flags-dream.md
@@ -1,0 +1,5 @@
+---
+"gt-next": patch
+---
+
+Add a withGTConfig flag for disabling invalid request locale warnings.

--- a/packages/next/src/__tests__/config.test.ts
+++ b/packages/next/src/__tests__/config.test.ts
@@ -1118,6 +1118,7 @@ describe('withGTConfig', () => {
         '_GENERALTRANSLATION_ENABLE_SSG',
         '_GENERALTRANSLATION_EXPERIMENTAL_LOCALE_RESOLUTION',
         '_GENERALTRANSLATION_EXPERIMENTAL_LOCALE_RESOLUTION_PARAM',
+        '_GENERALTRANSLATION_DISABLE_INVALID_LOCALE_WARNING',
       ];
 
       for (const key of expectedKeys) {
@@ -1159,6 +1160,18 @@ describe('withGTConfig', () => {
       expect(typeof result.env!._GENERALTRANSLATION_GT_SERVICES_ENABLED).toBe(
         'string'
       );
+      expect(
+        result.env!._GENERALTRANSLATION_DISABLE_INVALID_LOCALE_WARNING
+      ).toBe('false');
+    });
+
+    it('sets invalid locale warning env flag from withGTConfig props', async () => {
+      const withGTConfig = await getWithGTConfig();
+      const result = withGTConfig({}, { disableInvalidLocaleWarning: true });
+
+      expect(
+        result.env!._GENERALTRANSLATION_DISABLE_INVALID_LOCALE_WARNING
+      ).toBe('true');
     });
   });
 

--- a/packages/next/src/config-dir/I18NConfiguration.ts
+++ b/packages/next/src/config-dir/I18NConfiguration.ts
@@ -45,6 +45,7 @@ type I18NConfigurationParams = {
   _usingPlugin: boolean;
   _versionId?: string;
   customMapping?: CustomMapping | undefined;
+  disableInvalidLocaleWarning?: boolean;
   [key: string]: unknown;
 };
 
@@ -106,10 +107,12 @@ export class I18NConfiguration {
     _usingPlugin,
     headersAndCookies,
     customMapping,
+    disableInvalidLocaleWarning: _disableInvalidLocaleWarning,
     // Other metadata
     ...metadata
   }: I18NConfigurationParams) {
     void _dictionary;
+    void _disableInvalidLocaleWarning;
 
     // ----- CLOUD INTEGRATION ----- //
 

--- a/packages/next/src/config-dir/__tests__/I18NConfiguration.integration.test.ts
+++ b/packages/next/src/config-dir/__tests__/I18NConfiguration.integration.test.ts
@@ -93,6 +93,7 @@ describe('I18NConfiguration integration', () => {
       }) as GT['translateMany']);
     const config = createConfig({
       dictionary: './dictionary.json',
+      disableInvalidLocaleWarning: true,
       projectId: 'project-id',
       description: 'Clinical UI',
       renderSettings: {
@@ -122,5 +123,6 @@ describe('I18NConfiguration integration', () => {
       timeout: 4321,
     });
     expect(metadata).not.toHaveProperty('dictionary');
+    expect(metadata).not.toHaveProperty('disableInvalidLocaleWarning');
   });
 });

--- a/packages/next/src/config-dir/props/defaultWithGTConfigProps.ts
+++ b/packages/next/src/config-dir/props/defaultWithGTConfigProps.ts
@@ -45,6 +45,7 @@ type DefaultGTConfigProps = {
   experimentalEnableSSG: boolean;
   experimentalLocaleResolution: boolean;
   experimentalLocaleResolutionParam: string;
+  disableInvalidLocaleWarning: boolean;
 };
 
 export const defaultWithGTConfigProps: DefaultGTConfigProps = {
@@ -77,6 +78,7 @@ export const defaultWithGTConfigProps: DefaultGTConfigProps = {
   experimentalEnableSSG: false,
   experimentalLocaleResolution: false,
   experimentalLocaleResolutionParam: defaultExperimentalLocaleResolutionParam,
+  disableInvalidLocaleWarning: false,
 } as const;
 
 // exported separately because it's only used in production

--- a/packages/next/src/config-dir/props/withGTConfigProps.ts
+++ b/packages/next/src/config-dir/props/withGTConfigProps.ts
@@ -63,6 +63,7 @@ export type withGTConfigProps = {
   locales?: string[];
   defaultLocale?: string;
   ignoreBrowserLocales?: boolean;
+  disableInvalidLocaleWarning?: boolean;
   // Custom mapping
   /**@deprecated Use customMapping in gt.config.json instead */
   customMapping?: CustomMapping;

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -101,6 +101,7 @@ type WithGTConfigResult<TNextConfig extends object> = TNextConfig & NextConfig;
  * @param {number} [maxBatchSize=defaultInitGTProps.maxBatchSize] - Maximum translation requests in the same batch.
  * @param {number} [batchInterval=defaultInitGTProps.batchInterval] - The interval in milliseconds between batched translation requests.
  * @param {boolean} [ignoreBrowserLocales=defaultWithGTConfigProps.ignoreBrowserLocales] - Whether to ignore browser's preferred locales.
+ * @param {boolean} [disableInvalidLocaleWarning=defaultWithGTConfigProps.disableInvalidLocaleWarning] - Whether to disable invalid request locale warnings.
  * @param {object} headersAndCookies - Additional headers and cookies that can be passed for extended configuration.
  * @param {boolean} [experimentalEnableSSG=false] - Whether to enable SSG.
  * @param {boolean} [disableSSGWarnings=defaultWithGTConfigProps.disableSSGWarnings] - Whether to disable SSG warnings. (deprecated)
@@ -655,6 +656,8 @@ export function withGTConfig<TNextConfig extends object = NextConfig>(
         mergedConfig.experimentalLocaleResolution?.toString() || 'false',
       _GENERALTRANSLATION_EXPERIMENTAL_LOCALE_RESOLUTION_PARAM:
         mergedConfig.experimentalLocaleResolutionParam,
+      _GENERALTRANSLATION_DISABLE_INVALID_LOCALE_WARNING:
+        mergedConfig.disableInvalidLocaleWarning?.toString() || 'false',
     },
     ...(turboPackEnabled &&
       !experimentalTurbopack && {

--- a/packages/next/src/request/__tests__/localeValidation.test.ts
+++ b/packages/next/src/request/__tests__/localeValidation.test.ts
@@ -20,10 +20,13 @@ vi.mock('../../config-dir/getI18NConfig', () => ({
 }));
 
 describe('locale validation', () => {
+  const originalDisableInvalidLocaleWarning =
+    process.env._GENERALTRANSLATION_DISABLE_INVALID_LOCALE_WARNING;
   let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    delete process.env._GENERALTRANSLATION_DISABLE_INVALID_LOCALE_WARNING;
     consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     mockI18NConfig.getLocales.mockReturnValue(['en', 'fr']);
 
@@ -44,6 +47,12 @@ describe('locale validation', () => {
   });
 
   afterEach(() => {
+    if (originalDisableInvalidLocaleWarning === undefined) {
+      delete process.env._GENERALTRANSLATION_DISABLE_INVALID_LOCALE_WARNING;
+    } else {
+      process.env._GENERALTRANSLATION_DISABLE_INVALID_LOCALE_WARNING =
+        originalDisableInvalidLocaleWarning;
+    }
     consoleWarnSpy.mockRestore();
   });
 
@@ -71,6 +80,20 @@ describe('locale validation', () => {
     expect(consoleWarnSpy).toHaveBeenCalledWith(
       expect.stringContaining('Locale "llms.txt" is not valid')
     );
+  });
+
+  it('does not warn for invalid request locales when disabled by env', () => {
+    process.env._GENERALTRANSLATION_DISABLE_INVALID_LOCALE_WARNING = 'true';
+
+    expect(
+      resolveLocaleOrDefault(
+        'llms.txt',
+        mockI18NConfig as unknown as I18NConfiguration,
+        mockGt
+      )
+    ).toBe('en');
+
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
   });
 
   it('falls back to the default locale for unsupported request locales', () => {

--- a/packages/next/src/request/localeValidation.ts
+++ b/packages/next/src/request/localeValidation.ts
@@ -13,6 +13,12 @@ function determineSupportedLocale(
 }
 
 function warnInvalidLocale(locale: string, defaultLocale: string) {
+  if (
+    process.env._GENERALTRANSLATION_DISABLE_INVALID_LOCALE_WARNING === 'true'
+  ) {
+    return;
+  }
+
   console.warn(createInvalidRequestLocaleWarning(locale, defaultLocale));
 }
 


### PR DESCRIPTION
## Summary
- Add `disableInvalidLocaleWarning` to `withGTConfig`, defaulting to `true`.
- Emit `_GENERAL_TRANSLATION_DISABLE_INVALID_LOCALE_WARNING` from the Next config env and use it to suppress invalid request locale warnings.
- Add focused test coverage and a patch changeset for `gt-next`.

## Testing
- `pnpm --filter 'gt-next^...' build`
- `pnpm --filter gt-next test:js`
- `pnpm --filter gt-next typecheck`
- `pnpm exec oxlint packages/next/src/config-dir/props/withGTConfigProps.ts packages/next/src/config-dir/props/defaultWithGTConfigProps.ts packages/next/src/config.ts packages/next/src/request/localeValidation.ts packages/next/src/__tests__/config.test.ts packages/next/src/request/__tests__/localeValidation.test.ts`
- `pnpm exec oxfmt --check packages/next/src/config-dir/props/withGTConfigProps.ts packages/next/src/config-dir/props/defaultWithGTConfigProps.ts packages/next/src/config.ts packages/next/src/request/localeValidation.ts packages/next/src/__tests__/config.test.ts packages/next/src/request/__tests__/localeValidation.test.ts .changeset/sharp-flags-dream.md`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `disableInvalidLocaleWarning` option to `withGTConfig` (defaulting to `true`) that suppresses console warnings when a request arrives with an unrecognized locale — useful for preventing noise from requests to static files like `llms.txt`.

- `withGTConfigProps` and `defaultWithGTConfigProps` gain the new boolean flag; `config.ts` serialises it into a Next.js env var read at runtime by `localeValidation.ts`.
- Two issues need attention before merge: the changeset file is missing its opening `---` fence (so no version bump will be generated), and the new env var uses `_GENERAL_TRANSLATION_` instead of the established `_GENERALTRANSLATION_` prefix used by every other env var in the package.

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Two fixes needed before merge: the changeset file won't trigger a version bump, and the env var name is inconsistent with every other variable in the package.

The changeset file is missing its opening `---` fence, so the changesets toolchain will not recognize it and `gt-next` will not receive the patch bump or changelog entry. The new env var also uses `_GENERAL_TRANSLATION_` rather than the `_GENERALTRANSLATION_` prefix established by all other variables in this package — a naming mismatch that appears in production code, the runtime reader, and both test files. The core feature logic is correct, but these two issues should be resolved before merging.

`.changeset/sharp-flags-dream.md` (invalid format), `packages/next/src/config.ts` and `packages/next/src/request/localeValidation.ts` (inconsistent env var name).
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .changeset/sharp-flags-dream.md | Missing opening `---` fence makes the changeset invalid — version bump and changelog entry will be skipped by changesets tooling. |
| packages/next/src/config.ts | Emits new env var `_GENERAL_TRANSLATION_DISABLE_INVALID_LOCALE_WARNING` (inconsistent prefix vs all other `_GENERALTRANSLATION_*` vars) with correct boolean-to-string serialization logic. |
| packages/next/src/request/localeValidation.ts | Adds env-var guard to suppress invalid locale warnings; env var name uses wrong prefix (`_GENERAL_TRANSLATION_` instead of `_GENERALTRANSLATION_`). |
| packages/next/src/config-dir/props/defaultWithGTConfigProps.ts | Adds `disableInvalidLocaleWarning: true` to defaults — warnings off by default; intentional per PR description. |
| packages/next/src/config-dir/props/withGTConfigProps.ts | Adds optional `disableInvalidLocaleWarning?: boolean` to the public config props type — straightforward, no issues. |
| packages/next/src/__tests__/config.test.ts | Tests verify env var is present in output and reflects both `true` and `false` values; uses the same inconsistent env var name as production code. |
| packages/next/src/request/__tests__/localeValidation.test.ts | Adds a focused test for the suppression path with correct env var setup/teardown; logic is sound. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Dev as Developer (next.config.ts)
    participant WGT as withGTConfig()
    participant Env as Next.js process.env
    participant LV as localeValidation.ts
    participant Console as console.warn

    Dev->>WGT: "withGTConfig({}, { disableInvalidLocaleWarning: false })"
    WGT->>Env: "_GENERALTRANSLATION_DISABLE_INVALID_LOCALE_WARNING = 'false'"
    Note over Env: Injected at build / server start

    Note over LV: Request arrives with locale 'llms.txt'
    LV->>Env: read env var
    Env-->>LV: 'false'
    LV->>Console: console.warn(createInvalidRequestLocaleWarning(...))

    Dev->>WGT: "withGTConfig({}, { disableInvalidLocaleWarning: true }) [default]"
    WGT->>Env: "_GENERALTRANSLATION_DISABLE_INVALID_LOCALE_WARNING = 'true'"
    LV->>Env: read env var
    Env-->>LV: 'true'
    LV-->>LV: return early (no warning)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Dev as Developer (next.config.ts)
    participant WGT as withGTConfig()
    participant Env as Next.js process.env
    participant LV as localeValidation.ts
    participant Console as console.warn

    Dev->>WGT: "withGTConfig({}, { disableInvalidLocaleWarning: false })"
    WGT->>Env: "_GENERALTRANSLATION_DISABLE_INVALID_LOCALE_WARNING = 'false'"
    Note over Env: Injected at build / server start

    Note over LV: Request arrives with locale 'llms.txt'
    LV->>Env: read env var
    Env-->>LV: 'false'
    LV->>Console: console.warn(createInvalidRequestLocaleWarning(...))

    Dev->>WGT: "withGTConfig({}, { disableInvalidLocaleWarning: true }) [default]"
    WGT->>Env: "_GENERALTRANSLATION_DISABLE_INVALID_LOCALE_WARNING = 'true'"
    LV->>Env: read env var
    Env-->>LV: 'true'
    LV-->>LV: return early (no warning)
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0A.changeset%2Fsharp-flags-dream.md%3A1-2%0A**Invalid%20changeset%20frontmatter%20%E2%80%94%20missing%20opening%20%60---%60**%0A%0AThe%20changeset%20file%20is%20missing%20its%20opening%20fence.%20Changesets%20expects%20YAML%20frontmatter%20delimited%20by%20%60---%60%20on%20both%20sides%3B%20without%20the%20opening%20delimiter%20the%20file%20is%20not%20parsed%20as%20valid%20frontmatter%2C%20so%20%60changeset%20version%60%20will%20silently%20skip%20it%20%E2%80%94%20no%20version%20bump%20and%20no%20changelog%20entry%20will%20be%20generated%20for%20%60gt-next%60.%0A%0A%23%23%23%20Issue%202%20of%203%0Apackages%2Fnext%2Fsrc%2Fconfig.ts%3A659-660%0A**Env%20var%20name%20breaks%20the%20established%20%60_GENERALTRANSLATION_%60%20prefix%20convention**%0A%0AEvery%20other%20env%20variable%20injected%20by%20%60withGTConfig%60%20uses%20%60_GENERALTRANSLATION_%60%20%28GENERALTRANSLATION%20as%20one%20word%29%3A%20%60_GENERALTRANSLATION_DISABLE_SSG_WARNINGS%60%2C%20%60_GENERALTRANSLATION_ENABLE_SSG%60%2C%20etc.%20This%20new%20variable%20uses%20%60_GENERAL_TRANSLATION_%60%20%28with%20an%20extra%20underscore%29%2C%20breaking%20the%20convention.%20Any%20tooling%2C%20documentation%2C%20or%20allow-list%20that%20pattern-matches%20on%20%60_GENERALTRANSLATION_%60%20will%20miss%20this%20variable%2C%20and%20it%20creates%20a%20maintenance%20inconsistency%20across%20the%20codebase%20%28the%20same%20mismatch%20exists%20in%20%60localeValidation.ts%60%20and%20both%20test%20files%29.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20_GENERALTRANSLATION_DISABLE_INVALID_LOCALE_WARNING%3A%0A%20%20%20%20%20%20%20%20mergedConfig.disableInvalidLocaleWarning%3F.toString%28%29%20%7C%7C%20'true'%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Apackages%2Fnext%2Fsrc%2Frequest%2FlocaleValidation.ts%3A16-18%0ASame%20naming%20inconsistency%20as%20in%20%60config.ts%60%20%E2%80%94%20should%20use%20%60_GENERALTRANSLATION_%60%20to%20match%20all%20other%20env%20vars%20in%20this%20package.%0A%0A%60%60%60suggestion%0A%20%20if%20%28%0A%20%20%20%20process.env._GENERALTRANSLATION_DISABLE_INVALID_LOCALE_WARNING%20%3D%3D%3D%20'true'%0A%20%20%29%20%7B%0A%60%60%60%0A%0A&repo=generaltranslation%2Fgt&pr=1796&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fnext%2Fdisable-invalid-locale-warning%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fnext%2Fdisable-invalid-locale-warning%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0A.changeset%2Fsharp-flags-dream.md%3A1-2%0A**Invalid%20changeset%20frontmatter%20%E2%80%94%20missing%20opening%20%60---%60**%0A%0AThe%20changeset%20file%20is%20missing%20its%20opening%20fence.%20Changesets%20expects%20YAML%20frontmatter%20delimited%20by%20%60---%60%20on%20both%20sides%3B%20without%20the%20opening%20delimiter%20the%20file%20is%20not%20parsed%20as%20valid%20frontmatter%2C%20so%20%60changeset%20version%60%20will%20silently%20skip%20it%20%E2%80%94%20no%20version%20bump%20and%20no%20changelog%20entry%20will%20be%20generated%20for%20%60gt-next%60.%0A%0A%23%23%23%20Issue%202%20of%203%0Apackages%2Fnext%2Fsrc%2Fconfig.ts%3A659-660%0A**Env%20var%20name%20breaks%20the%20established%20%60_GENERALTRANSLATION_%60%20prefix%20convention**%0A%0AEvery%20other%20env%20variable%20injected%20by%20%60withGTConfig%60%20uses%20%60_GENERALTRANSLATION_%60%20%28GENERALTRANSLATION%20as%20one%20word%29%3A%20%60_GENERALTRANSLATION_DISABLE_SSG_WARNINGS%60%2C%20%60_GENERALTRANSLATION_ENABLE_SSG%60%2C%20etc.%20This%20new%20variable%20uses%20%60_GENERAL_TRANSLATION_%60%20%28with%20an%20extra%20underscore%29%2C%20breaking%20the%20convention.%20Any%20tooling%2C%20documentation%2C%20or%20allow-list%20that%20pattern-matches%20on%20%60_GENERALTRANSLATION_%60%20will%20miss%20this%20variable%2C%20and%20it%20creates%20a%20maintenance%20inconsistency%20across%20the%20codebase%20%28the%20same%20mismatch%20exists%20in%20%60localeValidation.ts%60%20and%20both%20test%20files%29.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20_GENERALTRANSLATION_DISABLE_INVALID_LOCALE_WARNING%3A%0A%20%20%20%20%20%20%20%20mergedConfig.disableInvalidLocaleWarning%3F.toString%28%29%20%7C%7C%20'true'%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Apackages%2Fnext%2Fsrc%2Frequest%2FlocaleValidation.ts%3A16-18%0ASame%20naming%20inconsistency%20as%20in%20%60config.ts%60%20%E2%80%94%20should%20use%20%60_GENERALTRANSLATION_%60%20to%20match%20all%20other%20env%20vars%20in%20this%20package.%0A%0A%60%60%60suggestion%0A%20%20if%20%28%0A%20%20%20%20process.env._GENERALTRANSLATION_DISABLE_INVALID_LOCALE_WARNING%20%3D%3D%3D%20'true'%0A%20%20%29%20%7B%0A%60%60%60%0A%0A&repo=generaltranslation%2Fgt&pr=1796&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=4"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=4"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
.changeset/sharp-flags-dream.md:1-2
**Invalid changeset frontmatter — missing opening `---`**

The changeset file is missing its opening fence. Changesets expects YAML frontmatter delimited by `---` on both sides; without the opening delimiter the file is not parsed as valid frontmatter, so `changeset version` will silently skip it — no version bump and no changelog entry will be generated for `gt-next`.

### Issue 2 of 3
packages/next/src/config.ts:659-660
**Env var name breaks the established `_GENERALTRANSLATION_` prefix convention**

Every other env variable injected by `withGTConfig` uses `_GENERALTRANSLATION_` (GENERALTRANSLATION as one word): `_GENERALTRANSLATION_DISABLE_SSG_WARNINGS`, `_GENERALTRANSLATION_ENABLE_SSG`, etc. This new variable uses `_GENERAL_TRANSLATION_` (with an extra underscore), breaking the convention. Any tooling, documentation, or allow-list that pattern-matches on `_GENERALTRANSLATION_` will miss this variable, and it creates a maintenance inconsistency across the codebase (the same mismatch exists in `localeValidation.ts` and both test files).

```suggestion
      _GENERALTRANSLATION_DISABLE_INVALID_LOCALE_WARNING:
        mergedConfig.disableInvalidLocaleWarning?.toString() || 'true',
```

### Issue 3 of 3
packages/next/src/request/localeValidation.ts:16-18
Same naming inconsistency as in `config.ts` — should use `_GENERALTRANSLATION_` to match all other env vars in this package.

```suggestion
  if (
    process.env._GENERALTRANSLATION_DISABLE_INVALID_LOCALE_WARNING === 'true'
  ) {
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: allow disabling invalid locale warn..."](https://github.com/generaltranslation/gt/commit/3b1050bfe383eaf50dfa2b477636fa2d7775e83e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41509882)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->