### PR TITLE
fix(i18n): skip interpolation in compiler-injected string prefetch calls

### DIFF
--- a/.changeset/prefetch-skip-interpolation.md
+++ b/.changeset/prefetch-skip-interpolation.md
@@ -1,0 +1,5 @@
+---
+"gt-i18n": patch
+---
+
+Skip interpolation in compiler-injected string prefetch calls so dev hot reload no longer logs "String interpolation failed" for messages with placeholders

--- a/packages/i18n/src/translation-functions/internal/__tests__/helpers.integration.test.ts
+++ b/packages/i18n/src/translation-functions/internal/__tests__/helpers.integration.test.ts
@@ -5,6 +5,7 @@ import { initializeI18nConfig } from '../../../i18n-config/singleton-operations'
 import { hashMessage } from '../../../utils/hashMessage';
 import { LookupOptions } from '../../types/options';
 import {
+  prefetchStringContentWithRuntimeFallback,
   resolveStringContentWithRuntimeFallback,
   resolveJsxWithRuntimeFallback,
 } from '../helpers';
@@ -125,6 +126,52 @@ describe('translation helpers (deep integration)', () => {
 
     expect(mockTranslateMany).toHaveBeenCalledTimes(1);
     expect(result).toEqual(translatedContent);
+  });
+
+  it('prefetchStringContentWithRuntimeFallback does not interpolate placeholder messages', async () => {
+    // Regression: compiler-injected prefetch calls (GtInternalRuntimeTranslateString)
+    // carry no variable values. Interpolating the discarded result used to warn
+    // "String interpolation failed" for every message with a placeholder.
+    const message = 'Hello {0}';
+    const options: LookupOptions = { $format: 'ICU' };
+    const hash = hashMessage(message, options);
+
+    setupManager({ [hash]: 'Bonjour {0}' });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await prefetchStringContentWithRuntimeFallback('fr', message, {
+      $format: 'ICU',
+    });
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('prefetchStringContentWithRuntimeFallback still registers missing translations', async () => {
+    const message = 'Trip for {0} guests';
+    const options: LookupOptions = { $format: 'ICU' };
+    const hash = hashMessage(message, options);
+
+    setupManager({});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    mockTranslateMany.mockResolvedValue({
+      [hash]: { success: true, translation: 'Voyage pour {0} personnes' },
+    });
+
+    const promise = prefetchStringContentWithRuntimeFallback('fr', message, {
+      $format: 'ICU',
+    });
+
+    await vi.advanceTimersByTimeAsync(50);
+    await promise;
+
+    expect(mockTranslateMany).toHaveBeenCalledTimes(1);
+    const sourcesArg = mockTranslateMany.mock.calls[0][0];
+    expect(sourcesArg[hash]).toBeDefined();
+    expect(sourcesArg[hash].source).toBe(message);
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
   });
 
   it('resolveStringContentWithRuntimeFallback falls back to source when translateMany fails', async () => {

--- a/packages/i18n/src/translation-functions/internal/__tests__/runtime-translate.test.ts
+++ b/packages/i18n/src/translation-functions/internal/__tests__/runtime-translate.test.ts
@@ -5,7 +5,7 @@ import {
   GtInternalRuntimeTranslateJsx,
   GtInternalRuntimeTranslateString,
 } from '../runtime-translate';
-import { tx } from '../tx';
+import { txPrefetch } from '../tx';
 
 vi.mock('../../../helpers/locale');
 vi.mock('../helpers');
@@ -17,10 +17,10 @@ describe('internal runtime translate helpers', () => {
     vi.mocked(getLocale).mockReturnValue('fr');
   });
 
-  it('translates strings with the compiler string format default', () => {
+  it('prefetches strings with the compiler string format default', () => {
     GtInternalRuntimeTranslateString('Hello', { $locale: 'es' });
 
-    expect(tx).toHaveBeenCalledWith('Hello', {
+    expect(txPrefetch).toHaveBeenCalledWith('Hello', {
       $format: 'ICU',
       $locale: 'es',
     });

--- a/packages/i18n/src/translation-functions/internal/helpers.ts
+++ b/packages/i18n/src/translation-functions/internal/helpers.ts
@@ -135,6 +135,27 @@ export async function resolveStringContentWithRuntimeFallback(
     sourceLocale: getI18nConfig().getDefaultLocale(),
   });
 }
+
+/**
+ * Lookup translation, fallback to runtime translate, without interpolating.
+ * For prefetch calls whose result is discarded — variable values only exist
+ * at the render-time call site, so interpolating here would fail for any
+ * message with placeholders.
+ */
+export async function prefetchStringContentWithRuntimeFallback(
+  locale: string,
+  content: StringContent,
+  options: LookupOptionsFor<StringFormat> = {}
+): Promise<void> {
+  const i18nCache = getI18nCache();
+  const lookupOptions = createLookupOptions(locale, options, 'STRING');
+  await i18nCache.lookupTranslationWithFallback(
+    lookupOptions.$locale,
+    content,
+    lookupOptions
+  );
+}
+
 /**
  * Add the default format to caller-provided lookup options.
  */

--- a/packages/i18n/src/translation-functions/internal/runtime-translate.ts
+++ b/packages/i18n/src/translation-functions/internal/runtime-translate.ts
@@ -8,7 +8,7 @@ import type {
   RuntimeTranslationOptions,
 } from '../types/options';
 import { resolveJsxWithRuntimeFallback } from './helpers';
-import { tx } from './tx';
+import { txPrefetch } from './tx';
 
 type RuntimeStringTranslationOptions = Omit<
   RuntimeTranslationOptions,
@@ -25,7 +25,10 @@ export const GtInternalRuntimeTranslateString = (
   content: string,
   options: RuntimeStringTranslationOptions = {}
 ) => {
-  return tx(content, { $format: 'ICU', ...options });
+  // Prefetch/registration only — the compiler-injected call discards the
+  // result, and variable values are unavailable here, so the translation
+  // must not be interpolated.
+  return txPrefetch(content, { $format: 'ICU', ...options });
 };
 
 export const GtInternalRuntimeTranslateJsx = (

--- a/packages/i18n/src/translation-functions/internal/tx.ts
+++ b/packages/i18n/src/translation-functions/internal/tx.ts
@@ -1,6 +1,9 @@
 import { RuntimeTranslationOptions } from '../types/options';
 import type { StringFormat } from '@generaltranslation/format/types';
-import { resolveStringContentWithRuntimeFallback } from './helpers';
+import {
+  prefetchStringContentWithRuntimeFallback,
+  resolveStringContentWithRuntimeFallback,
+} from './helpers';
 import { getI18nConfig } from '../../i18n-config/singleton-operations';
 import { getWritableConditionStore } from '../../condition-store/singleton-operations';
 
@@ -50,13 +53,45 @@ export async function txInternal({
   content: string;
   options: RuntimeTranslationOptionsWithFormat;
 }): Promise<string> {
-  const targetLocale = enableI18n
-    ? typeof options.$locale === 'string'
-      ? options.$locale
-      : locale
-    : getI18nConfig().getDefaultLocale();
+  const targetLocale = getTargetLocale({ locale, enableI18n, options });
   return resolveStringContentWithRuntimeFallback(targetLocale, content, {
     $format: 'STRING',
     ...options,
   });
+}
+
+/**
+ * Registers a message for runtime translation without interpolating the
+ * result. For compiler-injected prefetch calls: their return value is
+ * discarded and variable values only exist at the render-time call site, so
+ * interpolating here would fail for any message with placeholders.
+ */
+export async function txPrefetch(
+  content: string,
+  options: RuntimeTranslationOptionsWithFormat = {}
+): Promise<void> {
+  const conditionStore = getWritableConditionStore();
+  const locale = conditionStore.getLocale();
+  const enableI18n = conditionStore.getEnableI18n();
+  const targetLocale = getTargetLocale({ locale, enableI18n, options });
+  await prefetchStringContentWithRuntimeFallback(targetLocale, content, {
+    $format: 'STRING',
+    ...options,
+  });
+}
+
+function getTargetLocale({
+  locale,
+  enableI18n,
+  options,
+}: {
+  locale: string;
+  enableI18n: boolean;
+  options: RuntimeTranslationOptionsWithFormat;
+}): string {
+  return enableI18n
+    ? typeof options.$locale === 'string'
+      ? options.$locale
+      : locale
+    : getI18nConfig().getDefaultLocale();
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -975,7 +975,7 @@ importers:
   packages/next:
     dependencies:
       '@generaltranslation/compiler':
-        specifier: ^1.3.25
+        specifier: ^1.3.26
         version: 1.3.27
       '@generaltranslation/format':
         specifier: workspace:*


### PR DESCRIPTION
## Problem

With the compiler's `devHotReload` flag enabled, every module containing translatable strings gets a module-level prefetch injected:

```js
await Promise.all([GtInternalRuntimeTranslateString("Hello {0}", { "$_hash": "7b3fc168294a45c4" }), ...]);
```

These prefetch calls register strings for runtime translation. They carry no variable values — those only exist at the render-time call site — and their return value is discarded. But `GtInternalRuntimeTranslateString` ran the full resolve **and interpolate** pipeline, so for any message with a placeholder (t-macro output like `Hello {0}`, or `t()` messages like `Hello, {name}`), `IntlMessageFormat` threw a missing-variable error and the console filled with:

```
String interpolation failed for message: "Hello {0}".     // on en
String interpolation failed for message: "Bonjour {0}".   // on fr, after the translation resolves
```

One warning per placeholder-bearing string per locale, on every dev page load. Rendered output was unaffected — the warnings came only from the discarded prefetch results — but they made real interpolation failures impossible to distinguish from noise.

## Fix

Route the prefetch through a lookup-only path (`txPrefetch` → `prefetchStringContentWithRuntimeFallback`) that performs the cache lookup / runtime-translate registration without interpolating the discarded result.

## Validation

- Reproduced in the `vite-react` test app (gt-test-apps) with `devHotReload: true`: 8 warnings across en/fr before the fix, zero after, with identical rendered output (verified in headless Chromium in both `enableMacroTransform` modes; `t`Hello ${name}`` renders "Hello Brian" / "Bonjour Brian").
- New regression tests: prefetch of placeholder messages emits no warning, and still registers missing translations with `translateMany`.
- `pnpm test` (full repo), `pnpm lint`, `pnpm format` all pass.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes spurious "String interpolation failed" console warnings that appeared on every dev-mode page load when the compiler's `devHotReload` flag was enabled. The root cause was that compiler-injected module-level prefetch calls passed placeholder messages (e.g., `"Hello {0}"`) through the full resolve-and-interpolate pipeline even though no variable values were available and the return value was always discarded.

- **New `txPrefetch` / `prefetchStringContentWithRuntimeFallback` path** routes compiler-injected calls through a lookup-only pipeline that triggers cache registration and runtime translation without calling `interpolateMessage`, eliminating the warnings.
- **`GtInternalRuntimeTranslateString`** is updated to call `txPrefetch` instead of `tx`, changing its return type from `Promise<string>` to `Promise<void>` (correct, since compilers discard the result).
- **`getTargetLocale`** is extracted as a shared helper to deduplicate locale-resolution logic between `txInternal` and `txPrefetch`.
- Regression tests cover both the no-warning guarantee and the continued registration of missing translations via `translateMany`.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The fix is narrowly scoped to the compiler-injected prefetch path, leaving the render-time `tx` pipeline completely untouched.

The change routes compiler-injected prefetch calls through a new lookup-only path that skips interpolation. The existing `tx`/`txInternal` path is not modified, only refactored to share `getTargetLocale`. Cache registration and `translateMany` registration still occur as before, verified by integration tests. The return-type narrowing of `GtInternalRuntimeTranslateString` to `Promise<void>` is correct and intentional since compilers always discard the result.

No files require special attention. All five changed source files are straightforward and consistent with the stated intent.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/i18n/src/translation-functions/internal/helpers.ts | Adds `prefetchStringContentWithRuntimeFallback` — a lookup-only async function that skips `interpolateMessage`. Logic is correct; `createLookupOptions` still picks up the `$format` from the caller, preserving cache-key consistency. |
| packages/i18n/src/translation-functions/internal/tx.ts | Adds `txPrefetch` and extracts shared `getTargetLocale` helper; no logic changes to the existing `tx`/`txInternal` path. Refactoring is clean and duplication-free. |
| packages/i18n/src/translation-functions/internal/runtime-translate.ts | Switches `GtInternalRuntimeTranslateString` from `tx` to `txPrefetch`; return type narrows to `Promise<void>`, which is correct given the compiler discards the result. |
| packages/i18n/src/translation-functions/internal/__tests__/helpers.integration.test.ts | Two new integration tests: one asserts zero warnings for placeholder messages during prefetch; another verifies `translateMany` is still called for cache misses. Both are well-structured and cover the key regression. |
| packages/i18n/src/translation-functions/internal/__tests__/runtime-translate.test.ts | Unit test updated to assert `txPrefetch` (instead of `tx`) is called with the correct arguments; reflects the new code path accurately. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Compiler as Compiler-injected module
    participant GtInternal as GtInternalRuntimeTranslateString
    participant txP as txPrefetch
    participant prefetch as prefetchStringContentWithRuntimeFallback
    participant cache as i18nCache

    Note over Compiler: devHotReload prefetch call (result discarded)
    Compiler->>GtInternal: ""Hello {0}", { $_hash }"
    GtInternal->>txP: ""Hello {0}", { $format: ICU }"
    txP->>prefetch: "targetLocale, "Hello {0}", { $format: ICU }"
    prefetch->>cache: lookupTranslationWithFallback(...)
    cache-->>prefetch: cached translation or triggers translateMany
    prefetch-->>txP: void - no interpolation performed
    txP-->>GtInternal: void
    GtInternal-->>Compiler: Promise void - discarded

    Note over Compiler: Render-time call (result used for display)
    Compiler->>txP: tx path with variable values
    txP-->>Compiler: interpolated string e.g. Hello Brian
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Compiler as Compiler-injected module
    participant GtInternal as GtInternalRuntimeTranslateString
    participant txP as txPrefetch
    participant prefetch as prefetchStringContentWithRuntimeFallback
    participant cache as i18nCache

    Note over Compiler: devHotReload prefetch call (result discarded)
    Compiler->>GtInternal: ""Hello {0}", { $_hash }"
    GtInternal->>txP: ""Hello {0}", { $format: ICU }"
    txP->>prefetch: "targetLocale, "Hello {0}", { $format: ICU }"
    prefetch->>cache: lookupTranslationWithFallback(...)
    cache-->>prefetch: cached translation or triggers translateMany
    prefetch-->>txP: void - no interpolation performed
    txP-->>GtInternal: void
    GtInternal-->>Compiler: Promise void - discarded

    Note over Compiler: Render-time call (result used for display)
    Compiler->>txP: tx path with variable values
    txP-->>Compiler: interpolated string e.g. Hello Brian
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["chore: sync pnpm-lock.yaml with packages..."](https://github.com/generaltranslation/gt/commit/a823151edc8d982b5a1e258169d30e121e1a8a68) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44229092)</sub>

<!-- /greptile_comment -->