### PR TITLE
fix(i18n): forward configured model provider

### DIFF
--- a/.changeset/runtime-model-provider-config.md
+++ b/.changeset/runtime-model-provider-config.md
@@ -1,0 +1,5 @@
+---
+'gt-i18n': patch
+---
+
+Forward the top-level `modelProvider` configuration to runtime translation requests while allowing explicit runtime metadata to override it.

--- a/packages/i18n/src/i18n-cache/I18nCache.ts
+++ b/packages/i18n/src/i18n-cache/I18nCache.ts
@@ -130,6 +130,7 @@ class I18nCache<TranslationValue extends Translation = Translation> {
       devApiKey: params.devApiKey,
       apiKey: params.apiKey,
       runtimeUrl: params.runtimeUrl,
+      modelProvider: params.modelProvider,
       cacheExpiryTime: params.cacheExpiryTime,
       batchConfig: params.batchConfig,
       runtimeTranslation: params.runtimeTranslation,
@@ -151,7 +152,12 @@ class I18nCache<TranslationValue extends Translation = Translation> {
     this.createTranslateMany = createTranslateManyFactory(
       getI18nConfig().getGTClass(),
       this.config.runtimeTranslation?.timeout ?? DEFAULT_TRANSLATION_TIMEOUT,
-      this.config.runtimeTranslation?.metadata ?? {}
+      {
+        ...(this.config.modelProvider && {
+          modelProvider: this.config.modelProvider,
+        }),
+        ...this.config.runtimeTranslation?.metadata,
+      }
     );
 
     // Setup locale-keyed caches

--- a/packages/i18n/src/i18n-cache/__tests__/I18nCache.test.ts
+++ b/packages/i18n/src/i18n-cache/__tests__/I18nCache.test.ts
@@ -1074,6 +1074,31 @@ describe('I18nCache', () => {
     );
   });
 
+  it('forwards the top-level model provider to runtime translations', () => {
+    createCache({ modelProvider: 'anthropic' });
+
+    expect(createTranslateManyFactory).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.any(Number),
+      { modelProvider: 'anthropic' }
+    );
+  });
+
+  it('prefers runtime translation metadata over the top-level model provider', () => {
+    createCache({
+      modelProvider: 'anthropic',
+      runtimeTranslation: {
+        metadata: { modelProvider: 'openai' },
+      },
+    });
+
+    expect(createTranslateManyFactory).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.any(Number),
+      { modelProvider: 'openai' }
+    );
+  });
+
   it('lookupDictionaryWithFallback() respects source dictionary format options', async () => {
     const source = 'Hello {name}';
     const sourceOptions: LookupOptions = {

--- a/packages/i18n/src/i18n-cache/types.ts
+++ b/packages/i18n/src/i18n-cache/types.ts
@@ -48,6 +48,7 @@ export type I18nCacheConfig = {
   devApiKey?: string;
   apiKey?: string;
   runtimeUrl?: string | null;
+  modelProvider?: string;
   /**
    * Locale cache TTL in milliseconds. Undefined uses the default TTL, null
    * disables expiry, and a number sets an explicit TTL.


### PR DESCRIPTION
## Summary

- preserve the top-level `modelProvider` setting in the standardized i18n cache config
- forward it as runtime translation metadata
- let explicit `runtimeTranslation.metadata.modelProvider` override the compatibility setting

## Testing

- `pnpm --filter gt-i18n... build` — passed
- `pnpm --filter gt-i18n exec vitest run --config=./vitest.config.ts src/i18n-cache/__tests__/I18nCache.test.ts` — 53 passed
- `pnpm --filter gt-i18n typecheck` — passed

## Notes

- Includes a patch changeset for `gt-i18n`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a gap where the top-level `modelProvider` config field was stored but never forwarded to runtime translation requests. The fix plumbs it through `I18nCacheConfig` and merges it as base metadata in `createTranslateManyFactory`, while allowing explicit `runtimeTranslation.metadata` to override it.

- `types.ts`: Adds `modelProvider?: string` to `I18nCacheConfig` so the field survives the params-to-config normalization step.
- `I18nCache.ts`: Assigns `params.modelProvider` into `this.config`, then uses a conditional spread to include it as base metadata, with `runtimeTranslation.metadata` spread on top so it wins in case of conflict.
- `I18nCache.test.ts`: Adds two targeted unit tests — one for the forwarding path and one for the override precedence.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a minimal, targeted fix that threads a pre-existing config field through to the runtime translation call site without altering any other behavior.

All three affected code paths (type definition, constructor assignment, metadata merge) are simple and correct. The spread ordering `{ modelProvider, ...runtimeTranslation.metadata }` correctly lets explicit metadata win, which matches the stated intent and is covered by the new tests. Build, tests, and typecheck all pass per the PR notes. No edge-case regressions are apparent.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/i18n/src/i18n-cache/I18nCache.ts | Copies `modelProvider` into `this.config` and merges it as base metadata for `createTranslateManyFactory`; explicit `runtimeTranslation.metadata` spreads on top to override — logic is correct. |
| packages/i18n/src/i18n-cache/types.ts | Adds `modelProvider?: string` to `I18nCacheConfig` to persist the top-level field after params normalization; no issues. |
| packages/i18n/src/i18n-cache/__tests__/I18nCache.test.ts | Adds two unit tests: one verifying forwarding of top-level `modelProvider`, one verifying `runtimeTranslation.metadata` takes precedence; both are correctly structured. |
| .changeset/runtime-model-provider-config.md | Patch changeset for `gt-i18n` documenting the `modelProvider` forwarding fix. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User as User Config
    participant Ctor as I18nCache Constructor
    participant Config as this.config
    participant Factory as createTranslateManyFactory
    participant GT as GT.translateMany

    User->>Ctor: "{ modelProvider, runtimeTranslation: { metadata } }"
    Ctor->>Config: store modelProvider + runtimeTranslation
    Ctor->>Factory: (GTClass, timeout, merged metadata)
    Note over Factory: merged = { modelProvider, ...runtimeTranslation.metadata }
    Factory-->>Ctor: CreateTranslateMany fn

    GT->>Factory: "translateMany(sources, { ...metadata, targetLocale })"
    Factory-->>GT: translation result
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User as User Config
    participant Ctor as I18nCache Constructor
    participant Config as this.config
    participant Factory as createTranslateManyFactory
    participant GT as GT.translateMany

    User->>Ctor: "{ modelProvider, runtimeTranslation: { metadata } }"
    Ctor->>Config: store modelProvider + runtimeTranslation
    Ctor->>Factory: (GTClass, timeout, merged metadata)
    Note over Factory: merged = { modelProvider, ...runtimeTranslation.metadata }
    Factory-->>Ctor: CreateTranslateMany fn

    GT->>Factory: "translateMany(sources, { ...metadata, targetLocale })"
    Factory-->>GT: translation result
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(i18n): forward configured model prov..."](https://github.com/generaltranslation/gt/commit/9b699b37e67666f3d4faa306dcfa37deb92883a1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44697152)</sub>

<!-- /greptile_comment -->