### PR TITLE
fix: address CodeQL regex warnings

### DIFF
--- a/.changeset/codeql-path-regex.md
+++ b/.changeset/codeql-path-regex.md
@@ -1,0 +1,5 @@
+---
+'gt-next': patch
+---
+
+Escape backslashes in middleware path regex input before dynamic path matching.

--- a/packages/next/src/middleware-dir/__tests__/utils.test.ts
+++ b/packages/next/src/middleware-dir/__tests__/utils.test.ts
@@ -382,6 +382,19 @@ describe('getSharedPath', () => {
     ).toBe('/user/[id]/settings');
   });
 
+  it('should preserve regex metacharacter matching outside dynamic segments', () => {
+    const pathMap = {
+      '/files/v.+/[^/]+': '/files/[version]/[id]',
+    };
+
+    expect(getSharedPath('/files/v12/report', pathMap, undefined)).toBe(
+      '/files/[version]/[id]'
+    );
+    expect(getSharedPath('/files/v.+/report', pathMap, undefined)).toBe(
+      '/files/[version]/[id]'
+    );
+  });
+
   it('should return undefined for no matches', () => {
     expect(getSharedPath('/nonexistent', pathToSharedPath, undefined)).toBe(
       undefined

--- a/packages/next/src/middleware-dir/utils.ts
+++ b/packages/next/src/middleware-dir/utils.ts
@@ -20,6 +20,13 @@ export type ResponseConfig = {
   localeHeaderName: string;
 };
 
+const DYNAMIC_PATH_SEGMENT_PATTERN = '/[^/]+';
+const PATH_REGEX_SLASHES = /[\\/]/g;
+
+function escapePathRegexSlashes(pathPattern: string): string {
+  return pathPattern.replace(PATH_REGEX_SLASHES, '\\$&');
+}
+
 export function getResponse({
   type,
   originalUrl,
@@ -207,9 +214,9 @@ export function getSharedPath(
   // Try regex pattern match
   let candidateSharedPath = undefined;
   for (const [pattern, sharedPath] of Object.entries(pathToSharedPath)) {
-    if (pattern.includes('/[^/]+')) {
+    if (pattern.includes(DYNAMIC_PATH_SEGMENT_PATTERN)) {
       // Convert the pattern to a strict regex that matches the exact path structure
-      const regex = new RegExp(`^${pattern.replace(/\//g, '\\/')}$`);
+      const regex = new RegExp(`^${escapePathRegexSlashes(pattern)}$`);
       // Exact match
       if (regex.test(standardizedPathname)) {
         return sharedPath;
@@ -245,8 +252,8 @@ function inDefaultLocalePaths(
 
   // Try regex pattern match
   for (const path of defaultLocalePaths) {
-    if (path.includes('/[^/]+')) {
-      const regex = new RegExp(`^${path.replace(/\//g, '\\/')}$`);
+    if (path.includes(DYNAMIC_PATH_SEGMENT_PATTERN)) {
+      const regex = new RegExp(`^${escapePathRegexSlashes(path)}$`);
       if (regex.test(pathname)) {
         return true;
       }

--- a/tsdown.preset.mts
+++ b/tsdown.preset.mts
@@ -144,9 +144,40 @@ function resolveSourceFile(source: string, importer: string): string | null {
 function hasUseClientDirective(file: string): boolean {
   if (!existsSync(file)) return false;
   const code = readFileSync(file, 'utf8');
-  return /^\s*(?:(?:\/\/[^\n]*|\/\*[\s\S]*?\*\/)\s*)*['"]use client['"];?/.test(
-    code
+  const index = firstCodeIndex(code);
+  return (
+    code.startsWith("'use client'", index) ||
+    code.startsWith('"use client"', index)
   );
+}
+
+function firstCodeIndex(code: string): number {
+  let index = 0;
+  while (index < code.length) {
+    if (isWhitespace(code[index])) {
+      index += 1;
+      continue;
+    }
+
+    if (code.startsWith('//', index)) {
+      const nextLine = code.indexOf('\n', index + 2);
+      index = nextLine === -1 ? code.length : nextLine + 1;
+      continue;
+    }
+
+    if (code.startsWith('/*', index)) {
+      const commentEnd = code.indexOf('*/', index + 2);
+      index = commentEnd === -1 ? code.length : commentEnd + 2;
+      continue;
+    }
+
+    return index;
+  }
+  return index;
+}
+
+function isWhitespace(character: string): boolean {
+  return /\s/.test(character);
 }
 
 function outputSpecifier({


### PR DESCRIPTION
## Summary
- Escape backslashes alongside slashes before compiling middleware dynamic path regexes.
- Preserve existing regex metacharacter behavior outside dynamic path segments.
- Replace the tsdown use-client detector regex with a small scanner for leading whitespace/comments.

## Tests
- `pnpm exec oxfmt --check packages/next/src/middleware-dir/utils.ts packages/next/src/middleware-dir/__tests__/utils.test.ts tsdown.preset.mts .changeset/codeql-path-regex.md`
- `pnpm exec oxlint packages/next/src/middleware-dir/utils.ts packages/next/src/middleware-dir/__tests__/utils.test.ts tsdown.preset.mts`
- `pnpm --filter gt-next exec vitest run src/middleware-dir/__tests__/utils.test.ts`
- `pnpm --filter gt-next test:js`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two CodeQL regex warnings: it escapes regex metacharacters in static path segments before constructing dynamic path regexes in middleware path matching, and replaces the `use client` directive detector regex in `tsdown.preset.mts` with a manual whitespace/comment scanner using `startsWith`.

- **`packages/next/src/middleware-dir/utils.ts`**: Introduces `escapeRegexLiteral` and `createPathRegex` so that literal characters like `.`, `+`, and `\\` in static portions of path patterns are escaped before regex construction, preventing untrusted path strings from injecting regex syntax.
- **`tsdown.preset.mts`**: Replaces a potentially catastrophic `[\\s\\S]*?` regex over entire file contents with an explicit character-by-character scanner (`firstCodeIndex` + `isWhitespace`) that locates the first non-comment token and then uses a plain `startsWith` check.
- **`packages/next/src/middleware-dir/__tests__/utils.test.ts`**: Adds a regression test for literal regex metacharacters in path patterns (targeting `getSharedPath`).

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the regex escaping logic is correct and the manual comment-skipping scanner in tsdown replaces a problematic regex without introducing new edge-case failures.

The split-escape-rejoin approach in `createPathRegex` is mechanically sound — static segments are isolated, escaped, and reassembled with the raw dynamic pattern — and the `firstCodeIndex` scanner correctly handles all standard JS comment and whitespace forms. The only gap is a missing test for `inDefaultLocalePaths` with metacharacter inputs, which is addressed by the same underlying helper that is already tested via `getSharedPath`.

A test for `inDefaultLocalePaths` with literal metacharacter path patterns would be a worthwhile addition to `packages/next/src/middleware-dir/__tests__/utils.test.ts`.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/next/src/middleware-dir/utils.ts | Adds `escapeRegexLiteral` and `createPathRegex` to safely build path-matching regexes; the split-escape-rejoin logic is correct and applied consistently to both `getSharedPath` and `inDefaultLocalePaths`. |
| packages/next/src/middleware-dir/__tests__/utils.test.ts | Adds a regression test for metacharacter escaping in `getSharedPath`; the parallel fix in `inDefaultLocalePaths` is not covered by a test. |
| tsdown.preset.mts | Replaces a ReDoS-prone multi-line regex with a simple linear scanner; `firstCodeIndex` correctly handles line comments, block comments, and all ASCII whitespace. |
| .changeset/codeql-path-regex.md | Changelog entry for the patch; accurately describes the fix. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["path pattern string"] --> B{includes DYNAMIC_PATH_SEGMENT_PATTERN?}
    B -- No --> C[Skip — use exact string match only]
    B -- Yes --> D["split on '/[^/]+' → static segments array"]
    D --> E["map: escapeRegexLiteral each static segment"]
    E --> F["join with '/[^/]+' → escaped pattern string"]
    F --> G["new RegExp('^' + escaped + '$')"]
    G --> H["regex.test(pathname)"]
    H -- match --> I[Return shared path / true]
    H -- no match --> J[Continue to next pattern]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["path pattern string"] --> B{includes DYNAMIC_PATH_SEGMENT_PATTERN?}
    B -- No --> C[Skip — use exact string match only]
    B -- Yes --> D["split on '/[^/]+' → static segments array"]
    D --> E["map: escapeRegexLiteral each static segment"]
    E --> F["join with '/[^/]+' → escaped pattern string"]
    F --> G["new RegExp('^' + escaped + '$')"]
    G --> H["regex.test(pathname)"]
    H -- match --> I[Return shared path / true]
    H -- no match --> J[Continue to next pattern]
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fnext%2Fsrc%2Fmiddleware-dir%2F__tests__%2Futils.test.ts%3A385-396%0A**Missing%20test%20coverage%20for%20%60inDefaultLocalePaths%60**%0A%0AThe%20new%20test%20only%20exercises%20%60getSharedPath%60%2C%20but%20%60inDefaultLocalePaths%60%20received%20the%20same%20%60createPathRegex%60%20fix%20at%20line%20264%20of%20%60utils.ts%60.%20A%20path%20config%20entry%20like%20%60'%2Ffiles%2F%5C%5Cd%2B%2F%5B%5E%2F%5D%2B'%60%20in%20%60defaultLocalePaths%60%20would%20exercise%20the%20same%20code%20path%3B%20without%20a%20test%2C%20a%20future%20refactor%20of%20%60inDefaultLocalePaths%60%20could%20silently%20re-introduce%20the%20metacharacter%20injection%20without%20a%20red%20test.%0A%0A&repo=generaltranslation%2Fgt&pr=1807&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fodysseus%2Fcodeql-escaping-regex%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fodysseus%2Fcodeql-escaping-regex%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fnext%2Fsrc%2Fmiddleware-dir%2F__tests__%2Futils.test.ts%3A385-396%0A**Missing%20test%20coverage%20for%20%60inDefaultLocalePaths%60**%0A%0AThe%20new%20test%20only%20exercises%20%60getSharedPath%60%2C%20but%20%60inDefaultLocalePaths%60%20received%20the%20same%20%60createPathRegex%60%20fix%20at%20line%20264%20of%20%60utils.ts%60.%20A%20path%20config%20entry%20like%20%60'%2Ffiles%2F%5C%5Cd%2B%2F%5B%5E%2F%5D%2B'%60%20in%20%60defaultLocalePaths%60%20would%20exercise%20the%20same%20code%20path%3B%20without%20a%20test%2C%20a%20future%20refactor%20of%20%60inDefaultLocalePaths%60%20could%20silently%20re-introduce%20the%20metacharacter%20injection%20without%20a%20red%20test.%0A%0A&repo=generaltranslation%2Fgt&pr=1807&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/next/src/middleware-dir/__tests__/utils.test.ts:385-396
**Missing test coverage for `inDefaultLocalePaths`**

The new test only exercises `getSharedPath`, but `inDefaultLocalePaths` received the same `createPathRegex` fix at line 264 of `utils.ts`. A path config entry like `'/files/\\d+/[^/]+'` in `defaultLocalePaths` would exercise the same code path; without a test, a future refactor of `inDefaultLocalePaths` could silently re-introduce the metacharacter injection without a red test.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: address codeql regex warnings"](https://github.com/generaltranslation/gt/commit/c25b772982a235848d184b95cd83304f3ca445f6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41710502)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->