### PR TITLE
feat!: remove render internals from gt-react react-server entry

### DIFF
--- a/.changeset/prune-react-rsc-entry.md
+++ b/.changeset/prune-react-rsc-entry.md
@@ -1,0 +1,5 @@
+---
+"gt-react": patch
+---
+
+Remove RSC-only render internals from the `gt-react` react-server entry while keeping the compiler-injected internal translation exports available. The react-server declaration surface now also includes `RenderPipeline` and `RenderPreparedT`, matching the other `gt-react` entries.

--- a/packages/react/src/__tests__/context-rsc.test.ts
+++ b/packages/react/src/__tests__/context-rsc.test.ts
@@ -4,21 +4,22 @@ describe('gt-react react-server surface', () => {
   it('exports the RSC context surface', async () => {
     const mod = await import('../index.rsc');
     expect(mod.Branch).toBeTypeOf('function');
-    expect(mod.GtInternalBranch).toBeTypeOf('function');
+    expect('GtInternalBranch' in mod).toBe(false);
     expect(mod.Currency).toBeTypeOf('function');
     expect(mod.DateTime).toBeTypeOf('function');
     expect(mod.Derive).toBeTypeOf('function');
-    expect(mod.GtInternalDerive).toBeTypeOf('function');
+    expect('GtInternalDerive' in mod).toBe(false);
     expect(mod.Num).toBeTypeOf('function');
     expect(mod.Plural).toBeTypeOf('function');
     expect(mod.RelativeTime).toBeTypeOf('function');
     expect('RscT' in mod).toBe(false);
     expect(mod.T).toBeTypeOf('function');
+    expect(mod.GtInternalTranslateJsx).toBeTypeOf('function');
     expect(mod.Var).toBeTypeOf('function');
     expect(mod.GtInternalVar).toBeTypeOf('function');
     expect(mod.getFormatLocales).toBeTypeOf('function');
-    expect(mod.getPluralBranch).toBeTypeOf('function');
-    expect(mod.renderVariable).toBeTypeOf('function');
+    expect('getPluralBranch' in mod).toBe(false);
+    expect('renderVariable' in mod).toBe(false);
     expect(mod.GTProvider).toBeTypeOf('function');
     expect(mod.LocaleSelector).toBeTypeOf('function');
   });

--- a/packages/react/src/index.rsc.ts
+++ b/packages/react/src/index.rsc.ts
@@ -95,40 +95,23 @@ export function useCustomMapping(): CustomMapping {
 }
 // ===== Internal Components ===== //
 export {
-  GtInternalBranch,
-  GtInternalCurrency,
-  GtInternalDateTime,
-  GtInternalDerive,
-  GtInternalNum,
-  GtInternalPlural,
-  GtInternalRelativeTime,
+  T as GtInternalTranslateJsx,
   GtInternalVar,
 } from '@generaltranslation/react-core/components-rsc';
 
 // ===== Render Helpers ===== //
-export {
-  createRenderPipeline,
-  createRenderVariable,
-  renderDefaultChildren,
-  renderPreparedT,
-  renderTranslatedChildren,
-  renderVariable,
-} from '@generaltranslation/react-core/components-rsc';
+export { createRenderPipeline } from '@generaltranslation/react-core/components-rsc';
 
 // ===== Translation Helpers ===== //
 export {
   getFormatLocales,
-  getPluralBranch,
-  getShouldTranslate,
   getTranslationsSnapshot,
-  prepareT,
   t,
 } from '@generaltranslation/react-core/components-rsc';
 
 // ===== Internal ===== //
 export {
   getReactI18nCache,
-  getReadonlyConditionStore,
   setReactI18nCache,
 } from '@generaltranslation/react-core/components-rsc';
 
@@ -169,6 +152,11 @@ export type {
   ResolvedPluralProps,
   ResolvedRelativeTimeProps,
 } from '@generaltranslation/react-core/components-rsc';
+
+export type {
+  RenderPipeline,
+  RenderPreparedT,
+} from '@generaltranslation/react-core/pure';
 
 export type { SharedGTProviderProps } from './provider/GTProviderProps';
 export {


### PR DESCRIPTION
## TL;DR

Prune dead render internals from the `gt-react` react-server entry and align its type exports with the other `gt-react` entries.

## Code Changes

- Removed RSC-only render helper/internal component exports from `packages/react/src/index.rsc.ts`.
- Kept compiler-injected internals available: `GtInternalTranslateJsx`, `GtInternalVar`, and runtime translate exports.
- Added `RenderPipeline` and `RenderPreparedT` type exports to the react-server entry.
- Updated the RSC surface test and added a `gt-react` changeset.

## Notes / Flags

Sibling PRs touch other parts of `index.rsc.ts` (react-core cleanup, version-id removal); trivial merge conflicts expected.

Verification: `pnpm --filter gt-react... build`, `pnpm --filter gt-react test`, `pnpm lint:fix`, `pnpm format:fix`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prunes the `gt-react` react-server (`index.rsc.ts`) entry by removing RSC-only render internals that are no longer needed there, keeping only the compiler-injected translation exports (`GtInternalTranslateJsx`, `GtInternalVar`) and aligning the type surface with the other `gt-react` entries by adding `RenderPipeline` and `RenderPreparedT` type exports.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The code changes in `index.rsc.ts` are clean and internally consistent, but the changeset classifies a removal of public exports as `patch`, which could mislead consumers relying on semver.

The implementation itself is straightforward — symbols are removed and the remaining surface is coherent. The only meaningful concern is that multiple non-`GtInternal`-prefixed exports are dropped while the changeset says `patch`. If any downstream consumer imports those symbols they will get a broken import without any semver signal.

`.changeset/prune-react-rsc-entry.md` — the version bump type should be reviewed before merging.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .changeset/prune-react-rsc-entry.md | Describes the surface pruning correctly, but classifies as `patch` while the diff removes multiple public (non-`GtInternal`) exports — a breaking change that should be `major`. |
| packages/react/src/index.rsc.ts | Removes dead RSC-only render internals and aligns type exports with other entries; `T as GtInternalTranslateJsx` alias is correctly sourced from `components-rsc` and the remaining exports look consistent. |
| packages/react/src/__tests__/context-rsc.test.ts | Correctly flips removed exports to negative assertions and adds `GtInternalTranslateJsx` check; missing positive assertions for several retained exports (`createRenderPipeline`, `t`, etc.). |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.changeset%2Fprune-react-rsc-entry.md%3A2%0A**Changeset%20type%20conflicts%20with%20breaking-change%20indicator%20in%20the%20PR%20title**%0A%0AThe%20changeset%20marks%20this%20as%20%60patch%60%2C%20but%20the%20PR%20title%20carries%20the%20%60feat!%60%20suffix%20%28conventional-commits%20notation%20for%20a%20breaking%20change%29%20and%20the%20diff%20removes%20several%20previously%20public%2C%20non-%60GtInternal%60-prefixed%20exports%20from%20the%20RSC%20entry%3A%20%60renderVariable%60%2C%20%60createRenderVariable%60%2C%20%60renderDefaultChildren%60%2C%20%60renderPreparedT%60%2C%20%60renderTranslatedChildren%60%2C%20%60getPluralBranch%60%2C%20%60getShouldTranslate%60%2C%20%60prepareT%60%2C%20and%20%60getReadonlyConditionStore%60.%20Any%20consumer%20importing%20those%20symbols%20from%20the%20react-server%20entry%20will%20receive%20an%20unresolved-export%20error%20after%20upgrading.%20In%20changesets%20terminology%20this%20is%20a%20%60major%60%20bump%20%28or%20at%20minimum%20%60minor%60%20if%20the%20team%20considers%20the%20RSC%20surface%20fully%20internal%29%3B%20shipping%20it%20as%20%60patch%60%20risks%20silent%20breakage%20for%20downstream%20consumers%20who%20rely%20on%20semver.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Freact%2Fsrc%2F__tests__%2Fcontext-rsc.test.ts%3A17-25%0A**Retained%20value%20exports%20not%20covered%20by%20the%20surface%20test**%0A%0AAfter%20this%20change%20%60createRenderPipeline%60%2C%20%60t%60%2C%20%60getTranslationsSnapshot%60%2C%20%60getReactI18nCache%60%2C%20and%20%60setReactI18nCache%60%20are%20still%20exported%20from%20the%20RSC%20entry%2C%20but%20the%20test%20does%20not%20assert%20their%20presence.%20Because%20the%20test%20is%20the%20canonical%20surface%20contract%20for%20this%20entry%2C%20a%20future%20refactor%20that%20accidentally%20drops%20one%20of%20these%20would%20go%20undetected.%20Adding%20positive%20%60toBeTypeOf%28'function'%29%60%20checks%20for%20the%20remaining%20exports%20that%20are%20meant%20to%20stay%20would%20make%20the%20test%20more%20complete.%0A%0A&repo=generaltranslation%2Fgt&pr=1817&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22bg%2Fprune-gt-react-rsc-entry%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22bg%2Fprune-gt-react-rsc-entry%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.changeset%2Fprune-react-rsc-entry.md%3A2%0A**Changeset%20type%20conflicts%20with%20breaking-change%20indicator%20in%20the%20PR%20title**%0A%0AThe%20changeset%20marks%20this%20as%20%60patch%60%2C%20but%20the%20PR%20title%20carries%20the%20%60feat!%60%20suffix%20%28conventional-commits%20notation%20for%20a%20breaking%20change%29%20and%20the%20diff%20removes%20several%20previously%20public%2C%20non-%60GtInternal%60-prefixed%20exports%20from%20the%20RSC%20entry%3A%20%60renderVariable%60%2C%20%60createRenderVariable%60%2C%20%60renderDefaultChildren%60%2C%20%60renderPreparedT%60%2C%20%60renderTranslatedChildren%60%2C%20%60getPluralBranch%60%2C%20%60getShouldTranslate%60%2C%20%60prepareT%60%2C%20and%20%60getReadonlyConditionStore%60.%20Any%20consumer%20importing%20those%20symbols%20from%20the%20react-server%20entry%20will%20receive%20an%20unresolved-export%20error%20after%20upgrading.%20In%20changesets%20terminology%20this%20is%20a%20%60major%60%20bump%20%28or%20at%20minimum%20%60minor%60%20if%20the%20team%20considers%20the%20RSC%20surface%20fully%20internal%29%3B%20shipping%20it%20as%20%60patch%60%20risks%20silent%20breakage%20for%20downstream%20consumers%20who%20rely%20on%20semver.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Freact%2Fsrc%2F__tests__%2Fcontext-rsc.test.ts%3A17-25%0A**Retained%20value%20exports%20not%20covered%20by%20the%20surface%20test**%0A%0AAfter%20this%20change%20%60createRenderPipeline%60%2C%20%60t%60%2C%20%60getTranslationsSnapshot%60%2C%20%60getReactI18nCache%60%2C%20and%20%60setReactI18nCache%60%20are%20still%20exported%20from%20the%20RSC%20entry%2C%20but%20the%20test%20does%20not%20assert%20their%20presence.%20Because%20the%20test%20is%20the%20canonical%20surface%20contract%20for%20this%20entry%2C%20a%20future%20refactor%20that%20accidentally%20drops%20one%20of%20these%20would%20go%20undetected.%20Adding%20positive%20%60toBeTypeOf%28'function'%29%60%20checks%20for%20the%20remaining%20exports%20that%20are%20meant%20to%20stay%20would%20make%20the%20test%20more%20complete.%0A%0A&repo=generaltranslation%2Fgt&pr=1817&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
.changeset/prune-react-rsc-entry.md:2
**Changeset type conflicts with breaking-change indicator in the PR title**

The changeset marks this as `patch`, but the PR title carries the `feat!` suffix (conventional-commits notation for a breaking change) and the diff removes several previously public, non-`GtInternal`-prefixed exports from the RSC entry: `renderVariable`, `createRenderVariable`, `renderDefaultChildren`, `renderPreparedT`, `renderTranslatedChildren`, `getPluralBranch`, `getShouldTranslate`, `prepareT`, and `getReadonlyConditionStore`. Any consumer importing those symbols from the react-server entry will receive an unresolved-export error after upgrading. In changesets terminology this is a `major` bump (or at minimum `minor` if the team considers the RSC surface fully internal); shipping it as `patch` risks silent breakage for downstream consumers who rely on semver.

### Issue 2 of 2
packages/react/src/__tests__/context-rsc.test.ts:17-25
**Retained value exports not covered by the surface test**

After this change `createRenderPipeline`, `t`, `getTranslationsSnapshot`, `getReactI18nCache`, and `setReactI18nCache` are still exported from the RSC entry, but the test does not assert their presence. Because the test is the canonical surface contract for this entry, a future refactor that accidentally drops one of these would go undetected. Adding positive `toBeTypeOf('function')` checks for the remaining exports that are meant to stay would make the test more complete.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat!: prune gt-react RSC render interna..."](https://github.com/generaltranslation/gt/commit/05107e7aa3145ea635929d2c77c4f418720ce746) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41726916)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->