### PR TITLE
fix: avoid formatjs type enum runtime import

### DIFF
--- a/packages/core/src/derive/condenseVars.ts
+++ b/packages/core/src/derive/condenseVars.ts
@@ -1,12 +1,10 @@
-import {
-  type ArgumentElement,
-  TYPE,
-} from '@formatjs/icu-messageformat-parser/types.js';
+import type { ArgumentElement } from '@formatjs/icu-messageformat-parser/types.js';
 import { printAST } from '@formatjs/icu-messageformat-parser/printer.js';
 import { traverseIcu } from './utils/traverseIcu';
 import { VAR_IDENTIFIER } from './utils/constants';
 import { GTIndexedSelectElement } from './utils/types';
 import { isGTIndexedSelectElement } from './utils/traverseHelpers';
+import { ICU_TYPE } from './utils/icuTypes';
 interface GTIndexedArgumentElement extends ArgumentElement {
   value: `${typeof VAR_IDENTIFIER}${number}`;
 }
@@ -29,7 +27,7 @@ export function condenseVars(icuString: string): string {
 
   // Replace with argument
   function visitor(child: GTIndexedSelectElement): void {
-    (child as unknown as GTIndexedArgumentElement).type = TYPE.argument;
+    (child as unknown as GTIndexedArgumentElement).type = ICU_TYPE.argument;
     Reflect.deleteProperty(child, 'options');
   }
 

--- a/packages/core/src/derive/utils/icuTypes.ts
+++ b/packages/core/src/derive/utils/icuTypes.ts
@@ -1,0 +1,8 @@
+// Keep these in sync with @formatjs/icu-messageformat-parser's TYPE enum.
+export const ICU_TYPE = {
+  literal: 0,
+  argument: 1,
+  select: 5,
+  plural: 6,
+  tag: 8,
+} as const;

--- a/packages/core/src/derive/utils/traverseHelpers.ts
+++ b/packages/core/src/derive/utils/traverseHelpers.ts
@@ -3,22 +3,20 @@ import {
   GT_UNINDEXED_IDENTIFIER_REGEX,
 } from './regex';
 import { GTIndexedSelectElement, GTUnindexedSelectElement } from './types';
-import {
-  type MessageFormatElement,
-  TYPE,
-} from '@formatjs/icu-messageformat-parser/types.js';
+import type { MessageFormatElement } from '@formatjs/icu-messageformat-parser/types.js';
+import { ICU_TYPE } from './icuTypes';
 
 // Visit any _gt_# select
 export function isGTIndexedSelectElement(
   child: MessageFormatElement
 ): child is GTIndexedSelectElement {
   return (
-    child.type === TYPE.select &&
+    child.type === ICU_TYPE.select &&
     GT_INDEXED_IDENTIFIER_REGEX.test(child.value) &&
     !!child.options.other &&
     (child.options.other.value.length === 0 ||
       (child.options.other.value.length > 0 &&
-        child.options.other.value[0]?.type === TYPE.literal))
+        child.options.other.value[0]?.type === ICU_TYPE.literal))
   );
 }
 
@@ -27,11 +25,11 @@ export function isGTUnindexedSelectElement(
   child: MessageFormatElement
 ): child is GTUnindexedSelectElement {
   return (
-    child.type === TYPE.select &&
+    child.type === ICU_TYPE.select &&
     GT_UNINDEXED_IDENTIFIER_REGEX.test(child.value) &&
     !!child.options.other &&
     (child.options.other.value.length === 0 ||
       (child.options.other.value.length > 0 &&
-        child.options.other.value[0]?.type === TYPE.literal))
+        child.options.other.value[0]?.type === ICU_TYPE.literal))
   );
 }

--- a/packages/core/src/derive/utils/traverseIcu.ts
+++ b/packages/core/src/derive/utils/traverseIcu.ts
@@ -2,8 +2,8 @@ import {
   MessageFormatElement,
   parse,
   ParserOptions,
-  TYPE,
 } from '@formatjs/icu-messageformat-parser';
+import { ICU_TYPE } from './icuTypes';
 
 type TraverseIcuOptions = ParserOptions & {
   recurseIntoVisited?: boolean;
@@ -46,11 +46,11 @@ export function traverseIcu<T extends MessageFormatElement>({
     }
     // recurse on children
     if (!visited || recurseIntoVisited) {
-      if (child.type === TYPE.select || child.type === TYPE.plural) {
+      if (child.type === ICU_TYPE.select || child.type === ICU_TYPE.plural) {
         Object.values(child.options)
           .map((option) => option.value)
           .map(handleChildren);
-      } else if (child.type === TYPE.tag) {
+      } else if (child.type === ICU_TYPE.tag) {
         handleChildren(child.children);
       }
     }


### PR DESCRIPTION
## Summary
- replace runtime imports of the FormatJS `TYPE` enum in core derive helpers with local ICU type constants
- keep FormatJS AST imports type-only where they use the `types.js` subpath
- fixes TanStack Start dev hydration failing on `types.js` not exporting `TYPE`

## Testing
- `pnpm --filter generaltranslation test`
- `pnpm --filter generaltranslation build`
- `pnpm build`
- linked `gt-test-apps/base/tanstack-start` to this worktree, built it, and verified the `/ssr` locale selector in dev and preview for `fr`, `zh`, and `en`

## Notes
- No changeset included per task instructions.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces runtime imports of the FormatJS `TYPE` enum (sourced from `@formatjs/icu-messageformat-parser/types.js`) with a small local constant object `ICU_TYPE` in the four `core` derive helpers. The motivation is that certain bundlers used by TanStack Start in dev mode fail to resolve the `types.js` subpath as a runtime import, causing hydration errors.

- **`icuTypes.ts` (new):** Defines `ICU_TYPE` with the five enum values actually used in the codebase (`literal=0`, `argument=1`, `select=5`, `plural=6`, `tag=8`). All values were verified against the FormatJS source and are correct. A `as const` assertion gives TypeScript literal-type precision.
- **`condenseVars.ts`, `traverseHelpers.ts`, `traverseIcu.ts`:** All `TYPE` references are replaced with `ICU_TYPE`; all remaining FormatJS imports that carry only types are now correctly `import type`, eliminating the runtime symbol entirely.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the fix is narrow, the replacement values are verified correct, and no logic changes were made.

The five numeric constants in ICU_TYPE were cross-checked against the FormatJS source and are accurate. The only open question is whether future FormatJS versions could change these values without a compile-time catch, but that risk is low given how stable the ICU format is. All import type usage is correct and the runtime enum dependency is fully eliminated.

packages/core/src/derive/utils/icuTypes.ts — worth adding a compile-time sync guard so drift from the upstream enum is caught by the TypeScript compiler automatically.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/derive/utils/icuTypes.ts | New file defining local ICU_TYPE constants — numeric values verified correct against FormatJS source (literal=0, argument=1, select=5, plural=6, tag=8), but sync is comment-only with no compile-time guard |
| packages/core/src/derive/condenseVars.ts | Replaces runtime TYPE import from types.js with ICU_TYPE; keeps ArgumentElement as a type-only import; straightforward and correct |
| packages/core/src/derive/utils/traverseHelpers.ts | Swaps TYPE (runtime) for ICU_TYPE (local const) in two type-guard functions; logic is unchanged, values are correct |
| packages/core/src/derive/utils/traverseIcu.ts | Drops TYPE from the main parser import and uses ICU_TYPE instead; removes the only remaining runtime dependency on the FormatJS enum across all four files |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["@formatjs/icu-messageformat-parser/types.js"]
    B["icuTypes.ts\n(new)\nICU_TYPE local const"]
    C["condenseVars.ts"]
    D["traverseHelpers.ts"]
    E["traverseIcu.ts"]

    A -- "import type only\n(no runtime symbol)" --> C
    A -- "import type only\n(no runtime symbol)" --> D
    B -- "runtime value\nICU_TYPE.select/plural/tag/…" --> C
    B -- "runtime value\nICU_TYPE.select/literal" --> D
    B -- "runtime value\nICU_TYPE.select/plural/tag" --> E

    style A fill:#f9f,stroke:#999
    style B fill:#9cf,stroke:#36a
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["@formatjs/icu-messageformat-parser/types.js"]
    B["icuTypes.ts\n(new)\nICU_TYPE local const"]
    C["condenseVars.ts"]
    D["traverseHelpers.ts"]
    E["traverseIcu.ts"]

    A -- "import type only\n(no runtime symbol)" --> C
    A -- "import type only\n(no runtime symbol)" --> D
    B -- "runtime value\nICU_TYPE.select/plural/tag/…" --> C
    B -- "runtime value\nICU_TYPE.select/literal" --> D
    B -- "runtime value\nICU_TYPE.select/plural/tag" --> E

    style A fill:#f9f,stroke:#999
    style B fill:#9cf,stroke:#36a
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fcore%2Fsrc%2Fderive%2Futils%2FicuTypes.ts%3A1-8%0AThe%20comment%20is%20the%20only%20mechanism%20keeping%20%60ICU_TYPE%60%20in%20sync%20with%20the%20FormatJS%20%60TYPE%60%20enum.%20A%20compile-time%20assertion%20using%20the%20type-only%20import%20%28which%20is%20already%20safe%20to%20use%20here%29%20would%20catch%20any%20future%20drift%20without%20adding%20a%20runtime%20dependency.%20The%20five%20values%20in%20the%20new%20constant%20are%20correct%20today%2C%20but%20a%20future%20FormatJS%20major%20version%20could%20silently%20break%20this.%0A%0A%60%60%60suggestion%0Aimport%20type%20%7B%20TYPE%20%7D%20from%20'%40formatjs%2Ficu-messageformat-parser%2Ftypes.js'%3B%0A%0A%2F%2F%20Keep%20these%20in%20sync%20with%20%40formatjs%2Ficu-messageformat-parser's%20TYPE%20enum.%0Aexport%20const%20ICU_TYPE%20%3D%20%7B%0A%20%20literal%3A%200%2C%0A%20%20argument%3A%201%2C%0A%20%20select%3A%205%2C%0A%20%20plural%3A%206%2C%0A%20%20tag%3A%208%2C%0A%7D%20as%20const%3B%0A%0A%2F%2F%20Compile-time%20guard%3A%20fails%20if%20any%20value%20drifts%20from%20the%20FormatJS%20TYPE%20enum.%0Atype%20_SyncCheck%20%3D%20%7B%0A%20%20%5BK%20in%20keyof%20typeof%20ICU_TYPE%5D%3A%20%28typeof%20ICU_TYPE%29%5BK%5D%20extends%20TYPE%20%3F%20true%20%3A%20never%3B%0A%7D%3B%0A%60%60%60%0A%0A&repo=generaltranslation%2Fgt&pr=1804&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fodysseus%2Ftanstack-dev-formatjs-type-export%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fodysseus%2Ftanstack-dev-formatjs-type-export%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fcore%2Fsrc%2Fderive%2Futils%2FicuTypes.ts%3A1-8%0AThe%20comment%20is%20the%20only%20mechanism%20keeping%20%60ICU_TYPE%60%20in%20sync%20with%20the%20FormatJS%20%60TYPE%60%20enum.%20A%20compile-time%20assertion%20using%20the%20type-only%20import%20%28which%20is%20already%20safe%20to%20use%20here%29%20would%20catch%20any%20future%20drift%20without%20adding%20a%20runtime%20dependency.%20The%20five%20values%20in%20the%20new%20constant%20are%20correct%20today%2C%20but%20a%20future%20FormatJS%20major%20version%20could%20silently%20break%20this.%0A%0A%60%60%60suggestion%0Aimport%20type%20%7B%20TYPE%20%7D%20from%20'%40formatjs%2Ficu-messageformat-parser%2Ftypes.js'%3B%0A%0A%2F%2F%20Keep%20these%20in%20sync%20with%20%40formatjs%2Ficu-messageformat-parser's%20TYPE%20enum.%0Aexport%20const%20ICU_TYPE%20%3D%20%7B%0A%20%20literal%3A%200%2C%0A%20%20argument%3A%201%2C%0A%20%20select%3A%205%2C%0A%20%20plural%3A%206%2C%0A%20%20tag%3A%208%2C%0A%7D%20as%20const%3B%0A%0A%2F%2F%20Compile-time%20guard%3A%20fails%20if%20any%20value%20drifts%20from%20the%20FormatJS%20TYPE%20enum.%0Atype%20_SyncCheck%20%3D%20%7B%0A%20%20%5BK%20in%20keyof%20typeof%20ICU_TYPE%5D%3A%20%28typeof%20ICU_TYPE%29%5BK%5D%20extends%20TYPE%20%3F%20true%20%3A%20never%3B%0A%7D%3B%0A%60%60%60%0A%0A&repo=generaltranslation%2Fgt&pr=1804&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/core/src/derive/utils/icuTypes.ts:1-8
The comment is the only mechanism keeping `ICU_TYPE` in sync with the FormatJS `TYPE` enum. A compile-time assertion using the type-only import (which is already safe to use here) would catch any future drift without adding a runtime dependency. The five values in the new constant are correct today, but a future FormatJS major version could silently break this.

```suggestion
import type { TYPE } from '@formatjs/icu-messageformat-parser/types.js';

// Keep these in sync with @formatjs/icu-messageformat-parser's TYPE enum.
export const ICU_TYPE = {
  literal: 0,
  argument: 1,
  select: 5,
  plural: 6,
  tag: 8,
} as const;

// Compile-time guard: fails if any value drifts from the FormatJS TYPE enum.
type _SyncCheck = {
  [K in keyof typeof ICU_TYPE]: (typeof ICU_TYPE)[K] extends TYPE ? true : never;
};
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: avoid formatjs type enum runtime im..."](https://github.com/generaltranslation/gt/commit/5841b7c614dde0a5164fd6119c0fea5e3e269d1d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41678155)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->