### PR TITLE
fix: repair gt-react initializeGT types

### DIFF
--- a/.changeset/fix-react-initialize-gt-types.md
+++ b/.changeset/fix-react-initialize-gt-types.md
@@ -1,0 +1,5 @@
+---
+'gt-react': patch
+---
+
+Fix shipped types for the initializeGT export.

--- a/packages/react/src/index.types.ts
+++ b/packages/react/src/index.types.ts
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import type { TxProps } from './utils/TxProps';
 
 export { initializeGTSPA } from './setup/initializeGTSPA';
+export { initializeGTSRA as initializeGT } from './setup/initializeGTSRA';
 export { useLocaleSelector } from './components/useLocaleSelector';
 export { useRegionSelector } from './components/useRegionSelector';
 export {
@@ -63,7 +64,6 @@ export {
   mFallback,
   gtFallback,
   getFormatLocales,
-  initializeGT,
   getDefaultLocale,
   getLocaleProperties,
   getLocales,


### PR DESCRIPTION
## Summary
- alias gt-react's type-only initializeGT export to the local SRA initializer
- add a patch changeset for gt-react

## Verification
- pnpm --filter gt-react typecheck

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the `initializeGT` type export in `gt-react` by aliasing it to the local `initializeGTSRA` initializer instead of incorrectly re-exporting from `@generaltranslation/react-core/pure`. The `index.types.ts` file is used as the declared types for both the server (`index.server.ts`) and browser (`index.client.ts`) runtime entry points.

- **Server alignment**: `index.server.ts` already exports `initializeGTSRA as initializeGT`, so `index.types.ts` now correctly reflects the real server-side implementation.
- **Browser alignment**: The browser runtime (`index.client.ts`) uses `initializeGTSRAClient as initializeGT`, which shares the same type signature as `initializeGTSRA` (`(config: I18nConfigParams & ReactI18nCacheParams) => void`), so the shared types file remains accurate for browser consumers as well.
- A patch changeset is included to version-bump `gt-react` appropriately.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

A minimal, targeted types-only fix with no runtime behavior changes.

The change removes an outdated re-export of `initializeGT` from the upstream `react-core/pure` package and replaces it with a direct alias of the local `initializeGTSRA` function. Both the server (`index.server.ts`) and browser (`index.client.ts`) runtimes already resolve `initializeGT` to functions with the identical TypeScript signature `(config: I18nConfigParams & ReactI18nCacheParams) => void`, so the new types file faithfully reflects what consumers receive at runtime. No production logic is changed.

No files require special attention. The two touched files (`index.types.ts` and the changeset) are straightforward.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react/src/index.types.ts | Replaces the previously incorrect `initializeGT` re-export (from react-core/pure) with a local alias of `initializeGTSRA`, aligning declared types with the actual server and browser runtime implementations. |
| .changeset/fix-react-initialize-gt-types.md | Adds a patch changeset for `gt-react` describing the shipped-types fix. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Consumer as gt-react Consumer
    participant Types as index.types.ts (types)
    participant Server as index.server.ts (runtime)
    participant Client as index.client.ts (browser runtime)
    participant SRA as initializeGTSRA
    participant SRAClient as initializeGTSRAClient

    note over Types,SRA: Before this PR
    Consumer->>Types: import initializeGT
    Types-->>Consumer: initializeGT (from react-core/pure — wrong type)
    Consumer->>Server: call initializeGT (runtime)
    Server->>SRA: initializeGTSRA (actual impl)

    note over Types,SRA: After this PR
    Consumer->>Types: import initializeGT
    Types-->>Consumer: initializeGT (aliased to initializeGTSRA — correct type)
    Consumer->>Server: call initializeGT (runtime)
    Server->>SRA: initializeGTSRA ✅ types match
    Consumer->>Client: call initializeGT (browser runtime)
    Client->>SRAClient: initializeGTSRAClient (same signature) ✅ types match
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Consumer as gt-react Consumer
    participant Types as index.types.ts (types)
    participant Server as index.server.ts (runtime)
    participant Client as index.client.ts (browser runtime)
    participant SRA as initializeGTSRA
    participant SRAClient as initializeGTSRAClient

    note over Types,SRA: Before this PR
    Consumer->>Types: import initializeGT
    Types-->>Consumer: initializeGT (from react-core/pure — wrong type)
    Consumer->>Server: call initializeGT (runtime)
    Server->>SRA: initializeGTSRA (actual impl)

    note over Types,SRA: After this PR
    Consumer->>Types: import initializeGT
    Types-->>Consumer: initializeGT (aliased to initializeGTSRA — correct type)
    Consumer->>Server: call initializeGT (runtime)
    Server->>SRA: initializeGTSRA ✅ types match
    Consumer->>Client: call initializeGT (browser runtime)
    Client->>SRAClient: initializeGTSRAClient (same signature) ✅ types match
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: repair gt-react initializeGT types"](https://github.com/generaltranslation/gt/commit/b27c1556089d401fa10e61714762ba2d2b082a31) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41762381)</sub>

<!-- /greptile_comment -->