### PR TITLE
chore: remove inert compilerOptions from package manifests

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -149,25 +149,5 @@
         "./dist/runtime.d.cts"
       ]
     }
-  },
-  "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "generaltranslation/internal": [
-        "/dist/internal"
-      ],
-      "generaltranslation/id": [
-        "/dist/id"
-      ],
-      "generaltranslation/core": [
-        "/dist/core"
-      ],
-      "generaltranslation/types": [
-        "/dist/types"
-      ],
-      "generaltranslation/errors": [
-        "/dist/errors"
-      ]
-    }
   }
 }

--- a/packages/format/package.json
+++ b/packages/format/package.json
@@ -94,16 +94,5 @@
         "./dist/internal.d.cts"
       ]
     }
-  },
-  "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "@generaltranslation/format/types": [
-        "./dist/types"
-      ],
-      "@generaltranslation/format/internal": [
-        "./dist/internal"
-      ]
-    }
   }
 }

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -123,22 +123,5 @@
         "./dist/internal-types.d.cts"
       ]
     }
-  },
-  "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "gt-i18n/types": [
-        "/dist/types"
-      ],
-      "gt-i18n/fallbacks": [
-        "/dist/fallbacks"
-      ],
-      "gt-i18n/internal": [
-        "/dist/internal"
-      ],
-      "gt-i18n/internal/types": [
-        "/dist/internal-types"
-      ]
-    }
   }
 }

--- a/packages/locadex/package.json
+++ b/packages/locadex/package.json
@@ -55,7 +55,6 @@
     "url": "https://github.com/generaltranslation/gt/issues"
   },
   "homepage": "https://generaltranslation.com/",
-  "compilerOptions": {},
   "keywords": [
     "react",
     "translation",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -50,7 +50,6 @@
     "url": "https://github.com/generaltranslation/gt/issues"
   },
   "homepage": "https://generaltranslation.com/",
-  "compilerOptions": {},
   "keywords": [
     "react",
     "translation",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -158,38 +158,6 @@
       ]
     }
   },
-  "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "gt-next/config": [
-        "/dist/config"
-      ],
-      "gt-next/server": [
-        "/dist/server"
-      ],
-      "gt-next/middleware": [
-        "/dist/middleware"
-      ],
-      "gt-next/link": [
-        "/dist/link"
-      ],
-      "gt-next/internal/_dictionary": [
-        "/dist/internal/_dictionary"
-      ],
-      "gt-next/internal/_load-translations": [
-        "/dist/internal/_load-translations"
-      ],
-      "gt-next/internal/_load-dictionary": [
-        "/dist/internal/_load-dictionary"
-      ],
-      "gt-next/internal/_getLocale": [
-        "/dist/internal/_getLocale"
-      ],
-      "gt-next/internal/_getRegion": [
-        "/dist/internal/_getRegion"
-      ]
-    }
-  },
   "keywords": [
     "react",
     "translation",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -100,16 +100,5 @@
         "./dist/internal.d.cts"
       ]
     }
-  },
-  "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "gt-node/types": [
-        "./dist/types"
-      ],
-      "gt-node/internal": [
-        "./dist/internal"
-      ]
-    }
   }
 }

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -84,23 +84,6 @@
       ]
     }
   },
-  "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "@generaltranslation/react-core/pure": [
-        "./dist/pure"
-      ],
-      "@generaltranslation/react-core/hooks": [
-        "./dist/hooks"
-      ],
-      "@generaltranslation/react-core/components": [
-        "./dist/components"
-      ],
-      "@generaltranslation/react-core/components-rsc": [
-        "./dist/components-rsc"
-      ]
-    }
-  },
   "keywords": [
     "react",
     "translation",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -106,14 +106,6 @@
       ]
     }
   },
-  "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "gt-react/macros": [
-        "./dist/macros.d.cts"
-      ]
-    }
-  },
   "keywords": [
     "react",
     "translation",


### PR DESCRIPTION
## TL;DR

Remove inert top-level `compilerOptions` fields from package manifests. These fields are tsconfig-only metadata and are not read from `package.json` anywhere in the repo.

## Code Changes

- Deleted top-level `compilerOptions` blocks from `gt-next`, `gt-react`, `@generaltranslation/react-core`, `generaltranslation`, `gt-i18n`, `gt-node`, `@generaltranslation/format`, `@generaltranslation/mcp`, and `locadex` package manifests.
- Re-verified package metadata readers, build scripts, tsdown configs, turbo config, and scripts do not consume `compilerOptions` from `package.json`.
- No changeset: manifest-only cleanup with no published behavior change.

## Notes / Flags

Sibling PRs also edit `packages/i18n/package.json` and `packages/next/package.json` for subpath removals; trivial merge conflicts are expected.

Verification:

- `pnpm install --force --store-dir /private/tmp/gt-remove-inert-compiler-options-pnpm-store`
- `pnpm lint:fix`
- `pnpm format:fix`
- `pnpm --filter @generaltranslation/format... --filter generaltranslation... --filter gt-i18n... --filter gt-node... --filter @generaltranslation/react-core... --filter gt-react... --filter gt-next... --filter @generaltranslation/mcp... --filter locadex... build`
- `pnpm --filter gt-next --filter gt-react --filter @generaltranslation/react-core --filter generaltranslation --filter gt-i18n --filter gt-node --filter @generaltranslation/format --filter @generaltranslation/mcp --filter locadex test`

Default-store `pnpm install --force` hit pnpm global-store `ENOTEMPTY` rename errors twice at the final link step; rerunning with an isolated temporary store completed successfully.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes top-level `compilerOptions` blocks from nine `package.json` files across the monorepo. These fields are tsconfig-only metadata and have no effect when placed in a package manifest — no build tool, bundler, or runtime reads them from there.

- **Nine packages cleaned up**: `gt-next`, `gt-react`, `@generaltranslation/react-core`, `generaltranslation`, `gt-i18n`, `gt-node`, `@generaltranslation/format`, `@generaltranslation/mcp`, and `locadex` each had either populated `compilerOptions.paths` blocks or empty `compilerOptions: {}` objects removed.
- **No behavior change**: The actual subpath exports remain intact in each package's `exports` field; only the dead metadata is deleted.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — changes are purely additive deletions of dead metadata with no effect on build output, published exports, or runtime behavior.

Every touched file is a package manifest, and every removed field (compilerOptions) is a tsconfig-only construct that Node, pnpm, tsdown, and turbo all ignore when reading package.json. The exports maps that actually govern subpath resolution are untouched across all nine packages.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/next/package.json | Removed the largest compilerOptions block (10 subpath entries for gt-next/*); no published behavior change. |
| packages/core/package.json | Removed inert top-level compilerOptions block with baseUrl/paths entries — these fields are not read by any build tooling from package.json. |
| packages/react-core/package.json | Removed inert compilerOptions block with four @generaltranslation/react-core subpath entries. |
| packages/i18n/package.json | Removed inert compilerOptions block with four subpath path aliases; no build behavior change. |
| packages/node/package.json | Removed inert compilerOptions block with two gt-node subpath entries. |
| packages/format/package.json | Removed inert compilerOptions block with two subpath path aliases that had no effect outside a tsconfig. |
| packages/react/package.json | Removed inert compilerOptions block with a single gt-react/macros path alias. |
| packages/locadex/package.json | Removed empty compilerOptions: {} field — purely cosmetic cleanup. |
| packages/mcp/package.json | Removed empty compilerOptions: {} field — purely cosmetic cleanup. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[package.json] --> B["exports field (kept)"]
    A --> C["compilerOptions field (removed)"]
    B --> D["Node / pnpm / bundler subpath resolution"]
    C --> E["tsconfig.json — where compilerOptions belongs"]
    style C stroke:#f66,stroke-dasharray:5 5
    style E stroke:#999,fill:#f9f9f9
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[package.json] --> B["exports field (kept)"]
    A --> C["compilerOptions field (removed)"]
    B --> D["Node / pnpm / bundler subpath resolution"]
    C --> E["tsconfig.json — where compilerOptions belongs"]
    style C stroke:#f66,stroke-dasharray:5 5
    style E stroke:#999,fill:#f9f9f9
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["chore: remove inert compiler options fro..."](https://github.com/generaltranslation/gt/commit/1ce68d006e7fc9e08bebd45c7cb7defe9aa4bb28) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41726692)</sub>

<!-- /greptile_comment -->