### PR TITLE
test(gt-i18n): add I18nCache contract tests locking public-boundary behavior

### DIFF
--- a/packages/i18n/src/i18n-cache/__tests__/I18nCache.contract.config.test.ts
+++ b/packages/i18n/src/i18n-cache/__tests__/I18nCache.contract.config.test.ts
@@ -377,13 +377,21 @@ describe('I18nCache config contract', () => {
       cache.lookupTranslationWithFallback('fr', 'Three', { $format: 'ICU' }),
     ]);
 
+    // The batching contract: two requests, neither exceeding maxBatchSize,
+    // covering each miss exactly once. Which miss lands in which batch is an
+    // implementation detail.
     expect(translateManySpy).toHaveBeenCalledTimes(2);
-    expect(
-      Object.keys(translateManySpy.mock.calls[0][0] as object).length
-    ).toBe(2);
-    expect(
-      Object.keys(translateManySpy.mock.calls[1][0] as object).length
-    ).toBe(1);
+    const batches = translateManySpy.mock.calls.map((call) =>
+      Object.keys(call[0] as object)
+    );
+    for (const batch of batches) {
+      expect(batch.length).toBeLessThanOrEqual(2);
+    }
+    expect(batches.flat().sort()).toEqual(
+      ['One', 'Two', 'Three']
+        .map((source) => hashMessage(source, { $format: 'ICU' }))
+        .sort()
+    );
   });
 
   // ===== Dictionary loader plumbing ===== //

--- a/packages/i18n/src/i18n-cache/__tests__/I18nCache.contract.config.test.ts
+++ b/packages/i18n/src/i18n-cache/__tests__/I18nCache.contract.config.test.ts
@@ -1,0 +1,411 @@
+/**
+ * Contract tests for I18nCache config-time behavior: constructor validation,
+ * translation-loader routing, and runtime-translation plumbing.
+ *
+ * These tests exercise I18nCache ONLY through its public boundary so the
+ * validation/ directory and translations-loaders/ internals can be
+ * restructured or inlined without breaking behavior. Do not import or mock
+ * i18n-cache internals here; the only stubbed boundaries are global fetch,
+ * console, env, and GTRuntime.prototype.translateMany.
+ */
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  type MockInstance,
+} from 'vitest';
+import { GTRuntime } from 'generaltranslation/runtime';
+import { defaultCacheUrl } from 'generaltranslation/internal';
+import { I18nCache } from '../I18nCache';
+import { initializeI18nConfig } from '../../i18n-config/singleton-operations';
+import { hashMessage } from '../../utils/hashMessage';
+import type { LookupOptions } from '../../translation-functions/types/options';
+
+type TestGlobal = typeof globalThis & {
+  __generaltranslation?: unknown;
+};
+
+function resetGTGlobals() {
+  Reflect.deleteProperty(globalThis as TestGlobal, '__generaltranslation');
+}
+
+function initConfig(overrides: Record<string, unknown> = {}) {
+  resetGTGlobals();
+  initializeI18nConfig({
+    defaultLocale: 'en',
+    locales: ['en', 'fr', 'es'],
+    ...overrides,
+  });
+}
+
+/** Console calls whose first argument contains the given substring */
+function callsContaining(spy: MockInstance, substring: string) {
+  return spy.mock.calls.filter((call) => String(call[0]).includes(substring));
+}
+
+function mockFetchResponse(payload: unknown) {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(payload),
+  });
+}
+
+/** translateMany stub that succeeds for every requested hash */
+function succeedTranslateMany(
+  translate: (hash: string, source: unknown) => string
+) {
+  return vi
+    .spyOn(GTRuntime.prototype, 'translateMany')
+    .mockImplementation(async (sources) =>
+      Object.fromEntries(
+        Object.entries(sources as Record<string, { source: unknown }>).map(
+          ([hash, entry]) => [
+            hash,
+            { success: true, translation: translate(hash, entry.source) },
+          ]
+        )
+      )
+    ) as MockInstance;
+}
+
+describe('I18nCache config contract', () => {
+  let warnSpy: MockInstance;
+  let errorSpy: MockInstance;
+
+  beforeEach(() => {
+    initConfig();
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    resetGTGlobals();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+    vi.useRealTimers();
+  });
+
+  // ===== Constructor validation ===== //
+
+  it('throws and logs an error when loadDictionary is provided without a source dictionary', () => {
+    expect(
+      () =>
+        new I18nCache({
+          loadDictionary: async () => ({}),
+        })
+    ).toThrow('Validation errors occurred');
+
+    const errors = callsContaining(errorSpy, 'I18nCache:');
+    expect(errors.length).toBe(1);
+    expect(String(errors[0][0])).toContain(
+      'loadDictionary needs a source dictionary'
+    );
+  });
+
+  it('accepts loadDictionary when a source dictionary is provided', () => {
+    expect(
+      () =>
+        new I18nCache({
+          dictionary: { greeting: 'Hello' },
+          loadDictionary: async () => ({}),
+        })
+    ).not.toThrow();
+    expect(callsContaining(errorSpy, 'I18nCache:').length).toBe(0);
+  });
+
+  it('warns but does not throw when a custom runtimeUrl has no projectId or api keys', () => {
+    expect(
+      () =>
+        new I18nCache({
+          runtimeUrl: 'https://example.com/api',
+          loadTranslations: async () => ({}),
+        })
+    ).not.toThrow();
+
+    const warnings = callsContaining(warnSpy, 'I18nCache:');
+    expect(warnings.length).toBe(2);
+    expect(String(warnings[0][0])).toContain(
+      'Runtime translation needs a projectId'
+    );
+    expect(String(warnings[1][0])).toContain(
+      'Runtime translation needs devApiKey or apiKey'
+    );
+  });
+
+  it('emits no validation warnings or errors for a standard GT config', () => {
+    new I18nCache({
+      projectId: 'test-project',
+      apiKey: 'test-api-key',
+      loadTranslations: async () => ({}),
+    });
+
+    expect(callsContaining(warnSpy, 'I18nCache:').length).toBe(0);
+    expect(callsContaining(errorSpy, 'I18nCache:').length).toBe(0);
+  });
+
+  // ===== Translation loader routing ===== //
+
+  it('uses a custom loadTranslations loader and never fetches', async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+    const loadTranslations = vi
+      .fn()
+      .mockResolvedValue({ hash1: 'Bonjour le monde !' });
+    const cache = new I18nCache({
+      projectId: 'test-project',
+      loadTranslations,
+    });
+
+    const translations = await cache.loadTranslations('fr');
+
+    expect(loadTranslations).toHaveBeenCalledWith('fr');
+    expect(translations).toEqual({ hash1: 'Bonjour le monde !' });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('fetches from the default GT cache URL when projectId is set', async () => {
+    const payload = { hash1: 'Bonjour le monde !' };
+    const fetchSpy = mockFetchResponse(payload);
+    vi.stubGlobal('fetch', fetchSpy);
+    const cache = new I18nCache({ projectId: 'test-project' });
+
+    const translations = await cache.loadTranslations('fr');
+
+    expect(fetchSpy).toHaveBeenCalledWith(`${defaultCacheUrl}/test-project/fr`);
+    expect(translations).toEqual(payload);
+  });
+
+  it('includes the _versionId segment and _branchId query in the remote URL', async () => {
+    const fetchSpy = mockFetchResponse({});
+    vi.stubGlobal('fetch', fetchSpy);
+    const cache = new I18nCache({
+      projectId: 'test-project',
+      _versionId: 'v123',
+      _branchId: 'b9',
+    });
+
+    await cache.loadTranslations('fr');
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `${defaultCacheUrl}/test-project/fr/v123?branchId=b9`
+    );
+  });
+
+  it('fetches from a custom cacheUrl', async () => {
+    const fetchSpy = mockFetchResponse({});
+    vi.stubGlobal('fetch', fetchSpy);
+    const cache = new I18nCache({
+      projectId: 'test-project',
+      cacheUrl: 'https://cache.example.com',
+    });
+
+    await cache.loadTranslations('fr');
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://cache.example.com/test-project/fr'
+    );
+  });
+
+  it('warns once and returns {} when a custom cacheUrl has no projectId', async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+    const cache = new I18nCache({ cacheUrl: 'https://cache.example.com' });
+
+    // Two different locales force two loader invocations; the warning fires once
+    expect(await cache.loadTranslations('fr')).toEqual({});
+    expect(await cache.loadTranslations('es')).toEqual({});
+
+    const warnings = callsContaining(warnSpy, 'projectId');
+    expect(warnings.length).toBe(1);
+    expect(String(warnings[0][0])).toContain(
+      'Loading translations from a remote store needs a projectId'
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns {} silently when cacheUrl is null', async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+    const cache = new I18nCache({ cacheUrl: null });
+
+    expect(await cache.loadTranslations('fr')).toEqual({});
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('warns once and returns {} when no translation loader is configured', async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+    const cache = new I18nCache({});
+
+    expect(await cache.loadTranslations('fr')).toEqual({});
+    expect(await cache.loadTranslations('es')).toEqual({});
+
+    const warnings = callsContaining(warnSpy, 'No translation loader found');
+    expect(warnings.length).toBe(1);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('logs and returns {} when the remote fetch fails', async () => {
+    // current behavior: vitest runs as production for getRuntimeEnvironment(),
+    // so load errors are logged and swallowed instead of thrown
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: false, status: 404 })
+    );
+    const cache = new I18nCache({ projectId: 'test-project' });
+
+    expect(await cache.loadTranslations('fr')).toEqual({});
+
+    const errors = callsContaining(errorSpy, 'Failed to load translations');
+    expect(errors.length).toBe(1);
+  });
+
+  // ===== Runtime translation plumbing ===== //
+
+  const message = 'Hello {name}!';
+  const lookupOptions: LookupOptions = {
+    $format: 'ICU',
+    $context: 'greeting',
+    $id: 'greeting.hello',
+    $maxChars: 40,
+    $requiresReview: true,
+  };
+
+  it('passes runtimeTranslation timeout and metadata through to GTRuntime.translateMany', async () => {
+    const translateManySpy = succeedTranslateMany(() => 'Bonjour {name} !');
+    const cache = new I18nCache({
+      loadTranslations: async () => ({}),
+      runtimeTranslation: {
+        timeout: 5000,
+        metadata: { sourceLocale: 'en', modelProvider: 'test-provider' },
+      },
+    });
+
+    const translation = await cache.lookupTranslationWithFallback(
+      'fr',
+      message,
+      lookupOptions
+    );
+
+    expect(translation).toBe('Bonjour {name} !');
+    expect(translateManySpy).toHaveBeenCalledTimes(1);
+    const [sources, options, timeout] = translateManySpy.mock.calls[0];
+    const expectedHash = hashMessage(message, lookupOptions);
+    expect(sources).toEqual({
+      [expectedHash]: {
+        source: message,
+        metadata: {
+          hash: expectedHash,
+          context: 'greeting',
+          id: 'greeting.hello',
+          maxChars: 40,
+          requiresReview: true,
+          dataFormat: 'ICU',
+        },
+      },
+    });
+    expect(options).toEqual({
+      sourceLocale: 'en',
+      modelProvider: 'test-provider',
+      targetLocale: 'fr',
+    });
+    expect(timeout).toBe(5000);
+  });
+
+  it('defaults the runtime translation timeout to 12 seconds', async () => {
+    const translateManySpy = succeedTranslateMany(() => 'Bonjour !');
+    const cache = new I18nCache({ loadTranslations: async () => ({}) });
+
+    await cache.lookupTranslationWithFallback('fr', 'Hello!', {
+      $format: 'ICU',
+    });
+
+    expect(translateManySpy).toHaveBeenCalledTimes(1);
+    const [, options, timeout] = translateManySpy.mock.calls[0];
+    expect(options).toEqual({ targetLocale: 'fr' });
+    expect(timeout).toBe(12_000);
+  });
+
+  it('resolves the requested locale before calling translateMany', async () => {
+    const translateManySpy = succeedTranslateMany(() => 'Bonjour !');
+    const cache = new I18nCache({ loadTranslations: async () => ({}) });
+
+    await cache.lookupTranslationWithFallback('fr-FR', 'Hello!', {
+      $format: 'ICU',
+    });
+
+    expect(translateManySpy).toHaveBeenCalledTimes(1);
+    const [, options] = translateManySpy.mock.calls[0];
+    expect((options as { targetLocale: string }).targetLocale).toBe('fr');
+  });
+
+  it('batches concurrent cache misses into a single translateMany call', async () => {
+    const translateManySpy = succeedTranslateMany((hash) => `t-${hash}`);
+    const cache = new I18nCache({
+      loadTranslations: async () => ({}),
+      batchConfig: { maxBatchSize: 2 },
+    });
+
+    const [first, second] = await Promise.all([
+      cache.lookupTranslationWithFallback('fr', 'One', { $format: 'ICU' }),
+      cache.lookupTranslationWithFallback('fr', 'Two', { $format: 'ICU' }),
+    ]);
+
+    expect(translateManySpy).toHaveBeenCalledTimes(1);
+    const [sources] = translateManySpy.mock.calls[0];
+    expect(Object.keys(sources as object).length).toBe(2);
+    expect(first).toBe(`t-${hashMessage('One', { $format: 'ICU' })}`);
+    expect(second).toBe(`t-${hashMessage('Two', { $format: 'ICU' })}`);
+  });
+
+  it('splits misses that exceed maxBatchSize into separate calls', async () => {
+    const translateManySpy = succeedTranslateMany((hash) => `t-${hash}`);
+    const cache = new I18nCache({
+      loadTranslations: async () => ({}),
+      batchConfig: { maxBatchSize: 2 },
+    });
+
+    await Promise.all([
+      cache.lookupTranslationWithFallback('fr', 'One', { $format: 'ICU' }),
+      cache.lookupTranslationWithFallback('fr', 'Two', { $format: 'ICU' }),
+      cache.lookupTranslationWithFallback('fr', 'Three', { $format: 'ICU' }),
+    ]);
+
+    expect(translateManySpy).toHaveBeenCalledTimes(2);
+    expect(
+      Object.keys(translateManySpy.mock.calls[0][0] as object).length
+    ).toBe(2);
+    expect(
+      Object.keys(translateManySpy.mock.calls[1][0] as object).length
+    ).toBe(1);
+  });
+
+  // ===== Dictionary loader plumbing ===== //
+
+  it('loads the dictionary lazily and deduplicates concurrent loads', async () => {
+    const loadDictionary = vi.fn().mockResolvedValue({ greeting: 'Bonjour' });
+    const cache = new I18nCache({
+      loadTranslations: async () => ({}),
+      dictionary: { greeting: 'Hello' },
+      loadDictionary,
+    });
+
+    expect(loadDictionary).not.toHaveBeenCalled();
+
+    const [first, second] = await Promise.all([
+      cache.loadDictionary('fr'),
+      cache.loadDictionary('fr'),
+    ]);
+
+    expect(loadDictionary).toHaveBeenCalledTimes(1);
+    expect(loadDictionary).toHaveBeenCalledWith('fr');
+    expect(first).toEqual({ greeting: 'Bonjour' });
+    expect(second).toEqual({ greeting: 'Bonjour' });
+  });
+});

--- a/packages/i18n/src/i18n-cache/__tests__/I18nCache.contract.errors.test.ts
+++ b/packages/i18n/src/i18n-cache/__tests__/I18nCache.contract.errors.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { GTRuntime } from 'generaltranslation/runtime';
+import { I18nCache } from '../I18nCache';
+import { initializeI18nConfig } from '../../i18n-config/singleton-operations';
+import { hashMessage } from '../../utils/hashMessage';
+import type { LookupOptions } from '../../translation-functions/types/options';
+
+/**
+ * Contract tests for I18nCache error semantics.
+ *
+ * Locks in the observable error behavior of the PUBLIC I18nCache API:
+ * errors throw in development and are logged-and-swallowed in production,
+ * except DictionarySourceNotFoundError which always propagates. These tests
+ * import nothing from translations-manager/ and mock no internal modules.
+ * getRuntimeEnvironment() treats every NODE_ENV except 'development' as
+ * production, so vitest's default 'test' env exercises the production path.
+ */
+
+const message = 'Hello {name}!';
+const lookupOptions: LookupOptions = {
+  $format: 'ICU',
+  $context: 'greeting',
+};
+const expectedHash = hashMessage(message, lookupOptions);
+const translatedString = 'Bonjour {name} !';
+const invalidLocale = 'not a locale!!';
+
+type TestGlobal = typeof globalThis & {
+  __generaltranslation?: unknown;
+};
+
+function resetGTGlobals() {
+  Reflect.deleteProperty(globalThis as TestGlobal, '__generaltranslation');
+}
+
+function createCache(overrides: Record<string, unknown> = {}) {
+  return new I18nCache({
+    loadTranslations: vi
+      .fn()
+      .mockResolvedValue({ [expectedHash]: translatedString }),
+    ...overrides,
+  });
+}
+
+describe('I18nCache error contract', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    resetGTGlobals();
+    initializeI18nConfig({
+      defaultLocale: 'en',
+      locales: ['en', 'fr', 'es'],
+    });
+    consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    resetGTGlobals();
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it('production: invalid locale is logged and each read returns its fallback', async () => {
+    const cache = createCache();
+
+    expect(
+      cache.lookupTranslation(invalidLocale, message, lookupOptions)
+    ).toBeUndefined();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('not valid')
+    );
+
+    await expect(cache.loadTranslations(invalidLocale)).resolves.toEqual({});
+    await expect(cache.loadDictionary(invalidLocale)).resolves.toEqual({});
+    expect(cache.lookupDictionary(invalidLocale, 'greeting')).toBeUndefined();
+    expect(
+      cache.lookupDictionaryObj(invalidLocale, 'greeting')
+    ).toBeUndefined();
+
+    // getLookupTranslation degrades to an identity resolver
+    const resolver = await cache.getLookupTranslation(invalidLocale);
+    expect(resolver(message, lookupOptions)).toBe(message);
+  });
+
+  it('development: invalid locale throws from sync reads and rejects from async reads', async () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    const cache = createCache();
+
+    expect(() =>
+      cache.lookupTranslation(invalidLocale, message, lookupOptions)
+    ).toThrow('not valid');
+    expect(() => cache.lookupDictionary(invalidLocale, 'greeting')).toThrow(
+      'not valid'
+    );
+    await expect(cache.loadTranslations(invalidLocale)).rejects.toThrow(
+      'not valid'
+    );
+    await expect(cache.loadDictionary(invalidLocale)).rejects.toThrow(
+      'not valid'
+    );
+    await expect(cache.getLookupTranslation(invalidLocale)).rejects.toThrow(
+      'not valid'
+    );
+  });
+
+  it.each([
+    { name: 'production', env: undefined },
+    { name: 'development', env: 'development' },
+  ])(
+    'DictionarySourceNotFoundError propagates from lookupDictionaryWithFallback in $name',
+    async ({ env }) => {
+      if (env) vi.stubEnv('NODE_ENV', env);
+      const cache = createCache({
+        dictionary: { greeting: 'Hello' },
+        loadDictionary: vi.fn().mockResolvedValue({}),
+      });
+
+      await expect(
+        cache.lookupDictionaryWithFallback('fr', 'missing')
+      ).rejects.toMatchObject({
+        name: 'DictionarySourceNotFoundError',
+        message: 'I18nCache: source dictionary entry missing is not defined',
+      });
+    }
+  );
+
+  it.each([
+    { name: 'production', env: undefined },
+    { name: 'development', env: 'development' },
+  ])(
+    'DictionarySourceNotFoundError propagates from lookupDictionaryObjWithFallback in $name',
+    async ({ env }) => {
+      if (env) vi.stubEnv('NODE_ENV', env);
+      const cache = createCache({
+        dictionary: { greeting: 'Hello' },
+        loadDictionary: vi.fn().mockResolvedValue({}),
+      });
+
+      await expect(
+        cache.lookupDictionaryObjWithFallback('fr', 'missing')
+      ).rejects.toMatchObject({
+        name: 'DictionarySourceNotFoundError',
+      });
+    }
+  );
+
+  it('lookupDictionaryObjWithFallback returns the loaded target subtree when the source is missing', async () => {
+    const cache = createCache({
+      dictionary: { greeting: 'Hello' },
+      loadDictionary: vi.fn().mockResolvedValue({
+        extra: { title: 'Titre' },
+      }),
+    });
+
+    await expect(
+      cache.lookupDictionaryObjWithFallback('fr', 'extra')
+    ).resolves.toEqual({ title: 'Titre' });
+  });
+
+  it('production: a failing translations loader is logged and swallowed', async () => {
+    const cache = createCache({
+      loadTranslations: vi.fn().mockRejectedValue(new Error('Load failed')),
+    });
+
+    await expect(cache.loadTranslations('fr')).resolves.toEqual({});
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Load failed')
+    );
+
+    // The fallback path also swallows the loader failure
+    consoleErrorSpy.mockClear();
+    await expect(
+      cache.lookupTranslationWithFallback('fr', message, lookupOptions)
+    ).resolves.toBeUndefined();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Load failed')
+    );
+  });
+
+  it('development: a failing translations loader rejects', async () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    const cache = createCache({
+      loadTranslations: vi.fn().mockRejectedValue(new Error('Load failed')),
+    });
+
+    await expect(cache.loadTranslations('fr')).rejects.toThrow('Load failed');
+    await expect(
+      cache.lookupTranslationWithFallback('fr', message, lookupOptions)
+    ).rejects.toThrow('Load failed');
+  });
+
+  it.each([
+    { name: 'production', env: undefined },
+    { name: 'development', env: 'development' },
+  ])(
+    'runtime translateMany rejection resolves undefined in production, rejects in development ($name)',
+    async ({ env }) => {
+      if (env) vi.stubEnv('NODE_ENV', env);
+      vi.spyOn(GTRuntime.prototype, 'translateMany').mockRejectedValue(
+        new Error('API down')
+      );
+      const cache = createCache({
+        loadTranslations: vi.fn().mockResolvedValue({}),
+        runtimeTranslation: {},
+      });
+
+      const lookup = cache.lookupTranslationWithFallback(
+        'fr',
+        message,
+        lookupOptions
+      );
+      if (env === 'development') {
+        await expect(lookup).rejects.toThrow('API down');
+      } else {
+        await expect(lookup).resolves.toBeUndefined();
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          expect.stringContaining('API down')
+        );
+      }
+    }
+  );
+
+  it('runtime translateMany success:false entry resolves undefined in production', async () => {
+    vi.spyOn(GTRuntime.prototype, 'translateMany').mockResolvedValue({
+      [expectedHash]: {
+        success: false,
+        error: new Error('nope'),
+      },
+    } as unknown as Awaited<ReturnType<GTRuntime['translateMany']>>);
+    const cache = createCache({
+      loadTranslations: vi.fn().mockResolvedValue({}),
+      runtimeTranslation: {},
+    });
+
+    await expect(
+      cache.lookupTranslationWithFallback('fr', message, lookupOptions)
+    ).resolves.toBeUndefined();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('nope')
+    );
+  });
+});

--- a/packages/i18n/src/i18n-cache/__tests__/I18nCache.contract.errors.test.ts
+++ b/packages/i18n/src/i18n-cache/__tests__/I18nCache.contract.errors.test.ts
@@ -94,6 +94,9 @@ describe('I18nCache error contract', () => {
     expect(() => cache.lookupDictionary(invalidLocale, 'greeting')).toThrow(
       'not valid'
     );
+    expect(() => cache.lookupDictionaryObj(invalidLocale, 'greeting')).toThrow(
+      'not valid'
+    );
     await expect(cache.loadTranslations(invalidLocale)).rejects.toThrow(
       'not valid'
     );

--- a/packages/i18n/src/i18n-cache/__tests__/I18nCache.contract.expiry.test.ts
+++ b/packages/i18n/src/i18n-cache/__tests__/I18nCache.contract.expiry.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { GTRuntime } from 'generaltranslation/runtime';
+import { I18nCache } from '../I18nCache';
+import { initializeI18nConfig } from '../../i18n-config/singleton-operations';
+import { hashMessage } from '../../utils/hashMessage';
+import type { LookupOptions } from '../../translation-functions/types/options';
+
+/**
+ * Contract tests for I18nCache locale-cache expiry semantics.
+ *
+ * These tests lock in the observable TTL behavior of the PUBLIC I18nCache API
+ * so the internal cache layers can be restructured safely. They intentionally
+ * import nothing from translations-manager/ and mock no internal modules.
+ */
+
+const message = 'Hello {name}!';
+const lookupOptions: LookupOptions = {
+  $format: 'ICU',
+  $context: 'greeting',
+};
+const expectedHash = hashMessage(message, lookupOptions);
+const translatedString = 'Bonjour {name} !';
+
+// Characterized default: locale caches expire after 60 seconds.
+const DEFAULT_TTL = 60_000;
+
+type TestGlobal = typeof globalThis & {
+  __generaltranslation?: unknown;
+};
+
+function resetGTGlobals() {
+  Reflect.deleteProperty(globalThis as TestGlobal, '__generaltranslation');
+}
+
+function createCache(overrides: Record<string, unknown> = {}) {
+  return new I18nCache({
+    loadTranslations: vi
+      .fn()
+      .mockResolvedValue({ [expectedHash]: translatedString }),
+    ...overrides,
+  });
+}
+
+describe('I18nCache expiry contract', () => {
+  beforeEach(() => {
+    resetGTGlobals();
+    initializeI18nConfig({
+      defaultLocale: 'en',
+      locales: ['en', 'fr', 'es'],
+    });
+  });
+
+  afterEach(() => {
+    resetGTGlobals();
+    vi.useRealTimers();
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it('expires translations after the default TTL and reloads on demand', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+    const loadTranslations = vi
+      .fn()
+      .mockResolvedValueOnce({ [expectedHash]: translatedString })
+      .mockResolvedValueOnce({ [expectedHash]: 'Salut {name} !' });
+    const cache = createCache({ loadTranslations });
+
+    await cache.loadTranslations('fr');
+    expect(cache.lookupTranslation('fr', message, lookupOptions)).toBe(
+      translatedString
+    );
+
+    // Just under the default TTL: still cached
+    vi.advanceTimersByTime(DEFAULT_TTL - 1);
+    expect(cache.lookupTranslation('fr', message, lookupOptions)).toBe(
+      translatedString
+    );
+
+    // Past the default TTL: sync lookups miss
+    vi.advanceTimersByTime(2);
+    expect(
+      cache.lookupTranslation('fr', message, lookupOptions)
+    ).toBeUndefined();
+
+    // Loading again invokes the loader a second time and repopulates
+    const reloaded = await cache.loadTranslations('fr');
+    expect(reloaded[expectedHash]).toBe('Salut {name} !');
+    expect(loadTranslations).toHaveBeenCalledTimes(2);
+    expect(cache.lookupTranslation('fr', message, lookupOptions)).toBe(
+      'Salut {name} !'
+    );
+  });
+
+  it('cacheExpiryTime: null never expires translations or dictionaries', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+    const loadTranslations = vi
+      .fn()
+      .mockResolvedValue({ [expectedHash]: translatedString });
+    const loadDictionary = vi.fn().mockResolvedValue({ greeting: 'Bonjour' });
+    const cache = createCache({
+      cacheExpiryTime: null,
+      loadTranslations,
+      dictionary: { greeting: 'Hello' },
+      loadDictionary,
+    });
+
+    await cache.loadTranslations('fr');
+    await cache.loadDictionary('fr');
+
+    vi.advanceTimersByTime(999_999_999);
+
+    expect(cache.lookupTranslation('fr', message, lookupOptions)).toBe(
+      translatedString
+    );
+    expect(cache.lookupDictionary('fr', 'greeting')).toEqual({
+      entry: 'Bonjour',
+      options: {},
+    });
+
+    // Re-loading does not hit the loaders again
+    await cache.loadTranslations('fr');
+    await cache.loadDictionary('fr');
+    expect(loadTranslations).toHaveBeenCalledTimes(1);
+    expect(loadDictionary).toHaveBeenCalledTimes(1);
+  });
+
+  it('expires loaded dictionaries after the default TTL and reloads on demand', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+    const loadDictionary = vi
+      .fn()
+      .mockResolvedValueOnce({ greeting: 'Bonjour' })
+      .mockResolvedValueOnce({ greeting: 'Salut' });
+    const cache = createCache({
+      dictionary: { greeting: 'Hello' },
+      loadDictionary,
+    });
+
+    // Two loads within the TTL share one loader call
+    await cache.loadDictionary('fr');
+    await cache.loadDictionary('fr');
+    expect(loadDictionary).toHaveBeenCalledTimes(1);
+    expect(cache.lookupDictionary('fr', 'greeting')).toEqual({
+      entry: 'Bonjour',
+      options: {},
+    });
+
+    // Past the default TTL: sync lookups miss
+    vi.advanceTimersByTime(DEFAULT_TTL + 1);
+    expect(cache.lookupDictionary('fr', 'greeting')).toBeUndefined();
+
+    const reloaded = await cache.loadDictionary('fr');
+    expect(loadDictionary).toHaveBeenCalledTimes(2);
+    expect(reloaded).toEqual({ greeting: 'Salut' });
+    expect(cache.lookupDictionary('fr', 'greeting')).toEqual({
+      entry: 'Salut',
+      options: {},
+    });
+  });
+
+  it('never expires the default-locale source dictionary', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+    const loadDictionary = vi.fn().mockResolvedValue({ greeting: 'Bonjour' });
+    const cache = createCache({
+      dictionary: { greeting: 'Hello' },
+      loadDictionary,
+    });
+
+    vi.advanceTimersByTime(999_999_999);
+
+    expect(cache.lookupDictionary('en', 'greeting')).toEqual({
+      entry: 'Hello',
+      options: {},
+    });
+    await expect(cache.loadDictionary('en')).resolves.toEqual({
+      greeting: 'Hello',
+    });
+    expect(loadDictionary).not.toHaveBeenCalled();
+  });
+
+  it('starts the TTL when the load resolves, not when it starts', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+    let resolveTranslations!: (translations: Record<string, string>) => void;
+    const loadTranslations = vi.fn().mockReturnValue(
+      new Promise((resolve) => {
+        resolveTranslations = resolve;
+      })
+    );
+    const cache = createCache({
+      cacheExpiryTime: 5000,
+      loadTranslations,
+    });
+
+    const loadPromise = cache.loadTranslations('fr');
+    vi.advanceTimersByTime(4000);
+    resolveTranslations({ [expectedHash]: translatedString });
+    await loadPromise;
+
+    // 4999ms after the load resolved: still cached
+    vi.advanceTimersByTime(4999);
+    expect(cache.lookupTranslation('fr', message, lookupOptions)).toBe(
+      translatedString
+    );
+
+    // Past the TTL measured from resolution: expired
+    vi.advanceTimersByTime(2);
+    expect(
+      cache.lookupTranslation('fr', message, lookupOptions)
+    ).toBeUndefined();
+  });
+
+  it('deduplicates concurrent loads for the same locale', async () => {
+    const loadTranslations = vi
+      .fn()
+      .mockResolvedValue({ [expectedHash]: translatedString });
+    const loadDictionary = vi.fn().mockResolvedValue({ greeting: 'Bonjour' });
+    const cache = createCache({
+      loadTranslations,
+      dictionary: { greeting: 'Hello' },
+      loadDictionary,
+    });
+
+    const [translationsA, translationsB] = await Promise.all([
+      cache.loadTranslations('fr'),
+      cache.loadTranslations('fr'),
+    ]);
+    const [dictionaryA, dictionaryB] = await Promise.all([
+      cache.loadDictionary('fr'),
+      cache.loadDictionary('fr'),
+    ]);
+
+    expect(loadTranslations).toHaveBeenCalledTimes(1);
+    expect(loadDictionary).toHaveBeenCalledTimes(1);
+    expect(translationsA).toEqual(translationsB);
+    expect(dictionaryA).toEqual(dictionaryB);
+  });
+
+  it('deduplicates concurrent runtime-translation misses for the same message', async () => {
+    const unknownMessage = 'Unknown message';
+    const unknownOptions: LookupOptions = { $format: 'ICU' };
+    const unknownHash = hashMessage(unknownMessage, unknownOptions);
+    const translateManySpy = vi
+      .spyOn(GTRuntime.prototype, 'translateMany')
+      .mockResolvedValue({
+        [unknownHash]: {
+          success: true,
+          translation: 'Message inconnu',
+        },
+      } as Awaited<ReturnType<GTRuntime['translateMany']>>);
+    const cache = createCache({
+      loadTranslations: vi.fn().mockResolvedValue({}),
+      runtimeTranslation: {},
+    });
+
+    const [first, second] = await Promise.all([
+      cache.lookupTranslationWithFallback('fr', unknownMessage, unknownOptions),
+      cache.lookupTranslationWithFallback('fr', unknownMessage, unknownOptions),
+    ]);
+
+    expect(first).toBe('Message inconnu');
+    expect(second).toBe('Message inconnu');
+    expect(translateManySpy).toHaveBeenCalledTimes(1);
+    const [sources] = translateManySpy.mock.calls[0];
+    expect(Object.keys(sources)).toEqual([unknownHash]);
+  });
+});

--- a/packages/i18n/src/i18n-cache/__tests__/I18nCache.contract.lookup.test.ts
+++ b/packages/i18n/src/i18n-cache/__tests__/I18nCache.contract.lookup.test.ts
@@ -75,12 +75,10 @@ function spyOnTranslateMany() {
 }
 
 describe('I18nCache contract: lookup API', () => {
+  // Every test initializes the I18nConfig singleton through createCache(), so
+  // beforeEach only resets shared state.
   beforeEach(() => {
     resetGTGlobals();
-    initializeI18nConfig({
-      defaultLocale: 'en',
-      locales: ['en', 'fr', 'es'],
-    });
     vi.clearAllMocks();
   });
 

--- a/packages/i18n/src/i18n-cache/__tests__/I18nCache.contract.lookup.test.ts
+++ b/packages/i18n/src/i18n-cache/__tests__/I18nCache.contract.lookup.test.ts
@@ -1,0 +1,436 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { GTRuntime } from 'generaltranslation/runtime';
+import { I18nCache } from '../I18nCache';
+import type { TranslationsCacheMissEvent } from '../I18nCache';
+import { hashMessage } from '../../utils/hashMessage';
+import { LookupOptions } from '../../translation-functions/types/options';
+import { initializeI18nConfig } from '../../i18n-config/singleton-operations';
+
+/**
+ * Contract tests for the I18nCache PUBLIC boundary (lookup API).
+ *
+ * These tests lock in the observable behavior consumers rely on so that the
+ * internals (translations-manager, validation, loaders) can be restructured
+ * freely. They must only exercise the I18nCache class itself (public methods
+ * plus the protected onTranslationsCacheMiss hook) and stable helpers
+ * (hashMessage, initializeI18nConfig). Do not import from or mock internal
+ * module paths; runtime translation is observed by spying on
+ * GTRuntime.prototype.translateMany.
+ */
+
+const message = 'Hello {name}!';
+const lookupOptions: LookupOptions = {
+  $format: 'ICU',
+  $context: 'greeting',
+};
+const expectedHash = hashMessage(message, lookupOptions);
+const translatedString = 'Bonjour {name} !';
+
+type TestGlobal = typeof globalThis & {
+  __generaltranslation?: unknown;
+};
+
+class TestI18nCache extends I18nCache {
+  setTranslationsCacheMissListener(
+    listener: (event: TranslationsCacheMissEvent) => void
+  ) {
+    this.onTranslationsCacheMiss = listener;
+  }
+}
+
+function resetGTGlobals() {
+  Reflect.deleteProperty(globalThis as TestGlobal, '__generaltranslation');
+}
+
+function createCache(overrides: Record<string, unknown> = {}) {
+  const {
+    defaultLocale = 'en',
+    locales = ['en', 'fr', 'es'],
+    projectId,
+    devApiKey,
+    ...cacheOverrides
+  } = overrides;
+  resetGTGlobals();
+  initializeI18nConfig({
+    defaultLocale: defaultLocale as string,
+    locales: locales as string[],
+    projectId: projectId as string | undefined,
+    devApiKey: devApiKey as string | undefined,
+  });
+
+  return new TestI18nCache({
+    loadTranslations: vi
+      .fn()
+      .mockResolvedValue({ [expectedHash]: translatedString }),
+    projectId: projectId as string | undefined,
+    devApiKey: devApiKey as string | undefined,
+    ...cacheOverrides,
+  });
+}
+
+function spyOnTranslateMany() {
+  return vi
+    .spyOn(GTRuntime.prototype, 'translateMany')
+    .mockResolvedValue({} as never);
+}
+
+describe('I18nCache contract: lookup API', () => {
+  beforeEach(() => {
+    resetGTGlobals();
+    initializeI18nConfig({
+      defaultLocale: 'en',
+      locales: ['en', 'fr', 'es'],
+    });
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    resetGTGlobals();
+    vi.useRealTimers();
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  // ===== getVersionId() ===== //
+
+  it('getVersionId() returns the _versionId passed to the constructor', () => {
+    const cache = createCache({ _versionId: 'version-abc' });
+
+    expect(cache.getVersionId()).toBe('version-abc');
+  });
+
+  it('getVersionId() returns undefined when no _versionId was provided', () => {
+    const cache = createCache();
+
+    expect(cache.getVersionId()).toBeUndefined();
+  });
+
+  // ===== updateTranslations() ===== //
+
+  it('updateTranslations() seeds a new locale for synchronous lookups', () => {
+    const cache = createCache();
+
+    expect(
+      cache.lookupTranslation('es', message, lookupOptions)
+    ).toBeUndefined();
+
+    cache.updateTranslations({
+      es: { [expectedHash]: 'Hola {name}!' },
+    });
+
+    expect(cache.lookupTranslation('es', message, lookupOptions)).toBe(
+      'Hola {name}!'
+    );
+  });
+
+  it('updateTranslations() merges into an already-loaded locale', async () => {
+    const otherMessage = 'Goodbye {name}!';
+    const otherOptions: LookupOptions = { $format: 'ICU' };
+    const otherHash = hashMessage(otherMessage, otherOptions);
+    const cache = createCache();
+
+    await cache.loadTranslations('fr');
+
+    cache.updateTranslations({
+      fr: { [otherHash]: 'Au revoir {name} !' },
+    });
+
+    // New hash added, previously loaded hash retained
+    expect(cache.lookupTranslation('fr', otherMessage, otherOptions)).toBe(
+      'Au revoir {name} !'
+    );
+    expect(cache.lookupTranslation('fr', message, lookupOptions)).toBe(
+      translatedString
+    );
+
+    // Updating the same hash overwrites the existing translation
+    cache.updateTranslations({
+      fr: { [expectedHash]: 'Salut {name} !' },
+    });
+    expect(cache.lookupTranslation('fr', message, lookupOptions)).toBe(
+      'Salut {name} !'
+    );
+  });
+
+  it('updateTranslations() does not fire onTranslationsCacheMiss', async () => {
+    const cache = createCache();
+    const onTranslationsCacheMiss = vi.fn();
+    cache.setTranslationsCacheMissListener(onTranslationsCacheMiss);
+
+    cache.updateTranslations({
+      es: { [expectedHash]: 'Hola {name}!' },
+    });
+    await cache.loadTranslations('fr');
+    cache.updateTranslations({
+      fr: { [expectedHash]: 'Salut {name} !' },
+    });
+
+    expect(onTranslationsCacheMiss).not.toHaveBeenCalled();
+  });
+
+  // ===== getLookupTranslation() ===== //
+
+  it('getLookupTranslation() returns an identity resolver for the default locale', async () => {
+    const loadTranslations = vi.fn().mockResolvedValue({});
+    const cache = createCache({ loadTranslations });
+
+    const resolver = await cache.getLookupTranslation('en');
+
+    expect(resolver(message, lookupOptions)).toBe(message);
+    // Even unknown messages come back unchanged, with no load attempted
+    expect(resolver('Anything at all')).toBe('Anything at all');
+    expect(loadTranslations).not.toHaveBeenCalled();
+  });
+
+  it('getLookupTranslation() resolver resolves loaded translations and misses unknown hashes', async () => {
+    const cache = createCache();
+
+    const resolver = await cache.getLookupTranslation('fr');
+
+    expect(resolver(message, lookupOptions)).toBe(translatedString);
+    expect(resolver('Not translated', { $format: 'ICU' })).toBeUndefined();
+  });
+
+  it('getLookupTranslation() resolver honors options.$locale for other loaded locales', async () => {
+    const loadTranslations = vi
+      .fn()
+      .mockImplementation(async (locale: string) => ({
+        [expectedHash]: locale === 'fr' ? translatedString : 'Hola {name}!',
+      }));
+    const cache = createCache({ loadTranslations });
+
+    const resolver = await cache.getLookupTranslation('fr');
+    // Load the other locale so the override can resolve synchronously
+    await cache.loadTranslations('es');
+
+    expect(resolver(message, lookupOptions)).toBe(translatedString);
+    expect(resolver(message, { ...lookupOptions, $locale: 'es' })).toBe(
+      'Hola {name}!'
+    );
+  });
+
+  it('getLookupTranslation() resolver returns undefined for an unloaded $locale override', async () => {
+    const cache = createCache();
+
+    const resolver = await cache.getLookupTranslation('fr');
+
+    expect(
+      resolver(message, { ...lookupOptions, $locale: 'es' })
+    ).toBeUndefined();
+  });
+
+  it('getLookupTranslation() resolver returns the message for a default-locale $locale override', async () => {
+    const cache = createCache();
+
+    const resolver = await cache.getLookupTranslation('fr');
+
+    expect(resolver(message, { ...lookupOptions, $locale: 'en' })).toBe(
+      message
+    );
+  });
+
+  it('getLookupTranslation() resolver exposes a prefetchEntries function', async () => {
+    const cache = createCache();
+
+    const resolver = await cache.getLookupTranslation('fr');
+
+    expect(typeof resolver.prefetchEntries).toBe('function');
+  });
+
+  // ===== prefetchEntries ===== //
+
+  it('prefetchEntries is a no-op when dev hot reload is disabled', async () => {
+    const translateManySpy = spyOnTranslateMany();
+    const cache = createCache({
+      loadTranslations: vi.fn().mockResolvedValue({}),
+    });
+
+    const resolver = await cache.getLookupTranslation('fr');
+    await resolver.prefetchEntries?.([{ message, options: lookupOptions }]);
+
+    expect(translateManySpy).not.toHaveBeenCalled();
+    expect(resolver(message, lookupOptions)).toBeUndefined();
+  });
+
+  it('prefetchEntries runtime-translates missing entries when dev hot reload is enabled', async () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    const translateManySpy = spyOnTranslateMany().mockResolvedValue({
+      [expectedHash]: {
+        success: true,
+        translation: 'Préchargé {name} !',
+      },
+    } as never);
+    const cache = createCache({
+      projectId: 'test-project',
+      devApiKey: 'gtx-dev-key',
+      loadTranslations: vi.fn().mockResolvedValue({}),
+    });
+
+    const resolver = await cache.getLookupTranslation('fr');
+    await resolver.prefetchEntries?.([{ message, options: lookupOptions }]);
+
+    expect(translateManySpy).toHaveBeenCalledTimes(1);
+    const [sources, requestOptions] = translateManySpy.mock.calls[0];
+    expect(Object.keys(sources as object)).toEqual([expectedHash]);
+    expect(requestOptions).toMatchObject({ targetLocale: 'fr' });
+    // The prefetched translation is now available synchronously
+    expect(resolver(message, lookupOptions)).toBe('Préchargé {name} !');
+  });
+
+  it('prefetchEntries drops entries for other locales and warns', async () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const otherMessage = 'Other message';
+    const otherOptions: LookupOptions = { $format: 'ICU', $locale: 'es' };
+    const translateManySpy = spyOnTranslateMany().mockResolvedValue({
+      [expectedHash]: {
+        success: true,
+        translation: 'Préchargé {name} !',
+      },
+    } as never);
+    const cache = createCache({
+      projectId: 'test-project',
+      devApiKey: 'gtx-dev-key',
+      loadTranslations: vi.fn().mockResolvedValue({}),
+    });
+
+    const resolver = await cache.getLookupTranslation('fr');
+    await resolver.prefetchEntries?.([
+      { message, options: lookupOptions },
+      { message: otherMessage, options: otherOptions },
+    ]);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('prefetchEntries must all be the same locale')
+    );
+    // Only the matching-locale entry is requested
+    expect(translateManySpy).toHaveBeenCalledTimes(1);
+    const [sources] = translateManySpy.mock.calls[0];
+    expect(Object.keys(sources as object)).toEqual([expectedHash]);
+  });
+
+  it('prefetchEntries does not re-request entries already in the cache', async () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    const translateManySpy = spyOnTranslateMany();
+    const cache = createCache({
+      projectId: 'test-project',
+      devApiKey: 'gtx-dev-key',
+    });
+
+    const resolver = await cache.getLookupTranslation('fr');
+    await resolver.prefetchEntries?.([{ message, options: lookupOptions }]);
+
+    expect(translateManySpy).not.toHaveBeenCalled();
+    expect(resolver(message, lookupOptions)).toBe(translatedString);
+  });
+
+  // ===== getLookupDictionary() ===== //
+
+  it('getLookupDictionary() resolves the source dictionary for the default locale', async () => {
+    const loadDictionary = vi.fn().mockResolvedValue({});
+    const cache = createCache({
+      dictionary: {
+        greeting: 'Hello',
+        user: {
+          profile: {
+            name: 'Name',
+          },
+        },
+      },
+      loadDictionary,
+    });
+
+    const { lookupDictionary, lookupDictionaryObj } =
+      await cache.getLookupDictionary('en');
+
+    expect(lookupDictionary('greeting')).toEqual({
+      entry: 'Hello',
+      options: {},
+    });
+    expect(lookupDictionaryObj('user.profile')).toEqual({
+      name: 'Name',
+    });
+    expect(loadDictionary).not.toHaveBeenCalled();
+  });
+
+  it('getLookupDictionary() resolves the loaded target dictionary for a translated locale', async () => {
+    const cache = createCache({
+      dictionary: {
+        greeting: 'Hello',
+        user: {
+          profile: {
+            name: 'Name',
+          },
+        },
+      },
+      loadDictionary: vi.fn().mockResolvedValue({
+        greeting: 'Bonjour',
+        user: {
+          profile: {
+            name: 'Nom',
+          },
+        },
+      }),
+    });
+
+    const { lookupDictionary, lookupDictionaryObj } =
+      await cache.getLookupDictionary('fr');
+
+    expect(lookupDictionary('greeting')).toEqual({
+      entry: 'Bonjour',
+      options: {},
+    });
+    expect(lookupDictionaryObj('user.profile')).toEqual({
+      name: 'Nom',
+    });
+  });
+
+  it('getLookupDictionary() resolvers return undefined for missing ids', async () => {
+    const cache = createCache({
+      dictionary: {
+        greeting: 'Hello',
+      },
+      loadDictionary: vi.fn().mockResolvedValue({
+        greeting: 'Bonjour',
+      }),
+    });
+
+    const defaultResolvers = await cache.getLookupDictionary('en');
+    const targetResolvers = await cache.getLookupDictionary('fr');
+
+    expect(defaultResolvers.lookupDictionary('missing')).toBeUndefined();
+    expect(defaultResolvers.lookupDictionaryObj('missing')).toBeUndefined();
+    expect(targetResolvers.lookupDictionary('missing.path')).toBeUndefined();
+    expect(targetResolvers.lookupDictionaryObj('missing.path')).toBeUndefined();
+  });
+
+  // ===== lookupTranslation() with options.$locale ===== //
+
+  it('lookupTranslation() selects the cache by positional locale, not options.$locale', async () => {
+    // current behavior: options.$locale does not redirect lookupTranslation();
+    // the positional locale argument alone decides which locale cache is read
+    // (and whether the message is returned as-is for the default locale).
+    const loadTranslations = vi
+      .fn()
+      .mockImplementation(async (locale: string) => ({
+        [expectedHash]: locale === 'fr' ? translatedString : 'Hola {name}!',
+      }));
+    const cache = createCache({ loadTranslations });
+
+    await cache.loadTranslations('fr');
+    await cache.loadTranslations('es');
+
+    expect(
+      cache.lookupTranslation('fr', message, {
+        ...lookupOptions,
+        $locale: 'es',
+      })
+    ).toBe(translatedString);
+    expect(
+      cache.lookupTranslation('en', message, {
+        ...lookupOptions,
+        $locale: 'fr',
+      })
+    ).toBe(message);
+  });
+});


### PR DESCRIPTION
## Summary

Adds 56 characterization tests (4 files) that lock the observable behavior of the `I18nCache` public boundary so the internal cache layers can be simplified safely:

- `I18nCache.contract.lookup.test.ts` — `getLookupTranslation()` resolvers (incl. `$locale` overrides and expiry-immune snapshots), `getLookupDictionary()`, `updateTranslations()` merge semantics, prefetch gating/filtering, `getVersionId()`
- `I18nCache.contract.config.test.ts` — constructor validation (throw + warning surface), translation-loader routing (custom loader, GT remote URL shapes incl. `_versionId`/`_branchId`, warn-once fallbacks, `cacheUrl: null` opt-out), and runtime-translation plumbing (timeout, metadata, target-locale resolution, batch splitting) via a `GTRuntime.prototype.translateMany` spy
- `I18nCache.contract.expiry.test.ts` — TTL semantics (default 60s, `null` never expires, TTL starts at load resolution), never-expiring default-locale source dictionary, in-flight load/miss dedupe
- `I18nCache.contract.errors.test.ts` — production log-and-fallback vs development throw, `DictionarySourceNotFoundError` propagation in both modes, loader and `translateMany` failure surfaces

The tests exercise only the public API plus external seams (`GTRuntime.prototype.translateMany`, global `fetch`, console) and import nothing from the internal `translations-manager/`, `validation/`, or loader modules, so restructuring those internals cannot silently change consumer-visible behavior.

First PR of a small gt-i18n bundle-size stack; the follow-up refactors build on these tests.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds 56 characterization/contract tests across 4 new test files that lock in the observable public-boundary behavior of `I18nCache` before planned internal refactoring. All tests exercise the class exclusively through its public API and permitted seams (`GTRuntime.prototype.translateMany`, global `fetch`, `console`), with no imports from internal modules.

- **`I18nCache.contract.lookup.test.ts`** — covers `getLookupTranslation` resolvers (identity for default locale, `$locale` override, snapshot semantics), `getLookupDictionary`, `updateTranslations` merge/seed behavior, `prefetchEntries` gating/filtering, and `getVersionId`.
- **`I18nCache.contract.config.test.ts`** — covers constructor validation surface, translation-loader routing (custom loader, GT remote URL shapes including `_versionId`/`_branchId`, warn-once fallbacks, `cacheUrl: null` opt-out), and runtime-translation plumbing (timeout, metadata, locale resolution, batch splitting) via a `GTRuntime.prototype.translateMany` spy.
- **`I18nCache.contract.expiry.test.ts`** — covers TTL semantics (default 60 s, `null` never-expires, TTL starts at load resolution, never-expiring default-locale source dictionary), and in-flight load/miss deduplication.
- **`I18nCache.contract.errors.test.ts`** — covers production log-and-fallback vs development throw, `DictionarySourceNotFoundError` propagation, loader failure surfaces, and `translateMany` rejection/`success:false` handling.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Pure test addition with no production code changes — safe to merge.

All four files are new test files with no changes to production code. The tests are well-structured, use proper setup/teardown with vi.restoreAllMocks() and vi.useRealTimers(), and exercise only the public API plus approved seams. Previous review concerns (lookupDictionaryObj dev-mode gap, batch-split ordering brittleness, redundant beforeEach initConfig) have all been addressed in the head commit.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/i18n/src/i18n-cache/__tests__/I18nCache.contract.lookup.test.ts | 434-line contract test file covering lookup API: resolver identity for default locale, $locale override behavior, prefetchEntries gating (dev-only), dictionary lookup resolvers, updateTranslations merge semantics, and getVersionId. TestI18nCache subclass exposes protected onTranslationsCacheMiss hook cleanly. |
| packages/i18n/src/i18n-cache/__tests__/I18nCache.contract.config.test.ts | 419-line contract test file covering constructor validation surface, translation-loader routing (custom loader, default GT URL, _versionId/_branchId, cacheUrl variants, warn-once fallbacks), and runtime-translation plumbing including timeout, metadata pass-through, locale resolution, and batch-split semantics. |
| packages/i18n/src/i18n-cache/__tests__/I18nCache.contract.expiry.test.ts | 270-line contract test file covering TTL semantics (default 60 s, null never-expires), TTL-start-at-resolution behavior, never-expiring default-locale source dictionary, and in-flight deduplication for both translations and runtime-translation misses. Uses vi.useFakeTimers() with proper afterEach teardown. |
| packages/i18n/src/i18n-cache/__tests__/I18nCache.contract.errors.test.ts | 247-line contract test file covering production log-and-fallback vs development throw (locale validation, loader failures, translateMany rejection/success:false), DictionarySourceNotFoundError propagation in both modes, and the target-subtree-present fallback for lookupDictionaryObjWithFallback. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test(gt-i18n): address review feedback o..."](https://github.com/generaltranslation/gt/commit/55df35bfd9c4693efe8de3a9eec44e7aa400607a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44008062)</sub>

<!-- /greptile_comment -->