### PR TITLE
fix: honor dev hot reload runtime config

### DIFF
--- a/.changeset/runtime-dev-hot-reload-flags.md
+++ b/.changeset/runtime-dev-hot-reload-flags.md
@@ -1,0 +1,8 @@
+---
+'gt-i18n': patch
+'@generaltranslation/react-core': patch
+'gt-react': patch
+'gt-next': patch
+---
+
+Honor `files.gt.parsingFlags.devHotReload` in runtime translation paths, including granular string and JSX settings, and carry the setting through Next.js runtime configuration.

--- a/packages/i18n/src/config/types.ts
+++ b/packages/i18n/src/config/types.ts
@@ -47,7 +47,7 @@ export type GTConfig = {
       output?: string;
       parsingFlags?: {
         /**
-         * Dev hot reload config, gt-react browser runtime only.
+         * Dev hot reload config for compiler and runtime translation paths.
          * - `true` enables strings hot reload (jsx handled at runtime via Suspense)
          * - `{ strings?: boolean; jsx?: boolean }` enables selectively
          */

--- a/packages/i18n/src/i18n-cache/I18nCache.ts
+++ b/packages/i18n/src/i18n-cache/I18nCache.ts
@@ -520,7 +520,7 @@ class I18nCache<TranslationValue extends Translation = Translation> {
         ) => {
           if (
             process.env.NODE_ENV !== 'production' &&
-            getI18nConfig().isDevHotReloadEnabled()
+            getI18nConfig().isDevHotReloadEnabled('strings')
           ) {
             // Invariant: all prefetchEntries must be the same locale
             // TODO: investigate why we have made this an invariant, we may be able to drop this requirement

--- a/packages/i18n/src/i18n-config/I18nConfig.ts
+++ b/packages/i18n/src/i18n-config/I18nConfig.ts
@@ -32,6 +32,7 @@ export type I18nConfigParams = Pick<
   | 'apiKey'
   | 'cacheUrl'
   | 'runtimeUrl'
+  | 'files'
   | '_disableDevHotReload'
 >;
 
@@ -41,9 +42,11 @@ type RuntimeConfig = Pick<
 >;
 
 export type LocaleCandidates = string | string[] | undefined;
+export type DevHotReloadTarget = 'strings' | 'jsx';
 
 export class I18nConfig extends LocaleConfig {
   private runtimeConfig: RuntimeConfig;
+  private devHotReload: Record<DevHotReloadTarget, boolean>;
   private gtServicesEnabled: boolean;
   private logLevel: GeneralTranslationLogLevel;
 
@@ -57,6 +60,9 @@ export class I18nConfig extends LocaleConfig {
       runtimeUrl: params.runtimeUrl,
       _disableDevHotReload: params._disableDevHotReload,
     };
+    this.devHotReload = resolveDevHotReload(
+      params.files?.gt?.parsingFlags?.devHotReload
+    );
     this.gtServicesEnabled = gtServicesEnabled;
     this.logLevel = getGeneralTranslationLogLevel();
   }
@@ -133,8 +139,12 @@ export class I18nConfig extends LocaleConfig {
   /**
    * Returns true when development hot reload runtime translation requests can run.
    */
-  isDevHotReloadEnabled(): boolean {
+  isDevHotReloadEnabled(target?: DevHotReloadTarget): boolean {
+    const configured = target
+      ? this.devHotReload[target]
+      : this.devHotReload.strings || this.devHotReload.jsx;
     return (
+      configured &&
       !this.runtimeConfig._disableDevHotReload &&
       !!this.runtimeConfig.devApiKey &&
       !!this.runtimeConfig.projectId &&
@@ -193,6 +203,18 @@ export class I18nConfig extends LocaleConfig {
     }
     return localeConfig.determineLocale(candidates);
   }
+}
+
+function resolveDevHotReload(
+  value: boolean | { strings?: boolean; jsx?: boolean } | undefined
+): Record<DevHotReloadTarget, boolean> {
+  if (typeof value === 'boolean') {
+    return { strings: value, jsx: false };
+  }
+  return {
+    strings: value?.strings ?? false,
+    jsx: value?.jsx ?? false,
+  };
 }
 
 function getLocaleConfigParams(

--- a/packages/i18n/src/i18n-config/__tests__/I18nConfig.test.ts
+++ b/packages/i18n/src/i18n-config/__tests__/I18nConfig.test.ts
@@ -105,9 +105,44 @@ describe('I18nConfig', () => {
     const config = new I18nConfig({
       devApiKey: 'dev-key',
       projectId: 'project-id',
+      files: {
+        gt: { parsingFlags: { devHotReload: true } },
+      },
     });
 
     expect(config.isDevHotReloadEnabled()).toBe(true);
+    expect(config.isDevHotReloadEnabled('strings')).toBe(true);
+    expect(config.isDevHotReloadEnabled('jsx')).toBe(false);
+  });
+
+  it('honors granular dev hot reload settings', () => {
+    vi.stubEnv('NODE_ENV', 'development');
+
+    const config = new I18nConfig({
+      devApiKey: 'dev-key',
+      projectId: 'project-id',
+      files: {
+        gt: { parsingFlags: { devHotReload: { jsx: true } } },
+      },
+    });
+
+    expect(config.isDevHotReloadEnabled()).toBe(true);
+    expect(config.isDevHotReloadEnabled('strings')).toBe(false);
+    expect(config.isDevHotReloadEnabled('jsx')).toBe(true);
+  });
+
+  it('disables dev hot reload when the parsing flag is disabled', () => {
+    vi.stubEnv('NODE_ENV', 'development');
+
+    const config = new I18nConfig({
+      devApiKey: 'dev-key',
+      projectId: 'project-id',
+      files: {
+        gt: { parsingFlags: { devHotReload: false } },
+      },
+    });
+
+    expect(config.isDevHotReloadEnabled()).toBe(false);
   });
 
   it('disables dev hot reload when the config switch is set', () => {
@@ -116,6 +151,9 @@ describe('I18nConfig', () => {
     const config = new I18nConfig({
       devApiKey: 'dev-key',
       projectId: 'project-id',
+      files: {
+        gt: { parsingFlags: { devHotReload: true } },
+      },
       _disableDevHotReload: true,
     });
 
@@ -166,6 +204,13 @@ describe('I18nConfig', () => {
   ])('disables dev hot reload for $name', ({ config, environment }) => {
     vi.stubEnv('NODE_ENV', environment);
 
-    expect(new I18nConfig(config).isDevHotReloadEnabled()).toBe(false);
+    expect(
+      new I18nConfig({
+        files: {
+          gt: { parsingFlags: { devHotReload: true } },
+        },
+        ...config,
+      }).isDevHotReloadEnabled()
+    ).toBe(false);
   });
 });

--- a/packages/i18n/src/translation-functions/internal/getGT.ts
+++ b/packages/i18n/src/translation-functions/internal/getGT.ts
@@ -46,7 +46,7 @@ export async function getGTInternal(
   // production builds.
   const devHotReloadEnabled =
     process.env.NODE_ENV !== 'production' &&
-    getI18nConfig().isDevHotReloadEnabled();
+    getI18nConfig().isDevHotReloadEnabled('strings');
   const lookupTranslation = await i18nCache.getLookupTranslation(
     enableI18n ? locale : sourceLocale
   );

--- a/packages/next/src/__tests__/config.test.ts
+++ b/packages/next/src/__tests__/config.test.ts
@@ -1157,6 +1157,9 @@ describe('withGTConfig', () => {
           loadTranslationsPath: './loadTranslations.ts',
           getLocalePath: './getLocale.ts',
           getRegionPath: './getRegion.ts',
+          files: {
+            gt: { parsingFlags: { devHotReload: true } },
+          },
         }
       );
       const params = parseConfigParams(result);
@@ -1239,6 +1242,23 @@ describe('withGTConfig', () => {
       expect(parsed.projectId).toBeUndefined();
       expect(parsed.apiKey).toBeUndefined();
       expect(parsed.devApiKey).toBeUndefined();
+    });
+
+    it('exposes the dev hot reload flag to the runtime', async () => {
+      const withGTConfig = await getWithGTConfig();
+      const result = withGTConfig(
+        {},
+        {
+          files: {
+            gt: { parsingFlags: { devHotReload: { jsx: true } } },
+          },
+        }
+      );
+
+      const parsed = JSON.parse(
+        result.env!.NEXT_PUBLIC_GENERALTRANSLATION_I18N_CONFIG_PARAMS!
+      );
+      expect(parsed.files.gt.parsingFlags.devHotReload).toEqual({ jsx: true });
     });
 
     it('boolean flags are string "true"/"false", not booleans', async () => {

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -49,6 +49,7 @@ import { I18nConfigParams } from 'gt-i18n/internal/types';
 import { getRuntimeCredentials } from './setup/runtimeCredentials';
 
 type AutoderiveConfig = boolean | { jsx?: boolean; strings?: boolean };
+type DevHotReloadConfig = boolean | { jsx?: boolean; strings?: boolean };
 
 type ConfigFileShape = {
   customMapping?: CustomMapping;
@@ -56,6 +57,7 @@ type ConfigFileShape = {
     gt?: {
       parsingFlags?: {
         autoderive?: AutoderiveConfig;
+        devHotReload?: DevHotReloadConfig;
       };
     };
   };
@@ -566,6 +568,14 @@ export function withGTConfig<TNextConfig extends object = NextConfig>(
     locales: mergedConfig.locales,
     customMapping: mergedConfig.customMapping,
     runtimeUrl: mergedConfig.runtimeUrl,
+    files: {
+      gt: {
+        parsingFlags: {
+          devHotReload:
+            mergedConfig.files?.gt?.parsingFlags?.devHotReload ?? false,
+        },
+      },
+    },
   };
 
   const { type: _type, ...compilerOptions } =
@@ -755,7 +765,12 @@ export function withGTConfig<TNextConfig extends object = NextConfig>(
 }
 
 function isDevHotReloadEnabled(config: InternalGTConfigProps): boolean {
+  const value = config.files?.gt?.parsingFlags?.devHotReload;
+  const configured =
+    value === true ||
+    (typeof value === 'object' && !!(value.strings || value.jsx));
   return (
+    configured &&
     !!config.devApiKey &&
     !!config.projectId &&
     config.runtimeUrl !== null &&

--- a/packages/next/src/setup/__tests__/shared.test.ts
+++ b/packages/next/src/setup/__tests__/shared.test.ts
@@ -9,6 +9,9 @@ function setConfigEnv() {
       defaultLocale: 'en',
       locales: ['en', 'fr'],
       runtimeUrl: 'https://runtime.example.com',
+      files: {
+        gt: { parsingFlags: { devHotReload: { strings: true } } },
+      },
     });
   process.env._GENERALTRANSLATION_I18N_CONFIG_PARAMS = JSON.stringify({
     cacheUrl: 'https://cache.example.com',
@@ -57,6 +60,9 @@ describe('getParams', () => {
       cacheUrl: 'https://cache.example.com',
       localeCookieName: 'custom-locale',
       enableI18nCookieName: 'custom-enable-i18n',
+      files: {
+        gt: { parsingFlags: { devHotReload: { strings: true } } },
+      },
     });
     expect(nextI18nCacheParams).toMatchObject({
       projectId: 'project-id',

--- a/packages/next/src/setup/shared.ts
+++ b/packages/next/src/setup/shared.ts
@@ -28,6 +28,7 @@ export function getParams(): {
     locales: publicConfig.locales,
     customMapping: publicConfig.customMapping,
     runtimeUrl: publicConfig.runtimeUrl,
+    files: publicConfig.files,
     projectId,
     devApiKey,
     apiKey,

--- a/packages/react-core/src/components/translation/T.rsc.tsx
+++ b/packages/react-core/src/components/translation/T.rsc.tsx
@@ -46,7 +46,7 @@ async function RscT({
   const i18nCache = getReactI18nCache();
   if (
     process.env.NODE_ENV !== 'production' &&
-    getI18nConfig().isDevHotReloadEnabled()
+    getI18nConfig().isDevHotReloadEnabled('jsx')
   ) {
     targetJsxChildren = await i18nCache.lookupTranslationWithFallback(
       locale,

--- a/packages/react-core/src/components/translation/T.tsx
+++ b/packages/react-core/src/components/translation/T.tsx
@@ -62,7 +62,7 @@ function useComputeT({
   const prev = useRef<ReactNode | null>(null);
   if (
     process.env.NODE_ENV !== 'production' &&
-    getI18nConfig().isDevHotReloadEnabled() &&
+    getI18nConfig().isDevHotReloadEnabled('jsx') &&
     targetJsxChildren == null &&
     prev.current != null &&
     shouldTranslate

--- a/packages/react-core/src/hooks/external-store.ts
+++ b/packages/react-core/src/hooks/external-store.ts
@@ -34,7 +34,7 @@ export function useTranslate<T extends Translation>(
   if (
     process.env.NODE_ENV !== 'production' &&
     storeTranslation == null &&
-    getI18nConfig().isDevHotReloadEnabled()
+    getI18nConfig().isDevHotReloadEnabled('jsx')
   ) {
     // TODO: (separate PR): add configuration for a use() + suspense strategy
     // TODO: consider moving this to a useEffect

--- a/packages/react-core/src/hooks/external-store/useTrackedDictionaryObjResolver.ts
+++ b/packages/react-core/src/hooks/external-store/useTrackedDictionaryObjResolver.ts
@@ -21,7 +21,7 @@ export function useTrackedDictionaryObjResolver(): TrackedDictionaryObjResolver 
   const i18nStore = useI18nStore();
   const devHotReloadEnabled =
     process.env.NODE_ENV !== 'production' &&
-    getI18nConfig().isDevHotReloadEnabled();
+    getI18nConfig().isDevHotReloadEnabled('strings');
   const onMissingDictionaryObj = useHandleMissingDictionaryObject();
 
   const trackedKeysRef = useRef<Set<string> | null>(null);

--- a/packages/react-core/src/hooks/external-store/useTrackedDictionaryResolver.ts
+++ b/packages/react-core/src/hooks/external-store/useTrackedDictionaryResolver.ts
@@ -21,7 +21,7 @@ export function useTrackedDictionaryResolver(): TrackedDictionaryEntryResolver {
   const i18nStore = useI18nStore();
   const devHotReloadEnabled =
     process.env.NODE_ENV !== 'production' &&
-    getI18nConfig().isDevHotReloadEnabled();
+    getI18nConfig().isDevHotReloadEnabled('strings');
   const onMissingDictionaryEntry = useHandleMissingDictionaryEntry();
 
   const trackedKeysRef = useRef<Set<string> | null>(null);

--- a/packages/react-core/src/hooks/external-store/useTrackedTranslationResolver.ts
+++ b/packages/react-core/src/hooks/external-store/useTrackedTranslationResolver.ts
@@ -51,7 +51,7 @@ export function useTrackedTranslationResolver(
   const i18nStore = useI18nStore();
   const devHotReloadEnabled =
     process.env.NODE_ENV !== 'production' &&
-    getI18nConfig().isDevHotReloadEnabled();
+    getI18nConfig().isDevHotReloadEnabled('strings');
   const onMissingTranslation = useHandleMissingTranslation();
 
   /**
@@ -118,7 +118,7 @@ function usePreloadCompilerLookups(
   const locale = useLocale();
   const devHotReloadEnabled =
     process.env.NODE_ENV !== 'production' &&
-    getI18nConfig().isDevHotReloadEnabled();
+    getI18nConfig().isDevHotReloadEnabled('strings');
   const shouldTranslate = useShouldTranslate();
   const translationsSnapshot = useTranslationsSnapshot();
   const txHotReloadEnabled = useMemo(() => {

--- a/packages/react/src/i18n-cache/BrowserI18nCache.ts
+++ b/packages/react/src/i18n-cache/BrowserI18nCache.ts
@@ -40,6 +40,7 @@ export class BrowserI18nCache extends I18nCache<Translation> {
     const i18nConfig = getI18nConfig();
     const devHotReloadEnabled =
       !!config.loadTranslations && i18nConfig.isDevHotReloadEnabled();
+    const devHotReloadJsx = i18nConfig.isDevHotReloadEnabled('jsx');
     const projectId = i18nConfig.getProjectId()!;
     const loadTranslations = devHotReloadEnabled
       ? wrapLoaderWithLocalStorage(
@@ -56,7 +57,7 @@ export class BrowserI18nCache extends I18nCache<Translation> {
     });
 
     this._localStorageCaches = localStorageCaches;
-    this._devHotReloadJsx = devHotReloadEnabled;
+    this._devHotReloadJsx = devHotReloadJsx;
 
     this.htmlTagOptions = {
       ...DEFAULT_HTML_TAG_OPTIONS,


### PR DESCRIPTION
## Summary

- carry `files.gt.parsingFlags.devHotReload` into runtime configuration, including Next.js browser and server initialization
- gate string and JSX runtime translation paths independently
- preserve credential, URL, environment, and internal-disable safety checks
- add coverage for disabled and granular runtime settings

## Testing

- `pnpm --filter gt-react... build` — passed
- `pnpm --filter gt-next build:no-swc-plugin` — passed
- `pnpm --filter gt-i18n exec vitest run --config=./vitest.config.ts src/i18n-config/__tests__/I18nConfig.test.ts` — 15 passed
- `pnpm --filter @generaltranslation/react-core test` — 46 passed
- `pnpm --filter gt-react test` — 26 passed
- `pnpm --filter gt-next test:js` — 241 passed
- `pnpm --filter gt-i18n typecheck` — passed
- `pnpm --filter @generaltranslation/react-core typecheck` — passed
- `pnpm --filter gt-react typecheck` — passed
- `pnpm --filter gt-next typecheck` — passed

## Notes

- Includes patch changesets for `gt-i18n`, `@generaltranslation/react-core`, `gt-react`, and `gt-next`.
- Rust tests were not run because the SWC plugin is unchanged.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR threads `files.gt.parsingFlags.devHotReload` from the gt config file all the way into the runtime, allowing strings and JSX hot reload to be gated independently. The flag is now serialized into the Next.js public env var and forwarded through `getParams()` so both browser and server initialization pick it up.

- `I18nConfig` gains a `devHotReload` field (resolved by `resolveDevHotReload`) and `isDevHotReloadEnabled` accepts an optional `'strings' | 'jsx'` target, replacing the single combined check.
- All string-path call sites are updated to pass `'strings'`; JSX-path call sites pass `'jsx'`.
- `BrowserI18nCache` separates `devHotReloadJsx` from `devHotReloadEnabled`, but `devHotReloadEnabled` still uses the untargeted `isDevHotReloadEnabled()` rather than `isDevHotReloadEnabled('strings')`.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge with one targeted fix in BrowserI18nCache.

Every call site in the PR was updated to pass the correct target except `devHotReloadEnabled` in `BrowserI18nCache`, which still reads the untargeted `isDevHotReloadEnabled()`. A project that sets `devHotReload: { jsx: true }` and provides `loadTranslations` will have string translations wrapped in localStorage caching — behavior the user did not opt into. The rest of the change is clean, well-tested, and logically consistent.

packages/react/src/i18n-cache/BrowserI18nCache.ts — `devHotReloadEnabled` needs to use `isDevHotReloadEnabled('strings')`.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react/src/i18n-cache/BrowserI18nCache.ts | Adds `devHotReloadJsx` as a separate flag but `devHotReloadEnabled` still uses untargeted `isDevHotReloadEnabled()`, activating string localStorage caching when only JSX hot reload is configured. |
| packages/i18n/src/i18n-config/I18nConfig.ts | Adds `DevHotReloadTarget` type, `devHotReload` field, and `resolveDevHotReload` helper; correctly gates `isDevHotReloadEnabled` on both the flag and credentials/environment checks. |
| packages/next/src/config.ts | Adds `DevHotReloadConfig` type and threads it through `publicI18NConfigParams`; the standalone `isDevHotReloadEnabled` helper is updated to check the configured flag before credentials. |
| packages/next/src/setup/shared.ts | Adds `files: publicConfig.files` to the i18n config params forwarded to the runtime; straightforward plumbing change. |
| packages/react-core/src/components/translation/T.rsc.tsx | Correctly narrows the hot reload gate to `isDevHotReloadEnabled('jsx')` for RSC JSX translation. |
| packages/i18n/src/i18n-cache/I18nCache.ts | Updates the prefetch path to `isDevHotReloadEnabled('strings')` — correct for string translations. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["gt config file\nfiles.gt.parsingFlags.devHotReload"] --> B["withGTConfig (config.ts)\nserialize to NEXT_PUBLIC env var"]
    B --> C["getParams / shared.ts\npublicConfig.files forwarded"]
    C --> D["I18nConfig constructor\nresolveDevHotReload()"]
    D --> E{{"isDevHotReloadEnabled(target)"}}
    E -->|"'strings'"| F["String hot reload paths\nuseTrackedTranslationResolver\nuseTrackedDictionaryResolver\nI18nCache prefetch\ngetGT"]
    E -->|"'jsx'"| G["JSX hot reload paths\nT.tsx / T.rsc.tsx\nexternal-store.ts\nBrowserI18nCache._devHotReloadJsx"]
    E -->|"no target (strings OR jsx)"| H["BrowserI18nCache\ndevHotReloadEnabled ⚠️\nlocalStorage wrapping"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["gt config file\nfiles.gt.parsingFlags.devHotReload"] --> B["withGTConfig (config.ts)\nserialize to NEXT_PUBLIC env var"]
    B --> C["getParams / shared.ts\npublicConfig.files forwarded"]
    C --> D["I18nConfig constructor\nresolveDevHotReload()"]
    D --> E{{"isDevHotReloadEnabled(target)"}}
    E -->|"'strings'"| F["String hot reload paths\nuseTrackedTranslationResolver\nuseTrackedDictionaryResolver\nI18nCache prefetch\ngetGT"]
    E -->|"'jsx'"| G["JSX hot reload paths\nT.tsx / T.rsc.tsx\nexternal-store.ts\nBrowserI18nCache._devHotReloadJsx"]
    E -->|"no target (strings OR jsx)"| H["BrowserI18nCache\ndevHotReloadEnabled ⚠️\nlocalStorage wrapping"]
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Freact%2Fsrc%2Fi18n-cache%2FBrowserI18nCache.ts%3A41-43%0A%60devHotReloadEnabled%60%20still%20uses%20the%20target-less%20%60isDevHotReloadEnabled%28%29%60%2C%20which%20resolves%20to%20%60strings%20%7C%7C%20jsx%60.%20This%20means%20that%20if%20a%20project%20sets%20%60devHotReload%3A%20%7B%20jsx%3A%20true%20%7D%60%20%28strings%20disabled%29%20and%20provides%20%60loadTranslations%60%2C%20the%20localStorage%20string%20caching%20is%20activated%20even%20though%20the%20user%20never%20opted%20into%20string%20hot%20reload.%20Every%20other%20call%20site%20in%20this%20PR%20was%20updated%20to%20pass%20a%20target%20%E2%80%94%20this%20one%20was%20left%20behind.%0A%0A%60%60%60suggestion%0A%20%20%20%20const%20devHotReloadEnabled%20%3D%0A%20%20%20%20%20%20!!config.loadTranslations%20%26%26%20i18nConfig.isDevHotReloadEnabled%28'strings'%29%3B%0A%20%20%20%20const%20devHotReloadJsx%20%3D%20i18nConfig.isDevHotReloadEnabled%28'jsx'%29%3B%0A%60%60%60%0A%0A&repo=generaltranslation%2Fgt&pr=1899&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fmulti%2Fhonor-dev-hot-reload-config%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fmulti%2Fhonor-dev-hot-reload-config%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Freact%2Fsrc%2Fi18n-cache%2FBrowserI18nCache.ts%3A41-43%0A%60devHotReloadEnabled%60%20still%20uses%20the%20target-less%20%60isDevHotReloadEnabled%28%29%60%2C%20which%20resolves%20to%20%60strings%20%7C%7C%20jsx%60.%20This%20means%20that%20if%20a%20project%20sets%20%60devHotReload%3A%20%7B%20jsx%3A%20true%20%7D%60%20%28strings%20disabled%29%20and%20provides%20%60loadTranslations%60%2C%20the%20localStorage%20string%20caching%20is%20activated%20even%20though%20the%20user%20never%20opted%20into%20string%20hot%20reload.%20Every%20other%20call%20site%20in%20this%20PR%20was%20updated%20to%20pass%20a%20target%20%E2%80%94%20this%20one%20was%20left%20behind.%0A%0A%60%60%60suggestion%0A%20%20%20%20const%20devHotReloadEnabled%20%3D%0A%20%20%20%20%20%20!!config.loadTranslations%20%26%26%20i18nConfig.isDevHotReloadEnabled%28'strings'%29%3B%0A%20%20%20%20const%20devHotReloadJsx%20%3D%20i18nConfig.isDevHotReloadEnabled%28'jsx'%29%3B%0A%60%60%60%0A%0A&repo=generaltranslation%2Fgt&pr=1899&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/react/src/i18n-cache/BrowserI18nCache.ts:41-43
`devHotReloadEnabled` still uses the target-less `isDevHotReloadEnabled()`, which resolves to `strings || jsx`. This means that if a project sets `devHotReload: { jsx: true }` (strings disabled) and provides `loadTranslations`, the localStorage string caching is activated even though the user never opted into string hot reload. Every other call site in this PR was updated to pass a target — this one was left behind.

```suggestion
    const devHotReloadEnabled =
      !!config.loadTranslations && i18nConfig.isDevHotReloadEnabled('strings');
    const devHotReloadJsx = i18nConfig.isDevHotReloadEnabled('jsx');
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: honor dev hot reload runtime config"](https://github.com/generaltranslation/gt/commit/d6366a9d410a42cbe5b4cbf7ae123796e6af65fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44697146)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->