### PR TITLE
feat(next): make @generaltranslation/compiler an optional peer dependency

### DIFF
--- a/.changeset/wild-plums-search.md
+++ b/.changeset/wild-plums-search.md
@@ -1,0 +1,5 @@
+---
+'gt-next': minor
+---
+
+Make `@generaltranslation/compiler` an optional peer dependency instead of a hard dependency. It is only used by the experimental `experimentalCompilerOptions.type: 'babel'` webpack path, which already degrades gracefully with a warning when the package cannot be resolved. Users who enable the experimental babel compiler must now install `@generaltranslation/compiler` themselves; everyone else saves ~8.5MB of install weight (the compiler plus its Babel toolchain).

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -4,9 +4,15 @@
   "description": "A Next.js library for automatic internationalization.",
   "main": "dist/index.server.js",
   "peerDependencies": {
+    "@generaltranslation/compiler": "^1.3.25",
     "next": ">=13.0.0 <15.2.1 || >15.2.2",
     "react": ">=16.8.0 <20.0.0",
     "react-dom": ">=16.8.0 <20.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@generaltranslation/compiler": {
+      "optional": true
+    }
   },
   "files": [
     "dist",
@@ -22,7 +28,6 @@
     "./dist/utils/client-boundary.*"
   ],
   "dependencies": {
-    "@generaltranslation/compiler": "workspace:*",
     "@generaltranslation/format": "workspace:*",
     "@generaltranslation/react-core": "workspace:*",
     "@generaltranslation/supported-locales": "workspace:*",

--- a/packages/next/src/errors/createErrors.ts
+++ b/packages/next/src/errors/createErrors.ts
@@ -178,7 +178,13 @@ export const standardizedCanonicalLocalesWarning = (locales: string[]) =>
   `gt-next: The following canonical locales were standardized: ${locales.join(', ')}. Use the standardized codes in your config to avoid this warning.`;
 
 export const createGTCompilerUnresolvedWarning = (type: 'babel' | 'swc') =>
-  `gt-next (plugin): The GT ${type} compiler could not be resolved. Skipping compiler optimizations.`;
+  createGtNextPluginDiagnostic({
+    whatHappened: `The GT ${type} compiler could not be resolved`,
+    wayOut: 'Skipping compiler optimizations',
+    ...(type === 'babel' && {
+      fix: 'Install @generaltranslation/compiler to enable the experimental babel compiler',
+    }),
+  });
 
 export const customGetLocaleUnresolvedWarning = createGtNextDiagnostic({
   whatHappened: 'Custom getLocale() could not be resolved',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -978,8 +978,8 @@ importers:
   packages/next:
     dependencies:
       '@generaltranslation/compiler':
-        specifier: workspace:*
-        version: link:../compiler
+        specifier: ^1.3.25
+        version: 1.3.27
       '@generaltranslation/format':
         specifier: workspace:*
         version: link:../format
@@ -4114,6 +4114,13 @@ packages:
 
   '@formatjs/intl-relativetimeformat@11.4.13':
     resolution: {integrity: sha512-fNs6cpz9zIUEgTlE3kPSEyRfslxeMG19dT7sLz2C6U7Jxkx8xK/IH1ImZzCeqd6JlqE81O7uNW4oZTb1pz8lUw==}
+
+  '@generaltranslation/compiler@1.3.27':
+    resolution: {integrity: sha512-jUpCIXftnA+iYjdtEyaO+Aa4BoNFuqsx0OL6t7763+Iqgw1x5v6TWsYpGbG9kgr5SJ0zph7pG81nZznW0FstNw==}
+    engines: {node: '>=16.0.0'}
+
+  '@generaltranslation/format@0.1.1':
+    resolution: {integrity: sha512-HYfBdkrdMuA/Sj0tMrkdat4mnaNnN7Isf1u3IYwYUMvH21iWkqnWZ2KBKD2tboNux2T4SxyFMyCjnwg7tmEOlA==}
 
   '@hapi/hoek@9.3.0':
     resolution: {integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==}
@@ -11187,6 +11194,9 @@ packages:
     resolution: {integrity: sha512-ZaoiZwkSf0DwwB1ncdLKp+ggAldqxl5L1+SXaNIBGkPAqcu+xjVJLxlf3/S8vLt9UHx1xu5fz3lbzKCj5iOVdQ==}
     peerDependencies:
       next: '>=13.2.0'
+
+  generaltranslation@8.2.19:
+    resolution: {integrity: sha512-y4eWxZLe69ki8HRs2Hkf4IovdkQqX+KMRTXjRou8vb07ROTCIEVAyXpJ8KR6AM4YHbjq8ZozhpOcrCz+aW7elw==}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -20474,6 +20484,22 @@ snapshots:
       '@formatjs/intl-localematcher': 0.6.2
       tslib: 2.8.1
 
+  '@generaltranslation/compiler@1.3.27':
+    dependencies:
+      '@babel/generator': 7.29.1
+      '@babel/parser': 7.29.2
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@generaltranslation/format': 0.1.1
+      generaltranslation: 8.2.19
+      unplugin: 2.3.10
+    transitivePeerDependencies:
+      - supports-color
+
+  '@generaltranslation/format@0.1.1':
+    dependencies:
+      intl-messageformat: 10.7.16
+
   '@hapi/hoek@9.3.0':
     optional: true
 
@@ -29116,6 +29142,12 @@ snapshots:
   geist@1.7.0(next@15.5.9(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)):
     dependencies:
       next: 15.5.9(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+
+  generaltranslation@8.2.19:
+    dependencies:
+      '@formatjs/icu-messageformat-parser': 2.11.4
+      '@generaltranslation/format': 0.1.1
+      '@noble/hashes': 2.2.0
 
   gensync@1.0.0-beta.2: {}
 


### PR DESCRIPTION
## TL;DR

`@generaltranslation/compiler` was a hard dependency of gt-next, but its only use is a try/catch-guarded `require()` inside the webpack hook, reached only when a user opts into the experimental `experimentalCompilerOptions.type: 'babel'` path. The hard dependency dragged **~8.5MB** into every gt-next install (compiler dist 2.0MB + `@babel/parser` 1.9MB + `@babel/types` 3.0MB + `@babel/traverse` 0.8MB + `@babel/generator` 0.65MB + unplugin 228KB) for a feature most users never enable. It is now an optional peer dependency.

## Code Changes

- `packages/next/package.json`: moved `@generaltranslation/compiler` from `dependencies` to `peerDependencies` (`^1.3.25`) with `peerDependenciesMeta.optional: true`
- `packages/next/src/errors/createErrors.ts`: converted `createGTCompilerUnresolvedWarning` to the `createGtNextPluginDiagnostic()` format and, for the babel variant, added the fix guidance to install `@generaltranslation/compiler`
- Updated `pnpm-lock.yaml` and added a **minor** changeset

## Notes / Flags

- Safe by construction: the sole call site (`config.ts` webpack hook) already wraps the `require()` in try/catch, warns, and falls back to `type: 'none'`. No type imports leak from the package (`CompilerOptions` is defined locally in gt-next).
- Users of the experimental babel compiler must now `npm install @generaltranslation/compiler` — hence minor, not patch. The runtime warning now tells them exactly that. Docs for the experimental option should mention the extra install; happy to follow up if those live outside this repo.
- The swc compiler path is unaffected (it ships as a wasm file inside gt-next).
- `turbo build` and the gt-next JS test suite pass locally.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR demotes `@generaltranslation/compiler` from a hard `dependency` of `gt-next` to an optional `peerDependency`, saving ~8.5 MB for users who never enable the experimental `type: 'babel'` compiler path. The change is safe because the sole call site in `config.ts` already wraps the `require()` in a try/catch that falls back gracefully, and the structured warning message is updated to guide babel users toward installing the package themselves.

- **`package.json`**: compiler moved to `peerDependencies` (`^1.3.25`) with `peerDependenciesMeta.optional: true`; no type imports from the compiler leak into gt-next (the local `CompilerOptions` definition is used throughout).
- **`createErrors.ts`**: `createGTCompilerUnresolvedWarning` converted to the structured `createGtNextPluginDiagnostic` format, with a `fix` field added for the babel variant that tells users exactly what to install.
- **`pnpm-lock.yaml`**: compiler now resolves to published `1.3.27` from npm instead of `link:../compiler`; as a side effect the workspace link to `packages/compiler` is lost for local development.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for all production consumers; the only concern is a developer-workflow regression inside the monorepo.

The core change is correct and well-guarded: the try/catch in the webpack hook already existed, the error message is meaningfully improved, and the optional peer dep declaration is properly formed. The lockfile shows pnpm now pulls the compiler from npm (1.3.27) instead of packages/compiler (1.3.25), so contributors developing both packages simultaneously will silently test against the published copy rather than their local changes.

packages/next/package.json — consider adding @generaltranslation/compiler to devDependencies with workspace:* to restore the workspace link for monorepo contributors.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/next/package.json | Moves @generaltranslation/compiler from dependencies to optional peerDependencies with ^1.3.25 range; workspace link to the local compiler package is lost as a side effect |
| packages/next/src/errors/createErrors.ts | Converts createGTCompilerUnresolvedWarning to the structured diagnostic format and adds a fix hint for the babel case, guiding users to install the now-optional peer |
| .changeset/wild-plums-search.md | Minor changeset for gt-next correctly reflecting the breaking change (babel compiler users must now install the peer themselves) |
| pnpm-lock.yaml | Lockfile updated; compiler now resolves to npm 1.3.27 instead of the workspace link, and new transitive entries are added for Babel packages and generaltranslation |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[withGTConfig called] --> B{experimentalCompilerOptions.type?}
    B -- swc --> C[Resolve wasm file from gt-next dist]
    C --> D{wasm found?}
    D -- yes --> E[Add swcPlugin entry]
    D -- no --> F[warn: swc compiler unresolved\nfallback to none]
    B -- babel --> G[webpack hook fires]
    G --> H{turboPackEnabled?}
    H -- yes --> I[skip babel plugin\nnot compatible]
    H -- no --> J["require('@generaltranslation/compiler')"]
    J --> K{package installed?}
    K -- yes --> L[unshift gtUnplugin into webpack plugins]
    K -- no --> M["warn: install @generaltranslation/compiler\nfallback to type: 'none'"]
    B -- none --> N[No compiler plugin applied]
    style M fill:#ffe0b2
    style F fill:#ffe0b2
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[withGTConfig called] --> B{experimentalCompilerOptions.type?}
    B -- swc --> C[Resolve wasm file from gt-next dist]
    C --> D{wasm found?}
    D -- yes --> E[Add swcPlugin entry]
    D -- no --> F[warn: swc compiler unresolved\nfallback to none]
    B -- babel --> G[webpack hook fires]
    G --> H{turboPackEnabled?}
    H -- yes --> I[skip babel plugin\nnot compatible]
    H -- no --> J["require('@generaltranslation/compiler')"]
    J --> K{package installed?}
    K -- yes --> L[unshift gtUnplugin into webpack plugins]
    K -- no --> M["warn: install @generaltranslation/compiler\nfallback to type: 'none'"]
    B -- none --> N[No compiler plugin applied]
    style M fill:#ffe0b2
    style F fill:#ffe0b2
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fnext%2Fpackage.json%3A6-16%0A**Workspace%20link%20to%20%60packages%2Fcompiler%60%20is%20lost**%0A%0AMoving%20to%20%60peerDependencies%60%20without%20a%20%60workspace%3A*%60%20specifier%20causes%20pnpm%20to%20resolve%20%60%40generaltranslation%2Fcompiler%60%20from%20npm%20%28%601.3.27%60%29%20instead%20of%20the%20local%20workspace%20package%20%28%60link%3A..%2Fcompiler%60%2C%20currently%20at%20%601.3.25%60%29.%20Anyone%20modifying%20%60packages%2Fcompiler%60%20locally%20will%20not%20see%20their%20changes%20reflected%20when%20running%20%60gt-next%60%20tests%20%E2%80%94%20pnpm's%20auto-install-peers%20picks%20up%20the%20npm%20copy%2C%20not%20the%20workspace%20sibling.%20Adding%20%60%22%40generaltranslation%2Fcompiler%22%3A%20%22workspace%3A*%22%60%20to%20%60devDependencies%60%20restores%20the%20workspace%20link%20for%20contributors%20while%20leaving%20the%20optional%20peer%20dependency%20in%20place%20for%20downstream%20consumers.%0A%0A&repo=generaltranslation%2Fgt&pr=1851&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22bg%2Fcompiler-optional-peer-dep%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22bg%2Fcompiler-optional-peer-dep%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fnext%2Fpackage.json%3A6-16%0A**Workspace%20link%20to%20%60packages%2Fcompiler%60%20is%20lost**%0A%0AMoving%20to%20%60peerDependencies%60%20without%20a%20%60workspace%3A*%60%20specifier%20causes%20pnpm%20to%20resolve%20%60%40generaltranslation%2Fcompiler%60%20from%20npm%20%28%601.3.27%60%29%20instead%20of%20the%20local%20workspace%20package%20%28%60link%3A..%2Fcompiler%60%2C%20currently%20at%20%601.3.25%60%29.%20Anyone%20modifying%20%60packages%2Fcompiler%60%20locally%20will%20not%20see%20their%20changes%20reflected%20when%20running%20%60gt-next%60%20tests%20%E2%80%94%20pnpm's%20auto-install-peers%20picks%20up%20the%20npm%20copy%2C%20not%20the%20workspace%20sibling.%20Adding%20%60%22%40generaltranslation%2Fcompiler%22%3A%20%22workspace%3A*%22%60%20to%20%60devDependencies%60%20restores%20the%20workspace%20link%20for%20contributors%20while%20leaving%20the%20optional%20peer%20dependency%20in%20place%20for%20downstream%20consumers.%0A%0A&repo=generaltranslation%2Fgt&pr=1851&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/next/package.json:6-16
**Workspace link to `packages/compiler` is lost**

Moving to `peerDependencies` without a `workspace:*` specifier causes pnpm to resolve `@generaltranslation/compiler` from npm (`1.3.27`) instead of the local workspace package (`link:../compiler`, currently at `1.3.25`). Anyone modifying `packages/compiler` locally will not see their changes reflected when running `gt-next` tests — pnpm's auto-install-peers picks up the npm copy, not the workspace sibling. Adding `"@generaltranslation/compiler": "workspace:*"` to `devDependencies` restores the workspace link for contributors while leaving the optional peer dependency in place for downstream consumers.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(next): make @generaltranslation/com..."](https://github.com/generaltranslation/gt/commit/d0c041788745aea22fd4b6e666443463781a3e40) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44006034)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->