### PR TITLE
chore(react-core): deprecate $-prefixed sugar props on <T>

### DIFF
--- a/.changeset/deprecate-t-sugar-props.md
+++ b/.changeset/deprecate-t-sugar-props.md
@@ -1,0 +1,5 @@
+---
+'@generaltranslation/react-core': patch
+---
+
+Deprecate the `$`-prefixed sugar props on the `<T>` component (`$context`, `$id`, `$maxChars`, `$requiresReview`) in favor of the unprefixed forms (`context`, `id`, `maxChars`, `requiresReview`). Both forms keep working; support for the `$`-prefixed forms will be removed in the next major version. String-function options (`t()`, `gt()`, `msg()`) are unaffected.

--- a/packages/react-core/src/utils/translation/prepareT.shared.ts
+++ b/packages/react-core/src/utils/translation/prepareT.shared.ts
@@ -15,8 +15,37 @@ type StripDollarPrefix<T> = {
   [K in keyof T as K extends `$${infer Rest}` ? Rest : K]: T[K];
 };
 
+/**
+ * $-prefixed sugar props on <T>, deprecated in favor of the unprefixed
+ * forms. Declared explicitly (rather than reusing the shared options type)
+ * so the deprecation applies only to <T> component props — the $-prefixed
+ * options of the string functions (t(), gt(), msg()) are unaffected.
+ */
+type TSugarProps = {
+  /** @deprecated Use `context` instead. Support for `$context` will be removed in the next major version. */
+  $context?: string;
+  /** @deprecated Use `id` instead. Support for `$id` will be removed in the next major version. */
+  $id?: string;
+  /** @deprecated Use `maxChars` instead. Support for `$maxChars` will be removed in the next major version. */
+  $maxChars?: number;
+  /** @deprecated Use `requiresReview` instead. Support for `$requiresReview` will be removed in the next major version. */
+  $requiresReview?: boolean;
+  /** @internal Compiler-injected hash; not part of the public API. */
+  $_hash?: string;
+  /** @internal Always 'JSX' for <T>. */
+  $format?: 'JSX';
+};
+
+// Compile-time guard: TSugarProps must stay structurally identical to the
+// shared sugar options type it re-declares.
+type AssertExact<A, B> = A extends B ? (B extends A ? true : never) : never;
+type _TSugarPropsInSync = Expect<
+  AssertExact<TSugarProps, JsxTranslationOptionsWithSugar>
+>;
+type Expect<T extends true> = T;
+
 type JsxTranslationOptions = StripDollarPrefix<JsxTranslationOptionsWithSugar> &
-  JsxTranslationOptionsWithSugar;
+  TSugarProps;
 
 type PreparedT = {
   taggedSourceChildren: TaggedChildren;


### PR DESCRIPTION
## What

Marks the user-facing `$`-prefixed sugar props on the `<T>` component — `$context`, `$id`, `$maxChars`, `$requiresReview` — as `@deprecated` in favor of the unprefixed forms (`context`, `id`, `maxChars`, `requiresReview`), which are the supported spelling going forward. Message pattern: *"Use `context` instead. Support for `$context` will be removed in the next major version."*

## How

The `<T>` prop surface is assembled in `react-core`'s `prepareT.shared.ts` from the shared `JsxTranslationOptions` (gt-i18n) plus a StripDollarPrefix mapped type. Deprecating the shared type directly would leak the deprecation into string-function options and runtime lookup internals, so the `$`-props are re-declared as an explicit `TSugarProps` type carrying the JSDoc, with a compile-time `AssertExact` guard that fails the build if it ever drifts from the shared type. `$_hash` and `$format` are marked `@internal` (not deprecated — compiler-facing).

- The unprefixed successors already exist on the type (generated by StripDollarPrefix) and are already accepted at runtime.
- gt-react, gt-react-native, and gt-next all consume `<T>`/`TProps` from react-core, so the deprecation surfaces across all frameworks from this single change (verified in the emitted `.d.ts`).
- String-function options (`t()`, `gt()`, `msg()`) are unaffected.
- No behavior change; type-level only. Full repo build green, react-core suite green.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR deprecates the `$`-prefixed sugar props (`$context`, `$id`, `$maxChars`, `$requiresReview`) on the `<T>` component in favor of their unprefixed equivalents, while keeping both forms functional. The deprecation is scoped to `<T>` props only by re-declaring a dedicated `TSugarProps` type with `@deprecated` JSDoc.

- `TSugarProps` replaces the direct use of `JsxTranslationOptionsWithSugar` in the `JsxTranslationOptions` intersection, isolating the deprecation from string-function option types and propagating it to all consuming frameworks via their shared `TProps` import.
- A compile-time `AssertExact` guard is introduced to detect structural drift between `TSugarProps` and `JsxTranslationOptionsWithSugar`, though its current implementation has a silent-failure mode when the assertion evaluates to `never`.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Type-only change with no runtime behavior difference; both prop forms continue to work, so no regression risk for existing users.

The guard is the one thing that needs attention before it can be trusted for future drift detection; the rest of the change is straightforward and type-only with no runtime impact.

The AssertExact/Expect pattern in prepareT.shared.ts (lines 39-45) warrants a quick fix before the guard is relied upon for future drift detection.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react-core/src/utils/translation/prepareT.shared.ts | Introduces TSugarProps with @deprecated JSDoc for $-prefixed props; compile-time AssertExact guard has a silent-failure mode if AssertExact evaluates to `never` |
| .changeset/deprecate-t-sugar-props.md | Correct patch-level changeset entry documenting the deprecation and listing affected props |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["JsxTranslationOptionsWithSugar"]
    B["StripDollarPrefix mapped type"]
    C["TSugarProps NEW @deprecated"]
    D["AssertExact guard"]
    E["JsxTranslationOptions"]
    F["TProps"]
    G["gt-react / gt-next / gt-react-native"]
    A -->|StripDollarPrefix| B
    A -->|re-declared with @deprecated| C
    A -.->|structural equality check| D
    B --> E
    C --> E
    E --> F
    F --> G
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["JsxTranslationOptionsWithSugar"]
    B["StripDollarPrefix mapped type"]
    C["TSugarProps NEW @deprecated"]
    D["AssertExact guard"]
    E["JsxTranslationOptions"]
    F["TProps"]
    G["gt-react / gt-next / gt-react-native"]
    A -->|StripDollarPrefix| B
    A -->|re-declared with @deprecated| C
    A -.->|structural equality check| D
    B --> E
    C --> E
    E --> F
    F --> G
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Freact-core%2Fsrc%2Futils%2Ftranslation%2FprepareT.shared.ts%3A39-45%0AThe%20%60AssertExact%60%2F%60Expect%60%20guard%20silently%20passes%20when%20the%20types%20drift.%20TypeScript%20treats%20%60never%60%20as%20a%20subtype%20of%20everything%2C%20so%20%60Expect%3Cnever%3E%60%20satisfies%20%60T%20extends%20true%60%20without%20producing%20an%20error.%20Concretely%3A%20if%20%60JsxTranslationOptionsWithSugar%60%20gains%20a%20new%20optional%20%60%24%60-prefixed%20property%20that%20isn't%20added%20to%20%60TSugarProps%60%2C%20%60AssertExact%60%20evaluates%20to%20%60never%60%2C%20%60_TSugarPropsInSync%60%20becomes%20%60never%60%2C%20and%20no%20build%20error%20fires.%20Using%20%60false%60%20as%20the%20failure%20branch%20instead%20of%20%60never%60%2C%20combined%20with%20tuple-wrapped%20conditionals%20to%20prevent%20distribution%2C%20turns%20the%20silent%20%60never%60%20into%20a%20%60false%60%20that%20%60Expect%60%20will%20reject.%0A%0A%60%60%60suggestion%0A%2F%2F%20Compile-time%20guard%3A%20TSugarProps%20must%20stay%20structurally%20identical%20to%20the%0A%2F%2F%20shared%20sugar%20options%20type%20it%20re-declares.%0A%2F%2F%20Tuple-wrapping%20%28%5BA%5D%20extends%20%5BB%5D%29%20avoids%20distributive%20evaluation%20over%20%60never%60%2C%0A%2F%2F%20and%20%60false%60%20as%20the%20failure%20branch%20ensures%20Expect%3Cfalse%3E%20is%20a%20type%20error.%0Atype%20AssertExact%3CA%2C%20B%3E%20%3D%20%5BA%5D%20extends%20%5BB%5D%20%3F%20%28%5BB%5D%20extends%20%5BA%5D%20%3F%20true%20%3A%20false%29%20%3A%20false%3B%0Atype%20_TSugarPropsInSync%20%3D%20Expect%3C%0A%20%20AssertExact%3CTSugarProps%2C%20JsxTranslationOptionsWithSugar%3E%0A%3E%3B%0Atype%20Expect%3CT%20extends%20true%3E%20%3D%20T%3B%0A%60%60%60%0A%0A&repo=generaltranslation%2Fgt&pr=1884&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Freact-core%2Fdeprecate-t-sugar-props%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Freact-core%2Fdeprecate-t-sugar-props%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Freact-core%2Fsrc%2Futils%2Ftranslation%2FprepareT.shared.ts%3A39-45%0AThe%20%60AssertExact%60%2F%60Expect%60%20guard%20silently%20passes%20when%20the%20types%20drift.%20TypeScript%20treats%20%60never%60%20as%20a%20subtype%20of%20everything%2C%20so%20%60Expect%3Cnever%3E%60%20satisfies%20%60T%20extends%20true%60%20without%20producing%20an%20error.%20Concretely%3A%20if%20%60JsxTranslationOptionsWithSugar%60%20gains%20a%20new%20optional%20%60%24%60-prefixed%20property%20that%20isn't%20added%20to%20%60TSugarProps%60%2C%20%60AssertExact%60%20evaluates%20to%20%60never%60%2C%20%60_TSugarPropsInSync%60%20becomes%20%60never%60%2C%20and%20no%20build%20error%20fires.%20Using%20%60false%60%20as%20the%20failure%20branch%20instead%20of%20%60never%60%2C%20combined%20with%20tuple-wrapped%20conditionals%20to%20prevent%20distribution%2C%20turns%20the%20silent%20%60never%60%20into%20a%20%60false%60%20that%20%60Expect%60%20will%20reject.%0A%0A%60%60%60suggestion%0A%2F%2F%20Compile-time%20guard%3A%20TSugarProps%20must%20stay%20structurally%20identical%20to%20the%0A%2F%2F%20shared%20sugar%20options%20type%20it%20re-declares.%0A%2F%2F%20Tuple-wrapping%20%28%5BA%5D%20extends%20%5BB%5D%29%20avoids%20distributive%20evaluation%20over%20%60never%60%2C%0A%2F%2F%20and%20%60false%60%20as%20the%20failure%20branch%20ensures%20Expect%3Cfalse%3E%20is%20a%20type%20error.%0Atype%20AssertExact%3CA%2C%20B%3E%20%3D%20%5BA%5D%20extends%20%5BB%5D%20%3F%20%28%5BB%5D%20extends%20%5BA%5D%20%3F%20true%20%3A%20false%29%20%3A%20false%3B%0Atype%20_TSugarPropsInSync%20%3D%20Expect%3C%0A%20%20AssertExact%3CTSugarProps%2C%20JsxTranslationOptionsWithSugar%3E%0A%3E%3B%0Atype%20Expect%3CT%20extends%20true%3E%20%3D%20T%3B%0A%60%60%60%0A%0A&repo=generaltranslation%2Fgt&pr=1884&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/react-core/src/utils/translation/prepareT.shared.ts:39-45
The `AssertExact`/`Expect` guard silently passes when the types drift. TypeScript treats `never` as a subtype of everything, so `Expect<never>` satisfies `T extends true` without producing an error. Concretely: if `JsxTranslationOptionsWithSugar` gains a new optional `$`-prefixed property that isn't added to `TSugarProps`, `AssertExact` evaluates to `never`, `_TSugarPropsInSync` becomes `never`, and no build error fires. Using `false` as the failure branch instead of `never`, combined with tuple-wrapped conditionals to prevent distribution, turns the silent `never` into a `false` that `Expect` will reject.

```suggestion
// Compile-time guard: TSugarProps must stay structurally identical to the
// shared sugar options type it re-declares.
// Tuple-wrapping ([A] extends [B]) avoids distributive evaluation over `never`,
// and `false` as the failure branch ensures Expect<false> is a type error.
type AssertExact<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
type _TSugarPropsInSync = Expect<
  AssertExact<TSugarProps, JsxTranslationOptionsWithSugar>
>;
type Expect<T extends true> = T;
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["chore(react-core): deprecate $-prefixed ..."](https://github.com/generaltranslation/gt/commit/c182b5b4b6b5b16af01efd6d9b083f2cccf066c4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44586290)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->