### PR TITLE
fix(ci): sync pnpm-lock specifier for @generaltranslation/compiler

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -975,7 +975,7 @@ importers:
   packages/next:
     dependencies:
       '@generaltranslation/compiler':
-        specifier: ^1.3.25
+        specifier: ^1.3.26
         version: 1.3.27
       '@generaltranslation/format':
         specifier: workspace:*


### PR DESCRIPTION
The release commit (#1853) bumped `packages/next`'s `@generaltranslation/compiler` dependency to `^1.3.26` without updating the lockfile's recorded specifier (still `^1.3.25`). `pnpm install --frozen-lockfile` therefore fails on main, and every PR's CI fails in the install step before lint/tests run (see e.g. #1862–#1864).

One-line lockfile regeneration via `pnpm install`; the resolved version (1.3.27) was already compatible and is unchanged.

Main's push workflow only runs Release/CodeQL, which is why this wasn't caught at merge time.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a one-line lockfile specifier mismatch that caused every CI job's `pnpm install --frozen-lockfile` step to fail after the previous release commit bumped the `@generaltranslation/compiler` dependency range in `packages/next` without regenerating the lockfile.

- The specifier in `pnpm-lock.yaml` is updated from `^1.3.25` → `^1.3.26` to match `packages/next/package.json`; the already-resolved version (1.3.27) is not changed.
- No source code, package manifests, or test files are modified — this is a pure lockfile sync.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the only change is aligning the recorded specifier with the already-resolved dependency version.

The resolved package version (1.3.27) was already present in the lockfile and is unchanged; only the specifier string is updated to reflect what packages/next/package.json actually declares. There is no dependency upgrade, no source change, and no risk of introducing new behavior.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pnpm-lock.yaml | Updates the `@generaltranslation/compiler` specifier from `^1.3.25` to `^1.3.26` to match `packages/next/package.json`; the resolved version (1.3.27) is unchanged, restoring frozen-lockfile CI compatibility. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Dev as Developer
    participant GH as GitHub CI
    participant pnpm as pnpm install
    participant Lock as pnpm-lock.yaml

    Note over Dev,Lock: Before fix — specifier mismatch
    Dev->>GH: Push / open PR
    GH->>pnpm: pnpm install --frozen-lockfile
    pnpm->>Lock: read specifier (^1.3.25)
    Lock-->>pnpm: mismatch with package.json (^1.3.26)
    pnpm-->>GH: ERR_PNPM_FROZEN_LOCKFILE_WITH_UPDATED_LOCKFILE

    Note over Dev,Lock: After fix — specifier aligned
    Dev->>GH: This PR merged
    GH->>pnpm: pnpm install --frozen-lockfile
    pnpm->>Lock: read specifier (^1.3.26)
    Lock-->>pnpm: matches package.json (^1.3.26), resolved 1.3.27
    pnpm-->>GH: Install succeeds, CI continues
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Dev as Developer
    participant GH as GitHub CI
    participant pnpm as pnpm install
    participant Lock as pnpm-lock.yaml

    Note over Dev,Lock: Before fix — specifier mismatch
    Dev->>GH: Push / open PR
    GH->>pnpm: pnpm install --frozen-lockfile
    pnpm->>Lock: read specifier (^1.3.25)
    Lock-->>pnpm: mismatch with package.json (^1.3.26)
    pnpm-->>GH: ERR_PNPM_FROZEN_LOCKFILE_WITH_UPDATED_LOCKFILE

    Note over Dev,Lock: After fix — specifier aligned
    Dev->>GH: This PR merged
    GH->>pnpm: pnpm install --frozen-lockfile
    pnpm->>Lock: read specifier (^1.3.26)
    Lock-->>pnpm: matches package.json (^1.3.26), resolved 1.3.27
    pnpm-->>GH: Install succeeds, CI continues
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): sync pnpm-lock specifier for @g..."](https://github.com/generaltranslation/gt/commit/531ed0e7048b15788477d880dfbff9c82447e2c6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44239752)</sub>

<!-- /greptile_comment -->