### PR TITLE
docs: document diagnostic message conventions

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -69,6 +69,16 @@ Turbo tasks: `build`, `test`, `lint`, `lint:fix`, `format`, `format:fix`, `trans
 - Do not use default exports.
 - Avoid `useEffect` in React code. Prefer derived state, event handlers, refs, or framework data-loading patterns; only use `useEffect` when synchronizing with an external system.
 
+## Diagnostics and User-Facing Messages
+
+- Format new user-facing logs, warnings, errors, thrown error messages, and validation messages that report actionable problems with `createDiagnosticMessage()`. Import it from `generaltranslation/internal` outside `packages/core`; code inside `packages/core` can import the local implementation from `src/logging/diagnostics.ts`. Routine progress, status, and debug output does not need to be a diagnostic.
+- Prefer an existing package- or runtime-specific wrapper when one is available. For example, gt-next code should use `createGtNextDiagnostic()` for the `gt-next` prefix and `createGtNextPluginDiagnostic()` for the `gt-next (plugin)` prefix. If a package repeatedly supplies the same source, add or reuse a small typed wrapper instead of duplicating the prefix at every call site.
+- When calling `createDiagnosticMessage()` directly, set `source` to the owning package or runtime and set `severity` to `Error` or `Warning` when the diagnostic should include that label. Match the severity to the logger or console method that emits it. Do not manually embed package names, `Error:`, or `Warning:` in the message text.
+- Use the structured fields for their intended roles: `whatHappened` is required; `reassurance`, `why`, `fix`, and `wayOut` form the explanatory and recovery guidance; `details` holds variable context or error text; and `docsUrl` adds a Learn more link. Use `formatDiagnosticErrorDetails()` to safely turn an unknown caught value into `details`.
+- Let the formatter handle sentence punctuation, combine `whatHappened` with `why`, combine compatible `fix` and `wayOut` text, format detail lists, and order the final message. Do not recreate that formatting with string concatenation.
+- Create the diagnostic before passing it to `logger.error()`, `logger.warn()`, `console.error()`, `console.warn()`, or `new Error()`. Define a constant for a static diagnostic and a factory function for a diagnostic containing runtime values.
+- A body-only diagnostic may omit `source` and `severity` when an outer validation or publishing layer already owns that context. Avoid double-prefixing: either the diagnostic helper or the outer layer should add the source and severity, not both.
+
 ## Git and PR Conventions
 
 - Commit messages should follow Conventional Commits style (for example, `feat: add locale fallback` or `fix: preserve formatter options`).


### PR DESCRIPTION
## Summary
- add shared agent guidance for actionable user-facing diagnostics
- document package-specific helpers, prefixes, severities, and structured message fields
- cover emission, error details, formatter behavior, and double-prefix avoidance

## Testing
- git diff --check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new "Diagnostics and User-Facing Messages" section to `.claude/CLAUDE.md`, documenting the conventions for using `createDiagnosticMessage()` and its ecosystem of helpers across the monorepo. The new guidance covers import paths, package-specific wrappers, structured fields, formatter behavior, emission patterns, and double-prefix avoidance.

- The referenced functions (`createDiagnosticMessage`, `formatDiagnosticErrorDetails`, `createGtNextDiagnostic`, `createGtNextPluginDiagnostic`) all exist at the documented import paths, and the described structured fields match the `DiagnosticMessageInput` type exactly.
- The section correctly notes that only `gt-next` currently has a package-specific wrapper file; all other packages import `createDiagnosticMessage` directly from `generaltranslation/internal`, which is consistent with the guidance to add wrappers only when a source prefix is repeated.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only change to CLAUDE.md; no runtime code is modified.

All referenced functions, types, and import paths were verified against the actual codebase. The new section accurately describes existing behavior and adds useful conventions for contributors without introducing ambiguities or contradictions.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .claude/CLAUDE.md | Adds a Diagnostics and User-Facing Messages section with accurate references to existing functions, types, and import paths; no code is changed. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Need to emit an actionable message?] -->|Yes| B{Package-specific wrapper available?}
    A -->|No - routine/debug output| Z[Use plain logger/console]
    B -->|Yes e.g. gt-next| C[Use createGtNextDiagnostic or createGtNextPluginDiagnostic]
    B -->|No| D[Use createDiagnosticMessage directly - Set source + severity]
    C --> E[Populate structured fields: whatHappened required, reassurance/why/fix/wayOut/details/docsUrl optional]
    D --> E
    E --> F[Use formatDiagnosticErrorDetails for caught error details]
    F --> G[Pass result to logger.error / logger.warn / console.error / console.warn / new Error]
    G --> H{Outer layer already adds prefix?}
    H -->|Yes| I[Omit source + severity from diagnostic - body only]
    H -->|No| J[Let formatter build full prefixed message]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Need to emit an actionable message?] -->|Yes| B{Package-specific wrapper available?}
    A -->|No - routine/debug output| Z[Use plain logger/console]
    B -->|Yes e.g. gt-next| C[Use createGtNextDiagnostic or createGtNextPluginDiagnostic]
    B -->|No| D[Use createDiagnosticMessage directly - Set source + severity]
    C --> E[Populate structured fields: whatHappened required, reassurance/why/fix/wayOut/details/docsUrl optional]
    D --> E
    E --> F[Use formatDiagnosticErrorDetails for caught error details]
    F --> G[Pass result to logger.error / logger.warn / console.error / console.warn / new Error]
    G --> H{Outer layer already adds prefix?}
    H -->|Yes| I[Omit source + severity from diagnostic - body only]
    H -->|No| J[Let formatter build full prefixed message]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: document diagnostic message conven..."](https://github.com/generaltranslation/gt/commit/64d84a91273cd57dac076c75ee68df93c6c488bb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43110666)</sub>

<!-- /greptile_comment -->