### PR TITLE
fix(next): release optional compiler peer change as patch

### DIFF
--- a/.changeset/wild-plums-search.md
+++ b/.changeset/wild-plums-search.md
@@ -1,5 +1,5 @@
 ---
-'gt-next': minor
+'gt-next': patch
 ---
 
 Make `@generaltranslation/compiler` an optional peer dependency instead of a hard dependency. It is only used by the experimental `experimentalCompilerOptions.type: 'babel'` webpack path, which already degrades gracefully with a warning when the package cannot be resolved. Users who enable the experimental babel compiler must now install `@generaltranslation/compiler` themselves; everyone else saves ~8.5MB of install weight (the compiler plus its Babel toolchain).


### PR DESCRIPTION
## Summary

- change the gt-next changeset for the optional compiler peer dependency from minor to patch
- keep the fixed React package group on an 11.0.4 patch release instead of 11.1.0
- correct the release plan shown in #1853

## Validation

- pnpm changeset status (all affected packages are patch; none are minor or major)