### PR TITLE
fix: preserve enable i18n hydration state

### DIFF
--- a/.changeset/enable-i18n-prop-first.md
+++ b/.changeset/enable-i18n-prop-first.md
@@ -1,0 +1,6 @@
+---
+"gt-next": patch
+"gt-react": patch
+---
+
+Preserve enableI18n hydration state from server props and request cookies.

--- a/packages/next/src/__tests__/config.test.ts
+++ b/packages/next/src/__tests__/config.test.ts
@@ -192,6 +192,7 @@ describe('withGTConfig', () => {
       expect(params.headersAndCookies).toMatchObject({
         localeHeaderName: 'x-generaltranslation-locale',
         localeCookieName: 'generaltranslation.locale',
+        enableI18nCookieName: 'generaltranslation.enable-i18n',
         referrerLocaleCookieName: 'generaltranslation.referrer-locale',
         localeRoutingEnabledCookieName:
           'generaltranslation.locale-routing-enabled',
@@ -1460,6 +1461,9 @@ describe('withGTConfig', () => {
       );
       expect(params.headersAndCookies.localeCookieName).toBe(
         'generaltranslation.locale'
+      );
+      expect(params.headersAndCookies.enableI18nCookieName).toBe(
+        'generaltranslation.enable-i18n'
       );
     });
 

--- a/packages/next/src/config-dir/props/defaultWithGTConfigProps.ts
+++ b/packages/next/src/config-dir/props/defaultWithGTConfigProps.ts
@@ -5,6 +5,7 @@ import {
 } from 'generaltranslation/internal';
 import {
   defaultLocaleCookieName,
+  defaultEnableI18nCookieName,
   defaultResetLocaleCookieName,
   getDefaultRenderSettings,
   type RenderMethod,
@@ -35,6 +36,7 @@ type DefaultGTConfigProps = {
   headersAndCookies: {
     localeHeaderName: string;
     localeCookieName: string;
+    enableI18nCookieName: string;
     referrerLocaleCookieName: string;
     localeRoutingEnabledCookieName: string;
     resetLocaleCookieName: string;
@@ -59,6 +61,7 @@ export const defaultWithGTConfigProps: DefaultGTConfigProps = {
   headersAndCookies: {
     localeHeaderName: defaultLocaleHeaderName,
     localeCookieName: defaultLocaleCookieName,
+    enableI18nCookieName: defaultEnableI18nCookieName,
     referrerLocaleCookieName: defaultReferrerLocaleCookieName,
     localeRoutingEnabledCookieName: defaultLocaleRoutingEnabledCookieName,
     resetLocaleCookieName: defaultResetLocaleCookieName,

--- a/packages/next/src/config-dir/props/withGTConfigProps.ts
+++ b/packages/next/src/config-dir/props/withGTConfigProps.ts
@@ -3,6 +3,7 @@ import type { RenderMethod } from '@generaltranslation/react-core/pure';
 export type HeadersAndCookies = {
   localeHeaderName?: string;
   localeCookieName?: string;
+  enableI18nCookieName?: string;
   referrerLocaleCookieName?: string;
   localeRoutingEnabledCookieName?: string;
   resetLocaleCookieName?: string;

--- a/packages/next/src/pages-dir/__tests__/parseEnableI18n.test.ts
+++ b/packages/next/src/pages-dir/__tests__/parseEnableI18n.test.ts
@@ -1,0 +1,57 @@
+import type { GetServerSidePropsContext } from 'next';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { initializeI18nConfig } from '@generaltranslation/react-core/pure';
+import { parseEnableI18n } from '../parseEnableI18n';
+
+type TestGlobal = typeof globalThis & {
+  __generaltranslation?: unknown;
+};
+
+function resetGTGlobals() {
+  Reflect.deleteProperty(globalThis as TestGlobal, '__generaltranslation');
+}
+
+function createContext(cookies = {}): GetServerSidePropsContext {
+  return {
+    req: {
+      cookies,
+    },
+  } as GetServerSidePropsContext;
+}
+
+describe('parseEnableI18n', () => {
+  beforeEach(() => {
+    resetGTGlobals();
+    initializeI18nConfig();
+  });
+
+  it('defaults to true without a cookie', () => {
+    expect(parseEnableI18n(createContext())).toBe(true);
+  });
+
+  it('reads the default enableI18n cookie', () => {
+    expect(
+      parseEnableI18n(
+        createContext({
+          'generaltranslation.enable-i18n': 'false',
+        })
+      )
+    ).toBe(false);
+  });
+
+  it('uses the configured enableI18n cookie name', () => {
+    resetGTGlobals();
+    initializeI18nConfig({
+      enableI18nCookieName: 'custom-enable-i18n',
+    });
+
+    expect(
+      parseEnableI18n(
+        createContext({
+          'custom-enable-i18n': 'false',
+          'generaltranslation.enable-i18n': 'true',
+        })
+      )
+    ).toBe(false);
+  });
+});

--- a/packages/next/src/pages-dir/__tests__/parseLocale.test.ts
+++ b/packages/next/src/pages-dir/__tests__/parseLocale.test.ts
@@ -1,6 +1,6 @@
 import type { GetServerSidePropsContext } from 'next';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { initializeI18nConfig } from 'gt-i18n/internal';
+import { initializeI18nConfig } from '@generaltranslation/react-core/pure';
 import { parseLocale } from '../parseLocale';
 
 type TestGlobal = typeof globalThis & {
@@ -59,10 +59,14 @@ describe('parseLocale', () => {
   });
 
   it('uses configured header and cookie names', () => {
+    resetGTGlobals();
+    initializeI18nConfig({
+      ...localeConfig,
+      localeCookieName: 'custom-locale',
+    });
     process.env._GENERALTRANSLATION_I18N_CONFIG_PARAMS = JSON.stringify({
       headersAndCookies: {
         localeHeaderName: 'x-custom-locale',
-        localeCookieName: 'custom-locale',
       },
     });
     const context = createContext({

--- a/packages/next/src/pages-dir/__tests__/withGTServerSideProps.test.ts
+++ b/packages/next/src/pages-dir/__tests__/withGTServerSideProps.test.ts
@@ -1,5 +1,6 @@
 import type { GetServerSidePropsContext } from 'next';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { initializeI18nConfig } from '@generaltranslation/react-core/pure';
 
 const mockGetTranslationsSnapshot = vi.hoisted(() => vi.fn());
 const mockParseLocale = vi.hoisted(() => vi.fn());
@@ -17,8 +18,19 @@ import { withGTServerSideProps } from '../withGTServerSideProps';
 
 const context = { req: {} } as GetServerSidePropsContext;
 
+type TestGlobal = typeof globalThis & {
+  __generaltranslation?: unknown;
+};
+
+function resetGTGlobals() {
+  Reflect.deleteProperty(globalThis as TestGlobal, '__generaltranslation');
+}
+
 describe('withGTServerSideProps', () => {
   beforeEach(() => {
+    resetGTGlobals();
+    initializeI18nConfig();
+    delete process.env._GENERALTRANSLATION_I18N_CONFIG_PARAMS;
     mockParseLocale.mockReset();
     mockParseLocale.mockReturnValue('fr');
     mockGetTranslationsSnapshot.mockReset();
@@ -31,6 +43,7 @@ describe('withGTServerSideProps', () => {
     await expect(getServerSideProps(context)).resolves.toEqual({
       props: {
         locale: 'fr',
+        enableI18n: true,
         translations: { fr: { hash: 'Bonjour' } },
       },
     });
@@ -51,6 +64,27 @@ describe('withGTServerSideProps', () => {
       props: {
         renderedAt: 'now',
         locale: 'fr',
+        enableI18n: true,
+        translations: { fr: { hash: 'Bonjour' } },
+      },
+    });
+  });
+
+  it('adds enableI18n from the request cookie', async () => {
+    const getServerSideProps = withGTServerSideProps();
+
+    await expect(
+      getServerSideProps({
+        req: {
+          cookies: {
+            'generaltranslation.enable-i18n': 'false',
+          },
+        },
+      } as GetServerSidePropsContext)
+    ).resolves.toEqual({
+      props: {
+        locale: 'fr',
+        enableI18n: false,
         translations: { fr: { hash: 'Bonjour' } },
       },
     });

--- a/packages/next/src/pages-dir/parseEnableI18n.ts
+++ b/packages/next/src/pages-dir/parseEnableI18n.ts
@@ -1,0 +1,16 @@
+import { getI18nConfig } from '@generaltranslation/react-core/pure';
+import type { GetServerSidePropsContext, PreviewData } from 'next';
+import type { ParsedUrlQuery } from 'querystring';
+
+/**
+ * Resolve the user's enableI18n state from a Next Pages Router server-side request.
+ */
+export function parseEnableI18n<
+  Params extends ParsedUrlQuery = ParsedUrlQuery,
+  Preview extends PreviewData = PreviewData,
+>(context: GetServerSidePropsContext<Params, Preview>): boolean {
+  const cookieEnableI18n =
+    context.req.cookies?.[getI18nConfig().getEnableI18nCookieName()];
+  if (cookieEnableI18n === undefined) return true;
+  return cookieEnableI18n === 'true';
+}

--- a/packages/next/src/pages-dir/parseLocale.ts
+++ b/packages/next/src/pages-dir/parseLocale.ts
@@ -1,9 +1,8 @@
 import type { GetServerSidePropsContext, PreviewData } from 'next';
 import type { ParsedUrlQuery } from 'querystring';
-import { getI18nConfig } from 'gt-i18n/internal';
+import { getI18nConfig } from '@generaltranslation/react-core/pure';
 import { noLocalesCouldBeDeterminedWarning } from '../errors/ssg';
 import { defaultLocaleHeaderName } from '../utils/headers';
-import { defaultLocaleCookieName } from '@generaltranslation/react-core/pure';
 
 type HeaderValue = string | string[] | undefined;
 
@@ -14,13 +13,13 @@ export function parseLocale<
   Params extends ParsedUrlQuery = ParsedUrlQuery,
   Preview extends PreviewData = PreviewData,
 >(context: GetServerSidePropsContext<Params, Preview>): string {
-  const { headerName, cookieName, ignorePreferredLanguages } =
-    getParseLocaleParams();
+  const i18nConfig = getI18nConfig();
+  const { headerName, ignorePreferredLanguages } = getParseLocaleParams();
   const preferredLocales: string[] = [];
 
   addHeaderCandidates(preferredLocales, context.req.headers[headerName]);
 
-  const cookieLocale = context.req.cookies?.[cookieName];
+  const cookieLocale = context.req.cookies?.[i18nConfig.getLocaleCookieName()];
   if (cookieLocale) {
     preferredLocales.push(cookieLocale);
   }
@@ -35,7 +34,6 @@ export function parseLocale<
     console.warn(noLocalesCouldBeDeterminedWarning);
   }
 
-  const i18nConfig = getI18nConfig();
   return (
     i18nConfig
       .getGTClass()
@@ -46,7 +44,6 @@ export function parseLocale<
 
 function getParseLocaleParams(): {
   headerName: string;
-  cookieName: string;
   ignorePreferredLanguages: boolean;
 } {
   const privateConfig = JSON.parse(
@@ -57,9 +54,6 @@ function getParseLocaleParams(): {
     headerName:
       privateConfig.headersAndCookies?.localeHeaderName ||
       defaultLocaleHeaderName,
-    cookieName:
-      privateConfig.headersAndCookies?.localeCookieName ||
-      defaultLocaleCookieName,
     ignorePreferredLanguages: privateConfig.ignoreBrowserLocales || false,
   };
 }

--- a/packages/next/src/pages-dir/withGTServerSideProps.ts
+++ b/packages/next/src/pages-dir/withGTServerSideProps.ts
@@ -6,9 +6,11 @@ import type {
 import type { ParsedUrlQuery } from 'querystring';
 import { getTranslationsSnapshot } from 'gt-react';
 import { parseLocale } from './parseLocale';
+import { parseEnableI18n } from './parseEnableI18n';
 
 type GTServerSideProps = {
   locale: string;
+  enableI18n: boolean;
   translations: Awaited<ReturnType<typeof getTranslationsSnapshot>>;
 };
 
@@ -34,11 +36,13 @@ export function withGTServerSideProps<
 
     const props = await result.props;
     const locale = parseLocale(context);
+    const enableI18n = parseEnableI18n(context);
 
     return {
       props: {
         ...props,
         locale,
+        enableI18n,
         translations: await getTranslationsSnapshot(locale),
       },
     };

--- a/packages/next/src/setup/__tests__/initGT.test.ts
+++ b/packages/next/src/setup/__tests__/initGT.test.ts
@@ -56,6 +56,7 @@ describe('initializeGT', () => {
         defaultLocale: 'en',
         locales: ['en', 'fr'],
         localeCookieName: 'custom-locale',
+        enableI18nCookieName: 'custom-enable-i18n',
       },
       nextI18nCacheParams: {
         defaultLocale: 'en',
@@ -64,5 +65,8 @@ describe('initializeGT', () => {
     });
 
     expect(getI18nConfig().getLocaleCookieName()).toBe('custom-locale');
+    expect(getI18nConfig().getEnableI18nCookieName()).toBe(
+      'custom-enable-i18n'
+    );
   });
 });

--- a/packages/next/src/setup/__tests__/shared.test.ts
+++ b/packages/next/src/setup/__tests__/shared.test.ts
@@ -13,7 +13,10 @@ function setConfigEnv() {
   process.env._GENERALTRANSLATION_I18N_CONFIG_PARAMS = JSON.stringify({
     cacheUrl: 'https://cache.example.com',
     renderSettings: { timeout: 123 },
-    headersAndCookies: { localeCookieName: 'custom-locale' },
+    headersAndCookies: {
+      localeCookieName: 'custom-locale',
+      enableI18nCookieName: 'custom-enable-i18n',
+    },
     maxConcurrentRequests: 1,
     maxBatchSize: 2,
     batchInterval: 3,
@@ -53,6 +56,7 @@ describe('getParams', () => {
       devApiKey: 'dev-key',
       cacheUrl: 'https://cache.example.com',
       localeCookieName: 'custom-locale',
+      enableI18nCookieName: 'custom-enable-i18n',
     });
     expect(nextI18nCacheParams).toMatchObject({
       projectId: 'project-id',

--- a/packages/next/src/setup/shared.ts
+++ b/packages/next/src/setup/shared.ts
@@ -34,6 +34,7 @@ export function getParams(): {
     cacheUrl: privateConfig.cacheUrl,
     _disableDevHotReload: privateConfig._disableDevHotReload,
     localeCookieName: privateConfig.headersAndCookies?.localeCookieName,
+    enableI18nCookieName: privateConfig.headersAndCookies?.enableI18nCookieName,
   };
 
   // NextI18nCacheParams

--- a/packages/react/src/condition-store/__tests__/createBrowserConditionStore.test.ts
+++ b/packages/react/src/condition-store/__tests__/createBrowserConditionStore.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockSetCookieValue = vi.hoisted(() => vi.fn());
+const mockCookieValues = vi.hoisted(
+  () => new Map<string, string | undefined>()
+);
+const mockCookieNames = vi.hoisted(() => ({
+  locale: 'generaltranslation.locale',
+  region: 'generaltranslation.region',
+  enableI18n: 'generaltranslation.enable-i18n',
+}));
+
+vi.mock('../cookies', () => ({
+  getCookieValue: ({ cookieName }: { cookieName: string }) =>
+    mockCookieValues.get(cookieName),
+  setCookieValue: (...args: unknown[]) => mockSetCookieValue(...args),
+}));
+
+vi.mock('@generaltranslation/react-core/pure', () => ({
+  defaultResetLocaleCookieName: 'generaltranslation.locale-reset',
+  getI18nConfig: () => ({
+    resolveSupportedLocale: (locale?: string | string[]) => {
+      const resolved = Array.isArray(locale) ? locale[0] : locale;
+      return resolved || 'en';
+    },
+    getLocaleCookieName: () => mockCookieNames.locale,
+    getRegionCookieName: () => mockCookieNames.region,
+    getEnableI18nCookieName: () => mockCookieNames.enableI18n,
+  }),
+}));
+
+import { createOrUpdateBrowserConditionStore } from '../createBrowserConditionStore';
+
+type TestGlobal = typeof globalThis & {
+  __generaltranslation?: unknown;
+};
+
+function resetGTGlobals() {
+  Reflect.deleteProperty(globalThis as TestGlobal, '__generaltranslation');
+}
+
+describe('createOrUpdateBrowserConditionStore', () => {
+  beforeEach(() => {
+    resetGTGlobals();
+    mockSetCookieValue.mockReset();
+    mockCookieValues.clear();
+    mockCookieNames.locale = 'generaltranslation.locale';
+    mockCookieNames.region = 'generaltranslation.region';
+    mockCookieNames.enableI18n = 'generaltranslation.enable-i18n';
+  });
+
+  it('uses the enableI18n prop before the persisted cookie', () => {
+    mockCookieValues.set('generaltranslation.enable-i18n', 'true');
+
+    createOrUpdateBrowserConditionStore({
+      locale: 'fr',
+      enableI18n: false,
+    });
+
+    expect(mockSetCookieValue).toHaveBeenCalledWith({
+      cookieName: 'generaltranslation.enable-i18n',
+      value: 'false',
+    });
+  });
+
+  it('uses the persisted enableI18n cookie when the prop is omitted', () => {
+    mockCookieValues.set('generaltranslation.enable-i18n', 'false');
+
+    createOrUpdateBrowserConditionStore({
+      locale: 'fr',
+    });
+
+    expect(mockSetCookieValue).toHaveBeenCalledWith({
+      cookieName: 'generaltranslation.enable-i18n',
+      value: 'false',
+    });
+  });
+
+  it('uses _getEnableI18n when the prop and cookie are omitted', () => {
+    createOrUpdateBrowserConditionStore({
+      locale: 'fr',
+      _getEnableI18n: () => false,
+    });
+
+    expect(mockSetCookieValue).toHaveBeenCalledWith({
+      cookieName: 'generaltranslation.enable-i18n',
+      value: 'false',
+    });
+  });
+
+  it('defaults enableI18n to true without a prop or cookie', () => {
+    createOrUpdateBrowserConditionStore({
+      locale: 'fr',
+    });
+
+    expect(mockSetCookieValue).toHaveBeenCalledWith({
+      cookieName: 'generaltranslation.enable-i18n',
+      value: 'true',
+    });
+  });
+});

--- a/packages/react/src/condition-store/createBrowserConditionStore.ts
+++ b/packages/react/src/condition-store/createBrowserConditionStore.ts
@@ -25,8 +25,8 @@ export type CreateBrowserConditionStoreParams = Omit<
  *
  * This exists so we can keep the locale param as required in the constructor
  *
- * We want the values that we read from the cookies to override as this
- * persists state across page reloads
+ * Server-provided props are the first candidates for hydration consistency.
+ * Cookies fill in missing values to persist state across page reloads.
  *
  * Cookie names come from the I18nConfig singleton so custom names passed to
  * initializeGT() apply here without being threaded through provider props.
@@ -85,11 +85,13 @@ function determineEnableI18n({
   enableI18n,
   _getEnableI18n: getEnableI18n,
 }: CreateBrowserConditionStoreParams): boolean {
+  if (enableI18n !== undefined) return enableI18n;
+
   const cookieEnableI18n = getCookieValue({
     cookieName: getI18nConfig().getEnableI18nCookieName(),
   });
   if (cookieEnableI18n === undefined) {
-    return getEnableI18n?.() ?? enableI18n ?? true;
+    return getEnableI18n?.() ?? true;
   }
   return cookieEnableI18n === 'true';
 }


### PR DESCRIPTION
## Summary

- Make browser `enableI18n` resolution prop-first, then cookie, then custom getter, then default `true`.
- Pass request-cookie-derived `enableI18n` from `withGTServerSideProps` alongside locale and translations.
- Read Pages Router locale and enableI18n cookie names from `ReactI18nConfig`, including custom Next headers/cookies config.
- Add focused tests for client candidate order, Pages Router parsing, and config propagation.

## Testing

- `pnpm --filter gt-react... --filter gt-next... build`
- `pnpm --filter gt-react exec vitest run src/condition-store/__tests__/createBrowserConditionStore.test.ts src/condition-store/__tests__/BrowserConditionStore.test.ts`
- `pnpm --filter gt-next exec vitest run src/pages-dir/__tests__/parseEnableI18n.test.ts src/pages-dir/__tests__/withGTServerSideProps.test.ts src/pages-dir/__tests__/parseLocale.test.ts src/setup/__tests__/shared.test.ts src/setup/__tests__/initGT.test.ts`
- `pnpm --filter gt-next exec vitest run src/__tests__/config.test.ts`
- `pnpm exec oxlint packages/react/src/condition-store/createBrowserConditionStore.ts packages/react/src/condition-store/__tests__/createBrowserConditionStore.test.ts packages/next/src/pages-dir/parseEnableI18n.ts packages/next/src/pages-dir/parseLocale.ts packages/next/src/pages-dir/__tests__/parseEnableI18n.test.ts packages/next/src/pages-dir/__tests__/parseLocale.test.ts packages/next/src/pages-dir/__tests__/withGTServerSideProps.test.ts packages/next/src/setup/shared.ts packages/next/src/setup/__tests__/shared.test.ts packages/next/src/setup/__tests__/initGT.test.ts packages/next/src/config-dir/props/withGTConfigProps.ts packages/next/src/config-dir/props/defaultWithGTConfigProps.ts packages/next/src/__tests__/config.test.ts`
- `pnpm --filter gt-react typecheck`
- `pnpm --filter gt-next typecheck`
