### PR TITLE
ci: add Slack webhook smoke test

### DIFF
--- a/.github/workflows/slack-webhook-smoke-test.yml
+++ b/.github/workflows/slack-webhook-smoke-test.yml
@@ -1,0 +1,35 @@
+name: Slack Webhook Smoke Test
+
+on:
+  pull_request:
+    types:
+      - opened
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    name: Notify libraries pager
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Send Slack test notification
+        uses: slackapi/slack-github-action@v2.1.1
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "Libraries pager webhook smoke test",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "🧪 *Libraries pager webhook smoke test passed through GitHub Actions.*\n\n• Repository: `${{ github.repository }}`\n• Triggered by: `${{ github.actor }}`\n• Pull request: <${{ github.event.pull_request.html_url }}|#${{ github.event.pull_request.number }}>\n\nThis is a temporary test; no action is required."
+                  }
+                }
+              ]
+            }


### PR DESCRIPTION
## Summary

- Add a temporary pull-request workflow that sends one test message through `SLACK_WEBHOOK_URL` when this PR is opened.
- Verify the libraries pager webhook through GitHub Actions without merging any workflow into `main`.

## Testing

- `ruby -e "require 'yaml'; YAML.load_file(...)"` — passed
- `ruby -e "require 'yaml'; require 'json'; JSON.parse(...)"` — passed
- `git diff origin/main...HEAD --check` — passed

## Notes

- Changeset: not required because this temporary PR only tests repository infrastructure.
- This PR is not intended to merge. Opening it triggers the smoke test once; the Actions check fails if Slack rejects the webhook request.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a single temporary GitHub Actions workflow to smoke-test the Slack pager webhook by firing one notification when the PR is opened, without touching any application code.

- The workflow triggers on `pull_request: opened` with no `branches` filter and no job-level guard, so if this file were ever merged to `main` it would ping the Slack pager for every future PR opened in the repository.
- The third-party action is pinned to a mutable semver tag (`v2.1.1`) rather than a commit SHA, leaving a supply-chain gap if the tag is later moved upstream.

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to open for testing, but the missing branch guard means accidental merge would continuously ping the Slack pager on every new PR.

The workflow does what the PR description intends for the smoke test itself, but the `pull_request: opened` trigger has no scoping to prevent it from misfiring if this file reaches `main`. That silent blast-radius risk is the main concern; the mutable action tag is a secondary hardening issue.

.github/workflows/slack-webhook-smoke-test.yml — the trigger block and the action pin both need attention before this could be considered safe to merge.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/slack-webhook-smoke-test.yml | Temporary smoke-test workflow that sends a Slack notification on PR open; missing a branch guard that would prevent the workflow from pinging the Slack pager on every future PR if it accidentally lands on main. Action also pinned to a mutable tag. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Dev as Developer
    participant GH as GitHub Actions
    participant Slack as Slack Incoming Webhook

    Dev->>GH: Open Pull Request (PR opened event)
    GH->>GH: Read workflow from head branch
    GH->>GH: Resolve secrets.SLACK_WEBHOOK_URL
    GH->>Slack: POST JSON payload (mrkdwn block)
    alt Webhook accepted
        Slack-->>GH: 200 OK
        GH-->>Dev: Job passes ✅
    else Webhook rejected / secret missing
        Slack-->>GH: 4xx / empty URL error
        GH-->>Dev: Job fails ❌
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Dev as Developer
    participant GH as GitHub Actions
    participant Slack as Slack Incoming Webhook

    Dev->>GH: Open Pull Request (PR opened event)
    GH->>GH: Read workflow from head branch
    GH->>GH: Resolve secrets.SLACK_WEBHOOK_URL
    GH->>Slack: POST JSON payload (mrkdwn block)
    alt Webhook accepted
        Slack-->>GH: 200 OK
        GH-->>Dev: Job passes ✅
    else Webhook rejected / secret missing
        Slack-->>GH: 4xx / empty URL error
        GH-->>Dev: Job fails ❌
    end
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Fslack-webhook-smoke-test.yml%3A3-6%0A**No%20branch%20restriction%20%E2%80%94%20will%20spam%20pager%20if%20accidentally%20merged**%0A%0AThe%20%60pull_request%3A%20opened%60%20trigger%20has%20no%20%60branches%60%20filter%20and%20no%20job-level%20%60if%60%20condition%20scoped%20to%20this%20branch.%20If%20this%20workflow%20file%20lands%20on%20%60main%60%20%28even%20via%20a%20squash%2Frebase%20accident%29%2C%20it%20will%20fire%20and%20send%20a%20Slack%20pager%20notification%20for%20every%20subsequent%20PR%20opened%20in%20the%20repository.%20Adding%20an%20%60if%3A%20github.head_ref%20%3D%3D%20'%3Cbranch-name%3E'%60%20condition%20on%20the%20job%2C%20or%20a%20%60branches%3A%60%20restriction%20on%20the%20trigger%2C%20would%20eliminate%20this%20blast%20radius%20without%20changing%20the%20smoke-test%20behavior.%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2Fworkflows%2Fslack-webhook-smoke-test.yml%3A19%0A**Mutable%20action%20tag%20%E2%80%94%20pin%20to%20a%20commit%20SHA**%0A%0ATags%20like%20%60v2.1.1%60%20can%20be%20force-pushed%20by%20the%20upstream%20maintainer%2C%20allowing%20the%20action's%20code%20to%20change%20silently%20under%20a%20pinned%20tag%20reference.%20GitHub's%20security%20hardening%20guide%20and%20Dependabot%20recommend%20pinning%20third-party%20actions%20to%20a%20full%20commit%20SHA%20instead.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20uses%3A%20slackapi%2Fslack-github-action%4037d1d4ce0a9ade885e3caa9b0fa82ee62fa48f30%20%23%20v2.1.1%0A%60%60%60%0A%0A&repo=generaltranslation%2Fgt&pr=1904&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fci%2Ftest-slack-webhook%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fci%2Ftest-slack-webhook%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Fslack-webhook-smoke-test.yml%3A3-6%0A**No%20branch%20restriction%20%E2%80%94%20will%20spam%20pager%20if%20accidentally%20merged**%0A%0AThe%20%60pull_request%3A%20opened%60%20trigger%20has%20no%20%60branches%60%20filter%20and%20no%20job-level%20%60if%60%20condition%20scoped%20to%20this%20branch.%20If%20this%20workflow%20file%20lands%20on%20%60main%60%20%28even%20via%20a%20squash%2Frebase%20accident%29%2C%20it%20will%20fire%20and%20send%20a%20Slack%20pager%20notification%20for%20every%20subsequent%20PR%20opened%20in%20the%20repository.%20Adding%20an%20%60if%3A%20github.head_ref%20%3D%3D%20'%3Cbranch-name%3E'%60%20condition%20on%20the%20job%2C%20or%20a%20%60branches%3A%60%20restriction%20on%20the%20trigger%2C%20would%20eliminate%20this%20blast%20radius%20without%20changing%20the%20smoke-test%20behavior.%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2Fworkflows%2Fslack-webhook-smoke-test.yml%3A19%0A**Mutable%20action%20tag%20%E2%80%94%20pin%20to%20a%20commit%20SHA**%0A%0ATags%20like%20%60v2.1.1%60%20can%20be%20force-pushed%20by%20the%20upstream%20maintainer%2C%20allowing%20the%20action's%20code%20to%20change%20silently%20under%20a%20pinned%20tag%20reference.%20GitHub's%20security%20hardening%20guide%20and%20Dependabot%20recommend%20pinning%20third-party%20actions%20to%20a%20full%20commit%20SHA%20instead.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20uses%3A%20slackapi%2Fslack-github-action%4037d1d4ce0a9ade885e3caa9b0fa82ee62fa48f30%20%23%20v2.1.1%0A%60%60%60%0A%0A&repo=generaltranslation%2Fgt&pr=1904&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
.github/workflows/slack-webhook-smoke-test.yml:3-6
**No branch restriction — will spam pager if accidentally merged**

The `pull_request: opened` trigger has no `branches` filter and no job-level `if` condition scoped to this branch. If this workflow file lands on `main` (even via a squash/rebase accident), it will fire and send a Slack pager notification for every subsequent PR opened in the repository. Adding an `if: github.head_ref == '<branch-name>'` condition on the job, or a `branches:` restriction on the trigger, would eliminate this blast radius without changing the smoke-test behavior.

### Issue 2 of 2
.github/workflows/slack-webhook-smoke-test.yml:19
**Mutable action tag — pin to a commit SHA**

Tags like `v2.1.1` can be force-pushed by the upstream maintainer, allowing the action's code to change silently under a pinned tag reference. GitHub's security hardening guide and Dependabot recommend pinning third-party actions to a full commit SHA instead.

```suggestion
        uses: slackapi/slack-github-action@37d1d4ce0a9ade885e3caa9b0fa82ee62fa48f30 # v2.1.1
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: add Slack webhook smoke test"](https://github.com/generaltranslation/gt/commit/a895a212eccfbf799ec4abf934bd485de697a350) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44902739)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->