### PR TITLE
fix: export internal interpolation options

### DIFF
--- a/.changeset/internal-interpolation-options.md
+++ b/.changeset/internal-interpolation-options.md
@@ -1,0 +1,5 @@
+---
+'gt-i18n': patch
+---
+
+Export internal interpolation option types from the `gt-i18n/internal` entry point.

--- a/packages/i18n/src/internal.ts
+++ b/packages/i18n/src/internal.ts
@@ -1,3 +1,6 @@
+import type { StringFormat } from '@generaltranslation/format/types';
+import type { NormalizedLookupOptions } from './translation-functions/types/options';
+
 export { getGT, getGTInternal } from './translation-functions/internal/getGT';
 export {
   getMessages,
@@ -25,6 +28,7 @@ export type { LocaleCandidates } from './i18n-config/I18nConfig';
 export { getI18nCache, setI18nCache } from './i18n-cache/singleton-operations';
 export { getVersionId } from './helpers/versionId';
 export { interpolateMessage } from './translation-functions/utils/interpolation/interpolateMessage';
+export type InterpolationOptions = NormalizedLookupOptions<StringFormat>;
 export { isEncodedTranslationOptions } from './translation-functions/utils/isEncodedTranslationOptions';
 export { extractVariables } from './utils/extractVariables';
 export {


### PR DESCRIPTION
## Summary
- export the internal InterpolationOptions type from gt-i18n/internal via a bundled-safe alias
- add a patch changeset for gt-i18n

## Verification
- pnpm --filter gt-i18n typecheck
- pnpm --filter gt-i18n... build
- pnpm exec oxfmt --check packages/i18n/src/internal.ts .changeset/internal-interpolation-options.md
- pnpm exec oxlint packages/i18n/src/internal.ts
- pnpm build

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR exports the `InterpolationOptions` type from the `gt-i18n/internal` entry point, accompanied by a patch changeset, so that consumers of the internal API have access to that type without reaching into private modules.

- A new `export type InterpolationOptions = NormalizedLookupOptions<StringFormat>` is added to `internal.ts`, along with two supporting `import type` statements — however, an identical type alias already exists and is exported from `interpolateMessage.ts`; re-exporting from that file directly would avoid the duplication.
- The changeset correctly marks the change as a `patch` for `gt-i18n` with an accurate description.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The change is a pure type export with no runtime impact; the type itself is correct and structurally matches the existing definition.

The newly added `InterpolationOptions` alias in `internal.ts` is an independent redefinition of the same type that already lives in `interpolateMessage.ts`. While this won't cause any runtime breakage, it creates two canonical locations for the same type that could silently diverge under future edits. Everything else — the changeset scope, the generic instantiation, and the surrounding exports — looks correct.

packages/i18n/src/internal.ts — the duplicate type alias at line 31 is the only item worth revisiting.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/i18n/src/internal.ts | Adds `InterpolationOptions` type alias and two supporting imports; the alias duplicates an identical definition already exported from `interpolateMessage.ts`, which could be re-exported directly instead. |
| .changeset/internal-interpolation-options.md | Standard patch changeset for `gt-i18n` describing the new type export; content is accurate and correctly scoped. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["@generaltranslation/format/types\n(StringFormat)"] --> B
    C["translation-functions/types/options\n(NormalizedLookupOptions)"] --> B

    B["interpolateMessage.ts\nexport type InterpolationOptions =\nNormalizedLookupOptions<StringFormat>"]

    A --> D
    C --> D

    D["internal.ts\nexport type InterpolationOptions =\nNormalizedLookupOptions<StringFormat>\n⚠ duplicate alias"]

    B -->|"already exports\nInterpolationOptions"| E["gt-i18n/internal\n(public API)"]
    D -->|"also exports\nInterpolationOptions"| E

    style D fill:#fffbe6,stroke:#f0a500
    style B fill:#e6f4ea,stroke:#34a853
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["@generaltranslation/format/types\n(StringFormat)"] --> B
    C["translation-functions/types/options\n(NormalizedLookupOptions)"] --> B

    B["interpolateMessage.ts\nexport type InterpolationOptions =\nNormalizedLookupOptions<StringFormat>"]

    A --> D
    C --> D

    D["internal.ts\nexport type InterpolationOptions =\nNormalizedLookupOptions<StringFormat>\n⚠ duplicate alias"]

    B -->|"already exports\nInterpolationOptions"| E["gt-i18n/internal\n(public API)"]
    D -->|"also exports\nInterpolationOptions"| E

    style D fill:#fffbe6,stroke:#f0a500
    style B fill:#e6f4ea,stroke:#34a853
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fi18n%2Fsrc%2Finternal.ts%3A1-2%0A**Duplicate%20type%20alias%20instead%20of%20re-export**%0A%0A%60InterpolationOptions%60%20is%20already%20defined%20and%20exported%20from%20%60.%2Ftranslation-functions%2Futils%2Finterpolation%2FinterpolateMessage%60%20%28line%2013%20of%20that%20file%29%20as%20%60NormalizedLookupOptions%3CStringFormat%3E%60.%20Creating%20a%20second%2C%20independent%20alias%20here%20means%20the%20two%20definitions%20can%20drift%20if%20the%20source%20type%20ever%20changes%2C%20and%20it%20forces%20two%20new%20%60import%20type%60%20statements%20that%20serve%20no%20other%20purpose.%20Using%20%60export%20type%20%7B%20InterpolationOptions%20%7D%60%20from%20the%20source%20file%20would%20be%20bundle-safe%20%28type-only%20exports%20carry%20no%20runtime%20weight%29%20and%20keeps%20a%20single%20canonical%20definition.%0A%0A&repo=generaltranslation%2Fgt&pr=1832&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fodysseus%2Fi18n-internal-interpolation-options%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fodysseus%2Fi18n-internal-interpolation-options%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fi18n%2Fsrc%2Finternal.ts%3A1-2%0A**Duplicate%20type%20alias%20instead%20of%20re-export**%0A%0A%60InterpolationOptions%60%20is%20already%20defined%20and%20exported%20from%20%60.%2Ftranslation-functions%2Futils%2Finterpolation%2FinterpolateMessage%60%20%28line%2013%20of%20that%20file%29%20as%20%60NormalizedLookupOptions%3CStringFormat%3E%60.%20Creating%20a%20second%2C%20independent%20alias%20here%20means%20the%20two%20definitions%20can%20drift%20if%20the%20source%20type%20ever%20changes%2C%20and%20it%20forces%20two%20new%20%60import%20type%60%20statements%20that%20serve%20no%20other%20purpose.%20Using%20%60export%20type%20%7B%20InterpolationOptions%20%7D%60%20from%20the%20source%20file%20would%20be%20bundle-safe%20%28type-only%20exports%20carry%20no%20runtime%20weight%29%20and%20keeps%20a%20single%20canonical%20definition.%0A%0A&repo=generaltranslation%2Fgt&pr=1832&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/i18n/src/internal.ts:1-2
**Duplicate type alias instead of re-export**

`InterpolationOptions` is already defined and exported from `./translation-functions/utils/interpolation/interpolateMessage` (line 13 of that file) as `NormalizedLookupOptions<StringFormat>`. Creating a second, independent alias here means the two definitions can drift if the source type ever changes, and it forces two new `import type` statements that serve no other purpose. Using `export type { InterpolationOptions }` from the source file would be bundle-safe (type-only exports carry no runtime weight) and keeps a single canonical definition.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: export internal interpolation optio..."](https://github.com/generaltranslation/gt/commit/3ca021df2a3b3c184ec3f79393e497243e315f66) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41762488)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->