### PR TITLE
fix: vendor FormatJS ICU printer to avoid CommonJS printer subpath import

### DIFF
--- a/.changeset/tanstack-printast-dev.md
+++ b/.changeset/tanstack-printast-dev.md
@@ -1,0 +1,5 @@
+---
+"generaltranslation": patch
+---
+
+Vendor the FormatJS ICU AST printer so the ESM internal build no longer imports the CommonJS `printer.js` subpath, which Vite-based dev servers (e.g. TanStack Start) cannot load. Serialized output is byte-identical, so hashes are unchanged.

--- a/packages/core/src/__tests__/core-esm.test.ts
+++ b/packages/core/src/__tests__/core-esm.test.ts
@@ -105,6 +105,17 @@ describe('generaltranslation/core export', () => {
       "from '@formatjs/icu-messageformat-parser/types.js'"
     );
   });
+
+  it('does not leave the CommonJS FormatJS printer in the ESM graph', () => {
+    const internalEsmGraph = readBuiltFileGraph('internal.mjs').join('\n');
+
+    expect(internalEsmGraph).not.toContain(
+      'from "@formatjs/icu-messageformat-parser/printer.js"'
+    );
+    expect(internalEsmGraph).not.toContain(
+      "from '@formatjs/icu-messageformat-parser/printer.js'"
+    );
+  });
 });
 
 function readBuiltFileGraph(entryFileName: string) {

--- a/packages/core/src/derive/__tests__/condenseVarsPrinterRegression.test.ts
+++ b/packages/core/src/derive/__tests__/condenseVarsPrinterRegression.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest';
+import { parse } from '@formatjs/icu-messageformat-parser';
+import { condenseVars } from '../condenseVars';
+
+// Pins the exact serialized output produced by the FormatJS `printAST`
+// implementation that condenseVars historically used. The vendored printer
+// must keep every one of these outputs byte-identical, because the condensed
+// strings feed into hashing.
+describe('condenseVars printer regression', () => {
+  it.each([
+    ['single indexed select', '{_gt_1, select, other {}}', '{_gt_1}'],
+    [
+      'leading and trailing literals',
+      'Start {_gt_1, select, other {}} end.',
+      'Start {_gt_1} end.',
+    ],
+    ['plain argument', '{name} {_gt_1, select, other {}}', '{name} {_gt_1}'],
+    [
+      'number without style',
+      '{n, number} {_gt_1, select, other {}}',
+      '{n, number} {_gt_1}',
+    ],
+    [
+      'number with percent style',
+      '{n, number, percent} {_gt_1, select, other {}}',
+      '{n, number, percent} {_gt_1}',
+    ],
+    [
+      'number with simple skeleton',
+      '{n, number, ::percent} {_gt_1, select, other {}}',
+      '{n, number, ::percent} {_gt_1}',
+    ],
+    [
+      'number skeleton with token option',
+      '{n, number, ::compact-short currency/GBP} {_gt_1, select, other {}}',
+      '{n, number, ::compact-short currency/GBP} {_gt_1}',
+    ],
+    [
+      'number skeleton with multiple tokens',
+      '{n, number, ::percent .00 rounding-mode-floor} {_gt_1, select, other {}}',
+      '{n, number, ::percent .00 rounding-mode-floor} {_gt_1}',
+    ],
+    [
+      'number skeleton with multiple options',
+      '{n, number, ::currency/CAD unit-width-narrow} {_gt_1, select, other {}}',
+      '{n, number, ::currency/CAD unit-width-narrow} {_gt_1}',
+    ],
+    [
+      'date without style',
+      '{d, date} {_gt_1, select, other {}}',
+      '{d, date} {_gt_1}',
+    ],
+    [
+      'date with full style',
+      '{d, date, full} {_gt_1, select, other {}}',
+      '{d, date, full} {_gt_1}',
+    ],
+    [
+      'date with skeleton',
+      '{d, date, ::yyyyMMdd} {_gt_1, select, other {}}',
+      '{d, date, ::yyyyMMdd} {_gt_1}',
+    ],
+    [
+      'time with short style',
+      '{t, time, short} {_gt_1, select, other {}}',
+      '{t, time, short} {_gt_1}',
+    ],
+    [
+      'time with skeleton',
+      '{t, time, ::HHmm} {_gt_1, select, other {}}',
+      '{t, time, ::HHmm} {_gt_1}',
+    ],
+    [
+      'select with multiple options',
+      '{gender, select, male {He} female {She} other {They}} {_gt_1, select, other {}}',
+      '{gender,select,male{He} female{She} other{They}} {_gt_1}',
+    ],
+    [
+      'plural with pound',
+      '{count, plural, one {# item} other {# items}} {_gt_1, select, other {}}',
+      '{count,plural,one{# item} other{# items}} {_gt_1}',
+    ],
+    [
+      'plural with offset and exact matches',
+      '{count, plural, offset:2 =0 {none} =1 {one} other {# left}} {_gt_1, select, other {}}',
+      '{count,plural,offset:2 =0{none} =1{one} other{# left}} {_gt_1}',
+    ],
+    [
+      'selectordinal with pound',
+      '{place, selectordinal, one {#st} two {#nd} few {#rd} other {#th}} {_gt_1, select, other {}}',
+      '{place,selectordinal,one{#st} two{#nd} few{#rd} other{#th}} {_gt_1}',
+    ],
+    [
+      'indexed vars nested in plural with pound',
+      '{count, plural, one {# {_gt_1, select, other {}}} other {# {_gt_2, select, other {}}}}',
+      '{count,plural,one{# {_gt_1}} other{# {_gt_2}}}',
+    ],
+    [
+      'deeply nested indexed var',
+      '{count, plural, one {{status, select, yes {{_gt_1, select, other {}}} other {none}}} other {No}}',
+      '{count,plural,one{{status,select,yes{{_gt_1}} other{none}}} other{No}}',
+    ],
+    [
+      'nested tags',
+      '<b>Bold <i>italic {_gt_1, select, other {}}</i></b>',
+      '<b>Bold <i>italic {_gt_1}</i></b>',
+    ],
+    [
+      'tag with argument sibling',
+      '<link>Click {target} {_gt_1, select, other {}}</link>',
+      '<link>Click {target} {_gt_1}</link>',
+    ],
+    [
+      'quoted braces',
+      "Cost: '{'price'}' {_gt_1, select, other {}}",
+      "Cost: '{price}' {_gt_1}",
+    ],
+    [
+      'quoted brace run',
+      "Show '{'raw'}' and '}' {_gt_1, select, other {}}",
+      "Show '{raw} and }' {_gt_1}",
+    ],
+    [
+      'escaped apostrophes',
+      "It''s {_gt_1, select, other {}} o''clock",
+      "It's {_gt_1} o'clock",
+    ],
+    [
+      'lone apostrophe after select',
+      "{_gt_1, select, other {}}'s book",
+      "{_gt_1}''s book",
+    ],
+    [
+      'escaped pound inside plural',
+      "{count, plural, other {'#' # {_gt_1, select, other {}}}}",
+      "{count,plural,other{'#' # {_gt_1}}}",
+    ],
+    [
+      'unicode and emoji',
+      'Héllo 🎉 {_gt_1, select, other {}}',
+      'Héllo 🎉 {_gt_1}',
+    ],
+    [
+      'newlines and indentation',
+      'Line 1\nHas {_gt_1, select, other {}}\n  indented',
+      'Line 1\nHas {_gt_1}\n  indented',
+    ],
+    [
+      'adjacent indexed vars and argument',
+      '{_gt_1, select, other {}}{name}{_gt_2, select, other {}}',
+      '{_gt_1}{name}{_gt_2}',
+    ],
+    [
+      'indexed select with non-empty options',
+      '{_gt_1, select, one {won} other {lost}} trailing',
+      '{_gt_1} trailing',
+    ],
+  ])('serializes %s exactly as before', (_name, input, expected) => {
+    const result = condenseVars(input);
+
+    expect(result).toBe(expected);
+    expect(() => parse(result)).not.toThrow();
+  });
+});

--- a/packages/core/src/derive/condenseVars.ts
+++ b/packages/core/src/derive/condenseVars.ts
@@ -1,6 +1,6 @@
 import { TYPE } from '@formatjs/icu-messageformat-parser';
 import type { ArgumentElement } from '@formatjs/icu-messageformat-parser/types.js';
-import { printAST } from '@formatjs/icu-messageformat-parser/printer.js';
+import { printIcuAst } from './utils/printIcuAst';
 import { traverseIcu } from './utils/traverseIcu';
 import { VAR_IDENTIFIER } from './utils/constants';
 import { GTIndexedSelectElement } from './utils/types';
@@ -39,5 +39,5 @@ export function condenseVars(icuString: string): string {
   });
 
   // Serialize
-  return printAST(ast);
+  return printIcuAst(ast);
 }

--- a/packages/core/src/derive/utils/__tests__/printIcuAst.test.ts
+++ b/packages/core/src/derive/utils/__tests__/printIcuAst.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { parse } from '@formatjs/icu-messageformat-parser';
+// Test-only import of the CommonJS subpath the vendored printer replaces;
+// vitest runs in Node where CJS interop works.
+import { printAST } from '@formatjs/icu-messageformat-parser/printer.js';
+import { printIcuAst } from '../printIcuAst';
+
+const MESSAGES = [
+  '',
+  'Plain text without any variables',
+  'Hello {name}',
+  'Héllo 🎉 {name}, line\nbreak\tand tab',
+  '{a}{b}{c}',
+  // simple format elements with and without styles
+  '{n, number}',
+  '{n, number, percent}',
+  '{d, date}',
+  '{d, date, full}',
+  '{t, time}',
+  '{t, time, short}',
+  // number and date/time skeletons
+  '{n, number, ::percent}',
+  '{n, number, ::compact-short currency/GBP}',
+  '{n, number, ::percent .00 rounding-mode-floor}',
+  '{n, number, ::currency/CAD unit-width-narrow}',
+  '{n, number, ::measure-unit/length-meter unit-width-full-name}',
+  '{n, number, ::scale/0.01}',
+  '{d, date, ::yyyyMMdd}',
+  '{t, time, ::HHmm}',
+  // select
+  '{gender, select, male {He} female {She} other {They}}',
+  '{status, select, yes {{name} accepted} other {none}}',
+  '{_gt_1, select, other {}}',
+  // plural / selectordinal
+  '{count, plural, one {# item} other {# items}}',
+  '{count, plural, offset:2 =0 {none} =1 {one} other {# left}}',
+  '{place, selectordinal, one {#st} two {#nd} few {#rd} other {#th}}',
+  '{place, selectordinal, offset:1 one {a} other {b}}',
+  "{count, plural, other {'#' # {name}}}",
+  "{count, plural, other {'##' twice}}",
+  // nesting
+  '{count, plural, one {{status, select, yes {{name}} other {none}}} other {No}}',
+  '{status, select, a {{count, plural, one {#} other {## {name}}}} other {b}}',
+  // tags
+  '<b>Bold <i>italic {name}</i></b>',
+  '<link>Click {target}</link>',
+  '{count, plural, one {<b># item</b>} other {<b># items</b>}}',
+  // literal escaping
+  "Cost: '{'price'}'",
+  "Show '{'raw'}' and '}'",
+  "It''s {name} o''clock",
+  "{name}'s book",
+  "Hi ''{name}",
+  "{name}'' more",
+  "Join {_gt_1, select, other {Haas''}}",
+  'This literal mentions _gt_1 but has no select',
+];
+
+describe('printIcuAst', () => {
+  describe('matches FormatJS printAST byte-for-byte', () => {
+    it.each(MESSAGES.map((message) => [message]))('for %j', (message) => {
+      const ast = parse(message);
+
+      expect(printIcuAst(ast)).toBe(printAST(ast));
+    });
+
+    it.each(MESSAGES.map((message) => [message]))(
+      'for %j without parsed skeletons',
+      (message) => {
+        const ast = parse(message, { shouldParseSkeletons: false });
+
+        expect(printIcuAst(ast)).toBe(printAST(ast));
+      }
+    );
+  });
+
+  // FormatJS printAST emits `{_gt_1,select,other{Haas'}}` here; the trailing
+  // apostrophe swallows the closing brace on reparse. The vendored printer
+  // reproduces upstream output byte-for-byte, so it inherits the quirk.
+  // condenseVars never hits it: indexed selects are condensed to plain
+  // arguments before printing.
+  const UPSTREAM_REPARSE_QUIRKS = new Set([
+    "Join {_gt_1, select, other {Haas''}}",
+  ]);
+
+  it.each(
+    MESSAGES.filter(
+      (message) => message !== '' && !UPSTREAM_REPARSE_QUIRKS.has(message)
+    ).map((message) => [message])
+  )('produces reparseable output for %j', (message) => {
+    const printed = printIcuAst(parse(message));
+
+    expect(() => parse(printed)).not.toThrow();
+  });
+});

--- a/packages/core/src/derive/utils/printIcuAst.ts
+++ b/packages/core/src/derive/utils/printIcuAst.ts
@@ -1,3 +1,32 @@
+// The code in this file is adapted from the FormatJS printer,
+// https://github.com/formatjs/formatjs/blob/main/packages/icu-messageformat-parser/printer.ts
+// (published as `@formatjs/icu-messageformat-parser/printer.js`)
+// And is therefore MIT licensed
+
+/*!
+MIT License
+
+Copyright (c) 2023 FormatJS
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 import { SKELETON_TYPE, TYPE } from '@formatjs/icu-messageformat-parser';
 import type {
   DateElement,
@@ -16,11 +45,11 @@ type SimpleFormatStyle = NonNullable<
 >;
 
 /**
- * Vendored from FormatJS `@formatjs/icu-messageformat-parser/printer.js`
- * (MIT licensed, https://github.com/formatjs/formatjs). That subpath is
- * CommonJS-only, which browsers and Vite-based dev servers (e.g. TanStack
- * Start) cannot load from our ESM build, and the package's ESM variant uses
- * extensionless relative imports that fail Node resolution.
+ * Local copy of FormatJS `printAST` (see the license header above). The
+ * published printer subpath is CommonJS-only, which browsers and Vite-based
+ * dev servers (e.g. TanStack Start) cannot load from our ESM build, and the
+ * package's ESM variant uses extensionless relative imports that fail Node
+ * resolution.
  *
  * Output must stay byte-identical to FormatJS `printAST` because condensed
  * ICU strings feed into hashing.

--- a/packages/core/src/derive/utils/printIcuAst.ts
+++ b/packages/core/src/derive/utils/printIcuAst.ts
@@ -1,0 +1,144 @@
+import { SKELETON_TYPE, TYPE } from '@formatjs/icu-messageformat-parser';
+import type {
+  DateElement,
+  LiteralElement,
+  MessageFormatElement,
+  NumberElement,
+  NumberSkeleton,
+  PluralElement,
+  SelectElement,
+  TagElement,
+  TimeElement,
+} from '@formatjs/icu-messageformat-parser';
+
+type SimpleFormatStyle = NonNullable<
+  (DateElement | TimeElement | NumberElement)['style']
+>;
+
+/**
+ * Vendored from FormatJS `@formatjs/icu-messageformat-parser/printer.js`
+ * (MIT licensed, https://github.com/formatjs/formatjs). That subpath is
+ * CommonJS-only, which browsers and Vite-based dev servers (e.g. TanStack
+ * Start) cannot load from our ESM build, and the package's ESM variant uses
+ * extensionless relative imports that fail Node resolution.
+ *
+ * Output must stay byte-identical to FormatJS `printAST` because condensed
+ * ICU strings feed into hashing.
+ */
+export function printIcuAst(ast: MessageFormatElement[]): string {
+  return doPrintAst(ast, false);
+}
+
+function doPrintAst(ast: MessageFormatElement[], isInPlural: boolean): string {
+  const printedNodes = ast.map((el, i) => {
+    switch (el.type) {
+      case TYPE.literal:
+        return printLiteralElement(
+          el,
+          isInPlural,
+          i === 0,
+          i === ast.length - 1
+        );
+      case TYPE.argument:
+        return `{${el.value}}`;
+      case TYPE.date:
+      case TYPE.time:
+      case TYPE.number:
+        return printSimpleFormatElement(el);
+      case TYPE.plural:
+        return printPluralElement(el);
+      case TYPE.select:
+        return printSelectElement(el);
+      case TYPE.pound:
+        return '#';
+      case TYPE.tag:
+        return printTagElement(el);
+    }
+  });
+  return printedNodes.join('');
+}
+
+function printTagElement(el: TagElement): string {
+  return `<${el.value}>${printIcuAst(el.children)}</${el.value}>`;
+}
+
+function printEscapedMessage(message: string): string {
+  return message.replace(/([{}](?:[\s\S]*[{}])?)/, "'$1'");
+}
+
+function printLiteralElement(
+  { value }: LiteralElement,
+  isInPlural: boolean,
+  isFirstEl: boolean,
+  isLastEl: boolean
+): string {
+  let escaped = value;
+  // If this literal starts with a ' and it's not the 1st node, the node
+  // before it is non-literal and the `'` needs to be re-escaped
+  if (!isFirstEl && escaped[0] === "'") {
+    escaped = `''${escaped.slice(1)}`;
+  }
+  // Same logic but for last el
+  if (!isLastEl && escaped[escaped.length - 1] === "'") {
+    escaped = `${escaped.slice(0, escaped.length - 1)}''`;
+  }
+  escaped = printEscapedMessage(escaped);
+  // Upstream escapes only the first `#` (String#replace with a string
+  // pattern); keep the quirk so output stays byte-identical
+  return isInPlural ? escaped.replace('#', "'#'") : escaped;
+}
+
+function printSimpleFormatElement(
+  el: DateElement | TimeElement | NumberElement
+): string {
+  return `{${el.value}, ${TYPE[el.type]}${
+    el.style ? `, ${printArgumentStyle(el.style)}` : ''
+  }}`;
+}
+
+function printNumberSkeletonToken(
+  token: NumberSkeleton['tokens'][number]
+): string {
+  const { stem, options } = token;
+  return options.length === 0
+    ? stem
+    : `${stem}${options.map((o) => `/${o}`).join('')}`;
+}
+
+function printArgumentStyle(style: SimpleFormatStyle): string {
+  if (typeof style === 'string') {
+    return printEscapedMessage(style);
+  } else if (style.type === SKELETON_TYPE.dateTime) {
+    return `::${style.pattern}`;
+  } else {
+    return `::${style.tokens.map(printNumberSkeletonToken).join(' ')}`;
+  }
+}
+
+function printSelectElement(el: SelectElement): string {
+  const msg = [
+    el.value,
+    'select',
+    Object.keys(el.options)
+      .map((id) => `${id}{${doPrintAst(el.options[id].value, false)}}`)
+      .join(' '),
+  ].join(',');
+  return `{${msg}}`;
+}
+
+function printPluralElement(el: PluralElement): string {
+  const type = el.pluralType === 'cardinal' ? 'plural' : 'selectordinal';
+  const msg = [
+    el.value,
+    type,
+    [
+      el.offset ? `offset:${el.offset}` : '',
+      ...Object.keys(el.options).map(
+        (id) => `${id}{${doPrintAst(el.options[id].value, true)}}`
+      ),
+    ]
+      .filter(Boolean)
+      .join(' '),
+  ].join(',');
+  return `{${msg}}`;
+}


### PR DESCRIPTION
## Summary
- vendor the small FormatJS ICU AST printer into `packages/core` (`src/derive/utils/printIcuAst.ts`, adapted from `@formatjs/icu-messageformat-parser/printer.js`, MIT) and point `condenseVars` at it
- drop the `@formatjs/icu-messageformat-parser/printer.js` import from the built `internal.mjs`/`internal.cjs`, fixing TanStack Start/Vite dev where the browser received the raw CommonJS module (`exports is not defined` / `does not provide an export named 'printAST'`)
- add regression tests: pinned `condenseVars` serialization outputs (generated against the original FormatJS printer before the swap), byte-for-byte equivalence of the vendored printer vs FormatJS `printAST` across a broad ICU corpus (with and without parsed skeletons), and an ESM-graph test that `dist/internal.mjs` no longer imports the CJS printer subpath
- add a patch changeset for `generaltranslation`

## Why vendoring
- Runtime CJS interop (`require()` / namespace-import fallbacks) is not browser-safe for `internal.mjs`: Vite dev serves the CJS `printer.js` to the browser unchanged, where `exports` does not exist.
- Importing FormatJS's ESM `lib/printer.js` instead is not viable either: its extensionless relative imports (`./types`) fail Node/Vite module resolution in TanStack Start SSR.
- Bundling the CJS printer into our ESM build (previous revision of this PR) worked but pulled in the `tslib` CJS wrapper and grew `dist/internal.mjs` from `12.82 kB` raw / `3.79 kB` gzip to `38.32 kB` raw / `10.93 kB` gzip.
- Vendoring keeps `printAST` behavior byte-identical (so `condenseVars` output and hashes are unchanged) at `16.58 kB` raw / `5.32 kB` gzip (including the vendored file's MIT notice, preserved in the built output), and only imports `TYPE`/`SKELETON_TYPE` from the package root, which was already an import of `internal.mjs`.

## Testing
- `pnpm --filter generaltranslation build`
- `pnpm exec vitest run --config=./vitest.config.ts src/derive/__tests__/condenseVars.test.ts src/__tests__/core-esm.test.ts` in `packages/core`
- `pnpm --filter generaltranslation typecheck`
- `pnpm --filter generaltranslation test` (594 passed; existing `condenseVars` tests unchanged from `odysseus`)
- new regression tests were run against the original FormatJS printer first (green), then against the vendored printer (green, identical outputs)
- reproduced the bug in `base/tanstack-start` with published `generaltranslation@9.0.0-odysseus.5`: Vite dev served raw CJS `printer.js` (`exports.printAST = ...`) to the client
- packed this branch's `generaltranslation` tarball and overrode it in `base/tanstack-start`: dev server on port `34817` returned `200` for `/`, `/ssr`, `/spa`; crawled all 167 modules of the dev client graph — no `printer.js` module and no raw-CJS module served
- `pnpm build` + `vite preview` on port `34818`: `/`, `/ssr`, `/spa` returned `200`
