### PR TITLE
fix: wrap react rsc translate exports

### DIFF
--- a/.changeset/react-rsc-translate-wrappers.md
+++ b/.changeset/react-rsc-translate-wrappers.md
@@ -1,0 +1,5 @@
+---
+'gt-react': patch
+---
+
+Wrap react-server T and Tx exports so they receive RSC locale conditions.

--- a/packages/react/src/__tests__/index-rsc-translate-wrappers.test.ts
+++ b/packages/react/src/__tests__/index-rsc-translate-wrappers.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockGetI18nConfig,
+  mockGetLocale,
+  mockResolveSupportedLocale,
+  mockRscT,
+  mockRscTx,
+} = vi.hoisted(() => ({
+  mockGetI18nConfig: vi.fn(),
+  mockGetLocale: vi.fn(),
+  mockResolveSupportedLocale: vi.fn(),
+  mockRscT: vi.fn(),
+  mockRscTx: vi.fn(),
+}));
+
+vi.mock('gt-i18n', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('gt-i18n')>()),
+  getLocale: mockGetLocale,
+}));
+
+vi.mock('gt-i18n/internal', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('gt-i18n/internal')>()),
+  getI18nConfig: mockGetI18nConfig,
+}));
+
+vi.mock(
+  '@generaltranslation/react-core/components-rsc',
+  async (importOriginal) => ({
+    ...(await importOriginal<
+      typeof import('@generaltranslation/react-core/components-rsc')
+    >()),
+    T: mockRscT,
+    Tx: mockRscTx,
+  })
+);
+
+describe('gt-react RSC translate wrappers', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mockGetLocale.mockReturnValue('fr');
+    mockResolveSupportedLocale.mockImplementation((locale: string) => locale);
+    mockGetI18nConfig.mockReturnValue({
+      resolveSupportedLocale: mockResolveSupportedLocale,
+    });
+    mockRscT.mockResolvedValue('translated T');
+    mockRscTx.mockResolvedValue('translated Tx');
+  });
+
+  it('passes locale conditions to T', async () => {
+    const { T } = await import('../index.rsc');
+
+    await expect(T({ children: 'Hello' })).resolves.toBe('translated T');
+
+    expect(mockGetLocale).toHaveBeenCalledOnce();
+    expect(mockResolveSupportedLocale).toHaveBeenCalledWith('fr');
+    expect(mockRscT).toHaveBeenCalledWith({
+      children: 'Hello',
+      _locale: 'fr',
+      _enableI18n: true,
+    });
+    expect(T._gtt).toBe('translate-server');
+  });
+
+  it('passes locale conditions to Tx', async () => {
+    const { Tx } = await import('../index.rsc');
+
+    await expect(
+      Tx({ children: 'Hello', context: 'greeting', locale: 'es' })
+    ).resolves.toBe('translated Tx');
+
+    expect(mockGetLocale).not.toHaveBeenCalled();
+    expect(mockResolveSupportedLocale).toHaveBeenCalledWith('es');
+    expect(mockRscTx).toHaveBeenCalledWith({
+      children: 'Hello',
+      context: 'greeting',
+      _locale: 'es',
+      _enableI18n: true,
+    });
+    expect(Tx._gtt).toBe('translate-runtime');
+  });
+});

--- a/packages/react/src/index.rsc.ts
+++ b/packages/react/src/index.rsc.ts
@@ -9,7 +9,21 @@ import {
   getTranslations,
 } from 'gt-i18n/internal';
 import { getLocale, getRegion } from 'gt-i18n';
-import { use } from 'react';
+import { use, type ReactNode } from 'react';
+import {
+  T as RscT,
+  Tx as RscTx,
+} from '@generaltranslation/react-core/components-rsc';
+import type { TxProps } from './utils/TxProps';
+
+type TProps = Omit<Parameters<typeof RscT>[0], '_locale' | '_enableI18n'>;
+
+function getRscTranslationConditions(locale: string = getLocale()) {
+  return {
+    _locale: getI18nConfig().resolveSupportedLocale(locale),
+    _enableI18n: true,
+  };
+}
 
 // ===== Error for client components ===== //
 function failClientComponent(componentName: string) {
@@ -42,10 +56,28 @@ export {
   Num,
   Plural,
   RelativeTime,
-  T,
   Var,
-  Tx,
 } from '@generaltranslation/react-core/components-rsc';
+
+export async function T(props: TProps): Promise<ReactNode> {
+  return RscT({
+    ...props,
+    ...getRscTranslationConditions(),
+  });
+}
+
+/** @internal _gtt - The GT transformation for the component. */
+T._gtt = 'translate-server';
+
+export async function Tx({ locale, ...props }: TxProps): Promise<ReactNode> {
+  return RscTx({
+    ...props,
+    ...getRscTranslationConditions(locale || getLocale()),
+  });
+}
+
+/** @internal _gtt - The GT transformation for the component. */
+Tx._gtt = 'translate-runtime';
 
 // ===== Hooks (cannot reference context) ===== //
 


### PR DESCRIPTION
## Summary
- wrap gt-react react-server T and Tx exports so they inject locale conditions before calling react-core RSC components
- add focused tests for the hidden _locale/_enableI18n props
- add a patch changeset for gt-react

## Verification
- pnpm install --force
- pnpm --filter gt-react... build
- pnpm --filter gt-react build
- pnpm --filter gt-react test -- src/__tests__/index-rsc-translate-wrappers.test.ts
- pnpm exec oxfmt --check packages/react/src/index.rsc.ts packages/react/src/__tests__/index-rsc-translate-wrappers.test.ts .changeset/react-rsc-translate-wrappers.md
- pnpm exec oxlint packages/react/src/index.rsc.ts packages/react/src/__tests__/index-rsc-translate-wrappers.test.ts

## Caveats
- pnpm --filter gt-react typecheck currently fails on an existing unrelated index.types.ts initializeGT export mismatch.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wraps the `T` and `Tx` re-exports in `index.rsc.ts` so that every RSC call automatically injects the resolved `_locale` and `_enableI18n` conditions before delegating to the underlying `react-core` RSC components. Focused vitest unit tests verify the hidden prop injection and the `_gtt` markers.

- **`index.rsc.ts`**: `T` and `Tx` are no longer pass-through re-exports; each now calls `getRscTranslationConditions` to resolve the locale via `getI18nConfig().resolveSupportedLocale` and injects `_locale`/`_enableI18n` into the forwarded props. `_gtt` markers (`translate-server` / `translate-runtime`) are preserved on the wrapper functions.
- **Tests**: `vi.resetModules()` + dynamic `await import` pattern correctly isolates each test to a fresh module instance; both the locale-injection path and the `_gtt` tag are asserted. The fallback path for `Tx` when no explicit `locale` prop is provided is not yet covered.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The wrapper logic is sound and the locale injection is correctly applied in both T and Tx; the only gaps are a missing Tx fallback-locale test and a minor style inconsistency in how the default locale is passed.

The core locale-injection behavior is correct and well-tested for the happy path. The Tx wrapper leaves the no-locale branch untested, and there is a minor redundancy where locale || getLocale() is evaluated eagerly before entering getRscTranslationConditions even though the function default parameter would handle undefined cleanly.

packages/react/src/__tests__/index-rsc-translate-wrappers.test.ts — add a test for Tx without a locale prop to cover the getLocale() fallback branch.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react/src/index.rsc.ts | Wraps the re-exported RSC T and Tx with locale-injection helpers; logic is correct but Tx has a minor redundant getLocale() call via || instead of letting the default parameter handle it. |
| packages/react/src/__tests__/index-rsc-translate-wrappers.test.ts | Focused tests verify _locale/_enableI18n injection and _gtt markers; missing coverage for the Tx no-locale fallback path that triggers getLocale(). |
| .changeset/react-rsc-translate-wrappers.md | Patch-level changeset for gt-react; accurately describes the change. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant T_wrapper as T (index.rsc.ts)
    participant Tx_wrapper as Tx (index.rsc.ts)
    participant getRscConds as getRscTranslationConditions
    participant getLocale as getLocale (gt-i18n)
    participant i18nConfig as getI18nConfig()
    participant RscT as RscT (react-core)
    participant RscTx as RscTx (react-core)

    Caller->>T_wrapper: "T({ children, ...props })"
    T_wrapper->>getRscConds: getRscTranslationConditions()
    getRscConds->>getLocale: getLocale() [default param]
    getLocale-->>getRscConds: locale
    getRscConds->>i18nConfig: resolveSupportedLocale(locale)
    i18nConfig-->>getRscConds: resolvedLocale
    getRscConds-->>T_wrapper: "{ _locale, _enableI18n: true }"
    T_wrapper->>RscT: "RscT({ ...props, _locale, _enableI18n })"
    RscT-->>Caller: ReactNode

    Caller->>Tx_wrapper: "Tx({ children, locale?, ...props })"
    alt locale provided
        Tx_wrapper->>getRscConds: getRscTranslationConditions(locale)
    else locale absent
        Tx_wrapper->>getLocale: getLocale()
        getLocale-->>Tx_wrapper: fallbackLocale
        Tx_wrapper->>getRscConds: getRscTranslationConditions(fallbackLocale)
    end
    getRscConds->>i18nConfig: resolveSupportedLocale(locale)
    i18nConfig-->>getRscConds: resolvedLocale
    getRscConds-->>Tx_wrapper: "{ _locale, _enableI18n: true }"
    Tx_wrapper->>RscTx: "RscTx({ ...props, _locale, _enableI18n })"
    RscTx-->>Caller: ReactNode
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant T_wrapper as T (index.rsc.ts)
    participant Tx_wrapper as Tx (index.rsc.ts)
    participant getRscConds as getRscTranslationConditions
    participant getLocale as getLocale (gt-i18n)
    participant i18nConfig as getI18nConfig()
    participant RscT as RscT (react-core)
    participant RscTx as RscTx (react-core)

    Caller->>T_wrapper: "T({ children, ...props })"
    T_wrapper->>getRscConds: getRscTranslationConditions()
    getRscConds->>getLocale: getLocale() [default param]
    getLocale-->>getRscConds: locale
    getRscConds->>i18nConfig: resolveSupportedLocale(locale)
    i18nConfig-->>getRscConds: resolvedLocale
    getRscConds-->>T_wrapper: "{ _locale, _enableI18n: true }"
    T_wrapper->>RscT: "RscT({ ...props, _locale, _enableI18n })"
    RscT-->>Caller: ReactNode

    Caller->>Tx_wrapper: "Tx({ children, locale?, ...props })"
    alt locale provided
        Tx_wrapper->>getRscConds: getRscTranslationConditions(locale)
    else locale absent
        Tx_wrapper->>getLocale: getLocale()
        getLocale-->>Tx_wrapper: fallbackLocale
        Tx_wrapper->>getRscConds: getRscTranslationConditions(fallbackLocale)
    end
    getRscConds->>i18nConfig: resolveSupportedLocale(locale)
    i18nConfig-->>getRscConds: resolvedLocale
    getRscConds-->>Tx_wrapper: "{ _locale, _enableI18n: true }"
    Tx_wrapper->>RscTx: "RscTx({ ...props, _locale, _enableI18n })"
    RscTx-->>Caller: ReactNode
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Freact%2Fsrc%2F__tests__%2Findex-rsc-translate-wrappers.test.ts%3A66-83%0A**Missing%20test%20for%20%60Tx%60%20without%20an%20explicit%20locale**%0A%0AThe%20only%20%60Tx%60%20test%20supplies%20%60locale%3A%20'es'%60%2C%20so%20the%20branch%20where%20%60locale%60%20is%20absent%20%E2%80%94%20and%20the%20wrapper%20falls%20back%20to%20%60locale%20%7C%7C%20getLocale%28%29%60%20%E2%80%94%20is%20never%20exercised.%20Without%20a%20test%20covering%20that%20path%2C%20a%20regression%20that%20accidentally%20drops%20the%20%60getLocale%28%29%60%20call%20would%20be%20silently%20undetected%20while%20the%20two%20existing%20assertions%20still%20pass.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Freact%2Fsrc%2Findex.rsc.ts%3A72-77%0A**Redundant%20%60getLocale%28%29%60%20eager%20evaluation%20in%20%60Tx%60**%0A%0A%60locale%20%7C%7C%20getLocale%28%29%60%20evaluates%20%60getLocale%28%29%60%20before%20entering%20%60getRscTranslationConditions%60%2C%20even%20though%20the%20function%20already%20declares%20%60locale%3A%20string%20%3D%20getLocale%28%29%60%20as%20its%20default%20parameter.%20Passing%20%60locale%60%20directly%20lets%20the%20default%20trigger%20lazily%20only%20when%20%60locale%60%20is%20%60undefined%60%2C%20and%20removes%20the%20duplicate%20call%20site.%0A%0A%60%60%60suggestion%0Aexport%20async%20function%20Tx%28%7B%20locale%2C%20...props%20%7D%3A%20TxProps%29%3A%20Promise%3CReactNode%3E%20%7B%0A%20%20return%20RscTx%28%7B%0A%20%20%20%20...props%2C%0A%20%20%20%20...getRscTranslationConditions%28locale%29%2C%0A%20%20%7D%29%3B%0A%7D%0A%60%60%60%0A%0A&repo=generaltranslation%2Fgt&pr=1831&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fodysseus%2Freact-rsc-translate-wrappers%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fodysseus%2Freact-rsc-translate-wrappers%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Freact%2Fsrc%2F__tests__%2Findex-rsc-translate-wrappers.test.ts%3A66-83%0A**Missing%20test%20for%20%60Tx%60%20without%20an%20explicit%20locale**%0A%0AThe%20only%20%60Tx%60%20test%20supplies%20%60locale%3A%20'es'%60%2C%20so%20the%20branch%20where%20%60locale%60%20is%20absent%20%E2%80%94%20and%20the%20wrapper%20falls%20back%20to%20%60locale%20%7C%7C%20getLocale%28%29%60%20%E2%80%94%20is%20never%20exercised.%20Without%20a%20test%20covering%20that%20path%2C%20a%20regression%20that%20accidentally%20drops%20the%20%60getLocale%28%29%60%20call%20would%20be%20silently%20undetected%20while%20the%20two%20existing%20assertions%20still%20pass.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Freact%2Fsrc%2Findex.rsc.ts%3A72-77%0A**Redundant%20%60getLocale%28%29%60%20eager%20evaluation%20in%20%60Tx%60**%0A%0A%60locale%20%7C%7C%20getLocale%28%29%60%20evaluates%20%60getLocale%28%29%60%20before%20entering%20%60getRscTranslationConditions%60%2C%20even%20though%20the%20function%20already%20declares%20%60locale%3A%20string%20%3D%20getLocale%28%29%60%20as%20its%20default%20parameter.%20Passing%20%60locale%60%20directly%20lets%20the%20default%20trigger%20lazily%20only%20when%20%60locale%60%20is%20%60undefined%60%2C%20and%20removes%20the%20duplicate%20call%20site.%0A%0A%60%60%60suggestion%0Aexport%20async%20function%20Tx%28%7B%20locale%2C%20...props%20%7D%3A%20TxProps%29%3A%20Promise%3CReactNode%3E%20%7B%0A%20%20return%20RscTx%28%7B%0A%20%20%20%20...props%2C%0A%20%20%20%20...getRscTranslationConditions%28locale%29%2C%0A%20%20%7D%29%3B%0A%7D%0A%60%60%60%0A%0A&repo=generaltranslation%2Fgt&pr=1831&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/react/src/__tests__/index-rsc-translate-wrappers.test.ts:66-83
**Missing test for `Tx` without an explicit locale**

The only `Tx` test supplies `locale: 'es'`, so the branch where `locale` is absent — and the wrapper falls back to `locale || getLocale()` — is never exercised. Without a test covering that path, a regression that accidentally drops the `getLocale()` call would be silently undetected while the two existing assertions still pass.

### Issue 2 of 2
packages/react/src/index.rsc.ts:72-77
**Redundant `getLocale()` eager evaluation in `Tx`**

`locale || getLocale()` evaluates `getLocale()` before entering `getRscTranslationConditions`, even though the function already declares `locale: string = getLocale()` as its default parameter. Passing `locale` directly lets the default trigger lazily only when `locale` is `undefined`, and removes the duplicate call site.

```suggestion
export async function Tx({ locale, ...props }: TxProps): Promise<ReactNode> {
  return RscTx({
    ...props,
    ...getRscTranslationConditions(locale),
  });
}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: wrap react rsc translate exports"](https://github.com/generaltranslation/gt/commit/6f6060ab5dbdd8a1bdcb95824d939158d2cd543b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41762445)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->