### PR TITLE
fix(react-core): remove duplicated GTProp computation in writeChildrenAsObjects

### DIFF
--- a/.changeset/lucky-moons-refactor.md
+++ b/.changeset/lucky-moons-refactor.md
@@ -1,0 +1,5 @@
+---
+'@generaltranslation/react-core': patch
+---
+
+Remove duplicated GTProp computation in `writeChildrenAsObjects`. The result of `createGTProp()` was immediately overwritten by an inline copy of the same logic, and because both copies recursed into plural/branch subtrees, each level of `<Plural>`/`<Branch>` nesting doubled the serialization work. Branch subtrees are now serialized once.

--- a/packages/react-core/src/utils/internal/writeChildrenAsObjects.ts
+++ b/packages/react-core/src/utils/internal/writeChildrenAsObjects.ts
@@ -53,24 +53,22 @@ const createGTProp = (
     {}
   );
 
-  // Check if plural
-  if (transformation === 'plural' && branches) {
+  // Check if plural or branch
+  if (
+    (transformation === 'plural' || transformation === 'branch') &&
+    branches
+  ) {
     const newBranches: Record<string, JsxChildren> = {};
     Object.entries(branches).forEach(
       ([key, value]: [string, TaggedChildren]) => {
         newBranches[key] = writeChildrenAsObjects(value);
       }
     );
-    newGTProp = { ...newGTProp, b: newBranches, t: 'p' };
-  }
-  if (transformation === 'branch' && branches) {
-    const newBranches: Record<string, JsxChildren> = {};
-    Object.entries(branches).forEach(
-      ([key, value]: [string, TaggedChildren]) => {
-        newBranches[key] = writeChildrenAsObjects(value);
-      }
-    );
-    newGTProp = { ...newGTProp, b: newBranches, t: 'b' };
+    newGTProp = {
+      ...newGTProp,
+      b: newBranches,
+      t: transformation === 'plural' ? 'p' : 'b',
+    };
   }
 
   return Object.keys(newGTProp).length ? newGTProp : undefined;
@@ -114,40 +112,6 @@ const handleSingleChildElement = (
       props,
       generaltranslation.branches
     );
-
-    // Add translatable HTML content props
-    let newGTProp: GTProp = Object.entries(HTML_CONTENT_PROPS).reduce<GTProp>(
-      (acc, [minifiedName, fullName]) => {
-        const value = props[fullName];
-        if (typeof value === 'string') {
-          acc[minifiedName as keyof HtmlContentPropKeysRecord] = value;
-        }
-        return acc;
-      },
-      {}
-    );
-
-    // Check if plural
-    if (transformation === 'plural' && generaltranslation.branches) {
-      const newBranches: Record<string, JsxChildren> = {};
-      Object.entries(generaltranslation.branches).forEach(
-        ([key, value]: [string, TaggedChildren]) => {
-          newBranches[key] = writeChildrenAsObjects(value);
-        }
-      );
-      newGTProp = { ...newGTProp, b: newBranches, t: 'p' };
-    }
-    if (transformation === 'branch' && generaltranslation.branches) {
-      const newBranches: Record<string, JsxChildren> = {};
-      Object.entries(generaltranslation.branches).forEach(
-        ([key, value]: [string, TaggedChildren]) => {
-          newBranches[key] = writeChildrenAsObjects(value);
-        }
-      );
-      newGTProp = { ...newGTProp, b: newBranches, t: 'b' };
-    }
-
-    minifiedElement.d = Object.keys(newGTProp).length ? newGTProp : undefined;
   }
   if (props.children) {
     minifiedElement.c = writeChildrenAsObjects(props.children);


### PR DESCRIPTION
## TL;DR

In `handleSingleChildElement`, the result of `createGTProp()` was assigned to `minifiedElement.d` and then immediately overwritten by a 33-line inline copy of `createGTProp`'s own body computing the identical value. Beyond the dead computation, both copies recursively called `writeChildrenAsObjects` on every plural/branch subtree, so each level of `<Plural>`/`<Branch>` nesting doubled the serialization work (2^depth for nested branches). This deletes the inline copy so branch subtrees are serialized exactly once.

## Code Changes

- `packages/react-core/src/utils/internal/writeChildrenAsObjects.ts`
  - Deleted the inline duplicate of `createGTProp`'s body; `minifiedElement.d` is now set only via the `createGTProp()` call
  - Collapsed the two identical plural/branch blocks inside `createGTProp` into one (they differed only in `t: 'p'` vs `t: 'b'`)
- Added a patch changeset

## Notes / Flags

- Behavior-preserving by construction: the deleted code computed byte-for-byte the same value that overwrote the field, and the collapsed blocks were mutually exclusive (`transformation` is a single value).
- `createGTProp` is module-local; the exported `writeChildrenAsObjects` signature is unchanged.
- `turbo build test` for `@generaltranslation/react-core` and `gt-react` passes locally. There are no direct unit tests for this file — coverage comes from the broader rendering/translation suites.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes a ~33-line inline duplicate of `createGTProp`'s logic in `handleSingleChildElement` that overwrote the `minifiedElement.d` field immediately after it was already populated by the `createGTProp()` call above it. Additionally, two identical `if` blocks inside `createGTProp` (one for `'plural'`, one for `'branch'`) are collapsed into a single combined condition with a ternary for the `t` field.

- **Dead code removal**: the second assignment to `minifiedElement.d` used the same inputs and identical logic, so its result was byte-for-byte identical to the value it was overwriting.
- **Exponential work fix**: serialization work grew as 2^depth for nested `<Plural>`/`<Branch>` trees; the deletion reduces this to a single traversal per level.
- **Collapsed plural/branch blocks**: the two original `if` checks were always mutually exclusive — combining them with a ternary is strictly equivalent.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the removed code was provably dead and the consolidated branch logic is equivalent to what it replaced.

Both deleted and retained code paths use identical inputs and identical logic, so the output of minifiedElement.d is unchanged. The collapsed plural/branch blocks were mutually exclusive by design, making the ternary a precise structural equivalence.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react-core/src/utils/internal/writeChildrenAsObjects.ts | Removes ~33 lines of dead duplicate code that overwrote `minifiedElement.d` immediately after setting it via `createGTProp()`; collapses two mutually-exclusive plural/branch `if` blocks into one. Logic is equivalent and the performance fix is correct. |
| .changeset/lucky-moons-refactor.md | Patch changeset entry correctly scoped to `@generaltranslation/react-core`; description accurately describes the removed duplication and exponential serialization fix. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(react-core): remove duplicated GTPro..."](https://github.com/generaltranslation/gt/commit/870ce32d1afb916fdfe1ff63029dfb59111fef4e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43971881)</sub>

<!-- /greptile_comment -->