### PR TITLE
feat(next): add static props helper

### DIFF
--- a/.changeset/pages-static-props.md
+++ b/.changeset/pages-static-props.md
@@ -2,4 +2,4 @@
 'gt-next': patch
 ---
 
-Add `withGTStaticProps()` for hydrating each statically generated Pages Router locale with its relevant translation snapshot.
+Add `withGTStaticProps()` for hydrating each statically generated Pages Router locale with its relevant translation snapshot. Pages Router locale routing is required so Next.js generates the page once per locale.

--- a/.changeset/pages-static-props.md
+++ b/.changeset/pages-static-props.md
@@ -2,4 +2,4 @@
 'gt-next': patch
 ---
 
-Add `withGTStaticProps()` for hydrating statically generated Pages Router applications with translations for every configured locale.
+Add `withGTStaticProps()` for hydrating each statically generated Pages Router locale with its relevant translation snapshot.

--- a/.changeset/pages-static-props.md
+++ b/.changeset/pages-static-props.md
@@ -2,4 +2,4 @@
 'gt-next': patch
 ---
 
-Add `withGTStaticProps()` for hydrating Pages Router applications with locale-specific translations during static generation.
+Add `withGTStaticProps()` for hydrating statically generated Pages Router applications with translations for every configured locale.

--- a/.changeset/pages-static-props.md
+++ b/.changeset/pages-static-props.md
@@ -1,0 +1,5 @@
+---
+'gt-next': patch
+---
+
+Add `withGTStaticProps()` for hydrating Pages Router applications with locale-specific translations during static generation.

--- a/packages/next/src/errors/__tests__/createErrors.test.ts
+++ b/packages/next/src/errors/__tests__/createErrors.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import {
+  withGTStaticPropsClientError,
+  withGTStaticPropsRscError,
+} from '../createErrors';
+
+describe('withGTStaticProps errors', () => {
+  it('provides an actionable browser diagnostic', () => {
+    expect(withGTStaticPropsClientError).toBe(
+      'gt-next Error: withGTStaticProps() cannot run in the browser because static props are generated on the server by the Pages Router. Export withGTStaticProps() from a Pages Router page module.'
+    );
+  });
+
+  it('provides an actionable React Server Component diagnostic', () => {
+    expect(withGTStaticPropsRscError).toBe(
+      'gt-next Error: withGTStaticProps() is not available for React Server Components because this helper supports the Pages Router, not the App Router. Use gt-next build-time translation helpers in the App Router, or export withGTStaticProps() from a Pages Router page module.'
+    );
+  });
+});

--- a/packages/next/src/errors/__tests__/ssg.test.ts
+++ b/packages/next/src/errors/__tests__/ssg.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { withGTStaticPropsLocaleRoutingError } from '../ssg';
+
+describe('SSG errors', () => {
+  it('provides an actionable Pages Router locale-routing diagnostic', () => {
+    expect(withGTStaticPropsLocaleRoutingError).toBe(
+      'gt-next Error: withGTStaticProps() could not determine the statically generated locale because without Pages Router locale routing, Next.js generates only one version of this page. Add i18n locales and defaultLocale to your Next.js configuration.'
+    );
+  });
+});

--- a/packages/next/src/errors/createErrors.ts
+++ b/packages/next/src/errors/createErrors.ts
@@ -106,6 +106,21 @@ export const getTranslationsSnapshotRscError = createGtNextDiagnostic({
   fix: 'Use gt-next build-time translation helpers in the App Router, or call getTranslationsSnapshot() from a Pages Router entry point',
 });
 
+export const withGTStaticPropsClientError = createGtNextDiagnostic({
+  severity: 'Error',
+  whatHappened: 'withGTStaticProps() cannot run in the browser',
+  why: 'Static props are generated on the server by the Pages Router',
+  fix: 'Export withGTStaticProps() from a Pages Router page module',
+});
+
+export const withGTStaticPropsRscError = createGtNextDiagnostic({
+  severity: 'Error',
+  whatHappened:
+    'withGTStaticProps() is not available for React Server Components',
+  why: 'This helper supports the Pages Router, not the App Router',
+  fix: 'Use gt-next build-time translation helpers in the App Router, or export withGTStaticProps() from a Pages Router page module',
+});
+
 export const invalidLocalesError = (locales: string[]) =>
   createGtNextDiagnostic({
     severity: 'Error',

--- a/packages/next/src/errors/ssg.ts
+++ b/packages/next/src/errors/ssg.ts
@@ -10,3 +10,11 @@ export const noLocalesCouldBeDeterminedWarning = createGtNextDiagnostic({
   docsUrl:
     'https://generaltranslation.com/en/docs/next/guides/ssg#ssg-custom-get-locale',
 });
+
+export const withGTStaticPropsLocaleRoutingError = createGtNextDiagnostic({
+  severity: 'Error',
+  whatHappened:
+    'withGTStaticProps() could not determine the statically generated locale',
+  why: 'Without Pages Router locale routing, Next.js generates only one version of this page',
+  fix: 'Add i18n locales and defaultLocale to your Next.js configuration',
+});

--- a/packages/next/src/index.client.ts
+++ b/packages/next/src/index.client.ts
@@ -6,12 +6,15 @@ initializeGTClient();
 import type {
   GetServerSideProps,
   GetServerSidePropsContext,
-  GetStaticProps,
   PreviewData,
 } from 'next';
 import type { ParsedUrlQuery } from 'querystring';
 import type { WithGTServerSideProps } from './pages-dir/withGTServerSideProps';
-import type { WithGTStaticProps } from './pages-dir/withGTStaticProps';
+import type {
+  WithGTStaticProps,
+  WithGTStaticPropsFunction,
+} from './pages-dir/withGTStaticProps';
+import { withGTStaticPropsClientError } from './errors/createErrors';
 
 // ===== Unsupported Server APIs ===== //
 export function parseLocale<
@@ -35,33 +38,9 @@ export function withGTServerSideProps<
   );
 }
 
-export function withGTStaticProps<
-  Props extends Record<string, unknown> = Record<string, unknown>,
-  Params extends ParsedUrlQuery = ParsedUrlQuery,
-  Preview extends PreviewData = PreviewData,
->(
-  getStaticProps?: GetStaticProps<Props, Params, Preview>
-): GetStaticProps<WithGTStaticProps<Props>, Params, Preview>;
-export function withGTStaticProps<
-  Props extends Record<string, unknown> = Record<string, unknown>,
-  Params extends ParsedUrlQuery = ParsedUrlQuery,
-  Preview extends PreviewData = PreviewData,
->(
-  locale: string,
-  getStaticProps?: GetStaticProps<Props, Params, Preview>
-): GetStaticProps<WithGTStaticProps<Props>, Params, Preview>;
-export function withGTStaticProps<
-  Props extends Record<string, unknown> = Record<string, unknown>,
-  Params extends ParsedUrlQuery = ParsedUrlQuery,
-  Preview extends PreviewData = PreviewData,
->(
-  _firstArg?: string | GetStaticProps<Props, Params, Preview>,
-  _secondArg?: GetStaticProps<Props, Params, Preview>
-): GetStaticProps<WithGTStaticProps<Props>, Params, Preview> {
-  throw new Error(
-    'withGTStaticProps() is only available from gt-next on the server.'
-  );
-}
+export const withGTStaticProps: WithGTStaticPropsFunction = () => {
+  throw new Error(withGTStaticPropsClientError);
+};
 
 // ===== Components ===== //
 export {

--- a/packages/next/src/index.client.ts
+++ b/packages/next/src/index.client.ts
@@ -6,10 +6,12 @@ initializeGTClient();
 import type {
   GetServerSideProps,
   GetServerSidePropsContext,
+  GetStaticProps,
   PreviewData,
 } from 'next';
 import type { ParsedUrlQuery } from 'querystring';
 import type { WithGTServerSideProps } from './pages-dir/withGTServerSideProps';
+import type { WithGTStaticProps } from './pages-dir/withGTStaticProps';
 
 // ===== Unsupported Server APIs ===== //
 export function parseLocale<
@@ -30,6 +32,34 @@ export function withGTServerSideProps<
 ): GetServerSideProps<WithGTServerSideProps<Props>, Params, Preview> {
   throw new Error(
     'withGTServerSideProps() is only available from gt-next on the server.'
+  );
+}
+
+export function withGTStaticProps<
+  Props extends Record<string, unknown> = Record<string, unknown>,
+  Params extends ParsedUrlQuery = ParsedUrlQuery,
+  Preview extends PreviewData = PreviewData,
+>(
+  getStaticProps?: GetStaticProps<Props, Params, Preview>
+): GetStaticProps<WithGTStaticProps<Props>, Params, Preview>;
+export function withGTStaticProps<
+  Props extends Record<string, unknown> = Record<string, unknown>,
+  Params extends ParsedUrlQuery = ParsedUrlQuery,
+  Preview extends PreviewData = PreviewData,
+>(
+  locale: string,
+  getStaticProps?: GetStaticProps<Props, Params, Preview>
+): GetStaticProps<WithGTStaticProps<Props>, Params, Preview>;
+export function withGTStaticProps<
+  Props extends Record<string, unknown> = Record<string, unknown>,
+  Params extends ParsedUrlQuery = ParsedUrlQuery,
+  Preview extends PreviewData = PreviewData,
+>(
+  _firstArg?: string | GetStaticProps<Props, Params, Preview>,
+  _secondArg?: GetStaticProps<Props, Params, Preview>
+): GetStaticProps<WithGTStaticProps<Props>, Params, Preview> {
+  throw new Error(
+    'withGTStaticProps() is only available from gt-next on the server.'
   );
 }
 
@@ -85,4 +115,4 @@ export { isLocaleSupported } from './request/localeValidation';
 
 // ===== Types ===== //
 export type { GTTranslationOptions, RuntimeTranslationOptions } from 'gt-react';
-export type { WithGTServerSideProps };
+export type { WithGTServerSideProps, WithGTStaticProps };

--- a/packages/next/src/index.rsc.ts
+++ b/packages/next/src/index.rsc.ts
@@ -4,13 +4,18 @@ import { initializeGTServer } from './setup/initGT.server';
 import type {
   GetServerSideProps,
   GetServerSidePropsContext,
-  GetStaticProps,
   PreviewData,
 } from 'next';
 import type { ParsedUrlQuery } from 'querystring';
-import { getTranslationsSnapshotRscError } from './errors/createErrors';
+import {
+  getTranslationsSnapshotRscError,
+  withGTStaticPropsRscError,
+} from './errors/createErrors';
 import type { WithGTServerSideProps } from './pages-dir/withGTServerSideProps';
-import type { WithGTStaticProps } from './pages-dir/withGTStaticProps';
+import type {
+  WithGTStaticProps,
+  WithGTStaticPropsFunction,
+} from './pages-dir/withGTStaticProps';
 initializeGTServer();
 
 // ===== Components ===== //
@@ -80,33 +85,9 @@ export function withGTServerSideProps<
  * Placeholder for withGTStaticProps()
  * This function is for next-pages use, not next-app use
  */
-export function withGTStaticProps<
-  Props extends Record<string, unknown> = Record<string, unknown>,
-  Params extends ParsedUrlQuery = ParsedUrlQuery,
-  Preview extends PreviewData = PreviewData,
->(
-  getStaticProps?: GetStaticProps<Props, Params, Preview>
-): GetStaticProps<WithGTStaticProps<Props>, Params, Preview>;
-export function withGTStaticProps<
-  Props extends Record<string, unknown> = Record<string, unknown>,
-  Params extends ParsedUrlQuery = ParsedUrlQuery,
-  Preview extends PreviewData = PreviewData,
->(
-  locale: string,
-  getStaticProps?: GetStaticProps<Props, Params, Preview>
-): GetStaticProps<WithGTStaticProps<Props>, Params, Preview>;
-export function withGTStaticProps<
-  Props extends Record<string, unknown> = Record<string, unknown>,
-  Params extends ParsedUrlQuery = ParsedUrlQuery,
-  Preview extends PreviewData = PreviewData,
->(
-  _firstArg?: string | GetStaticProps<Props, Params, Preview>,
-  _secondArg?: GetStaticProps<Props, Params, Preview>
-): GetStaticProps<WithGTStaticProps<Props>, Params, Preview> {
-  throw new Error(
-    'withGTStaticProps() is only available for the Pages Router.'
-  );
-}
+export const withGTStaticProps: WithGTStaticPropsFunction = () => {
+  throw new Error(withGTStaticPropsRscError);
+};
 
 // ===== gt-react Components ===== //
 export { Derive } from 'gt-react';

--- a/packages/next/src/index.rsc.ts
+++ b/packages/next/src/index.rsc.ts
@@ -4,11 +4,13 @@ import { initializeGTServer } from './setup/initGT.server';
 import type {
   GetServerSideProps,
   GetServerSidePropsContext,
+  GetStaticProps,
   PreviewData,
 } from 'next';
 import type { ParsedUrlQuery } from 'querystring';
 import { getTranslationsSnapshotRscError } from './errors/createErrors';
 import type { WithGTServerSideProps } from './pages-dir/withGTServerSideProps';
+import type { WithGTStaticProps } from './pages-dir/withGTStaticProps';
 initializeGTServer();
 
 // ===== Components ===== //
@@ -74,6 +76,38 @@ export function withGTServerSideProps<
   );
 }
 
+/**
+ * Placeholder for withGTStaticProps()
+ * This function is for next-pages use, not next-app use
+ */
+export function withGTStaticProps<
+  Props extends Record<string, unknown> = Record<string, unknown>,
+  Params extends ParsedUrlQuery = ParsedUrlQuery,
+  Preview extends PreviewData = PreviewData,
+>(
+  getStaticProps?: GetStaticProps<Props, Params, Preview>
+): GetStaticProps<WithGTStaticProps<Props>, Params, Preview>;
+export function withGTStaticProps<
+  Props extends Record<string, unknown> = Record<string, unknown>,
+  Params extends ParsedUrlQuery = ParsedUrlQuery,
+  Preview extends PreviewData = PreviewData,
+>(
+  locale: string,
+  getStaticProps?: GetStaticProps<Props, Params, Preview>
+): GetStaticProps<WithGTStaticProps<Props>, Params, Preview>;
+export function withGTStaticProps<
+  Props extends Record<string, unknown> = Record<string, unknown>,
+  Params extends ParsedUrlQuery = ParsedUrlQuery,
+  Preview extends PreviewData = PreviewData,
+>(
+  _firstArg?: string | GetStaticProps<Props, Params, Preview>,
+  _secondArg?: GetStaticProps<Props, Params, Preview>
+): GetStaticProps<WithGTStaticProps<Props>, Params, Preview> {
+  throw new Error(
+    'withGTStaticProps() is only available for the Pages Router.'
+  );
+}
+
 // ===== gt-react Components ===== //
 export { Derive } from 'gt-react';
 
@@ -100,4 +134,4 @@ export { isLocaleSupported } from './request/localeValidation';
 
 // ===== Types ===== //
 export type { GTTranslationOptions, RuntimeTranslationOptions } from 'gt-react';
-export type { WithGTServerSideProps };
+export type { WithGTServerSideProps, WithGTStaticProps };

--- a/packages/next/src/index.server.ts
+++ b/packages/next/src/index.server.ts
@@ -14,6 +14,8 @@ initializeGT();
 export { parseLocale } from './pages-dir/parseLocale';
 export { withGTServerSideProps } from './pages-dir/withGTServerSideProps';
 export type { WithGTServerSideProps } from './pages-dir/withGTServerSideProps';
+export { withGTStaticProps } from './pages-dir/withGTStaticProps';
+export type { WithGTStaticProps } from './pages-dir/withGTStaticProps';
 
 // ===== Components ===== //
 export {

--- a/packages/next/src/index.types.ts
+++ b/packages/next/src/index.types.ts
@@ -3,10 +3,12 @@ import { T as _T } from './server-dir/buildtime/T';
 import type {
   GetServerSideProps,
   GetServerSidePropsContext,
+  GetStaticProps,
   PreviewData,
 } from 'next';
 import type { ParsedUrlQuery } from 'querystring';
 import type { WithGTServerSideProps } from './pages-dir/withGTServerSideProps';
+import type { WithGTStaticProps } from './pages-dir/withGTStaticProps';
 import {
   useTranslations as _useTranslations,
   useLocale as _useLocale,
@@ -366,6 +368,39 @@ export function withGTServerSideProps<
 }
 
 /**
+ * Wraps a Pages Router `getStaticProps` function and adds the locale and
+ * translations snapshot for each statically generated locale variant.
+ *
+ * Pass a locale before the optional page function to override the locale for
+ * pages generated without a Next.js locale context.
+ */
+export function withGTStaticProps<
+  Props extends Record<string, unknown> = Record<string, unknown>,
+  Params extends ParsedUrlQuery = ParsedUrlQuery,
+  Preview extends PreviewData = PreviewData,
+>(
+  getStaticProps?: GetStaticProps<Props, Params, Preview>
+): GetStaticProps<WithGTStaticProps<Props>, Params, Preview>;
+export function withGTStaticProps<
+  Props extends Record<string, unknown> = Record<string, unknown>,
+  Params extends ParsedUrlQuery = ParsedUrlQuery,
+  Preview extends PreviewData = PreviewData,
+>(
+  locale: string,
+  getStaticProps?: GetStaticProps<Props, Params, Preview>
+): GetStaticProps<WithGTStaticProps<Props>, Params, Preview>;
+export function withGTStaticProps<
+  Props extends Record<string, unknown> = Record<string, unknown>,
+  Params extends ParsedUrlQuery = ParsedUrlQuery,
+  Preview extends PreviewData = PreviewData,
+>(
+  _firstArg?: string | GetStaticProps<Props, Params, Preview>,
+  _secondArg?: GetStaticProps<Props, Params, Preview>
+): GetStaticProps<WithGTStaticProps<Props>, Params, Preview> {
+  throw new Error(typesFileError);
+}
+
+/**
  * Checks whether a locale is valid and supported by the current gt-next config.
  *
  * @param locale - The locale candidate to validate.
@@ -559,6 +594,7 @@ export type {
   GTTranslationOptions,
   RuntimeTranslationOptions,
   WithGTServerSideProps,
+  WithGTStaticProps,
 };
 
 export type { StringFormat };

--- a/packages/next/src/index.types.ts
+++ b/packages/next/src/index.types.ts
@@ -370,8 +370,8 @@ export function withGTServerSideProps<
 }
 
 /**
- * Wraps a Pages Router `getStaticProps` function and adds translation
- * snapshots for every configured locale.
+ * Wraps a Pages Router `getStaticProps` function and adds the generated locale
+ * and its translation snapshot. The default locale uses an empty snapshot.
  */
 export const withGTStaticProps: WithGTStaticPropsFunction = () => {
   throw new Error(typesFileError);

--- a/packages/next/src/index.types.ts
+++ b/packages/next/src/index.types.ts
@@ -370,11 +370,8 @@ export function withGTServerSideProps<
 }
 
 /**
- * Wraps a Pages Router `getStaticProps` function and adds the locale and
- * translations snapshot for each statically generated locale variant.
- *
- * Pass a locale before the optional page function to override the locale for
- * pages generated without a Next.js locale context.
+ * Wraps a Pages Router `getStaticProps` function and adds translation
+ * snapshots for every configured locale.
  */
 export const withGTStaticProps: WithGTStaticPropsFunction = () => {
   throw new Error(typesFileError);

--- a/packages/next/src/index.types.ts
+++ b/packages/next/src/index.types.ts
@@ -3,12 +3,14 @@ import { T as _T } from './server-dir/buildtime/T';
 import type {
   GetServerSideProps,
   GetServerSidePropsContext,
-  GetStaticProps,
   PreviewData,
 } from 'next';
 import type { ParsedUrlQuery } from 'querystring';
 import type { WithGTServerSideProps } from './pages-dir/withGTServerSideProps';
-import type { WithGTStaticProps } from './pages-dir/withGTStaticProps';
+import type {
+  WithGTStaticProps,
+  WithGTStaticPropsFunction,
+} from './pages-dir/withGTStaticProps';
 import {
   useTranslations as _useTranslations,
   useLocale as _useLocale,
@@ -374,31 +376,9 @@ export function withGTServerSideProps<
  * Pass a locale before the optional page function to override the locale for
  * pages generated without a Next.js locale context.
  */
-export function withGTStaticProps<
-  Props extends Record<string, unknown> = Record<string, unknown>,
-  Params extends ParsedUrlQuery = ParsedUrlQuery,
-  Preview extends PreviewData = PreviewData,
->(
-  getStaticProps?: GetStaticProps<Props, Params, Preview>
-): GetStaticProps<WithGTStaticProps<Props>, Params, Preview>;
-export function withGTStaticProps<
-  Props extends Record<string, unknown> = Record<string, unknown>,
-  Params extends ParsedUrlQuery = ParsedUrlQuery,
-  Preview extends PreviewData = PreviewData,
->(
-  locale: string,
-  getStaticProps?: GetStaticProps<Props, Params, Preview>
-): GetStaticProps<WithGTStaticProps<Props>, Params, Preview>;
-export function withGTStaticProps<
-  Props extends Record<string, unknown> = Record<string, unknown>,
-  Params extends ParsedUrlQuery = ParsedUrlQuery,
-  Preview extends PreviewData = PreviewData,
->(
-  _firstArg?: string | GetStaticProps<Props, Params, Preview>,
-  _secondArg?: GetStaticProps<Props, Params, Preview>
-): GetStaticProps<WithGTStaticProps<Props>, Params, Preview> {
+export const withGTStaticProps: WithGTStaticPropsFunction = () => {
   throw new Error(typesFileError);
-}
+};
 
 /**
  * Checks whether a locale is valid and supported by the current gt-next config.

--- a/packages/next/src/pages-dir/__tests__/withGTStaticProps.test.ts
+++ b/packages/next/src/pages-dir/__tests__/withGTStaticProps.test.ts
@@ -51,6 +51,15 @@ describe('withGTStaticProps', () => {
     expect(mockGetTranslationsSnapshot).toHaveBeenCalledWith('fr');
   });
 
+  it('requires Pages Router locale routing', async () => {
+    const getStaticProps = withGTStaticProps();
+
+    await expect(getStaticProps({} as GetStaticPropsContext)).rejects.toThrow(
+      'gt-next Error: withGTStaticProps() could not determine the statically generated locale because without Pages Router locale routing, Next.js generates only one version of this page. Add i18n locales and defaultLocale to your Next.js configuration.'
+    );
+    expect(mockGetTranslationsSnapshot).not.toHaveBeenCalled();
+  });
+
   it('generates an isolated translation snapshot for each locale context', async () => {
     const pageGetStaticProps = vi.fn(
       async (currentContext: GetStaticPropsContext) => ({

--- a/packages/next/src/pages-dir/__tests__/withGTStaticProps.test.ts
+++ b/packages/next/src/pages-dir/__tests__/withGTStaticProps.test.ts
@@ -38,24 +38,20 @@ describe('withGTStaticProps', () => {
     }));
   });
 
-  it('adds translations for every configured locale without a page handler', async () => {
+  it('adds only the generated locale and its translations', async () => {
     const getStaticProps = withGTStaticProps();
 
     await expect(getStaticProps(context)).resolves.toEqual({
       props: {
-        translations: {
-          en: { hash: 'en translation' },
-          fr: { hash: 'fr translation' },
-          es: { hash: 'es translation' },
-        },
+        locale: 'fr',
+        translations: { fr: { hash: 'fr translation' } },
       },
     });
-    expect(mockGetTranslationsSnapshot).toHaveBeenNthCalledWith(1, 'en');
-    expect(mockGetTranslationsSnapshot).toHaveBeenNthCalledWith(2, 'fr');
-    expect(mockGetTranslationsSnapshot).toHaveBeenNthCalledWith(3, 'es');
+    expect(mockGetTranslationsSnapshot).toHaveBeenCalledOnce();
+    expect(mockGetTranslationsSnapshot).toHaveBeenCalledWith('fr');
   });
 
-  it('merges every translation snapshot with page props', async () => {
+  it('generates an isolated translation snapshot for each locale context', async () => {
     const pageGetStaticProps = vi.fn(
       async (currentContext: GetStaticPropsContext) => ({
         props: {
@@ -65,17 +61,44 @@ describe('withGTStaticProps', () => {
     );
     const getStaticProps = withGTStaticProps(pageGetStaticProps);
 
-    await expect(getStaticProps(context)).resolves.toEqual({
-      props: {
-        greeting: 'Greeting for fr',
-        translations: {
-          en: { hash: 'en translation' },
-          fr: { hash: 'fr translation' },
-          es: { hash: 'es translation' },
+    await expect(
+      Promise.all([
+        getStaticProps({ ...context, locale: 'fr' }),
+        getStaticProps({ ...context, locale: 'es' }),
+      ])
+    ).resolves.toEqual([
+      {
+        props: {
+          greeting: 'Greeting for fr',
+          locale: 'fr',
+          translations: { fr: { hash: 'fr translation' } },
         },
       },
-    });
-    expect(pageGetStaticProps).toHaveBeenCalledWith(context);
+      {
+        props: {
+          greeting: 'Greeting for es',
+          locale: 'es',
+          translations: { es: { hash: 'es translation' } },
+        },
+      },
+    ]);
+    expect(pageGetStaticProps).toHaveBeenCalledTimes(2);
+    expect(mockGetTranslationsSnapshot).toHaveBeenCalledWith('fr');
+    expect(mockGetTranslationsSnapshot).toHaveBeenCalledWith('es');
+  });
+
+  it('uses an empty translation snapshot for the default locale', async () => {
+    const getStaticProps = withGTStaticProps();
+
+    await expect(getStaticProps({ ...context, locale: 'en' })).resolves.toEqual(
+      {
+        props: {
+          locale: 'en',
+          translations: {},
+        },
+      }
+    );
+    expect(mockGetTranslationsSnapshot).not.toHaveBeenCalled();
   });
 
   it('preserves incremental static regeneration options', async () => {
@@ -91,11 +114,8 @@ describe('withGTStaticProps', () => {
     await expect(getStaticProps(context)).resolves.toEqual({
       props: {
         renderedAt: 'build',
-        translations: {
-          en: { hash: 'en translation' },
-          fr: { hash: 'fr translation' },
-          es: { hash: 'es translation' },
-        },
+        locale: 'fr',
+        translations: { fr: { hash: 'fr translation' } },
       },
       revalidate: 60,
     });

--- a/packages/next/src/pages-dir/__tests__/withGTStaticProps.test.ts
+++ b/packages/next/src/pages-dir/__tests__/withGTStaticProps.test.ts
@@ -1,0 +1,165 @@
+import type { GetStaticPropsContext } from 'next';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { initializeI18nConfig } from '@generaltranslation/react-core/pure';
+
+const mockGetTranslationsSnapshot = vi.hoisted(() => vi.fn());
+
+vi.mock('gt-react', () => ({
+  getTranslationsSnapshot: (...args: unknown[]) =>
+    mockGetTranslationsSnapshot(...args),
+}));
+
+import { withGTStaticProps } from '../withGTStaticProps';
+
+const context = {
+  locale: 'fr',
+  locales: ['en', 'fr', 'es'],
+  defaultLocale: 'en',
+} as GetStaticPropsContext;
+
+type TestGlobal = typeof globalThis & {
+  __generaltranslation?: unknown;
+};
+
+function resetGTGlobals() {
+  Reflect.deleteProperty(globalThis as TestGlobal, '__generaltranslation');
+}
+
+describe('withGTStaticProps', () => {
+  beforeEach(() => {
+    resetGTGlobals();
+    initializeI18nConfig({
+      defaultLocale: 'en',
+      locales: ['en', 'fr', 'es'],
+    });
+    mockGetTranslationsSnapshot.mockReset();
+    mockGetTranslationsSnapshot.mockImplementation(async (locale: string) => ({
+      [locale]: { hash: `${locale} translation` },
+    }));
+  });
+
+  it('adds the generated locale and its translations without a page handler', async () => {
+    const getStaticProps = withGTStaticProps();
+
+    await expect(getStaticProps(context)).resolves.toEqual({
+      props: {
+        locale: 'fr',
+        translations: { fr: { hash: 'fr translation' } },
+      },
+    });
+    expect(mockGetTranslationsSnapshot).toHaveBeenCalledWith('fr');
+  });
+
+  it('generates props and translations for each locale context', async () => {
+    const pageGetStaticProps = vi.fn(
+      async (currentContext: GetStaticPropsContext) => ({
+        props: {
+          greeting: `Greeting for ${currentContext.locale}`,
+        },
+      })
+    );
+    const getStaticProps = withGTStaticProps(pageGetStaticProps);
+
+    await expect(
+      Promise.all([
+        getStaticProps({ ...context, locale: 'fr' }),
+        getStaticProps({ ...context, locale: 'es' }),
+      ])
+    ).resolves.toEqual([
+      {
+        props: {
+          greeting: 'Greeting for fr',
+          locale: 'fr',
+          translations: { fr: { hash: 'fr translation' } },
+        },
+      },
+      {
+        props: {
+          greeting: 'Greeting for es',
+          locale: 'es',
+          translations: { es: { hash: 'es translation' } },
+        },
+      },
+    ]);
+    expect(pageGetStaticProps).toHaveBeenCalledTimes(2);
+    expect(mockGetTranslationsSnapshot).toHaveBeenCalledWith('fr');
+    expect(mockGetTranslationsSnapshot).toHaveBeenCalledWith('es');
+  });
+
+  it('preserves incremental static regeneration options', async () => {
+    const getStaticProps = withGTStaticProps(
+      async (_context: GetStaticPropsContext) => ({
+        props: {
+          renderedAt: 'build',
+        },
+        revalidate: 60,
+      })
+    );
+
+    await expect(getStaticProps(context)).resolves.toEqual({
+      props: {
+        renderedAt: 'build',
+        locale: 'fr',
+        translations: { fr: { hash: 'fr translation' } },
+      },
+      revalidate: 60,
+    });
+  });
+
+  it('uses an explicit locale parameter', async () => {
+    const getStaticProps = withGTStaticProps(
+      'es',
+      async (_context: GetStaticPropsContext) => ({
+        props: {
+          renderedAt: 'build',
+        },
+      })
+    );
+
+    await expect(getStaticProps(context)).resolves.toEqual({
+      props: {
+        renderedAt: 'build',
+        locale: 'es',
+        translations: { es: { hash: 'es translation' } },
+      },
+    });
+    expect(mockGetTranslationsSnapshot).toHaveBeenCalledWith('es');
+  });
+
+  it('falls back to the configured default locale', async () => {
+    const getStaticProps = withGTStaticProps();
+
+    await expect(getStaticProps({} as GetStaticPropsContext)).resolves.toEqual({
+      props: {
+        locale: 'en',
+        translations: { en: { hash: 'en translation' } },
+      },
+    });
+  });
+
+  it('preserves redirects without loading translations', async () => {
+    const redirect = {
+      destination: '/login',
+      permanent: false,
+    };
+    const getStaticProps = withGTStaticProps(
+      async (_context: GetStaticPropsContext) => ({
+        redirect,
+      })
+    );
+
+    await expect(getStaticProps(context)).resolves.toEqual({ redirect });
+    expect(mockGetTranslationsSnapshot).not.toHaveBeenCalled();
+  });
+
+  it('preserves notFound results without loading translations', async () => {
+    const getStaticProps = withGTStaticProps(
+      async (_context: GetStaticPropsContext) => ({
+        notFound: true,
+      })
+    );
+
+    await expect(getStaticProps(context)).resolves.toEqual({ notFound: true });
+    expect(mockGetTranslationsSnapshot).not.toHaveBeenCalled();
+  });
+});

--- a/packages/next/src/pages-dir/__tests__/withGTStaticProps.test.ts
+++ b/packages/next/src/pages-dir/__tests__/withGTStaticProps.test.ts
@@ -38,19 +38,24 @@ describe('withGTStaticProps', () => {
     }));
   });
 
-  it('adds the generated locale and its translations without a page handler', async () => {
+  it('adds translations for every configured locale without a page handler', async () => {
     const getStaticProps = withGTStaticProps();
 
     await expect(getStaticProps(context)).resolves.toEqual({
       props: {
-        locale: 'fr',
-        translations: { fr: { hash: 'fr translation' } },
+        translations: {
+          en: { hash: 'en translation' },
+          fr: { hash: 'fr translation' },
+          es: { hash: 'es translation' },
+        },
       },
     });
-    expect(mockGetTranslationsSnapshot).toHaveBeenCalledWith('fr');
+    expect(mockGetTranslationsSnapshot).toHaveBeenNthCalledWith(1, 'en');
+    expect(mockGetTranslationsSnapshot).toHaveBeenNthCalledWith(2, 'fr');
+    expect(mockGetTranslationsSnapshot).toHaveBeenNthCalledWith(3, 'es');
   });
 
-  it('generates props and translations for each locale context', async () => {
+  it('merges every translation snapshot with page props', async () => {
     const pageGetStaticProps = vi.fn(
       async (currentContext: GetStaticPropsContext) => ({
         props: {
@@ -60,30 +65,17 @@ describe('withGTStaticProps', () => {
     );
     const getStaticProps = withGTStaticProps(pageGetStaticProps);
 
-    await expect(
-      Promise.all([
-        getStaticProps({ ...context, locale: 'fr' }),
-        getStaticProps({ ...context, locale: 'es' }),
-      ])
-    ).resolves.toEqual([
-      {
-        props: {
-          greeting: 'Greeting for fr',
-          locale: 'fr',
-          translations: { fr: { hash: 'fr translation' } },
+    await expect(getStaticProps(context)).resolves.toEqual({
+      props: {
+        greeting: 'Greeting for fr',
+        translations: {
+          en: { hash: 'en translation' },
+          fr: { hash: 'fr translation' },
+          es: { hash: 'es translation' },
         },
       },
-      {
-        props: {
-          greeting: 'Greeting for es',
-          locale: 'es',
-          translations: { es: { hash: 'es translation' } },
-        },
-      },
-    ]);
-    expect(pageGetStaticProps).toHaveBeenCalledTimes(2);
-    expect(mockGetTranslationsSnapshot).toHaveBeenCalledWith('fr');
-    expect(mockGetTranslationsSnapshot).toHaveBeenCalledWith('es');
+    });
+    expect(pageGetStaticProps).toHaveBeenCalledWith(context);
   });
 
   it('preserves incremental static regeneration options', async () => {
@@ -99,41 +91,13 @@ describe('withGTStaticProps', () => {
     await expect(getStaticProps(context)).resolves.toEqual({
       props: {
         renderedAt: 'build',
-        locale: 'fr',
-        translations: { fr: { hash: 'fr translation' } },
+        translations: {
+          en: { hash: 'en translation' },
+          fr: { hash: 'fr translation' },
+          es: { hash: 'es translation' },
+        },
       },
       revalidate: 60,
-    });
-  });
-
-  it('uses an explicit locale parameter', async () => {
-    const getStaticProps = withGTStaticProps(
-      'es',
-      async (_context: GetStaticPropsContext) => ({
-        props: {
-          renderedAt: 'build',
-        },
-      })
-    );
-
-    await expect(getStaticProps(context)).resolves.toEqual({
-      props: {
-        renderedAt: 'build',
-        locale: 'es',
-        translations: { es: { hash: 'es translation' } },
-      },
-    });
-    expect(mockGetTranslationsSnapshot).toHaveBeenCalledWith('es');
-  });
-
-  it('falls back to the configured default locale', async () => {
-    const getStaticProps = withGTStaticProps();
-
-    await expect(getStaticProps({} as GetStaticPropsContext)).resolves.toEqual({
-      props: {
-        locale: 'en',
-        translations: { en: { hash: 'en translation' } },
-      },
     });
   });
 

--- a/packages/next/src/pages-dir/withGTStaticProps.ts
+++ b/packages/next/src/pages-dir/withGTStaticProps.ts
@@ -6,6 +6,7 @@ import { getTranslationsSnapshot } from 'gt-react';
 type TranslationsSnapshot = Awaited<ReturnType<typeof getTranslationsSnapshot>>;
 
 type GTStaticProps = {
+  locale: string;
   translations: TranslationsSnapshot;
 };
 
@@ -30,23 +31,17 @@ export function withGTStaticProps<
     }
 
     const props = await result.props;
-    const snapshots = await Promise.all(
-      getI18nConfig()
-        .getLocales()
-        .map((locale) => getTranslationsSnapshot(locale))
-    );
-    const translations = snapshots.reduce<TranslationsSnapshot>(
-      (allTranslations, snapshot) => ({
-        ...allTranslations,
-        ...snapshot,
-      }),
-      {}
-    );
+    const i18nConfig = getI18nConfig();
+    const defaultLocale = i18nConfig.getDefaultLocale();
+    const locale = context.locale || context.defaultLocale || defaultLocale;
+    const translations =
+      locale === defaultLocale ? {} : await getTranslationsSnapshot(locale);
 
     return {
       ...result,
       props: {
         ...props,
+        locale,
         translations,
       },
     };

--- a/packages/next/src/pages-dir/withGTStaticProps.ts
+++ b/packages/next/src/pages-dir/withGTStaticProps.ts
@@ -1,0 +1,68 @@
+import type { GetStaticProps, GetStaticPropsContext, PreviewData } from 'next';
+import type { ParsedUrlQuery } from 'querystring';
+import { getI18nConfig } from '@generaltranslation/react-core/pure';
+import { getTranslationsSnapshot } from 'gt-react';
+
+type GTStaticProps = {
+  locale: string;
+  translations: Awaited<ReturnType<typeof getTranslationsSnapshot>>;
+};
+
+export type WithGTStaticProps<
+  Props extends Record<string, unknown> = Record<string, unknown>,
+> = Props & GTStaticProps;
+
+export function withGTStaticProps<
+  Props extends Record<string, unknown> = Record<string, unknown>,
+  Params extends ParsedUrlQuery = ParsedUrlQuery,
+  Preview extends PreviewData = PreviewData,
+>(
+  getStaticProps?: GetStaticProps<Props, Params, Preview>
+): GetStaticProps<WithGTStaticProps<Props>, Params, Preview>;
+
+export function withGTStaticProps<
+  Props extends Record<string, unknown> = Record<string, unknown>,
+  Params extends ParsedUrlQuery = ParsedUrlQuery,
+  Preview extends PreviewData = PreviewData,
+>(
+  locale: string,
+  getStaticProps?: GetStaticProps<Props, Params, Preview>
+): GetStaticProps<WithGTStaticProps<Props>, Params, Preview>;
+
+export function withGTStaticProps<
+  Props extends Record<string, unknown> = Record<string, unknown>,
+  Params extends ParsedUrlQuery = ParsedUrlQuery,
+  Preview extends PreviewData = PreviewData,
+>(
+  firstArg?: string | GetStaticProps<Props, Params, Preview>,
+  secondArg?: GetStaticProps<Props, Params, Preview>
+): GetStaticProps<WithGTStaticProps<Props>, Params, Preview> {
+  const localeArg = typeof firstArg === 'string' ? firstArg : undefined;
+  const getStaticProps = typeof firstArg === 'function' ? firstArg : secondArg;
+
+  return async (context: GetStaticPropsContext<Params, Preview>) => {
+    const result = getStaticProps
+      ? await getStaticProps(context)
+      : { props: {} as Props };
+
+    if (!('props' in result)) {
+      return result;
+    }
+
+    const props = await result.props;
+    const locale =
+      localeArg ||
+      context.locale ||
+      context.defaultLocale ||
+      getI18nConfig().getDefaultLocale();
+
+    return {
+      ...result,
+      props: {
+        ...props,
+        locale,
+        translations: await getTranslationsSnapshot(locale),
+      },
+    };
+  };
+}

--- a/packages/next/src/pages-dir/withGTStaticProps.ts
+++ b/packages/next/src/pages-dir/withGTStaticProps.ts
@@ -3,9 +3,10 @@ import type { ParsedUrlQuery } from 'querystring';
 import { getI18nConfig } from '@generaltranslation/react-core/pure';
 import { getTranslationsSnapshot } from 'gt-react';
 
+type TranslationsSnapshot = Awaited<ReturnType<typeof getTranslationsSnapshot>>;
+
 type GTStaticProps = {
-  locale: string;
-  translations: Awaited<ReturnType<typeof getTranslationsSnapshot>>;
+  translations: TranslationsSnapshot;
 };
 
 export type WithGTStaticProps<
@@ -18,28 +19,7 @@ export function withGTStaticProps<
   Preview extends PreviewData = PreviewData,
 >(
   getStaticProps?: GetStaticProps<Props, Params, Preview>
-): GetStaticProps<WithGTStaticProps<Props>, Params, Preview>;
-
-export function withGTStaticProps<
-  Props extends Record<string, unknown> = Record<string, unknown>,
-  Params extends ParsedUrlQuery = ParsedUrlQuery,
-  Preview extends PreviewData = PreviewData,
->(
-  locale: string,
-  getStaticProps?: GetStaticProps<Props, Params, Preview>
-): GetStaticProps<WithGTStaticProps<Props>, Params, Preview>;
-
-export function withGTStaticProps<
-  Props extends Record<string, unknown> = Record<string, unknown>,
-  Params extends ParsedUrlQuery = ParsedUrlQuery,
-  Preview extends PreviewData = PreviewData,
->(
-  firstArg?: string | GetStaticProps<Props, Params, Preview>,
-  secondArg?: GetStaticProps<Props, Params, Preview>
 ): GetStaticProps<WithGTStaticProps<Props>, Params, Preview> {
-  const localeArg = typeof firstArg === 'string' ? firstArg : undefined;
-  const getStaticProps = typeof firstArg === 'function' ? firstArg : secondArg;
-
   return async (context: GetStaticPropsContext<Params, Preview>) => {
     const result = getStaticProps
       ? await getStaticProps(context)
@@ -50,18 +30,24 @@ export function withGTStaticProps<
     }
 
     const props = await result.props;
-    const locale =
-      localeArg ||
-      context.locale ||
-      context.defaultLocale ||
-      getI18nConfig().getDefaultLocale();
+    const snapshots = await Promise.all(
+      getI18nConfig()
+        .getLocales()
+        .map((locale) => getTranslationsSnapshot(locale))
+    );
+    const translations = snapshots.reduce<TranslationsSnapshot>(
+      (allTranslations, snapshot) => ({
+        ...allTranslations,
+        ...snapshot,
+      }),
+      {}
+    );
 
     return {
       ...result,
       props: {
         ...props,
-        locale,
-        translations: await getTranslationsSnapshot(locale),
+        translations,
       },
     };
   };

--- a/packages/next/src/pages-dir/withGTStaticProps.ts
+++ b/packages/next/src/pages-dir/withGTStaticProps.ts
@@ -2,6 +2,7 @@ import type { GetStaticProps, GetStaticPropsContext, PreviewData } from 'next';
 import type { ParsedUrlQuery } from 'querystring';
 import { getI18nConfig } from '@generaltranslation/react-core/pure';
 import { getTranslationsSnapshot } from 'gt-react';
+import { withGTStaticPropsLocaleRoutingError } from '../errors/ssg';
 
 type TranslationsSnapshot = Awaited<ReturnType<typeof getTranslationsSnapshot>>;
 
@@ -14,6 +15,11 @@ export type WithGTStaticProps<
   Props extends Record<string, unknown> = Record<string, unknown>,
 > = Props & GTStaticProps;
 
+/**
+ * Wraps a Pages Router getStaticProps() function with locale-specific GT props.
+ * Next.js Pages Router locale routing must be configured so getStaticProps()
+ * runs once for each locale.
+ */
 export function withGTStaticProps<
   Props extends Record<string, unknown> = Record<string, unknown>,
   Params extends ParsedUrlQuery = ParsedUrlQuery,
@@ -22,6 +28,10 @@ export function withGTStaticProps<
   getStaticProps?: GetStaticProps<Props, Params, Preview>
 ): GetStaticProps<WithGTStaticProps<Props>, Params, Preview> {
   return async (context: GetStaticPropsContext<Params, Preview>) => {
+    if (!context.locale) {
+      throw new Error(withGTStaticPropsLocaleRoutingError);
+    }
+
     const result = getStaticProps
       ? await getStaticProps(context)
       : { props: {} as Props };
@@ -33,7 +43,7 @@ export function withGTStaticProps<
     const props = await result.props;
     const i18nConfig = getI18nConfig();
     const defaultLocale = i18nConfig.getDefaultLocale();
-    const locale = context.locale || context.defaultLocale || defaultLocale;
+    const locale = context.locale;
     const translations =
       locale === defaultLocale ? {} : await getTranslationsSnapshot(locale);
 

--- a/packages/next/src/pages-dir/withGTStaticProps.ts
+++ b/packages/next/src/pages-dir/withGTStaticProps.ts
@@ -66,3 +66,5 @@ export function withGTStaticProps<
     };
   };
 }
+
+export type WithGTStaticPropsFunction = typeof withGTStaticProps;


### PR DESCRIPTION
## Summary

- add `withGTStaticProps()` for wrapping optional Pages Router `getStaticProps` functions
- require Pages Router locale routing and report an actionable structured diagnostic when it is missing
- attach only the generated locale and its `getTranslationsSnapshot()` result
- return an empty translations object for the default locale
- preserve ISR, redirect, and `notFound` results
- centralize the callable type in `withGTStaticProps.ts` for all conditional entrypoints
- use structured `gt-next` diagnostics for unsupported browser and React Server Component calls
- expose matching runtime/type surfaces and add a patch changeset for `gt-next`

## Important behavior

Pages Router locale routing must be configured with `i18n.locales` and `i18n.defaultLocale` in the Next.js configuration. This is the Pages Router equivalent of the App Router SSG example using `[locale]` and `generateStaticParams()`: Next.js invokes `getStaticProps` separately for every configured locale variant. If `context.locale` is absent, `withGTStaticProps()` now throws an actionable configuration error instead of silently generating only the default locale.

Each generated page carries only its relevant snapshot: `{}` for the default locale, `{ fr: ... }` for French, `{ zh: ... }` for Chinese, and so on.

`LocaleSelector` updates GT locale state, but a static app must navigate to the matching Next locale variant so `_app` receives new page props. The production fixture passes a locale-aware `_reload` handler to `GTProvider` using `router.push(router.pathname, router.asPath, { locale })`. That changes `/fr/static-props` to `/zh/static-props`, replacing the French provider snapshot with the Chinese snapshot.

## Testing

- `pnpm --filter gt-next test:js` (25 files, 240 tests)
- `pnpm --filter gt-next typecheck`
- `pnpm --filter gt-next build:no-swc-plugin`
- focused `oxlint` and `oxfmt --check`
- linked production Next.js 16.2.9 Pages Router build reports `/static-props` as SSG and generates all configured locale variants
- production artifacts verified: default `{}`, French only `{ fr: ... }`, Chinese only `{ zh: ... }`
- headless Google Chrome verified English -> French -> Chinese through the rendered `LocaleSelector`; URLs, generated locale, provider snapshot keys, `<T>` output, and `useGT` output all changed together with no runtime or hydration errors

The aggregate `pnpm --filter gt-next... build` built all JavaScript dependencies, then stopped at the existing Rust SWC-plugin step because `cargo` is not installed in this environment.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Pages Router static props support for GT locale hydration. The main changes are:

- New `withGTStaticProps()` helper for Pages Router `getStaticProps`.
- Locale-routing diagnostics when Next.js does not provide `context.locale`.
- Locale-specific translation snapshots for static pages.
- Client, server, RSC, and type entrypoint exports.
- Tests for snapshots, default locale output, redirects, `notFound`, and ISR passthrough.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/next/src/pages-dir/withGTStaticProps.ts | Adds the Pages Router static props wrapper with locale checks and snapshot injection. |
| packages/next/src/pages-dir/__tests__/withGTStaticProps.test.ts | Adds tests for locale snapshots and existing `getStaticProps` result shapes. |
| packages/next/src/index.client.ts | Adds the browser placeholder export and matching static props types. |
| packages/next/src/index.rsc.ts | Adds the React Server Component placeholder export and matching static props types. |
| packages/next/src/index.server.ts | Exports the server implementation and static props type. |
| packages/next/src/index.types.ts | Adds the type-surface placeholder and static props type export. |
| packages/next/src/errors/createErrors.ts | Adds structured diagnostics for unsupported browser and RSC calls. |
| packages/next/src/errors/ssg.ts | Adds the structured diagnostic for missing Pages Router locale routing. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(next): require locale routing for st..."](https://github.com/generaltranslation/gt/commit/ebe94b9c4495538ac0d63de2dbf4eb0992e59d7c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43860163)</sub>

<!-- /greptile_comment -->