### PR TITLE
feat!: remove useVersionId from public API

### DIFF
--- a/.changeset/remove-version-id-exports.md
+++ b/.changeset/remove-version-id-exports.md
@@ -1,0 +1,10 @@
+---
+"@generaltranslation/react-core": major
+"gt-next": major
+"gt-react": major
+"gt-react-native": major
+---
+
+Remove `useVersionId` from public package entrypoints.
+
+The `getVersionId` helper remains available from public function entrypoints and `gt-i18n/internal`.

--- a/packages/next/src/__tests__/rscComponentWrappers.test.tsx
+++ b/packages/next/src/__tests__/rscComponentWrappers.test.tsx
@@ -33,7 +33,6 @@ const { mockComponents, mockGetRequestConditions } = vi.hoisted(() => ({
     useGTClass: vi.fn(),
     useLocaleProperties: vi.fn(),
     useLocales: vi.fn(),
-    useVersionId: vi.fn(),
     Var: vi.fn(),
   },
   mockGetRequestConditions: vi.fn(),
@@ -141,7 +140,6 @@ describe('rsc component wrappers', () => {
     expect(module.useLocaleProperties).toBeTypeOf('function');
     expect(module.useLocales).toBeTypeOf('function');
     expect(module.useDefaultLocale).toBeTypeOf('function');
-    expect(module.useVersionId).toBeTypeOf('function');
   });
 
   it('initializes GT from the server entrypoint', async () => {

--- a/packages/next/src/index.client.ts
+++ b/packages/next/src/index.client.ts
@@ -63,7 +63,6 @@ export {
   useRegion,
   useSetLocale,
   useTranslations,
-  useVersionId,
 } from 'gt-react';
 
 // ===== Functions ===== //

--- a/packages/next/src/index.rsc.ts
+++ b/packages/next/src/index.rsc.ts
@@ -83,7 +83,6 @@ export {
   useGTClass,
   useLocaleProperties,
   useLocales,
-  useVersionId,
 } from 'gt-react';
 
 // ===== gt-react Functions ===== //

--- a/packages/next/src/index.server.ts
+++ b/packages/next/src/index.server.ts
@@ -45,7 +45,6 @@ export {
   useRegion,
   useSetLocale,
   useTranslations,
-  useVersionId,
 } from 'gt-react';
 
 // ===== Functions ===== //

--- a/packages/next/src/index.types.ts
+++ b/packages/next/src/index.types.ts
@@ -24,7 +24,6 @@ import {
   Plural as _Plural,
   Derive as _Derive,
   useLocaleDirection as _useLocaleDirection,
-  useVersionId as _useVersionId,
 } from 'gt-react';
 import {
   LocaleSelector as _LocaleSelector,
@@ -518,19 +517,6 @@ export const useLocaleProperties: typeof _useLocaleProperties = () => {
  * const arabicDir = useLocaleDirection('ar'); // 'rtl'
  */
 export const useLocaleDirection: typeof _useLocaleDirection = () => {
-  throw new Error(typesFileError);
-};
-
-/**
- * Returns the version ID for the current source, if set.
- *
- * @returns {string | undefined} The version ID.
- *
- * @example
- * const versionId = useVersionId();
- * console.log(versionId); // 'abc123'
- */
-export const useVersionId: typeof _useVersionId = () => {
   throw new Error(typesFileError);
 };
 

--- a/packages/react-core/src/hooks.ts
+++ b/packages/react-core/src/hooks.ts
@@ -21,7 +21,6 @@ export {
   useGTClass,
   useLocaleProperties,
   useLocaleDirection,
-  useVersionId,
 } from './hooks/utils';
 export { useInternalLocaleSelector } from './hooks/useInternalLocaleSelector';
 export type { InternalLocaleSelectorResult } from './hooks/useInternalLocaleSelector';

--- a/packages/react-core/src/hooks/utils.ts
+++ b/packages/react-core/src/hooks/utils.ts
@@ -2,7 +2,7 @@ import type { LocaleProperties } from '@generaltranslation/format/types';
 import { useMemo } from 'react';
 import { useEnableI18n, useLocale } from './condition-store';
 import { getFormatLocales } from './utils/getFormatLocales';
-import { getI18nConfig, getVersionId } from 'gt-i18n/internal';
+import { getI18nConfig } from 'gt-i18n/internal';
 
 const EMPTY_LOCALES_PROP: string[] = [];
 
@@ -48,8 +48,4 @@ export function useLocaleDirection(locale?: string): 'ltr' | 'rtl' {
     () => getI18nConfig().getGTClass().getLocaleDirection(resolvedLocale),
     [resolvedLocale]
   );
-}
-
-export function useVersionId(): string | undefined {
-  return getVersionId();
 }

--- a/packages/react-native/src/index.tsx
+++ b/packages/react-native/src/index.tsx
@@ -27,7 +27,6 @@ export {
   useMessages,
   useRegion,
   useTranslations,
-  useVersionId,
 } from '@generaltranslation/react-core/hooks';
 export {
   useSetLocale,

--- a/packages/react/src/index.client.ts
+++ b/packages/react/src/index.client.ts
@@ -50,7 +50,6 @@ export {
   useMessages,
   useTranslations,
   useLocaleDirection,
-  useVersionId,
   useGTClass,
   useLocaleProperties,
 } from '@generaltranslation/react-core/hooks';

--- a/packages/react/src/index.rsc.ts
+++ b/packages/react/src/index.rsc.ts
@@ -65,16 +65,6 @@ export function useLocale() {
 export function useRegion() {
   return getRegion();
 }
-export function useVersionId() {
-  throw new Error(
-    createDiagnosticMessage({
-      source: 'gt-react',
-      severity: 'Error',
-      whatHappened: 'useVersionId() is not implemented in the RSC entry point',
-      fix: 'Use getVersionId() or import useVersionId() from a supported runtime entry point.',
-    })
-  );
-}
 export function useLocales() {
   return getI18nConfig().getLocales();
 }

--- a/packages/react/src/index.server.ts
+++ b/packages/react/src/index.server.ts
@@ -69,7 +69,6 @@ export {
   useMessages,
   useTranslations,
   useLocaleDirection,
-  useVersionId,
   useGTClass,
   useLocaleProperties,
 } from '@generaltranslation/react-core/hooks';

--- a/packages/react/src/index.types.ts
+++ b/packages/react/src/index.types.ts
@@ -49,7 +49,6 @@ export {
   useMessages,
   useTranslations,
   useLocaleDirection,
-  useVersionId,
   useGTClass,
   useLocaleProperties,
 } from '@generaltranslation/react-core/hooks';


### PR DESCRIPTION
## TL;DR

Remove `useVersionId` from public React package entrypoints while keeping `getVersionId` available from public function surfaces and `gt-i18n/internal`.

## Code Changes

- Removed the `useVersionId` implementation from `@generaltranslation/react-core/hooks`.
- Removed downstream `useVersionId` re-exports from `gt-react`, `gt-next`, and `gt-react-native` entrypoints.
- Updated the gt-next RSC wrapper export test and added a changeset for the public API removal.

## Notes / Flags

`getVersionId` is intentionally retained. A sibling PR (`bg/i18n-api-cleanup`) dedupes other `gt-i18n` root/internal helper duplicates and deliberately excludes `getVersionId`; trivial merge conflicts remain possible around adjacent API cleanup changes.

Verification run: `pnpm build`; `pnpm --filter @generaltranslation/react-core --filter gt-react --filter gt-next --filter gt-react-native test`; `pnpm lint:fix`; `pnpm format:fix`. `pnpm lint:fix` reports existing warnings unrelated to this change.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes `useVersionId` from all public React package entrypoints (`gt-react`, `gt-next`, `gt-react-native`, and `@generaltranslation/react-core`) as a breaking API change. The underlying `getVersionId` non-hook helper is intentionally preserved across all function-level exports and RSC surfaces.

- Removes the `useVersionId` implementation from `react-core/src/hooks/utils.ts` and its re-export chain through every package entrypoint (client, server, RSC, types).
- Cleans up the corresponding RSC shim that previously threw a diagnostic error in `gt-react/index.rsc.ts`, the types stub in both `gt-next` and `gt-react` types files, and the vitest mock + assertion in the RSC component wrappers test.
- Adds a changeset marking a major version bump for all four affected packages, with a note that `getVersionId` remains on public function surfaces.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — this is a clean public API removal with no remaining production references to useVersionId and getVersionId correctly retained on all function surfaces.

The removal is applied consistently across every affected entrypoint (client, server, RSC, types, React Native) and the underlying getVersionId function remains accessible through all existing paths. The test cleanup matches the production change exactly, and the changeset correctly marks the impacted packages as major bumps.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react-core/src/hooks/utils.ts | Removes the useVersionId function implementation and its getVersionId import; remaining hooks are untouched. |
| packages/react-core/src/hooks.ts | Removes useVersionId from the hooks barrel export; all other exports remain. |
| packages/react/src/index.rsc.ts | Drops the RSC-error shim for useVersionId; getVersionId is still exported from the Functions section. |
| packages/next/src/index.types.ts | Removes the useVersionId types-file stub and its import; no other type stubs affected. |
| packages/next/src/__tests__/rscComponentWrappers.test.tsx | Removes useVersionId from the gt-react mock object and drops the corresponding export assertion; getVersionId mock entry is correctly retained. |
| .changeset/remove-version-id-exports.md | Changeset correctly marks all four affected packages as major bumps with an accurate description of what was removed and what was retained. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Before["Before (removed)"]
        A["useVersionId()\nreact-core/hooks/utils.ts"] -->|"calls"| B["getVersionId()\ngt-i18n/internal"]
        A --> C["@generaltranslation/react-core/hooks"]
        C --> D["gt-react client/server/types"]
        C --> E["gt-react-native"]
        D --> F["gt-next client/server/RSC/types"]
        G["gt-react RSC shim\n(threw diagnostic error)"] --> F
    end

    subgraph After["After (retained)"]
        H["getVersionId()\ngt-i18n/internal"] --> I["react-core/pure.ts"]
        I --> J["gt-react client/server/RSC/types\n(function export)"]
        I --> K["gt-next client/server/RSC/types\n(function export)"]
        I --> L["gt-node"]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    subgraph Before["Before (removed)"]
        A["useVersionId()\nreact-core/hooks/utils.ts"] -->|"calls"| B["getVersionId()\ngt-i18n/internal"]
        A --> C["@generaltranslation/react-core/hooks"]
        C --> D["gt-react client/server/types"]
        C --> E["gt-react-native"]
        D --> F["gt-next client/server/RSC/types"]
        G["gt-react RSC shim\n(threw diagnostic error)"] --> F
    end

    subgraph After["After (retained)"]
        H["getVersionId()\ngt-i18n/internal"] --> I["react-core/pure.ts"]
        I --> J["gt-react client/server/RSC/types\n(function export)"]
        I --> K["gt-next client/server/RSC/types\n(function export)"]
        I --> L["gt-node"]
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["feat!: remove useVersionId exports"](https://github.com/generaltranslation/gt/commit/fb747d0fb69f99b73a8c1a16cb6eaa6388cfc64f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41726575)</sub>

<!-- /greptile_comment -->