### PR TITLE
fix(example): use named React Native Babel plugin export

### DIFF
--- a/examples/expo-react-native/babel.config.js
+++ b/examples/expo-react-native/babel.config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const { plugin: gtPlugin } = require('gt-react-native/plugin');
 
 module.exports = function (api) {
   api.cache(true);
@@ -14,7 +15,7 @@ module.exports = function (api) {
     ],
     plugins: [
       [
-        require('gt-react-native/plugin').default,
+        gtPlugin,
         {
           entryPointFilePath: path.resolve(__dirname, 'index.ts'),
         },


### PR DESCRIPTION
## Summary

- update the Expo React Native Babel config to use the named `plugin` export
- preserve the existing plugin options and entrypoint behavior

## Testing

- `pnpm --filter gt-react-native... build` — passed
- loaded `examples/expo-react-native/babel.config.js` with Node and asserted the configured plugin is callable — passed

## Notes

- No changeset: this only updates an ignored example workspace.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a broken Babel plugin reference in the Expo React Native example. The `gt-react-native/plugin` entry point exports a named `plugin` symbol — not a default export — so the previous `require(...).default` access would have resolved to `undefined`, silently preventing the plugin from running.

- Replaces `.default` access with a named destructuring `const { plugin: gtPlugin } = require('gt-react-native/plugin')`, which aligns with the actual module export in `packages/react-native/src/plugin.ts`.
- All existing plugin options (`entryPointFilePath`) and the `api.cache(true)` behavior are preserved unchanged.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — a one-line fix to a single example config file with no impact on published packages.

The change corrects a broken module access in an example's Babel config. The named `plugin` export exists in `packages/react-native/src/plugin.ts`, confirming the new destructuring is accurate. No logic, API surface, or package output is affected.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| examples/expo-react-native/babel.config.js | Fixes `.default` access to use the correct named `plugin` export from `gt-react-native/plugin`; all options and cache behavior preserved. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[babel.config.js loads] --> B["require('gt-react-native/plugin')"]
    B --> C{Export resolution}
    C -->|"Before: .default"| D["undefined — no default export"]
    C -->|"After: named plugin"| E["plugin function resolved correctly"]
    E --> F["Babel plugin applied with entryPointFilePath option"]
    D --> G["Plugin silently skipped — transform never runs"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[babel.config.js loads] --> B["require('gt-react-native/plugin')"]
    B --> C{Export resolution}
    C -->|"Before: .default"| D["undefined — no default export"]
    C -->|"After: named plugin"| E["plugin function resolved correctly"]
    E --> F["Babel plugin applied with entryPointFilePath option"]
    D --> G["Plugin silently skipped — transform never runs"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(example): use named React Native Bab..."](https://github.com/generaltranslation/gt/commit/1a7c4da23c25417c121d9ed14fbc64ded54ae707) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44697153)</sub>

<!-- /greptile_comment -->