### PR TITLE
fix(cli): move @babel/types to dependencies

### DIFF
--- a/.changeset/cli-babel-types-dependency.md
+++ b/.changeset/cli-babel-types-dependency.md
@@ -1,0 +1,5 @@
+---
+"gt": patch
+---
+
+Move `@babel/types` from `devDependencies` to `dependencies`. The CLI imports `@babel/types` at runtime across its parsing/JSX-injection code, but it was only declared as a dev dependency and left external in the published build. On strict/isolated installs (e.g. pnpm on Vercel) consumers hit `ERR_MODULE_NOT_FOUND: Cannot find package '@babel/types'` when running `gtx-cli translate`. It now sits alongside the other `@babel/*` runtime dependencies so it is installed for consumers.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -112,6 +112,7 @@
     "@babel/parser": "^7.25.7",
     "@babel/plugin-transform-react-jsx": "^7.25.9",
     "@babel/traverse": "^7.25.7",
+    "@babel/types": "^7.25.7",
     "@clack/prompts": "1.0.0-alpha.6",
     "@formatjs/icu-messageformat-parser": "^2.11.4",
     "@generaltranslation/format": "workspace:*",
@@ -148,7 +149,6 @@
     "yaml": "^2.8.0"
   },
   "devDependencies": {
-    "@babel/types": "^7.28.4",
     "@types/babel__generator": "^7.27.0",
     "@types/babel__traverse": "^7.20.6",
     "@types/figlet": "^1.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -603,6 +603,9 @@ importers:
       '@babel/traverse':
         specifier: ^7.25.7
         version: 7.28.4
+      '@babel/types':
+        specifier: ^7.25.7
+        version: 7.28.4
       '@clack/prompts':
         specifier: 1.0.0-alpha.6
         version: 1.0.0-alpha.6
@@ -706,9 +709,6 @@ importers:
         specifier: ^2.8.0
         version: 2.8.1
     devDependencies:
-      '@babel/types':
-        specifier: ^7.28.4
-        version: 7.28.4
       '@types/babel__generator':
         specifier: ^7.27.0
         version: 7.27.0


### PR DESCRIPTION
## TL;DR

`gt` (the CLI, published as `gt` / consumed via `gtx-cli`) imports `@babel/types` at runtime but declared it only as a `devDependency`. tsdown leaves `@babel/types` as an external import in the published `dist`, so on strict/isolated installs (e.g. pnpm on Vercel) consumers hit `ERR_MODULE_NOT_FOUND: Cannot find package '@babel/types'` when running `gtx-cli translate`. This moves it to `dependencies`.

## Code Changes

- `packages/cli/package.json`: move `@babel/types` from `devDependencies` to `dependencies`, alongside the other `@babel/*` runtime deps (`@babel/generator`, `@babel/parser`, `@babel/traverse`). Aligned the version range to `^7.25.7` to match those siblings (the resolved version stays `7.28.4`).
- `pnpm-lock.yaml`: reclassify the existing `@babel/types` entry dev → prod (no version change; `--frozen-lockfile` passes).
- Added a changeset (`gt`: patch).

## Notes / Flags

- `@babel/types` is used for runtime AST construction (`t.identifier(...)`, etc.) across ~48 source files under `packages/cli/src`, so it is a true runtime dependency.
- Repro: a downstream Next.js app on pnpm/Vercel running `gtx-cli translate` at build time fails with `Cannot find package '@babel/types' imported from .../node_modules/gt/dist/react/parse/wrapContent.js`. Working around it downstream currently requires `pnpm.packageExtensions` to inject the missing dep.
- I could not run the full `pnpm build`/`pnpm test` here; a CI run / local verification would be good.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a runtime dependency miscategorization: `@babel/types` was listed under `devDependencies` despite being imported at runtime across ~48 CLI source files, causing `ERR_MODULE_NOT_FOUND` failures on strict/isolated installs (e.g. pnpm on Vercel).

- Moves `@babel/types` from `devDependencies` to `dependencies` in `packages/cli/package.json`, aligning its version range to `^7.25.7` to match the other `@babel/*` runtime deps (`@babel/parser`, `@babel/traverse`, `@babel/generator`).
- Updates `pnpm-lock.yaml` to reclassify the entry (no version change; resolved version remains `7.28.4`).
- Adds a changeset marking the `gt` package with a patch bump.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change correctly reclassifies a runtime dependency that was miscategorized, unblocking consumers on strict package managers without any version change to the resolved package.

The change is narrow and accurate: @babel/types is genuinely used at runtime across the CLI's AST-manipulation code and was always being resolved transitively via the other @babel/* deps, so moving it to dependencies is the correct fix. The version floor shifting from ^7.28.4 to ^7.25.7 is intentional alignment with sibling packages and the lockfile confirms the resolved version stays at 7.28.4. No logic changes, no new code paths, and the lockfile diff is consistent with the package.json change.

No files require special attention. All three changed files (package.json, pnpm-lock.yaml, and the changeset) are consistent with each other.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/package.json | Moves @babel/types from devDependencies (^7.28.4) to dependencies (^7.25.7), aligned with sibling @babel/* runtime deps. The version floor is slightly loosened but the resolved version is unchanged at 7.28.4. |
| pnpm-lock.yaml | Reclassifies @babel/types from devDependencies to dependencies in the lockfile; no version change. |
| .changeset/cli-babel-types-dependency.md | New changeset file accurately describing the fix and its impact on consumers. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Consumer installs gtx-cli] --> B{Dependency type?}
    B -- Before fix: devDependency --> C[❌ @babel/types NOT installed\nfor consumers]
    B -- After fix: dependency --> D[✅ @babel/types installed\nalongside other @babel/* deps]
    C --> E[ERR_MODULE_NOT_FOUND\nwhen running gtx-cli translate\non strict/isolated installs\ne.g. pnpm on Vercel]
    D --> F[CLI runtime AST operations\nt.identifier, t.jsxElement, etc.\nwork correctly]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Consumer installs gtx-cli] --> B{Dependency type?}
    B -- Before fix: devDependency --> C[❌ @babel/types NOT installed\nfor consumers]
    B -- After fix: dependency --> D[✅ @babel/types installed\nalongside other @babel/* deps]
    C --> E[ERR_MODULE_NOT_FOUND\nwhen running gtx-cli translate\non strict/isolated installs\ne.g. pnpm on Vercel]
    D --> F[CLI runtime AST operations\nt.identifier, t.jsxElement, etc.\nwork correctly]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(cli): move @babel/types to dependenc..."](https://github.com/generaltranslation/gt/commit/84b4285695706d920b10f2c2dd63a93efd43ba10) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42150576)</sub>

<!-- /greptile_comment -->