### PR TITLE
fix: link compiler workspace for releases

### DIFF
--- a/.changeset/bright-tools-release.md
+++ b/.changeset/bright-tools-release.md
@@ -1,7 +1,12 @@
 ---
 '@generaltranslation/compiler': patch
+'@generaltranslation/python-extractor': patch
+'@generaltranslation/react-core-linter': patch
+'@generaltranslation/supported-locales': patch
 'gt': patch
 'gt-next': patch
+'gt-sanity': patch
+'locadex': patch
 ---
 
 Retrigger package publication after repairing release workspace dependency resolution.

--- a/.changeset/bright-tools-release.md
+++ b/.changeset/bright-tools-release.md
@@ -1,0 +1,7 @@
+---
+'@generaltranslation/compiler': patch
+'gt': patch
+'gt-next': patch
+---
+
+Retrigger package publication after repairing release workspace dependency resolution.

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -66,6 +66,7 @@
   },
   "homepage": "https://generaltranslation.com/",
   "devDependencies": {
+    "@generaltranslation/compiler": "workspace:*",
     "@edge-runtime/vm": "^4.0.0",
     "@types/node": "catalog:",
     "@types/react": ">=18.0.0 <20.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -974,9 +974,6 @@ importers:
 
   packages/next:
     dependencies:
-      '@generaltranslation/compiler':
-        specifier: ^1.3.26
-        version: 1.3.27
       '@generaltranslation/format':
         specifier: workspace:*
         version: link:../format
@@ -1002,6 +999,9 @@ importers:
       '@edge-runtime/vm':
         specifier: ^4.0.0
         version: 4.0.4
+      '@generaltranslation/compiler':
+        specifier: workspace:*
+        version: link:../compiler
       '@types/node':
         specifier: 'catalog:'
         version: 22.13.10
@@ -4099,13 +4099,6 @@ packages:
 
   '@formatjs/intl-relativetimeformat@11.4.13':
     resolution: {integrity: sha512-fNs6cpz9zIUEgTlE3kPSEyRfslxeMG19dT7sLz2C6U7Jxkx8xK/IH1ImZzCeqd6JlqE81O7uNW4oZTb1pz8lUw==}
-
-  '@generaltranslation/compiler@1.3.27':
-    resolution: {integrity: sha512-jUpCIXftnA+iYjdtEyaO+Aa4BoNFuqsx0OL6t7763+Iqgw1x5v6TWsYpGbG9kgr5SJ0zph7pG81nZznW0FstNw==}
-    engines: {node: '>=16.0.0'}
-
-  '@generaltranslation/format@0.1.1':
-    resolution: {integrity: sha512-HYfBdkrdMuA/Sj0tMrkdat4mnaNnN7Isf1u3IYwYUMvH21iWkqnWZ2KBKD2tboNux2T4SxyFMyCjnwg7tmEOlA==}
 
   '@hapi/hoek@9.3.0':
     resolution: {integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==}
@@ -11179,9 +11172,6 @@ packages:
     resolution: {integrity: sha512-ZaoiZwkSf0DwwB1ncdLKp+ggAldqxl5L1+SXaNIBGkPAqcu+xjVJLxlf3/S8vLt9UHx1xu5fz3lbzKCj5iOVdQ==}
     peerDependencies:
       next: '>=13.2.0'
-
-  generaltranslation@8.2.19:
-    resolution: {integrity: sha512-y4eWxZLe69ki8HRs2Hkf4IovdkQqX+KMRTXjRou8vb07ROTCIEVAyXpJ8KR6AM4YHbjq8ZozhpOcrCz+aW7elw==}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -20469,22 +20459,6 @@ snapshots:
       '@formatjs/intl-localematcher': 0.6.2
       tslib: 2.8.1
 
-  '@generaltranslation/compiler@1.3.27':
-    dependencies:
-      '@babel/generator': 7.29.1
-      '@babel/parser': 7.29.2
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
-      '@generaltranslation/format': 0.1.1
-      generaltranslation: 8.2.19
-      unplugin: 2.3.10
-    transitivePeerDependencies:
-      - supports-color
-
-  '@generaltranslation/format@0.1.1':
-    dependencies:
-      intl-messageformat: 10.7.16
-
   '@hapi/hoek@9.3.0':
     optional: true
 
@@ -29127,12 +29101,6 @@ snapshots:
   geist@1.7.0(next@15.5.9(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)):
     dependencies:
       next: 15.5.9(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-
-  generaltranslation@8.2.19:
-    dependencies:
-      '@formatjs/icu-messageformat-parser': 2.11.4
-      '@generaltranslation/format': 0.1.1
-      '@noble/hashes': 2.2.0
 
   gensync@1.0.0-beta.2: {}
 

--- a/scripts/check-release-versions.mjs
+++ b/scripts/check-release-versions.mjs
@@ -42,6 +42,44 @@ const changedManifests = git(
 
 const errors = [];
 
+const packageManifests = git(
+  'ls-tree',
+  '-r',
+  '--name-only',
+  head,
+  '--',
+  'packages'
+)
+  .split('\n')
+  .filter((path) => /^packages\/[^/]+\/package\.json$/.test(path))
+  .map((path) => ({
+    path,
+    manifest: JSON.parse(git('show', `${head}:${path}`)),
+  }));
+
+const workspacePackages = new Map(
+  packageManifests
+    .filter(({ manifest }) => manifest.name)
+    .map(({ manifest }) => [manifest.name, manifest])
+);
+
+for (const { path, manifest } of packageManifests) {
+  for (const peerName of Object.keys(manifest.peerDependencies ?? {})) {
+    if (!workspacePackages.has(peerName)) continue;
+
+    const workspaceRange =
+      manifest.dependencies?.[peerName] ??
+      manifest.devDependencies?.[peerName] ??
+      manifest.optionalDependencies?.[peerName];
+
+    if (!workspaceRange?.startsWith('workspace:')) {
+      errors.push(
+        `${manifest.name} declares internal peer ${peerName} without a workspace dependency in ${path}`
+      );
+    }
+  }
+}
+
 for (const manifestPath of changedManifests) {
   const manifest = JSON.parse(git('show', `${head}:${manifestPath}`));
   if (manifest.private || !manifest.name || !manifest.version) continue;


### PR DESCRIPTION
## Summary

- add `@generaltranslation/compiler` as a `workspace:*` dev dependency of `gt-next` so the unpublished peer version resolves locally during release bootstrap
- refresh the lockfile to remove the stale registry-resolved compiler snapshot
- extend release validation to reject any internal peer dependency that is not backed by a workspace dependency

## Investigation

The failed release had exactly one unsafe internal edge: `gt-next` declared `@generaltranslation/compiler@^1.3.28` as an optional peer while `1.3.28` was still waiting to be published. All other internal package dependencies already use `workspace:*`.

No changeset is added because `gt-next@11.0.5` and the other recovery versions were already bumped by the failed release commit and remain unpublished; this change makes that pending release installable.

## Validation

- `pnpm install --no-frozen-lockfile`
- `pnpm install --frozen-lockfile`
- `pnpm format`
- `pnpm exec oxlint scripts/check-release-versions.mjs`
- `node --check scripts/check-release-versions.mjs`
- verified the enhanced guard rejects the failed release commit with the missing workspace dependency error
- audited every workspace package for other non-workspace internal dependency ranges

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a failed release by properly linking `@generaltranslation/compiler` as a `workspace:*` dev dependency of `gt-next` so pnpm resolves it locally instead of fetching the not-yet-published `1.3.28` from the registry. It also adds a new pre-release validation step that guards against this class of issue recurring.

- **`packages/next/package.json`**: Adds `@generaltranslation/compiler: workspace:*` under `devDependencies`; the compiler was previously resolved from the registry as `1.3.27` (via a `dependencies` entry), which broke the release when `1.3.28` was not yet published.
- **`pnpm-lock.yaml`**: Refreshed to remove the now-unreferenced registry snapshot for `@generaltranslation/compiler@1.3.27` and its orphaned transitive deps, replacing the entry with a `link:../compiler` workspace reference.
- **`scripts/check-release-versions.mjs`**: Adds a whole-workspace scan that rejects any package whose `peerDependencies` contains an internal workspace package without a corresponding `workspace:` range in its dependencies or devDependencies, preventing this class of release failure in the future.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a targeted fix to a broken release state with no behavioral changes to the library itself.

The package.json change is mechanical: moving one internal dep from a registry range to a workspace link, consistent with how every other internal package is already declared. The lockfile refresh is a direct consequence. The new validation script correctly scans all workspace manifests and rejects any internal peer without a workspace backing dep, and the logic handles all three dep buckets (dependencies, devDependencies, optionalDependencies). No library behavior changes; the compiler is a dev-time build tool and will not appear in the published package.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/next/package.json | Moves @generaltranslation/compiler from a registry-resolved dependency to a workspace dev dependency, aligning it with all other internal packages. |
| pnpm-lock.yaml | Removes the stale registry snapshot for @generaltranslation/compiler@1.3.27 and its now-orphaned transitive deps; replaces the resolved entry with a link:../compiler workspace reference under devDependencies. |
| scripts/check-release-versions.mjs | Adds a pre-release guard that walks every workspace package manifest at HEAD and rejects any internal peer dependency that is not backed by a workspace: range in dependencies, devDependencies, or optionalDependencies. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[check-release-versions.mjs runs] --> B[git ls-tree: collect all package manifests at HEAD]
    B --> C[Build workspacePackages map by name]
    C --> D{For each package: iterate peerDependencies}
    D --> E{Is peer an internal workspace package?}
    E -- No --> D
    E -- Yes --> F{Does pkg have a workspace: backing dep?}
    F -- Yes --> D
    F -- No --> G[Push error: missing workspace dependency]
    G --> D
    D --> H[For each changed manifest: check npm registry]
    H --> I{Already published?}
    I -- Yes --> J[Push error: version already published]
    I -- No --> K{Version advances npm latest?}
    K -- No --> L[Push error: version does not advance]
    K -- Yes --> H
    H --> M{Any errors?}
    M -- Yes --> N[Exit 1 with error list]
    M -- No --> O[Exit 0: validation passed]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[check-release-versions.mjs runs] --> B[git ls-tree: collect all package manifests at HEAD]
    B --> C[Build workspacePackages map by name]
    C --> D{For each package: iterate peerDependencies}
    D --> E{Is peer an internal workspace package?}
    E -- No --> D
    E -- Yes --> F{Does pkg have a workspace: backing dep?}
    F -- Yes --> D
    F -- No --> G[Push error: missing workspace dependency]
    G --> D
    D --> H[For each changed manifest: check npm registry]
    H --> I{Already published?}
    I -- Yes --> J[Push error: version already published]
    I -- No --> K{Version advances npm latest?}
    K -- No --> L[Push error: version does not advance]
    K -- Yes --> H
    H --> M{Any errors?}
    M -- Yes --> N[Exit 1 with error list]
    M -- No --> O[Exit 0: validation passed]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: link compiler workspace for release..."](https://github.com/generaltranslation/gt/commit/3ea1a610a6b338e4bf01097cdc8ab78f4dd8962f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44327897)</sub>

<!-- /greptile_comment -->