### PR TITLE
feat(next): add middleware regex filter

### DIFF
--- a/.changeset/next-middleware-regex-filter.md
+++ b/.changeset/next-middleware-regex-filter.md
@@ -1,0 +1,5 @@
+---
+'gt-next': patch
+---
+
+Add a `regexFilter` option to `createNextMiddleware` for limiting i18n middleware routing to matching pathnames.

--- a/packages/next/src/errors/createErrors.ts
+++ b/packages/next/src/errors/createErrors.ts
@@ -4,6 +4,7 @@ import { getLocaleProperties } from '@generaltranslation/format';
 import {
   createGtNextDiagnostic,
   createGtNextPluginDiagnostic,
+  formatDiagnosticErrorDetails,
 } from './diagnostics';
 import { BABEL_PLUGIN_SUPPORT, SWC_PLUGIN_SUPPORT } from '../plugin/constants';
 
@@ -130,6 +131,17 @@ export const createInvalidRequestLocaleWarning = (
     whatHappened: `Locale "${locale}" is not valid or is not supported by this app`,
     wayOut: `The default locale "${defaultLocale}" will be used for this request`,
     fix: 'Use a valid BCP 47 locale code, add a custom mapping, or configure the locale in gt-next',
+  });
+
+export const createInvalidMiddlewareRegexError = (
+  regexFilter: string,
+  error: unknown
+) =>
+  createGtNextDiagnostic({
+    severity: 'Error',
+    whatHappened: `regexFilter "${regexFilter}" is not a valid regular expression`,
+    fix: 'Pass a valid JavaScript regular expression string to createNextMiddleware()',
+    details: formatDiagnosticErrorDetails(error),
   });
 
 // ---- WARNINGS ---- //

--- a/packages/next/src/middleware-dir/__tests__/middleware.edge.test.ts
+++ b/packages/next/src/middleware-dir/__tests__/middleware.edge.test.ts
@@ -218,6 +218,22 @@ describe('Middleware Integration Tests', () => {
       // Source map next() is bare — no locale header or routing cookie
       expect(res.headers.get(LOCALE_HEADER)).toBeNull();
     });
+
+    it('2.8: regexFilter applies i18n middleware only to matching paths', () => {
+      setEnvConfig();
+      const middleware = createNextMiddleware({
+        regexFilter: '^/(?!excluded(?:/|$)).*',
+      });
+
+      const includedRes = middleware(createRequest('/about'));
+      const excludedRes = middleware(createRequest('/excluded/about'));
+
+      expect(getResponseType(includedRes)).toBe('rewrite');
+      expect(getResponsePath(includedRes)).toBe('/en/about');
+      expect(getResponseType(excludedRes)).toBe('next');
+      expect(excludedRes.headers.get(LOCALE_HEADER)).toBeNull();
+      expect(excludedRes.cookies.get(ROUTING_COOKIE)).toBeUndefined();
+    });
   });
 
   // ================================================================

--- a/packages/next/src/middleware-dir/__tests__/middleware.edge.test.ts
+++ b/packages/next/src/middleware-dir/__tests__/middleware.edge.test.ts
@@ -238,7 +238,9 @@ describe('Middleware Integration Tests', () => {
     it('2.9: invalid regexFilter throws a descriptive error', () => {
       expect(() =>
         createNextMiddleware({ regexFilter: '[unclosed' })
-      ).toThrowError('gt-next middleware: invalid regexFilter "[unclosed"');
+      ).toThrowError(
+        'gt-next Error: regexFilter "[unclosed" is not a valid regular expression.'
+      );
     });
   });
 

--- a/packages/next/src/middleware-dir/__tests__/middleware.edge.test.ts
+++ b/packages/next/src/middleware-dir/__tests__/middleware.edge.test.ts
@@ -234,6 +234,12 @@ describe('Middleware Integration Tests', () => {
       expect(excludedRes.headers.get(LOCALE_HEADER)).toBeNull();
       expect(excludedRes.cookies.get(ROUTING_COOKIE)).toBeUndefined();
     });
+
+    it('2.9: invalid regexFilter throws a descriptive error', () => {
+      expect(() =>
+        createNextMiddleware({ regexFilter: '[unclosed' })
+      ).toThrowError('gt-next middleware: invalid regexFilter "[unclosed"');
+    });
   });
 
   // ================================================================

--- a/packages/next/src/middleware-dir/createNextMiddleware.ts
+++ b/packages/next/src/middleware-dir/createNextMiddleware.ts
@@ -1,7 +1,10 @@
 import { isSameDialect, standardizeLocale } from '@generaltranslation/format';
 import { GTRuntime } from 'generaltranslation/runtime';
 import { libraryDefaultLocale } from 'generaltranslation/internal';
-import { createUnsupportedLocalesWarning } from '../errors/createErrors';
+import {
+  createInvalidMiddlewareRegexError,
+  createUnsupportedLocalesWarning,
+} from '../errors/createErrors';
 import { NextRequest, NextResponse } from 'next/server';
 import {
   defaultLocaleRoutingEnabledCookieName,
@@ -63,15 +66,12 @@ export function createNextMiddleware({
   pathConfig?: PathConfig;
 } = {}) {
   let pathFilter: RegExp | undefined;
-  try {
-    pathFilter =
-      regexFilter === undefined ? undefined : new RegExp(regexFilter);
-  } catch (error) {
-    throw new SyntaxError(
-      `gt-next middleware: invalid regexFilter "${regexFilter}": ${
-        error instanceof Error ? error.message : String(error)
-      }`
-    );
+  if (regexFilter !== undefined) {
+    try {
+      pathFilter = new RegExp(regexFilter);
+    } catch (error) {
+      throw new Error(createInvalidMiddlewareRegexError(regexFilter, error));
+    }
   }
 
   // i18n config

--- a/packages/next/src/middleware-dir/createNextMiddleware.ts
+++ b/packages/next/src/middleware-dir/createNextMiddleware.ts
@@ -45,6 +45,7 @@ type MiddlewareEnvConfig = {
  * @param {boolean} [config.localeRouting=true] - Flag to enable or disable automatic locale-based routing.
  * @param {boolean} [config.prefixDefaultLocale=false] - Flag to enable or disable prefixing the default locale to the pathname, i.e., /en/about -> /about
  * @param {boolean} [config.ignoreSourceMaps=true] - Flag to enable or disable ignoring source maps
+ * @param {string} [config.regexFilter] - Regular expression that request pathnames must match for i18n middleware to be applied
  * @param {PathConfig} [config.pathConfig] - Path configuration for locale routing
  * @returns {function} - A middleware function that processes the request and response.
  */
@@ -52,13 +53,18 @@ export function createNextMiddleware({
   localeRouting = true,
   prefixDefaultLocale = false,
   ignoreSourceMaps = true,
+  regexFilter,
   pathConfig = {},
 }: {
   localeRouting?: boolean;
   prefixDefaultLocale?: boolean;
   ignoreSourceMaps?: boolean;
+  regexFilter?: string;
   pathConfig?: PathConfig;
 } = {}) {
+  const pathFilter =
+    regexFilter === undefined ? undefined : new RegExp(regexFilter);
+
   // i18n config
   let envParams: MiddlewareEnvConfig | undefined;
   if (process.env._GENERALTRANSLATION_I18N_CONFIG_PARAMS) {
@@ -164,6 +170,10 @@ export function createNextMiddleware({
    * @returns {NextResponse} - The Next.js response, either continuing the request or redirecting to the localized URL.
    */
   function middleware(req: NextRequest) {
+    if (pathFilter && !pathFilter.test(req.nextUrl.pathname)) {
+      return NextResponse.next();
+    }
+
     // Ignore source maps
     if (
       ignoreSourceMaps &&

--- a/packages/next/src/middleware-dir/createNextMiddleware.ts
+++ b/packages/next/src/middleware-dir/createNextMiddleware.ts
@@ -62,8 +62,17 @@ export function createNextMiddleware({
   regexFilter?: string;
   pathConfig?: PathConfig;
 } = {}) {
-  const pathFilter =
-    regexFilter === undefined ? undefined : new RegExp(regexFilter);
+  let pathFilter: RegExp | undefined;
+  try {
+    pathFilter =
+      regexFilter === undefined ? undefined : new RegExp(regexFilter);
+  } catch (error) {
+    throw new SyntaxError(
+      `gt-next middleware: invalid regexFilter "${regexFilter}": ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+  }
 
   // i18n config
   let envParams: MiddlewareEnvConfig | undefined;


### PR DESCRIPTION
## Summary
- add a `regexFilter` string option to `createNextMiddleware()`
- bypass i18n middleware with a bare `NextResponse.next()` when the pathname does not match
- cover matching and excluded paths with an edge-runtime integration test
- add a patch changeset for `gt-next`

Documentation: https://github.com/generaltranslation/content/pull/348

## Testing
- `pnpm --filter gt-next test:js`
- `pnpm --filter gt-next typecheck`
- `pnpm exec oxlint packages/next/src/middleware-dir/createNextMiddleware.ts packages/next/src/middleware-dir/__tests__/middleware.edge.test.ts`
- `pnpm exec oxfmt --check packages/next/src/middleware-dir/createNextMiddleware.ts packages/next/src/middleware-dir/__tests__/middleware.edge.test.ts .changeset/next-middleware-regex-filter.md`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `regexFilter` string option to `createNextMiddleware()` that lets callers limit i18n processing to pathnames that match the supplied pattern, bypassing all locale logic with a bare `NextResponse.next()` for non-matching paths.

- The regex is compiled once at factory time (`new RegExp(regexFilter)`) with a try/catch that rethrows a structured `gt-next Error` diagnostic, satisfying the previously raised concern about unhandled `SyntaxError` at module init.
- The per-request check (`pathFilter.test(req.nextUrl.pathname)`) runs before source-map detection and all locale logic; since no flags are passed the `RegExp` instance is stateless and safe to reuse across requests.
- Two new edge-runtime tests cover the matching/exclusion happy path and the invalid-pattern error path, and a patch changeset is included.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the feature is narrowly scoped, compiled at factory time rather than per-request, and guarded by both a try/catch with a descriptive error and two edge-runtime integration tests.

The regex is compiled once and is flag-free, so there is no lastIndex statefulness across requests. Invalid patterns throw immediately with a structured diagnostic. The bypass path returns a plain NextResponse.next() that correctly omits locale headers and cookies. No existing behaviour is altered for callers that omit regexFilter.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/next/src/middleware-dir/createNextMiddleware.ts | Adds regexFilter option: compiled once at factory time with proper error handling, applied per-request against req.nextUrl.pathname before any i18n logic runs |
| packages/next/src/errors/createErrors.ts | Adds createInvalidMiddlewareRegexError diagnostic following the existing severity/whatHappened/fix pattern; correctly re-exports formatDiagnosticErrorDetails |
| packages/next/src/middleware-dir/__tests__/middleware.edge.test.ts | Two new edge-runtime tests cover the happy path (matching vs. excluded pathname) and the invalid-regex error path; assertions are thorough |
| .changeset/next-middleware-regex-filter.md | Correctly tagged as a patch changeset for gt-next with a clear description of the new option |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Incoming NextRequest] --> B{pathFilter set?}
    B -- No --> D{ignoreSourceMaps and source map path?}
    B -- Yes --> C{pathname matches regexFilter?}
    C -- No --> E[Return bare NextResponse.next]
    C -- Yes --> D
    D -- Yes --> F[Return bare NextResponse.next]
    D -- No --> G[Locale Detection via getLocaleFromRequest]
    G --> H{Locale routing decision}
    H --> I[Redirect or Rewrite with locale prefix]
    H --> J[NextResponse.next with locale headers and cookies]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Incoming NextRequest] --> B{pathFilter set?}
    B -- No --> D{ignoreSourceMaps and source map path?}
    B -- Yes --> C{pathname matches regexFilter?}
    C -- No --> E[Return bare NextResponse.next]
    C -- Yes --> D
    D -- Yes --> F[Return bare NextResponse.next]
    D -- No --> G[Locale Detection via getLocaleFromRequest]
    G --> H{Locale routing decision}
    H --> I[Redirect or Rewrite with locale prefix]
    H --> J[NextResponse.next with locale headers and cookies]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(next): use diagnostics for invalid m..."](https://github.com/generaltranslation/gt/commit/04d8964d85f18774fdffc3b92d8c135624857ec2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43096935)</sub>

<!-- /greptile_comment -->