### PR TITLE
fix: resolve next config swc plugin path in esm

### DIFF
--- a/.changeset/fix-next-config-esm-dirname.md
+++ b/.changeset/fix-next-config-esm-dirname.md
@@ -1,0 +1,5 @@
+---
+'gt-next': patch
+---
+
+Fix SWC plugin path resolution in the ESM config build.

--- a/packages/next/src/__tests__/config.test.ts
+++ b/packages/next/src/__tests__/config.test.ts
@@ -1258,6 +1258,27 @@ describe('withGTConfig', () => {
   // 13. Compiler configuration
   // ==============================
   describe('13. Compiler configuration', () => {
+    it('keeps the SWC compiler enabled when resolving the plugin path', async () => {
+      const withGTConfig = await getWithGTConfig();
+
+      const result = withGTConfig(
+        {},
+        { experimentalCompilerOptions: { type: 'swc' } }
+      );
+      const params = parseConfigParams(result);
+
+      expect(params.experimentalCompilerOptions.type).toBe('swc');
+      expect(result.experimental!.swcPlugins).toEqual([
+        [
+          expect.stringMatching(/gt_swc_plugin\.wasm$/),
+          expect.objectContaining({
+            autoderiveJsx: false,
+            autoderiveStrings: false,
+          }),
+        ],
+      ]);
+    });
+
     it('uses a Turbopack-specific babel compiler warning', async () => {
       const withGTConfig = await getWithGTConfig();
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import fs from 'fs';
+import { fileURLToPath } from 'node:url';
 import type { NextConfig } from 'next';
 import {
   defaultWithGTConfigProps,
@@ -46,6 +47,16 @@ import {
 } from './errors/cacheComponents';
 import { I18nConfigParams } from 'gt-i18n/internal/types';
 import { getRuntimeCredentials } from './setup/runtimeCredentials';
+
+const configDirname =
+  typeof __dirname === 'string'
+    ? __dirname
+    : path.dirname(
+        fileURLToPath(
+          // @ts-expect-error import.meta is available in the ESM build.
+          import.meta.url
+        )
+      );
 
 type AutoderiveConfig = boolean | { jsx?: boolean; strings?: boolean };
 
@@ -251,11 +262,17 @@ export function withGTConfig<TNextConfig extends object = NextConfig>(
   if (mergedConfig.experimentalCompilerOptions?.type === 'swc') {
     try {
       if (turboPackEnabled) {
-        const absolutePath = path.resolve(__dirname, './gt_swc_plugin.wasm');
+        const absolutePath = path.resolve(
+          configDirname,
+          './gt_swc_plugin.wasm'
+        );
         resolvedWasmFilePath =
           './' + path.relative(process.cwd(), absolutePath).replace(/\\/g, '/');
       } else {
-        resolvedWasmFilePath = path.resolve(__dirname, './gt_swc_plugin.wasm');
+        resolvedWasmFilePath = path.resolve(
+          configDirname,
+          './gt_swc_plugin.wasm'
+        );
       }
     } catch (error) {
       console.error(


### PR DESCRIPTION
## Summary
- replace gt-next config SWC wasm path resolution with a CJS/ESM-safe dirname helper
- add a regression test that SWC compiler config stays enabled when resolving the plugin path
- add a patch changeset for gt-next

## Tests
- pnpm --filter @generaltranslation/format --filter generaltranslation --filter gt-i18n --filter @generaltranslation/react-core --filter gt-react --filter @generaltranslation/compiler build
- pnpm --filter gt-next exec vitest run src/__tests__/config.test.ts
- pnpm --filter gt-next build:no-swc-plugin
- node --input-type=module -e "import { createRequire } from 'node:module'; const baseRequire = createRequire(new URL('./packages/next/dist/config.mjs', import.meta.url)); function req(id) { if (id === 'next/package.json') return { version: '16.1.0' }; return baseRequire(id); } req.resolve = (id, options) => id === 'next/package.json' ? 'next/package.json' : baseRequire.resolve(id, options); globalThis.require = req; const { withGTConfig } = await import('./packages/next/dist/config.mjs'); const result = withGTConfig({}, { experimentalCompilerOptions: { type: 'swc' }, runtimeUrl: '', cacheUrl: null }); const params = JSON.parse(result.env._GENERALTRANSLATION_I18N_CONFIG_PARAMS); console.log(params.experimentalCompilerOptions.type); console.log(result.experimental.swcPlugins[0][0]);"

## Notes
- Initial pnpm install attempts failed in the shared pnpm store while linking expo/sanity bins, but package-level builds and focused tests completed after dependency dist outputs were built.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes `__dirname` usage inside `config.ts` so the SWC plugin path resolves correctly in the ESM (`.mjs`) build output, where `__dirname` is not natively available. A module-level `configDirname` helper picks `__dirname` in CJS and falls back to `path.dirname(fileURLToPath(import.meta.url))` in ESM, and a regression test verifies the `swcPlugins` entry is populated (not silently cleared) when the SWC compiler is requested.

- **`packages/next/src/config.ts`**: Replaces two direct `__dirname` references in the SWC wasm path resolution block with the new `configDirname` constant, which is correct for both the CJS `.js` build (where `__dirname` is a string) and the ESM `.mjs` build (where it uses `import.meta.url`).
- **`packages/next/src/__tests__/config.test.ts`**: Adds a regression test asserting that requesting `type: 'swc'` keeps `experimentalCompilerOptions.type` as `'swc'` and produces a `swcPlugins` entry whose path ends with `gt_swc_plugin.wasm`.
- **`.changeset/fix-next-config-esm-dirname.md`**: Adds a patch-level changeset entry for `gt-next`.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is surgical, touching only the two __dirname call sites in the SWC path block, and the regression test directly validates the fix.

The configDirname shim uses the standard CJS/ESM dual-build pattern (typeof __dirname === 'string' guard + fileURLToPath(import.meta.url) fallback), the @ts-expect-error is correctly positioned for the CommonJS TypeScript config, and tsdown produces separate .js and .mjs artifacts so each branch is exercised in the right runtime. No existing behaviour is changed in the CJS build path.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/next/src/config.ts | Introduces configDirname CJS/ESM compatibility shim; replaces two __dirname usages in the SWC wasm path resolution block — fix looks correct and minimal. |
| packages/next/src/__tests__/config.test.ts | Adds a targeted regression test for the SWC plugin path resolution; correctly asserts both compiler type preservation and the wasm path pattern. |
| .changeset/fix-next-config-esm-dirname.md | Patch changeset for gt-next — correctly scoped and described. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Module initialisation] --> B{typeof __dirname === 'string'?}
    B -- Yes: CJS build .js --> C[configDirname = __dirname]
    B -- No: ESM build .mjs --> D[configDirname = path.dirname fileURLToPath import.meta.url]
    C --> E[withGTConfig called with type swc]
    D --> E
    E --> F{TURBOPACK env set?}
    F -- Yes --> G[absolutePath resolved from configDirname, wasmFilePath set as relative]
    F -- No --> H[resolvedWasmFilePath set as absolute from configDirname]
    G --> I[swcPlugins entry added to NextConfig]
    H --> I
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Module initialisation] --> B{typeof __dirname === 'string'?}
    B -- Yes: CJS build .js --> C[configDirname = __dirname]
    B -- No: ESM build .mjs --> D[configDirname = path.dirname fileURLToPath import.meta.url]
    C --> E[withGTConfig called with type swc]
    D --> E
    E --> F{TURBOPACK env set?}
    F -- Yes --> G[absolutePath resolved from configDirname, wasmFilePath set as relative]
    F -- No --> H[resolvedWasmFilePath set as absolute from configDirname]
    G --> I[swcPlugins entry added to NextConfig]
    H --> I
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: resolve next config swc plugin path..."](https://github.com/generaltranslation/gt/commit/31171934e46a30dc69aff3f10108dd24f5f59bc5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41762428)</sub>

<!-- /greptile_comment -->