### PR TITLE
fix(node): carry scoped request conditions

### DIFF
--- a/.changeset/scoped-node-conditions.md
+++ b/.changeset/scoped-node-conditions.md
@@ -1,0 +1,5 @@
+---
+'gt-node': patch
+---
+
+Allow `withGT` scopes to carry and update the request region and i18n enablement alongside the locale.

--- a/packages/node/src/async-i18n-cache/AsyncConditionStore.ts
+++ b/packages/node/src/async-i18n-cache/AsyncConditionStore.ts
@@ -2,11 +2,13 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 import type { ScopedConditionStoreInterface } from 'gt-i18n/internal/types';
 import { getI18nConfig } from 'gt-i18n/internal';
 
-type Store = {
+export type AsyncConditionStoreRunParams = {
   locale: string;
   region?: string;
   enableI18n?: boolean;
 };
+
+type Store = AsyncConditionStoreRunParams;
 
 const OUTSIDE_SCOPE_MESSAGE =
   'AsyncConditionStore: getLocale() called outside of a withGT() scope.';
@@ -34,8 +36,20 @@ export class AsyncConditionStore implements ScopedConditionStoreInterface {
   /**
    * TODO: should this be a static function
    * */
-  run<T>(locale: string, callback: () => T): T {
-    return this.store.run({ locale: resolveLocale(locale) }, callback);
+  run<T>(
+    conditions: string | AsyncConditionStoreRunParams,
+    callback: () => T
+  ): T {
+    const { locale, region, enableI18n } =
+      typeof conditions === 'string' ? { locale: conditions } : conditions;
+    return this.store.run(
+      {
+        locale: resolveLocale(locale),
+        region,
+        enableI18n,
+      },
+      callback
+    );
   }
 
   getLocale(): string {
@@ -62,9 +76,6 @@ export class AsyncConditionStore implements ScopedConditionStoreInterface {
     return store.region;
   }
 
-  /**
-   * TODO: implement
-   */
   getEnableI18n(): boolean {
     const store = this.store.getStore();
     if (!store) {
@@ -77,11 +88,20 @@ export class AsyncConditionStore implements ScopedConditionStoreInterface {
     return store.enableI18n ?? true;
   }
 
-  setLocale = (_locale: string): void => {};
+  setLocale = (locale: string): void => {
+    const store = this.store.getStore();
+    if (store) store.locale = resolveLocale(locale);
+  };
 
-  setRegion = (_region: string | undefined): void => {};
+  setRegion = (region: string | undefined): void => {
+    const store = this.store.getStore();
+    if (store) store.region = region;
+  };
 
-  setEnableI18n = (_enableI18n: boolean): void => {};
+  setEnableI18n = (enableI18n: boolean): void => {
+    const store = this.store.getStore();
+    if (store) store.enableI18n = enableI18n;
+  };
 }
 
 function resolveLocale(locale?: string): string {

--- a/packages/node/src/async-i18n-cache/__tests__/AsyncConditionStore.test.ts
+++ b/packages/node/src/async-i18n-cache/__tests__/AsyncConditionStore.test.ts
@@ -71,4 +71,46 @@ describe('AsyncConditionStore', () => {
 
     expect(store.run('fr', () => store.getLocale())).toBe('fr');
   });
+
+  it('carries all scoped conditions inside run()', () => {
+    setTestCache();
+    const store = new AsyncConditionStore();
+
+    const conditions = store.run(
+      { locale: 'fr', region: 'CA', enableI18n: false },
+      () => ({
+        locale: store.getLocale(),
+        region: store.getRegion(),
+        enableI18n: store.getEnableI18n(),
+      })
+    );
+
+    expect(conditions).toEqual({
+      locale: 'fr',
+      region: 'CA',
+      enableI18n: false,
+    });
+  });
+
+  it('updates conditions within the active scope', () => {
+    setTestCache();
+    const store = new AsyncConditionStore();
+
+    const conditions = store.run('en', () => {
+      store.setLocale('fr');
+      store.setRegion('FR');
+      store.setEnableI18n(false);
+      return {
+        locale: store.getLocale(),
+        region: store.getRegion(),
+        enableI18n: store.getEnableI18n(),
+      };
+    });
+
+    expect(conditions).toEqual({
+      locale: 'fr',
+      region: 'FR',
+      enableI18n: false,
+    });
+  });
 });

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -1,5 +1,5 @@
 export { initializeGT } from './setup/initializeGT';
-export { withGT } from './setup/withGT';
+export { withGT, type WithGTOptions } from './setup/withGT';
 export { msg } from 'gt-i18n';
 export { derive, declareVar } from 'gt-i18n';
 export { decodeVars, decodeMsg, decodeOptions } from 'gt-i18n';

--- a/packages/node/src/setup/__tests__/withGT.test.ts
+++ b/packages/node/src/setup/__tests__/withGT.test.ts
@@ -4,6 +4,7 @@ import { initializeGT } from '../initializeGT';
 import { withGT } from '../withGT';
 import { tx } from 'gt-i18n/internal';
 import { hashSource } from 'generaltranslation/id';
+import { getAsyncConditionStore } from '../../async-i18n-cache/singleton-operations';
 
 type TestGlobal = typeof globalThis & {
   __generaltranslation?: unknown;
@@ -37,6 +38,26 @@ describe.sequential('withGT', () => {
     expect(locale).toBe('es');
   });
 
+  it('provides scoped region and i18n conditions', () => {
+    const conditions = withGT(
+      { locale: 'fr', region: 'CA', enableI18n: false },
+      () => {
+        const store = getAsyncConditionStore();
+        return {
+          locale: store.getLocale(),
+          region: store.getRegion(),
+          enableI18n: store.getEnableI18n(),
+        };
+      }
+    );
+
+    expect(conditions).toEqual({
+      locale: 'fr',
+      region: 'CA',
+      enableI18n: false,
+    });
+  });
+
   it('preserves same-language default locale dialects', () => {
     resetGTGlobals();
     initializeGT({
@@ -62,5 +83,20 @@ describe.sequential('withGT', () => {
     await expect(
       withGT('en-US', () => tx('Hello', { $locale: 'fr' }))
     ).resolves.toBe('Bonjour');
+  });
+
+  it('returns source content when i18n is disabled for the scope', async () => {
+    resetGTGlobals();
+    initializeGT({
+      defaultLocale: 'en-US',
+      locales: ['en-US', 'fr'],
+      loadTranslations: () => ({
+        [hashSource({ source: 'Hello', dataFormat: 'STRING' })]: 'Bonjour',
+      }),
+    });
+
+    await expect(
+      withGT({ locale: 'fr', enableI18n: false }, () => tx('Hello'))
+    ).resolves.toBe('Hello');
   });
 });

--- a/packages/node/src/setup/withGT.ts
+++ b/packages/node/src/setup/withGT.ts
@@ -1,8 +1,11 @@
 import { getAsyncConditionStore } from '../async-i18n-cache/singleton-operations';
+import type { AsyncConditionStoreRunParams } from '../async-i18n-cache/AsyncConditionStore';
+
+export type WithGTOptions = AsyncConditionStoreRunParams;
 
 /**
  * This function wraps entry points to provide GT context
  */
-export function withGT<T>(locale: string, fn: () => T): T {
-  return getAsyncConditionStore().run<T>(locale, fn);
+export function withGT<T>(conditions: string | WithGTOptions, fn: () => T): T {
+  return getAsyncConditionStore().run<T>(conditions, fn);
 }


### PR DESCRIPTION
## Summary

- allow `withGT` to accept scoped locale, region, and `enableI18n` conditions while retaining the string locale shorthand
- carry all conditions through `AsyncLocalStorage`
- make condition setters update the active request scope
- verify disabled i18n returns source content

## Testing

- `pnpm --filter gt-node... build` — passed
- `pnpm --filter gt-node exec vitest run --config=./vitest.config.ts src/async-i18n-cache/__tests__/AsyncConditionStore.test.ts src/setup/__tests__/withGT.test.ts` — 11 passed
- `pnpm --filter gt-node typecheck` — passed

## Notes

- Includes a patch changeset for `gt-node`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends `withGT` and `AsyncConditionStore` to accept a structured `{locale, region, enableI18n}` options object in addition to the existing locale string shorthand, and wires up the previously no-op `setLocale`/`setRegion`/`setEnableI18n` setters to mutate the active `AsyncLocalStorage` scope in place.

- `AsyncConditionStore.run()` now accepts `string | AsyncConditionStoreRunParams`, resolving the locale and storing all three conditions in the async context.
- `setLocale`, `setRegion`, and `setEnableI18n` now actively update the store object retrieved from the current context, replacing the previous stub implementations.
- `WithGTOptions` is exported from `gt-node`'s public index, and new tests cover scoped-condition propagation and `enableI18n: false` returning source content end-to-end.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for typical sequential middleware usage; the setter mutation model works as advertised but carries a non-obvious hazard in concurrent fan-out patterns.

The core logic is correct: each withGT() call creates a fresh store object so concurrent requests are fully isolated from each other. Within a single request scope the setters mutate the shared object in place, which works correctly for the intended sequential middleware pattern. The only hazard is concurrent fan-out within one scope where a setter in one branch races with a getter in another branch.

packages/node/src/async-i18n-cache/AsyncConditionStore.ts — specifically the new setter implementations and their interaction with concurrent async operations in the same scope.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/node/src/async-i18n-cache/AsyncConditionStore.ts | Implements full-condition support in run() (locale, region, enableI18n) and activates setters that directly mutate the AsyncLocalStorage store object; setter mutation is safe for sequential chains but visible to concurrent siblings in the same scope. |
| packages/node/src/setup/withGT.ts | Widens the locale: string parameter to string | WithGTOptions and re-exports the WithGTOptions type; change is minimal and correct. |
| packages/node/src/async-i18n-cache/__tests__/AsyncConditionStore.test.ts | Adds two well-scoped tests covering full-condition propagation through run() and sequential setter updates; coverage is appropriate. |
| packages/node/src/setup/__tests__/withGT.test.ts | Adds two tests: scoped region/i18n conditions via object shorthand, and end-to-end verification that enableI18n: false returns source content. |
| packages/node/src/index.ts | Exports WithGTOptions type alongside withGT; no logic change. |
| .changeset/scoped-node-conditions.md | Correct patch-level changeset for gt-node. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant withGT
    participant AsyncConditionStore
    participant AsyncLocalStorage
    participant Callback

    Caller->>withGT: "withGT("fr" | {locale, region, enableI18n}, fn)"
    withGT->>AsyncConditionStore: run(conditions, fn)
    AsyncConditionStore->>AsyncConditionStore: "resolve string | object conditions"
    AsyncConditionStore->>AsyncLocalStorage: "store.run({locale, region, enableI18n}, fn)"
    AsyncLocalStorage->>Callback: execute fn() with scoped store
    Callback->>AsyncConditionStore: getLocale() / getRegion() / getEnableI18n()
    AsyncConditionStore->>AsyncLocalStorage: getStore()
    AsyncLocalStorage-->>AsyncConditionStore: "{locale, region, enableI18n}"
    AsyncConditionStore-->>Callback: resolved value
    Note over Callback,AsyncLocalStorage: setLocale/setRegion/setEnableI18n mutate the shared store object in-place
    Callback-->>Caller: T
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant withGT
    participant AsyncConditionStore
    participant AsyncLocalStorage
    participant Callback

    Caller->>withGT: "withGT("fr" | {locale, region, enableI18n}, fn)"
    withGT->>AsyncConditionStore: run(conditions, fn)
    AsyncConditionStore->>AsyncConditionStore: "resolve string | object conditions"
    AsyncConditionStore->>AsyncLocalStorage: "store.run({locale, region, enableI18n}, fn)"
    AsyncLocalStorage->>Callback: execute fn() with scoped store
    Callback->>AsyncConditionStore: getLocale() / getRegion() / getEnableI18n()
    AsyncConditionStore->>AsyncLocalStorage: getStore()
    AsyncLocalStorage-->>AsyncConditionStore: "{locale, region, enableI18n}"
    AsyncConditionStore-->>Callback: resolved value
    Note over Callback,AsyncLocalStorage: setLocale/setRegion/setEnableI18n mutate the shared store object in-place
    Callback-->>Caller: T
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fnode%2Fsrc%2Fasync-i18n-cache%2FAsyncConditionStore.ts%3A91-104%0A**Setter%20mutations%20are%20shared%20across%20concurrent%20async%20operations%20in%20the%20same%20scope**%0A%0A%60AsyncLocalStorage.run%28obj%2C%20callback%29%60%20stores%20the%20%60obj%60%20reference%20in%20the%20context.%20All%20async%20work%20spawned%20inside%20the%20callback%20%E2%80%94%20including%20concurrent%20branches%20in%20a%20%60Promise.all%60%20%E2%80%94%20retrieves%20the%20same%20object%20reference%20from%20%60getStore%28%29%60.%20Direct%20field%20mutation%20therefore%20propagates%20immediately%20to%20sibling%20tasks%20still%20running%20in%20the%20same%20scope.%20For%20example%2C%20if%20middleware%20fans%20out%20two%20concurrent%20translations%20and%20one%20branch%20calls%20%60setLocale%28'fr'%29%60%2C%20the%20other%20branch%20may%20observe%20%60'fr'%60%20instead%20of%20the%20originally%20bound%20locale%2C%20depending%20on%20microtask%20ordering.%0A%0AThis%20is%20acceptable%20for%20strictly%20sequential%20middleware%20chains%20but%20is%20a%20non-obvious%20footgun%20in%20any%20fan-out%20pattern.%20Consider%20documenting%20that%20setters%20are%20safe%20only%20when%20the%20active%20scope%20is%20otherwise%20idle%2C%20or%20adopt%20a%20%60store.run%28%7B...getStore%28%29%2C%20locale%7D%2C%20continuation%29%60%20approach%20that%20creates%20a%20child%20context%20instead%20of%20mutating%20the%20shared%20one.%0A%0A&repo=generaltranslation%2Fgt&pr=1900&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fnode%2Fcarry-request-conditions%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fnode%2Fcarry-request-conditions%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fnode%2Fsrc%2Fasync-i18n-cache%2FAsyncConditionStore.ts%3A91-104%0A**Setter%20mutations%20are%20shared%20across%20concurrent%20async%20operations%20in%20the%20same%20scope**%0A%0A%60AsyncLocalStorage.run%28obj%2C%20callback%29%60%20stores%20the%20%60obj%60%20reference%20in%20the%20context.%20All%20async%20work%20spawned%20inside%20the%20callback%20%E2%80%94%20including%20concurrent%20branches%20in%20a%20%60Promise.all%60%20%E2%80%94%20retrieves%20the%20same%20object%20reference%20from%20%60getStore%28%29%60.%20Direct%20field%20mutation%20therefore%20propagates%20immediately%20to%20sibling%20tasks%20still%20running%20in%20the%20same%20scope.%20For%20example%2C%20if%20middleware%20fans%20out%20two%20concurrent%20translations%20and%20one%20branch%20calls%20%60setLocale%28'fr'%29%60%2C%20the%20other%20branch%20may%20observe%20%60'fr'%60%20instead%20of%20the%20originally%20bound%20locale%2C%20depending%20on%20microtask%20ordering.%0A%0AThis%20is%20acceptable%20for%20strictly%20sequential%20middleware%20chains%20but%20is%20a%20non-obvious%20footgun%20in%20any%20fan-out%20pattern.%20Consider%20documenting%20that%20setters%20are%20safe%20only%20when%20the%20active%20scope%20is%20otherwise%20idle%2C%20or%20adopt%20a%20%60store.run%28%7B...getStore%28%29%2C%20locale%7D%2C%20continuation%29%60%20approach%20that%20creates%20a%20child%20context%20instead%20of%20mutating%20the%20shared%20one.%0A%0A&repo=generaltranslation%2Fgt&pr=1900&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/node/src/async-i18n-cache/AsyncConditionStore.ts:91-104
**Setter mutations are shared across concurrent async operations in the same scope**

`AsyncLocalStorage.run(obj, callback)` stores the `obj` reference in the context. All async work spawned inside the callback — including concurrent branches in a `Promise.all` — retrieves the same object reference from `getStore()`. Direct field mutation therefore propagates immediately to sibling tasks still running in the same scope. For example, if middleware fans out two concurrent translations and one branch calls `setLocale('fr')`, the other branch may observe `'fr'` instead of the originally bound locale, depending on microtask ordering.

This is acceptable for strictly sequential middleware chains but is a non-obvious footgun in any fan-out pattern. Consider documenting that setters are safe only when the active scope is otherwise idle, or adopt a `store.run({...getStore(), locale}, continuation)` approach that creates a child context instead of mutating the shared one.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(node): carry scoped request conditio..."](https://github.com/generaltranslation/gt/commit/957772ef30d92f5d0b262404bb23e7fa1970b02b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44697151)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->