### PR TITLE
fix(core): canonicalize translation upload source locale

### DIFF
--- a/.changeset/canonical-upload-source-locales.md
+++ b/.changeset/canonical-upload-source-locales.md
@@ -1,0 +1,5 @@
+---
+'generaltranslation': patch
+---
+
+Resolve custom source-locale aliases before uploading translation files.

--- a/packages/core/src/__tests__/uploadTranslations.test.ts
+++ b/packages/core/src/__tests__/uploadTranslations.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { GT } from '../index';
+import { _uploadTranslations } from '../translate/uploadTranslations';
+
+vi.mock('../translate/uploadTranslations', () => ({
+  _uploadTranslations: vi.fn(),
+}));
+
+describe('GT.uploadTranslations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(_uploadTranslations).mockResolvedValue({
+      data: [],
+      count: 0,
+      batchCount: 0,
+    });
+  });
+
+  it('canonicalizes the configured source locale', async () => {
+    const gt = new GT({
+      apiKey: 'test-api-key',
+      projectId: 'test-project',
+      sourceLocale: 'brand-english',
+      customMapping: {
+        'brand-english': {
+          code: 'en-US',
+          name: 'Brand English',
+        },
+      },
+    });
+    const files = [
+      {
+        source: {
+          content: '',
+          fileName: 'messages.json',
+          fileFormat: 'JSON' as const,
+          locale: 'brand-english',
+        },
+        translations: [
+          {
+            content: '{}',
+            fileName: 'messages.json',
+            fileFormat: 'JSON' as const,
+            locale: 'fr',
+          },
+        ],
+      },
+    ];
+
+    await gt.uploadTranslations(files, { sourceLocale: 'brand-english' });
+
+    expect(_uploadTranslations).toHaveBeenCalledWith(
+      expect.any(Array),
+      { sourceLocale: 'en-US' },
+      expect.any(Object)
+    );
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -739,6 +739,10 @@ export class GT extends GTRuntime {
       throw new Error(error);
     }
 
+    mergedOptions.sourceLocale = this.resolveCanonicalLocale(
+      mergedOptions.sourceLocale
+    );
+
     // Ensure all translation locales use canonical locales
     const targetFiles = files.map((f) => ({
       ...f,


### PR DESCRIPTION
## Summary

- canonicalize `uploadTranslations` source locales after validating that one was provided
- make custom locale aliases behave consistently with `uploadSourceFiles`
- add a regression covering a configured custom mapping

## Testing

- `pnpm --filter generaltranslation... build` — passed
- `pnpm --filter generaltranslation exec vitest run --config=./vitest.config.ts src/__tests__/uploadTranslations.test.ts` — 1 passed
- `pnpm --filter generaltranslation typecheck` — passed

## Notes

- Includes a patch changeset for `generaltranslation`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR canonicalizes the `sourceLocale` option in `uploadTranslations` (after the null-guard) so custom locale aliases resolve to their BCP-47 codes before the API call, and adds a regression test covering a configured custom mapping.

- `mergedOptions.sourceLocale` is now resolved through `resolveCanonicalLocale`, matching the behaviour introduced for `uploadSourceFiles` — but `f.source.locale` inside each file object is not canonicalized, leaving a gap relative to `uploadSourceFiles` (which maps that field too).
- The regression test verifies the options-level locale is resolved but uses `expect.any(Array)` for the files argument, so the uncanonicalized `source.locale` goes undetected by the suite.

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The options-level locale fix is correct, but `f.source.locale` is left un-canonicalized and the test doesn't catch it — callers using custom aliases may send raw alias strings to the backend in the source file reference.

The core intent of the PR (resolving the options `sourceLocale`) works correctly. The gap is that `f.source.locale` inside each file object goes through the map unchanged, which is exactly the field that `uploadSourceFiles` also canonicalizes. Whether the backend ignores it or uses it for validation is unclear from the frontend code alone, but if it matters, custom-alias users will see broken behaviour. The test's use of `expect.any(Array)` means this gap is invisible to CI.

`packages/core/src/index.ts` around the `targetFiles` map and `packages/core/src/__tests__/uploadTranslations.test.ts` where the files argument assertion is too loose.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/core/src/index.ts | Adds canonicalization of `mergedOptions.sourceLocale` in `uploadTranslations` after the null check, but `f.source.locale` within each file object is not canonicalized — inconsistent with `uploadSourceFiles` which handles both. Also mutates a `const`-declared object's property rather than building the merged options immutably. |
| packages/core/src/__tests__/uploadTranslations.test.ts | New regression test verifies the options-level `sourceLocale` is canonicalized, but uses `expect.any(Array)` for the files argument so it does not catch whether `f.source.locale` is also resolved — leaving a gap in coverage for the parity claim. |
| .changeset/canonical-upload-source-locales.md | Patch changeset correctly scoped to `generaltranslation`; description is accurate. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant GT as GT.uploadTranslations
    participant _ut as _uploadTranslations

    Caller->>GT: "uploadTranslations(files, { sourceLocale: 'brand-english' })"
    GT->>GT: "merge options (sourceLocale = alias ?? this.sourceLocale)"
    GT->>GT: validate sourceLocale not null
    GT->>GT: resolveCanonicalLocale(mergedOptions.sourceLocale) → 'en-US'
    Note over GT: options.sourceLocale canonicalized
    GT->>GT: map files → canonicalize t.locale for each translation
    Note over GT: f.source.locale NOT canonicalized (still 'brand-english')
    GT->>_ut: "_uploadTranslations(targetFiles, { sourceLocale: 'en-US' }, config)"
    _ut-->>GT: "{ data, count, batchCount }"
    GT-->>Caller: UploadFilesResponse
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant GT as GT.uploadTranslations
    participant _ut as _uploadTranslations

    Caller->>GT: "uploadTranslations(files, { sourceLocale: 'brand-english' })"
    GT->>GT: "merge options (sourceLocale = alias ?? this.sourceLocale)"
    GT->>GT: validate sourceLocale not null
    GT->>GT: resolveCanonicalLocale(mergedOptions.sourceLocale) → 'en-US'
    Note over GT: options.sourceLocale canonicalized
    GT->>GT: map files → canonicalize t.locale for each translation
    Note over GT: f.source.locale NOT canonicalized (still 'brand-english')
    GT->>_ut: "_uploadTranslations(targetFiles, { sourceLocale: 'en-US' }, config)"
    _ut-->>GT: "{ data, count, batchCount }"
    GT-->>Caller: UploadFilesResponse
```

</a>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `packages/core/src/index.ts`, line 747-753 ([link](https://github.com/generaltranslation/gt/blob/6b779194d42f7e41f250f414aaba3d2e19687e17/packages/core/src/index.ts#L747-L753)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`f.source.locale` not canonicalized for custom aliases**

   `uploadSourceFiles` canonicalizes `f.source.locale` for every file (line 687), but `uploadTranslations` only maps translation locales — leaving `source.locale` as the raw alias (e.g. `'brand-english'`). If the backend uses that field to match or validate the source file, custom alias users will get a mismatch. The PR's stated goal is parity with `uploadSourceFiles`, so `f.source.locale` should be wrapped in `this.resolveCanonicalLocale(f.source.locale)` inside the same `targetFiles` map.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/core/src/index.ts
   Line: 747-753

   Comment:
   **`f.source.locale` not canonicalized for custom aliases**

   `uploadSourceFiles` canonicalizes `f.source.locale` for every file (line 687), but `uploadTranslations` only maps translation locales — leaving `source.locale` as the raw alias (e.g. `'brand-english'`). If the backend uses that field to match or validate the source file, custom alias users will get a mismatch. The PR's stated goal is parity with `uploadSourceFiles`, so `f.source.locale` should be wrapped in `this.resolveCanonicalLocale(f.source.locale)` inside the same `targetFiles` map.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fcore%2Fsrc%2Findex.ts%0ALine%3A%20747-753%0A%0AComment%3A%0A**%60f.source.locale%60%20not%20canonicalized%20for%20custom%20aliases**%0A%0A%60uploadSourceFiles%60%20canonicalizes%20%60f.source.locale%60%20for%20every%20file%20%28line%20687%29%2C%20but%20%60uploadTranslations%60%20only%20maps%20translation%20locales%20%E2%80%94%20leaving%20%60source.locale%60%20as%20the%20raw%20alias%20%28e.g.%20%60'brand-english'%60%29.%20If%20the%20backend%20uses%20that%20field%20to%20match%20or%20validate%20the%20source%20file%2C%20custom%20alias%20users%20will%20get%20a%20mismatch.%20The%20PR's%20stated%20goal%20is%20parity%20with%20%60uploadSourceFiles%60%2C%20so%20%60f.source.locale%60%20should%20be%20wrapped%20in%20%60this.resolveCanonicalLocale%28f.source.locale%29%60%20inside%20the%20same%20%60targetFiles%60%20map.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=generaltranslation%2Fgt&pr=1895&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fcore%2Fcanonicalize-upload-source-locale%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fcore%2Fcanonicalize-upload-source-locale%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fcore%2Fsrc%2Findex.ts%0ALine%3A%20747-753%0A%0AComment%3A%0A**%60f.source.locale%60%20not%20canonicalized%20for%20custom%20aliases**%0A%0A%60uploadSourceFiles%60%20canonicalizes%20%60f.source.locale%60%20for%20every%20file%20%28line%20687%29%2C%20but%20%60uploadTranslations%60%20only%20maps%20translation%20locales%20%E2%80%94%20leaving%20%60source.locale%60%20as%20the%20raw%20alias%20%28e.g.%20%60'brand-english'%60%29.%20If%20the%20backend%20uses%20that%20field%20to%20match%20or%20validate%20the%20source%20file%2C%20custom%20alias%20users%20will%20get%20a%20mismatch.%20The%20PR's%20stated%20goal%20is%20parity%20with%20%60uploadSourceFiles%60%2C%20so%20%60f.source.locale%60%20should%20be%20wrapped%20in%20%60this.resolveCanonicalLocale%28f.source.locale%29%60%20inside%20the%20same%20%60targetFiles%60%20map.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=generaltranslation%2Fgt&pr=1895&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>


2. `packages/core/src/index.ts`, line 730-744 ([link](https://github.com/generaltranslation/gt/blob/6b779194d42f7e41f250f414aaba3d2e19687e17/packages/core/src/index.ts#L730-L744)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> Mutating a property of a `const`-declared object is valid JS/TS but inconsistent with the rest of the class — `uploadSourceFiles` builds the canonical locale inline when constructing `mergedOptions`, and `enqueueFiles` spreads into a new object. Consider applying the same pattern here for consistency.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/core/src/index.ts
   Line: 730-744

   Comment:
   Mutating a property of a `const`-declared object is valid JS/TS but inconsistent with the rest of the class — `uploadSourceFiles` builds the canonical locale inline when constructing `mergedOptions`, and `enqueueFiles` spreads into a new object. Consider applying the same pattern here for consistency.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fcore%2Fsrc%2Findex.ts%0ALine%3A%20730-744%0A%0AComment%3A%0AMutating%20a%20property%20of%20a%20%60const%60-declared%20object%20is%20valid%20JS%2FTS%20but%20inconsistent%20with%20the%20rest%20of%20the%20class%20%E2%80%94%20%60uploadSourceFiles%60%20builds%20the%20canonical%20locale%20inline%20when%20constructing%20%60mergedOptions%60%2C%20and%20%60enqueueFiles%60%20spreads%20into%20a%20new%20object.%20Consider%20applying%20the%20same%20pattern%20here%20for%20consistency.%0A%0A%60%60%60suggestion%0A%20%20%20%20const%20rawSourceLocale%20%3D%20options.sourceLocale%20%3F%3F%20this.sourceLocale%3B%0A%0A%20%20%20%20%2F%2F%20Require%20source%20locale%0A%20%20%20%20if%20%28!rawSourceLocale%29%20%7B%0A%20%20%20%20%20%20const%20error%20%3D%20noSourceLocaleProvidedError%28'uploadTranslations'%29%3B%0A%20%20%20%20%20%20gtInstanceLogger.error%28error%29%3B%0A%20%20%20%20%20%20throw%20new%20Error%28error%29%3B%0A%20%20%20%20%7D%0A%0A%20%20%20%20const%20mergedOptions%3A%20UploadFilesOptions%20%3D%20%7B%0A%20%20%20%20%20%20...options%2C%0A%20%20%20%20%20%20sourceLocale%3A%20this.resolveCanonicalLocale%28rawSourceLocale%29%2C%0A%20%20%20%20%7D%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=generaltranslation%2Fgt&pr=1895&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fcore%2Fcanonicalize-upload-source-locale%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fcore%2Fcanonicalize-upload-source-locale%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fcore%2Fsrc%2Findex.ts%0ALine%3A%20730-744%0A%0AComment%3A%0AMutating%20a%20property%20of%20a%20%60const%60-declared%20object%20is%20valid%20JS%2FTS%20but%20inconsistent%20with%20the%20rest%20of%20the%20class%20%E2%80%94%20%60uploadSourceFiles%60%20builds%20the%20canonical%20locale%20inline%20when%20constructing%20%60mergedOptions%60%2C%20and%20%60enqueueFiles%60%20spreads%20into%20a%20new%20object.%20Consider%20applying%20the%20same%20pattern%20here%20for%20consistency.%0A%0A%60%60%60suggestion%0A%20%20%20%20const%20rawSourceLocale%20%3D%20options.sourceLocale%20%3F%3F%20this.sourceLocale%3B%0A%0A%20%20%20%20%2F%2F%20Require%20source%20locale%0A%20%20%20%20if%20%28!rawSourceLocale%29%20%7B%0A%20%20%20%20%20%20const%20error%20%3D%20noSourceLocaleProvidedError%28'uploadTranslations'%29%3B%0A%20%20%20%20%20%20gtInstanceLogger.error%28error%29%3B%0A%20%20%20%20%20%20throw%20new%20Error%28error%29%3B%0A%20%20%20%20%7D%0A%0A%20%20%20%20const%20mergedOptions%3A%20UploadFilesOptions%20%3D%20%7B%0A%20%20%20%20%20%20...options%2C%0A%20%20%20%20%20%20sourceLocale%3A%20this.resolveCanonicalLocale%28rawSourceLocale%29%2C%0A%20%20%20%20%7D%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=generaltranslation%2Fgt&pr=1895&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Apackages%2Fcore%2Fsrc%2Findex.ts%3A747-753%0A**%60f.source.locale%60%20not%20canonicalized%20for%20custom%20aliases**%0A%0A%60uploadSourceFiles%60%20canonicalizes%20%60f.source.locale%60%20for%20every%20file%20%28line%20687%29%2C%20but%20%60uploadTranslations%60%20only%20maps%20translation%20locales%20%E2%80%94%20leaving%20%60source.locale%60%20as%20the%20raw%20alias%20%28e.g.%20%60'brand-english'%60%29.%20If%20the%20backend%20uses%20that%20field%20to%20match%20or%20validate%20the%20source%20file%2C%20custom%20alias%20users%20will%20get%20a%20mismatch.%20The%20PR's%20stated%20goal%20is%20parity%20with%20%60uploadSourceFiles%60%2C%20so%20%60f.source.locale%60%20should%20be%20wrapped%20in%20%60this.resolveCanonicalLocale%28f.source.locale%29%60%20inside%20the%20same%20%60targetFiles%60%20map.%0A%0A%23%23%23%20Issue%202%20of%203%0Apackages%2Fcore%2Fsrc%2F__tests__%2FuploadTranslations.test.ts%3A52-57%0A**Test%20doesn't%20assert%20%60source.locale%60%20is%20canonicalized**%0A%0AThe%20first%20argument%20is%20matched%20with%20%60expect.any%28Array%29%60%2C%20so%20if%20%60source.locale%60%20is%20passed%20through%20as%20%60'brand-english'%60%20instead%20of%20%60'en-US'%60%20the%20test%20still%20passes.%20Because%20%60uploadSourceFiles%60%20canonicalizes%20%60f.source.locale%60%20and%20the%20PR%20claims%20parity%2C%20the%20assertion%20should%20use%20%60expect.arrayContaining%60%20%28or%20a%20concrete%20matcher%29%20to%20verify%20that%20%60source.locale%60%20has%20been%20resolved%20to%20%60'en-US'%60%20as%20well.%0A%0A%23%23%23%20Issue%203%20of%203%0Apackages%2Fcore%2Fsrc%2Findex.ts%3A730-744%0AMutating%20a%20property%20of%20a%20%60const%60-declared%20object%20is%20valid%20JS%2FTS%20but%20inconsistent%20with%20the%20rest%20of%20the%20class%20%E2%80%94%20%60uploadSourceFiles%60%20builds%20the%20canonical%20locale%20inline%20when%20constructing%20%60mergedOptions%60%2C%20and%20%60enqueueFiles%60%20spreads%20into%20a%20new%20object.%20Consider%20applying%20the%20same%20pattern%20here%20for%20consistency.%0A%0A%60%60%60suggestion%0A%20%20%20%20const%20rawSourceLocale%20%3D%20options.sourceLocale%20%3F%3F%20this.sourceLocale%3B%0A%0A%20%20%20%20%2F%2F%20Require%20source%20locale%0A%20%20%20%20if%20%28!rawSourceLocale%29%20%7B%0A%20%20%20%20%20%20const%20error%20%3D%20noSourceLocaleProvidedError%28'uploadTranslations'%29%3B%0A%20%20%20%20%20%20gtInstanceLogger.error%28error%29%3B%0A%20%20%20%20%20%20throw%20new%20Error%28error%29%3B%0A%20%20%20%20%7D%0A%0A%20%20%20%20const%20mergedOptions%3A%20UploadFilesOptions%20%3D%20%7B%0A%20%20%20%20%20%20...options%2C%0A%20%20%20%20%20%20sourceLocale%3A%20this.resolveCanonicalLocale%28rawSourceLocale%29%2C%0A%20%20%20%20%7D%3B%0A%60%60%60%0A%0A&repo=generaltranslation%2Fgt&pr=1895&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fcore%2Fcanonicalize-upload-source-locale%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fcore%2Fcanonicalize-upload-source-locale%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Apackages%2Fcore%2Fsrc%2Findex.ts%3A747-753%0A**%60f.source.locale%60%20not%20canonicalized%20for%20custom%20aliases**%0A%0A%60uploadSourceFiles%60%20canonicalizes%20%60f.source.locale%60%20for%20every%20file%20%28line%20687%29%2C%20but%20%60uploadTranslations%60%20only%20maps%20translation%20locales%20%E2%80%94%20leaving%20%60source.locale%60%20as%20the%20raw%20alias%20%28e.g.%20%60'brand-english'%60%29.%20If%20the%20backend%20uses%20that%20field%20to%20match%20or%20validate%20the%20source%20file%2C%20custom%20alias%20users%20will%20get%20a%20mismatch.%20The%20PR's%20stated%20goal%20is%20parity%20with%20%60uploadSourceFiles%60%2C%20so%20%60f.source.locale%60%20should%20be%20wrapped%20in%20%60this.resolveCanonicalLocale%28f.source.locale%29%60%20inside%20the%20same%20%60targetFiles%60%20map.%0A%0A%23%23%23%20Issue%202%20of%203%0Apackages%2Fcore%2Fsrc%2F__tests__%2FuploadTranslations.test.ts%3A52-57%0A**Test%20doesn't%20assert%20%60source.locale%60%20is%20canonicalized**%0A%0AThe%20first%20argument%20is%20matched%20with%20%60expect.any%28Array%29%60%2C%20so%20if%20%60source.locale%60%20is%20passed%20through%20as%20%60'brand-english'%60%20instead%20of%20%60'en-US'%60%20the%20test%20still%20passes.%20Because%20%60uploadSourceFiles%60%20canonicalizes%20%60f.source.locale%60%20and%20the%20PR%20claims%20parity%2C%20the%20assertion%20should%20use%20%60expect.arrayContaining%60%20%28or%20a%20concrete%20matcher%29%20to%20verify%20that%20%60source.locale%60%20has%20been%20resolved%20to%20%60'en-US'%60%20as%20well.%0A%0A%23%23%23%20Issue%203%20of%203%0Apackages%2Fcore%2Fsrc%2Findex.ts%3A730-744%0AMutating%20a%20property%20of%20a%20%60const%60-declared%20object%20is%20valid%20JS%2FTS%20but%20inconsistent%20with%20the%20rest%20of%20the%20class%20%E2%80%94%20%60uploadSourceFiles%60%20builds%20the%20canonical%20locale%20inline%20when%20constructing%20%60mergedOptions%60%2C%20and%20%60enqueueFiles%60%20spreads%20into%20a%20new%20object.%20Consider%20applying%20the%20same%20pattern%20here%20for%20consistency.%0A%0A%60%60%60suggestion%0A%20%20%20%20const%20rawSourceLocale%20%3D%20options.sourceLocale%20%3F%3F%20this.sourceLocale%3B%0A%0A%20%20%20%20%2F%2F%20Require%20source%20locale%0A%20%20%20%20if%20%28!rawSourceLocale%29%20%7B%0A%20%20%20%20%20%20const%20error%20%3D%20noSourceLocaleProvidedError%28'uploadTranslations'%29%3B%0A%20%20%20%20%20%20gtInstanceLogger.error%28error%29%3B%0A%20%20%20%20%20%20throw%20new%20Error%28error%29%3B%0A%20%20%20%20%7D%0A%0A%20%20%20%20const%20mergedOptions%3A%20UploadFilesOptions%20%3D%20%7B%0A%20%20%20%20%20%20...options%2C%0A%20%20%20%20%20%20sourceLocale%3A%20this.resolveCanonicalLocale%28rawSourceLocale%29%2C%0A%20%20%20%20%7D%3B%0A%60%60%60%0A%0A&repo=generaltranslation%2Fgt&pr=1895&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
packages/core/src/index.ts:747-753
**`f.source.locale` not canonicalized for custom aliases**

`uploadSourceFiles` canonicalizes `f.source.locale` for every file (line 687), but `uploadTranslations` only maps translation locales — leaving `source.locale` as the raw alias (e.g. `'brand-english'`). If the backend uses that field to match or validate the source file, custom alias users will get a mismatch. The PR's stated goal is parity with `uploadSourceFiles`, so `f.source.locale` should be wrapped in `this.resolveCanonicalLocale(f.source.locale)` inside the same `targetFiles` map.

### Issue 2 of 3
packages/core/src/__tests__/uploadTranslations.test.ts:52-57
**Test doesn't assert `source.locale` is canonicalized**

The first argument is matched with `expect.any(Array)`, so if `source.locale` is passed through as `'brand-english'` instead of `'en-US'` the test still passes. Because `uploadSourceFiles` canonicalizes `f.source.locale` and the PR claims parity, the assertion should use `expect.arrayContaining` (or a concrete matcher) to verify that `source.locale` has been resolved to `'en-US'` as well.

### Issue 3 of 3
packages/core/src/index.ts:730-744
Mutating a property of a `const`-declared object is valid JS/TS but inconsistent with the rest of the class — `uploadSourceFiles` builds the canonical locale inline when constructing `mergedOptions`, and `enqueueFiles` spreads into a new object. Consider applying the same pattern here for consistency.

```suggestion
    const rawSourceLocale = options.sourceLocale ?? this.sourceLocale;

    // Require source locale
    if (!rawSourceLocale) {
      const error = noSourceLocaleProvidedError('uploadTranslations');
      gtInstanceLogger.error(error);
      throw new Error(error);
    }

    const mergedOptions: UploadFilesOptions = {
      ...options,
      sourceLocale: this.resolveCanonicalLocale(rawSourceLocale),
    };
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(core): canonicalize translation uplo..."](https://github.com/generaltranslation/gt/commit/6b779194d42f7e41f250f414aaba3d2e19687e17) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44697149)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->