### PR TITLE
refactor(cli): flatten workflow step lifecycle

### DIFF
--- a/.changeset/simplify-cli-workflow-steps.md
+++ b/.changeset/simplify-cli-workflow-steps.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+Flatten the CLI workflow step lifecycle by folding completion behavior into each step's `run()` method and removing the unused shared step protocol.

--- a/packages/cli/src/api/saveLocalEdits.ts
+++ b/packages/cli/src/api/saveLocalEdits.ts
@@ -25,7 +25,6 @@ export async function saveLocalEdits(settings: Settings): Promise<void> {
   // Run the branch step
   const branchStep = new BranchStep(gt, settings);
   const branchResult = await branchStep.run();
-  await branchStep.wait();
   if (!branchResult) {
     return logErrorAndExit(branchResolutionError);
   }

--- a/packages/cli/src/workflows/download.ts
+++ b/packages/cli/src/workflows/download.ts
@@ -63,7 +63,6 @@ export async function runDownloadWorkflow({
     // Run the branch step
     const branchStep = new BranchStep(gt, options);
     const branchResult = await branchStep.run();
-    await branchStep.wait();
     if (!branchResult) {
       return logErrorAndExit(branchResolutionError);
     }
@@ -101,7 +100,6 @@ export async function runDownloadWorkflow({
       timeoutDuration,
       forceRetranslation,
     });
-    await pollStep.wait();
 
     if (pollResult.fileTracker.failed.size > 0) {
       logger.error(
@@ -162,7 +160,6 @@ export async function runDownloadWorkflow({
     resolveOutputPath,
     forceDownload,
   });
-  await downloadStep.wait();
 
   // If polling timed out, report failure even though we downloaded what we could
   if (pollTimedOut) {

--- a/packages/cli/src/workflows/enqueue.ts
+++ b/packages/cli/src/workflows/enqueue.ts
@@ -40,7 +40,6 @@ export async function runEnqueueWorkflow({
 
     // (1) run the branch step
     const branchData = await branchStep.run();
-    await branchStep.wait();
     if (!branchData) {
       return logErrorAndExit(branchResolutionError);
     }
@@ -64,7 +63,6 @@ export async function runEnqueueWorkflow({
     }
 
     const enqueueResult = await enqueueStep.run(filesToEnqueue);
-    await enqueueStep.wait();
 
     logger.debug('Enqueue result: ' + JSON.stringify(enqueueResult, null, 2));
 

--- a/packages/cli/src/workflows/publish.ts
+++ b/packages/cli/src/workflows/publish.ts
@@ -29,7 +29,6 @@ export async function runPublishWorkflow(
     if (allFileRefs.length === 0) return;
     const publishStep = new PublishStep(gt);
     await publishStep.run(allFileRefs);
-    await publishStep.wait();
   } catch (error) {
     logger.warn(
       `Failed to publish files: ${error instanceof Error ? error.message : String(error)}`

--- a/packages/cli/src/workflows/setupProject.ts
+++ b/packages/cli/src/workflows/setupProject.ts
@@ -38,7 +38,6 @@ export async function runSetupProjectWorkflow(
 
     // first run the branch step
     const branchData = await branchStep.run();
-    await branchStep.wait();
 
     if (!branchData) {
       return logErrorAndExit(branchResolutionError);
@@ -46,11 +45,9 @@ export async function runSetupProjectWorkflow(
 
     // then run the upload step
     const uploadedFiles = await uploadStep.run({ files, branchData });
-    await uploadStep.wait();
 
     // then run the setup step
     await setupStep.run(uploadedFiles, options.force ?? false);
-    await setupStep.wait();
 
     return { branchData };
   } catch (error) {

--- a/packages/cli/src/workflows/stage.ts
+++ b/packages/cli/src/workflows/stage.ts
@@ -49,19 +49,16 @@ export async function runStageFilesWorkflow({
 
     // first run the branch step
     const branchData = await branchStep.run();
-    await branchStep.wait();
     if (!branchData) {
       return logErrorAndExit(branchResolutionError);
     }
 
     // then run the upload step
     const uploadedFiles = await uploadStep.run({ files, branchData });
-    await uploadStep.wait();
 
     // optionally run the user edit diffs step
     if (options?.saveLocal) {
       await userEditDiffsStep.run(uploadedFiles);
-      await userEditDiffsStep.wait();
     }
 
     // then run the tag step (non-fatal — tagging failure should not block translations)
@@ -70,7 +67,6 @@ export async function runStageFilesWorkflow({
         const userProvidedTag = !!options.tag;
         const tagStep = new TagStep(gt, settings, userProvidedTag);
         await tagStep.run(uploadedFiles);
-        await tagStep.wait();
       } catch {
         logger.warn('Failed to create translation tag. Continuing...');
       }
@@ -78,7 +74,6 @@ export async function runStageFilesWorkflow({
 
     // then run the setup step
     await setupStep.run(uploadedFiles);
-    await setupStep.wait();
 
     // then run the enqueue step
     const { filesToEnqueue, skippedFiles } = await filterFilesForEnqueue({
@@ -94,7 +89,6 @@ export async function runStageFilesWorkflow({
     }
 
     const enqueueResult = await enqueueStep.run(filesToEnqueue);
-    await enqueueStep.wait();
 
     return { branchData, enqueueResult };
   } catch (error) {

--- a/packages/cli/src/workflows/steps/BranchStep.ts
+++ b/packages/cli/src/workflows/steps/BranchStep.ts
@@ -1,4 +1,3 @@
-import { WorkflowStep } from './WorkflowStep.js';
 import { logErrorAndExit } from '../../console/logging.js';
 import { logger } from '../../console/logger.js';
 import type { GT } from 'generaltranslation';
@@ -16,14 +15,13 @@ type BranchStepClient = Pick<GT, 'queryBranchData' | 'createBranch'>;
 type BranchStepSettings = Pick<Settings, 'branchOptions'>;
 
 // Step 1: Resolve the current branch id & update API with branch information
-export class BranchStep extends WorkflowStep<null, BranchData | null> {
+export class BranchStep {
   private spinner = logger.createSpinner('dots');
   private branchData: BranchData;
   private settings: BranchStepSettings;
   private gt: BranchStepClient;
 
   constructor(gt: BranchStepClient, settings: BranchStepSettings) {
-    super();
     this.gt = gt;
     this.settings = settings;
     this.branchData = {
@@ -192,9 +190,5 @@ export class BranchStep extends WorkflowStep<null, BranchData | null> {
     this.spinner.stop(chalk.green('Branch information resolved successfully'));
 
     return this.branchData;
-  }
-
-  async wait(): Promise<void> {
-    return;
   }
 }

--- a/packages/cli/src/workflows/steps/DownloadStep.ts
+++ b/packages/cli/src/workflows/steps/DownloadStep.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk';
 import path from 'node:path';
-import { WorkflowStep } from './WorkflowStep.js';
 import { logger } from '../../console/logger.js';
 import {
   BatchedFiles,
@@ -19,18 +18,13 @@ export type DownloadTranslationsInput = {
   forceDownload?: boolean;
 };
 
-export class DownloadTranslationsStep extends WorkflowStep<
-  DownloadTranslationsInput,
-  boolean
-> {
+export class DownloadTranslationsStep {
   private spinner: ReturnType<typeof logger.createProgressBar> | null = null;
 
   constructor(
     private gt: GT,
     private settings: Settings
-  ) {
-    super();
-  }
+  ) {}
 
   async run({
     fileTracker,
@@ -266,9 +260,5 @@ export class DownloadTranslationsStep extends WorkflowStep<
       failed: remainingFiles,
       skipped: allSkipped,
     };
-  }
-
-  async wait(): Promise<void> {
-    return;
   }
 }

--- a/packages/cli/src/workflows/steps/EnqueueStep.ts
+++ b/packages/cli/src/workflows/steps/EnqueueStep.ts
@@ -1,53 +1,37 @@
 import type { EnqueueFilesResult } from 'generaltranslation/types';
-import { WorkflowStep } from './WorkflowStep.js';
 import { logger } from '../../console/logger.js';
 import { GT } from 'generaltranslation';
 import { Settings } from '../../types/index.js';
 import type { FileReference } from 'generaltranslation/types';
 import chalk from 'chalk';
 
-export class EnqueueStep extends WorkflowStep<
-  FileReference[],
-  EnqueueFilesResult
-> {
+export class EnqueueStep {
   private spinner = logger.createSpinner('dots');
-  private result: EnqueueFilesResult | null = null;
-  private spinnerStarted = false;
 
   constructor(
     private gt: GT,
     private settings: Settings,
     private force?: boolean
-  ) {
-    super();
-  }
+  ) {}
 
   async run(files: FileReference[]): Promise<EnqueueFilesResult> {
     if (files.length === 0) {
-      this.result = {
+      return {
         jobData: {},
         locales: this.settings.locales,
         message: 'No files need to be enqueued',
       };
-      return this.result;
     }
 
     this.spinner.start('Enqueuing translations...');
-    this.spinnerStarted = true;
 
-    this.result = await this.gt.enqueueFiles(files, {
+    const result = await this.gt.enqueueFiles(files, {
       sourceLocale: this.settings.defaultLocale,
       targetLocales: this.settings.locales,
       modelProvider: this.settings.modelProvider,
       force: this.force,
     });
-
-    return this.result;
-  }
-
-  async wait(): Promise<void> {
-    if (this.result && this.spinnerStarted) {
-      this.spinner.stop(chalk.green('Translations enqueued successfully'));
-    }
+    this.spinner.stop(chalk.green('Translations enqueued successfully'));
+    return result;
   }
 }

--- a/packages/cli/src/workflows/steps/PollJobsStep.ts
+++ b/packages/cli/src/workflows/steps/PollJobsStep.ts
@@ -1,5 +1,4 @@
 import chalk from 'chalk';
-import { WorkflowStep } from './WorkflowStep.js';
 import { logger } from '../../console/logger.js';
 import { GT } from 'generaltranslation';
 import { EnqueueFilesResult } from 'generaltranslation/types';
@@ -30,16 +29,11 @@ export type PollJobsOutput = {
   fileTracker: FileStatusTracker;
 };
 
-export class PollTranslationJobsStep extends WorkflowStep<
-  PollJobsInput,
-  PollJobsOutput
-> {
+export class PollTranslationJobsStep {
   private spinner: ReturnType<typeof logger.createProgressBar> | null = null;
   private previousProgress = 0;
 
-  constructor(private gt: GT) {
-    super();
-  }
+  constructor(private gt: GT) {}
 
   async run({
     fileTracker,
@@ -396,9 +390,5 @@ export class PollTranslationJobsStep extends WorkflowStep<
     }
 
     return newSuffixText.join('\n');
-  }
-
-  async wait(): Promise<void> {
-    return;
   }
 }

--- a/packages/cli/src/workflows/steps/PublishStep.ts
+++ b/packages/cli/src/workflows/steps/PublishStep.ts
@@ -1,15 +1,12 @@
-import { WorkflowStep } from './WorkflowStep.js';
 import { logger } from '../../console/logger.js';
 import { GT } from 'generaltranslation';
 import type { PublishFileEntry } from 'generaltranslation/types';
 import chalk from 'chalk';
 
-export class PublishStep extends WorkflowStep<PublishFileEntry[], void> {
+export class PublishStep {
   private spinner = logger.createSpinner('dots');
 
-  constructor(private gt: GT) {
-    super();
-  }
+  constructor(private gt: GT) {}
 
   async run(files: PublishFileEntry[]): Promise<void> {
     if (files.length === 0) return;
@@ -40,9 +37,5 @@ export class PublishStep extends WorkflowStep<PublishFileEntry[], void> {
         `Publish error: ${err instanceof Error ? err.message : String(err)}`
       );
     }
-  }
-
-  async wait(): Promise<void> {
-    return;
   }
 }

--- a/packages/cli/src/workflows/steps/SetupStep.ts
+++ b/packages/cli/src/workflows/steps/SetupStep.ts
@@ -34,6 +34,13 @@ export class SetupStep {
       return files;
     }
 
+    if (result.status !== 'queued' || !result.setupJobId) {
+      this.spinner.stop(
+        chalk.yellow('Setup status unknown — proceeding without setup')
+      );
+      return files;
+    }
+
     // Poll for completion
     const start = Date.now();
     const pollInterval = 5000; // 5 seconds

--- a/packages/cli/src/workflows/steps/SetupStep.ts
+++ b/packages/cli/src/workflows/steps/SetupStep.ts
@@ -1,33 +1,26 @@
 import { FileReference } from 'generaltranslation/types';
-import { WorkflowStep } from './WorkflowStep.js';
 import { logger } from '../../console/logger.js';
 import { GT } from 'generaltranslation';
 import { Settings } from '../../types/index.js';
 import chalk from 'chalk';
 
-export class SetupStep extends WorkflowStep<FileReference[], FileReference[]> {
+export class SetupStep {
   private spinner = logger.createSpinner('dots');
-  private setupJobId: string | null = null;
-  private files: FileReference[] | null = null;
-  private completed = false;
 
   constructor(
     private gt: GT,
     private settings: Settings,
     private timeoutMs: number
-  ) {
-    super();
-  }
+  ) {}
 
   async run(
     files: FileReference[],
     force: boolean = false
   ): Promise<FileReference[]> {
-    this.files = files;
     this.spinner.start('Setting up project...');
 
     if (files.length === 0) {
-      this.completed = true;
+      this.spinner.stop(chalk.green('Setup successfully completed'));
       return [];
     }
 
@@ -37,31 +30,8 @@ export class SetupStep extends WorkflowStep<FileReference[], FileReference[]> {
     });
 
     if (result.status === 'completed') {
-      this.completed = true;
-      return files;
-    }
-
-    if (result.status === 'queued') {
-      this.setupJobId = result.setupJobId;
-      return files;
-    }
-
-    // Unknown status
-    this.completed = true;
-    return files;
-  }
-
-  async wait(): Promise<void> {
-    if (this.completed) {
       this.spinner.stop(chalk.green('Setup successfully completed'));
-      return;
-    }
-
-    if (!this.setupJobId) {
-      this.spinner.stop(
-        chalk.yellow('Setup status unknown — proceeding without setup')
-      );
-      return;
+      return files;
     }
 
     // Poll for completion
@@ -69,18 +39,18 @@ export class SetupStep extends WorkflowStep<FileReference[], FileReference[]> {
     const pollInterval = 5000; // 5 seconds
 
     while (Date.now() - start < this.timeoutMs) {
-      const status = await this.gt.checkJobStatus([this.setupJobId]);
+      const status = await this.gt.checkJobStatus([result.setupJobId]);
 
       if (!status[0]) {
         this.spinner.stop(
           chalk.yellow('Setup status unknown — proceeding without setup')
         );
-        return;
+        return files;
       }
 
       if (status[0].status === 'completed') {
         this.spinner.stop(chalk.green('Setup successfully completed'));
-        return;
+        return files;
       }
 
       if (status[0].status === 'failed') {
@@ -89,7 +59,7 @@ export class SetupStep extends WorkflowStep<FileReference[], FileReference[]> {
             `Setup failed: ${status[0].error?.message || 'Unknown error'} — proceeding without setup`
           )
         );
-        return;
+        return files;
       }
 
       await new Promise((r) => setTimeout(r, pollInterval));
@@ -99,5 +69,6 @@ export class SetupStep extends WorkflowStep<FileReference[], FileReference[]> {
     this.spinner.stop(
       chalk.yellow('Setup timed out — proceeding without setup')
     );
+    return files;
   }
 }

--- a/packages/cli/src/workflows/steps/TagStep.ts
+++ b/packages/cli/src/workflows/steps/TagStep.ts
@@ -1,22 +1,18 @@
 import type { CreateTagResult } from 'generaltranslation/types';
-import { WorkflowStep } from './WorkflowStep.js';
 import { logger } from '../../console/logger.js';
 import { GT } from 'generaltranslation';
 import { Settings } from '../../types/index.js';
 import type { FileReference } from 'generaltranslation/types';
 import chalk from 'chalk';
 
-export class TagStep extends WorkflowStep<FileReference[], CreateTagResult> {
+export class TagStep {
   private spinner = logger.createSpinner('dots');
-  private result: CreateTagResult | null = null;
 
   constructor(
     private gt: GT,
     private settings: Settings,
     private userProvided: boolean
-  ) {
-    super();
-  }
+  ) {}
 
   async run(files: FileReference[]): Promise<CreateTagResult> {
     if (this.userProvided) {
@@ -24,7 +20,7 @@ export class TagStep extends WorkflowStep<FileReference[], CreateTagResult> {
     }
 
     try {
-      this.result = await this.gt.createTag({
+      const result = await this.gt.createTag({
         tagId: this.settings.tag!,
         files: files.map((f) => ({
           fileId: f.fileId,
@@ -33,21 +29,17 @@ export class TagStep extends WorkflowStep<FileReference[], CreateTagResult> {
         })),
         message: this.settings.tagMessage,
       });
+      if (this.userProvided) {
+        this.spinner.stop(
+          chalk.green(`Tagged as ${chalk.bold(result.tag.tagId)}`)
+        );
+      }
+      return result;
     } catch (error) {
       if (this.userProvided) {
         this.spinner.stop(chalk.yellow('Failed to create translation tag'));
       }
       throw error;
-    }
-
-    return this.result;
-  }
-
-  async wait(): Promise<void> {
-    if (this.result && this.userProvided) {
-      this.spinner.stop(
-        chalk.green(`Tagged as ${chalk.bold(this.result.tag.tagId)}`)
-      );
     }
   }
 }

--- a/packages/cli/src/workflows/steps/UploadSourcesStep.ts
+++ b/packages/cli/src/workflows/steps/UploadSourcesStep.ts
@@ -1,5 +1,4 @@
 import type { FileToUpload } from 'generaltranslation/types';
-import { WorkflowStep } from './WorkflowStep.js';
 import { logger } from '../../console/logger.js';
 import { recordWarning } from '../../state/translateWarnings.js';
 import type { GT } from 'generaltranslation';
@@ -27,19 +26,13 @@ type UploadSourcesClient = Pick<
 >;
 type UploadSourcesSettings = Pick<Settings, 'defaultLocale' | 'modelProvider'>;
 
-export class UploadSourcesStep extends WorkflowStep<
-  { files: FileToUpload[]; branchData: BranchData },
-  FileReference[]
-> {
+export class UploadSourcesStep {
   private spinner = logger.createSpinner('dots');
-  private result: FileReference[] | null = null;
 
   constructor(
     private gt: UploadSourcesClient,
     private settings: UploadSourcesSettings
-  ) {
-    super();
-  }
+  ) {}
 
   /**
    * Detects file moves by comparing local files against orphaned files.
@@ -191,7 +184,7 @@ export class UploadSourcesStep extends WorkflowStep<
       files.map((f) => [`${f.fileId}:${f.versionId}`, f])
     );
 
-    this.result = response.uploadedFiles.map((uploadedFile) => {
+    const result = response.uploadedFiles.map((uploadedFile) => {
       const localFile = localFileMap.get(
         `${uploadedFile.fileId}:${uploadedFile.versionId}`
       );
@@ -203,7 +196,7 @@ export class UploadSourcesStep extends WorkflowStep<
     });
 
     // Merge files that were already uploaded into the result
-    this.result.push(
+    result.push(
       ...filesToSkipUpload.map((f) => ({
         fileId: f.fileId,
         versionId: f.versionId,
@@ -219,10 +212,6 @@ export class UploadSourcesStep extends WorkflowStep<
     const moveMsg = moves.length > 0 ? ` (${moves.length} moved)` : '';
     this.spinner.stop(chalk.green(`Files uploaded successfully${moveMsg}`));
 
-    return this.result;
-  }
-
-  async wait(): Promise<void> {
-    return;
+    return result;
   }
 }

--- a/packages/cli/src/workflows/steps/UploadTranslationsStep.ts
+++ b/packages/cli/src/workflows/steps/UploadTranslationsStep.ts
@@ -1,4 +1,3 @@
-import { WorkflowStep } from './WorkflowStep.js';
 import { logger } from '../../console/logger.js';
 import { GT } from 'generaltranslation';
 import { Settings } from '../../types/index.js';
@@ -57,19 +56,13 @@ export function partitionTranslationsByLockfile(
   return { filesToUpload, skippedCount };
 }
 
-export class UploadTranslationsStep extends WorkflowStep<
-  UploadTranslationsInput,
-  FileReference[]
-> {
+export class UploadTranslationsStep {
   private spinner = logger.createSpinner('dots');
-  private result: FileReference[] = [];
 
   constructor(
     private gt: GT,
     private settings: Settings
-  ) {
-    super();
-  }
+  ) {}
 
   async run({ files }: UploadTranslationsInput): Promise<FileReference[]> {
     // Filter to only files that have translations
@@ -116,10 +109,10 @@ export class UploadTranslationsStep extends WorkflowStep<
       modelProvider: this.settings.modelProvider,
     });
 
-    this.result = response.uploadedFiles;
+    const result = response.uploadedFiles;
     // Report the server-confirmed count, not the attempted count — the
     // endpoint drops files it failed to persist without erroring
-    const uploadedCount = this.result.length;
+    const uploadedCount = result.length;
     this.spinner.stop(
       chalk.green(
         `Uploaded ${uploadedCount} translation file${uploadedCount !== 1 ? 's' : ''}${skippedCount > 0 ? `, skipped ${skippedCount} unchanged` : ''}`
@@ -134,9 +127,9 @@ export class UploadTranslationsStep extends WorkflowStep<
       );
     }
 
-    this.recordUploadedHashes(lockfile, filesToUpload, this.result);
+    this.recordUploadedHashes(lockfile, filesToUpload, result);
 
-    return this.result;
+    return result;
   }
 
   /**
@@ -175,9 +168,5 @@ export class UploadTranslationsStep extends WorkflowStep<
       }
     }
     writeLockfile(lockfile.data, lockfile.originalV1);
-  }
-
-  async wait(): Promise<void> {
-    return;
   }
 }

--- a/packages/cli/src/workflows/steps/UserEditDiffsStep.ts
+++ b/packages/cli/src/workflows/steps/UserEditDiffsStep.ts
@@ -1,41 +1,25 @@
 import type { FileReference } from 'generaltranslation/types';
-import { WorkflowStep } from './WorkflowStep.js';
 import { logger } from '../../console/logger.js';
 import { Settings } from '../../types/index.js';
 import chalk from 'chalk';
 import { collectAndSendUserEditDiffs } from '../../api/collectUserEditDiffs.js';
 
-export class UserEditDiffsStep extends WorkflowStep<
-  FileReference[],
-  FileReference[]
-> {
+export class UserEditDiffsStep {
   private spinner = logger.createSpinner('dots');
-  private succeeded = false;
-  private failed = false;
 
-  constructor(private settings: Settings) {
-    super();
-  }
+  constructor(private settings: Settings) {}
 
   async run(files: FileReference[]): Promise<FileReference[]> {
     this.spinner.start('Updating translations...');
 
     try {
       await collectAndSendUserEditDiffs(files, this.settings);
-      this.succeeded = true;
+      this.spinner.stop(chalk.green('Updated translations'));
     } catch {
       // Non-fatal; keep going to enqueue
-      this.failed = true;
+      this.spinner.stop(chalk.yellow('Could not update translations'));
     }
 
     return files;
-  }
-
-  async wait(): Promise<void> {
-    if (this.succeeded) {
-      this.spinner.stop(chalk.green('Updated translations'));
-    } else if (this.failed) {
-      this.spinner.stop(chalk.yellow('Could not update translations'));
-    }
   }
 }

--- a/packages/cli/src/workflows/steps/WorkflowStep.ts
+++ b/packages/cli/src/workflows/steps/WorkflowStep.ts
@@ -1,5 +1,0 @@
-export abstract class WorkflowStep<TInput = void, TOutput = void> {
-  abstract run(input: TInput): Promise<TOutput>;
-
-  abstract wait(): Promise<void>;
-}

--- a/packages/cli/src/workflows/steps/__tests__/EnqueueStep.test.ts
+++ b/packages/cli/src/workflows/steps/__tests__/EnqueueStep.test.ts
@@ -33,7 +33,6 @@ describe('EnqueueStep', () => {
     const step = new EnqueueStep(gt as unknown as GT, settings);
 
     const result = await step.run([]);
-    await step.wait();
 
     expect(result).toEqual({
       jobData: {},

--- a/packages/cli/src/workflows/steps/__tests__/SetupStep.test.ts
+++ b/packages/cli/src/workflows/steps/__tests__/SetupStep.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { GT } from 'generaltranslation';
+import type { FileReference } from 'generaltranslation/types';
+import type { Settings } from '../../../types/index.js';
+import { SetupStep } from '../SetupStep.js';
+
+const spinner = {
+  start: vi.fn(),
+  stop: vi.fn(),
+};
+
+vi.mock('../../../console/logger.js', () => ({
+  logger: {
+    createSpinner: vi.fn(() => spinner),
+  },
+}));
+
+describe('SetupStep', () => {
+  const gt = {
+    setupProject: vi.fn(),
+    checkJobStatus: vi.fn(),
+  };
+
+  const settings = {
+    locales: ['es'],
+  } as Settings;
+
+  const files = [
+    {
+      branchId: 'branch-id',
+      fileId: 'file-id',
+      versionId: 'version-id',
+    },
+  ] as FileReference[];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    ['an unexpected status', { status: 'unknown' }],
+    ['a queued response without a job ID', { status: 'queued' }],
+  ])('does not poll for %s', async (_description, setupResult) => {
+    gt.setupProject.mockResolvedValue(setupResult);
+    const step = new SetupStep(gt as unknown as GT, settings, 1_000);
+
+    const result = await step.run(files);
+
+    expect(result).toBe(files);
+    expect(gt.checkJobStatus).not.toHaveBeenCalled();
+    expect(spinner.stop).toHaveBeenCalledWith(
+      expect.stringContaining('Setup status unknown')
+    );
+  });
+});

--- a/packages/cli/src/workflows/upload.ts
+++ b/packages/cli/src/workflows/upload.ts
@@ -45,14 +45,12 @@ export async function runUploadFilesWorkflow({
 
     // Step 1: Resolve branch information
     const branchData = await branchStep.run();
-    await branchStep.wait();
 
     if (!branchData) {
       return logErrorAndExit(branchResolutionError);
     }
 
     await uploadStep.run({ files: files.map((f) => f.source), branchData });
-    await uploadStep.wait();
 
     // Step 3: Upload translations (if any exist)
     const filesWithTranslations = files.filter(
@@ -62,7 +60,6 @@ export async function runUploadFilesWorkflow({
       await uploadTranslationsStep.run({
         files: filesWithTranslations,
       });
-      await uploadTranslationsStep.wait();
     }
 
     logger.success('All files uploaded successfully');


### PR DESCRIPTION
## TL;DR

Flatten the CLI workflow step lifecycle so each step performs its work in a single run() call.

## Code Changes

- Remove the WorkflowStep base class and no-op wait() implementations.
- Fold meaningful completion behavior into each step run() method.
- Replace cross-phase instance state with local values where possible.
- Add a patch changeset for gt.

## Notes / Flags

Validated with the full gt test suite, type checking, build, oxlint, and oxfmt.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR flattens the two-phase `run()` / `wait()` lifecycle that was enforced by the `WorkflowStep` abstract base class. Completion behaviour (spinner stops, polling loops) is folded directly into each step's `run()` method, and all `step.wait()` call-sites are removed from the workflow orchestrators.

- **WorkflowStep deleted** — the abstract base class and its `run`/`wait` interface are removed; each step is now a plain class with a single `run()` call that carries out all of its work.
- **Instance state eliminated** — cross-phase fields like `this.result`, `this.setupJobId`, `this.completed`, `this.spinnerStarted`, `this.succeeded`, and `this.failed` are replaced with local variables, reducing the surface area for accidental state leakage.
- **SetupStep polling consolidated** — the polling loop that previously lived in `wait()` is now inside `run()`, with a new `SetupStep` unit test covering the non-polling paths (unknown status, `queued` without a job ID).

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all functional paths are preserved and the change is strictly a structural simplification.

Every step's observable behaviour (spinner messages, return values, polling logic) is identical before and after the refactor. The only real logic moved is SetupStep's polling loop, which is covered by the new unit test. Instance-state fields were intermediary artefacts of the two-phase design and carry no semantic meaning on their own; removing them reduces the chance of subtle state bugs in future changes.

No files require special attention. The most complex change is in SetupStep, which now has a dedicated test.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/workflows/steps/WorkflowStep.ts | Deleted — the abstract WorkflowStep base class (run/wait interface) is fully removed. |
| packages/cli/src/workflows/steps/SetupStep.ts | Polling loop moved from wait() into run(); all exit paths (empty, completed, queued+no-id, unknown, failed, timeout) now stop the spinner and return files correctly. |
| packages/cli/src/workflows/steps/EnqueueStep.ts | Folded wait() into run(); spinner stop now fires inline after enqueueFiles returns, guarded correctly by the early-return for empty file lists. |
| packages/cli/src/workflows/steps/TagStep.ts | Spinner stop moved into run(); success and error paths both stop the spinner when userProvided is true, preserving the previous conditional behavior. |
| packages/cli/src/workflows/steps/UserEditDiffsStep.ts | Dropped succeeded/failed instance fields; spinner stop moved inline into run() for both success and catch paths. |
| packages/cli/src/workflows/steps/UploadSourcesStep.ts | Removed result instance field and no-op wait(); result is now a local variable returned directly. |
| packages/cli/src/workflows/steps/__tests__/SetupStep.test.ts | New test covering the two non-polling SetupStep paths (unknown status, queued without job ID); verifies spinner message and absence of checkJobStatus calls. |
| packages/cli/src/workflows/stage.ts | All step.wait() call-sites removed; functional orchestration logic is unchanged. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Orchestrator as Workflow orchestrator
    participant Step as WorkflowStep
    participant API as GT API

    Note over Orchestrator,API: Before — two-phase lifecycle
    Orchestrator->>Step: run(input)
    Step->>API: API call
    API-->>Step: response
    Step-->>Orchestrator: output
    Orchestrator->>Step: wait()
    Step->>Step: stop spinner / poll

    Note over Orchestrator,API: After — single run() call
    Orchestrator->>Step: run(input)
    Step->>API: API call
    API-->>Step: response
    Step->>Step: stop spinner / poll inline
    Step-->>Orchestrator: output
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(cli): guard unknown setup statuses"](https://github.com/generaltranslation/gt/commit/2cf0c6a34c9ff1df9f3ee90e7dab27147c610877) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44631317)</sub>

<!-- /greptile_comment -->