### PR TITLE
fix: accept gt config objects in runtime options

### DIFF
--- a/.changeset/calm-tools-config.md
+++ b/.changeset/calm-tools-config.md
@@ -1,0 +1,7 @@
+---
+'@generaltranslation/compiler': patch
+'gt-i18n': patch
+'gt-react': patch
+---
+
+Accept parsed `gt.config.json` objects in the compiler and React SPA configuration types.

--- a/packages/compiler/src/__tests__/index.test.ts
+++ b/packages/compiler/src/__tests__/index.test.ts
@@ -152,6 +152,35 @@ describe('gtUnplugin config loading', () => {
     }
   });
 
+  it('accepts a parsed gt.config.json as top-level options', async () => {
+    const cwd = createTempDir();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      const output = await transformWithPlugin(
+        {
+          defaultLocale: 'en',
+          locales: ['en', 'es'],
+          files: {
+            gt: {
+              output: 'src/_gt/[locale].json',
+              parsingFlags: {
+                enableAutoJsxInjection: true,
+              },
+            },
+          },
+          _versionId: 'test-version',
+        },
+        cwd
+      );
+
+      expect(output).toContain('GtInternalTranslateJsx');
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   it('preserves default behavior when auto-loaded gt.config.json has ordinary project settings', async () => {
     const cwd = createTempDir();
     writeGTConfig(cwd, {

--- a/packages/compiler/src/__tests__/index.test.ts
+++ b/packages/compiler/src/__tests__/index.test.ts
@@ -181,6 +181,39 @@ describe('gtUnplugin config loading', () => {
     }
   });
 
+  it('merges partial top-level options with the auto-loaded config', async () => {
+    const cwd = createTempDir();
+    writeGTConfig(cwd, {
+      files: {
+        gt: {
+          parsingFlags: {
+            enableAutoJsxInjection: true,
+          },
+        },
+      },
+    });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      const output = await transformWithPlugin(
+        {
+          defaultLocale: 'en',
+          files: {
+            gt: {
+              output: 'src/_gt/[locale].json',
+            },
+          },
+        },
+        cwd
+      );
+
+      expect(output).toContain('GtInternalTranslateJsx');
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   it('preserves default behavior when auto-loaded gt.config.json has ordinary project settings', async () => {
     const cwd = createTempDir();
     writeGTConfig(cwd, {

--- a/packages/compiler/src/config.ts
+++ b/packages/compiler/src/config.ts
@@ -7,9 +7,14 @@ export type LogLevel = 'silent' | 'error' | 'warn' | 'info' | 'debug';
 /**
  * The only relevant parts of the GT config that we are concerned with
  */
-type GTConfig = {
+export type GTConfig = {
+  defaultLocale?: string;
+  locales?: string[];
+  projectId?: string;
+  _versionId?: string;
   files?: {
     gt?: {
+      output?: string;
       parsingFlags?: {
         enableAutoJsxInjection?: boolean;
         autoderive?: boolean | { jsx?: boolean; strings?: boolean };

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -6,7 +6,7 @@ import generate from '@babel/generator';
 import traverse from '@babel/traverse';
 
 // Core modules
-import { PluginConfig } from './config';
+import { GTConfig, PluginConfig } from './config';
 
 // Import passes
 import { collectionPass } from './passes/collectionPass';
@@ -62,9 +62,7 @@ import { runtimeTranslatePass } from './passes/runtimeTranslatePass';
 /**
  * GT Universal Plugin Options
  */
-export interface GTUnpluginOptions extends PluginConfig {
-  // Inherits from PluginConfig
-}
+export interface GTUnpluginOptions extends PluginConfig, GTConfig {}
 
 export const MISSING_GT_CONFIG_WARNING =
   '[@generaltranslation/compiler] No gtConfig found. Auto JSX injection and parsingFlags features require a gt.config.json. See https://generaltranslation.com/en/docs/react/concepts/compiler.';
@@ -113,6 +111,16 @@ function loadGTConfigFromCwd(): GTConfigLoadResult {
   }
 }
 
+function hasInlineGTConfig(options: GTUnpluginOptions): boolean {
+  return (
+    options.defaultLocale !== undefined ||
+    options.locales !== undefined ||
+    options.projectId !== undefined ||
+    options._versionId !== undefined ||
+    options.files !== undefined
+  );
+}
+
 /**
  * GT Universal Plugin - Main entry point
  *
@@ -123,7 +131,9 @@ const gtUnplugin = createUnplugin<GTUnpluginOptions | undefined>(
   (options = {}) => {
     const gtConfigLoadResult = options.gtConfig
       ? ({ gtConfig: options.gtConfig, status: 'loaded' } as const)
-      : loadGTConfigFromCwd();
+      : hasInlineGTConfig(options)
+        ? ({ gtConfig: options, status: 'loaded' } as const)
+        : loadGTConfigFromCwd();
     const loadedGTConfig =
       gtConfigLoadResult.status === 'loaded'
         ? gtConfigLoadResult.gtConfig

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -121,6 +121,61 @@ function hasInlineGTConfig(options: GTUnpluginOptions): boolean {
   );
 }
 
+function getInlineGTConfig(options: GTUnpluginOptions): GTConfig | undefined {
+  if (!hasInlineGTConfig(options)) return undefined;
+
+  return {
+    ...(options.defaultLocale !== undefined
+      ? { defaultLocale: options.defaultLocale }
+      : {}),
+    ...(options.locales !== undefined ? { locales: options.locales } : {}),
+    ...(options.projectId !== undefined
+      ? { projectId: options.projectId }
+      : {}),
+    ...(options._versionId !== undefined
+      ? { _versionId: options._versionId }
+      : {}),
+    ...(options.files !== undefined ? { files: options.files } : {}),
+  };
+}
+
+function mergeGTConfigs(base: GTConfig, override: GTConfig): GTConfig {
+  const mergedConfig = { ...base, ...override };
+  if (!base.files && !override.files) return mergedConfig;
+
+  const files = { ...base.files, ...override.files };
+  if (base.files?.gt || override.files?.gt) {
+    const gt = { ...base.files?.gt, ...override.files?.gt };
+    if (base.files?.gt?.parsingFlags || override.files?.gt?.parsingFlags) {
+      gt.parsingFlags = {
+        ...base.files?.gt?.parsingFlags,
+        ...override.files?.gt?.parsingFlags,
+      };
+    }
+    files.gt = gt;
+  }
+
+  return { ...mergedConfig, files };
+}
+
+function resolveGTConfig(options: GTUnpluginOptions): GTConfigLoadResult {
+  if (options.gtConfig) {
+    return { gtConfig: options.gtConfig, status: 'loaded' };
+  }
+
+  const inlineGTConfig = getInlineGTConfig(options);
+  const diskGTConfig = loadGTConfigFromCwd();
+  if (!inlineGTConfig) return diskGTConfig;
+
+  return {
+    gtConfig:
+      diskGTConfig.status === 'loaded'
+        ? mergeGTConfigs(diskGTConfig.gtConfig, inlineGTConfig)
+        : inlineGTConfig,
+    status: 'loaded',
+  };
+}
+
 /**
  * GT Universal Plugin - Main entry point
  *
@@ -129,11 +184,7 @@ function hasInlineGTConfig(options: GTUnpluginOptions): boolean {
  */
 const gtUnplugin = createUnplugin<GTUnpluginOptions | undefined>(
   (options = {}) => {
-    const gtConfigLoadResult = options.gtConfig
-      ? ({ gtConfig: options.gtConfig, status: 'loaded' } as const)
-      : hasInlineGTConfig(options)
-        ? ({ gtConfig: options, status: 'loaded' } as const)
-        : loadGTConfigFromCwd();
+    const gtConfigLoadResult = resolveGTConfig(options);
     const loadedGTConfig =
       gtConfigLoadResult.status === 'loaded'
         ? gtConfigLoadResult.gtConfig

--- a/packages/i18n/src/config/types.ts
+++ b/packages/i18n/src/config/types.ts
@@ -44,6 +44,7 @@ export type GTConfig = {
   // parsing options (shared with compiler via gt.config.json)
   files?: {
     gt?: {
+      output?: string;
       parsingFlags?: {
         /**
          * Dev hot reload config, gt-react browser runtime only.


### PR DESCRIPTION
## Summary
- accept parsed gt.config.json objects directly in compiler plugin adapters and normalize them into compiler config
- allow files.gt.output in shared runtime config types so gt.config.json can be spread into initializeGTSPA
- add compiler regression coverage and release changesets

## Testing
- pnpm --filter @generaltranslation/compiler test
- pnpm --filter @generaltranslation/compiler typecheck
- pnpm --filter gt-i18n typecheck
- pnpm --filter gt-react typecheck
- focused builds for @generaltranslation/compiler, gt-i18n, and gt-react
- linked gt-test-apps/base/vite-react to this worktree: pnpm typecheck and pnpm build
- git diff --check

Full workspace build reached gt-next and stopped because cargo is unavailable in this environment; all affected package builds passed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR lets parsed GT config objects flow into compiler and runtime options. The main changes are:

- Accept top-level GT config fields in compiler plugin options.
- Merge partial inline GT config with the auto-loaded disk config.
- Add `files.gt.output` to shared runtime config types.
- Add compiler tests for parsed and partial config handling.
- Add patch changesets for the affected packages.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/compiler/src/index.ts | Adds config resolution helpers that merge top-level GT config fields with disk config when both are present. |
| packages/compiler/src/config.ts | Exports the compiler GT config type and adds the top-level fields needed by parsed config objects. |
| packages/i18n/src/config/types.ts | Allows `files.gt.output` in the shared runtime config type. |
| packages/compiler/src/__tests__/index.test.ts | Adds tests for parsed top-level config and partial inline config merging. |
| .changeset/calm-tools-config.md | Adds patch release notes for the compiler, i18n, and React packages. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(compiler): merge inline and disk con..."](https://github.com/generaltranslation/gt/commit/47830115991ef0b6a2adf94b5fd049197f84d8b2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44028149)</sub>

<!-- /greptile_comment -->