### PR TITLE
fix(gt-next): exclude IDs from SWC hashes

### DIFF
--- a/.changeset/quiet-hashes-ignore-ids.md
+++ b/.changeset/quiet-hashes-ignore-ids.md
@@ -1,0 +1,5 @@
+---
+'gt-next': patch
+---
+
+Exclude custom translation IDs from SWC-generated content hashes to match the TypeScript compiler and runtime.

--- a/packages/next/swc-plugin/src/ast/traversal.rs
+++ b/packages/next/swc-plugin/src/ast/traversal.rs
@@ -47,10 +47,6 @@ impl<'a> JsxTraversal<'a> {
 
     // Build sanitized children directly from JSX children
     if let Some(sanitized_children) = self.build_sanitized_children(&element.children) {
-      // Get the id from the element
-      let id = extract_attribute_from_jsx_attr(element, "id")
-        .or_else(|| extract_attribute_from_jsx_attr(element, "$id"));
-
       // Get the context from the element
       let context = extract_attribute_from_jsx_attr(element, "context")
         .or_else(|| extract_attribute_from_jsx_attr(element, "$context"));
@@ -64,11 +60,10 @@ impl<'a> JsxTraversal<'a> {
         || jsx_attr_contains_derive_call(element, "$context");
       let has_static = JsxHasher::contains_static(&sanitized_children) || has_derive_in_context;
       
-      // Create the full SanitizedData structure to match TypeScript implementation
+      // Create the full SanitizedData structure to match TypeScript compiler inputs
       use crate::hash::SanitizedData;
       let sanitized_data = SanitizedData {
         source: Some(Box::new(sanitized_children)),
-        id,
         context,
         max_chars,
         data_format: Some("JSX".to_string()),
@@ -101,7 +96,6 @@ impl<'a> JsxTraversal<'a> {
       
       let sanitized_data = SanitizedData {
         source: Some(Box::new(empty_children)),
-        id: None,
         context: None,
         max_chars: None,
         data_format: Some("JSX".to_string()),
@@ -1175,6 +1169,39 @@ mod tests {
   mod calculate_element_hash_tests {
     use super::*;
 
+    fn create_string_attr(name: &str, value: &str) -> JSXAttrOrSpread {
+      JSXAttrOrSpread::JSXAttr(JSXAttr {
+        span: DUMMY_SP,
+        name: JSXAttrName::Ident(IdentName {
+          span: DUMMY_SP,
+          sym: Atom::new(name),
+        }),
+        value: Some(JSXAttrValue::Str(Str {
+          span: DUMMY_SP,
+          value: Atom::new(value).into(),
+          raw: None,
+        })),
+      })
+    }
+
+    fn create_number_attr(name: &str, value: f64) -> JSXAttrOrSpread {
+      JSXAttrOrSpread::JSXAttr(JSXAttr {
+        span: DUMMY_SP,
+        name: JSXAttrName::Ident(IdentName {
+          span: DUMMY_SP,
+          sym: Atom::new(name),
+        }),
+        value: Some(JSXAttrValue::JSXExprContainer(JSXExprContainer {
+          span: DUMMY_SP,
+          expr: JSXExpr::Expr(Box::new(Expr::Lit(Lit::Num(Number {
+            span: DUMMY_SP,
+            value,
+            raw: None,
+          })))),
+        })),
+      })
+    }
+
     // Helper to create JSX element with children
     fn create_jsx_element_with_children(tag_name: &str, children: Vec<JSXElementChild>) -> JSXElement {
       JSXElement {
@@ -1330,6 +1357,46 @@ mod tests {
       // Same content should produce same hash
       assert_eq!(hash1, hash2, "Same content should produce same hash");
       assert!(!hash1.is_empty(), "Hash should not be empty for identical content");
+    }
+
+    #[test]
+    fn custom_id_does_not_change_hash() {
+      let visitor = create_test_visitor();
+      let mut first =
+        create_jsx_element_with_children("T", vec![create_jsx_text_child("Hello world")]);
+      first.opening.attrs = vec![
+        create_string_attr("id", "first-id"),
+        create_string_attr("context", "greeting"),
+        create_number_attr("maxChars", 40.0),
+      ];
+
+      let mut second = first.clone();
+      second.opening.attrs[0] = create_string_attr("id", "second-id");
+
+      let mut first_traversal = JsxTraversal::new(&visitor);
+      let (first_hash, first_json) = first_traversal.calculate_element_hash(&first);
+      let mut second_traversal = JsxTraversal::new(&visitor);
+      let (second_hash, second_json) = second_traversal.calculate_element_hash(&second);
+
+      assert_eq!(first_hash, second_hash, "Custom ID should not change hash");
+      assert_eq!(
+        first_json, second_json,
+        "Custom ID should not be serialized"
+      );
+      assert!(!first_json.contains("first-id"));
+      assert!(!second_json.contains("second-id"));
+
+      let mut different_context = first.clone();
+      different_context.opening.attrs[1] = create_string_attr("context", "farewell");
+      let mut context_traversal = JsxTraversal::new(&visitor);
+      let (context_hash, _) = context_traversal.calculate_element_hash(&different_context);
+      assert_ne!(first_hash, context_hash, "Context should change hash");
+
+      let mut different_content = first;
+      different_content.children = vec![create_jsx_text_child("Goodbye world")];
+      let mut content_traversal = JsxTraversal::new(&visitor);
+      let (content_hash, _) = content_traversal.calculate_element_hash(&different_content);
+      assert_ne!(first_hash, content_hash, "Content should change hash");
     }
   }
 

--- a/packages/next/swc-plugin/src/hash.rs
+++ b/packages/next/swc-plugin/src/hash.rs
@@ -94,14 +94,12 @@ pub enum SanitizedChildren {
   Wrapped { c: Box<SanitizedChildren> },
 }
 
-/// Sanitized data structure for hashing (matches TypeScript hashSource.ts)
+/// Sanitized data structure for hashing (matches TypeScript compiler inputs)
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SanitizedData {
   #[serde(skip_serializing_if = "Option::is_none")]
   pub source: Option<Box<SanitizedChildren>>,
-  #[serde(skip_serializing_if = "Option::is_none")]
-  pub id: Option<String>,
   #[serde(skip_serializing_if = "Option::is_none")]
   pub context: Option<String>,
   #[serde(skip_serializing_if = "Option::is_none")]
@@ -373,7 +371,6 @@ mod tests {
       SanitizedChildren::Single(Box::new(SanitizedChild::Text("Hello world".to_string())));
     let sanitized_data = SanitizedData {
       source: Some(Box::new(children.clone())),
-      id: None,
       context: None,
       max_chars: None,
       data_format: Some("JSX".to_string()),
@@ -391,26 +388,25 @@ mod tests {
   }
 
   #[test]
-  fn test_hash_source_with_context_and_id() {
+  fn test_hash_source_with_context_and_content() {
     let children = SanitizedChildren::Single(Box::new(SanitizedChild::Text("Hello".to_string())));
 
     let data1 = SanitizedData {
       source: Some(Box::new(children.clone())),
-      id: None,
       context: None,
       max_chars: None,
       data_format: Some("JSX".to_string()),
     };
     let data2 = SanitizedData {
       source: Some(Box::new(children.clone())),
-      id: None,
       context: Some("context".to_string()),
       max_chars: None,
       data_format: Some("JSX".to_string()),
     };
     let data3 = SanitizedData {
-      source: Some(Box::new(children)),
-      id: Some("id".to_string()),
+      source: Some(Box::new(SanitizedChildren::Single(Box::new(
+        SanitizedChild::Text("Goodbye".to_string()),
+      )))),
       context: None,
       max_chars: None,
       data_format: Some("JSX".to_string()),
@@ -420,13 +416,9 @@ mod tests {
     let hash2 = JsxHasher::hash_string(&JsxHasher::stable_stringify(&data2).unwrap());
     let hash3 = JsxHasher::hash_string(&JsxHasher::stable_stringify(&data3).unwrap());
 
-    // All should be different
     assert_ne!(hash1, hash2, "Context should change hash");
-    assert_ne!(hash1, hash3, "ID should change hash");
-    assert_ne!(
-      hash2, hash3,
-      "Context and ID should produce different hashes"
-    );
+    assert_ne!(hash1, hash3, "Content should change hash");
+    assert_ne!(hash2, hash3, "Context and content should change hash");
   }
 
   #[test]
@@ -435,7 +427,6 @@ mod tests {
       SanitizedChildren::Single(Box::new(SanitizedChild::Text("test text".to_string())));
     let data = SanitizedData {
       source: Some(Box::new(children)),
-      id: None,
       context: None,
       max_chars: None,
       data_format: Some("JSX".to_string()),
@@ -468,7 +459,6 @@ mod tests {
     let empty_children = SanitizedChildren::Multiple(vec![]);
     let data = SanitizedData {
       source: Some(Box::new(empty_children)),
-      id: None,
       context: None,
       max_chars: None,
       data_format: Some("JSX".to_string()),
@@ -506,7 +496,6 @@ mod tests {
 
     let data = SanitizedData {
       source: Some(Box::new(children.clone())),
-      id: None,
       context: None,
       max_chars: None,
       data_format: Some("JSX".to_string()),
@@ -528,7 +517,6 @@ mod tests {
 
     let data2 = SanitizedData {
       source: Some(Box::new(children2)),
-      id: None,
       context: None,
       max_chars: None,
       data_format: Some("JSX".to_string()),

--- a/packages/next/swc-plugin/src/visitor/transform.rs
+++ b/packages/next/swc-plugin/src/visitor/transform.rs
@@ -436,7 +436,8 @@ pub fn validate_string_literal_or_derive(&self,expr: &Expr, errors: &mut Vec<Str
     }
 
     // Extract the options content
-    let (id, context, max_chars, format, has_derive_context) = extract_id_and_context_from_options(options);
+    let (_, context, max_chars, format, has_derive_context) =
+      extract_id_and_context_from_options(options);
 
     // If context contains derive(), skip hashing — CLI handles resolution
     if has_derive_context {
@@ -449,7 +450,6 @@ pub fn validate_string_literal_or_derive(&self,expr: &Expr, errors: &mut Vec<Str
       source: Some(Box::new(SanitizedChildren::Single(Box::new(
         SanitizedChild::Text(string_content.unwrap()),
       )))),
-      id,
       context,
       max_chars,
       data_format: Some(format.unwrap_or_else(|| "ICU".to_string())),
@@ -2731,6 +2731,42 @@ mod tests {
   mod hash_calculation {
     use super::*;
 
+    fn create_string_arg(value: &str) -> ExprOrSpread {
+      ExprOrSpread {
+        spread: None,
+        expr: Box::new(Expr::Lit(Lit::Str(Str {
+          span: DUMMY_SP,
+          value: Atom::new(value).into(),
+          raw: None,
+        }))),
+      }
+    }
+
+    fn create_options_arg(id: &str, context: &str) -> ExprOrSpread {
+      ExprOrSpread {
+        spread: None,
+        expr: Box::new(Expr::Object(ObjectLit {
+          span: DUMMY_SP,
+          props: vec![
+            create_string_prop("$id", id, DUMMY_SP),
+            create_string_prop("$context", context, DUMMY_SP),
+            PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
+              key: PropName::Ident(IdentName {
+                span: DUMMY_SP,
+                sym: Atom::new("$maxChars"),
+              }),
+              value: Box::new(Expr::Lit(Lit::Num(Number {
+                span: DUMMY_SP,
+                value: 40.0,
+                raw: None,
+              }))),
+            }))),
+            create_string_prop("$format", "ICU", DUMMY_SP),
+          ],
+        })),
+      }
+    }
+
     #[test]
     fn calculates_hash_for_empty_element() {
       let mut visitor =
@@ -2765,6 +2801,63 @@ mod tests {
       let (hash2, _) = traversal2.calculate_element_hash(&element2);
 
       assert_ne!(hash1, hash2);
+    }
+
+    #[test]
+    fn custom_id_does_not_change_call_hash() {
+      let mut visitor = TransformVisitor::new(
+        LogLevel::Silent,
+        false,
+        None,
+        false,
+        false,
+        false,
+        StringCollector::new(),
+      );
+      let message = create_string_arg("Hello world");
+      let first_options = create_options_arg("first-id", "greeting");
+      let second_options = create_options_arg("second-id", "greeting");
+
+      let (first_hash, first_json) =
+        visitor.calculate_hash_for_call_expr(&message, Some(&first_options));
+      let (second_hash, second_json) =
+        visitor.calculate_hash_for_call_expr(&message, Some(&second_options));
+
+      assert_eq!(first_hash, second_hash, "Custom ID should not change hash");
+      assert_eq!(
+        first_json, second_json,
+        "Custom ID should not be serialized"
+      );
+      assert!(!first_json.unwrap().contains("first-id"));
+      assert!(!second_json.unwrap().contains("second-id"));
+
+      let different_context_options = create_options_arg("first-id", "farewell");
+      let (context_hash, _) =
+        visitor.calculate_hash_for_call_expr(&message, Some(&different_context_options));
+      assert_ne!(first_hash, context_hash, "Context should change hash");
+
+      let different_message = create_string_arg("Goodbye world");
+      let (content_hash, _) =
+        visitor.calculate_hash_for_call_expr(&different_message, Some(&first_options));
+      assert_ne!(first_hash, content_hash, "Content should change hash");
+
+      visitor.string_collector.initialize_aggregator(0);
+      let call_expr = CallExpr {
+        span: DUMMY_SP,
+        ctxt: SyntaxContext::empty(),
+        callee: Callee::Expr(Box::new(Expr::Ident(Ident {
+          span: DUMMY_SP,
+          sym: Atom::new("t"),
+          optional: false,
+          ctxt: SyntaxContext::empty(),
+        }))),
+        args: vec![message.clone(), first_options.clone()],
+        type_args: None,
+      };
+      visitor.track_translation_callback(&call_expr, &message, 0);
+
+      let collected = visitor.string_collector.get_translation_data(0).unwrap();
+      assert_eq!(collected.content[0].id.as_deref(), Some("first-id"));
     }
   }
 


### PR DESCRIPTION
## Summary
- exclude custom translation IDs from SWC sanitized hash inputs for JSX and translation callbacks
- preserve callback IDs in collected runtime metadata
- add regressions proving ID-only changes keep hashes stable while content and context changes invalidate them
- add a patch changeset for gt-next

## Tests
- `cargo test --manifest-path packages/next/swc-plugin/Cargo.toml` (297 passed)
- `cargo clippy --manifest-path packages/next/swc-plugin/Cargo.toml` (passes with existing warnings)
- `pnpm --filter gt-next test:js` (240 passed)
- `pnpm --filter gt-next typecheck`
- `pnpm --filter gt-next build`

Related to #1878.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes an inconsistency in the SWC plugin where custom translation `id` values were being included in the hash input for `SanitizedData`, causing different hashes for translations that differed only in their explicit ID — while the TypeScript compiler already excluded IDs from its hash inputs. The fix removes the `id` field from `SanitizedData` in both JSX and translation-callback code paths, while still preserving IDs in the collected runtime metadata for `t()` calls.

- **`hash.rs`**: Drops `id: Option<String>` from `SanitizedData`; renames an existing test to accurately reflect that it exercises content/context changes, not ID changes.
- **`traversal.rs` / `transform.rs`**: Stop extracting/feeding `id` into hash inputs for both JSX elements and translation-callback expressions; `track_translation_callback` still extracts `id` and passes it to `create_translation_content` so runtime metadata is unaffected.
- New regression tests added for both code paths assert ID-only changes produce stable hashes while content and context changes still invalidate them.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is well-scoped, well-tested, and closes a concrete behavioral gap between the SWC plugin and the TypeScript compiler.

All four changed files are internally consistent: SanitizedData loses its id field, every construction site is updated, and the ID is still forwarded to runtime metadata in track_translation_callback. New regression tests cover the three cases that matter — same ID/different ID (hash must be equal), different context (hash must differ), and different content (hash must differ). The existing 297 Rust tests and 240 JS tests all pass.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/next/swc-plugin/src/hash.rs | Removes `id` field from `SanitizedData`; all existing usages cleanly updated; a test is renamed to better reflect its intent (content vs ID variance). |
| packages/next/swc-plugin/src/ast/traversal.rs | Stops extracting `id` from JSX element attrs before building `SanitizedData`; adds a thorough regression test covering ID-stable, context-sensitive, and content-sensitive hash cases. |
| packages/next/swc-plugin/src/visitor/transform.rs | Discards `id` from `extract_id_and_context_from_options` in `calculate_hash_for_call_expr` while `track_translation_callback` still extracts and forwards it to `create_translation_content`, preserving it in collected metadata. |
| .changeset/quiet-hashes-ignore-ids.md | Patch changeset for `gt-next` with an accurate description of the behavioral fix. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[JSX element or t call] --> B{Code path}
    B --> C[JSX: calculate_element_hash]
    B --> D[Callback: calculate_hash_for_call_expr]

    C --> E[Extract context and maxChars - ID skipped]
    D --> F[Extract context, maxChars, format - ID discarded]

    E --> G[Build SanitizedData: source + context + maxChars + dataFormat]
    F --> G

    G --> H[stable_stringify to SHA256 to 16-char hash]

    D --> I[track_translation_callback]
    I --> J[extract_id_and_context_from_options - ID preserved here]
    J --> K[create_translation_content with id, context, hash]
    K --> L[string_collector metadata - ID stored for runtime]

    H --> M[_hash injected into JSX or t args]
    L --> N[Metadata emitted to CLI and runtime]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[JSX element or t call] --> B{Code path}
    B --> C[JSX: calculate_element_hash]
    B --> D[Callback: calculate_hash_for_call_expr]

    C --> E[Extract context and maxChars - ID skipped]
    D --> F[Extract context, maxChars, format - ID discarded]

    E --> G[Build SanitizedData: source + context + maxChars + dataFormat]
    F --> G

    G --> H[stable_stringify to SHA256 to 16-char hash]

    D --> I[track_translation_callback]
    I --> J[extract_id_and_context_from_options - ID preserved here]
    J --> K[create_translation_content with id, context, hash]
    K --> L[string_collector metadata - ID stored for runtime]

    H --> M[_hash injected into JSX or t args]
    L --> N[Metadata emitted to CLI and runtime]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(gt-next): exclude ids from swc hashe..."](https://github.com/generaltranslation/gt/commit/bec951e5ad464f0fd3b7a53a66487c8ec39b9091) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44554946)</sub>

<!-- /greptile_comment -->