### PR TITLE
feat(react): add request locale parser

### DIFF
--- a/.changeset/green-rivers-parse.md
+++ b/.changeset/green-rivers-parse.md
@@ -1,0 +1,9 @@
+---
+'gt-i18n': patch
+'gt-node': patch
+'gt-react': patch
+---
+
+Add `parseLocale(request)` to resolve server-rendered React locales from the configured cookie, the `Accept-Language` header, or the default locale.
+
+Share cookie and `Accept-Language` parsing across the framework packages.

--- a/packages/i18n/src/internal.ts
+++ b/packages/i18n/src/internal.ts
@@ -54,3 +54,4 @@ export { createGlobalSingleton } from './globals/createGlobalSingleton';
 export type { GlobalSingleton } from './globals/createGlobalSingleton';
 export { getRuntimeEnvironment } from './utils/getRuntimeEnvironment';
 export { hashMessage } from './utils/hashMessage';
+export { getCookieValue, parseAcceptLanguage } from './utils/request';

--- a/packages/i18n/src/utils/__tests__/request.test.ts
+++ b/packages/i18n/src/utils/__tests__/request.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { getCookieValue, parseAcceptLanguage } from '../request';
+
+describe('parseAcceptLanguage', () => {
+  it('sorts locale candidates by quality', () => {
+    expect(parseAcceptLanguage('es;q=0.5, fr;q=0.9, en')).toEqual([
+      'en',
+      'fr',
+      'es',
+    ]);
+  });
+
+  it('supports multiple header values', () => {
+    expect(parseAcceptLanguage(['es;q=0.5', 'fr;q=0.9'])).toEqual(['fr', 'es']);
+  });
+
+  it('preserves header order for equal quality values', () => {
+    expect(parseAcceptLanguage('fr, es;q=1, en')).toEqual(['fr', 'es', 'en']);
+  });
+
+  it('finds the quality value among other parameters', () => {
+    expect(parseAcceptLanguage('es;foo=bar;q=0.5, fr;q=0.9')).toEqual([
+      'fr',
+      'es',
+    ]);
+  });
+
+  it('omits wildcards and unacceptable or invalid candidates', () => {
+    expect(parseAcceptLanguage('*, en;q=0, es;q=invalid, fr;q=2')).toEqual([]);
+  });
+});
+
+describe('getCookieValue', () => {
+  it('reads an exact cookie name without requiring spaces', () => {
+    expect(
+      getCookieValue('other=value;locale=fr;locale-extra=es', 'locale')
+    ).toBe('fr');
+  });
+
+  it('decodes cookie values and preserves equals signs', () => {
+    expect(getCookieValue('locale=brand%2Dfrench%3Dca', 'locale')).toBe(
+      'brand-french=ca'
+    );
+  });
+
+  it('returns undefined when the cookie is absent', () => {
+    expect(getCookieValue('other=value', 'locale')).toBeUndefined();
+  });
+});

--- a/packages/i18n/src/utils/request.ts
+++ b/packages/i18n/src/utils/request.ts
@@ -1,0 +1,49 @@
+type HeaderValue = string | string[] | null | undefined;
+
+/**
+ * Parse an Accept-Language header into locale candidates by preference.
+ */
+export function parseAcceptLanguage(header: HeaderValue): string[] {
+  const headerValues = Array.isArray(header) ? header : [header];
+
+  return headerValues
+    .flatMap((value) => value?.split(',') ?? [])
+    .map((entry, index) => {
+      const [locale = '', ...parameters] = entry
+        .split(';')
+        .map((value) => value.trim());
+      const qualityParameter = parameters.find((parameter) =>
+        parameter.toLowerCase().startsWith('q=')
+      );
+      const quality = Number(qualityParameter?.slice(2) ?? 1);
+      return { locale, quality, index };
+    })
+    .filter(
+      ({ locale, quality }) =>
+        locale !== '' && locale !== '*' && quality > 0 && quality <= 1
+    )
+    .sort((a, b) => b.quality - a.quality || a.index - b.index)
+    .map(({ locale }) => locale);
+}
+
+/**
+ * Read and decode a value from a Cookie header or document.cookie string.
+ */
+export function getCookieValue(
+  cookieHeader: string | null | undefined,
+  cookieName: string
+): string | undefined {
+  const prefix = `${cookieName}=`;
+  const cookie = cookieHeader
+    ?.split(';')
+    .map((value) => value.trim())
+    .find((value) => value.startsWith(prefix));
+  if (!cookie) return undefined;
+
+  const value = cookie.slice(prefix.length);
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}

--- a/packages/next/src/condition-store/AsyncConditionStore.ts
+++ b/packages/next/src/condition-store/AsyncConditionStore.ts
@@ -2,7 +2,11 @@ import { AsyncReadonlyConditionStoreInterface } from 'gt-i18n/internal/types';
 import { createDiagnosticMessage } from 'generaltranslation/internal';
 import { cookies, headers } from 'next/headers';
 import { noLocalesCouldBeDeterminedWarning } from '../errors/ssg';
-import { createConditionStoreSingleton, getI18nConfig } from 'gt-i18n/internal';
+import {
+  createConditionStoreSingleton,
+  getI18nConfig,
+  parseAcceptLanguage,
+} from 'gt-i18n/internal';
 import {
   defaultLocaleCookieName,
   defaultRegionCookieName,
@@ -122,14 +126,9 @@ function createDefaultGetLocale({
 
     // Preferred languages
     if (!ignorePreferredLanguages) {
-      const acceptedLocales = headersList
-        .get('accept-language')
-        ?.split(',')
-        .map((item: string) => item.split(';')?.[0].trim());
-
-      if (acceptedLocales) {
-        preferredLocales.push(...acceptedLocales);
-      }
+      preferredLocales.push(
+        ...parseAcceptLanguage(headersList.get('accept-language'))
+      );
     }
 
     // Warn if no locales found

--- a/packages/next/src/middleware-dir/utils.ts
+++ b/packages/next/src/middleware-dir/utils.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { standardizeLocale } from '@generaltranslation/format';
 import { GTRuntime } from 'generaltranslation/runtime';
 import { NextURL } from 'next/dist/server/web/next-url';
+import { parseAcceptLanguage } from 'gt-i18n/internal';
 
 export type PathConfig = {
   [key: string]: string | { [key: string]: string };
@@ -353,12 +354,7 @@ export function getLocaleFromRequest(
 
   // Get locales from accept-language header
   if (process.env._GENERALTRANSLATION_IGNORE_BROWSER_LOCALES === 'false') {
-    const acceptedLocales =
-      headerList
-        .get('accept-language')
-        ?.split(',')
-        .map((item) => item.split(';')?.[0].trim()) || [];
-    if (acceptedLocales) candidates.push(...acceptedLocales);
+    candidates.push(...parseAcceptLanguage(headerList.get('accept-language')));
   }
 
   // Get default locale

--- a/packages/next/src/pages-dir/parseLocale.ts
+++ b/packages/next/src/pages-dir/parseLocale.ts
@@ -1,6 +1,7 @@
 import type { GetServerSidePropsContext, PreviewData } from 'next';
 import type { ParsedUrlQuery } from 'querystring';
 import { getI18nConfig } from '@generaltranslation/react-core/pure';
+import { parseAcceptLanguage } from 'gt-i18n/internal';
 import { noLocalesCouldBeDeterminedWarning } from '../errors/ssg';
 import { defaultLocaleHeaderName } from '../utils/headers';
 
@@ -26,7 +27,7 @@ export function parseLocale<
 
   if (!ignorePreferredLanguages) {
     preferredLocales.push(
-      ...getAcceptLanguageCandidates(context.req.headers['accept-language'])
+      ...parseAcceptLanguage(context.req.headers['accept-language'])
     );
   }
 
@@ -64,15 +65,4 @@ function addHeaderCandidates(candidates: string[], headerValue: HeaderValue) {
   } else if (headerValue) {
     candidates.push(headerValue);
   }
-}
-
-function getAcceptLanguageCandidates(headerValue: HeaderValue): string[] {
-  const headerValues = Array.isArray(headerValue) ? headerValue : [headerValue];
-  return headerValues.flatMap(
-    (value) =>
-      value
-        ?.split(',')
-        .map((item) => item.split(';')?.[0].trim())
-        .filter(Boolean) || []
-  );
 }

--- a/packages/next/src/utils/__tests__/client-boundary.test.tsx
+++ b/packages/next/src/utils/__tests__/client-boundary.test.tsx
@@ -11,7 +11,8 @@ const { mockGetI18nConfig, mockInitializeGTClient, mockRefresh } = vi.hoisted(
   })
 );
 
-vi.mock('gt-i18n/internal', () => ({
+vi.mock('gt-i18n/internal', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('gt-i18n/internal')>()),
   getI18nConfig: mockGetI18nConfig,
 }));
 

--- a/packages/next/src/utils/client-boundary.tsx
+++ b/packages/next/src/utils/client-boundary.tsx
@@ -12,7 +12,7 @@
 export { LocaleSelector as Client_LocaleSelector } from 'gt-react';
 export { RegionSelector as Client_RegionSelector } from 'gt-react';
 
-import { getI18nConfig, I18nConfig } from 'gt-i18n/internal';
+import { getCookieValue, getI18nConfig, I18nConfig } from 'gt-i18n/internal';
 import { GTProvider, type SharedGTProviderProps } from 'gt-react';
 import { usePathname, useRouter } from 'next/navigation';
 import { useCallback, useEffect } from 'react';
@@ -75,10 +75,8 @@ function usePathCheck({
     const locales = i18nConfig.getLocales();
     const defaultLocale = i18nConfig.getDefaultLocale();
     const middlewareEnabled =
-      document.cookie
-        .split('; ')
-        .find((row) => row.startsWith(`${localeRoutingEnabledCookieName}=`))
-        ?.split('=')[1] === 'true';
+      getCookieValue(document.cookie, localeRoutingEnabledCookieName) ===
+      'true';
     if (middlewareEnabled && pathnameMatchesRegex(pathname, pathRegex)) {
       // Extract locale from pathname
       const extractedLocale =

--- a/packages/node/src/helpers/getRequestLocale.ts
+++ b/packages/node/src/helpers/getRequestLocale.ts
@@ -1,4 +1,4 @@
-import { getI18nConfig } from 'gt-i18n/internal';
+import { getI18nConfig, parseAcceptLanguage } from 'gt-i18n/internal';
 
 /**
  * A request object like interface
@@ -7,31 +7,6 @@ import { getI18nConfig } from 'gt-i18n/internal';
  */
 interface RequestLike {
   headers: Record<string, string | string[] | undefined>;
-}
-
-/**
- * Parse the Accept-Language header into an array of locales
- * @param header - The Accept-Language header
- * @returns An array of locales
- *
- * @example
- * const locales = parseAcceptLanguage('fr-FR,fr;q=0.9,en;q=0.8');
- * console.log(locales); // ['fr-FR', 'fr', 'en']
- */
-function parseAcceptLanguage(header: string): string[] {
-  return header
-    .split(',')
-    .map((entry) => {
-      const [locale, quality] = entry.trim().split(';');
-      const qPart = quality?.split('=')[1];
-      const q = qPart !== undefined ? parseFloat(qPart) : 1;
-      return {
-        locale: locale.trim(),
-        quality: isNaN(q) ? 1 : q,
-      };
-    })
-    .sort((a, b) => b.quality - a.quality)
-    .map((entry) => entry.locale);
 }
 
 /**
@@ -57,12 +32,7 @@ export function getRequestLocale(request: RequestLike): string {
 
   // Get the accept-language header
   const acceptLanguage = request.headers['accept-language'];
-  const headerValue = Array.isArray(acceptLanguage)
-    ? acceptLanguage[0]
-    : acceptLanguage;
-
-  // Parse the accept-language header
-  const preferredLocales = headerValue ? parseAcceptLanguage(headerValue) : [];
+  const preferredLocales = parseAcceptLanguage(acceptLanguage);
   return (
     i18nConfig.determineLocale(preferredLocales) ||
     i18nConfig.getDefaultLocale()

--- a/packages/react/src/__tests__/context-rsc.test.ts
+++ b/packages/react/src/__tests__/context-rsc.test.ts
@@ -22,5 +22,6 @@ describe('gt-react react-server surface', () => {
     expect('renderVariable' in mod).toBe(false);
     expect(mod.GTProvider).toBeTypeOf('function');
     expect(mod.LocaleSelector).toBeTypeOf('function');
+    expect(mod.parseLocale).toBeTypeOf('function');
   });
 });

--- a/packages/react/src/__tests__/react-package.test.ts
+++ b/packages/react/src/__tests__/react-package.test.ts
@@ -70,6 +70,7 @@ describe('gt-react package exports', () => {
 
           assert.equal(typeof react.GTProvider, 'function');
           assert.equal(typeof react.T, 'function');
+          assert.equal(typeof react.parseLocale, 'function');
           assert.equal(typeof react.GtInternalVar, 'function');
           assert.equal(typeof react.GtInternalRuntimeTranslateString, 'function');
         `,
@@ -103,10 +104,11 @@ describe('gt-react package exports', () => {
       '-e',
       `
           import assert from 'node:assert/strict';
-          import { GTProvider, GtInternalRuntimeTranslateString, GtInternalVar, T } from 'gt-react';
+          import { GTProvider, GtInternalRuntimeTranslateString, GtInternalVar, parseLocale, T } from 'gt-react';
 
           assert.equal(typeof GTProvider, 'function');
           assert.equal(typeof T, 'function');
+          assert.equal(typeof parseLocale, 'function');
           assert.equal(typeof GtInternalVar, 'function');
           assert.equal(typeof GtInternalRuntimeTranslateString, 'function');
         `,

--- a/packages/react/src/condition-store/cookies.ts
+++ b/packages/react/src/condition-store/cookies.ts
@@ -1,3 +1,5 @@
+import { getCookieValue as getCookieValueFromString } from 'gt-i18n/internal';
+
 /**
  * Minimally parses a cookie value for a given cookie name
  * @param cookieName - The name of the cookie
@@ -9,11 +11,7 @@ export function getCookieValue({
   cookieName: string;
 }): string | undefined {
   if (typeof document === 'undefined') return undefined;
-  const rawCookieValue = document.cookie
-    .split('; ')
-    .find((row) => row.startsWith(`${cookieName}=`))
-    ?.split('=')[1];
-  return rawCookieValue;
+  return getCookieValueFromString(document.cookie, cookieName);
 }
 
 /**

--- a/packages/react/src/functions/__tests__/parseLocale.test.ts
+++ b/packages/react/src/functions/__tests__/parseLocale.test.ts
@@ -1,0 +1,75 @@
+import { initializeI18nConfig } from '@generaltranslation/react-core/pure';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { parseLocale } from '../parseLocale';
+
+type TestGlobal = typeof globalThis & {
+  __generaltranslation?: unknown;
+};
+
+function resetGTGlobals() {
+  Reflect.deleteProperty(globalThis as TestGlobal, '__generaltranslation');
+}
+
+function createRequest(headers: HeadersInit = {}): Request {
+  return new Request('https://example.com', { headers });
+}
+
+describe('parseLocale(request)', () => {
+  beforeEach(() => {
+    resetGTGlobals();
+    initializeI18nConfig({
+      defaultLocale: 'en',
+      locales: ['en', 'es', 'fr', 'brand-french'],
+      customMapping: {
+        'brand-french': {
+          code: 'fr',
+          name: 'Brand French',
+        },
+      },
+    });
+  });
+
+  it('uses the locale cookie before Accept-Language', () => {
+    const request = createRequest({
+      cookie: 'other=value; generaltranslation.locale=brand-french',
+      'accept-language': 'es,en;q=0.8',
+    });
+
+    expect(parseLocale(request)).toBe('fr');
+  });
+
+  it('uses the configured locale cookie name', () => {
+    resetGTGlobals();
+    initializeI18nConfig({
+      defaultLocale: 'en',
+      locales: ['en', 'es', 'fr'],
+      localeCookieName: 'custom-locale',
+    });
+    const request = createRequest({
+      cookie: 'generaltranslation.locale=es;custom-locale=fr',
+    });
+
+    expect(parseLocale(request)).toBe('fr');
+  });
+
+  it('falls back to Accept-Language in quality order', () => {
+    const request = createRequest({
+      cookie: 'generaltranslation.locale=unsupported',
+      'accept-language': 'es;q=0.5, fr;q=0.9, en;q=0',
+    });
+
+    expect(parseLocale(request)).toBe('fr');
+  });
+
+  it('decodes the locale cookie value', () => {
+    const request = createRequest({
+      cookie: 'generaltranslation.locale=brand%2Dfrench',
+    });
+
+    expect(parseLocale(request)).toBe('fr');
+  });
+
+  it('falls back to the configured default locale', () => {
+    expect(parseLocale(createRequest())).toBe('en');
+  });
+});

--- a/packages/react/src/functions/parseLocale.ts
+++ b/packages/react/src/functions/parseLocale.ts
@@ -1,0 +1,33 @@
+import { getI18nConfig } from '@generaltranslation/react-core/pure';
+import { getCookieValue, parseAcceptLanguage } from 'gt-i18n/internal';
+
+type RequestWithHeaders = Pick<Request, 'headers'>;
+
+/**
+ * Resolve the user's locale from a Web Request.
+ *
+ * The configured locale cookie takes precedence over the Accept-Language
+ * header. If neither contains a supported locale, the configured default
+ * locale is returned.
+ *
+ * This is intended for incoming server requests. A Request created in the
+ * browser does not automatically include document cookies or Accept-Language.
+ */
+export function parseLocale(request: RequestWithHeaders): string {
+  const i18nConfig = getI18nConfig();
+  const candidates: string[] = [];
+  const cookieLocale = getCookieValue(
+    request.headers.get('cookie'),
+    i18nConfig.getLocaleCookieName()
+  );
+
+  if (cookieLocale) {
+    candidates.push(cookieLocale);
+  }
+
+  candidates.push(
+    ...parseAcceptLanguage(request.headers.get('accept-language'))
+  );
+
+  return i18nConfig.resolveSupportedLocale(candidates);
+}

--- a/packages/react/src/index.client.ts
+++ b/packages/react/src/index.client.ts
@@ -5,6 +5,7 @@ import type { TxProps } from './utils/TxProps';
 
 export { initializeGTSPA } from './setup/initializeGTSPA';
 export { initializeGTSRAClient as initializeGT } from './setup/initializeGTSRAClient';
+export { parseLocale } from './functions/parseLocale';
 export { useLocaleSelector } from './components/useLocaleSelector';
 export { useRegionSelector } from './components/useRegionSelector';
 export {

--- a/packages/react/src/index.rsc.ts
+++ b/packages/react/src/index.rsc.ts
@@ -1,5 +1,7 @@
 // React Server Component context surface.
 
+export { parseLocale } from './functions/parseLocale';
+
 import { createDiagnosticMessage } from 'generaltranslation/internal';
 import { CustomMapping } from 'generaltranslation/types';
 import {

--- a/packages/react/src/index.server.ts
+++ b/packages/react/src/index.server.ts
@@ -9,6 +9,7 @@ import type { TxProps } from './utils/TxProps';
 // React Server Component frameworks.
 
 export { initializeGTSRA as initializeGT } from './setup/initializeGTSRA';
+export { parseLocale } from './functions/parseLocale';
 export { useLocaleSelector } from './components/useLocaleSelector';
 export { useRegionSelector } from './components/useRegionSelector';
 export {

--- a/packages/react/src/index.types.ts
+++ b/packages/react/src/index.types.ts
@@ -5,6 +5,7 @@ import type { TxProps } from './utils/TxProps';
 
 export { initializeGTSPA } from './setup/initializeGTSPA';
 export { initializeGTSRA as initializeGT } from './setup/initializeGTSRA';
+export { parseLocale } from './functions/parseLocale';
 export { useLocaleSelector } from './components/useLocaleSelector';
 export { useRegionSelector } from './components/useRegionSelector';
 export {

--- a/packages/tanstack-start/src/functions/parseLocale.ts
+++ b/packages/tanstack-start/src/functions/parseLocale.ts
@@ -5,6 +5,7 @@ import {
   setCookie,
 } from '@tanstack/react-start/server';
 import { getI18nConfig } from '@generaltranslation/react-core/pure';
+import { getCookieValue, parseAcceptLanguage } from 'gt-i18n/internal';
 import type { LocaleResolverConfig } from 'gt-i18n/internal/types';
 
 export const determineLocale = createIsomorphicFn()
@@ -35,11 +36,7 @@ function determineLocaleServer({
   const cookie = getCookie(localeCookieName);
   if (cookie) candidates.push(cookie);
 
-  const headers =
-    getRequestHeader('accept-language')
-      ?.split(',')
-      .map((item) => item.split(';')?.[0].trim()) || [];
-  candidates.push(...headers);
+  candidates.push(...parseAcceptLanguage(getRequestHeader('accept-language')));
 
   if (candidates.length === 0) {
     console.warn(
@@ -71,10 +68,7 @@ function determineLocaleClient({
   const localeCookieName = i18nConfig.getLocaleCookieName();
   const candidates: string[] = [];
 
-  const cookie = document.cookie
-    .split('; ')
-    .find((row) => row.startsWith(`${localeCookieName}=`))
-    ?.slice(localeCookieName.length + 1);
+  const cookie = getCookieValue(document.cookie, localeCookieName);
   if (cookie) candidates.push(cookie);
 
   if (candidates.length === 0) {


### PR DESCRIPTION
## Summary
- add `parseLocale(request)` to `gt-react` with locale-cookie, `Accept-Language`, and configured-default fallback behavior
- export it from the client, server, RSC, and types entrypoints as requested
- move the framework-neutral cookie and `Accept-Language` parsers into `gt-i18n/internal`
- reuse the shared parsers in `gt-react`, `gt-node`, `gt-next`, and `gt-tanstack-start` while retaining each framework request API and locale-precedence behavior
- add patch changesets for `gt-i18n`, `gt-node`, and `gt-react`; the fixed React package group is included automatically

The shared `Accept-Language` parser handles quality ordering, stable ties, array-valued headers, multiple parameters, wildcard and `q=0` rejection, and invalid or out-of-range qualities. The cookie parser performs exact-name matching, safe URI decoding, and preserves values containing `=`.

## Testing
- `pnpm --filter gt-i18n build`, typecheck, and test
- `pnpm --filter gt-node typecheck`, test, and build
- `pnpm --filter gt-react typecheck`, test, and build
- `pnpm --filter gt-tanstack-start typecheck`, test, and build
- `pnpm --filter gt-next build:no-swc-plugin`, typecheck, and test:js
- `pnpm lint`
- `pnpm format`
- `pnpm changeset status`

The full `gt-next` build still requires the Rust `cargo` toolchain for its SWC plugin, which is unavailable in this environment; its TypeScript build completed through `build:no-swc-plugin`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a shared `parseAcceptLanguage` and `getCookieValue` utility in `gt-i18n/internal`, then migrates all framework packages (`gt-react`, `gt-next`, `gt-node`, `gt-tanstack-start`) to use them. It also adds a new `parseLocale(request)` function to `gt-react`, exported from all four entrypoints (client, server, RSC, types).

- **Shared parsers in `gt-i18n/internal`**: `parseAcceptLanguage` handles quality-sorted output, stable tie-breaking, wildcard/`q=0`/invalid-quality rejection, and array-valued headers. `getCookieValue` performs exact-name matching with URI decoding.
- **`gt-react` `parseLocale`**: resolves locale from cookie → Accept-Language → default, using the web `Request` API with `Pick<Request, 'headers'>` for broad compatibility. JSDoc notes the server-intent caveat.
- **Migration improvements**: the old `gt-next` middleware and AsyncConditionStore did not sort Accept-Language entries by quality; the new shared parser corrects this silently. The old `gt-node` handler only consumed the first element of an array Accept-Language header; the new handler correctly processes all values.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. All changed packages correctly adopt the shared parsers, and the quality-sorting fix in gt-next middleware and AsyncConditionStore is a correctness improvement with no breaking surface.

The changes are well-scoped: new shared utilities in gt-i18n/internal replace inline header/cookie parsing duplicated across five packages. Each migration preserves existing locale-precedence logic. The behavioral improvements (quality-sorted Accept-Language, full array-header consumption in gt-node) are strictly more correct. Tests cover all edge cases including NaN, wildcards, q=0, out-of-range quality, URI-encoded cookie values, and default-locale fallback.

No files require special attention. All migrated packages use the shared parsers consistently.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/i18n/src/utils/request.ts | New shared parsers: parseAcceptLanguage handles quality sorting, NaN/wildcard/out-of-range filtering, stable index-based tiebreaking, and array headers; getCookieValue uses exact-prefix matching with URI decoding. Well tested. |
| packages/react/src/functions/parseLocale.ts | New parseLocale(request) resolves locale via cookie then Accept-Language then default using the shared parsers; uses Pick<Request, 'headers'> for broad compatibility. JSDoc notes the server-intent caveat. |
| packages/node/src/helpers/getRequestLocale.ts | Migrated to shared parseAcceptLanguage; now correctly processes all elements of array Accept-Language headers instead of only the first one. |
| packages/next/src/middleware-dir/utils.ts | Migrated Accept-Language parsing to shared utility; middleware now correctly respects quality ordering (old code did not sort by q-value). |
| packages/next/src/condition-store/AsyncConditionStore.ts | Replaced inline Accept-Language splitting with shared parseAcceptLanguage; quality-sorting now applied in the async condition store as well. |
| packages/next/src/utils/client-boundary.tsx | Replaced inline cookie splitting with getCookieValue; mock updated to use importOriginal so other gt-i18n/internal exports survive the mock boundary. |
| packages/tanstack-start/src/functions/parseLocale.ts | Migrated both server-side Accept-Language and client-side cookie parsing to the shared utilities. Logic and behavior are unchanged. |
| packages/react/src/condition-store/cookies.ts | getCookieValue now delegates to the shared parser; also correctly preserves '=' characters inside cookie values (prior code truncated at the first '='). |
| packages/i18n/src/utils/__tests__/request.test.ts | Good coverage: quality sorting, multi-header arrays, stable ties, parameter ordering, wildcard/q=0/NaN/out-of-range rejection, exact cookie name matching, URI decoding, and absent-cookie case. |
| packages/react/src/functions/__tests__/parseLocale.test.ts | Tests cover cookie precedence, custom cookie name, Accept-Language quality fallback, URI-decoded cookie values, and default-locale fallback. |
| packages/next/src/pages-dir/parseLocale.ts | Removed local getAcceptLanguageCandidates in favour of shared parseAcceptLanguage; quality sorting now applies to Pages Router server-side requests. |

</details>

<sub>Reviews (2): Last reviewed commit: ["feat(react): add request locale parser"](https://github.com/generaltranslation/gt/commit/c3c8486e2d1c95eb5f8caad30b1e88c238788dcb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43176430)</sub>

<!-- /greptile_comment -->