### PR TITLE
fix: interpolate default string helpers

### DIFF
--- a/.changeset/client-default-interpolation.md
+++ b/.changeset/client-default-interpolation.md
@@ -1,0 +1,7 @@
+---
+'@generaltranslation/react-core': patch
+'gt-next': patch
+---
+
+Fix source interpolation for default-locale string helpers.
+Clarify that `tx()` does not apply ICU formatting by default.

--- a/packages/next/src/server-dir/runtime/tx.ts
+++ b/packages/next/src/server-dir/runtime/tx.ts
@@ -26,7 +26,7 @@ type TxOptions = FormatVariables & {
  * @param {string} [options.$context] - Additional context for the translation process, which may influence the translation's outcome.
  * @param {number} [options.$maxChars] - The maximum number of characters to translate.
  * @param {string|number|boolean|Date} [options.<variable>] - Variables to interpolate into the message, passed as top-level keys (e.g. `{ price: 29.99 }`).
- * @param {StringFormat} [options.$format] - The data format for the message (e.g., 'ICU', 'STRING'). Defaults to 'ICU'.
+ * @param {StringFormat} [options.$format] - The data format for the message. ICU formatting is only applied when explicitly requested with `$format: 'ICU'`.
  *
  * @returns {Promise<string>} - A promise that resolves to the translated content string, or the original content if no translation is needed.
  *

--- a/packages/react-core/src/functions/translation/__tests__/t.test.ts
+++ b/packages/react-core/src/functions/translation/__tests__/t.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ReactI18nCache } from '../../../i18n-cache/ReactI18nCache';
+import { setReactI18nCache } from '../../../i18n-cache/singleton-operations';
+import { setReadonlyConditionStore } from '../../../condition-store/singleton-operations';
+import { initializeI18nConfig } from '../../../setup/i18nConfig';
+import { t } from '../t';
+
+type TestGlobal = typeof globalThis & {
+  __generaltranslation?: unknown;
+};
+
+function resetGTGlobals() {
+  Reflect.deleteProperty(globalThis as TestGlobal, '__generaltranslation');
+}
+
+const lookupTranslation = vi.fn();
+
+function setup() {
+  initializeI18nConfig(
+    {
+      defaultLocale: 'en',
+      locales: ['en', 'fr'],
+    },
+    'SPA'
+  );
+  setReadonlyConditionStore({
+    getLocale: () => 'en',
+    getRegion: () => undefined,
+    getEnableI18n: () => true,
+    setLocale: () => {},
+    setRegion: () => {},
+    setEnableI18n: () => {},
+  });
+  setReactI18nCache({
+    lookupTranslation,
+  } as unknown as ReactI18nCache);
+}
+
+describe('t', () => {
+  beforeEach(() => {
+    resetGTGlobals();
+    lookupTranslation.mockReset();
+    setup();
+  });
+
+  it('interpolates source strings when translation is not required', () => {
+    expect(t('hello, {name}', { name: 'brian' })).toBe('hello, brian');
+  });
+
+  it('keeps tagged template literal lookup in string format', () => {
+    t`hello, ${'brian'}`;
+
+    expect(lookupTranslation).toHaveBeenCalledWith('en', 'hello, brian', {
+      $format: 'STRING',
+    });
+  });
+});

--- a/packages/react-core/src/functions/translation/t.ts
+++ b/packages/react-core/src/functions/translation/t.ts
@@ -41,7 +41,11 @@ export const t: StringOrTemplateSyncResolutionFunction = (
   if (typeof messageOrStrings === 'string') {
     const options = values.at(0) as GTTranslationOptions | undefined;
     const locale = options?.$locale ?? getLocale();
-    return resolveStringContent(locale, messageOrStrings, options);
+    return resolveStringContent(
+      locale,
+      messageOrStrings,
+      createLookupOptions(locale, options ?? {}, 'ICU')
+    );
   }
 
   // t`Hello, ${name}`

--- a/packages/react-core/src/hooks/__tests__/useGT.test.ts
+++ b/packages/react-core/src/hooks/__tests__/useGT.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useLocale } from '../condition-store';
+import { useTrackedTranslationResolver } from '../external-store/useTrackedTranslationResolver';
+import { useDefaultLocale } from '../i18n-config';
+import { useShouldTranslate } from '../utils';
+import { useGT } from '../useGT';
+
+vi.mock('react', () => ({
+  useCallback: <T extends (...args: unknown[]) => unknown>(callback: T) =>
+    callback,
+}));
+
+vi.mock('../condition-store', () => ({
+  useLocale: vi.fn(),
+}));
+
+vi.mock('../external-store/useTrackedTranslationResolver', () => ({
+  useTrackedTranslationResolver: vi.fn(),
+}));
+
+vi.mock('../i18n-config', () => ({
+  useDefaultLocale: vi.fn(),
+}));
+
+vi.mock('../utils', () => ({
+  useShouldTranslate: vi.fn(),
+}));
+
+describe('useGT', () => {
+  beforeEach(() => {
+    vi.mocked(useLocale).mockReturnValue('en');
+    vi.mocked(useDefaultLocale).mockReturnValue('en');
+    vi.mocked(useShouldTranslate).mockReturnValue(false);
+    vi.mocked(useTrackedTranslationResolver).mockReturnValue(vi.fn());
+  });
+
+  it('interpolates source strings when translation is not required', () => {
+    const gt = useGT();
+
+    expect(gt('hello, {name}', { name: 'brian' })).toBe('hello, brian');
+  });
+});

--- a/packages/react-core/src/hooks/useGT.ts
+++ b/packages/react-core/src/hooks/useGT.ts
@@ -23,19 +23,20 @@ export function useGT(_messages?: Message[]): GTFunctionType {
    */
   return useCallback(
     (message: string, options: GTTranslationOptions = {}) => {
-      if (!shouldTranslate) {
-        return interpolateMessage({
-          options,
-          source: message,
-          sourceLocale: defaultLocale,
-        });
-      }
-
       const lookupOptions = createLookupOptions<StringFormat>(
         options.$locale ?? locale,
         options,
         'ICU'
       );
+
+      if (!shouldTranslate) {
+        return interpolateMessage({
+          options: lookupOptions,
+          source: message,
+          sourceLocale: defaultLocale,
+        });
+      }
+
       const translation = resolveTranslation({
         locale: lookupOptions.$locale,
         message,


### PR DESCRIPTION
## Summary
- Normalize source fallback options for `useGT()` and standalone `t("...", options)` so ICU placeholders interpolate when translation is not required.
- Preserve tagged-template lookup behavior; the tagged form still uses the existing string-format lookup path.
- Clarify `tx()` docs so ICU formatting is described as opt-in via `$format: 'ICU'`.
- Add patch changeset entries for `@generaltranslation/react-core` and `gt-next`.

## Testing
- `pnpm --filter @generaltranslation/react-core test`
- `pnpm --filter @generaltranslation/react-core typecheck`
- `pnpm format`
- `pnpm --filter @generaltranslation/react-core... build`
- Linked `gt-test-apps/base/next-app-router` to this worktree and verified dev + production builds/browser locale switching for `gt("hello, {name}", { name: "brian" })` in `en`, `fr`, and `zh`.