### PR TITLE
fix: support gt-next config ESM import

### DIFF
--- a/.changeset/next-config-esm-require.md
+++ b/.changeset/next-config-esm-require.md
@@ -1,0 +1,5 @@
+---
+'gt-next': patch
+---
+
+Fix ESM imports of `gt-next/config` by resolving Next.js and React package versions with an explicit Node require.

--- a/packages/next/src/__tests__/packageExports.test.ts
+++ b/packages/next/src/__tests__/packageExports.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from 'vitest';
 
 const packageRoot = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
 const distInitGTServerPath = join(packageRoot, 'dist/setup/initGT.server.mjs');
+const distConfigPath = join(packageRoot, 'dist/config.mjs');
 
 describe('gt-next package exports', () => {
   it('uses RSC-specific declarations for the react-server condition', () => {
@@ -81,5 +82,33 @@ describe('gt-next package exports', () => {
       expect(result.status, result.stderr).toBe(0);
       expect(result.stdout).toContain('ok');
     }
+  });
+
+  const distConfigIt = existsSync(distConfigPath) ? it : it.skip;
+
+  distConfigIt('loads the config entry from Node ESM', () => {
+    const result = spawnSync(
+      process.execPath,
+      [
+        '--input-type=module',
+        '--eval',
+        `
+          import { withGTConfig } from 'gt-next/config';
+
+          if (typeof withGTConfig !== 'function') {
+            throw new Error('withGTConfig export not found');
+          }
+
+          console.log('ok');
+        `,
+      ],
+      {
+        cwd: packageRoot,
+        encoding: 'utf8',
+      }
+    );
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('ok');
   });
 });

--- a/packages/next/src/plugin/getStableNextVersionInfo.ts
+++ b/packages/next/src/plugin/getStableNextVersionInfo.ts
@@ -1,3 +1,5 @@
+import { createRequire } from 'module';
+
 import {
   createUnresolvedNextVersionError,
   createUnresolvedReactVersionError,
@@ -9,6 +11,10 @@ import {
   SWC_PLUGIN_SUPPORT,
 } from './constants';
 
+// @ts-expect-error gt-next declaration emit still uses CommonJS, but the ESM
+// config build needs import.meta.url because Node config files do not define require.
+const moduleRequire = createRequire(import.meta.url);
+
 /**
  * Get the next version of the package.
  */
@@ -16,12 +22,12 @@ function getPackageVersion(packageName: string): string {
   const packageJsonPath = `${packageName}/package.json`;
 
   try {
-    const resolvedPackageJsonPath = require.resolve(packageJsonPath, {
+    const resolvedPackageJsonPath = moduleRequire.resolve(packageJsonPath, {
       paths: [process.cwd()],
     });
-    return require(resolvedPackageJsonPath).version;
+    return moduleRequire(resolvedPackageJsonPath).version;
   } catch (_error) {
-    return require(packageJsonPath).version;
+    return moduleRequire(packageJsonPath).version;
   }
 }
 


### PR DESCRIPTION
## Summary
- Resolve Next/React package versions in gt-next/config through createRequire(import.meta.url) so Node ESM config imports do not rely on a global require.
- Add a package export regression test for importing gt-next/config from Node ESM.
- Add a patch changeset for gt-next.

## Tests
- pnpm --filter gt-next build:no-swc-plugin
- pnpm --dir packages/next exec vitest run src/__tests__/packageExports.test.ts
- node --input-type=module --eval "import { withGTConfig } from 'gt-next/config'; if (typeof withGTConfig !== 'function') throw new Error('withGTConfig missing'); console.log('ok')"\n- pnpm --dir packages/next exec oxfmt --check src/plugin/getStableNextVersionInfo.ts src/__tests__/packageExports.test.ts\n- pnpm --dir packages/next exec oxlint src/plugin/getStableNextVersionInfo.ts src/__tests__/packageExports.test.ts

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes `gt-next/config` imports from Node ESM entry points by replacing bare `require` calls in `getStableNextVersionInfo.ts` with a `createRequire(import.meta.url)`-based equivalent, and adds a regression test that spawns a child process to verify the ESM import works end-to-end.

- **Core fix** (`getStableNextVersionInfo.ts`): All three `require` / `require.resolve` call sites are replaced with `moduleRequire`, created via `createRequire(import.meta.url)`. The `@ts-expect-error` is needed because the tsconfig targets CommonJS but the ESM config build is produced separately by tsdown.
- **Regression test** (`packageExports.test.ts`): A new `distConfigIt` test spawns `node --input-type=module` to import `withGTConfig` from `gt-next/config`, guarded by an `existsSync` check on `dist/config.mjs` to skip gracefully on fresh checkouts.
- **Changeset**: Correctly scoped as a `patch` for `gt-next`.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the fix correctly targets the ESM config build path and does not touch the server or RSC entry points.

The `createRequire(import.meta.url)` approach is the idiomatic Node.js solution and the change is narrow. The new regression test only exercises the ESM path, leaving the CJS `dist/config.js` fallback untested; and the `@ts-expect-error` will become a build error if the tsconfig module target is ever updated to an ESM-compatible setting.

packages/next/src/__tests__/packageExports.test.ts — the CJS config fallback is not covered by the new test.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/next/src/plugin/getStableNextVersionInfo.ts | Replaces bare `require` calls with `createRequire(import.meta.url)` so the module works in Node ESM environments; `@ts-expect-error` is needed because the tsconfig targets CommonJS but is harmless for the ESM config build. |
| packages/next/src/__tests__/packageExports.test.ts | Adds a regression test that spawns a child Node process to import `withGTConfig` from `gt-next/config` under `--input-type=module`; correctly guards on the dist file's existence, but only validates the ESM path and not the CJS fallback. |
| .changeset/next-config-esm-require.md | Patch changeset for gt-next describing the ESM config fix; description is accurate and appropriately scoped. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User as next.config.mjs (ESM)
    participant Config as gt-next/config (dist/config.mjs)
    participant GSNVI as getStableNextVersionInfo.ts
    participant CR as createRequire(import.meta.url)
    participant FS as Node FS / package.json

    User->>Config: "import { withGTConfig }"
    Config->>GSNVI: evaluate module (top-level)
    GSNVI->>CR: createRequire(import.meta.url)
    Note over CR: Creates a CJS-style require anchored to the ESM file URL
    GSNVI->>CR: moduleRequire.resolve('next/package.json')
    CR->>FS: resolve next/package.json
    FS-->>CR: /path/to/next/package.json
    CR->>FS: require('/path/to/next/package.json')
    FS-->>CR: version string
    CR-->>GSNVI: version string
    GSNVI-->>Config: turboConfigStable, rootParamStability, etc.
    Config-->>User: withGTConfig function ready
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User as next.config.mjs (ESM)
    participant Config as gt-next/config (dist/config.mjs)
    participant GSNVI as getStableNextVersionInfo.ts
    participant CR as createRequire(import.meta.url)
    participant FS as Node FS / package.json

    User->>Config: "import { withGTConfig }"
    Config->>GSNVI: evaluate module (top-level)
    GSNVI->>CR: createRequire(import.meta.url)
    Note over CR: Creates a CJS-style require anchored to the ESM file URL
    GSNVI->>CR: moduleRequire.resolve('next/package.json')
    CR->>FS: resolve next/package.json
    FS-->>CR: /path/to/next/package.json
    CR->>FS: require('/path/to/next/package.json')
    FS-->>CR: version string
    CR-->>GSNVI: version string
    GSNVI-->>Config: turboConfigStable, rootParamStability, etc.
    Config-->>User: withGTConfig function ready
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fnext%2Fsrc%2F__tests__%2FpackageExports.test.ts%3A87-113%0A**CJS%20fallback%20not%20covered%20by%20regression%20test**%0A%0AThe%20new%20test%20validates%20importing%20%60gt-next%2Fconfig%60%20under%20%60--input-type%3Dmodule%60%2C%20which%20exercises%20the%20%60.mjs%60%20ESM%20build.%20The%20%60package.json%60%20exports%20for%20%60.%2Fconfig%60%20also%20expose%20a%20%60%22default%22%3A%20%22.%2Fdist%2Fconfig.js%22%60%20CJS%20fallback%20%28used%20when%20a%20consumer's%20%60next.config.js%60%20is%20plain%20CommonJS%29.%20That%20path%20runs%20the%20same%20%60createRequire%28import.meta.url%29%60%20source%20through%20a%20CJS%20transformation%20done%20by%20tsdown%2FRollup.%20If%20tsdown%20ever%20changes%20how%20it%20handles%20%60import.meta.url%60%20in%20CJS%20output%2C%20the%20CJS%20config%20path%20could%20silently%20regress%20with%20no%20test%20to%20catch%20it.%20Adding%20a%20parallel%20%60spawnSync%60%20with%20%60--input-type%3Dcommonjs%60%20%28or%20%60require%28'gt-next%2Fconfig'%29%60%29%20against%20%60dist%2Fconfig.js%60%20would%20close%20the%20gap.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fnext%2Fsrc%2Fplugin%2FgetStableNextVersionInfo.ts%3A14-16%0A**%60%40ts-expect-error%60%20will%20cause%20a%20build%20error%20if%20tsconfig%20is%20ever%20updated%20to%20ESM**%0A%0AThe%20directive%20suppresses%20the%20TypeScript%20error%20for%20%60import.meta.url%60%20under%20%60%22module%22%3A%20%22CommonJS%22%60.%20That's%20valid%20right%20now%2C%20but%20if%20the%20tsconfig%20is%20updated%20to%20%60NodeNext%60%20or%20%60ESNext%60%20in%20the%20future%2C%20the%20%60%40ts-expect-error%60%20will%20flip%20to%20an%20%22Unused%20'%40ts-expect-error'%20directive%22%20error%20and%20break%20the%20TypeScript%20build.%20The%20comment%20explains%20the%20intent%20clearly%2C%20but%20it%20might%20be%20worth%20noting%20this%20dependency%20explicitly%20so%20future%20tsconfig%20changes%20don't%20catch%20maintainers%20off%20guard.%0A%0A&repo=generaltranslation%2Fgt&pr=1826&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fodysseus%2Fnext-config-esm-require%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fodysseus%2Fnext-config-esm-require%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fnext%2Fsrc%2F__tests__%2FpackageExports.test.ts%3A87-113%0A**CJS%20fallback%20not%20covered%20by%20regression%20test**%0A%0AThe%20new%20test%20validates%20importing%20%60gt-next%2Fconfig%60%20under%20%60--input-type%3Dmodule%60%2C%20which%20exercises%20the%20%60.mjs%60%20ESM%20build.%20The%20%60package.json%60%20exports%20for%20%60.%2Fconfig%60%20also%20expose%20a%20%60%22default%22%3A%20%22.%2Fdist%2Fconfig.js%22%60%20CJS%20fallback%20%28used%20when%20a%20consumer's%20%60next.config.js%60%20is%20plain%20CommonJS%29.%20That%20path%20runs%20the%20same%20%60createRequire%28import.meta.url%29%60%20source%20through%20a%20CJS%20transformation%20done%20by%20tsdown%2FRollup.%20If%20tsdown%20ever%20changes%20how%20it%20handles%20%60import.meta.url%60%20in%20CJS%20output%2C%20the%20CJS%20config%20path%20could%20silently%20regress%20with%20no%20test%20to%20catch%20it.%20Adding%20a%20parallel%20%60spawnSync%60%20with%20%60--input-type%3Dcommonjs%60%20%28or%20%60require%28'gt-next%2Fconfig'%29%60%29%20against%20%60dist%2Fconfig.js%60%20would%20close%20the%20gap.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fnext%2Fsrc%2Fplugin%2FgetStableNextVersionInfo.ts%3A14-16%0A**%60%40ts-expect-error%60%20will%20cause%20a%20build%20error%20if%20tsconfig%20is%20ever%20updated%20to%20ESM**%0A%0AThe%20directive%20suppresses%20the%20TypeScript%20error%20for%20%60import.meta.url%60%20under%20%60%22module%22%3A%20%22CommonJS%22%60.%20That's%20valid%20right%20now%2C%20but%20if%20the%20tsconfig%20is%20updated%20to%20%60NodeNext%60%20or%20%60ESNext%60%20in%20the%20future%2C%20the%20%60%40ts-expect-error%60%20will%20flip%20to%20an%20%22Unused%20'%40ts-expect-error'%20directive%22%20error%20and%20break%20the%20TypeScript%20build.%20The%20comment%20explains%20the%20intent%20clearly%2C%20but%20it%20might%20be%20worth%20noting%20this%20dependency%20explicitly%20so%20future%20tsconfig%20changes%20don't%20catch%20maintainers%20off%20guard.%0A%0A&repo=generaltranslation%2Fgt&pr=1826&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/next/src/__tests__/packageExports.test.ts:87-113
**CJS fallback not covered by regression test**

The new test validates importing `gt-next/config` under `--input-type=module`, which exercises the `.mjs` ESM build. The `package.json` exports for `./config` also expose a `"default": "./dist/config.js"` CJS fallback (used when a consumer's `next.config.js` is plain CommonJS). That path runs the same `createRequire(import.meta.url)` source through a CJS transformation done by tsdown/Rollup. If tsdown ever changes how it handles `import.meta.url` in CJS output, the CJS config path could silently regress with no test to catch it. Adding a parallel `spawnSync` with `--input-type=commonjs` (or `require('gt-next/config')`) against `dist/config.js` would close the gap.

### Issue 2 of 2
packages/next/src/plugin/getStableNextVersionInfo.ts:14-16
**`@ts-expect-error` will cause a build error if tsconfig is ever updated to ESM**

The directive suppresses the TypeScript error for `import.meta.url` under `"module": "CommonJS"`. That's valid right now, but if the tsconfig is updated to `NodeNext` or `ESNext` in the future, the `@ts-expect-error` will flip to an "Unused '@ts-expect-error' directive" error and break the TypeScript build. The comment explains the intent clearly, but it might be worth noting this dependency explicitly so future tsconfig changes don't catch maintainers off guard.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: support gt-next config ESM import"](https://github.com/generaltranslation/gt/commit/537236b520a8631d1edd8f5426d7cb43ce0632af) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41762038)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->