### PR TITLE
fix(next): share path regex with client routing

### DIFF
--- a/.changeset/next-path-regex-config.md
+++ b/.changeset/next-path-regex-config.md
@@ -1,0 +1,5 @@
+---
+'gt-next': patch
+---
+
+Move middleware path filtering to `withGTConfig` and apply it to client-side locale path checks.

--- a/packages/next/src/__tests__/config.test.ts
+++ b/packages/next/src/__tests__/config.test.ts
@@ -1034,6 +1034,14 @@ describe('withGTConfig', () => {
       );
     });
 
+    it('invalid pathRegex throws a descriptive error', async () => {
+      const withGTConfig = await getWithGTConfig();
+
+      expect(() => withGTConfig({}, { pathRegex: '[unclosed' })).toThrowError(
+        'gt-next Error: pathRegex "[unclosed" is not a valid regular expression.'
+      );
+    });
+
     it('missing loader files throw respective build errors', async () => {
       const withGTConfig = await getWithGTConfig();
 
@@ -1201,6 +1209,15 @@ describe('withGTConfig', () => {
 
       expect(result.env!.MY_EXISTING_VAR).toBe('hello');
       expect(result.env!._GENERALTRANSLATION_I18N_CONFIG_PARAMS).toBeDefined();
+    });
+
+    it('exposes pathRegex to middleware and client code', async () => {
+      const withGTConfig = await getWithGTConfig();
+      const pathRegex = '^/(?!uk(?:/|$)).*';
+
+      const result = withGTConfig({}, { pathRegex });
+
+      expect(result.env!._GENERALTRANSLATION_PATH_REGEX).toBe(pathRegex);
     });
 
     it('I18N_CONFIG_PARAMS contains non-credential config as JSON string', async () => {

--- a/packages/next/src/config-dir/props/withGTConfigProps.ts
+++ b/packages/next/src/config-dir/props/withGTConfigProps.ts
@@ -54,6 +54,8 @@ export type BaseWithGTConfigProps = {
   defaultLocale?: string;
   ignoreBrowserLocales?: boolean;
   disableInvalidLocaleWarning?: boolean;
+  /** Regular expression source that limits i18n middleware routing by pathname. */
+  pathRegex?: string;
   // Rendering
   renderSettings?: {
     method: RenderMethod;

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -23,6 +23,7 @@ import {
   unresolvedLoadDictionaryBuildError,
   unresolvedLoadTranslationsBuildError,
 } from './errors/createErrors';
+import { compilePathRegex } from './utils/pathRegex';
 import {
   getLocaleProperties,
   isValidLocale,
@@ -113,6 +114,7 @@ type WithGTConfigResult<TNextConfig extends object> = TNextConfig & NextConfig;
  * @param {number} [batchInterval=defaultInitGTProps.batchInterval] - The interval in milliseconds between batched translation requests.
  * @param {boolean} [ignoreBrowserLocales=defaultWithGTConfigProps.ignoreBrowserLocales] - Whether to ignore browser's preferred locales.
  * @param {boolean} [disableInvalidLocaleWarning=defaultWithGTConfigProps.disableInvalidLocaleWarning] - Whether to disable invalid request locale warnings.
+ * @param {string|undefined} [pathRegex] - Regular expression that request pathnames must match for i18n middleware to be applied.
  * @param {object} headersAndCookies - Additional headers and cookies that can be passed for extended configuration.
  * @param {object} metadata - Additional metadata that can be passed for extended configuration.
  *
@@ -239,6 +241,8 @@ export function withGTConfig<TNextConfig extends object = NextConfig>(
     experimentalCompilerOptions: mergedExperimentalCompilerOptions,
     _usingPlugin: true, // flag to indicate plugin usage
   };
+
+  compilePathRegex(mergedConfig.pathRegex);
 
   // clear up any issues with the compiler options
   validateCompiler(mergedConfig);
@@ -651,6 +655,10 @@ export function withGTConfig<TNextConfig extends object = NextConfig>(
         requestFunctionPaths.getRegion ? 'true' : 'false',
       _GENERALTRANSLATION_DISABLE_INVALID_LOCALE_WARNING:
         mergedConfig.disableInvalidLocaleWarning?.toString() || 'false',
+      // nextConfig.env intentionally makes this available to client-boundary.tsx.
+      ...(mergedConfig.pathRegex !== undefined && {
+        _GENERALTRANSLATION_PATH_REGEX: mergedConfig.pathRegex,
+      }),
     },
     ...(turboPackEnabled &&
       !experimentalTurbopack && {

--- a/packages/next/src/errors/createErrors.ts
+++ b/packages/next/src/errors/createErrors.ts
@@ -133,14 +133,14 @@ export const createInvalidRequestLocaleWarning = (
     fix: 'Use a valid BCP 47 locale code, add a custom mapping, or configure the locale in gt-next',
   });
 
-export const createInvalidMiddlewareRegexError = (
-  regexFilter: string,
+export const createInvalidPathRegexError = (
+  pathRegex: string,
   error: unknown
 ) =>
   createGtNextDiagnostic({
     severity: 'Error',
-    whatHappened: `regexFilter "${regexFilter}" is not a valid regular expression`,
-    fix: 'Pass a valid JavaScript regular expression string to createNextMiddleware()',
+    whatHappened: `pathRegex "${pathRegex}" is not a valid regular expression`,
+    fix: 'Pass a valid JavaScript regular expression string to withGTConfig()',
     details: formatDiagnosticErrorDetails(error),
   });
 

--- a/packages/next/src/middleware-dir/__tests__/middleware.edge.test.ts
+++ b/packages/next/src/middleware-dir/__tests__/middleware.edge.test.ts
@@ -100,10 +100,13 @@ describe('Middleware Integration Tests', () => {
         process.env._GENERALTRANSLATION_GT_SERVICES_ENABLED,
       _GENERALTRANSLATION_IGNORE_BROWSER_LOCALES:
         process.env._GENERALTRANSLATION_IGNORE_BROWSER_LOCALES,
+      _GENERALTRANSLATION_PATH_REGEX:
+        process.env._GENERALTRANSLATION_PATH_REGEX,
     };
     // Default: GT services disabled
     delete process.env._GENERALTRANSLATION_GT_SERVICES_ENABLED;
     delete process.env._GENERALTRANSLATION_IGNORE_BROWSER_LOCALES;
+    delete process.env._GENERALTRANSLATION_PATH_REGEX;
   });
 
   afterEach(() => {
@@ -219,11 +222,10 @@ describe('Middleware Integration Tests', () => {
       expect(res.headers.get(LOCALE_HEADER)).toBeNull();
     });
 
-    it('2.8: regexFilter applies i18n middleware only to matching paths', () => {
+    it('2.8: pathRegex applies i18n middleware only to matching paths', () => {
       setEnvConfig();
-      const middleware = createNextMiddleware({
-        regexFilter: '^/(?!excluded(?:/|$)).*',
-      });
+      process.env._GENERALTRANSLATION_PATH_REGEX = '^/(?!excluded(?:/|$)).*';
+      const middleware = createNextMiddleware();
 
       const includedRes = middleware(createRequest('/about'));
       const excludedRes = middleware(createRequest('/excluded/about'));
@@ -235,11 +237,11 @@ describe('Middleware Integration Tests', () => {
       expect(excludedRes.cookies.get(ROUTING_COOKIE)).toBeUndefined();
     });
 
-    it('2.9: invalid regexFilter throws a descriptive error', () => {
-      expect(() =>
-        createNextMiddleware({ regexFilter: '[unclosed' })
-      ).toThrowError(
-        'gt-next Error: regexFilter "[unclosed" is not a valid regular expression.'
+    it('2.9: invalid pathRegex throws a descriptive error', () => {
+      process.env._GENERALTRANSLATION_PATH_REGEX = '[unclosed';
+
+      expect(() => createNextMiddleware()).toThrowError(
+        'gt-next Error: pathRegex "[unclosed" is not a valid regular expression.'
       );
     });
   });

--- a/packages/next/src/middleware-dir/createNextMiddleware.ts
+++ b/packages/next/src/middleware-dir/createNextMiddleware.ts
@@ -1,10 +1,7 @@
 import { isSameDialect, standardizeLocale } from '@generaltranslation/format';
 import { GTRuntime } from 'generaltranslation/runtime';
 import { libraryDefaultLocale } from 'generaltranslation/internal';
-import {
-  createInvalidMiddlewareRegexError,
-  createUnsupportedLocalesWarning,
-} from '../errors/createErrors';
+import { createUnsupportedLocalesWarning } from '../errors/createErrors';
 import { NextRequest, NextResponse } from 'next/server';
 import {
   defaultLocaleRoutingEnabledCookieName,
@@ -27,6 +24,7 @@ import {
 import { defaultLocaleHeaderName } from '../utils/headers';
 import type { CustomMapping } from '@generaltranslation/format/types';
 import type { HeadersAndCookies } from '../config-dir/props/withGTConfigProps';
+import { compilePathRegex, pathnameMatchesRegex } from '../utils/pathRegex';
 
 const NEXT_JS_SOURCE_MAP_PATH = '/__nextjs_source-map';
 
@@ -48,7 +46,6 @@ type MiddlewareEnvConfig = {
  * @param {boolean} [config.localeRouting=true] - Flag to enable or disable automatic locale-based routing.
  * @param {boolean} [config.prefixDefaultLocale=false] - Flag to enable or disable prefixing the default locale to the pathname, i.e., /en/about -> /about
  * @param {boolean} [config.ignoreSourceMaps=true] - Flag to enable or disable ignoring source maps
- * @param {string} [config.regexFilter] - Regular expression that request pathnames must match for i18n middleware to be applied
  * @param {PathConfig} [config.pathConfig] - Path configuration for locale routing
  * @returns {function} - A middleware function that processes the request and response.
  */
@@ -56,23 +53,16 @@ export function createNextMiddleware({
   localeRouting = true,
   prefixDefaultLocale = false,
   ignoreSourceMaps = true,
-  regexFilter,
   pathConfig = {},
 }: {
   localeRouting?: boolean;
   prefixDefaultLocale?: boolean;
   ignoreSourceMaps?: boolean;
-  regexFilter?: string;
   pathConfig?: PathConfig;
 } = {}) {
-  let pathFilter: RegExp | undefined;
-  if (regexFilter !== undefined) {
-    try {
-      pathFilter = new RegExp(regexFilter);
-    } catch (error) {
-      throw new Error(createInvalidMiddlewareRegexError(regexFilter, error));
-    }
-  }
+  const pathRegex = compilePathRegex(
+    process.env._GENERALTRANSLATION_PATH_REGEX
+  );
 
   // i18n config
   let envParams: MiddlewareEnvConfig | undefined;
@@ -179,7 +169,7 @@ export function createNextMiddleware({
    * @returns {NextResponse} - The Next.js response, either continuing the request or redirecting to the localized URL.
    */
   function middleware(req: NextRequest) {
-    if (pathFilter && !pathFilter.test(req.nextUrl.pathname)) {
+    if (!pathnameMatchesRegex(req.nextUrl.pathname, pathRegex)) {
       return NextResponse.next();
     }
 

--- a/packages/next/src/utils/__tests__/client-boundary.test.tsx
+++ b/packages/next/src/utils/__tests__/client-boundary.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockGetI18nConfig, mockInitializeGTClient, mockRefresh } = vi.hoisted(
+  () => ({
+    mockGetI18nConfig: vi.fn(),
+    mockInitializeGTClient: vi.fn(),
+    mockRefresh: vi.fn(),
+  })
+);
+
+vi.mock('gt-i18n/internal', () => ({
+  getI18nConfig: mockGetI18nConfig,
+}));
+
+vi.mock('gt-react', () => ({
+  GTProvider: ({ children }: { children?: React.ReactNode }) => children,
+  LocaleSelector: () => null,
+  RegionSelector: () => null,
+}));
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/uk',
+  useRouter: () => ({ refresh: mockRefresh }),
+}));
+
+vi.mock('../../setup/initGT.client', () => ({
+  initializeGTClient: mockInitializeGTClient,
+}));
+
+describe('Client_GTProvider', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    process.env._GENERALTRANSLATION_PATH_REGEX = '^/(?!uk(?:/|$)).*';
+    document.cookie = 'generaltranslation.locale-routing-enabled=true;path=/';
+    mockGetI18nConfig.mockReturnValue({
+      determineLocale: vi.fn(),
+      getDefaultLocale: () => 'en',
+      getLocales: () => ['en', 'en-GB', 'fr'],
+      isGTServicesEnabled: () => false,
+      resolveAliasLocale: (locale: string) => locale,
+      standardizeLocale: (locale: string) => locale,
+    });
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterEach(() => {
+    delete process.env._GENERALTRANSLATION_PATH_REGEX;
+    document.cookie =
+      'generaltranslation.locale-routing-enabled=;max-age=0;path=/';
+    globalThis.IS_REACT_ACT_ENVIRONMENT = false;
+  });
+
+  it('does not refresh excluded paths when the routing cookie is stale', async () => {
+    const { Client_GTProvider } = await import('../client-boundary');
+    const container = document.createElement('div');
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <Client_GTProvider dictionaries={{}} locale='en-GB' translations={{}}>
+          content
+        </Client_GTProvider>
+      );
+    });
+
+    expect(mockGetI18nConfig).toHaveBeenCalled();
+    expect(mockRefresh).not.toHaveBeenCalled();
+
+    await act(async () => root.unmount());
+  });
+});

--- a/packages/next/src/utils/__tests__/pathRegex.test.ts
+++ b/packages/next/src/utils/__tests__/pathRegex.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { compilePathRegex, pathnameMatchesRegex } from '../pathRegex';
+
+describe('pathRegex', () => {
+  it('matches every pathname when no regex is configured', () => {
+    expect(pathnameMatchesRegex('/uk')).toBe(true);
+  });
+
+  it('excludes pathnames outside the configured regex', () => {
+    const pathRegex = compilePathRegex('^/(?!uk(?:/|$)).*');
+
+    expect(pathnameMatchesRegex('/about', pathRegex)).toBe(true);
+    expect(pathnameMatchesRegex('/uk', pathRegex)).toBe(false);
+    expect(pathnameMatchesRegex('/uk/about', pathRegex)).toBe(false);
+  });
+});

--- a/packages/next/src/utils/client-boundary.tsx
+++ b/packages/next/src/utils/client-boundary.tsx
@@ -21,6 +21,10 @@ import {
   defaultLocaleRoutingEnabledCookieName,
   defaultReferrerLocaleCookieName,
 } from './cookies';
+import { compilePathRegex, pathnameMatchesRegex } from './pathRegex';
+
+// withGTConfig exposes this build-time value to both middleware and client code.
+const pathRegex = compilePathRegex(process.env._GENERALTRANSLATION_PATH_REGEX);
 
 /**
  * Only need to initalize client. We know server was already
@@ -75,7 +79,7 @@ function usePathCheck({
         .split('; ')
         .find((row) => row.startsWith(`${localeRoutingEnabledCookieName}=`))
         ?.split('=')[1] === 'true';
-    if (middlewareEnabled) {
+    if (middlewareEnabled && pathnameMatchesRegex(pathname, pathRegex)) {
       // Extract locale from pathname
       const extractedLocale =
         extractLocale(pathname, i18nConfig) || defaultLocale;

--- a/packages/next/src/utils/pathRegex.ts
+++ b/packages/next/src/utils/pathRegex.ts
@@ -1,0 +1,18 @@
+import { createInvalidPathRegexError } from '../errors/createErrors';
+
+export function compilePathRegex(pathRegex?: string): RegExp | undefined {
+  if (pathRegex === undefined) return undefined;
+
+  try {
+    return new RegExp(pathRegex);
+  } catch (error) {
+    throw new Error(createInvalidPathRegexError(pathRegex, error));
+  }
+}
+
+export function pathnameMatchesRegex(
+  pathname: string,
+  pathRegex?: RegExp
+): boolean {
+  return pathRegex?.test(pathname) ?? true;
+}


### PR DESCRIPTION
## Summary
- move path filtering from `createNextMiddleware()` to the `withGTConfig()` `pathRegex` option
- distribute the validated value through `_GENERALTRANSLATION_PATH_REGEX` to middleware and client code
- skip client locale-path refresh checks for excluded paths, including the `/uk` to `en-GB` case with a stale routing cookie
- add a patch changeset for `gt-next`

Follow-up to #1841.

Documentation: https://github.com/generaltranslation/content/pull/351

## Testing
- `pnpm --filter gt-next test:js` (230 tests)
- `pnpm --filter gt-next typecheck`
- `pnpm --filter gt-next build:no-swc-plugin`
- focused oxlint and oxfmt checks
- `pnpm exec changeset status --since origin/main`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR centralises path-exclusion logic by moving it from the `regexFilter` parameter on `createNextMiddleware()` into a new `pathRegex` option on `withGTConfig()`. The compiled regex is validated at build time, then distributed as `_GENERALTRANSLATION_PATH_REGEX` to both middleware (Edge runtime) and the client bundle so that the same exclusion set is respected on both sides.

- Introduces `packages/next/src/utils/pathRegex.ts` with `compilePathRegex` / `pathnameMatchesRegex`, used by middleware and client boundary alike.
- Guards the client-side `router.refresh()` call in `usePathCheck` so that excluded paths (e.g. `/uk` aliased to `en-GB`) no longer trigger a stale-cookie refresh loop.
- Removes the `regexFilter` parameter from `createNextMiddleware`; the changeset is marked `patch` — worth confirming `regexFilter` was never in a published release before this lands.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The change is safe to merge; the only open question is whether the changeset bump level correctly reflects the removal of the regexFilter parameter from the public API.

The implementation is solid end-to-end with good test coverage. The afterEach loop in the middleware tests properly restores _GENERALTRANSLATION_PATH_REGEX. The one uncertainty is whether the patch-level changeset correctly reflects the removal of the public regexFilter parameter from createNextMiddleware.

.changeset/next-path-regex-config.md — confirm the bump level against the publish history of #1841.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .changeset/next-path-regex-config.md | Marks the release as a patch for gt-next; worth confirming regexFilter was never published before this PR, since removing a parameter from a public function signature is technically a breaking change. |
| packages/next/src/utils/pathRegex.ts | New shared utility: compilePathRegex validates and compiles a string to RegExp, pathnameMatchesRegex returns true when no regex is configured. Clean, well-tested. |
| packages/next/src/utils/client-boundary.tsx | Adds module-level pathRegex constant compiled from the build-time env var; guards usePathCheck's router.refresh() call so excluded paths (e.g. /uk) are skipped. |
| packages/next/src/middleware-dir/createNextMiddleware.ts | Removes the regexFilter parameter; replaces it with compilePathRegex(process.env._GENERALTRANSLATION_PATH_REGEX) called at factory time, maintaining the same runtime guard logic. |
| packages/next/src/config.ts | Calls compilePathRegex at build time to validate the developer-supplied pathRegex, then injects the raw string into nextConfig.env for both middleware and client bundle consumption. |
| packages/next/src/utils/__tests__/client-boundary.test.tsx | New jsdom test verifying that router.refresh() is not called for excluded paths when the routing cookie is set; uses vi.resetModules() to re-evaluate the module-level pathRegex per test. |
| packages/next/src/middleware-dir/__tests__/middleware.edge.test.ts | Updates tests 2.8 and 2.9 to set pathRegex via the environment variable instead of the removed regexFilter param; correctly restores the env key in afterEach via the savedEnv loop. |
| packages/next/src/utils/__tests__/pathRegex.test.ts | New unit tests for compilePathRegex and pathnameMatchesRegex covering the undefined (pass-all) and configured-regex cases. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["withGTConfig(props)"] --> B["compilePathRegex(mergedConfig.pathRegex)\n(validate only, throw if invalid)"]
    B --> C["Set env._GENERALTRANSLATION_PATH_REGEX\n= mergedConfig.pathRegex string"]
    C --> D{{"Build-time env injection"}}
    D --> E["Edge Middleware\ncreateNextMiddleware()"]
    D --> F["Client Bundle\nclient-boundary.tsx\n(module-level const)"]
    E --> G["compilePathRegex(process.env._GENERALTRANSLATION_PATH_REGEX)"]
    F --> H["compilePathRegex(process.env._GENERALTRANSLATION_PATH_REGEX)"]
    G --> I["middleware(req)\npathnameMatchesRegex → NextResponse.next() if excluded"]
    H --> J["usePathCheck()\npathnameMatchesRegex → skip refresh if excluded"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["withGTConfig(props)"] --> B["compilePathRegex(mergedConfig.pathRegex)\n(validate only, throw if invalid)"]
    B --> C["Set env._GENERALTRANSLATION_PATH_REGEX\n= mergedConfig.pathRegex string"]
    C --> D{{"Build-time env injection"}}
    D --> E["Edge Middleware\ncreateNextMiddleware()"]
    D --> F["Client Bundle\nclient-boundary.tsx\n(module-level const)"]
    E --> G["compilePathRegex(process.env._GENERALTRANSLATION_PATH_REGEX)"]
    F --> H["compilePathRegex(process.env._GENERALTRANSLATION_PATH_REGEX)"]
    G --> I["middleware(req)\npathnameMatchesRegex → NextResponse.next() if excluded"]
    H --> J["usePathCheck()\npathnameMatchesRegex → skip refresh if excluded"]
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.changeset%2Fnext-path-regex-config.md%3A2%0A**Changeset%20bump%20level%20may%20need%20to%20be%20%60minor%60**%0A%0A%60createNextMiddleware%60%20previously%20accepted%20a%20%60regexFilter%60%20parameter%20%28added%20in%20%231841%29.%20This%20PR%20removes%20it%20entirely%20%E2%80%94%20no%20deprecation%2C%20no%20runtime%20fallback.%20If%20%231841%20was%20published%20before%20this%20PR%20lands%2C%20any%20consumer%20who%20passed%20%60regexFilter%60%20will%20silently%20lose%20their%20path-filter%20configuration%20in%20JavaScript%20%28TypeScript%20callers%20will%20get%20a%20compile%20error%29.%20Semver%20convention%20treats%20removing%20a%20public%20parameter%20as%20a%20breaking%20change%2C%20warranting%20at%20least%20a%20%60minor%60%20bump.%20If%20%231841%20was%20never%20released%20and%20%60regexFilter%60%20was%20never%20part%20of%20a%20published%20version%2C%20%60patch%60%20is%20fine.%0A%0A&repo=generaltranslation%2Fgt&pr=1844&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fnext%2Fpath-regex-config%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fnext%2Fpath-regex-config%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.changeset%2Fnext-path-regex-config.md%3A2%0A**Changeset%20bump%20level%20may%20need%20to%20be%20%60minor%60**%0A%0A%60createNextMiddleware%60%20previously%20accepted%20a%20%60regexFilter%60%20parameter%20%28added%20in%20%231841%29.%20This%20PR%20removes%20it%20entirely%20%E2%80%94%20no%20deprecation%2C%20no%20runtime%20fallback.%20If%20%231841%20was%20published%20before%20this%20PR%20lands%2C%20any%20consumer%20who%20passed%20%60regexFilter%60%20will%20silently%20lose%20their%20path-filter%20configuration%20in%20JavaScript%20%28TypeScript%20callers%20will%20get%20a%20compile%20error%29.%20Semver%20convention%20treats%20removing%20a%20public%20parameter%20as%20a%20breaking%20change%2C%20warranting%20at%20least%20a%20%60minor%60%20bump.%20If%20%231841%20was%20never%20released%20and%20%60regexFilter%60%20was%20never%20part%20of%20a%20published%20version%2C%20%60patch%60%20is%20fine.%0A%0A&repo=generaltranslation%2Fgt&pr=1844&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.changeset/next-path-regex-config.md:2
**Changeset bump level may need to be `minor`**

`createNextMiddleware` previously accepted a `regexFilter` parameter (added in #1841). This PR removes it entirely — no deprecation, no runtime fallback. If #1841 was published before this PR lands, any consumer who passed `regexFilter` will silently lose their path-filter configuration in JavaScript (TypeScript callers will get a compile error). Semver convention treats removing a public parameter as a breaking change, warranting at least a `minor` bump. If #1841 was never released and `regexFilter` was never part of a published version, `patch` is fine.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(next): share path regex with client ..."](https://github.com/generaltranslation/gt/commit/f6ef65f7f9719ce5210fa1c97aff7b3d64f4d64b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43161510)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->