### PR TITLE
fix: remove accidental useShouldTranslate export from react-core hooks

### DIFF
--- a/.changeset/remove-use-should-translate-export.md
+++ b/.changeset/remove-use-should-translate-export.md
@@ -1,0 +1,5 @@
+---
+'@generaltranslation/react-core': patch
+---
+
+Remove the accidental `useShouldTranslate` export from `@generaltranslation/react-core/hooks`. The hook is an internal implementation detail and was never meant to be public.

--- a/packages/react-core/src/hooks.ts
+++ b/packages/react-core/src/hooks.ts
@@ -17,7 +17,6 @@ export { useMessages } from './hooks/useMessages';
 export { useTranslations } from './hooks/useTranslations';
 export {
   useFormatLocales,
-  useShouldTranslate,
   useLocaleProperties,
   useLocaleDirection,
 } from './hooks/utils';


### PR DESCRIPTION
## TL;DR

Remove the `useShouldTranslate` export that #1816 accidentally re-added to the public `@generaltranslation/react-core/hooks` entry.

## Code Changes

- Drop `useShouldTranslate` from the export list in `packages/react-core/src/hooks.ts`. The hook remains available internally from `./hooks/utils`.
- Add a patch changeset for `@generaltranslation/react-core`.

## Notes / Flags

- #1815 had already removed `useShouldTranslate` from `/hooks` (see `.changeset/clean-react-core-api-surface.md`); the export slipped back in via a conflict resolution when #1816 replaced `useGTClass` in the same export slot.
- No sibling package (`gt-react`, `gt-react-native`, `gt-next`) re-exports it, so this is the only site.
- Verification: `pnpm --filter @generaltranslation/react-core test` (46 tests pass), `oxfmt --check` on changed files.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the accidental re-export of `useShouldTranslate` from the public `@generaltranslation/react-core/hooks` entry point. The hook was originally removed in #1815 but slipped back in during a conflict resolution in #1816 when `useGTClass` was replaced in the same export slot.

- **`packages/react-core/src/hooks.ts`**: Drops `useShouldTranslate` from the `./hooks/utils` re-export group; the hook remains available internally and all other public exports are unaffected.
- **`.changeset/remove-use-should-translate-export.md`**: Adds a patch-level changeset accurately describing the removal as fixing an accidental public exposure of an internal hook.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — a one-line removal of an unintended export with a correct changeset and no impact on internal consumers.

The change is a single-line deletion from a public re-export group. `useShouldTranslate` continues to exist in `./hooks/utils` for internal use, so no internal callers break. No sibling packages re-export the hook, and the changeset correctly marks this as a patch. There are no logic changes, no new code paths, and nothing that could introduce a regression.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react-core/src/hooks.ts | Removes `useShouldTranslate` from the public hooks entry point; all remaining exports and formatting are correct. |
| .changeset/remove-use-should-translate-export.md | Adds a patch-level changeset for `@generaltranslation/react-core` accurately describing the removed accidental export. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: remove accidental useShouldTranslat..."](https://github.com/generaltranslation/gt/commit/081907dfc9e5198ed389863110810330a03cc7ce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41757259)</sub>

<!-- /greptile_comment -->