### PR TITLE
chore: stop publishing unreachable index.types runtime bundles

### DIFF
--- a/.changeset/large-boxes-shrink.md
+++ b/.changeset/large-boxes-shrink.md
@@ -1,0 +1,6 @@
+---
+'gt-react': patch
+'gt-next': patch
+---
+
+Stop publishing unreachable `index.types` runtime bundles. The `index.types` entry only backs the exports map's `types` conditions, so only its declaration files are ever resolved; the runtime `.cjs`/`.mjs` artifacts (and sourcemaps) were dead weight in the published package (~179KB in gt-react, ~83KB in gt-next). They are now deleted after each build.

--- a/packages/next/tsdown.config.mts
+++ b/packages/next/tsdown.config.mts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'tsdown';
 import {
+  createRemoveRuntimeArtifactsHook,
   createTsdownUnbundleConfig,
   createUseClientBoundaryPlugin,
 } from '../../tsdown.preset.mts';
@@ -10,38 +11,52 @@ const neverBundle = [
 ];
 
 export default defineConfig([
-  createTsdownUnbundleConfig({
-    format: 'cjs',
-    cjsDefault: false,
-    deps: {
-      neverBundle,
-    },
-    outExtensions: () => ({ js: '.js', dts: '.d.ts' }),
-    plugins: [
-      createUseClientBoundaryPlugin({
-        name: 'gt-next:use-client-boundaries',
-        outputExtension: '.js',
-      }),
-    ],
-  }),
-  createTsdownUnbundleConfig({
-    format: 'esm',
-    clean: false,
-    deps: {
-      neverBundle,
-    },
-    outExtensions: () => ({ js: '.mjs', dts: '.d.ts' }),
-    // Server-only modules use require() for lazy loading. Don't emit rolldown's
-    // `createRequire`-from-`node:module` shim: it's statically reachable from
-    // client init code and breaks client bundlers (Turbopack "node:module"
-    // external; webpack UnhandledSchemeError). Next provides `require` for the
-    // guarded, server-only call sites in every bundling context that runs them.
-    outputOptions: { polyfillRequire: false },
-    plugins: [
-      createUseClientBoundaryPlugin({
-        name: 'gt-next:use-client-boundaries',
-        outputExtension: '.mjs',
-      }),
-    ],
-  }),
+  {
+    ...createTsdownUnbundleConfig({
+      format: 'cjs',
+      cjsDefault: false,
+      deps: {
+        neverBundle,
+      },
+      outExtensions: () => ({ js: '.js', dts: '.d.ts' }),
+      plugins: [
+        createUseClientBoundaryPlugin({
+          name: 'gt-next:use-client-boundaries',
+          outputExtension: '.js',
+        }),
+      ],
+    }),
+    // src/index.types.ts only backs the exports map's "types" condition; its
+    // declarations ship, but its runtime modules are unreachable.
+    onSuccess: createRemoveRuntimeArtifactsHook(process.cwd(), 'dist', [
+      'index.types.js',
+      'index.types.js.map',
+    ]),
+  },
+  {
+    ...createTsdownUnbundleConfig({
+      format: 'esm',
+      clean: false,
+      deps: {
+        neverBundle,
+      },
+      outExtensions: () => ({ js: '.mjs', dts: '.d.ts' }),
+      // Server-only modules use require() for lazy loading. Don't emit rolldown's
+      // `createRequire`-from-`node:module` shim: it's statically reachable from
+      // client init code and breaks client bundlers (Turbopack "node:module"
+      // external; webpack UnhandledSchemeError). Next provides `require` for the
+      // guarded, server-only call sites in every bundling context that runs them.
+      outputOptions: { polyfillRequire: false },
+      plugins: [
+        createUseClientBoundaryPlugin({
+          name: 'gt-next:use-client-boundaries',
+          outputExtension: '.mjs',
+        }),
+      ],
+    }),
+    onSuccess: createRemoveRuntimeArtifactsHook(process.cwd(), 'dist', [
+      'index.types.mjs',
+      'index.types.mjs.map',
+    ]),
+  },
 ]);

--- a/packages/react/src/__tests__/react-package.test.ts
+++ b/packages/react/src/__tests__/react-package.test.ts
@@ -13,8 +13,6 @@ const runtimeArtifactNames = [
   'index.client.mjs',
   'index.server.cjs',
   'index.server.mjs',
-  'index.types.cjs',
-  'index.types.mjs',
   'macros.cjs',
   'macros.mjs',
 ].sort();
@@ -156,8 +154,6 @@ describe('gt-react package exports', () => {
       'dist/index.client.mjs',
       'dist/index.server.cjs',
       'dist/index.server.mjs',
-      'dist/index.types.cjs',
-      'dist/index.types.mjs',
     ]) {
       expect(readFileSync(join(packageRoot, file), 'utf8')).toMatch(
         /^['"]use client['"];?/

--- a/packages/react/tsdown.config.mts
+++ b/packages/react/tsdown.config.mts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'tsdown';
 import {
+  createRemoveRuntimeArtifactsHook,
   createTsdownConfig,
   createUseClientBoundaryPlugin,
 } from '../../tsdown.preset.mts';
@@ -32,6 +33,11 @@ const entries = [
   'src/macros.ts',
 ];
 
+// src/index.types.ts only backs the exports map's "types" conditions; its
+// declaration outputs are published but its runtime bundles are unreachable,
+// so they are deleted after each build.
+const typesOnlyEntry = 'src/index.types.ts';
+
 export default defineConfig(
   entries.flatMap((entry, index) => {
     const entryDeps = entry.startsWith('src/index.') ? contextDeps : deps;
@@ -51,6 +57,12 @@ export default defineConfig(
             outputExtension: '.cjs',
           }),
         ],
+        ...(entry === typesOnlyEntry && {
+          onSuccess: createRemoveRuntimeArtifactsHook(process.cwd(), 'dist', [
+            'index.types.cjs',
+            'index.types.cjs.map',
+          ]),
+        }),
       },
       {
         ...esmConfig,
@@ -65,6 +77,12 @@ export default defineConfig(
             outputExtension: '.mjs',
           }),
         ],
+        ...(entry === typesOnlyEntry && {
+          onSuccess: createRemoveRuntimeArtifactsHook(process.cwd(), 'dist', [
+            'index.types.mjs',
+            'index.types.mjs.map',
+          ]),
+        }),
       },
     ];
   })

--- a/tsdown.preset.mts
+++ b/tsdown.preset.mts
@@ -253,22 +253,32 @@ function getEntryName(entry: string) {
   return basename(entry, extname(entry));
 }
 
-function createRemoveTypeRuntimeArtifactsHook(
+export function createRemoveRuntimeArtifactsHook(
+  packageDir: string,
   outDir: string,
-  typeEntry: string,
-  packageDir: string
+  artifactNames: string[]
 ) {
-  const typeEntryName = getEntryName(typeEntry);
-  const artifacts = [
-    resolve(packageDir, outDir, `${typeEntryName}.cjs.min.cjs`),
-    resolve(packageDir, outDir, `${typeEntryName}.cjs.min.cjs.map`),
-  ];
+  const artifacts = artifactNames.map((name) =>
+    resolve(packageDir, outDir, name)
+  );
 
   return async () => {
     await Promise.all(
       artifacts.map((artifact) => rm(artifact, { force: true }))
     );
   };
+}
+
+function createRemoveTypeRuntimeArtifactsHook(
+  outDir: string,
+  typeEntry: string,
+  packageDir: string
+) {
+  const typeEntryName = getEntryName(typeEntry);
+  return createRemoveRuntimeArtifactsHook(packageDir, outDir, [
+    `${typeEntryName}.cjs.min.cjs`,
+    `${typeEntryName}.cjs.min.cjs.map`,
+  ]);
 }
 
 export function createTsdownMinifiedDualFormatConfig({


### PR DESCRIPTION
## TL;DR

`src/index.types.ts` in gt-react and gt-next exists only to back the `types` conditions of the exports map — every runtime condition resolves to `index.client`/`index.server`/`index.rsc`. The runtime bundles it emitted were published anyway: **179KB (~27% of dist) in gt-react** and **~83KB in gt-next**, sourcemaps included, with the gt-react copy even re-bundling the entire client surface. Nothing can resolve them (the exports map blocks deep imports), so they are now deleted after each build. Declaration outputs are untouched.

## Code Changes

- `tsdown.preset.mts`: extracted the existing artifact-removal pattern into an exported `createRemoveRuntimeArtifactsHook(packageDir, outDir, artifactNames)`; `createRemoveTypeRuntimeArtifactsHook` now delegates to it
- `packages/react/tsdown.config.mts`: the `src/index.types.ts` CJS/ESM configs get `onSuccess` hooks removing `dist/index.types.{cjs,mjs}` and their maps
- `packages/next/tsdown.config.mts`: same for `dist/index.types.{js,mjs}` in the unbundled build
- `packages/react/src/__tests__/react-package.test.ts`: dropped `index.types.cjs`/`index.types.mjs` from the expected runtime artifact list and the use-client banner check — the "no unexpected dist files" assertion now also guards against the artifacts reappearing

## Notes / Flags

- Verified after rebuild: only `index.types.d.*` files remain in both packages' dist; `gt-react` tests (including the package-exports suite) and `gt-next` JS tests pass.
- gt-react-native is unaffected — it uses a different unbundled build with a single `index.tsx` entry and no `index.types` entry, so fixed-sibling parity doesn't apply here.
- No consumer-facing behavior change; this is npm publish/install weight only (bundlers never resolved these files).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR eliminates dead-weight runtime bundles (`index.types.{cjs,mjs}` and their sourcemaps) that were being published in `gt-react` (~179 KB) and `gt-next` (~83 KB) despite being unreachable — the exports map's `types` condition only needs the declaration files, never the JS bundles.

- **`tsdown.preset.mts`**: Generalises the existing artifact-removal pattern into an exported `createRemoveRuntimeArtifactsHook(packageDir, outDir, artifactNames[])` helper; the old `createRemoveTypeRuntimeArtifactsHook` now delegates to it.
- **`packages/react/tsdown.config.mts`** and **`packages/next/tsdown.config.mts`**: Both add `onSuccess` hooks that call `rm({ force: true })` on the unreachable runtime artifacts after each build.
- **`react-package.test.ts`**: Drops the deleted files from the expected artifact list, and the `readdirSync` equality assertion now doubles as a regression guard if the deletion hooks ever stop firing.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — no runtime behaviour changes, only build-output post-processing that removes files nothing can resolve.

All four changed files make targeted, self-consistent edits: the new helper is a straightforward generalisation of the existing pattern, the hook wiring matches the configured output extensions in both packages, and the test update correctly removes the deleted files from the expected-artifact list while also adding a regression guard via the readdirSync equality assertion. Declaration outputs are untouched, and no consumer-visible API changes.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tsdown.preset.mts | Extracts `createRemoveRuntimeArtifactsHook` (now exported, generic) from the old private `createRemoveTypeRuntimeArtifactsHook`; old function now delegates to the new one. Parameter ordering is consistent and correct. |
| packages/react/tsdown.config.mts | Adds conditional `onSuccess` hooks to remove `index.types.cjs`/`.cjs.map` and `index.types.mjs`/`.mjs.map` after each build when processing the `typesOnlyEntry`. Logic and artifact names match the expected tsdown/rolldown output extensions. |
| packages/next/tsdown.config.mts | Wraps both unbundled configs in object-literal spreads and attaches `onSuccess` hooks removing `index.types.js`/`.js.map` (CJS) and `index.types.mjs`/`.mjs.map` (ESM). Artifact names align with the configured `outExtensions`. |
| packages/react/src/__tests__/react-package.test.ts | Removes `index.types.cjs` and `index.types.mjs` from the expected runtime artifact list and the "use client" banner assertion. The `readdirSync` equality check now also acts as a regression guard if the deletion hooks silently fail. |
| .changeset/large-boxes-shrink.md | Patch-level changeset for both `gt-react` and `gt-next` documenting the publish-weight reduction with accurate size figures. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[tsdown build starts] --> B[CJS build step]
    A --> C[ESM build step]

    B --> D[Emit index.types.cjs + .cjs.map]
    C --> E[Emit index.types.mjs + .mjs.map]

    D --> F[onSuccess hook fires]
    E --> G[onSuccess hook fires]

    F --> H["rm(index.types.cjs, force:true)\nrm(index.types.cjs.map, force:true)"]
    G --> I["rm(index.types.mjs, force:true)\nrm(index.types.mjs.map, force:true)"]

    H --> J[dist/ — only .d.ts remains for index.types]
    I --> J

    subgraph Published dist/
        J --> K[index.types.d.ts ✅]
        J --> L[index.types.d.mts ✅]
        J --> M[index.types.cjs ❌ deleted]
        J --> N[index.types.mjs ❌ deleted]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[tsdown build starts] --> B[CJS build step]
    A --> C[ESM build step]

    B --> D[Emit index.types.cjs + .cjs.map]
    C --> E[Emit index.types.mjs + .mjs.map]

    D --> F[onSuccess hook fires]
    E --> G[onSuccess hook fires]

    F --> H["rm(index.types.cjs, force:true)\nrm(index.types.cjs.map, force:true)"]
    G --> I["rm(index.types.mjs, force:true)\nrm(index.types.mjs.map, force:true)"]

    H --> J[dist/ — only .d.ts remains for index.types]
    I --> J

    subgraph Published dist/
        J --> K[index.types.d.ts ✅]
        J --> L[index.types.d.mts ✅]
        J --> M[index.types.cjs ❌ deleted]
        J --> N[index.types.mjs ❌ deleted]
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: stop publishing unreachable index..."](https://github.com/generaltranslation/gt/commit/38c34b3028708616c2df977d1c096a614acba443) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43972023)</sub>

<!-- /greptile_comment -->