### PR TITLE
fix: rename react native fallback prop

### DIFF
--- a/.changeset/react-native-fallback-option.md
+++ b/.changeset/react-native-fallback-option.md
@@ -1,0 +1,5 @@
+---
+"gt-react-native": patch
+---
+
+Rename the React Native `GTProvider` loading fallback prop to `fallback`.

--- a/packages/react-native/src/provider/GTProvider.tsx
+++ b/packages/react-native/src/provider/GTProvider.tsx
@@ -26,7 +26,7 @@ export type GTProviderProps = Omit<
   Omit<NativeConditionStoreParams, 'locale' | '_reload'> & {
     children?: ReactNode;
     locale?: LocaleCandidates;
-    loadingFallback?: ReactNode;
+    fallback?: ReactNode;
   };
 
 type LoadedGTProviderProps = Omit<NativeGTProviderProps, 'translations'>;
@@ -41,8 +41,8 @@ export function GTProvider(props: GTProviderProps) {
  * SSR style applications.
  */
 function LoadableGTProvider(props: GTProviderProps) {
-  const { loadingFallback, ...providerProps } = props;
-  const fallback = loadingFallback ?? <DefaultLoadingFallback />;
+  const { fallback, ...providerProps } = props;
+  const renderedFallback = fallback ?? <DefaultLoadingFallback />;
   const { locale, region, enableI18n } = providerProps;
   // Keep native conditions in React state so condition-store writes trigger rerenders.
   const [nativeConditions, setNativeConditions] =
@@ -83,7 +83,7 @@ function LoadableGTProvider(props: GTProviderProps) {
           translations={fallbackTranslations}
           _reload={reload}
         >
-          {fallback}
+          {renderedFallback}
         </NativeGTProvider>
       }
     >


### PR DESCRIPTION
## Summary
- Rename the React Native `GTProvider` loading fallback prop from `loadingFallback` to `fallback`.
- Add a patch changeset for `gt-react-native`.

## Testing
- `pnpm --filter gt-react-native... build`
- `pnpm --filter gt-react-native test`
- `pnpm --filter gt-react-native typecheck`
- `pnpm exec oxlint packages/react-native`
- `pnpm exec oxfmt --check packages/react-native/src/provider/GTProvider.tsx .changeset/react-native-fallback-option.md`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR renames the `GTProvider` loading fallback prop in `gt-react-native` from `loadingFallback` to `fallback`, and adds a patch changeset. The prop was introduced only one commit prior on this prerelease branch, so no stable-release consumers are affected.

- Renames `loadingFallback?: ReactNode` to `fallback?: ReactNode` in `GTProviderProps`, updates destructuring in `LoadableGTProvider`, and introduces `renderedFallback` as the resolved local variable to avoid shadowing the new prop name inside the JSX tree.
- Adds a `.changeset/react-native-fallback-option.md` entry marking the `gt-react-native` package for a patch release.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — this is a clean, self-contained prop rename with no remaining references to the old name anywhere in the package.

The rename is complete: the type definition, destructuring, and all JSX usages are consistently updated. The `loadingFallback` name was introduced only in the immediately preceding commit on this prerelease branch, so no stable-release consumers are affected. A repo-wide grep confirmed zero lingering references to the old prop name.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react-native/src/provider/GTProvider.tsx | Prop renamed from `loadingFallback` to `fallback`; local variable renamed to `renderedFallback` to prevent shadowing — logic is correct and all references updated. |
| .changeset/react-native-fallback-option.md | Changeset entry marks `gt-react-native` for a patch release; appropriate given the prop was first introduced on this prerelease branch in the immediately preceding commit. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User as App / User
    participant GTP as GTProvider
    participant LGTP as LoadableGTProvider
    participant Susp as React Suspense
    participant NGTP as NativeGTProvider
    participant LDGTP as LoadedGTProvider

    User->>GTP: "render GTProvider fallback={...}"
    GTP->>LGTP: forwards all props
    LGTP->>LGTP: "destructure { fallback, ...providerProps }"
    LGTP->>LGTP: "renderedFallback = fallback ?? DefaultLoadingFallback"
    LGTP->>Susp: "render Suspense fallback={NativeGTProvider > renderedFallback}"
    Susp-->>NGTP: (while loading) render NativeGTProvider w/ empty translations
    NGTP-->>User: shows renderedFallback inside GT context
    Susp->>LDGTP: (once loaded) render LoadedGTProvider
    LDGTP->>NGTP: render NativeGTProvider w/ real translations
    NGTP-->>User: shows app children with full i18n context
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User as App / User
    participant GTP as GTProvider
    participant LGTP as LoadableGTProvider
    participant Susp as React Suspense
    participant NGTP as NativeGTProvider
    participant LDGTP as LoadedGTProvider

    User->>GTP: "render GTProvider fallback={...}"
    GTP->>LGTP: forwards all props
    LGTP->>LGTP: "destructure { fallback, ...providerProps }"
    LGTP->>LGTP: "renderedFallback = fallback ?? DefaultLoadingFallback"
    LGTP->>Susp: "render Suspense fallback={NativeGTProvider > renderedFallback}"
    Susp-->>NGTP: (while loading) render NativeGTProvider w/ empty translations
    NGTP-->>User: shows renderedFallback inside GT context
    Susp->>LDGTP: (once loaded) render LoadedGTProvider
    LDGTP->>NGTP: render NativeGTProvider w/ real translations
    NGTP-->>User: shows app children with full i18n context
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: rename react native fallback prop"](https://github.com/generaltranslation/gt/commit/da56eda20cde87b414450913305c8a4ea34b98b4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41670715)</sub>

<!-- /greptile_comment -->