### PR TITLE
perf(react-core): stub dev hot-reload hooks in production

### DIFF
--- a/.changeset/dev-hot-reload-dce.md
+++ b/.changeset/dev-hot-reload-dce.md
@@ -1,0 +1,6 @@
+---
+"@generaltranslation/react-core": patch
+"gt-i18n": patch
+---
+
+Statically gate dev hot-reload code paths (tracked resolver invalidation, missing-translation queue, T hot-reload fallbacks, getGT dev preload) behind `process.env.NODE_ENV !== 'production'` so bundlers can drop them from production builds. Behavior is unchanged: the existing runtime `isDevHotReloadEnabled()` check still applies in development.

--- a/.changeset/dev-hot-reload-production-stubs.md
+++ b/.changeset/dev-hot-reload-production-stubs.md
@@ -1,0 +1,5 @@
+---
+"@generaltranslation/react-core": patch
+---
+
+Use production no-op stubs for dev hot-reload hooks so bundlers can drop more dev-only hot-reload code.

--- a/packages/i18n/src/translation-functions/internal/getGT.ts
+++ b/packages/i18n/src/translation-functions/internal/getGT.ts
@@ -42,7 +42,11 @@ export async function getGTInternal(
   // Get the translation resolver
   const i18nCache = getI18nCache();
   const sourceLocale = getI18nConfig().getDefaultLocale();
-  const devHotReloadEnabled = getI18nConfig().isDevHotReloadEnabled();
+  // Statically gated so bundlers can drop dev hot-reload work from
+  // production builds.
+  const devHotReloadEnabled =
+    process.env.NODE_ENV !== 'production' &&
+    getI18nConfig().isDevHotReloadEnabled();
   const lookupTranslation = await i18nCache.getLookupTranslation(
     enableI18n ? locale : sourceLocale
   );

--- a/packages/react-core/src/components/translation/T.rsc.tsx
+++ b/packages/react-core/src/components/translation/T.rsc.tsx
@@ -44,7 +44,10 @@ async function RscT({
 
   let targetJsxChildren: JsxChildren | undefined;
   const i18nCache = getReactI18nCache();
-  if (getI18nConfig().isDevHotReloadEnabled()) {
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    getI18nConfig().isDevHotReloadEnabled()
+  ) {
     targetJsxChildren = await i18nCache.lookupTranslationWithFallback(
       locale,
       prepared.sourceJsxChildren,

--- a/packages/react-core/src/components/translation/T.tsx
+++ b/packages/react-core/src/components/translation/T.tsx
@@ -61,6 +61,7 @@ function useComputeT({
   // TODO: account for success vs loading vs failed request states
   const prev = useRef<ReactNode | null>(null);
   if (
+    process.env.NODE_ENV !== 'production' &&
     getI18nConfig().isDevHotReloadEnabled() &&
     targetJsxChildren == null &&
     prev.current != null &&

--- a/packages/react-core/src/hooks/external-store.ts
+++ b/packages/react-core/src/hooks/external-store.ts
@@ -31,7 +31,11 @@ export function useTranslate<T extends Translation>(
     () => i18nStore.getTranslateSnapshot(lookup, translationsSnapshot)
   );
 
-  if (storeTranslation == null && getI18nConfig().isDevHotReloadEnabled()) {
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    storeTranslation == null &&
+    getI18nConfig().isDevHotReloadEnabled()
+  ) {
     // TODO: (separate PR): add configuration for a use() + suspense strategy
     // TODO: consider moving this to a useEffect
     onMissingTranslation(lookup);

--- a/packages/react-core/src/hooks/external-store/__tests__/useSubscribeToTrackedLookups.test.ts
+++ b/packages/react-core/src/hooks/external-store/__tests__/useSubscribeToTrackedLookups.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type Subscribe = (listener: () => void) => () => void;
+type GetSnapshot = () => number;
+
+const reactMocks = vi.hoisted(() => ({
+  useCallback: vi.fn(
+    <T extends (...args: unknown[]) => unknown>(callback: T) => callback
+  ),
+  useRef: vi.fn(<T>(initialValue: T) => ({ current: initialValue })),
+  useSyncExternalStore: vi.fn(),
+}));
+
+vi.mock('react', () => reactMocks);
+
+const originalNodeEnv = process.env.NODE_ENV;
+
+describe('useSubscribeToTrackedLookups', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  it('does not subscribe to tracked lookup events in production', async () => {
+    process.env.NODE_ENV = 'production';
+    const subscribeToEvents = vi.fn(() => vi.fn());
+    const { useSubscribeToTrackedLookups } =
+      await import('../useSubscribeToTrackedLookups');
+
+    useSubscribeToTrackedLookups(
+      { current: new Set(['matching-key']) },
+      subscribeToEvents,
+      (lookup: { key: string }) => lookup.key
+    );
+
+    expect(subscribeToEvents).not.toHaveBeenCalled();
+    expect(reactMocks.useSyncExternalStore).not.toHaveBeenCalled();
+  });
+
+  it('subscribes and filters tracked lookup events in development', async () => {
+    process.env.NODE_ENV = 'development';
+    const listener = vi.fn();
+    const unsubscribe = vi.fn();
+    let onEvent: ((lookup: { key: string }) => void) | undefined;
+    const subscribeToEvents = vi.fn((callback) => {
+      onEvent = callback;
+      return unsubscribe;
+    });
+
+    reactMocks.useSyncExternalStore.mockImplementationOnce(
+      (subscribe: Subscribe, getSnapshot: GetSnapshot) => {
+        expect(subscribe(listener)).toBe(unsubscribe);
+        return getSnapshot();
+      }
+    );
+    const { useSubscribeToTrackedLookups } =
+      await import('../useSubscribeToTrackedLookups');
+
+    useSubscribeToTrackedLookups(
+      { current: new Set(['matching-key']) },
+      subscribeToEvents,
+      (lookup: { key: string }) => lookup.key
+    );
+
+    expect(subscribeToEvents).toHaveBeenCalledTimes(1);
+
+    onEvent?.({ key: 'other-key' });
+    expect(listener).not.toHaveBeenCalled();
+
+    onEvent?.({ key: 'matching-key' });
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/react-core/src/hooks/external-store/useSubscribeToTrackedLookups.ts
+++ b/packages/react-core/src/hooks/external-store/useSubscribeToTrackedLookups.ts
@@ -6,6 +6,12 @@ import {
 } from 'react';
 import type { StoreListener, Unsubscribe } from '../../i18n-store/storeTypes';
 
+type UseSubscribeToTrackedLookups = <L>(
+  trackedKeysRef: RefObject<Set<string> | null>,
+  subscribeToEvents: (onEvent: (lookup: L) => void) => Unsubscribe,
+  getListenerKey: (lookup: L) => string
+) => void;
+
 /**
  * Subscribe to store events, but only trigger re-renders when the event's
  * lookup is in the tracked keys set. Shared by the tracked translation and
@@ -16,7 +22,7 @@ import type { StoreListener, Unsubscribe } from '../../i18n-store/storeTypes';
  * updated. This is technically not pure, but it is an acceptable trade since it
  * only drives dev translation hot reload.
  */
-export function useSubscribeToTrackedLookups<L>(
+function useSubscribeToTrackedLookupsDev<L>(
   trackedKeysRef: RefObject<Set<string> | null>,
   subscribeToEvents: (onEvent: (lookup: L) => void) => Unsubscribe,
   getListenerKey: (lookup: L) => string
@@ -24,15 +30,23 @@ export function useSubscribeToTrackedLookups<L>(
   // invalidation counter for triggering updates
   const versionRef = useRef(0);
   const subscribe = useCallback(
-    (listener: StoreListener) =>
-      subscribeToEvents((lookup) => {
+    (listener: StoreListener) => {
+      return subscribeToEvents((lookup) => {
         if (!trackedKeysRef.current!.has(getListenerKey(lookup))) return;
         versionRef.current++;
         listener();
-      }),
+      });
+    },
     [subscribeToEvents, getListenerKey, trackedKeysRef]
   );
   const getSnapshot = useCallback(() => versionRef.current, []);
 
   useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 }
+
+const useSubscribeToTrackedLookupsProd: UseSubscribeToTrackedLookups = () => {};
+
+export const useSubscribeToTrackedLookups: UseSubscribeToTrackedLookups =
+  process.env.NODE_ENV === 'production'
+    ? useSubscribeToTrackedLookupsProd
+    : useSubscribeToTrackedLookupsDev;

--- a/packages/react-core/src/hooks/external-store/useTrackedDictionaryObjResolver.ts
+++ b/packages/react-core/src/hooks/external-store/useTrackedDictionaryObjResolver.ts
@@ -19,7 +19,9 @@ export type TrackedDictionaryObjResolver = (
 export function useTrackedDictionaryObjResolver(): TrackedDictionaryObjResolver {
   const dictionariesSnapshot = useDictionariesSnapshot();
   const i18nStore = useI18nStore();
-  const devHotReloadEnabled = getI18nConfig().isDevHotReloadEnabled();
+  const devHotReloadEnabled =
+    process.env.NODE_ENV !== 'production' &&
+    getI18nConfig().isDevHotReloadEnabled();
   const onMissingDictionaryObj = useHandleMissingDictionaryObject();
 
   const trackedKeysRef = useRef<Set<string> | null>(null);

--- a/packages/react-core/src/hooks/external-store/useTrackedDictionaryResolver.ts
+++ b/packages/react-core/src/hooks/external-store/useTrackedDictionaryResolver.ts
@@ -19,7 +19,9 @@ export type TrackedDictionaryEntryResolver = (
 export function useTrackedDictionaryResolver(): TrackedDictionaryEntryResolver {
   const dictionariesSnapshot = useDictionariesSnapshot();
   const i18nStore = useI18nStore();
-  const devHotReloadEnabled = getI18nConfig().isDevHotReloadEnabled();
+  const devHotReloadEnabled =
+    process.env.NODE_ENV !== 'production' &&
+    getI18nConfig().isDevHotReloadEnabled();
   const onMissingDictionaryEntry = useHandleMissingDictionaryEntry();
 
   const trackedKeysRef = useRef<Set<string> | null>(null);

--- a/packages/react-core/src/hooks/external-store/useTrackedTranslationResolver.ts
+++ b/packages/react-core/src/hooks/external-store/useTrackedTranslationResolver.ts
@@ -49,7 +49,9 @@ export function useTrackedTranslationResolver(
 ): TrackedTranslationResolver {
   const translationsSnapshot = useTranslationsSnapshot();
   const i18nStore = useI18nStore();
-  const devHotReloadEnabled = getI18nConfig().isDevHotReloadEnabled();
+  const devHotReloadEnabled =
+    process.env.NODE_ENV !== 'production' &&
+    getI18nConfig().isDevHotReloadEnabled();
   const onMissingTranslation = useHandleMissingTranslation();
 
   /**
@@ -114,7 +116,9 @@ function usePreloadCompilerLookups(
 ) {
   const i18nStore = useI18nStore();
   const locale = useLocale();
-  const devHotReloadEnabled = getI18nConfig().isDevHotReloadEnabled();
+  const devHotReloadEnabled =
+    process.env.NODE_ENV !== 'production' &&
+    getI18nConfig().isDevHotReloadEnabled();
   const shouldTranslate = useShouldTranslate();
   const translationsSnapshot = useTranslationsSnapshot();
   const txHotReloadEnabled = useMemo(() => {

--- a/packages/react-core/src/hooks/utils/missing-translation.ts
+++ b/packages/react-core/src/hooks/utils/missing-translation.ts
@@ -99,7 +99,11 @@ export function useHandleMissingDictionaryObject(): OnMissingDictionaryObj {
  * HMR translation needs to be deferred to post-commit phase
  */
 function useDevHotReloadQueue() {
-  const devHotReloadEnabled = getI18nConfig().isDevHotReloadEnabled();
+  // Statically gated so bundlers can drop dev hot-reload work from
+  // production builds.
+  const devHotReloadEnabled =
+    process.env.NODE_ENV !== 'production' &&
+    getI18nConfig().isDevHotReloadEnabled();
   const shouldTranslate = useShouldTranslate();
   const i18nStore = useI18nStore();
 

--- a/packages/react-core/src/hooks/utils/missing-translation.ts
+++ b/packages/react-core/src/hooks/utils/missing-translation.ts
@@ -38,8 +38,16 @@ type PendingLookup =
  * in development hot reload
  */
 
+const noopOnMissingTranslation: OnMissingTranslation = () => {};
+const noopOnMissingDictionaryEntry: OnMissingDictionaryEntry = () => {};
+const noopOnMissingDictionaryObj: OnMissingDictionaryObj = () => {};
+
 // TODO: reduce code duplication with the three below functions
-export function useHandleMissingTranslation(): OnMissingTranslation {
+function useHandleMissingTranslationProd(): OnMissingTranslation {
+  return noopOnMissingTranslation;
+}
+
+function useHandleMissingTranslationDev(): OnMissingTranslation {
   const customHandleMissing = useGTContext()?.onMissingTranslation;
   const pureHandleMissing = useDevHotReloadQueue();
 
@@ -58,7 +66,11 @@ export function useHandleMissingTranslation(): OnMissingTranslation {
   );
 }
 
-export function useHandleMissingDictionaryEntry(): OnMissingDictionaryEntry {
+function useHandleMissingDictionaryEntryProd(): OnMissingDictionaryEntry {
+  return noopOnMissingDictionaryEntry;
+}
+
+function useHandleMissingDictionaryEntryDev(): OnMissingDictionaryEntry {
   const customHandleMissing = useGTContext()?.onMissingDictionaryEntry;
   const pureHandleMissing = useDevHotReloadQueue();
 
@@ -77,7 +89,11 @@ export function useHandleMissingDictionaryEntry(): OnMissingDictionaryEntry {
   );
 }
 
-export function useHandleMissingDictionaryObject(): OnMissingDictionaryObj {
+function useHandleMissingDictionaryObjectProd(): OnMissingDictionaryObj {
+  return noopOnMissingDictionaryObj;
+}
+
+function useHandleMissingDictionaryObjectDev(): OnMissingDictionaryObj {
   const customHandleMissing = useGTContext()?.onMissingDictionaryObj;
   const pureHandleMissing = useDevHotReloadQueue();
   return useCallback(
@@ -94,6 +110,21 @@ export function useHandleMissingDictionaryObject(): OnMissingDictionaryObj {
     [customHandleMissing, pureHandleMissing]
   );
 }
+
+export const useHandleMissingTranslation: () => OnMissingTranslation =
+  process.env.NODE_ENV === 'production'
+    ? useHandleMissingTranslationProd
+    : useHandleMissingTranslationDev;
+
+export const useHandleMissingDictionaryEntry: () => OnMissingDictionaryEntry =
+  process.env.NODE_ENV === 'production'
+    ? useHandleMissingDictionaryEntryProd
+    : useHandleMissingDictionaryEntryDev;
+
+export const useHandleMissingDictionaryObject: () => OnMissingDictionaryObj =
+  process.env.NODE_ENV === 'production'
+    ? useHandleMissingDictionaryObjectProd
+    : useHandleMissingDictionaryObjectDev;
 
 /**
  * HMR translation needs to be deferred to post-commit phase


### PR DESCRIPTION
## TL;DR

Follow-up to #1811. This moves the remaining dev hot-reload hook implementations behind module-level production stubs so production bundlers can drop more dev-only hot-reload code.

## Code Changes

- Exports a production no-op implementation of `useSubscribeToTrackedLookups`, while preserving the existing dev subscription implementation.
- Exports production no-op missing-translation handlers, while preserving the existing dev queue implementation.
- Adds focused tests that production does not subscribe and development still filters tracked lookup events.
- Adds a changeset for `@generaltranslation/react-core`.

## Bundle Check

Measured against temp tarball installs in `~/code/bengubler.com`, comparing this branch against #1811's rebased branch.

Commands used:

```sh
pnpm --filter @generaltranslation/react-core test
pnpm --filter @generaltranslation/react-core typecheck
pnpm lint

# In temp copies of ~/code/bengubler.com with gt packages installed from local tarballs:
pnpm install --force --dir /tmp/gt-pr-1771-followup-measure/baseline-app
pnpm install --force --dir /tmp/gt-pr-1771-followup-measure/experiment-app
pnpm exec next experimental-analyze --output
NEXT_TELEMETRY_DISABLED=1 pnpm exec next build
```

Observed impact vs #1811:

- Homepage analyzer client JS: -701 raw bytes / -272 analyzer-compressed bytes; GT-attributed: -698 raw / -274 compressed.
- Emitted browser static JS: -699 raw bytes / -104 gzip bytes.
- Route analyzer aggregate across 23 route records: GT-attributed -20.0 KB raw / -7.8 KB compressed. This is route-attributed analyzer output, not a single browser payload.

## Notes / Flags

This intentionally keeps dev behavior in the dev implementation, but makes the production export a no-op at module scope so bundlers have a cleaner DCE target.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR follows up on #1811 by applying the production-stub/DCE pattern to `useSubscribeToTrackedLookups` and the three `useHandleMissing*` hooks in `missing-translation.ts`. Each dev implementation is renamed with a `Dev` suffix, a module-level production no-op is assigned for the `Prod` variant, and the export is a module-level conditional so bundlers can dead-code-eliminate the dev branch.

- `useSubscribeToTrackedLookups.ts`: production export is now `() => {}`, preventing `useSyncExternalStore` and event subscription overhead in production builds; dev path is unchanged.
- `missing-translation.ts`: all three handler hooks return stable module-level no-op functions in production, preserving the dev hot-reload queue only for development; call sites in `external-store.ts` and `useTrackedTranslationResolver.ts` are already guarded by `process.env.NODE_ENV !== 'production'` checks before invoking these handlers, so no behavioral change occurs.
- New test file verifies the production no-op and dev event-filtering behaviors for `useSubscribeToTrackedLookups`.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; all call sites already guard with process.env.NODE_ENV !== 'production' before invoking these handlers, so the production no-ops introduce no behavioral change.

The module-level conditional assignments are a well-understood bundler DCE pattern, and cross-checking the call sites in external-store.ts and useTrackedTranslationResolver.ts confirms the production no-ops are never reached by paths that would have exercised the dev queue or custom handler. The new tests cover the production and dev branches of useSubscribeToTrackedLookups correctly. The only gap is parallel test coverage for the missing-translation.ts stubs.

missing-translation.ts would benefit from tests mirroring those added for useSubscribeToTrackedLookups.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react-core/src/hooks/external-store/useSubscribeToTrackedLookups.ts | Renames dev implementation to useSubscribeToTrackedLookupsDev, adds a module-level production no-op, and exports the appropriate variant based on process.env.NODE_ENV for DCE. |
| packages/react-core/src/hooks/utils/missing-translation.ts | Applies the same production-stub pattern to all three missing-translation handler hooks; production variants return stable module-level no-ops, dev variants retain full hook logic. |
| packages/react-core/src/hooks/external-store/__tests__/useSubscribeToTrackedLookups.test.ts | New test file verifying production no-op (no subscriptions, no useSyncExternalStore) and dev filtering (matching key triggers listener, non-matching does not). |
| .changeset/dev-hot-reload-production-stubs.md | Patch-level changeset entry for @generaltranslation/react-core. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Module Evaluation] --> B{NODE_ENV === production?}
    B -- yes --> C[Prod no-op variants\nAll four hooks return stable empty functions]
    B -- no --> D[Dev variants\nuseSubscribeToTrackedLookupsDev\nuseHandleMissingTranslationDev\nuseHandleMissingDictionaryEntryDev\nuseHandleMissingDictionaryObjectDev]
    C --> E[Bundler DCE eliminates\nDev variants and all\ndev-only dependencies]
    D --> F[useDevHotReloadQueue\nuseGTContext\nuseSyncExternalStore\nuseEffect]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Module Evaluation] --> B{NODE_ENV === production?}
    B -- yes --> C[Prod no-op variants\nAll four hooks return stable empty functions]
    B -- no --> D[Dev variants\nuseSubscribeToTrackedLookupsDev\nuseHandleMissingTranslationDev\nuseHandleMissingDictionaryEntryDev\nuseHandleMissingDictionaryObjectDev]
    C --> E[Bundler DCE eliminates\nDev variants and all\ndev-only dependencies]
    D --> F[useDevHotReloadQueue\nuseGTContext\nuseSyncExternalStore\nuseEffect]
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Freact-core%2Fsrc%2Fhooks%2Futils%2Fmissing-translation.ts%3A114-127%0A**No%20tests%20for%20the%20%60missing-translation.ts%60%20production%20stubs**%0A%0AThe%20PR%20adds%20a%20focused%20test%20suite%20for%20%60useSubscribeToTrackedLookups%60%20covering%20both%20the%20production%20no-op%20and%20development%20filtering%20paths%2C%20but%20the%20identical%20%22production%20returns%20stable%20noop%2C%20dev%20calls%20hooks%22%20pattern%20introduced%20for%20%60useHandleMissingTranslation%60%2C%20%60useHandleMissingDictionaryEntry%60%2C%20and%20%60useHandleMissingDictionaryObject%60%20has%20no%20corresponding%20tests.%20Since%20%60vi.resetModules%28%29%60%20%2B%20dynamic%20import%20is%20already%20the%20established%20pattern%20in%20the%20new%20test%20file%2C%20adding%20a%20parallel%20set%20of%20tests%20for%20these%20three%20exports%20would%20complete%20the%20coverage%20story.%0A%0A&repo=generaltranslation%2Fgt&pr=1812&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22bg%2Fdev-hot-reload-dce-followup%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22bg%2Fdev-hot-reload-dce-followup%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Freact-core%2Fsrc%2Fhooks%2Futils%2Fmissing-translation.ts%3A114-127%0A**No%20tests%20for%20the%20%60missing-translation.ts%60%20production%20stubs**%0A%0AThe%20PR%20adds%20a%20focused%20test%20suite%20for%20%60useSubscribeToTrackedLookups%60%20covering%20both%20the%20production%20no-op%20and%20development%20filtering%20paths%2C%20but%20the%20identical%20%22production%20returns%20stable%20noop%2C%20dev%20calls%20hooks%22%20pattern%20introduced%20for%20%60useHandleMissingTranslation%60%2C%20%60useHandleMissingDictionaryEntry%60%2C%20and%20%60useHandleMissingDictionaryObject%60%20has%20no%20corresponding%20tests.%20Since%20%60vi.resetModules%28%29%60%20%2B%20dynamic%20import%20is%20already%20the%20established%20pattern%20in%20the%20new%20test%20file%2C%20adding%20a%20parallel%20set%20of%20tests%20for%20these%20three%20exports%20would%20complete%20the%20coverage%20story.%0A%0A&repo=generaltranslation%2Fgt&pr=1812&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/react-core/src/hooks/utils/missing-translation.ts:114-127
**No tests for the `missing-translation.ts` production stubs**

The PR adds a focused test suite for `useSubscribeToTrackedLookups` covering both the production no-op and development filtering paths, but the identical "production returns stable noop, dev calls hooks" pattern introduced for `useHandleMissingTranslation`, `useHandleMissingDictionaryEntry`, and `useHandleMissingDictionaryObject` has no corresponding tests. Since `vi.resetModules()` + dynamic import is already the established pattern in the new test file, adding a parallel set of tests for these three exports would complete the coverage story.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["perf(react-core): stub dev hot-reload ho..."](https://github.com/generaltranslation/gt/commit/53375775309b0314db68066ac66bc7480ce387db) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41721676)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->