### PR TITLE
chore(core): deprecate hashSource id option

### DIFF
--- a/.changeset/tidy-pandas-hash.md
+++ b/.changeset/tidy-pandas-hash.md
@@ -1,0 +1,5 @@
+---
+'generaltranslation': patch
+---
+
+Deprecate the `id` option in `hashSource` ahead of its removal in the next major version.

--- a/packages/core/src/id/__tests__/hashSource.test.ts
+++ b/packages/core/src/id/__tests__/hashSource.test.ts
@@ -80,3 +80,28 @@ describe('hashSource requiresReview', () => {
     ).toBe('2ef012fb27e5f019');
   });
 });
+
+describe('hashSource id compatibility', () => {
+  it('continues to include the deprecated id in the hash', () => {
+    const withoutId = hashSource({
+      source: 'Hello world',
+      dataFormat: 'ICU',
+    });
+    const withFirstId = hashSource({
+      source: 'Hello world',
+      id: 'first-id',
+      dataFormat: 'ICU',
+    });
+    const withSecondId = hashSource({
+      source: 'Hello world',
+      id: 'second-id',
+      dataFormat: 'ICU',
+    });
+
+    expect(withFirstId).not.toBe(withoutId);
+    expect(withSecondId).not.toBe(withFirstId);
+    // Existing callers that still pass an ID must keep their current hashes.
+    expect(withFirstId).toBe('b654d66386ed785a');
+    expect(withSecondId).toBe('8220228ac45bb5ee');
+  });
+});

--- a/packages/core/src/id/hashSource.ts
+++ b/packages/core/src/id/hashSource.ts
@@ -25,7 +25,8 @@ export function hashString(string: string): string {
  *
  * @param {any} childrenAsObjects - The children objects to be hashed.
  * @param {string} [context] - The context for the children.
- * @param {string} [id] - The ID for the JSX children object.
+ * @param {string} [id] - Deprecated custom ID. It remains part of the hash for
+ * backward compatibility, but will be removed in the next major version.
  * @param {number} [maxChars] - The maxChars limit for the JSX children object.
  * @param {string} [dataFormat] - The data format of the sources.
  * @param {function} [hashFunction] - Custom hash function.

--- a/packages/core/src/id/types.ts
+++ b/packages/core/src/id/types.ts
@@ -2,6 +2,11 @@ import type { DataFormat } from '@generaltranslation/format/types';
 
 export type HashMetadata = {
   context?: string;
+  /**
+   * @deprecated Custom IDs are not used by current translation tooling. This
+   * field will be removed in the next major version. Omit it to use the
+   * content-based hash.
+   */
   id?: string;
   maxChars?: number;
   requiresReview?: boolean;


### PR DESCRIPTION
## Summary

- mark HashMetadata.id as deprecated ahead of removal in the next major version
- preserve the current ID-sensitive hash behavior for existing direct callers
- add pinned compatibility coverage and a patch changeset for generaltranslation

## Tests

- pnpm --filter generaltranslation test
- pnpm --filter generaltranslation typecheck
- pnpm exec oxlint packages/core/src/id/hashSource.ts packages/core/src/id/types.ts packages/core/src/id/__tests__/hashSource.test.ts
- pnpm exec oxfmt --check packages/core/src/id/hashSource.ts packages/core/src/id/types.ts packages/core/src/id/__tests__/hashSource.test.ts .changeset/tidy-pandas-hash.md
- pnpm build

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR deprecates the `id` field of `HashMetadata` ahead of its removal in the next major version, without changing any hashing behavior. The `id` field remains part of the computed hash for backward compatibility with existing callers.

- `types.ts` gains a `@deprecated` TSDoc tag on `HashMetadata.id`, giving TypeScript users a strikethrough warning at call sites that still pass `id`.
- `hashSource.ts` JSDoc is updated to describe the deprecation; the runtime implementation (`...(id && { id })`) is untouched.
- A new pinned-hash test suite asserts specific SHA-256 hex values for `id`-bearing calls, preventing silent hash drift during future refactors.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — only documentation and test additions; the hashing runtime is untouched.

All four changed files are either documentation (JSDoc / TSDoc), a changeset entry, or new tests. The hashSource implementation itself is not modified, so existing hash outputs are guaranteed stable. The pinned-hash tests provide a concrete regression guard for the compatibility promise.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .changeset/tidy-pandas-hash.md | New patch changeset documenting the `id` deprecation in `hashSource`; correctly classified as a patch release. |
| packages/core/src/id/types.ts | Adds `@deprecated` TSDoc to `HashMetadata.id`; will cause TypeScript to render a strikethrough on any call site that passes `id`, no logic changes. |
| packages/core/src/id/hashSource.ts | JSDoc `@param id` updated to note deprecation; implementation unchanged — `id` still participates in the hash via the existing `...(id && { id })` spread. |
| packages/core/src/id/__tests__/hashSource.test.ts | Adds a pinned-hash compatibility suite that asserts specific SHA-256 hex values for `id`-bearing calls, guarding against accidental hash drift. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["hashSource({ source, id?, context?, ... })"] --> B{id provided?}
    B -- "yes (deprecated)" --> C["Include id in sanitizedData\n...(id && { id })"]
    B -- "no" --> D["Omit id from sanitizedData"]
    C --> E["stringify(sanitizedData)"]
    D --> E
    E --> F["hashFunction(stringifiedData)"]
    F --> G["16-char hex hash"]

    style C fill:#ffe0b2,stroke:#e65100
    style B fill:#fff9c4,stroke:#f9a825
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["hashSource({ source, id?, context?, ... })"] --> B{id provided?}
    B -- "yes (deprecated)" --> C["Include id in sanitizedData\n...(id && { id })"]
    B -- "no" --> D["Omit id from sanitizedData"]
    C --> E["stringify(sanitizedData)"]
    D --> E
    E --> F["hashFunction(stringifiedData)"]
    F --> G["16-char hex hash"]

    style C fill:#ffe0b2,stroke:#e65100
    style B fill:#fff9c4,stroke:#f9a825
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(core): deprecate hashSource id opt..."](https://github.com/generaltranslation/gt/commit/8731cd6cab4692048726862752597b2bcb3b4925) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44554047)</sub>

<!-- /greptile_comment -->