### PR TITLE
chore: exit odysseus prerelease mode

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "odysseus",
   "initialVersions": {
     "gt": "2.14.37",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - odysseus
 
 permissions:
   id-token: write # Required for OIDC


### PR DESCRIPTION
## Summary

- Mark Changesets prerelease mode as `exit` so the normal `main` release workflow can generate the stable release PR after `odysseus` merges.
- Stop the release workflow from triggering on `odysseus`, preventing another Odysseus prerelease run once pre mode has exited.

## Validation

- `pnpm exec oxfmt --check .changeset/pre.json .github/workflows/release.yml`
- `git diff --check`
- `pnpm exec changeset status --since origin/main --verbose`
- Throwaway worktree: ran `pnpm run version-packages` with `GITHUB_TOKEN` to confirm Changesets removes `.changeset/pre.json`, consumes queued changesets, and produces stable package versions.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR exits the Changesets prerelease mode for the `odysseus` release and stops the release workflow from firing on the `odysseus` branch, preparing the repo for a stable publish once `odysseus` merges to `main`.

- **`.changeset/pre.json`**: Flips `mode` from `\"pre\"` to `\"exit\"`, so the next `version-packages` run on `main` will consume all 60+ queued changesets and produce stable semver versions rather than another prerelease.
- **`.github/workflows/release.yml`**: Removes `odysseus` from the `on.push.branches` trigger, preventing any spurious prerelease CI run now that exit mode is set. The existing `odysseus-release` job (`if: github.ref_name == 'odysseus'`) becomes unreachable dead code but causes no harm.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Two-line config-only change with no production logic modified; safe to merge.

Both changes are mechanical and well-scoped: flipping a single JSON field in pre.json and removing one branch from a workflow trigger. The author validated the end-to-end behavior in a throwaway worktree before opening the PR. The odysseus-release job left in the workflow is harmless dead code — it can only fire when ref_name == 'odysseus', which can no longer happen since odysseus was removed from the trigger list.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .changeset/pre.json | Sets Changesets mode from "pre" to "exit", signaling the next version-packages run should consume all queued changesets and produce stable (non-prerelease) versions. |
| .github/workflows/release.yml | Removes the `odysseus` branch from the `on.push.branches` trigger, preventing the workflow from running on any further pushes to `odysseus`. The `odysseus-release` job remains in the file but is now unreachable dead code since no push to `odysseus` can trigger the workflow. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Dev as Developer
    participant Odysseus as odysseus branch
    participant Main as main branch
    participant CS as Changesets Action
    participant NPM as npm registry

    Dev->>Odysseus: Merge this PR (mode: exit, remove odysseus trigger)
    Note over Odysseus: pre.json mode = "exit"<br/>No more CI runs on odysseus

    Odysseus->>Main: "Merge odysseus -> main"
    Main->>CS: Push triggers Release workflow (main only)
    CS->>CS: Detects exit mode in pre.json
    CS->>Main: Opens stable release PR (consumes queued changesets, removes pre.json)
    Main->>CS: Release PR merged
    CS->>NPM: Publishes stable package versions
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Dev as Developer
    participant Odysseus as odysseus branch
    participant Main as main branch
    participant CS as Changesets Action
    participant NPM as npm registry

    Dev->>Odysseus: Merge this PR (mode: exit, remove odysseus trigger)
    Note over Odysseus: pre.json mode = "exit"<br/>No more CI runs on odysseus

    Odysseus->>Main: "Merge odysseus -> main"
    Main->>CS: Push triggers Release workflow (main only)
    CS->>CS: Detects exit mode in pre.json
    CS->>Main: Opens stable release PR (consumes queued changesets, removes pre.json)
    Main->>CS: Release PR merged
    CS->>NPM: Publishes stable package versions
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: exit odysseus prerelease mode"](https://github.com/generaltranslation/gt/commit/13e425cea7f490e481470da8aafba41216dcc854) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41721295)</sub>

<!-- /greptile_comment -->