### PR TITLE
F/cli upload overwrite

### DIFF
--- a/.changeset/sharp-rabbits-sniff.md
+++ b/.changeset/sharp-rabbits-sniff.md
@@ -1,0 +1,5 @@
+---
+"gt": patch
+---
+
+Make `upload` command overwrite content

--- a/packages/cli/src/workflows/steps/UploadTranslationsStep.ts
+++ b/packages/cli/src/workflows/steps/UploadTranslationsStep.ts
@@ -55,11 +55,22 @@ export class UploadTranslationsStep extends WorkflowStep<
     });
 
     this.result = response.uploadedFiles;
+    // Report the server-confirmed count, not the attempted count — the
+    // endpoint drops files it failed to persist without erroring
+    const uploadedCount = this.result.length;
     this.spinner.stop(
       chalk.green(
-        `Uploaded ${totalTranslations} translation file${totalTranslations !== 1 ? 's' : ''}`
+        `Uploaded ${uploadedCount} translation file${uploadedCount !== 1 ? 's' : ''}`
       )
     );
+    if (uploadedCount < totalTranslations) {
+      const missingCount = totalTranslations - uploadedCount;
+      logger.warn(
+        chalk.yellow(
+          `${missingCount} translation file${missingCount !== 1 ? 's were' : ' was'} not persisted by the server`
+        )
+      );
+    }
 
     return this.result;
   }

--- a/packages/cli/src/workflows/steps/UploadTranslationsStep.ts
+++ b/packages/cli/src/workflows/steps/UploadTranslationsStep.ts
@@ -3,7 +3,6 @@ import { logger } from '../../console/logger.js';
 import { GT } from 'generaltranslation';
 import { Settings } from '../../types/index.js';
 import chalk from 'chalk';
-import { BranchData } from '../../types/branch.js';
 import type { FileReference, FileToUpload } from 'generaltranslation/types';
 
 type UploadTranslationsInput = {
@@ -11,7 +10,6 @@ type UploadTranslationsInput = {
     source: FileToUpload;
     translations: FileToUpload[];
   }[];
-  branchData: BranchData;
 };
 
 export class UploadTranslationsStep extends WorkflowStep<
@@ -28,88 +26,29 @@ export class UploadTranslationsStep extends WorkflowStep<
     super();
   }
 
-  async run({
-    files,
-    branchData,
-  }: UploadTranslationsInput): Promise<FileReference[]> {
+  async run({ files }: UploadTranslationsInput): Promise<FileReference[]> {
     // Filter to only files that have translations
-    const filesWithTranslations = files.filter(
-      (f) => f.translations.length > 0
-    );
+    const filesToUpload = files.filter((f) => f.translations.length > 0);
 
-    if (filesWithTranslations.length === 0) {
+    if (filesToUpload.length === 0) {
       logger.info(
         'No translation files to upload... skipping upload translations step'
       );
       return [];
     }
 
-    const totalTranslations = filesWithTranslations.reduce(
+    const totalTranslations = filesToUpload.reduce(
       (acc, f) => acc + f.translations.length,
       0
     );
 
     this.spinner.start(
-      `Syncing ${totalTranslations} translation file${totalTranslations !== 1 ? 's' : ''} with General Translation API...`
+      `Uploading ${totalTranslations} translation file${totalTranslations !== 1 ? 's' : ''} to the General Translation API...`
     );
 
-    // Build the query for existing translation files
-    const translatedFilesQuery = filesWithTranslations.flatMap((f) =>
-      f.translations.map((t) => ({
-        fileId: t.fileId,
-        versionId: t.versionId,
-        branchId: t.branchId ?? branchData.currentBranch.id,
-        locale: t.locale,
-      }))
-    );
-
-    // Query for existing translation files
-    const fileData = await this.gt.queryFileData({
-      translatedFiles: translatedFilesQuery,
-    });
-
-    // Build a map of existing translations: branchId:fileId:versionId:locale
-    const existingTranslationsMap = new Set<string>();
-    fileData.translatedFiles?.forEach((f) => {
-      existingTranslationsMap.add(
-        `${f.branchId}:${f.fileId}:${f.versionId}:${f.locale}`
-      );
-    });
-
-    // Filter out translations that already exist
-    const filesToUpload = filesWithTranslations
-      .map((f) => {
-        const newTranslations = f.translations.filter((t) => {
-          const branchId = t.branchId ?? branchData.currentBranch.id;
-          const key = `${branchId}:${t.fileId}:${t.versionId}:${t.locale}`;
-          return !existingTranslationsMap.has(key);
-        });
-
-        return {
-          source: f.source,
-          translations: newTranslations,
-        };
-      })
-      .filter((f) => f.translations.length > 0);
-
-    const skippedCount =
-      totalTranslations -
-      filesToUpload.reduce((acc, f) => acc + f.translations.length, 0);
-
-    if (filesToUpload.length === 0) {
-      this.spinner.stop(
-        chalk.green(
-          `All ${totalTranslations} translation files already uploaded`
-        )
-      );
-      return [];
-    }
-
-    const uploadCount = filesToUpload.reduce(
-      (acc, f) => acc + f.translations.length,
-      0
-    );
-
+    // Local translation files are the source of truth: upload every resolved
+    // translation file. The upload endpoint is an upsert, so translations
+    // that already exist on the platform are overwritten.
     const response = await this.gt.uploadTranslations(filesToUpload, {
       sourceLocale: this.settings.defaultLocale,
       modelProvider: this.settings.modelProvider,
@@ -118,7 +57,7 @@ export class UploadTranslationsStep extends WorkflowStep<
     this.result = response.uploadedFiles;
     this.spinner.stop(
       chalk.green(
-        `Translation files synced successfully! Uploaded: (${uploadCount}), Skipped: (${skippedCount})`
+        `Uploaded ${totalTranslations} translation file${totalTranslations !== 1 ? 's' : ''}`
       )
     );
 

--- a/packages/cli/src/workflows/steps/UploadTranslationsStep.ts
+++ b/packages/cli/src/workflows/steps/UploadTranslationsStep.ts
@@ -3,6 +3,13 @@ import { logger } from '../../console/logger.js';
 import { GT } from 'generaltranslation';
 import { Settings } from '../../types/index.js';
 import chalk from 'chalk';
+import {
+  readLockfile,
+  writeLockfile,
+  findOrCreateEntry,
+  type EntryMap,
+} from '../../fs/config/downloadedVersions.js';
+import { hashStringSync } from '../../utils/hash.js';
 import type { FileReference, FileToUpload } from 'generaltranslation/types';
 
 type UploadTranslationsInput = {
@@ -11,6 +18,43 @@ type UploadTranslationsInput = {
     translations: FileToUpload[];
   }[];
 };
+
+// The server includes the locale on each uploaded translation, but the
+// shared FileReference type does not declare it
+type UploadedTranslationReference = FileReference & { locale?: string };
+
+/**
+ * Splits translations into ones that need uploading and ones that can be
+ * skipped because their content still matches the gt-lock.json hash recorded
+ * at the last sync (download/translate/upload). Files without a lock entry —
+ * or with a stale versionId — are always uploaded.
+ */
+export function partitionTranslationsByLockfile(
+  files: UploadTranslationsInput['files'],
+  entryMap: EntryMap
+): {
+  filesToUpload: UploadTranslationsInput['files'];
+  skippedCount: number;
+} {
+  let skippedCount = 0;
+  const filesToUpload = files
+    .map((file) => {
+      const translations = file.translations.filter((translation) => {
+        const entry = entryMap.get(translation.fileId);
+        if (!entry || entry.versionId !== translation.versionId) return true;
+        const lockHash = entry.translations[translation.locale]?.postProcessHash;
+        if (!lockHash || lockHash !== hashStringSync(translation.content)) {
+          return true;
+        }
+        skippedCount++;
+        return false;
+      });
+      return { source: file.source, translations };
+    })
+    .filter((file) => file.translations.length > 0);
+
+  return { filesToUpload, skippedCount };
+}
 
 export class UploadTranslationsStep extends WorkflowStep<
   UploadTranslationsInput,
@@ -28,11 +72,31 @@ export class UploadTranslationsStep extends WorkflowStep<
 
   async run({ files }: UploadTranslationsInput): Promise<FileReference[]> {
     // Filter to only files that have translations
-    const filesToUpload = files.filter((f) => f.translations.length > 0);
+    const withTranslations = files.filter((f) => f.translations.length > 0);
+
+    if (withTranslations.length === 0) {
+      logger.info(
+        'No translation files to upload... skipping upload translations step'
+      );
+      return [];
+    }
+
+    // Local translation files are the source of truth: everything local is
+    // uploaded (the endpoint is an upsert, so existing translations are
+    // overwritten). The one optimization is the lockfile: files whose content
+    // hash still matches gt-lock.json are unchanged since the last sync and
+    // can be skipped. Without a lockfile, everything uploads.
+    const lockfile = readLockfile(this.settings);
+    const { filesToUpload, skippedCount } = partitionTranslationsByLockfile(
+      withTranslations,
+      lockfile.entryMap
+    );
 
     if (filesToUpload.length === 0) {
       logger.info(
-        'No translation files to upload... skipping upload translations step'
+        chalk.green(
+          `All ${skippedCount} translation file${skippedCount !== 1 ? 's are' : ' is'} unchanged since the last sync... skipping upload translations step`
+        )
       );
       return [];
     }
@@ -46,9 +110,6 @@ export class UploadTranslationsStep extends WorkflowStep<
       `Uploading ${totalTranslations} translation file${totalTranslations !== 1 ? 's' : ''} to the General Translation API...`
     );
 
-    // Local translation files are the source of truth: upload every resolved
-    // translation file. The upload endpoint is an upsert, so translations
-    // that already exist on the platform are overwritten.
     const response = await this.gt.uploadTranslations(filesToUpload, {
       sourceLocale: this.settings.defaultLocale,
       modelProvider: this.settings.modelProvider,
@@ -60,7 +121,7 @@ export class UploadTranslationsStep extends WorkflowStep<
     const uploadedCount = this.result.length;
     this.spinner.stop(
       chalk.green(
-        `Uploaded ${uploadedCount} translation file${uploadedCount !== 1 ? 's' : ''}`
+        `Uploaded ${uploadedCount} translation file${uploadedCount !== 1 ? 's' : ''}${skippedCount > 0 ? `, skipped ${skippedCount} unchanged` : ''}`
       )
     );
     if (uploadedCount < totalTranslations) {
@@ -72,7 +133,47 @@ export class UploadTranslationsStep extends WorkflowStep<
       );
     }
 
+    this.recordUploadedHashes(lockfile, filesToUpload, this.result);
+
     return this.result;
+  }
+
+  /**
+   * Records the content hash of each server-confirmed upload in gt-lock.json
+   * so unchanged files are skipped on the next run.
+   */
+  private recordUploadedHashes(
+    lockfile: ReturnType<typeof readLockfile>,
+    uploaded: UploadTranslationsInput['files'],
+    confirmed: UploadedTranslationReference[]
+  ): void {
+    const confirmedKeys = new Set(
+      confirmed
+        .filter((file) => file.locale)
+        .map((file) => `${file.fileId}:${file.locale}`)
+    );
+    if (confirmedKeys.size === 0) return;
+
+    const updatedAt = new Date().toISOString();
+    for (const file of uploaded) {
+      for (const translation of file.translations) {
+        if (!confirmedKeys.has(`${translation.fileId}:${translation.locale}`)) {
+          continue;
+        }
+        const entry = findOrCreateEntry(
+          lockfile.entryMap,
+          lockfile.data.entries,
+          translation.fileId,
+          translation.versionId
+        );
+        entry.translations[translation.locale] = {
+          ...entry.translations[translation.locale],
+          updatedAt,
+          postProcessHash: hashStringSync(translation.content),
+        };
+      }
+    }
+    writeLockfile(lockfile.data, lockfile.originalV1);
   }
 
   async wait(): Promise<void> {

--- a/packages/cli/src/workflows/steps/UploadTranslationsStep.ts
+++ b/packages/cli/src/workflows/steps/UploadTranslationsStep.ts
@@ -42,7 +42,8 @@ export function partitionTranslationsByLockfile(
       const translations = file.translations.filter((translation) => {
         const entry = entryMap.get(translation.fileId);
         if (!entry || entry.versionId !== translation.versionId) return true;
-        const lockHash = entry.translations[translation.locale]?.postProcessHash;
+        const lockHash =
+          entry.translations[translation.locale]?.postProcessHash;
         if (!lockHash || lockHash !== hashStringSync(translation.content)) {
           return true;
         }

--- a/packages/cli/src/workflows/steps/__tests__/UploadTranslationsStep.test.ts
+++ b/packages/cli/src/workflows/steps/__tests__/UploadTranslationsStep.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { UploadTranslationsStep } from '../UploadTranslationsStep.js';
+import { logger } from '../../../console/logger.js';
 import type { GT } from 'generaltranslation';
 import type { Settings } from '../../../types/index.js';
 import type { FileToUpload } from 'generaltranslation/types';
@@ -154,7 +155,7 @@ describe('UploadTranslationsStep', () => {
     expect(mockGt.uploadTranslations).not.toHaveBeenCalled();
   });
 
-  it('reports the number of uploaded translation files', async () => {
+  it('reports the server-confirmed number of uploaded translation files', async () => {
     const files = [
       {
         source: makeSource('file-1'),
@@ -169,7 +170,13 @@ describe('UploadTranslationsStep', () => {
       },
     ];
 
-    mockGt.uploadTranslations.mockResolvedValue({ uploadedFiles: [] });
+    mockGt.uploadTranslations.mockResolvedValue({
+      uploadedFiles: [
+        { fileId: 'file-1', locale: 'es' },
+        { fileId: 'file-1', locale: 'fr' },
+        { fileId: 'file-2', locale: 'es' },
+      ],
+    });
 
     const step = new UploadTranslationsStep(
       mockGt as unknown as GT,
@@ -179,6 +186,46 @@ describe('UploadTranslationsStep', () => {
 
     expect(mockSpinner.stop).toHaveBeenCalledWith(
       expect.stringContaining('Uploaded 3 translation files')
+    );
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('warns when the server persists fewer files than were uploaded', async () => {
+    const files = [
+      {
+        source: makeSource('file-1'),
+        translations: [
+          makeTranslation('file-1', 'es'),
+          makeTranslation('file-1', 'fr'),
+        ],
+      },
+      {
+        source: makeSource('file-2'),
+        translations: [makeTranslation('file-2', 'es')],
+      },
+    ];
+
+    // The endpoint silently drops files it failed to persist (no error,
+    // just a smaller uploadedFiles array)
+    mockGt.uploadTranslations.mockResolvedValue({
+      uploadedFiles: [
+        { fileId: 'file-1', locale: 'es' },
+        { fileId: 'file-2', locale: 'es' },
+      ],
+    });
+
+    const step = new UploadTranslationsStep(
+      mockGt as unknown as GT,
+      mockSettings
+    );
+    const result = await step.run({ files });
+
+    expect(result).toHaveLength(2);
+    expect(mockSpinner.stop).toHaveBeenCalledWith(
+      expect.stringContaining('Uploaded 2 translation files')
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('1 translation file was not persisted')
     );
   });
 });

--- a/packages/cli/src/workflows/steps/__tests__/UploadTranslationsStep.test.ts
+++ b/packages/cli/src/workflows/steps/__tests__/UploadTranslationsStep.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { UploadTranslationsStep } from '../UploadTranslationsStep.js';
+import type { GT } from 'generaltranslation';
+import type { Settings } from '../../../types/index.js';
+import type { FileToUpload } from 'generaltranslation/types';
+
+// Mock the GT class
+const mockGt = {
+  queryFileData: vi.fn(),
+  uploadTranslations: vi.fn(),
+};
+
+const mockSpinner = vi.hoisted(() => ({
+  start: vi.fn(),
+  stop: vi.fn(),
+  message: vi.fn(),
+}));
+
+// Mock the logger
+vi.mock('../../../console/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    createSpinner: () => mockSpinner,
+  },
+}));
+
+const mockSettings = {
+  defaultLocale: 'en',
+  modelProvider: undefined,
+} as unknown as Settings;
+
+function makeSource(fileId: string): FileToUpload {
+  return {
+    content: `source content ${fileId}`,
+    fileName: `${fileId}.json`,
+    fileFormat: 'JSON',
+    locale: 'en',
+    fileId,
+    versionId: `version-${fileId}`,
+  };
+}
+
+function makeTranslation(fileId: string, locale: string): FileToUpload {
+  return {
+    content: `translated content ${fileId} ${locale}`,
+    fileName: `${locale}/${fileId}.json`,
+    fileFormat: 'JSON',
+    locale,
+    fileId,
+    versionId: `version-${fileId}`,
+  };
+}
+
+describe('UploadTranslationsStep', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uploads every resolved translation file, including ones that already exist on the platform', async () => {
+    const files = [
+      {
+        source: makeSource('file-1'),
+        translations: [
+          makeTranslation('file-1', 'es'),
+          makeTranslation('file-1', 'fr'),
+        ],
+      },
+    ];
+
+    // Simulate the platform already having both translations for this
+    // (fileId, versionId, locale). Local files are the source of truth, so
+    // they must still be uploaded (the endpoint is an upsert).
+    mockGt.queryFileData.mockResolvedValue({
+      translatedFiles: [
+        {
+          branchId: 'branch-123',
+          fileId: 'file-1',
+          versionId: 'version-file-1',
+          locale: 'es',
+        },
+        {
+          branchId: 'branch-123',
+          fileId: 'file-1',
+          versionId: 'version-file-1',
+          locale: 'fr',
+        },
+      ],
+    });
+    mockGt.uploadTranslations.mockResolvedValue({
+      uploadedFiles: [
+        { fileId: 'file-1', locale: 'es' },
+        { fileId: 'file-1', locale: 'fr' },
+      ],
+    });
+
+    const step = new UploadTranslationsStep(
+      mockGt as unknown as GT,
+      mockSettings
+    );
+    const result = await step.run({ files });
+
+    // No existence check: everything local is sent
+    expect(mockGt.queryFileData).not.toHaveBeenCalled();
+    expect(mockGt.uploadTranslations).toHaveBeenCalledTimes(1);
+    expect(mockGt.uploadTranslations).toHaveBeenCalledWith(files, {
+      sourceLocale: 'en',
+      modelProvider: undefined,
+    });
+    expect(result).toEqual([
+      { fileId: 'file-1', locale: 'es' },
+      { fileId: 'file-1', locale: 'fr' },
+    ]);
+  });
+
+  it('filters out files without translations before uploading', async () => {
+    const withTranslations = {
+      source: makeSource('file-1'),
+      translations: [makeTranslation('file-1', 'es')],
+    };
+    const withoutTranslations = {
+      source: makeSource('file-2'),
+      translations: [],
+    };
+
+    mockGt.uploadTranslations.mockResolvedValue({
+      uploadedFiles: [{ fileId: 'file-1', locale: 'es' }],
+    });
+
+    const step = new UploadTranslationsStep(
+      mockGt as unknown as GT,
+      mockSettings
+    );
+    await step.run({ files: [withTranslations, withoutTranslations] });
+
+    expect(mockGt.uploadTranslations).toHaveBeenCalledWith(
+      [withTranslations],
+      expect.any(Object)
+    );
+  });
+
+  it('skips the upload entirely when no files have translations', async () => {
+    const step = new UploadTranslationsStep(
+      mockGt as unknown as GT,
+      mockSettings
+    );
+    const result = await step.run({
+      files: [{ source: makeSource('file-1'), translations: [] }],
+    });
+
+    expect(result).toEqual([]);
+    expect(mockGt.queryFileData).not.toHaveBeenCalled();
+    expect(mockGt.uploadTranslations).not.toHaveBeenCalled();
+  });
+
+  it('reports the number of uploaded translation files', async () => {
+    const files = [
+      {
+        source: makeSource('file-1'),
+        translations: [
+          makeTranslation('file-1', 'es'),
+          makeTranslation('file-1', 'fr'),
+        ],
+      },
+      {
+        source: makeSource('file-2'),
+        translations: [makeTranslation('file-2', 'es')],
+      },
+    ];
+
+    mockGt.uploadTranslations.mockResolvedValue({ uploadedFiles: [] });
+
+    const step = new UploadTranslationsStep(
+      mockGt as unknown as GT,
+      mockSettings
+    );
+    await step.run({ files });
+
+    expect(mockSpinner.stop).toHaveBeenCalledWith(
+      expect.stringContaining('Uploaded 3 translation files')
+    );
+  });
+});

--- a/packages/cli/src/workflows/steps/__tests__/UploadTranslationsStep.test.ts
+++ b/packages/cli/src/workflows/steps/__tests__/UploadTranslationsStep.test.ts
@@ -1,6 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { UploadTranslationsStep } from '../UploadTranslationsStep.js';
+import {
+  UploadTranslationsStep,
+  partitionTranslationsByLockfile,
+} from '../UploadTranslationsStep.js';
 import { logger } from '../../../console/logger.js';
+import {
+  readLockfile,
+  writeLockfile,
+  buildEntryMap,
+  type DownloadedVersionEntry,
+} from '../../../fs/config/downloadedVersions.js';
+import { hashStringSync } from '../../../utils/hash.js';
 import type { GT } from 'generaltranslation';
 import type { Settings } from '../../../types/index.js';
 import type { FileToUpload } from 'generaltranslation/types';
@@ -23,9 +33,24 @@ vi.mock('../../../console/logger.js', () => ({
     info: vi.fn(),
     debug: vi.fn(),
     warn: vi.fn(),
+    error: vi.fn(),
     createSpinner: () => mockSpinner,
   },
 }));
+
+// Mock only the lockfile I/O; keep the pure helpers (buildEntryMap,
+// findOrCreateEntry) real
+vi.mock('../../../fs/config/downloadedVersions.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import('../../../fs/config/downloadedVersions.js')
+    >();
+  return {
+    ...actual,
+    readLockfile: vi.fn(),
+    writeLockfile: vi.fn(),
+  };
+});
 
 const mockSettings = {
   defaultLocale: 'en',
@@ -54,9 +79,18 @@ function makeTranslation(fileId: string, locale: string): FileToUpload {
   };
 }
 
+function mockLockfile(entries: DownloadedVersionEntry[]): void {
+  vi.mocked(readLockfile).mockReturnValue({
+    data: { version: 2, branchId: 'branch-123', entries },
+    entryMap: buildEntryMap(entries),
+    originalV1: null,
+  });
+}
+
 describe('UploadTranslationsStep', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockLockfile([]);
   });
 
   it('uploads every resolved translation file, including ones that already exist on the platform', async () => {
@@ -155,6 +189,122 @@ describe('UploadTranslationsStep', () => {
     expect(mockGt.uploadTranslations).not.toHaveBeenCalled();
   });
 
+  it('skips translations whose content still matches the gt-lock.json hash', async () => {
+    const unchanged = makeTranslation('file-1', 'es');
+    const edited = makeTranslation('file-1', 'fr');
+    mockLockfile([
+      {
+        fileId: 'file-1',
+        versionId: 'version-file-1',
+        translations: {
+          es: { postProcessHash: hashStringSync(unchanged.content) },
+          fr: { postProcessHash: hashStringSync('older fr content') },
+        },
+      },
+    ]);
+    mockGt.uploadTranslations.mockResolvedValue({
+      uploadedFiles: [{ fileId: 'file-1', locale: 'fr' }],
+    });
+
+    const step = new UploadTranslationsStep(
+      mockGt as unknown as GT,
+      mockSettings
+    );
+    await step.run({
+      files: [
+        { source: makeSource('file-1'), translations: [unchanged, edited] },
+      ],
+    });
+
+    expect(mockGt.uploadTranslations).toHaveBeenCalledWith(
+      [{ source: makeSource('file-1'), translations: [edited] }],
+      expect.any(Object)
+    );
+    expect(mockSpinner.stop).toHaveBeenCalledWith(
+      expect.stringContaining('skipped 1 unchanged')
+    );
+  });
+
+  it('uploads translations whose lock entry is for a stale source version', async () => {
+    const translation = makeTranslation('file-1', 'es');
+    mockLockfile([
+      {
+        fileId: 'file-1',
+        versionId: 'old-version',
+        translations: {
+          es: { postProcessHash: hashStringSync(translation.content) },
+        },
+      },
+    ]);
+    mockGt.uploadTranslations.mockResolvedValue({
+      uploadedFiles: [{ fileId: 'file-1', locale: 'es' }],
+    });
+
+    const step = new UploadTranslationsStep(
+      mockGt as unknown as GT,
+      mockSettings
+    );
+    await step.run({
+      files: [{ source: makeSource('file-1'), translations: [translation] }],
+    });
+
+    expect(mockGt.uploadTranslations).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips the API call entirely when every translation matches the lockfile', async () => {
+    const translation = makeTranslation('file-1', 'es');
+    mockLockfile([
+      {
+        fileId: 'file-1',
+        versionId: 'version-file-1',
+        translations: {
+          es: { postProcessHash: hashStringSync(translation.content) },
+        },
+      },
+    ]);
+
+    const step = new UploadTranslationsStep(
+      mockGt as unknown as GT,
+      mockSettings
+    );
+    const result = await step.run({
+      files: [{ source: makeSource('file-1'), translations: [translation] }],
+    });
+
+    expect(result).toEqual([]);
+    expect(mockGt.uploadTranslations).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining('unchanged since the last sync')
+    );
+  });
+
+  it('records content hashes for server-confirmed uploads in the lockfile', async () => {
+    const es = makeTranslation('file-1', 'es');
+    const fr = makeTranslation('file-1', 'fr');
+    // Server confirms es but silently drops fr
+    mockGt.uploadTranslations.mockResolvedValue({
+      uploadedFiles: [{ fileId: 'file-1', locale: 'es' }],
+    });
+
+    const step = new UploadTranslationsStep(
+      mockGt as unknown as GT,
+      mockSettings
+    );
+    await step.run({
+      files: [{ source: makeSource('file-1'), translations: [es, fr] }],
+    });
+
+    expect(writeLockfile).toHaveBeenCalledTimes(1);
+    const [written] = vi.mocked(writeLockfile).mock.calls[0]!;
+    const entry = written.entries.find((e) => e.fileId === 'file-1');
+    expect(entry?.translations.es?.postProcessHash).toBe(
+      hashStringSync(es.content)
+    );
+    // Unconfirmed uploads must not be recorded, or they would be skipped
+    // (and never retried) on the next run
+    expect(entry?.translations.fr).toBeUndefined();
+  });
+
   it('reports the server-confirmed number of uploaded translation files', async () => {
     const files = [
       {
@@ -227,5 +377,61 @@ describe('UploadTranslationsStep', () => {
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining('1 translation file was not persisted')
     );
+  });
+});
+
+describe('partitionTranslationsByLockfile', () => {
+  it('uploads everything when the lockfile has no entries', () => {
+    const files = [
+      {
+        source: makeSource('file-1'),
+        translations: [makeTranslation('file-1', 'es')],
+      },
+    ];
+    const { filesToUpload, skippedCount } = partitionTranslationsByLockfile(
+      files,
+      buildEntryMap([])
+    );
+    expect(filesToUpload).toEqual(files);
+    expect(skippedCount).toBe(0);
+  });
+
+  it('uploads translations with a lock entry but no recorded hash', () => {
+    const files = [
+      {
+        source: makeSource('file-1'),
+        translations: [makeTranslation('file-1', 'es')],
+      },
+    ];
+    const { filesToUpload, skippedCount } = partitionTranslationsByLockfile(
+      files,
+      buildEntryMap([
+        {
+          fileId: 'file-1',
+          versionId: 'version-file-1',
+          translations: { es: { updatedAt: '2026-07-14T00:00:00.000Z' } },
+        },
+      ])
+    );
+    expect(filesToUpload).toEqual(files);
+    expect(skippedCount).toBe(0);
+  });
+
+  it('drops files entirely when all their translations are unchanged', () => {
+    const unchanged = makeTranslation('file-1', 'es');
+    const { filesToUpload, skippedCount } = partitionTranslationsByLockfile(
+      [{ source: makeSource('file-1'), translations: [unchanged] }],
+      buildEntryMap([
+        {
+          fileId: 'file-1',
+          versionId: 'version-file-1',
+          translations: {
+            es: { postProcessHash: hashStringSync(unchanged.content) },
+          },
+        },
+      ])
+    );
+    expect(filesToUpload).toEqual([]);
+    expect(skippedCount).toBe(1);
   });
 });

--- a/packages/cli/src/workflows/upload.ts
+++ b/packages/cli/src/workflows/upload.ts
@@ -61,7 +61,6 @@ export async function runUploadFilesWorkflow({
     if (filesWithTranslations.length > 0) {
       await uploadTranslationsStep.run({
         files: filesWithTranslations,
-        branchData,
       });
       await uploadTranslationsStep.wait();
     }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR simplifies the `upload` command by removing the pre-upload existence check and making local translation files the authoritative source of truth — every resolved translation is now sent unconditionally, relying on the endpoint's upsert semantics to overwrite what is already on the platform.

- **Removed deduplication logic**: the `queryFileData` call, `existingTranslationsMap` set, and `branchData` parameter are all dropped from `UploadTranslationsStep`, eliminating an extra round-trip and the skip-if-present filter.
- **Server-confirmed count in output**: the success message now reports `response.uploadedFiles.length` rather than the pre-upload count, and a `logger.warn` fires when the server persists fewer files than were sent.
- **New test suite** (`UploadTranslationsStep.test.ts`) covers the overwrite behaviour, the partial-persistence warning, the empty-translations early-exit, and the source-only file filter.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change removes a round-trip existence check in favour of a straightforward upsert upload, and the new behaviour is well-covered by the added test suite.

The logic change is small and self-contained: remove the deduplication filter, pass all local translations to the upload endpoint, and surface the server-confirmed count. All affected branches are exercised by the new tests, and upload.ts requires only a one-line call-site update.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/workflows/steps/UploadTranslationsStep.ts | Removes the "skip existing" deduplication logic; local files are now always uploaded as the source of truth. Also removes the `branchData` dependency and emits a server-confirmed count with a warning on partial persistence. Minor defensive gap on `response.uploadedFiles` null-safety. |
| packages/cli/src/workflows/upload.ts | Drops the `branchData` argument from `uploadTranslationsStep.run()`; the outer pre-filter of `filesWithTranslations` is now slightly redundant with the identical filter inside `run()`, but this is harmless. |
| packages/cli/src/workflows/steps/__tests__/UploadTranslationsStep.test.ts | New test suite covering the overwrite behaviour: verifies that `queryFileData` is never called, filters out source-only files, guards the no-translations early-exit, and asserts both the server-confirmed count in the success message and the partial-persistence warning. |
| .changeset/sharp-rabbits-sniff.md | Changeset entry correctly classifying the behaviour change as a patch bump for the `gt` package. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CLI as upload.ts
    participant BranchStep
    participant UploadSourcesStep
    participant UploadTranslationsStep
    participant GT_API as GT API

    CLI->>BranchStep: run()
    BranchStep->>GT_API: resolve branch
    GT_API-->>BranchStep: branchData
    BranchStep-->>CLI: branchData

    CLI->>UploadSourcesStep: "run({ files, branchData })"
    UploadSourcesStep->>GT_API: upload sources
    GT_API-->>UploadSourcesStep: ok
    UploadSourcesStep-->>CLI: done

    CLI->>UploadTranslationsStep: "run({ files })"
    note over UploadTranslationsStep: filter files with translations
    note over UploadTranslationsStep: (no queryFileData round-trip)
    UploadTranslationsStep->>GT_API: uploadTranslations (upsert)
    GT_API-->>UploadTranslationsStep: "{ uploadedFiles }"
    note over UploadTranslationsStep: warn if uploadedFiles.length < total
    UploadTranslationsStep-->>CLI: FileReference[]

    CLI-->>CLI: logger.success
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CLI as upload.ts
    participant BranchStep
    participant UploadSourcesStep
    participant UploadTranslationsStep
    participant GT_API as GT API

    CLI->>BranchStep: run()
    BranchStep->>GT_API: resolve branch
    GT_API-->>BranchStep: branchData
    BranchStep-->>CLI: branchData

    CLI->>UploadSourcesStep: "run({ files, branchData })"
    UploadSourcesStep->>GT_API: upload sources
    GT_API-->>UploadSourcesStep: ok
    UploadSourcesStep-->>CLI: done

    CLI->>UploadTranslationsStep: "run({ files })"
    note over UploadTranslationsStep: filter files with translations
    note over UploadTranslationsStep: (no queryFileData round-trip)
    UploadTranslationsStep->>GT_API: uploadTranslations (upsert)
    GT_API-->>UploadTranslationsStep: "{ uploadedFiles }"
    note over UploadTranslationsStep: warn if uploadedFiles.length < total
    UploadTranslationsStep-->>CLI: FileReference[]

    CLI-->>CLI: logger.success
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: review"](https://github.com/generaltranslation/gt/commit/987f1a0999423a419362a1399d34df261e66342e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44332885)</sub>

<!-- /greptile_comment -->