### PR TITLE
ci: add typecheck and plain-Node ESM smoke test to PR checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,8 +78,14 @@ jobs:
       - name: Build packages
         run: pnpm exec turbo build --filter='...[origin/${{ github.base_ref }}]' --filter='!gt-next-middleware-e2e' --filter='!./examples/*'
 
+      - name: Run typecheck
+        run: pnpm exec turbo typecheck --filter='...[origin/${{ github.base_ref }}]' --filter='!gt-next-middleware-e2e' --filter='!./examples/*'
+
       - name: Run tests
         run: pnpm exec turbo test --filter='...[origin/${{ github.base_ref }}]' --filter='!gt-next-middleware-e2e' --filter='!./examples/*'
+
+      - name: Run smoke tests
+        run: pnpm exec turbo smoke --filter='...[origin/${{ github.base_ref }}]' --filter='!gt-next-middleware-e2e' --filter='!./examples/*'
 
   test-builds:
     strategy:

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -49,7 +49,8 @@
     "test:watch": "vitest",
     "bench": "vitest bench --run --config vitest.config.bench.ts",
     "bench:unit:json": "vitest bench --run --config vitest.config.bench.ts --outputJson benchmarks/results/unit-latest.json",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "smoke": "node scripts/smoke.mjs"
   },
   "repository": {
     "type": "git",

--- a/packages/next/scripts/smoke.mjs
+++ b/packages/next/scripts/smoke.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+// Import the built `gt-next/config` entry the way a real next.config does:
+// plain Node, no bundler. Catches module-evaluation-time regressions the
+// bundled test apps can't (e.g. bare `require`/`__dirname` in the ESM build,
+// exports-map paths pointing at files that don't exist).
+import { createRequire } from 'node:module';
+
+const failures = [];
+
+try {
+  const esm = await import('gt-next/config');
+  if (typeof esm.withGTConfig !== 'function') {
+    failures.push('ESM: withGTConfig is not a function');
+  }
+} catch (error) {
+  failures.push(`ESM: import('gt-next/config') threw: ${error}`);
+}
+
+try {
+  const require = createRequire(import.meta.url);
+  const cjs = require('gt-next/config');
+  if (typeof cjs.withGTConfig !== 'function') {
+    failures.push('CJS: withGTConfig is not a function');
+  }
+} catch (error) {
+  failures.push(`CJS: require('gt-next/config') threw: ${error}`);
+}
+
+if (failures.length > 0) {
+  console.error('gt-next smoke test failed:');
+  for (const failure of failures) {
+    console.error(`  - ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.warn('gt-next smoke test passed (ESM + CJS config entry)');

--- a/turbo.json
+++ b/turbo.json
@@ -27,6 +27,10 @@
       "cache": false,
       "env": ["VITE_CI_TEST_GT_PROJECT_ID", "VITE_CI_TEST_GT_API_KEY"]
     },
+    "smoke": {
+      "dependsOn": ["build", "^build"],
+      "cache": false
+    },
     "test:watch": {
       "cache": false,
       "persistent": true


### PR DESCRIPTION
## TL;DR

Adds two gates to CI that would have caught the release blockers fixed in #1827: a `turbo typecheck` step and a plain-Node ESM/CJS import smoke test for `gt-next/config`. Draft while #1827 is in review — this PR is stacked on that branch and should be retargeted to `odysseus` once it merges.

## Code Changes

- **`.github/workflows/ci.yml`**: two new steps in the `tests` job, using the same change-based filters as the existing build/test steps:
  - `Run typecheck` (after build): `turbo typecheck` over changed packages and their dependents. The `typecheck` task already existed in `turbo.json` and every package has the script — it just never ran in CI. tsdown's dts emit passes unresolved re-exports through, so `tsc --noEmit` is the only thing that catches them.
  - `Run smoke tests` (after tests): runs the new `smoke` turbo task for changed packages that define one.
- **`turbo.json`**: new `smoke` task (`dependsOn: ["build", "^build"]`, uncached). Build dependencies are cache hits by the time it runs in CI, so the added cost is negligible.
- **`packages/next/scripts/smoke.mjs`** + `smoke` script in `package.json`: imports `gt-next/config` via package self-reference from plain Node — `await import()` for the ESM build and `createRequire` for the CJS build — and asserts `withGTConfig` is exported. This exercises the exports map and module-evaluation-time code the way a real `next.config.mjs` does, which no bundled test app can (all in-repo apps use `next.config.ts` transpiled to CJS, which is why the `require is not defined` crash shipped unnoticed).

## Notes / Flags

- **Stacked on #1827** (base is `bg/fix-release-api-blockers`): typecheck fails on plain `odysseus` until those fixes land (gt-react's `initializeGT` re-export, react-core's `resolveStringContent` options). Retarget to `odysseus` after merge.
- Verified locally with the exact CI commands against `origin/odysseus`: 35 typecheck tasks pass; the smoke task runs for gt-next and passes (and is a no-op for packages without a `smoke` script).
- The typecheck step covers the `tests/apps/*` workspace members (same filters as the test step, examples excluded). All pass today.
- Only gt-next has a smoke script for now; the same pattern would fit other packages whose entries are loaded by plain Node (e.g. the CLI), but that's left for follow-ups.
