### PR TITLE
fix(core): accept ID-only setup project references

### DIFF
--- a/.changeset/setup-project-id-references.md
+++ b/.changeset/setup-project-id-references.md
@@ -1,0 +1,5 @@
+---
+'generaltranslation': patch
+---
+
+Allow `setupProject` callers to pass only the branch, file, and version IDs that the API request uses.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,6 +20,7 @@ import {
   _setupProject,
   SetupProjectResult,
   SetupProjectOptions,
+  type SetupProjectFileReference,
 } from './translate/setupProject';
 import {
   _enqueueFiles,
@@ -75,7 +76,7 @@ import type {
   CreateBranchResult,
 } from './translate/createBranch';
 import { _createBranch } from './translate/createBranch';
-import type { FileReference, FileReferenceIds } from './types-dir/api/file';
+import type { FileReferenceIds } from './types-dir/api/file';
 import {
   _processFileMoves,
   type MoveMapping,
@@ -239,12 +240,12 @@ export class GT extends GTRuntime {
    * files that have already been uploaded via uploadSourceFiles. The setup jobs are queued
    * for processing and will generate a project setup based on the source files.
    *
-   * @param {FileReference[]} files - Array of file references containing IDs of previously uploaded source files
+   * @param {SetupProjectFileReference[]} files - Array of file references containing IDs of previously uploaded source files
    * @param {SetupProjectOptions} [options] - Optional settings for target locales and timeout.
    * @returns {Promise<SetupProjectResult>} Object containing the jobId and status
    */
   async setupProject(
-    files: FileReference[],
+    files: SetupProjectFileReference[],
     options?: SetupProjectOptions
   ): Promise<SetupProjectResult> {
     this._validateAuth('setupProject');

--- a/packages/core/src/translate/__tests__/setupProject.test.ts
+++ b/packages/core/src/translate/__tests__/setupProject.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { _setupProject, SetupProjectResult } from '../setupProject';
+import {
+  _setupProject,
+  type SetupProjectFileReference,
+  SetupProjectResult,
+} from '../setupProject';
 import { TranslationRequestConfig } from '../../types';
 import { FileReference } from '../../types-dir/api/file';
 import { apiRequest } from '../utils/apiRequest';
@@ -88,6 +92,28 @@ describe('_setupProject', () => {
     expect(result.status).toBe('queued');
     // @ts-expect-error - setupJobId is not defined in the type
     expect(result.setupJobId).toBe('setup-job-123');
+  });
+
+  it('accepts references containing only the IDs sent to the API', async () => {
+    const files: SetupProjectFileReference[] = [
+      {
+        branchId: 'branch-123',
+        fileId: 'file-123',
+        versionId: 'version-456',
+      },
+    ];
+
+    vi.mocked(apiRequest).mockResolvedValue({ status: 'completed' });
+
+    await _setupProject(files, mockConfig);
+
+    expect(apiRequest).toHaveBeenCalledWith(
+      mockConfig,
+      '/v2/project/setup/generate',
+      expect.objectContaining({
+        body: expect.objectContaining({ files }),
+      })
+    );
   });
 
   it('should use custom timeout when provided', async () => {

--- a/packages/core/src/translate/setupProject.ts
+++ b/packages/core/src/translate/setupProject.ts
@@ -2,6 +2,11 @@ import { TranslationRequestConfig } from '../types';
 import { apiRequest } from './utils/apiRequest';
 import type { FileReference } from '../types-dir/api/file';
 
+export type SetupProjectFileReference = Pick<
+  FileReference,
+  'branchId' | 'fileId' | 'versionId'
+>;
+
 export type SetupProjectResult =
   | { setupJobId: string; status: 'queued' }
   | { status: 'completed' };
@@ -21,7 +26,7 @@ export type SetupProjectOptions = {
  * @returns The result of the API call.
  */
 export async function _setupProject(
-  files: FileReference[],
+  files: SetupProjectFileReference[],
   config: TranslationRequestConfig,
   options?: SetupProjectOptions
 ): Promise<SetupProjectResult> {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -42,6 +42,7 @@ export type {
 export type { EnqueueFilesOptions } from './translate/enqueueFiles';
 export type { EnqueueFilesResult, Updates } from './types-dir/api/enqueueFiles';
 export type { CreateTagOptions, CreateTagResult } from './translate/createTag';
+export type { SetupProjectFileReference } from './translate/setupProject';
 export type { FileToUpload } from './types-dir/api/file';
 export type { FileUpload } from './types-dir/api/uploadFiles';
 export type { FileReference } from './types-dir/api/file';


### PR DESCRIPTION
## Summary

- add an exported `SetupProjectFileReference` type containing only the IDs sent to the setup API
- accept ID-only references in both the public and internal setup methods
- cover the minimal reference shape with a regression test

## Testing

- `pnpm --filter generaltranslation exec vitest run --config=./vitest.config.ts src/translate/__tests__/setupProject.test.ts` — 12 passed
- `pnpm --filter generaltranslation... build` — passed
- `pnpm --filter generaltranslation typecheck` — passed

## Notes

- Includes a patch changeset for `generaltranslation`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR relaxes the parameter type of `setupProject` (both public and internal) from requiring the full `FileReference` shape to a new `SetupProjectFileReference` type that only requires the three IDs (`branchId`, `fileId`, `versionId`) that are actually forwarded to the API. The change is fully backward-compatible since any existing `FileReference` satisfies the narrower type.

- Introduces `SetupProjectFileReference = Pick<FileReference, 'branchId' | 'fileId' | 'versionId'>` in `setupProject.ts` and exports it via `types.ts` and `index.ts`.
- Updates `_setupProject` and the public `GT.setupProject` method signatures to use the new type, removes the now-unused `FileReference` import from `index.ts`.
- Adds a regression test that passes an ID-only reference and asserts the correct IDs are forwarded to the API.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the type change is strictly additive and no runtime behavior changes.

The new SetupProjectFileReference type is a structural subset of the existing FileReference, so all call sites passing full FileReference objects continue to work without modification. The implementation body was already mapping to only the three IDs, so narrowing the accepted type simply makes the contract accurate. The regression test correctly exercises the minimal shape and verifies the right payload is forwarded to the API.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/translate/setupProject.ts | Introduces `SetupProjectFileReference` as `Pick<FileReference, 'branchId' | 'fileId' | 'versionId'>` and narrows the parameter type of `_setupProject`; backward-compatible since `FileReference` satisfies the new type. |
| packages/core/src/index.ts | Updates the public `setupProject` method's parameter type from `FileReference[]` to `SetupProjectFileReference[]`, exports the new type, and drops the now-unused `FileReference` import. |
| packages/core/src/types.ts | Adds a re-export of `SetupProjectFileReference` to the package's public type surface; no issues found. |
| packages/core/src/translate/__tests__/setupProject.test.ts | Adds a regression test that passes an ID-only reference array and verifies those IDs are forwarded to the API; test logic is sound because `_setupProject` maps to new objects with the same values, satisfying deep-equality assertions. |
| .changeset/setup-project-id-references.md | Patch changeset for `generaltranslation` describing the relaxed `setupProject` parameter type; accurately scoped. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant GT as GT.setupProject(files: SetupProjectFileReference[])
    participant Internal as _setupProject
    participant API as /v2/project/setup/generate

    Caller->>GT: files (branchId, fileId, versionId only)
    GT->>Internal: files, config, options
    Internal->>Internal: "map files to {branchId, fileId, versionId}"
    Internal->>API: "POST { files, locales, force }, timeout"
    API-->>Internal: SetupProjectResult
    Internal-->>GT: result
    GT-->>Caller: result
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant GT as GT.setupProject(files: SetupProjectFileReference[])
    participant Internal as _setupProject
    participant API as /v2/project/setup/generate

    Caller->>GT: files (branchId, fileId, versionId only)
    GT->>Internal: files, config, options
    Internal->>Internal: "map files to {branchId, fileId, versionId}"
    Internal->>API: "POST { files, locales, force }, timeout"
    API-->>Internal: SetupProjectResult
    Internal-->>GT: result
    GT-->>Caller: result
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(core): accept ID-only setup project ..."](https://github.com/generaltranslation/gt/commit/7def04aaab37fcfc242ac695f188c5fc163f1eb6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44697147)</sub>

<!-- /greptile_comment -->