### PR TITLE
perf(react-core): extract cookie-name constants into a dependency-free module

### DIFF
--- a/.changeset/proud-hands-shrink.md
+++ b/.changeset/proud-hands-shrink.md
@@ -1,0 +1,5 @@
+---
+'@generaltranslation/react-core': patch
+---
+
+Move the default cookie-name constants (`defaultLocaleCookieName`, `defaultRegionCookieName`, `defaultEnableI18nCookieName`, `defaultResetLocaleCookieName`) into a dependency-free module. They were co-located with `ReactI18nConfig`, so importing just a cookie name from `@generaltranslation/react-core/pure` could drag the `gt-i18n/internal` runtime (~60KB) into size-constrained bundles like gt-next's edge middleware. The `/pure` entry re-exports them unchanged.

--- a/packages/react-core/src/pure.ts
+++ b/packages/react-core/src/pure.ts
@@ -28,7 +28,7 @@ export {
   defaultLocaleCookieName,
   defaultRegionCookieName,
   defaultResetLocaleCookieName,
-} from './setup/i18nConfig';
+} from './setup/cookieNames';
 export { getDefaultRenderSettings } from './utils/rendering/getDefaultRenderSettings';
 
 export type {

--- a/packages/react-core/src/setup/cookieNames.ts
+++ b/packages/react-core/src/setup/cookieNames.ts
@@ -1,0 +1,23 @@
+// Dependency-free module: these constants are imported by size-constrained
+// consumers (e.g. gt-next's edge middleware), which must not pull in the
+// ReactI18nConfig class or its gt-i18n imports.
+
+/**
+ * Cookie name for tracking the user's selected locale.
+ */
+export const defaultLocaleCookieName = 'generaltranslation.locale';
+
+/**
+ * Cookie name for tracking the user's selected region.
+ */
+export const defaultRegionCookieName = 'generaltranslation.region';
+
+/**
+ * Cookie name for persisting the enableI18n feature flag.
+ */
+export const defaultEnableI18nCookieName = 'generaltranslation.enable-i18n';
+
+/**
+ * Cookie name for tracking the locale reset.
+ */
+export const defaultResetLocaleCookieName = 'generaltranslation.locale-reset';

--- a/packages/react-core/src/setup/i18nConfig.ts
+++ b/packages/react-core/src/setup/i18nConfig.ts
@@ -5,26 +5,11 @@ import {
   setI18nConfig as setBaseI18nConfig,
 } from 'gt-i18n/internal';
 import type { I18nConfigParams as BaseI18nConfigParams } from 'gt-i18n/internal/types';
-
-/**
- * Cookie name for tracking the user's selected locale.
- */
-export const defaultLocaleCookieName = 'generaltranslation.locale';
-
-/**
- * Cookie name for tracking the user's selected region.
- */
-export const defaultRegionCookieName = 'generaltranslation.region';
-
-/**
- * Cookie name for persisting the enableI18n feature flag.
- */
-export const defaultEnableI18nCookieName = 'generaltranslation.enable-i18n';
-
-/**
- * Cookie name for tracking the locale reset.
- */
-export const defaultResetLocaleCookieName = 'generaltranslation.locale-reset';
+import {
+  defaultEnableI18nCookieName,
+  defaultLocaleCookieName,
+  defaultRegionCookieName,
+} from './cookieNames';
 
 /**
  * Helps us distinguish behavior for SPA vs server-rendered apps.


### PR DESCRIPTION
## TL;DR

gt-next's edge middleware imports only two string constants (`defaultLocaleCookieName`, `defaultResetLocaleCookieName`) from `@generaltranslation/react-core/pure`, but those constants lived in `setup/i18nConfig.ts` — the same module that defines `class ReactI18nConfig extends I18nConfig` and imports from `gt-i18n/internal` (a 52KB bundled module) plus `generaltranslation/internal` (~10KB). Because react-core builds unbundled and the module has a class hierarchy and a top-level `Symbol.for`, minifiers can't reliably prove it droppable, so up to ~62KB could ride into every Next.js edge middleware bundle for the sake of four strings. The constants now live in a dependency-free module that compiles to ~250 bytes.

## Code Changes

- Added `packages/react-core/src/setup/cookieNames.ts` with the four cookie-name constants (no imports)
- `setup/i18nConfig.ts` imports the three it uses as constructor defaults instead of defining them
- `pure.ts` re-exports the constants from the new module — same names on the same `/pure` entry, so the public API is unchanged

## Notes / Flags

- Pure refactor; the constant values and every consumer-facing export are identical. All monorepo consumers (gt-next middleware, `defaultWithGTConfigProps`, `AsyncConditionStore`, gt-react's `BrowserConditionStore`) import via `@generaltranslation/react-core/pure`, which is unaffected.
- Verified in the rebuilt dist: `dist/setup/cookieNames.mjs` is a standalone ~250B module with zero imports, and `dist/pure.mjs` resolves the constants from it rather than from `setup/i18nConfig.mjs`.
- react-core, gt-react, and gt-next test suites pass locally.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts four cookie-name string constants out of `setup/i18nConfig.ts` — which carries `ReactI18nConfig`, a `Symbol.for` call, and heavy `gt-i18n/internal` imports — into a new zero-dependency `setup/cookieNames.ts` module. The `/pure` entry point re-exports all four constants from the new module, leaving the public API byte-for-byte identical while dropping ~62KB from edge-middleware bundles that only needed the strings.

- **`cookieNames.ts`** — new ~250B file with four `export const` declarations and no imports; `pure.ts` now resolves the constants directly from here.
- **`i18nConfig.ts`** — imports the three constants it actually uses (`defaultLocaleCookieName`, `defaultRegionCookieName`, `defaultEnableI18nCookieName`) from `./cookieNames`; `defaultResetLocaleCookieName` is correctly absent because `ReactI18nConfig` never exposes it.
- **Changeset** — correctly typed as a patch release with an accurate description of the motivation.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Pure constant extraction with no logic changes; the public API exposed by /pure is identical and all affected constants retain the same string values.

The change moves four string literals to a new zero-dependency file and updates two import sites. Constant values, export names, and the /pure entry point surface are all unchanged. No runtime paths are modified, no new dependencies are introduced, and the three constants still needed by ReactI18nConfig are correctly imported from the new module.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react-core/src/setup/cookieNames.ts | New dependency-free module defining all four cookie-name constants (~250B, zero imports). Correctly isolates them from the heavy class hierarchy in i18nConfig.ts. |
| packages/react-core/src/pure.ts | Re-export source for all four cookie-name constants switched from ./setup/i18nConfig to ./setup/cookieNames; public API is identical, bundle weight for edge-middleware consumers drops ~62KB. |
| packages/react-core/src/setup/i18nConfig.ts | Removes the three inline constant definitions it used as constructor defaults and imports them from ./cookieNames instead; defaultResetLocaleCookieName is correctly omitted because ReactI18nConfig never used it. |
| .changeset/proud-hands-shrink.md | Patch-level changeset entry accurately describing the motivation and all four affected constants. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["@generaltranslation/react-core/pure\n(pure.ts)"] -->|"re-exports all 4 constants\n(was: i18nConfig)"| B["setup/cookieNames.ts\n~250B, zero imports"]
    C["setup/i18nConfig.ts\n(ReactI18nConfig class)"] -->|"imports 3 used constants"| B
    D["gt-next edge middleware"] -->|"imports cookie names only"| A
    E["gt-i18n/internal ~52KB\ngeneraltranslation/internal ~10KB"] -->|"only loaded by"| C
    style B fill:#d4edda,stroke:#28a745
    style E fill:#f8d7da,stroke:#dc3545
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["@generaltranslation/react-core/pure\n(pure.ts)"] -->|"re-exports all 4 constants\n(was: i18nConfig)"| B["setup/cookieNames.ts\n~250B, zero imports"]
    C["setup/i18nConfig.ts\n(ReactI18nConfig class)"] -->|"imports 3 used constants"| B
    D["gt-next edge middleware"] -->|"imports cookie names only"| A
    E["gt-i18n/internal ~52KB\ngeneraltranslation/internal ~10KB"] -->|"only loaded by"| C
    style B fill:#d4edda,stroke:#28a745
    style E fill:#f8d7da,stroke:#dc3545
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["perf(react-core): extract cookie-name co..."](https://github.com/generaltranslation/gt/commit/7cf7d29fc8389131fb085a560248f3ec92f9989f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43986883)</sub>

<!-- /greptile_comment -->