### PR TITLE
fix: provide native loading fallback context

### DIFF
--- a/.changeset/native-loading-fallback-context.md
+++ b/.changeset/native-loading-fallback-context.md
@@ -1,0 +1,5 @@
+---
+"gt-react-native": patch
+---
+
+Render `GTProvider` loading fallbacks inside the native GT context so app children can safely be used as the fallback while translations load.

--- a/packages/react-native/src/provider/GTProvider.tsx
+++ b/packages/react-native/src/provider/GTProvider.tsx
@@ -14,7 +14,10 @@ import {
 } from '../utils/getInitialNativeConditions';
 import { resolveLocale } from '../utils/resolveLocale';
 import { loadTranslations, type LocaleTranslations } from './loadTranslations';
-import { NativeGTProvider } from './NativeGTProvider';
+import {
+  NativeGTProvider,
+  type NativeGTProviderProps,
+} from './NativeGTProvider';
 
 export type GTProviderProps = Omit<
   InternalGTProviderProps,
@@ -27,15 +30,17 @@ export type GTProviderProps = Omit<
   };
 
 type LoadableGTProviderProps = Omit<GTProviderProps, 'loadingFallback'>;
+type LoadedGTProviderProps = Omit<NativeGTProviderProps, 'translations'>;
 type TranslationSnapshot = Record<Locale, LocaleTranslations>;
 
 export function GTProvider(props: GTProviderProps) {
   const { loadingFallback, ...providerProps } = props;
 
   return (
-    <Suspense fallback={loadingFallback ?? <DefaultLoadingFallback />}>
-      <LoadableGTProvider {...providerProps} />
-    </Suspense>
+    <LoadableGTProvider
+      {...providerProps}
+      loadingFallback={loadingFallback ?? <DefaultLoadingFallback />}
+    />
   );
 }
 
@@ -43,8 +48,11 @@ export function GTProvider(props: GTProviderProps) {
  * This wrapper takes the place of a loader that would be present in
  * SSR style applications.
  */
-function LoadableGTProvider(props: LoadableGTProviderProps) {
-  const { locale, region, enableI18n } = props;
+function LoadableGTProvider(
+  props: LoadableGTProviderProps & { loadingFallback: ReactNode }
+) {
+  const { loadingFallback, ...providerProps } = props;
+  const { locale, region, enableI18n } = providerProps;
   // Keep native conditions in React state so condition-store writes trigger rerenders.
   const [nativeConditions, setNativeConditions] =
     useState<NativeConditionStoreState>(() => ({
@@ -55,10 +63,9 @@ function LoadableGTProvider(props: LoadableGTProviderProps) {
   const activeLocale = resolveLocale(locale ?? nativeConditions.locale);
   const activeRegion = region ?? nativeConditions.region;
   const activeEnableI18n = enableI18n ?? nativeConditions.enableI18n;
-  const localeTranslations = use(loadTranslations(activeLocale));
-  const translations = useMemo<TranslationSnapshot>(
-    () => ({ [activeLocale]: localeTranslations }),
-    [activeLocale, localeTranslations]
+  const fallbackTranslations = useMemo<TranslationSnapshot>(
+    () => ({ [activeLocale]: {} }),
+    [activeLocale]
   );
   const reload = useCallback(
     (state: NativeConditionStoreState) => {
@@ -75,13 +82,44 @@ function LoadableGTProvider(props: LoadableGTProviderProps) {
   );
 
   return (
+    <Suspense
+      fallback={
+        <NativeGTProvider
+          {...providerProps}
+          locale={activeLocale}
+          region={activeRegion}
+          enableI18n={activeEnableI18n}
+          translations={fallbackTranslations}
+          _reload={reload}
+        >
+          {loadingFallback}
+        </NativeGTProvider>
+      }
+    >
+      <LoadedGTProvider
+        {...providerProps}
+        locale={activeLocale}
+        region={activeRegion}
+        enableI18n={activeEnableI18n}
+        _reload={reload}
+      />
+    </Suspense>
+  );
+}
+
+function LoadedGTProvider(props: LoadedGTProviderProps) {
+  const activeLocale = resolveLocale(props.locale);
+  const localeTranslations = use(loadTranslations(activeLocale));
+  const translations = useMemo<TranslationSnapshot>(
+    () => ({ [activeLocale]: localeTranslations }),
+    [activeLocale, localeTranslations]
+  );
+
+  return (
     <NativeGTProvider
       {...props}
       locale={activeLocale}
-      region={activeRegion}
-      enableI18n={activeEnableI18n}
       translations={translations}
-      _reload={reload}
     />
   );
 }

--- a/packages/react-native/src/provider/GTProvider.tsx
+++ b/packages/react-native/src/provider/GTProvider.tsx
@@ -29,29 +29,20 @@ export type GTProviderProps = Omit<
     loadingFallback?: ReactNode;
   };
 
-type LoadableGTProviderProps = Omit<GTProviderProps, 'loadingFallback'>;
 type LoadedGTProviderProps = Omit<NativeGTProviderProps, 'translations'>;
 type TranslationSnapshot = Record<Locale, LocaleTranslations>;
 
 export function GTProvider(props: GTProviderProps) {
-  const { loadingFallback, ...providerProps } = props;
-
-  return (
-    <LoadableGTProvider
-      {...providerProps}
-      loadingFallback={loadingFallback ?? <DefaultLoadingFallback />}
-    />
-  );
+  return <LoadableGTProvider {...props} />;
 }
 
 /**
  * This wrapper takes the place of a loader that would be present in
  * SSR style applications.
  */
-function LoadableGTProvider(
-  props: LoadableGTProviderProps & { loadingFallback: ReactNode }
-) {
+function LoadableGTProvider(props: GTProviderProps) {
   const { loadingFallback, ...providerProps } = props;
+  const fallback = loadingFallback ?? <DefaultLoadingFallback />;
   const { locale, region, enableI18n } = providerProps;
   // Keep native conditions in React state so condition-store writes trigger rerenders.
   const [nativeConditions, setNativeConditions] =
@@ -92,7 +83,7 @@ function LoadableGTProvider(
           translations={fallbackTranslations}
           _reload={reload}
         >
-          {loadingFallback}
+          {fallback}
         </NativeGTProvider>
       }
     >


### PR DESCRIPTION
## Summary
- Render the `gt-react-native` Suspense fallback inside `NativeGTProvider` with an empty translation snapshot.
- Share the resolved locale, region, enableI18n state, and reload callback between fallback and loaded provider paths.
- Prevent `loadingFallback={children}` from rendering app children outside GT context while translations load.

## Testing
- `pnpm --filter gt-react-native... build`
- `pnpm --filter gt-react-native test`
- `pnpm --filter gt-react-native typecheck`
- `pnpm exec oxfmt --check packages/react-native/src/provider/GTProvider.tsx`
- `pnpm exec oxlint packages/react-native/src/provider/GTProvider.tsx`

## Changeset
- Added patch changeset for `gt-react-native`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a gap in `gt-react-native`'s provider setup where the Suspense loading fallback was rendered without any GT context, meaning components inside it could not consume translations or locale state. The fix restructures `GTProvider` so the `Suspense` boundary lives inside `LoadableGTProvider`, and its fallback is always wrapped in a `NativeGTProvider` backed by an empty translation snapshot — sharing the same resolved locale, region, enableI18n, and reload callback with the fully-loaded path.

- `LoadableGTProvider` now owns locale resolution, the `reload` callback, and the `Suspense` boundary; `LoadedGTProvider` is a new, thin leaf component whose sole job is calling `use(loadTranslations(…))` and forwarding real translations to `NativeGTProvider`.
- The empty `fallbackTranslations` object `{ [activeLocale]: {} }` is memoized in `LoadableGTProvider` and passed directly to the fallback `NativeGTProvider`, ensuring the context shape is consistent between loading and loaded states.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The change is safe to merge; it correctly wraps the loading fallback in GT context without breaking the loaded path.

The restructuring is logically sound — locale resolution, the reload callback, and the Suspense boundary are all in the right place, and the empty-translation fallback snapshot is a clean solution. The only notable rough edge is the redundant resolveLocale call inside LoadedGTProvider, which relies silently on idempotency but does not cause wrong behavior. No data loss, no broken context, no missing required props.

Only GTProvider.tsx changed; the redundant resolveLocale call in LoadedGTProvider is worth a second look but is not blocking.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react-native/src/provider/GTProvider.tsx | Refactors GTProvider so the Suspense fallback is wrapped in NativeGTProvider (with empty translations), ensuring GT context is always available during loading. Introduces LoadedGTProvider as the suspending leaf; minor redundant resolveLocale call inside it. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant App
    participant GTProvider
    participant LoadableGTProvider
    participant Suspense
    participant NativeGTProvider_Fallback as NativeGTProvider (fallback)
    participant LoadedGTProvider
    participant NativeGTProvider_Loaded as NativeGTProvider (loaded)

    App->>GTProvider: render
    GTProvider->>LoadableGTProvider: render (with loadingFallback)
    LoadableGTProvider->>LoadableGTProvider: "resolveLocale / build reload / build fallbackTranslations={}"
    LoadableGTProvider->>Suspense: render

    Note over Suspense: While loadTranslations() is pending...
    Suspense->>NativeGTProvider_Fallback: render fallback
    NativeGTProvider_Fallback-->>App: GT context + empty translations + loadingFallback UI

    Note over Suspense: loadTranslations() resolves...
    Suspense->>LoadedGTProvider: render content
    LoadedGTProvider->>LoadedGTProvider: use(loadTranslations(locale)) ✓
    LoadedGTProvider->>NativeGTProvider_Loaded: render with real translations
    NativeGTProvider_Loaded-->>App: GT context + real translations + children
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant App
    participant GTProvider
    participant LoadableGTProvider
    participant Suspense
    participant NativeGTProvider_Fallback as NativeGTProvider (fallback)
    participant LoadedGTProvider
    participant NativeGTProvider_Loaded as NativeGTProvider (loaded)

    App->>GTProvider: render
    GTProvider->>LoadableGTProvider: render (with loadingFallback)
    LoadableGTProvider->>LoadableGTProvider: "resolveLocale / build reload / build fallbackTranslations={}"
    LoadableGTProvider->>Suspense: render

    Note over Suspense: While loadTranslations() is pending...
    Suspense->>NativeGTProvider_Fallback: render fallback
    NativeGTProvider_Fallback-->>App: GT context + empty translations + loadingFallback UI

    Note over Suspense: loadTranslations() resolves...
    Suspense->>LoadedGTProvider: render content
    LoadedGTProvider->>LoadedGTProvider: use(loadTranslations(locale)) ✓
    LoadedGTProvider->>NativeGTProvider_Loaded: render with real translations
    NativeGTProvider_Loaded-->>App: GT context + real translations + children
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Freact-native%2Fsrc%2Fprovider%2FGTProvider.tsx%3A110-111%0A%60LoadedGTProvider%60%20receives%20%60locale%60%20already%20resolved%20to%20a%20%60Locale%60%20string%20%28set%20to%20%60activeLocale%60%20by%20%60LoadableGTProvider%60%29%2C%20so%20calling%20%60resolveLocale%60%20a%20second%20time%20is%20redundant.%20While%20%60resolveSupportedLocale%60%20is%20effectively%20idempotent%20for%20a%20fully-resolved%20locale%2C%20this%20double-call%20adds%20an%20implicit%20dependency%20on%20that%20idempotency%20and%20makes%20the%20data%20flow%20less%20clear.%0A%0A%60%60%60suggestion%0Afunction%20LoadedGTProvider%28props%3A%20LoadedGTProviderProps%29%20%7B%0A%20%20const%20activeLocale%20%3D%20props.locale%20as%20string%3B%0A%60%60%60%0A%0A&repo=generaltranslation%2Fgt&pr=1800&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fodysseus%2Freact-native-loading-fallback%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fodysseus%2Freact-native-loading-fallback%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Freact-native%2Fsrc%2Fprovider%2FGTProvider.tsx%3A110-111%0A%60LoadedGTProvider%60%20receives%20%60locale%60%20already%20resolved%20to%20a%20%60Locale%60%20string%20%28set%20to%20%60activeLocale%60%20by%20%60LoadableGTProvider%60%29%2C%20so%20calling%20%60resolveLocale%60%20a%20second%20time%20is%20redundant.%20While%20%60resolveSupportedLocale%60%20is%20effectively%20idempotent%20for%20a%20fully-resolved%20locale%2C%20this%20double-call%20adds%20an%20implicit%20dependency%20on%20that%20idempotency%20and%20makes%20the%20data%20flow%20less%20clear.%0A%0A%60%60%60suggestion%0Afunction%20LoadedGTProvider%28props%3A%20LoadedGTProviderProps%29%20%7B%0A%20%20const%20activeLocale%20%3D%20props.locale%20as%20string%3B%0A%60%60%60%0A%0A&repo=generaltranslation%2Fgt&pr=1800&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/react-native/src/provider/GTProvider.tsx:110-111
`LoadedGTProvider` receives `locale` already resolved to a `Locale` string (set to `activeLocale` by `LoadableGTProvider`), so calling `resolveLocale` a second time is redundant. While `resolveSupportedLocale` is effectively idempotent for a fully-resolved locale, this double-call adds an implicit dependency on that idempotency and makes the data flow less clear.

```suggestion
function LoadedGTProvider(props: LoadedGTProviderProps) {
  const activeLocale = props.locale as string;
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: simplify native provider fallb..."](https://github.com/generaltranslation/gt/commit/e9de0ce6476efad8cca4f73d76f4220f314a199a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41575502)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->