### PR TITLE
chore: release compiler patch

### DIFF
--- a/.changeset/silver-valley-compiler.md
+++ b/.changeset/silver-valley-compiler.md
@@ -1,0 +1,5 @@
+---
+'@generaltranslation/compiler': patch
+---
+
+Release a patch version of `@generaltranslation/compiler`.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -975,7 +975,7 @@ importers:
   packages/next:
     dependencies:
       '@generaltranslation/compiler':
-        specifier: ^1.3.25
+        specifier: ^1.3.26
         version: 1.3.27
       '@generaltranslation/format':
         specifier: workspace:*


### PR DESCRIPTION
## Summary

- add a patch changeset for `@generaltranslation/compiler`
- sync the `packages/next` compiler specifier in `pnpm-lock.yaml` after release commit #1853 changed the manifest to `^1.3.26`

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm changeset status`
- `git diff --check`