### PR TITLE
build: emit type entrypoints as declarations only

### DIFF
--- a/.changeset/large-boxes-shrink.md
+++ b/.changeset/large-boxes-shrink.md
@@ -3,4 +3,4 @@
 'gt-next': patch
 ---
 
-Stop publishing unreachable `index.types` runtime bundles. The `index.types` entry only backs the exports map's `types` conditions, so only its declaration files are ever resolved; the runtime `.cjs`/`.mjs` artifacts (and sourcemaps) were dead weight in the published package (~179KB in gt-react, ~83KB in gt-next). They are now deleted after each build.
+Convert the `index.types` entrypoints to declaration files and publish only their compiled `.d.ts` artifacts. This removes unreachable runtime bundles and sourcemaps from `gt-react` and `gt-next`.

--- a/packages/next/src/__tests__/packageExports.test.ts
+++ b/packages/next/src/__tests__/packageExports.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { pathToFileURL, fileURLToPath } from 'node:url';
 import { spawnSync } from 'node:child_process';
@@ -29,6 +29,14 @@ describe('gt-next package exports', () => {
   });
 
   const distIt = existsSync(distInitGTServerPath) ? it : it.skip;
+
+  distIt('publishes the types entrypoint as a declaration only', () => {
+    expect(
+      readdirSync(join(packageRoot, 'dist'))
+        .filter((file) => file.startsWith('index.types.'))
+        .sort()
+    ).toEqual(['index.types.d.ts']);
+  });
 
   distIt('keeps custom request functions visible to bundler aliases', () => {
     const serverBuild = readFileSync(distInitGTServerPath, 'utf8');

--- a/packages/next/src/errors/createErrors.ts
+++ b/packages/next/src/errors/createErrors.ts
@@ -93,12 +93,6 @@ export const conflictingConfigurationBuildError = (conflicts: string[]) =>
     '\n'
   )}`;
 
-export const typesFileError = createGtNextDiagnostic({
-  severity: 'Error',
-  whatHappened: 'A types-only entry point was executed at runtime',
-  fix: 'Import from the appropriate gt-next runtime entry point instead',
-});
-
 export const getTranslationsSnapshotRscError = createGtNextDiagnostic({
   severity: 'Error',
   whatHappened:

--- a/packages/next/src/index.types.d.ts
+++ b/packages/next/src/index.types.d.ts
@@ -1,4 +1,3 @@
-import { typesFileError } from './errors/createErrors';
 import { T as _T } from './server-dir/buildtime/T';
 import type {
   GetServerSideProps,
@@ -68,13 +67,11 @@ type Messages = Message[];
  *
  * @returns {JSX.Element} The provider component for General Translation context.
  */
-export function GTProvider(
+export declare function GTProvider(
   _: {
     id?: string;
   } & Partial<Parameters<typeof _GTProvider>[0]>
-): React.ReactNode {
-  throw new Error(typesFileError);
-}
+): React.ReactNode;
 
 /**
  * Build-time translation component that renders its children in the user's given locale.
@@ -105,11 +102,7 @@ export function GTProvider(
  *
  * @throws {Error} If a plural translation is requested but the `n` option is not provided.
  */
-export const T: typeof _T = () => {
-  throw new Error(typesFileError);
-};
-/** @internal _gtt - The GT transformation for the component. */
-T._gtt = 'translate';
+export declare const T: typeof _T;
 
 /**
  * The `<Currency>` component renders a formatted currency string, allowing customization of name, default value, currency type, and formatting options.
@@ -128,11 +121,7 @@ T._gtt = 'translate';
  * @param {Intl.NumberFormatOptions} [options] - Optional formatting options to customize how the currency is displayed.
  * @returns {React.JSX.Element} The formatted currency component.
  */
-export const Currency: typeof _Currency = () => {
-  throw new Error(typesFileError);
-};
-/** @internal _gtt - The GT transformation for the component. */
-Currency._gtt = 'variable-currency';
+export declare const Currency: typeof _Currency;
 
 /**
  * The `<DateTime>` component renders a formatted date or time string, allowing customization of the name, default value, and formatting options.
@@ -149,11 +138,7 @@ Currency._gtt = 'variable-currency';
  * @param {Intl.DateTimeFormatOptions} [options={}] - Optional formatting options for the date, following `Intl.DateTimeFormatOptions` specifications.
  * @returns {Promise<React.JSX.Element>} The formatted date or time component.
  */
-export const DateTime: typeof _DateTime = () => {
-  throw new Error(typesFileError);
-};
-/** @internal _gtt - The GT transformation for the component. */
-DateTime._gtt = 'variable-datetime';
+export declare const DateTime: typeof _DateTime;
 
 /**
  * The `<RelativeTime>` component renders a localized relative time string
@@ -171,11 +156,7 @@ DateTime._gtt = 'variable-datetime';
  * @param {Intl.RelativeTimeFormatOptions} [options={}] - Formatting options.
  * @returns {Promise<React.JSX.Element>} The formatted relative time component.
  */
-export const RelativeTime: typeof _RelativeTime = () => {
-  throw new Error(typesFileError);
-};
-/** @internal _gtt - The GT transformation for the component. */
-RelativeTime._gtt = 'variable-relative-time';
+export declare const RelativeTime: typeof _RelativeTime;
 
 /**
  * The `<Num>` component renders a formatted number string, allowing customization of the name, default value, and formatting options.
@@ -194,11 +175,7 @@ RelativeTime._gtt = 'variable-relative-time';
  * @param {Intl.NumberFormatOptions} [options={}] - Optional formatting options for the number, following `Intl.NumberFormatOptions` specifications.
  * @returns {React.JSX.Element} The formatted number component.
  */
-export const Num: typeof _Num = () => {
-  throw new Error(typesFileError);
-};
-/** @internal _gtt - The GT transformation for the component. */
-Num._gtt = 'variable-number';
+export declare const Num: typeof _Num;
 
 /**
  * The `<Var>` component renders a variable value, which can either be passed as `children` or a `value`.
@@ -214,11 +191,7 @@ Num._gtt = 'variable-number';
  * @param {any} [children] - The content to render inside the component. If provided, it will take precedence over `value`.
  * @returns {React.JSX.Element} The rendered variable component with either `children` or `value`.
  */
-export const Var: typeof _Var = () => {
-  throw new Error(typesFileError);
-};
-/** @internal _gtt - The GT transformation for the component. */
-Var._gtt = 'variable-variable';
+export declare const Var: typeof _Var;
 
 /**
  * Marks JSX children as derivable by the GT compiler and CLI.
@@ -252,11 +225,7 @@ Var._gtt = 'variable-variable';
  * @param {T extends React.ReactNode} children - JSX content to derive for translation extraction.
  * @returns {T} The same children, unchanged at runtime.
  */
-export const Derive: typeof _Derive = () => {
-  throw new Error(typesFileError);
-};
-/** @internal _gtt - The GT transformation for the component. */
-Derive._gtt = 'derive';
+export declare const Derive: typeof _Derive;
 
 /**
  * The `<Branch>` component dynamically renders a specified branch of content or a fallback child component.
@@ -282,11 +251,7 @@ Derive._gtt = 'derive';
  * @param {...{[key: string]: any}} [branches] - A spread object containing possible branches as keys and their corresponding content as values.
  * @returns {React.JSX.Element} The rendered branch or fallback content.
  */
-export const Branch: typeof _Branch = () => {
-  throw new Error(typesFileError);
-};
-/** @internal _gtt - The GT transformation for the component. */
-Branch._gtt = 'branch';
+export declare const Branch: typeof _Branch;
 
 /**
  * The `<Plural>` component dynamically renders content based on the plural form of the given number (`n`).
@@ -313,11 +278,7 @@ Branch._gtt = 'branch';
  * @returns {React.JSX.Element} The rendered content corresponding to the plural form of `n`, or the fallback content.
  * @throws {Error} If `n` is not provided or not a valid number.
  */
-export const Plural: typeof _Plural = () => {
-  throw new Error(typesFileError);
-};
-/** @internal _gtt - The GT transformation for the component. */
-Plural._gtt = 'plural';
+export declare const Plural: typeof _Plural;
 
 /**
  * A dropdown component that allows users to select a locale.
@@ -325,18 +286,14 @@ Plural._gtt = 'plural';
  * @param {object} customNames - An optional object to map locales to custom names.
  * @returns {React.ReactElement | null} The rendered locale dropdown component or null to prevent rendering.
  */
-export const LocaleSelector: typeof _LocaleSelector = () => {
-  throw new Error(typesFileError);
-};
+export declare const LocaleSelector: typeof _LocaleSelector;
 
 /**
  * A dropdown component that allows users to select a region.
  * @param {string[]} regions - An optional list of ISO 3166 region codes to use for the dropdown. If not provided, regions are inferred from the supported locales in the `<GTProvider>` context.
  * @returns {React.ReactElement | null} The rendered region dropdown component or null to prevent rendering.
  */
-export const RegionSelector: typeof _RegionSelector = () => {
-  throw new Error(typesFileError);
-};
+export declare const RegionSelector: typeof _RegionSelector;
 
 /**
  * Resolve the user's locale from a Next Pages Router server-side request.
@@ -344,26 +301,22 @@ export const RegionSelector: typeof _RegionSelector = () => {
  * @param context - The GetServerSideProps context for the request.
  * @returns The resolved locale.
  */
-export function parseLocale<
+export declare function parseLocale<
   Params extends ParsedUrlQuery = ParsedUrlQuery,
   Preview extends PreviewData = PreviewData,
->(_: GetServerSidePropsContext<Params, Preview>): string {
-  throw new Error(typesFileError);
-}
+>(_: GetServerSidePropsContext<Params, Preview>): string;
 
 /**
  * Wraps a Pages Router `getServerSideProps` function and adds the resolved GT
  * locale and translations snapshot to returned page props.
  */
-export function withGTServerSideProps<
+export declare function withGTServerSideProps<
   Props extends Record<string, unknown> = Record<string, unknown>,
   Params extends ParsedUrlQuery = ParsedUrlQuery,
   Preview extends PreviewData = PreviewData,
 >(
   _?: GetServerSideProps<Props, Params, Preview>
-): GetServerSideProps<WithGTServerSideProps<Props>, Params, Preview> {
-  throw new Error(typesFileError);
-}
+): GetServerSideProps<WithGTServerSideProps<Props>, Params, Preview>;
 
 /**
  * Checks whether a locale is valid and supported by the current gt-next config.
@@ -371,9 +324,7 @@ export function withGTServerSideProps<
  * @param locale - The locale candidate to validate.
  * @returns True when the locale resolves to one of the configured locales.
  */
-export function isLocaleSupported(_: unknown): boolean {
-  throw new Error(typesFileError);
-}
+export declare function isLocaleSupported(_: unknown): boolean;
 
 /**
  * Returns the string translation function `t`.
@@ -398,11 +349,9 @@ export function isLocaleSupported(_: unknown): boolean {
  * </>);
  *
  */
-export const useGT: (
+export declare const useGT: (
   _messages?: Messages
-) => (message: string, options?: GTTranslationOptions) => string = () => {
-  throw new Error(typesFileError);
-};
+) => (message: string, options?: GTTranslationOptions) => string;
 
 /**
  * Returns the dictionary access function `t`.
@@ -418,9 +367,7 @@ export const useGT: (
  * const t = useTranslations();
  * console.log(t('hello')); // Translates item 'hello'
  */
-export const useTranslations: typeof _useTranslations = () => {
-  throw new Error(typesFileError);
-};
+export declare const useTranslations: typeof _useTranslations;
 
 /**
  * Returns the user's current locale.
@@ -431,17 +378,11 @@ export const useTranslations: typeof _useTranslations = () => {
  * const locale = useLocale();
  * console.log(locale); // 'en-US'
  */
-export const useLocale: typeof _useLocale = () => {
-  throw new Error(typesFileError);
-};
+export declare const useLocale: typeof _useLocale;
 
-export const useSetLocale: typeof _useSetLocale = () => {
-  throw new Error(typesFileError);
-};
+export declare const useSetLocale: typeof _useSetLocale;
 
-export const useLocaleSelector: typeof _useLocaleSelector = () => {
-  throw new Error(typesFileError);
-};
+export declare const useLocaleSelector: typeof _useLocaleSelector;
 
 /**
  * Returns the user's current region.
@@ -452,9 +393,7 @@ export const useLocaleSelector: typeof _useLocaleSelector = () => {
  * const region = useRegion();
  * console.log(region); // 'US'
  */
-export const useRegion: typeof _useRegion = () => {
-  throw new Error(typesFileError);
-};
+export declare const useRegion: typeof _useRegion;
 
 /**
  * Returns the user's list of supported locales.
@@ -465,9 +404,7 @@ export const useRegion: typeof _useRegion = () => {
  * const locales = useLocales();
  * console.log(locale); // ['en-US', 'fr', 'jp]
  */
-export const useLocales: typeof _useLocales = () => {
-  throw new Error(typesFileError);
-};
+export declare const useLocales: typeof _useLocales;
 
 /**
  * Returns the application's default locale.
@@ -480,9 +417,7 @@ export const useLocales: typeof _useLocales = () => {
  * const locale = useDefaultLocale();
  * console.log(locale); // 'en-US'
  */
-export const useDefaultLocale: typeof _useDefaultLocale = () => {
-  throw new Error(typesFileError);
-};
+export declare const useDefaultLocale: typeof _useDefaultLocale;
 
 /**
  * Returns the locale properties for the given locale.
@@ -494,9 +429,7 @@ export const useDefaultLocale: typeof _useDefaultLocale = () => {
  * const localeProperties = useLocaleProperties('en-US');
  * console.log(localeProperties);
  */
-export const useLocaleProperties: typeof _useLocaleProperties = () => {
-  throw new Error(typesFileError);
-};
+export declare const useLocaleProperties: typeof _useLocaleProperties;
 
 /**
  * Retrieves the text direction ('ltr' or 'rtl') for the current or specified locale from the `<GTProvider>` context.
@@ -510,9 +443,7 @@ export const useLocaleProperties: typeof _useLocaleProperties = () => {
  * const dir = useLocaleDirection(); // e.g., 'ltr'
  * const arabicDir = useLocaleDirection('ar'); // 'rtl'
  */
-export const useLocaleDirection: typeof _useLocaleDirection = () => {
-  throw new Error(typesFileError);
-};
+export declare const useLocaleDirection: typeof _useLocaleDirection;
 
 /**
  * Registers a message to be translated. Returns the message unchanged if no options are provided.
@@ -546,14 +477,12 @@ export const useLocaleDirection: typeof _useLocaleDirection = () => {
  * // "Hello, Alice!" id: "greetings.0"
  * // "Hello, Bob!" id: "greetings.1"
  */
-export const useMessages: (
+export declare const useMessages: (
   _messages?: Messages
 ) => <T extends string | null | undefined>(
   encodedMsg: T,
   options?: GTTranslationOptions
-) => T extends string ? string : T = () => {
-  throw new Error(typesFileError);
-};
+) => T extends string ? string : T;
 
 export type {
   GTTranslationOptions,

--- a/packages/next/tsdown.config.mts
+++ b/packages/next/tsdown.config.mts
@@ -1,6 +1,5 @@
 import { defineConfig } from 'tsdown';
 import {
-  createRemoveRuntimeArtifactsHook,
   createTsdownUnbundleConfig,
   createUseClientBoundaryPlugin,
 } from '../../tsdown.preset.mts';
@@ -11,52 +10,49 @@ const neverBundle = [
 ];
 
 export default defineConfig([
+  createTsdownUnbundleConfig({
+    format: 'cjs',
+    cjsDefault: false,
+    deps: {
+      neverBundle,
+    },
+    outExtensions: () => ({ js: '.js', dts: '.d.ts' }),
+    plugins: [
+      createUseClientBoundaryPlugin({
+        name: 'gt-next:use-client-boundaries',
+        outputExtension: '.js',
+      }),
+    ],
+  }),
+  createTsdownUnbundleConfig({
+    format: 'esm',
+    clean: false,
+    deps: {
+      neverBundle,
+    },
+    outExtensions: () => ({ js: '.mjs', dts: '.d.ts' }),
+    // Server-only modules use require() for lazy loading. Don't emit rolldown's
+    // `createRequire`-from-`node:module` shim: it's statically reachable from
+    // client init code and breaks client bundlers (Turbopack "node:module"
+    // external; webpack UnhandledSchemeError). Next provides `require` for the
+    // guarded, server-only call sites in every bundling context that runs them.
+    outputOptions: { polyfillRequire: false },
+    plugins: [
+      createUseClientBoundaryPlugin({
+        name: 'gt-next:use-client-boundaries',
+        outputExtension: '.mjs',
+      }),
+    ],
+  }),
   {
-    ...createTsdownUnbundleConfig({
-      format: 'cjs',
-      cjsDefault: false,
-      deps: {
-        neverBundle,
-      },
-      outExtensions: () => ({ js: '.js', dts: '.d.ts' }),
-      plugins: [
-        createUseClientBoundaryPlugin({
-          name: 'gt-next:use-client-boundaries',
-          outputExtension: '.js',
-        }),
-      ],
-    }),
-    // src/index.types.ts only backs the exports map's "types" condition; its
-    // declarations ship, but its runtime modules are unreachable.
-    onSuccess: createRemoveRuntimeArtifactsHook(process.cwd(), 'dist', [
-      'index.types.js',
-      'index.types.js.map',
-    ]),
-  },
-  {
-    ...createTsdownUnbundleConfig({
-      format: 'esm',
-      clean: false,
-      deps: {
-        neverBundle,
-      },
-      outExtensions: () => ({ js: '.mjs', dts: '.d.ts' }),
-      // Server-only modules use require() for lazy loading. Don't emit rolldown's
-      // `createRequire`-from-`node:module` shim: it's statically reachable from
-      // client init code and breaks client bundlers (Turbopack "node:module"
-      // external; webpack UnhandledSchemeError). Next provides `require` for the
-      // guarded, server-only call sites in every bundling context that runs them.
-      outputOptions: { polyfillRequire: false },
-      plugins: [
-        createUseClientBoundaryPlugin({
-          name: 'gt-next:use-client-boundaries',
-          outputExtension: '.mjs',
-        }),
-      ],
-    }),
-    onSuccess: createRemoveRuntimeArtifactsHook(process.cwd(), 'dist', [
-      'index.types.mjs',
-      'index.types.mjs.map',
-    ]),
+    entry: ['src/index.types.d.ts'],
+    format: ['esm'],
+    dts: {
+      emitDtsOnly: true,
+      sourcemap: false,
+    },
+    sourcemap: false,
+    clean: false,
+    outExtensions: () => ({ dts: '.d.ts' }),
   },
 ]);

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -4,7 +4,7 @@
   "description": "A React library for automatic internationalization.",
   "main": "./dist/index.server.cjs",
   "module": "./dist/index.server.mjs",
-  "types": "./dist/index.types.d.cts",
+  "types": "./dist/index.types.d.ts",
   "files": [
     "dist",
     "CHANGELOG.md"
@@ -69,21 +69,21 @@
       },
       "browser": {
         "require": {
-          "types": "./dist/index.types.d.cts",
+          "types": "./dist/index.types.d.ts",
           "default": "./dist/index.client.cjs"
         },
         "import": {
-          "types": "./dist/index.types.d.mts",
+          "types": "./dist/index.types.d.ts",
           "default": "./dist/index.client.mjs"
         },
         "default": "./dist/index.client.mjs"
       },
       "require": {
-        "types": "./dist/index.types.d.cts",
+        "types": "./dist/index.types.d.ts",
         "default": "./dist/index.server.cjs"
       },
       "import": {
-        "types": "./dist/index.types.d.mts",
+        "types": "./dist/index.types.d.ts",
         "default": "./dist/index.server.mjs"
       },
       "default": "./dist/index.server.mjs"

--- a/packages/react/src/__tests__/react-package.test.ts
+++ b/packages/react/src/__tests__/react-package.test.ts
@@ -169,6 +169,35 @@ describe('gt-react package exports', () => {
     ).toEqual(runtimeArtifactNames);
   });
 
+  it('publishes the types entrypoint as a declaration only', () => {
+    expect(
+      readdirSync(join(packageRoot, 'dist'))
+        .filter((file) => file.startsWith('index.types.'))
+        .sort()
+    ).toEqual(['index.types.d.ts']);
+
+    const packageJson = JSON.parse(
+      readFileSync(join(packageRoot, 'package.json'), 'utf8')
+    ) as {
+      types: string;
+      exports: {
+        '.': {
+          browser: { require: { types: string }; import: { types: string } };
+          require: { types: string };
+          import: { types: string };
+        };
+      };
+    };
+
+    expect([
+      packageJson.types,
+      packageJson.exports['.'].browser.require.types,
+      packageJson.exports['.'].browser.import.types,
+      packageJson.exports['.'].require.types,
+      packageJson.exports['.'].import.types,
+    ]).toEqual(Array(5).fill('./dist/index.types.d.ts'));
+  });
+
   it('bundles workspace subpath imports in runtime artifacts', () => {
     const workspaceSubpathImportPattern =
       /(?:(?:import|export)\s+(?:[^"']+\s+from\s+)?|require\(\s*)["']((?:@generaltranslation\/format|@generaltranslation\/react-core|generaltranslation|gt-i18n)\/[^"']+)["']/g;

--- a/packages/react/src/index.types.d.ts
+++ b/packages/react/src/index.types.d.ts
@@ -1,5 +1,3 @@
-'use client';
-
 import type { ReactNode } from 'react';
 import type { TxProps } from './utils/TxProps';
 
@@ -33,9 +31,7 @@ export {
   Num,
 } from '@generaltranslation/react-core/components';
 
-export async function Tx(_props: TxProps): Promise<ReactNode> {
-  throw new Error('Tx is only supported via RSC');
-}
+export declare function Tx(_props: TxProps): Promise<ReactNode>;
 
 // ===== Hooks ===== //
 export {

--- a/packages/react/tsdown.config.mts
+++ b/packages/react/tsdown.config.mts
@@ -1,6 +1,5 @@
 import { defineConfig } from 'tsdown';
 import {
-  createRemoveRuntimeArtifactsHook,
   createTsdownConfig,
   createUseClientBoundaryPlugin,
 } from '../../tsdown.preset.mts';
@@ -29,61 +28,55 @@ const entries = [
   'src/index.rsc.ts',
   'src/index.client.ts',
   'src/index.server.ts',
-  'src/index.types.ts',
   'src/macros.ts',
 ];
 
-// src/index.types.ts only backs the exports map's "types" conditions; its
-// declaration outputs are published but its runtime bundles are unreachable,
-// so they are deleted after each build.
-const typesOnlyEntry = 'src/index.types.ts';
-
 export default defineConfig(
-  entries.flatMap((entry, index) => {
-    const entryDeps = entry.startsWith('src/index.') ? contextDeps : deps;
-    const [cjsConfig, esmConfig] = createTsdownConfig([entry], entryDeps);
+  entries
+    .flatMap((entry, index) => {
+      const entryDeps = entry.startsWith('src/index.') ? contextDeps : deps;
+      const [cjsConfig, esmConfig] = createTsdownConfig([entry], entryDeps);
 
-    return [
-      {
-        ...cjsConfig,
-        clean: index === 0,
-        define: {
-          'import.meta.env': '{}',
+      return [
+        {
+          ...cjsConfig,
+          clean: index === 0,
+          define: {
+            'import.meta.env': '{}',
+          },
+          plugins: [
+            createUseClientBoundaryPlugin({
+              emittedSourceFiles: entries,
+              name: 'gt-react:use-client-boundaries',
+              outputExtension: '.cjs',
+            }),
+          ],
         },
-        plugins: [
-          createUseClientBoundaryPlugin({
-            emittedSourceFiles: entries,
-            name: 'gt-react:use-client-boundaries',
-            outputExtension: '.cjs',
-          }),
-        ],
-        ...(entry === typesOnlyEntry && {
-          onSuccess: createRemoveRuntimeArtifactsHook(process.cwd(), 'dist', [
-            'index.types.cjs',
-            'index.types.cjs.map',
-          ]),
-        }),
-      },
-      {
-        ...esmConfig,
-        deps: {
-          onlyBundle: false,
-          ...entryDeps,
+        {
+          ...esmConfig,
+          deps: {
+            onlyBundle: false,
+            ...entryDeps,
+          },
+          plugins: [
+            createUseClientBoundaryPlugin({
+              emittedSourceFiles: entries,
+              name: 'gt-react:use-client-boundaries',
+              outputExtension: '.mjs',
+            }),
+          ],
         },
-        plugins: [
-          createUseClientBoundaryPlugin({
-            emittedSourceFiles: entries,
-            name: 'gt-react:use-client-boundaries',
-            outputExtension: '.mjs',
-          }),
-        ],
-        ...(entry === typesOnlyEntry && {
-          onSuccess: createRemoveRuntimeArtifactsHook(process.cwd(), 'dist', [
-            'index.types.mjs',
-            'index.types.mjs.map',
-          ]),
-        }),
+      ];
+    })
+    .concat({
+      entry: ['src/index.types.d.ts'],
+      format: ['esm'],
+      dts: {
+        emitDtsOnly: true,
+        sourcemap: false,
       },
-    ];
-  })
+      sourcemap: false,
+      clean: false,
+      outExtensions: () => ({ dts: '.d.ts' }),
+    })
 );

--- a/tsdown.preset.mts
+++ b/tsdown.preset.mts
@@ -253,32 +253,22 @@ function getEntryName(entry: string) {
   return basename(entry, extname(entry));
 }
 
-export function createRemoveRuntimeArtifactsHook(
-  packageDir: string,
-  outDir: string,
-  artifactNames: string[]
-) {
-  const artifacts = artifactNames.map((name) =>
-    resolve(packageDir, outDir, name)
-  );
-
-  return async () => {
-    await Promise.all(
-      artifacts.map((artifact) => rm(artifact, { force: true }))
-    );
-  };
-}
-
 function createRemoveTypeRuntimeArtifactsHook(
   outDir: string,
   typeEntry: string,
   packageDir: string
 ) {
   const typeEntryName = getEntryName(typeEntry);
-  return createRemoveRuntimeArtifactsHook(packageDir, outDir, [
-    `${typeEntryName}.cjs.min.cjs`,
-    `${typeEntryName}.cjs.min.cjs.map`,
-  ]);
+  const artifacts = [
+    resolve(packageDir, outDir, `${typeEntryName}.cjs.min.cjs`),
+    resolve(packageDir, outDir, `${typeEntryName}.cjs.min.cjs.map`),
+  ];
+
+  return async () => {
+    await Promise.all(
+      artifacts.map((artifact) => rm(artifact, { force: true }))
+    );
+  };
 }
 
 export function createTsdownMinifiedDualFormatConfig({


### PR DESCRIPTION
## Summary
- convert the gt-react and gt-next index.types entrypoints to declaration sources
- use tsdown declaration-only builds to emit one bundled index.types.d.ts without runtime artifacts or sourcemaps
- update gt-react type conditions and add artifact regression coverage
- patch-bump gt-react and gt-next

## Testing
- pnpm --filter gt-react build
- pnpm --filter gt-next build:no-swc-plugin
- pnpm --filter gt-react --filter gt-next typecheck
- pnpm --dir packages/react exec vitest run src/__tests__/react-package.test.ts
- pnpm --dir packages/next exec vitest run src/__tests__/packageExports.test.ts
- pnpm exec oxlint on changed TypeScript files
- pnpm exec oxfmt --check on changed files
- git diff --check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR converts the `index.types` entrypoints in `gt-react` and `gt-next` from runtime TypeScript modules (with throw-at-runtime stubs) to pure `.d.ts` declaration sources, then uses tsdown's `dts: { emitDtsOnly: true }` mode to emit a single bundled `index.types.d.ts` per package with no `.cjs`/`.mjs` bundles or sourcemaps.

- **Build cleanup**: Removes `createRemoveRuntimeArtifactsHook` from `tsdown.preset.mts` and the corresponding `onSuccess` deletion hooks; the declaration-only config block never generates runtime artifacts in the first place.
- **Package metadata**: Updates `gt-react`'s `package.json` to point all non-`react-server` `types` conditions from format-specific `.d.cts`/`.d.mts` extensions to the single unified `./dist/index.types.d.ts`.
- **Regression coverage**: Adds `distIt` tests in both packages that assert exactly one `index.types.*` file exists in `dist/` and that all relevant `package.json` `types` fields resolve to it.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change only affects build tooling and published artifact layout, not any runtime logic.

The conversion from .ts runtime stubs to .d.ts declaration sources is mechanically correct: all throw bodies are replaced with declare stubs, the 'use client' directive is dropped (meaningless in a declaration file), and the _gtt marker properties are preserved via typeof references to the real implementations. The emitDtsOnly build path never produces runtime bundles, so the previous post-build deletion hooks are no longer needed. Regression tests in both packages verify the expected output shape. No runtime paths are touched.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tsdown.preset.mts | Removes the exported createRemoveRuntimeArtifactsHook by inlining its body into the private createRemoveTypeRuntimeArtifactsHook; no callers remain in the monorepo after gt-react and gt-next configs are updated. |
| packages/next/src/index.types.d.ts | Converted from a .ts runtime module (with throw-at-runtime bodies) to a pure .d.ts declaration source; typesFileError import removed, all exports converted to declare stubs. |
| packages/react/src/index.types.d.ts | Converted from .ts (with 'use client' directive and a runtime Tx throw stub) to a pure .d.ts; Tx is now a declare function, all other exports unchanged. |
| packages/next/tsdown.config.mts | Replaces the spread-with-onSuccess pattern with a dedicated dts: { emitDtsOnly: true } config block that never produces runtime bundles. |
| packages/react/tsdown.config.mts | Removes src/index.types.ts from the main entries array and appends a declaration-only config block via .concat(). |
| packages/react/package.json | Updates types top-level field and all non-react-server types conditions in exports from .d.cts/.d.mts to the unified ./dist/index.types.d.ts. |
| packages/react/src/__tests__/react-package.test.ts | Adds a regression test verifying only index.types.d.ts is emitted and all five types conditions in package.json point to ./dist/index.types.d.ts. |
| packages/next/src/__tests__/packageExports.test.ts | Adds a distIt test for gt-next verifying only index.types.d.ts is present in dist/. |
| packages/next/src/errors/createErrors.ts | Removes the typesFileError diagnostic export; no longer needed now that index.types is declaration-only. |
| .changeset/large-boxes-shrink.md | Changeset description updated to describe the declaration-only build approach. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Before
        A1[src/index.types.ts] -->|tsdown CJS build| B1[dist/index.types.js]
        A1 -->|tsdown CJS build| B2[dist/index.types.js.map]
        A1 -->|tsdown ESM build| B3[dist/index.types.mjs]
        A1 -->|tsdown ESM build| B4[dist/index.types.mjs.map]
        A1 -->|tsdown CJS dts| B5[dist/index.types.d.ts]
        B1 -->|onSuccess hook| C1[deleted]
        B2 -->|onSuccess hook| C1
        B3 -->|onSuccess hook| C1
        B4 -->|onSuccess hook| C1
    end

    subgraph After
        A2[src/index.types.d.ts] -->|tsdown emitDtsOnly| B6[dist/index.types.d.ts]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    subgraph Before
        A1[src/index.types.ts] -->|tsdown CJS build| B1[dist/index.types.js]
        A1 -->|tsdown CJS build| B2[dist/index.types.js.map]
        A1 -->|tsdown ESM build| B3[dist/index.types.mjs]
        A1 -->|tsdown ESM build| B4[dist/index.types.mjs.map]
        A1 -->|tsdown CJS dts| B5[dist/index.types.d.ts]
        B1 -->|onSuccess hook| C1[deleted]
        B2 -->|onSuccess hook| C1
        B3 -->|onSuccess hook| C1
        B4 -->|onSuccess hook| C1
    end

    subgraph After
        A2[src/index.types.d.ts] -->|tsdown emitDtsOnly| B6[dist/index.types.d.ts]
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["build: emit type entrypoints as declarat..."](https://github.com/generaltranslation/gt/commit/a4d4e86998f690be18a53227ad5a6db11e376969) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44307385)</sub>

<!-- /greptile_comment -->