### PR TITLE
feat: expand supported locales

### DIFF
--- a/.changeset/new-pumas-shout.md
+++ b/.changeset/new-pumas-shout.md
@@ -1,0 +1,5 @@
+---
+"@generaltranslation/supported-locales": patch
+---
+
+Expand supported locales

--- a/packages/supported-locales/src/supportedLocales.ts
+++ b/packages/supported-locales/src/supportedLocales.ts
@@ -11,10 +11,16 @@ const supportedLocales = {
     'ar-OM', // Oman
     'ar-SA', // Saudi Arabia
   ],
+  az: ['az'], // Azerbaijani
   bg: ['bg'], // Bulgarian
   bn: ['bn'], // Bengali
   bs: ['bs'], // Bosnian
-  ca: ['ca'], // Catalan
+  ca: [
+    // Catalan
+    'ca',
+    'ca-ES', // Spain
+  ],
+  cnr: ['cnr'], // Montenegrin
   cs: ['cs'], // Czech
   cy: ['cy'], // Welsh
   da: ['da'], // Danish
@@ -55,6 +61,11 @@ const supportedLocales = {
     'es-VE', // Venezuela
   ],
   et: ['et'], // Estonian
+  eu: [
+    // Basque
+    'eu',
+    'eu-ES', // Spain
+  ],
   fa: ['fa'], // Persian
   fi: ['fi'], // Finnish
   fil: ['fil'], // Filipino
@@ -67,6 +78,11 @@ const supportedLocales = {
     'fr-CA', // Canada
     'fr-CH', // Switzerland
     'fr-SN', // Senegal
+  ],
+  gl: [
+    // Galician
+    'gl',
+    'gl-ES', // Spain
   ],
   gu: ['gu'], // Gujarati
   ha: ['ha'], // Hausa
@@ -151,6 +167,7 @@ const supportedLocales = {
   uz: ['uz'], // Uzbek
   vi: ['vi'], // Vietnamese
   yo: ['yo'], // Yoruba
+  zgh: ['zgh'], // Standard Moroccan Tamazight
   zh: [
     // Chinese
     'zh',


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR expands the `@generaltranslation/supported-locales` package with 6 new locale entries: Azerbaijani (`az`), Montenegrin (`cnr`), Standard Moroccan Tamazight (`zgh`), and regional variants for Basque (`eu`/`eu-ES`), Galician (`gl`/`gl-ES`), and Catalan (`ca-ES`). All additions use valid BCP 47 / ISO 639-1 or ISO 639-3 language tags and are inserted in correct alphabetical order.

- Adds top-level locale keys for `az`, `cnr`, `eu`, `gl`, and `zgh`, each following the same structural pattern as existing entries in the map.
- Extends the existing `ca` entry with the `ca-ES` regional variant, consistent with how other region-qualified locales (e.g., `eu-ES`, `gl-ES`) are represented.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — purely additive data change with no logic modifications.

All six new locale additions use valid BCP 47 language tags (az, cnr, eu, eu-ES, gl, gl-ES, ca-ES, zgh), are inserted in alphabetical order, and follow the exact same structural pattern as every existing entry in the map. The changeset is correctly typed as a patch. No logic, exports, or consumers are touched.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/supported-locales/src/supportedLocales.ts | Adds 6 new locale entries (az, cnr, eu/eu-ES, gl/gl-ES, ca-ES, zgh) in correct alphabetical order using valid BCP 47 tags; no logic changes. |
| .changeset/new-pumas-shout.md | Changeset file correctly marking the supported-locales package as a patch release with a brief description of the change. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[supportedLocales map] --> B[Existing locales]
    A --> C[New in this PR]

    C --> D["az: ['az']\nAzerbaijani"]
    C --> E["ca: ['ca', 'ca-ES']\nCatalan + Spain"]
    C --> F["cnr: ['cnr']\nMontenegrin"]
    C --> G["eu: ['eu', 'eu-ES']\nBasque + Spain"]
    C --> H["gl: ['gl', 'gl-ES']\nGalician + Spain"]
    C --> I["zgh: ['zgh']\nStd. Moroccan Tamazight"]

    style C fill:#d4edda,stroke:#28a745
    style D fill:#e8f5e9
    style E fill:#e8f5e9
    style F fill:#e8f5e9
    style G fill:#e8f5e9
    style H fill:#e8f5e9
    style I fill:#e8f5e9
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[supportedLocales map] --> B[Existing locales]
    A --> C[New in this PR]

    C --> D["az: ['az']\nAzerbaijani"]
    C --> E["ca: ['ca', 'ca-ES']\nCatalan + Spain"]
    C --> F["cnr: ['cnr']\nMontenegrin"]
    C --> G["eu: ['eu', 'eu-ES']\nBasque + Spain"]
    C --> H["gl: ['gl', 'gl-ES']\nGalician + Spain"]
    C --> I["zgh: ['zgh']\nStd. Moroccan Tamazight"]

    style C fill:#d4edda,stroke:#28a745
    style D fill:#e8f5e9
    style E fill:#e8f5e9
    style F fill:#e8f5e9
    style G fill:#e8f5e9
    style H fill:#e8f5e9
    style I fill:#e8f5e9
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["feat: expand supported locales"](https://github.com/generaltranslation/gt/commit/10187a68752001d9906676fd97c9224cc2586739) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43090158)</sub>

<!-- /greptile_comment -->