### PR TITLE
fix: recover skipped package releases

### DIFF
--- a/.changeset/silver-valley-compiler.md
+++ b/.changeset/silver-valley-compiler.md
@@ -1,5 +1,11 @@
 ---
 '@generaltranslation/compiler': patch
+'@generaltranslation/python-extractor': patch
+'@generaltranslation/react-core-linter': patch
+'@generaltranslation/supported-locales': patch
+'gt': patch
+'gt-sanity': patch
+'locadex': patch
 ---
 
-Release a patch version of `@generaltranslation/compiler`.
+Recover the stable releases skipped after the Odysseus version regression and publish the accumulated package changes under new npm versions.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
 
       - uses: pnpm/action-setup@v4
         name: Install pnpm
@@ -35,6 +37,10 @@ jobs:
           node-version: 24.18.0
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Validate release versions
+        if: startsWith(github.event.head_commit.message, '[ci] release')
+        run: pnpm run check:release-versions
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "build:release": "turbo run build:release --filter='./packages/*'",
     "bench": "turbo run bench",
     "size": "size-limit",
+    "check:release-versions": "node scripts/check-release-versions.mjs",
     "format": "oxfmt --check .",
     "format:fix": "oxfmt .",
     "changeset": "changeset",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gt",
-  "version": "2.14.53",
+  "version": "2.14.58",
   "main": "dist/index.js",
   "bin": "bin/main.js",
   "files": [

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@generaltranslation/compiler",
-  "version": "1.3.26",
+  "version": "1.3.27",
   "description": "Universal plugin for compile-time optimization of GT translation components",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/gtx-cli/package.json
+++ b/packages/gtx-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gtx-cli",
-  "version": "2.14.53",
+  "version": "2.14.58",
   "description": "CLI tool for AI-powered i18n (wrapper for gt)",
   "main": "dist/index.js",
   "bin": "bin/main.js",

--- a/packages/locadex/package.json
+++ b/packages/locadex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "locadex",
-  "version": "1.0.188",
+  "version": "1.0.193",
   "description": "An AI agent for internationalization",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/python-extractor/package.json
+++ b/packages/python-extractor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@generaltranslation/python-extractor",
-  "version": "0.2.23",
+  "version": "0.2.25",
   "description": "Python source code extraction for General Translation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gt-sanity",
-  "version": "2.0.18",
+  "version": "2.0.21",
   "description": "General Translation integration with Sanity",
   "keywords": [
     "sanity",

--- a/packages/supported-locales/package.json
+++ b/packages/supported-locales/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@generaltranslation/supported-locales",
-  "version": "2.1.3",
+  "version": "2.1.5",
   "description": "List of supported locales for General Translation",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/scripts/check-release-versions.mjs
+++ b/scripts/check-release-versions.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+
+const base = process.argv[2] ?? 'HEAD^';
+const head = process.argv[3] ?? 'HEAD';
+
+function git(...args) {
+  return execFileSync('git', args, { encoding: 'utf8' }).trim();
+}
+
+function parseStableVersion(version) {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version);
+  return match?.slice(1).map(Number);
+}
+
+function compareVersions(left, right) {
+  const leftParts = parseStableVersion(left);
+  const rightParts = parseStableVersion(right);
+
+  if (!leftParts || !rightParts) {
+    throw new Error(`Cannot compare non-stable versions: ${left} and ${right}`);
+  }
+
+  for (let index = 0; index < leftParts.length; index++) {
+    if (leftParts[index] !== rightParts[index]) {
+      return leftParts[index] - rightParts[index];
+    }
+  }
+  return 0;
+}
+
+const changedManifests = git(
+  'diff',
+  '--name-only',
+  base,
+  head,
+  '--',
+  'packages/*/package.json'
+)
+  .split('\n')
+  .filter(Boolean);
+
+const errors = [];
+
+for (const manifestPath of changedManifests) {
+  const manifest = JSON.parse(git('show', `${head}:${manifestPath}`));
+  if (manifest.private || !manifest.name || !manifest.version) continue;
+
+  const registryUrl = `https://registry.npmjs.org/${encodeURIComponent(manifest.name)}`;
+  const response = await fetch(registryUrl);
+
+  if (response.status === 404) continue;
+  if (!response.ok) {
+    throw new Error(
+      `Failed to read npm metadata for ${manifest.name}: ${response.status}`
+    );
+  }
+
+  const metadata = await response.json();
+  const latest = metadata['dist-tags']?.latest;
+
+  if (metadata.versions?.[manifest.version]) {
+    errors.push(`${manifest.name}@${manifest.version} is already published`);
+    continue;
+  }
+
+  if (latest && compareVersions(manifest.version, latest) <= 0) {
+    errors.push(
+      `${manifest.name}@${manifest.version} does not advance npm latest ${latest}`
+    );
+  }
+}
+
+if (errors.length > 0) {
+  console.error('Release version validation failed:');
+  for (const error of errors) console.error(`- ${error}`);
+  process.exit(1);
+}
+
+process.stdout.write(
+  `Validated ${changedManifests.length} changed package version${changedManifests.length === 1 ? '' : 's'}.\n`
+);

--- a/scripts/check-release-versions.mjs
+++ b/scripts/check-release-versions.mjs
@@ -18,9 +18,7 @@ function compareVersions(left, right) {
   const leftParts = parseStableVersion(left);
   const rightParts = parseStableVersion(right);
 
-  if (!leftParts || !rightParts) {
-    throw new Error(`Cannot compare non-stable versions: ${left} and ${right}`);
-  }
+  if (!leftParts || !rightParts) return undefined;
 
   for (let index = 0; index < leftParts.length; index++) {
     if (leftParts[index] !== rightParts[index]) {
@@ -33,6 +31,7 @@ function compareVersions(left, right) {
 const changedManifests = git(
   'diff',
   '--name-only',
+  '--diff-filter=AM',
   base,
   head,
   '--',
@@ -65,7 +64,10 @@ for (const manifestPath of changedManifests) {
     continue;
   }
 
-  if (latest && compareVersions(manifest.version, latest) <= 0) {
+  const versionComparison = latest
+    ? compareVersions(manifest.version, latest)
+    : undefined;
+  if (versionComparison !== undefined && versionComparison <= 0) {
     errors.push(
       `${manifest.name}@${manifest.version} does not advance npm latest ${latest}`
     );


### PR DESCRIPTION
## Summary

- align the eight skipped Odysseus package baselines with their latest npm versions
- expand the recovery changeset so the next release uses new, publishable versions
- fail `[ci] release` before publishing when a changed package version already exists or does not advance npm latest

## Affected packages

- `gt` / `gtx-cli`
- `@generaltranslation/compiler`
- `@generaltranslation/python-extractor`
- `@generaltranslation/react-core-linter`
- `@generaltranslation/supported-locales`
- `gt-sanity`
- `locadex`

The expected recovery versions are `gt` / `gtx-cli` 2.14.59, compiler 1.3.28, python-extractor 0.2.26, react-core-linter 0.1.11, supported-locales 2.1.6, gt-sanity 2.0.22, and locadex 1.0.194. Changesets also schedules the dependent fixed React/Next group at 11.0.5.

## Validation

- `pnpm changeset status`
- verified every expected recovery version is currently unused on npm
- reproduced the July 4 collision as a failure with `scripts/check-release-versions.mjs`
- `pnpm format`
- `pnpm exec oxlint scripts/check-release-versions.mjs`
- `node --check scripts/check-release-versions.mjs`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR recovers eight packages that had their npm releases skipped during the Odysseus prerelease cycle by aligning each package's in-repo baseline version to its current npm `latest`, then expanding the existing `silver-valley-compiler` changeset so the next automated release lands at the correct new versions. It also adds `scripts/check-release-versions.mjs`, a new preflight guard wired into the release workflow, which fails the `[ci] release` job before publishing whenever a bumped version already exists on npm or does not strictly advance `dist-tags.latest`.

- **Baseline realignment**: seven `package.json` files are manually advanced to the npm-published floor (e.g. `gt` 2.14.53 → 2.14.58), so changesets' pending patch bump produces the intended recovery version (2.14.59). `gtx-cli` reaches 2.14.59 automatically via its `gt: workspace:*` dependency, without a separate changeset entry.
- **Release guard script**: uses only built-in Node.js APIs (`node:child_process`, `fetch`), handles pre-release `dist-tags.latest` safely (returns `undefined` from `compareVersions` to skip the advancement check), and excludes deleted manifests via `--diff-filter=AM`.
- **Workflow wiring**: `fetch-depth: 2` is added so `HEAD^` is available; the validation step is placed before `pnpm install` for fast-fail behaviour on collision.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — version baselines are consistent with the described npm state, the new script is self-contained, and the workflow change is narrowly scoped to the [ci] release commit path.

The baseline bumps are mechanical and clearly map to the stated npm-published versions. The new script uses only built-in Node APIs, correctly handles non-stable dist-tags, and excludes deleted manifests. The workflow addition is a fast-fail guard with no side effects on normal pushes.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/check-release-versions.mjs | New guard script: validates that each changed package.json version is not already on npm and strictly advances dist-tags.latest; handles pre-release latest tags and deleted manifests correctly. |
| .github/workflows/release.yml | Adds fetch-depth:2 so HEAD^ is available to the script, and inserts the validation step before the expensive build/install steps, gated on the [ci] release commit message. |
| .changeset/silver-valley-compiler.md | Expands the existing compiler changeset to cover all six packages that had skipped Odysseus releases; description updated to explain the recovery intent. |
| packages/cli/package.json | Advances the gt baseline from 2.14.53 to 2.14.58, so the pending changeset bumps it to the intended recovery version 2.14.59. |
| packages/gtx-cli/package.json | Baseline advanced from 2.14.53 to 2.14.58; reaches 2.14.59 via changesets transitive bump through its gt workspace:* dependency. |
| packages/compiler/package.json | Baseline advanced from 1.3.26 to 1.3.27; changeset will bump to recovery target 1.3.28. |
| packages/locadex/package.json | Baseline advanced from 1.0.188 to 1.0.193; changeset will bump to recovery target 1.0.194. |
| packages/python-extractor/package.json | Baseline advanced from 0.2.23 to 0.2.25; changeset will bump to recovery target 0.2.26. |
| packages/sanity/package.json | Baseline advanced from 2.0.18 to 2.0.21; changeset will bump to recovery target 2.0.22. |
| packages/supported-locales/package.json | Baseline advanced from 2.1.3 to 2.1.5; changeset will bump to recovery target 2.1.6. |
| package.json | Adds the check:release-versions npm script that the workflow invokes. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Dev as Developer
    participant GH as GitHub / CI
    participant CS as changesets/action
    participant Script as check-release-versions.mjs
    participant NPM as npm Registry

    Dev->>GH: Merge feature PR to main
    GH->>CS: Run release workflow
    CS->>GH: Create/update [ci] release PR
    Dev->>GH: Merge [ci] release PR to main
    GH->>GH: Checkout (fetch-depth: 2)
    GH->>Script: pnpm run check:release-versions
    Script->>Script: "git diff --diff-filter=AM HEAD^ HEAD"
    loop For each changed manifest
        Script->>NPM: GET registry.npmjs.org/package
        NPM-->>Script: metadata
        alt Version already published or does not advance
            Script->>Script: Record error
        else OK
            Script->>Script: Continue
        end
    end
    alt Errors found
        Script->>GH: exit(1) blocks publish
    else All clear
        GH->>GH: pnpm install + build
        GH->>CS: publish packages
        CS->>NPM: Publish bumped versions
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Dev as Developer
    participant GH as GitHub / CI
    participant CS as changesets/action
    participant Script as check-release-versions.mjs
    participant NPM as npm Registry

    Dev->>GH: Merge feature PR to main
    GH->>CS: Run release workflow
    CS->>GH: Create/update [ci] release PR
    Dev->>GH: Merge [ci] release PR to main
    GH->>GH: Checkout (fetch-depth: 2)
    GH->>Script: pnpm run check:release-versions
    Script->>Script: "git diff --diff-filter=AM HEAD^ HEAD"
    loop For each changed manifest
        Script->>NPM: GET registry.npmjs.org/package
        NPM-->>Script: metadata
        alt Version already published or does not advance
            Script->>Script: Record error
        else OK
            Script->>Script: Continue
        end
    end
    alt Errors found
        Script->>GH: exit(1) blocks publish
    else All clear
        GH->>GH: pnpm install + build
        GH->>CS: publish packages
        CS->>NPM: Publish bumped versions
    end
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: harden release version validation"](https://github.com/generaltranslation/gt/commit/145ca3e3bb855e3e5c9b88b0b1ee84c7145c9c35) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44301553)</sub>

<!-- /greptile_comment -->