### PR TITLE
fix: repair broken type surfaces and ESM config entry before odysseus release

### DIFF
--- a/.changeset/fix-i18n-interpolation-options-dts.md
+++ b/.changeset/fix-i18n-interpolation-options-dts.md
@@ -1,0 +1,5 @@
+---
+"gt-i18n": patch
+---
+
+Fix the shipped `gt-i18n/internal` declarations referencing `InterpolationOptions` without declaring it (`stripInternal` removed the `@internal`-tagged alias but kept the reference, breaking consumers compiling with `skipLibCheck: false`). The type now lives in the shared options module, resolves in the emitted declarations, and is nameable from `gt-i18n/internal/types`.

--- a/.changeset/fix-next-config-esm-require.md
+++ b/.changeset/fix-next-config-esm-require.md
@@ -1,0 +1,5 @@
+---
+"gt-next": patch
+---
+
+Fix `gt-next/config` crashing at import time from ESM configs (`next.config.mjs` or `"type": "module"`). Version probing and the SWC wasm path resolution used bare `require` and `__dirname`, which don't exist in the ESM build; they now go through a CJS/ESM-safe compat helper, so `withGTConfig` works and the SWC compiler plugin resolves correctly from both module formats.

--- a/.changeset/fix-react-initialize-gt-types.md
+++ b/.changeset/fix-react-initialize-gt-types.md
@@ -1,0 +1,5 @@
+---
+"gt-react": patch
+---
+
+Fix the shared types entry re-exporting `initializeGT` from `@generaltranslation/react-core/pure`, which no longer exports it. The alias now points at the local `initializeGTSRA` wrapper like the runtime entries, so `gt-react` typechecks again and `initializeGT` is fully typed instead of degrading to `any`.

--- a/packages/i18n/src/translation-functions/types/options.ts
+++ b/packages/i18n/src/translation-functions/types/options.ts
@@ -120,3 +120,8 @@ export type NormalizedLookupOptions<T extends DataFormat> =
     $format: T;
     $locale: string;
   };
+
+/**
+ * Options for string interpolation, as accepted by `interpolateMessage`.
+ */
+export type InterpolationOptions = NormalizedLookupOptions<StringFormat>;

--- a/packages/i18n/src/translation-functions/types/options.ts
+++ b/packages/i18n/src/translation-functions/types/options.ts
@@ -123,5 +123,7 @@ export type NormalizedLookupOptions<T extends DataFormat> =
 
 /**
  * Options for string interpolation, as accepted by `interpolateMessage`.
+ * `$locale` and `$format` may be omitted: interpolation falls back to the
+ * source locale and 'STRING' format.
  */
-export type InterpolationOptions = NormalizedLookupOptions<StringFormat>;
+export type InterpolationOptions = LookupOptionsFor<StringFormat>;

--- a/packages/i18n/src/translation-functions/utils/interpolation/interpolateMessage.ts
+++ b/packages/i18n/src/translation-functions/utils/interpolation/interpolateMessage.ts
@@ -1,16 +1,6 @@
-import {
-  TranslationOptions,
-  NormalizedLookupOptions,
-} from '../../types/options';
+import { TranslationOptions, InterpolationOptions } from '../../types/options';
 import { interpolateIcuMessage } from './interpolateIcuMessage';
 import { interpolateStringMessage } from './interpolateStringMessage';
-import type { StringFormat } from '@generaltranslation/format/types';
-
-/**
- * Options for string interpolation
- * @internal
- */
-export type InterpolationOptions = NormalizedLookupOptions<StringFormat>;
 
 /**
  * Interpolation router function for all {@link StringFormat} types

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -33,6 +33,7 @@ import {
   rootParamStability,
   turboConfigStable,
 } from './plugin/getStableNextVersionInfo';
+import { distDir, nodeRequire } from './plugin/nodeCompat';
 import { validateCompiler } from './config-dir/utils/validateCompiler';
 import {
   REQUEST_FUNCTION_ALIASES,
@@ -251,11 +252,11 @@ export function withGTConfig<TNextConfig extends object = NextConfig>(
   if (mergedConfig.experimentalCompilerOptions?.type === 'swc') {
     try {
       if (turboPackEnabled) {
-        const absolutePath = path.resolve(__dirname, './gt_swc_plugin.wasm');
+        const absolutePath = path.resolve(distDir, './gt_swc_plugin.wasm');
         resolvedWasmFilePath =
           './' + path.relative(process.cwd(), absolutePath).replace(/\\/g, '/');
       } else {
-        resolvedWasmFilePath = path.resolve(__dirname, './gt_swc_plugin.wasm');
+        resolvedWasmFilePath = path.resolve(distDir, './gt_swc_plugin.wasm');
       }
     } catch (error) {
       console.error(
@@ -692,9 +693,9 @@ export function withGTConfig<TNextConfig extends object = NextConfig>(
         // Try to load GT compiler if available
         if (mergedConfig.experimentalCompilerOptions?.type === 'babel') {
           try {
-            const {
-              webpack: gtUnplugin,
-            } = require('@generaltranslation/compiler');
+            const { webpack: gtUnplugin } = nodeRequire(
+              '@generaltranslation/compiler'
+            );
             webpackConfig.plugins.unshift(
               gtUnplugin(mergedConfig.experimentalCompilerOptions || {})
             );

--- a/packages/next/src/plugin/getStableNextVersionInfo.ts
+++ b/packages/next/src/plugin/getStableNextVersionInfo.ts
@@ -8,6 +8,7 @@ import {
   STABLE_TURBO_CONFIG_VERSION,
   SWC_PLUGIN_SUPPORT,
 } from './constants';
+import { nodeRequire } from './nodeCompat';
 
 /**
  * Get the next version of the package.
@@ -16,12 +17,12 @@ function getPackageVersion(packageName: string): string {
   const packageJsonPath = `${packageName}/package.json`;
 
   try {
-    const resolvedPackageJsonPath = require.resolve(packageJsonPath, {
+    const resolvedPackageJsonPath = nodeRequire.resolve(packageJsonPath, {
       paths: [process.cwd()],
     });
-    return require(resolvedPackageJsonPath).version;
+    return nodeRequire(resolvedPackageJsonPath).version;
   } catch (_error) {
-    return require(packageJsonPath).version;
+    return nodeRequire(packageJsonPath).version;
   }
 }
 

--- a/packages/next/src/plugin/nodeCompat.ts
+++ b/packages/next/src/plugin/nodeCompat.ts
@@ -1,0 +1,21 @@
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// The `gt-next/config` entry runs in plain Node (next.config is loaded, not
+// bundled), so the ESM build (`dist/config.mjs`) has no CJS `require` or
+// `__dirname` and the build's `polyfillRequire: false` means rolldown won't
+// inject them. Derive both here; only import this module from the config
+// graph — `createRequire` from `node:module` breaks client bundlers.
+
+export const nodeRequire: NodeJS.Require =
+  typeof require === 'function' ? require : createRequire(import.meta.url);
+
+const nodeCompatDirname: string =
+  typeof __dirname === 'string'
+    ? __dirname
+    : path.dirname(fileURLToPath(import.meta.url));
+
+// This module is emitted to <dist>/plugin/, one level below dist assets like
+// gt_swc_plugin.wasm, in both the CJS and ESM builds.
+export const distDir: string = path.resolve(nodeCompatDirname, '..');

--- a/packages/next/tsconfig.json
+++ b/packages/next/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "CommonJS",
+    "module": "ESNext",
     "moduleResolution": "node",
     "sourceMap": true,
     "declarationMap": true,

--- a/packages/react/src/index.types.ts
+++ b/packages/react/src/index.types.ts
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import type { TxProps } from './utils/TxProps';
 
 export { initializeGTSPA } from './setup/initializeGTSPA';
+export { initializeGTSRA as initializeGT } from './setup/initializeGTSRA';
 export { useLocaleSelector } from './components/useLocaleSelector';
 export { useRegionSelector } from './components/useRegionSelector';
 export {
@@ -63,7 +64,6 @@ export {
   mFallback,
   gtFallback,
   getFormatLocales,
-  initializeGT,
   getDefaultLocale,
   getLocaleProperties,
   getLocales,


### PR DESCRIPTION
## TL;DR

Fixes three release blockers found while auditing the odysseus public API surfaces: gt-react ships broken type declarations, `gt-next/config` crashes at import time from ESM configs, and gt-i18n's shipped declarations reference an undeclared type.

## Code Changes

**gt-react — broken types entry**
- `src/index.types.ts` re-exported `initializeGT` from `@generaltranslation/react-core/pure`, which no longer exports it (removed in #1815; the runtime entries were updated but the shared types entry was missed). `pnpm --filter gt-react typecheck` failed with TS2305, consumers with `skipLibCheck: false` got a hard error on any `gt-react` import, and everyone else got `any` for `initializeGT`. Now aliases the local `initializeGTSRA` wrapper, matching `index.server.ts`.

**gt-next — ESM config build unusable**
- `dist/config.mjs` executed bare `require.resolve`/`require` at module-evaluation time (version probing) and `__dirname` (SWC wasm path), none of which exist in plain-Node ESM. Any `next.config.mjs` / `"type": "module"` project crashed on `import 'gt-next/config'`; the SWC compiler silently downgraded to `'none'`. All in-repo test apps use `next.config.ts` (transpiled to CJS), which is why nothing caught it.
- Added `src/plugin/nodeCompat.ts` exporting a CJS/ESM-safe `nodeRequire` and `distDir`, used by `getStableNextVersionInfo.ts` and `config.ts` (including the lazy `require('@generaltranslation/compiler')` in the webpack hook). `polyfillRequire: false` stays as-is — the compat module is only imported from the config graph, which is never client-bundled.
- `tsconfig.json`: `module: CommonJS` → `ESNext` (typecheck-only; tsdown does the real transpile). Required for `import.meta`, and aligns with every other package in the repo — gt-next was the lone outlier.

**gt-i18n — dangling type in shipped declarations**
- `dist/internal.d.mts` declared `interpolateMessage(... options: InterpolationOptions ...)` but never declared or imported `InterpolationOptions`: the alias was tagged `@internal` and `stripInternal: true` removed the declaration while keeping the reference. Since gt-react's and gt-next's own d.ts import from `gt-i18n/internal`, any app compiling with `skipLibCheck: false` broke just by importing them.
- Moved the alias into `translation-functions/types/options.ts` (next to `NormalizedLookupOptions`, which it wraps) and dropped the `@internal` tag. The emitted declarations now import it from the shared options chunk, and it's nameable from `gt-i18n/internal/types` via the existing `export type *`.

Patch changesets added for `gt-react`, `gt-next`, and `gt-i18n`.

## Notes / Flags

- **Verification:** typecheck + build + full test suites pass for gt-react (21), gt-next (223), gt-i18n (251); gt-tanstack-start (re-exports `initializeGT`) typechecks. Plain-Node smoke tests: `await import('gt-next/config')` (ESM) and `require('gt-next/config')` (CJS) both load; `nodeCompat` resolves `distDir` to `<pkg>/dist` and `next/package.json` in both formats.
- The SWC path couldn't be exercised fully end-to-end locally: the workspace's next@15.2.3 is below the plugin's 16.1.0 gate, so `validateCompiler` downgrades before wasm resolution. The `distDir` resolution itself is verified in both formats.
- The `module: ESNext` tsconfig flip is the one change with wider blast radius — worth a second look, though tsc is noEmit-only for this package.
- Process gap that let these ship: CI runs lint/build/test but never `typecheck`, and tsdown's dts emit passes unresolved re-exports through. Recommend adding `turbo typecheck` and a plain-Node ESM import smoke test to the release gate (not included in this PR).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes three release blockers discovered while auditing the odysseus public API surfaces before release: a broken `initializeGT` re-export in `gt-react`'s shared types entry, an ESM crash on `import 'gt-next/config'` caused by bare `require`/`__dirname` usage in the `.mjs` build, and a dangling `InterpolationOptions` reference in `gt-i18n`'s shipped declarations.

- **gt-react** (`index.types.ts`): Drops the removed `@generaltranslation/react-core/pure` re-export of `initializeGT` and aliases the local `initializeGTSRA` wrapper instead, matching `index.server.ts` and restoring correct types for all consumers.
- **gt-next** (`nodeCompat.ts`, `config.ts`, `getStableNextVersionInfo.ts`, `tsconfig.json`): Introduces a CJS/ESM-safe `nodeRequire`/`distDir` compat helper; replaces all bare `require`, `require.resolve`, and `__dirname` uses in the config graph with it. The tsconfig `module` setting is updated from `CommonJS` to `ESNext` to allow `import.meta` to typecheck — note that `moduleResolution` remains `"node"`, which is a mismatched combination for `module: ESNext` and may produce TypeScript diagnostics (see inline comment).
- **gt-i18n** (`options.ts`, `interpolateMessage.ts`): Promotes `InterpolationOptions` from an `@internal`-tagged alias (stripped from `.d.mts` by `stripInternal`) to a proper public export in the shared options module, resolving the dangling type reference in shipped declarations.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The three targeted fixes are correct and well-scoped; the `moduleResolution: "node"` + `module: "ESNext"` mismatch in the next package tsconfig is the only thing worth a follow-up.

All three bug fixes are mechanically sound: the `initializeGT` alias points at the right local wrapper, `nodeRequire`/`distDir` correctly handle both module formats at runtime, and `InterpolationOptions` is now properly declared in the shared options module. The one loose end is the `tsconfig.json` module/moduleResolution pairing — `"ESNext"` + `"node"` is a known mismatched combination in TypeScript 5.x that can surface diagnostics in editors and strict CI configurations, even though it doesn't block the build today.

packages/next/tsconfig.json — the `module`/`moduleResolution` mismatch is worth revisiting before the next typecheck-in-CI effort described in the PR notes.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/next/src/plugin/nodeCompat.ts | New ESM/CJS compat shim exporting `nodeRequire` and `distDir`; runtime branching is correct and `import.meta.url` is only evaluated in the ESM path. |
| packages/next/tsconfig.json | Flipped `module` from `CommonJS` to `ESNext` to allow `import.meta` to typecheck; `moduleResolution` stays `"node"`, which is a mismatched combination for ESNext — harmless here (tsdown builds, tsc is noEmit-only) but TypeScript may emit diagnostics about it. |
| packages/next/src/config.ts | Replaces `__dirname` with `distDir` for wasm path resolution and `require(...)` with `nodeRequire(...)` in the lazy webpack hook; both substitutions are correct and preserve original semantics. |
| packages/next/src/plugin/getStableNextVersionInfo.ts | Replaces bare `require`/`require.resolve` calls with `nodeRequire`/`nodeRequire.resolve` throughout; semantics unchanged, ESM-safe. |
| packages/react/src/index.types.ts | Drops the broken re-export of `initializeGT` from `@generaltranslation/react-core/pure` (removed upstream) and aliases the local `initializeGTSRA` instead, matching `index.server.ts`. |
| packages/i18n/src/translation-functions/types/options.ts | Adds `InterpolationOptions` as a named public export (alias for `NormalizedLookupOptions<StringFormat>`), fixing the dangling declaration in shipped `.d.mts` files. |
| packages/i18n/src/translation-functions/utils/interpolation/interpolateMessage.ts | Removes the `@internal`-tagged `InterpolationOptions` alias and its associated `StringFormat` import, importing the type from the shared options module instead. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["next.config.mjs / next.config.ts"] -->|"import 'gt-next/config'"| B["dist/config.mjs OR dist/config.js"]
    B --> C["nodeCompat.ts"]
    C -->|"typeof require === 'function'"| D{"CJS or ESM?"}
    D -->|"CJS (dist/config.js)"| E["use native require"]
    D -->|"ESM (dist/config.mjs)"| F["createRequire(import.meta.url)"]
    E --> G["nodeRequire"]
    F --> G
    G --> H["getStableNextVersionInfo.ts\n(version probing)"]
    G --> I["lazy require('@generaltranslation/compiler')\n(webpack hook)"]
    C -->|"path.resolve(nodeCompatDirname, '..')"| J["distDir = dist/"]
    J --> K["path.resolve(distDir, './gt_swc_plugin.wasm')"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["next.config.mjs / next.config.ts"] -->|"import 'gt-next/config'"| B["dist/config.mjs OR dist/config.js"]
    B --> C["nodeCompat.ts"]
    C -->|"typeof require === 'function'"| D{"CJS or ESM?"}
    D -->|"CJS (dist/config.js)"| E["use native require"]
    D -->|"ESM (dist/config.mjs)"| F["createRequire(import.meta.url)"]
    E --> G["nodeRequire"]
    F --> G
    G --> H["getStableNextVersionInfo.ts\n(version probing)"]
    G --> I["lazy require('@generaltranslation/compiler')\n(webpack hook)"]
    C -->|"path.resolve(nodeCompatDirname, '..')"| J["distDir = dist/"]
    J --> K["path.resolve(distDir, './gt_swc_plugin.wasm')"]
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fnext%2Ftsconfig.json%3A4-5%0A%60module%3A%20%22ESNext%22%60%20paired%20with%20%60moduleResolution%3A%20%22node%22%60%20is%20a%20mismatched%20combination%20%E2%80%94%20TypeScript%205.x%20expects%20%60moduleResolution%60%20to%20be%20%60%22bundler%22%60%2C%20%60%22node16%22%60%2C%20or%20%60%22nodenext%22%60%20when%20%60module%60%20is%20%60%22ESNext%22%60.%20While%20this%20is%20typecheck-only%20%28%60tsc%60%20is%20noEmit%20here%20and%20tsdown%20handles%20the%20real%20build%29%2C%20editors%20and%20CI%20runs%20may%20surface%20a%20TS5110%20diagnostic%20on%20this%20combination.%20Using%20%60%22bundler%22%60%20would%20be%20the%20idiomatic%20match%20for%20ESNext%20output%20in%20a%20monorepo%20with%20a%20bundler-driven%20build.%0A%0A%60%60%60suggestion%0A%20%20%20%20%22module%22%3A%20%22ESNext%22%2C%0A%20%20%20%20%22moduleResolution%22%3A%20%22bundler%22%2C%0A%60%60%60%0A%0A&repo=generaltranslation%2Fgt&pr=1827&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22bg%2Ffix-release-api-blockers%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22bg%2Ffix-release-api-blockers%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fnext%2Ftsconfig.json%3A4-5%0A%60module%3A%20%22ESNext%22%60%20paired%20with%20%60moduleResolution%3A%20%22node%22%60%20is%20a%20mismatched%20combination%20%E2%80%94%20TypeScript%205.x%20expects%20%60moduleResolution%60%20to%20be%20%60%22bundler%22%60%2C%20%60%22node16%22%60%2C%20or%20%60%22nodenext%22%60%20when%20%60module%60%20is%20%60%22ESNext%22%60.%20While%20this%20is%20typecheck-only%20%28%60tsc%60%20is%20noEmit%20here%20and%20tsdown%20handles%20the%20real%20build%29%2C%20editors%20and%20CI%20runs%20may%20surface%20a%20TS5110%20diagnostic%20on%20this%20combination.%20Using%20%60%22bundler%22%60%20would%20be%20the%20idiomatic%20match%20for%20ESNext%20output%20in%20a%20monorepo%20with%20a%20bundler-driven%20build.%0A%0A%60%60%60suggestion%0A%20%20%20%20%22module%22%3A%20%22ESNext%22%2C%0A%20%20%20%20%22moduleResolution%22%3A%20%22bundler%22%2C%0A%60%60%60%0A%0A&repo=generaltranslation%2Fgt&pr=1827&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/next/tsconfig.json:4-5
`module: "ESNext"` paired with `moduleResolution: "node"` is a mismatched combination — TypeScript 5.x expects `moduleResolution` to be `"bundler"`, `"node16"`, or `"nodenext"` when `module` is `"ESNext"`. While this is typecheck-only (`tsc` is noEmit here and tsdown handles the real build), editors and CI runs may surface a TS5110 diagnostic on this combination. Using `"bundler"` would be the idiomatic match for ESNext output in a monorepo with a bundler-driven build.

```suggestion
    "module": "ESNext",
    "moduleResolution": "bundler",
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(i18n): declare InterpolationOptions ..."](https://github.com/generaltranslation/gt/commit/d661c98f5826905020401a478f29cbb42694523c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41762347)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->