### PR TITLE
chore: remove unused workspace dependencies

### DIFF
--- a/.changeset/tame-crabs-provide.md
+++ b/.changeset/tame-crabs-provide.md
@@ -1,0 +1,8 @@
+---
+'gt-react': patch
+'gt-next': patch
+'gt-i18n': patch
+'@generaltranslation/react-core': patch
+---
+
+Remove unused dependencies: `@generaltranslation/supported-locales` from gt-react, gt-next, gt-i18n, and @generaltranslation/react-core, and `@generaltranslation/format` from gt-react. Nothing in these packages imports them, so this only reduces install weight.

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -52,7 +52,6 @@
     "definition": "dist/index.d.cts"
   },
   "dependencies": {
-    "@generaltranslation/supported-locales": "workspace:*",
     "@generaltranslation/format": "workspace:*",
     "generaltranslation": "workspace:*"
   },

--- a/packages/i18n/tsconfig.json
+++ b/packages/i18n/tsconfig.json
@@ -18,9 +18,6 @@
     },
     {
       "path": "../core"
-    },
-    {
-      "path": "../supported-locales"
     }
   ]
 }

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -25,7 +25,6 @@
     "@generaltranslation/compiler": "workspace:*",
     "@generaltranslation/format": "workspace:*",
     "@generaltranslation/react-core": "workspace:*",
-    "@generaltranslation/supported-locales": "workspace:*",
     "generaltranslation": "workspace:*",
     "gt-react": "workspace:*",
     "gt-i18n": "workspace:*"

--- a/packages/next/tsconfig.json
+++ b/packages/next/tsconfig.json
@@ -19,9 +19,6 @@
       "path": "../react"
     },
     {
-      "path": "../supported-locales"
-    },
-    {
       "path": "../i18n"
     }
   ]

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -12,7 +12,6 @@
   },
   "dependencies": {
     "@generaltranslation/format": "workspace:*",
-    "@generaltranslation/supported-locales": "workspace:*",
     "generaltranslation": "workspace:*",
     "gt-i18n": "workspace:*"
   },

--- a/packages/react-core/tsconfig.json
+++ b/packages/react-core/tsconfig.json
@@ -18,9 +18,6 @@
       "path": "../core"
     },
     {
-      "path": "../supported-locales"
-    },
-    {
       "path": "../i18n"
     }
   ]

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -17,8 +17,6 @@
     "react-dom": ">=18.0.0"
   },
   "dependencies": {
-    "@generaltranslation/format": "workspace:*",
-    "@generaltranslation/supported-locales": "workspace:*",
     "generaltranslation": "workspace:*",
     "@generaltranslation/react-core": "workspace:*",
     "gt-i18n": "workspace:*"

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -19,9 +19,6 @@
       "path": "../core"
     },
     {
-      "path": "../supported-locales"
-    },
-    {
       "path": "../i18n"
     }
   ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -890,9 +890,6 @@ importers:
       '@generaltranslation/format':
         specifier: workspace:*
         version: link:../format
-      '@generaltranslation/supported-locales':
-        specifier: workspace:*
-        version: link:../supported-locales
       generaltranslation:
         specifier: workspace:*
         version: link:../core
@@ -986,9 +983,6 @@ importers:
       '@generaltranslation/react-core':
         specifier: workspace:*
         version: link:../react-core
-      '@generaltranslation/supported-locales':
-        specifier: workspace:*
-        version: link:../supported-locales
       generaltranslation:
         specifier: workspace:*
         version: link:../core
@@ -1073,15 +1067,9 @@ importers:
 
   packages/react:
     dependencies:
-      '@generaltranslation/format':
-        specifier: workspace:*
-        version: link:../format
       '@generaltranslation/react-core':
         specifier: workspace:*
         version: link:../react-core
-      '@generaltranslation/supported-locales':
-        specifier: workspace:*
-        version: link:../supported-locales
       generaltranslation:
         specifier: workspace:*
         version: link:../core
@@ -1116,9 +1104,6 @@ importers:
       '@generaltranslation/format':
         specifier: workspace:*
         version: link:../format
-      '@generaltranslation/supported-locales':
-        specifier: workspace:*
-        version: link:../supported-locales
       generaltranslation:
         specifier: workspace:*
         version: link:../core


### PR DESCRIPTION
## TL;DR

Removes dependencies that nothing in the owning package imports:

- `@generaltranslation/supported-locales` from `gt-react`, `gt-next`, `gt-i18n`, and `@generaltranslation/react-core`
- `@generaltranslation/format` from `gt-react`

This is pure install-weight reduction for every consumer of these packages; no source code changes.

## Code Changes

- Dropped the dependency entries from the four `package.json` files
- Removed the corresponding `../supported-locales` TypeScript project references from each package's `tsconfig.json`
- Updated `pnpm-lock.yaml`
- Added a patch changeset

## Notes / Flags

- Verified with `grep` across source and built `dist` output that neither package is referenced anywhere in these packages. The only real consumers of `@generaltranslation/supported-locales` in the monorepo are the CLI packages, which keep their own dependency.
- `gt-react` never imports `@generaltranslation/format` directly; format code reaches it only bundled inside `generaltranslation`, which declares its own dependency (build-time resolution is unaffected).
- `intl-messageformat` in `packages/core` was also flagged, but it is already correctly a devDependency (used by a test), so it was left alone.
- `turbo build` for all four packages passes locally.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This is a pure dependency-cleanup PR with no source code changes. It removes workspace packages that nothing in the owning package actually imports, reducing install weight for every consumer.

- Drops `@generaltranslation/supported-locales` from `gt-react`, `gt-next`, `gt-i18n`, and `@generaltranslation/react-core`, and `@generaltranslation/format` from `gt-react`. Source-level grep across all four packages confirms zero import sites.
- Matching `tsconfig.json` project references and `pnpm-lock.yaml` workspace links are removed consistently, keeping the monorepo in a coherent state.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — no source code is modified; only unused workspace links are removed from package manifests, tsconfigs, and the lockfile.

Every removed dependency was confirmed absent from the source of its owning package. The tsconfig project references and lockfile entries are updated in lockstep. The changeset is correctly scoped as a patch. No runtime behavior changes.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .changeset/tame-crabs-provide.md | Patch-level changeset documenting the removal of unused dependencies across four packages. |
| packages/i18n/package.json | Removes @generaltranslation/supported-locales from dependencies; no source file in this package imports it. |
| packages/next/package.json | Removes @generaltranslation/supported-locales from dependencies; confirmed unused in package source. |
| packages/react/package.json | Removes both @generaltranslation/format and @generaltranslation/supported-locales; neither is imported in the package source. |
| packages/react-core/package.json | Removes @generaltranslation/supported-locales from dependencies; confirmed unused in source. |
| pnpm-lock.yaml | Lockfile updated consistently to remove the four workspace links that correspond to the dropped dependencies. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    gtreact[gt-react]
    gtnext[gt-next]
    gti18n[gt-i18n]
    reactcore[react-core]
    gt[generaltranslation]
    fmt[format]

    gtreact --> gt
    gtreact --> reactcore
    gtreact --> gti18n
    reactcore --> fmt
    reactcore --> gt
    reactcore --> gti18n
    gti18n --> fmt
    gti18n --> gt
    gtnext --> gtreact
    gtnext --> reactcore
    gtnext --> gti18n
    gtnext --> fmt

    removed1[supported-locales - REMOVED from all four packages]:::removed
    removed2[format dep - REMOVED from gt-react]:::removed

    classDef removed fill:#ffcccc,stroke:#cc0000,color:#990000
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    gtreact[gt-react]
    gtnext[gt-next]
    gti18n[gt-i18n]
    reactcore[react-core]
    gt[generaltranslation]
    fmt[format]

    gtreact --> gt
    gtreact --> reactcore
    gtreact --> gti18n
    reactcore --> fmt
    reactcore --> gt
    reactcore --> gti18n
    gti18n --> fmt
    gti18n --> gt
    gtnext --> gtreact
    gtnext --> reactcore
    gtnext --> gti18n
    gtnext --> fmt

    removed1[supported-locales - REMOVED from all four packages]:::removed
    removed2[format dep - REMOVED from gt-react]:::removed

    classDef removed fill:#ffcccc,stroke:#cc0000,color:#990000
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: remove unused workspace dependenc..."](https://github.com/generaltranslation/gt/commit/6e46b013c66b4eed268e900f67eb28322edbd5bf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43971714)</sub>

<!-- /greptile_comment -->