### PR TITLE
fix: add gt-react rsc missing stubs

### DIFF
--- a/.changeset/react-rsc-missing-stubs.md
+++ b/.changeset/react-rsc-missing-stubs.md
@@ -1,0 +1,5 @@
+---
+'gt-react': patch
+---
+
+Add explicit RSC entry point stubs for default type-surface exports that are not available in React Server Components.

--- a/packages/react/src/__tests__/context-rsc.test.ts
+++ b/packages/react/src/__tests__/context-rsc.test.ts
@@ -22,5 +22,37 @@ describe('gt-react react-server surface', () => {
     expect('renderVariable' in mod).toBe(false);
     expect(mod.GTProvider).toBeTypeOf('function');
     expect(mod.LocaleSelector).toBeTypeOf('function');
+    expect(mod.RegionSelector).toBeTypeOf('function');
+    expect(mod.initializeGTSPA).toBeTypeOf('function');
+    expect(mod.useLocaleSelector).toBeTypeOf('function');
+    expect(mod.useRegionSelector).toBeTypeOf('function');
+    expect(mod.useSetLocale).toBeTypeOf('function');
+    expect(mod.useSetRegion).toBeTypeOf('function');
+    expect(mod.useSetEnableI18n).toBeTypeOf('function');
+    expect(mod.useEnableI18n).toBeTypeOf('function');
+    expect(mod.useFormatLocales).toBeTypeOf('function');
+  });
+
+  it('throws for default type-surface APIs that are not available in RSC', async () => {
+    const mod = await import('../index.rsc');
+    const throwingExports = [
+      'useLocaleSelector',
+      'useRegionSelector',
+      'useSetLocale',
+      'useSetRegion',
+      'useSetEnableI18n',
+      'useEnableI18n',
+      'useFormatLocales',
+    ] as const;
+
+    for (const exportName of throwingExports) {
+      expect(() => mod[exportName]()).toThrow(
+        `${exportName} cannot be consumed via the RSC entry point`
+      );
+    }
+
+    await expect(mod.initializeGTSPA({} as never)).rejects.toThrow(
+      'initializeGTSPA cannot be consumed via the RSC entry point'
+    );
   });
 });

--- a/packages/react/src/index.rsc.ts
+++ b/packages/react/src/index.rsc.ts
@@ -11,27 +11,55 @@ import {
 import { getLocale, getRegion } from 'gt-i18n';
 import { use } from 'react';
 
-// ===== Error for client components ===== //
-function failClientComponent(componentName: string) {
+type InitializeGTSPA = typeof import('./setup/initializeGTSPA').initializeGTSPA;
+type UseLocaleSelector =
+  typeof import('./components/useLocaleSelector').useLocaleSelector;
+type UseRegionSelector =
+  typeof import('./components/useRegionSelector').useRegionSelector;
+type UseSetLocale = typeof import('./hooks/conditions-store').useSetLocale;
+type UseSetRegion = typeof import('./hooks/conditions-store').useSetRegion;
+type UseSetEnableI18n =
+  typeof import('./hooks/conditions-store').useSetEnableI18n;
+
+// ===== Error for client exports ===== //
+function failClientExport(exportName: string): never {
   throw new Error(
     createDiagnosticMessage({
       source: 'gt-react',
       severity: 'Error',
-      whatHappened: `${componentName} cannot be consumed via the RSC entry point`,
-      fix: 'Import this component from a client or server runtime entry point instead.',
+      whatHappened: `${exportName} cannot be consumed via the RSC entry point`,
+      fix: 'Import this API from a client or server runtime entry point instead.',
     })
   );
 }
 
 export function GTProvider() {
-  return failClientComponent('GTProvider');
+  return failClientExport('GTProvider');
 }
 export function LocaleSelector() {
-  return failClientComponent('LocaleSelector');
+  return failClientExport('LocaleSelector');
 }
 export function RegionSelector() {
-  return failClientComponent('RegionSelector');
+  return failClientExport('RegionSelector');
 }
+export const initializeGTSPA: InitializeGTSPA = async () => {
+  return failClientExport('initializeGTSPA');
+};
+export const useLocaleSelector: UseLocaleSelector = (_locales) => {
+  return failClientExport('useLocaleSelector');
+};
+export const useRegionSelector: UseRegionSelector = (_options) => {
+  return failClientExport('useRegionSelector');
+};
+export const useSetLocale: UseSetLocale = () => {
+  return failClientExport('useSetLocale');
+};
+export const useSetRegion: UseSetRegion = () => {
+  return failClientExport('useSetRegion');
+};
+export const useSetEnableI18n: UseSetEnableI18n = () => {
+  return failClientExport('useSetEnableI18n');
+};
 
 // ===== Components ===== //
 export {
@@ -64,8 +92,14 @@ export function useLocale() {
 export function useRegion() {
   return getRegion();
 }
+export function useEnableI18n(): boolean {
+  return failClientExport('useEnableI18n');
+}
 export function useLocales() {
   return getI18nConfig().getLocales();
+}
+export function useFormatLocales(_localesProp?: string[]): string[] {
+  return failClientExport('useFormatLocales');
 }
 export function useLocaleDirection(locale: string) {
   return getI18nConfig().getGTClass().getLocaleDirection(locale);


### PR DESCRIPTION
## Summary
- add explicit throwing stubs in gt-react's RSC entry point for default type-surface APIs missing at runtime
- cover the RSC surface with export and throwing behavior tests
- add a patch changeset for gt-react

## Verification
- pnpm install
- pnpm --filter gt-react... build
- pnpm --dir packages/react exec vitest run src/__tests__/context-rsc.test.ts
- pnpm exec oxfmt --check packages/react/src/index.rsc.ts packages/react/src/__tests__/context-rsc.test.ts .changeset/react-rsc-missing-stubs.md
- node --conditions=react-server export check for the eight added names

## Caveat
- pnpm --filter gt-react typecheck currently fails on existing src/index.types.ts export of initializeGT from @generaltranslation/react-core/pure, which does not export that member.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds eight explicit throwing stubs to `gt-react`'s RSC entry point (`index.rsc.ts`) for client-only APIs that were previously absent from the `react-server` export surface, along with a matching patch changeset and test coverage.

- **New stubs**: `initializeGTSPA`, `useLocaleSelector`, `useRegionSelector`, `useSetLocale`, `useSetRegion`, `useSetEnableI18n`, `useEnableI18n`, and `useFormatLocales` are now exported from `index.rsc.ts` and throw a descriptive diagnostic error when called in an RSC context.
- **Tests**: The RSC surface test is extended with an export-presence check for all eight stubs and a throwing-behavior test; `initializeGTSPA` is correctly exercised with `rejects.toThrow` since its stub is async.
- **Rename**: The internal helper `failClientComponent` is renamed to `failClientExport` to better reflect its broader usage across hooks and functions, not just components.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the change is additive and all stubs correctly throw at runtime.

The stubs for useEnableI18n and useFormatLocales carry manually written signatures rather than the type-alias pattern used for all other stubs in this PR, so a future change to those hook signatures in react-core would go undetected by TypeScript. Everything else — the async stub for initializeGTSPA, the rename of failClientComponent to failClientExport, and the new tests — looks correct.

packages/react/src/index.rsc.ts — the useEnableI18n and useFormatLocales stubs lack type alias anchoring.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react/src/index.rsc.ts | Adds eight explicit throwing stubs for client-only APIs on the RSC entry point; six stubs are anchored to typed aliases for signature safety, but useEnableI18n and useFormatLocales are typed manually without alias anchoring. |
| packages/react/src/__tests__/context-rsc.test.ts | Extends the RSC surface test to verify exports and throwing behavior for all eight new stubs; initializeGTSPA is correctly tested via rejects.toThrow for its async path. |
| .changeset/react-rsc-missing-stubs.md | Patch changeset for gt-react describing the RSC stub additions; content is accurate. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Consumer imports from gt-react RSC entry\nindex.rsc.ts] --> B{Is the API\nRSC-compatible?}
    B -- Yes --> C[Real implementation returned\ne.g. useLocale, useGT, T, Branch ...]
    B -- No --> D[failClientExport throws\ndiagnostic error]

    subgraph "New throwing stubs (this PR)"
        D --> E[initializeGTSPA]
        D --> F[useLocaleSelector]
        D --> G[useRegionSelector]
        D --> H[useSetLocale]
        D --> I[useSetRegion]
        D --> J[useSetEnableI18n]
        D --> K[useEnableI18n]
        D --> L[useFormatLocales]
    end

    subgraph "Pre-existing throwing stubs"
        D --> M[GTProvider]
        D --> N[LocaleSelector]
        D --> O[RegionSelector]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Consumer imports from gt-react RSC entry\nindex.rsc.ts] --> B{Is the API\nRSC-compatible?}
    B -- Yes --> C[Real implementation returned\ne.g. useLocale, useGT, T, Branch ...]
    B -- No --> D[failClientExport throws\ndiagnostic error]

    subgraph "New throwing stubs (this PR)"
        D --> E[initializeGTSPA]
        D --> F[useLocaleSelector]
        D --> G[useRegionSelector]
        D --> H[useSetLocale]
        D --> I[useSetRegion]
        D --> J[useSetEnableI18n]
        D --> K[useEnableI18n]
        D --> L[useFormatLocales]
    end

    subgraph "Pre-existing throwing stubs"
        D --> M[GTProvider]
        D --> N[LocaleSelector]
        D --> O[RegionSelector]
    end
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Freact%2Fsrc%2Findex.rsc.ts%3A95-103%0A**Missing%20type%20aliases%20for%20%60useEnableI18n%60%20and%20%60useFormatLocales%60%20stubs**%0A%0AThe%20six%20other%20stubs%20added%20in%20this%20PR%20all%20use%20%60typeof%20import%28...%29%60%20type%20aliases%20%28e.g.%2C%20%60UseSetLocale%60%2C%20%60UseLocaleSelector%60%29%20so%20that%20TypeScript%20will%20catch%20a%20signature%20change%20in%20the%20source%20hook.%20%60useEnableI18n%60%20and%20%60useFormatLocales%60%20are%20typed%20manually%20instead%2C%20so%20a%20signature%20change%20in%20%60%40generaltranslation%2Freact-core%2Fhooks%60%20would%20silently%20leave%20the%20stubs%20mismatched.%20Consider%20adding%3A%0A%0A%60%60%60ts%0Atype%20UseEnableI18n%20%3D%20typeof%20import%28'%40generaltranslation%2Freact-core%2Fhooks'%29.useEnableI18n%3B%0Atype%20UseFormatLocales%20%3D%20typeof%20import%28'%40generaltranslation%2Freact-core%2Fhooks'%29.useFormatLocales%3B%0A%60%60%60%0A%0Aand%20annotating%20the%20stubs%20accordingly.%0A%0A&repo=generaltranslation%2Fgt&pr=1833&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fodysseus%2Freact-rsc-missing-stubs%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fodysseus%2Freact-rsc-missing-stubs%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Freact%2Fsrc%2Findex.rsc.ts%3A95-103%0A**Missing%20type%20aliases%20for%20%60useEnableI18n%60%20and%20%60useFormatLocales%60%20stubs**%0A%0AThe%20six%20other%20stubs%20added%20in%20this%20PR%20all%20use%20%60typeof%20import%28...%29%60%20type%20aliases%20%28e.g.%2C%20%60UseSetLocale%60%2C%20%60UseLocaleSelector%60%29%20so%20that%20TypeScript%20will%20catch%20a%20signature%20change%20in%20the%20source%20hook.%20%60useEnableI18n%60%20and%20%60useFormatLocales%60%20are%20typed%20manually%20instead%2C%20so%20a%20signature%20change%20in%20%60%40generaltranslation%2Freact-core%2Fhooks%60%20would%20silently%20leave%20the%20stubs%20mismatched.%20Consider%20adding%3A%0A%0A%60%60%60ts%0Atype%20UseEnableI18n%20%3D%20typeof%20import%28'%40generaltranslation%2Freact-core%2Fhooks'%29.useEnableI18n%3B%0Atype%20UseFormatLocales%20%3D%20typeof%20import%28'%40generaltranslation%2Freact-core%2Fhooks'%29.useFormatLocales%3B%0A%60%60%60%0A%0Aand%20annotating%20the%20stubs%20accordingly.%0A%0A&repo=generaltranslation%2Fgt&pr=1833&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/react/src/index.rsc.ts:95-103
**Missing type aliases for `useEnableI18n` and `useFormatLocales` stubs**

The six other stubs added in this PR all use `typeof import(...)` type aliases (e.g., `UseSetLocale`, `UseLocaleSelector`) so that TypeScript will catch a signature change in the source hook. `useEnableI18n` and `useFormatLocales` are typed manually instead, so a signature change in `@generaltranslation/react-core/hooks` would silently leave the stubs mismatched. Consider adding:

```ts
type UseEnableI18n = typeof import('@generaltranslation/react-core/hooks').useEnableI18n;
type UseFormatLocales = typeof import('@generaltranslation/react-core/hooks').useFormatLocales;
```

and annotating the stubs accordingly.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: add gt-react rsc missing stubs"](https://github.com/generaltranslation/gt/commit/e6f512a4839e08e2d050a1db35c00a73191d568b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41762503)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->