### PR TITLE
fix(examples): restore Vercel workspace deployments

### DIFF
--- a/examples/next-gt-starter/package.json
+++ b/examples/next-gt-starter/package.json
@@ -2,6 +2,7 @@
   "name": "next-starter",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "pnpm@10.20.0",
   "scripts": {
     "dev": "next dev",
     "build": "gt translate; next build;",

--- a/examples/next-gt-starter/vercel.json
+++ b/examples/next-gt-starter/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "installCommand": "corepack pnpm install --frozen-lockfile"
+}

--- a/examples/next-gt-starter/vercel.json
+++ b/examples/next-gt-starter/vercel.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "rustup toolchain install stable --profile minimal --target wasm32-wasip1 && RUSTUP_TOOLCHAIN=stable pnpm exec turbo run build",
+  "buildCommand": "rustup toolchain install stable --profile minimal --target wasm32-wasip1 && RUSTUP_TOOLCHAIN=stable pnpm exec turbo run build --env-mode=loose",
   "installCommand": "corepack pnpm install --frozen-lockfile"
 }

--- a/examples/next-gt-starter/vercel.json
+++ b/examples/next-gt-starter/vercel.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "rustup toolchain install stable --profile minimal --target wasm32-wasip1 && RUSTUP_TOOLCHAIN=stable pnpm exec turbo run build",
   "installCommand": "corepack pnpm install --frozen-lockfile"
 }

--- a/examples/vite-create-app/package.json
+++ b/examples/vite-create-app/package.json
@@ -2,6 +2,7 @@
   "name": "vite-create-app",
   "private": true,
   "version": "0.0.0",
+  "packageManager": "pnpm@10.20.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/examples/vite-create-app/src/main.tsx
+++ b/examples/vite-create-app/src/main.tsx
@@ -1,18 +1,29 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';
-import App from './App.tsx';
-import { GTProvider } from 'gt-react';
+import { initializeGTSPA } from 'gt-react';
 import gtConfig from '../gt.config.json';
 
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <GTProvider
-      {...gtConfig}
-      projectId={import.meta.env.VITE_GT_PROJECT_ID}
-      devApiKey={import.meta.env.VITE_GT_API_KEY}
-    >
+async function renderApp() {
+  await initializeGTSPA({
+    ...gtConfig,
+    loadTranslations: async (locale) => {
+      try {
+        const translations = await import(`./_gt/${locale}.json`);
+        return translations.default;
+      } catch {
+        return {};
+      }
+    },
+  });
+
+  const { default: App } = await import('./App.tsx');
+
+  createRoot(document.getElementById('root')!).render(
+    <StrictMode>
       <App />
-    </GTProvider>
-  </StrictMode>
-);
+    </StrictMode>
+  );
+}
+
+renderApp();

--- a/examples/vite-create-app/src/main.tsx
+++ b/examples/vite-create-app/src/main.tsx
@@ -26,4 +26,6 @@ async function renderApp() {
   );
 }
 
-renderApp();
+renderApp().catch((error) => {
+  console.error('Failed to initialize the app:', error);
+});

--- a/examples/vite-create-app/vercel.json
+++ b/examples/vite-create-app/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "installCommand": "corepack pnpm install --frozen-lockfile"
+}

--- a/examples/vite-create-app/vercel.json
+++ b/examples/vite-create-app/vercel.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "pnpm exec turbo run build --env-mode=loose",
   "installCommand": "corepack pnpm install --frozen-lockfile"
 }


### PR DESCRIPTION
## Summary

- make the two connected Vercel example projects install through Corepack and pnpm 10.20.0 so `workspace:*` dependencies resolve from the monorepo
- initialize the Vite example through the current `initializeGTSPA` workspace API before rendering

## Testing

- `cd examples/vite-create-app && corepack pnpm --version` — passed (`10.20.0`)
- `cd examples/vite-create-app && corepack pnpm install --frozen-lockfile` — passed and linked all 47 workspace projects
- `cd examples/next-gt-starter && corepack pnpm install --frozen-lockfile` — passed and linked all 47 workspace projects
- `pnpm --filter vite-create-app typecheck` — passed
- `pnpm exec turbo run typecheck --filter=next-starter` — passed
- `pnpm --filter vite-create-app lint` — passed
- `pnpm exec oxfmt --check examples/vite-create-app/package.json examples/vite-create-app/src/main.tsx examples/vite-create-app/vercel.json examples/next-gt-starter/package.json examples/next-gt-starter/vercel.json` — passed
- `pnpm --filter vite-create-app exec vite build` — passed
- `pnpm --filter next-starter exec next build` — passed

## Notes

- Changeset: not required because only example app deployment configuration and initialization changed.
- The local Vite bundle check skipped `gt translate` to avoid creating translation jobs.
- Vercel project settings now include source files outside each app root so the root lockfile and workspace packages are available.
- Direct Vercel previews passed: [Next starter](https://example-gt-next-starter-nrn62o3x6-gt-examples.vercel.app) and [Vite](https://example-vite-create-68by84s7e-gt-examples.vercel.app).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes Vercel workspace deployments for both the `next-gt-starter` and `vite-create-app` examples by switching to Corepack-managed pnpm so `workspace:*` dependencies resolve correctly from the monorepo root lockfile.

- Adds `\"packageManager\": \"pnpm@10.20.0\"` to both example `package.json` files and new `vercel.json` files that set `installCommand` to `corepack pnpm install --frozen-lockfile` and route builds through Turbo.
- Refactors `vite-create-app/src/main.tsx` from the old `GTProvider` JSX wrapper pattern to the `initializeGTSPA` SPA-init API, which blocks rendering until translations are loaded; a `.catch()` handler logs failures to `console.error` so the promise rejection is no longer silently swallowed.
- The `next-gt-starter` build command additionally installs the Rust `stable` toolchain with the `wasm32-wasip1` target before invoking `turbo run build`, which is required by a WASM-compiled dependency in the workspace.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — changes are confined to example app deployment config and initialization, with no impact on library packages or production code paths.

All five changed files are in example apps only. The Corepack/pnpm pinning correctly restores workspace resolution, the new vercel.json files follow standard Vercel configuration patterns, and the main.tsx refactor properly uses the SPA init API with credentials auto-read from environment variables via addRuntimeCredentials.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| examples/vite-create-app/src/main.tsx | Switches from GTProvider wrapper to initializeGTSPA SPA pattern; error handling added via .catch(); projectId/devApiKey no longer passed explicitly but are auto-read via addRuntimeCredentials from VITE_GT_PROJECT_ID/VITE_GT_DEV_API_KEY |
| examples/vite-create-app/vercel.json | New file configuring Vercel to use corepack pnpm install and turbo build, enabling workspace:* resolution |
| examples/next-gt-starter/vercel.json | New file adding build/install commands; build installs Rust stable with wasm32-wasip1 target before running turbo build |
| examples/next-gt-starter/package.json | Adds packageManager field (pnpm@10.20.0) required for Corepack to resolve the correct pnpm version on Vercel |
| examples/vite-create-app/package.json | Adds packageManager field (pnpm@10.20.0) required for Corepack to resolve the correct pnpm version on Vercel |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant main.tsx
    participant initializeGTSPA
    participant addRuntimeCredentials
    participant BrowserI18nCache
    participant App

    Browser->>main.tsx: load module
    main.tsx->>initializeGTSPA: call with gtConfig + loadTranslations
    initializeGTSPA->>addRuntimeCredentials: read VITE_GT_PROJECT_ID / VITE_GT_DEV_API_KEY from import.meta.env
    addRuntimeCredentials-->>initializeGTSPA: merged config
    initializeGTSPA->>BrowserI18nCache: initialize i18n cache
    initializeGTSPA->>initializeGTSPA: getTranslationsSnapshot (await locale)
    initializeGTSPA-->>main.tsx: translations ready
    main.tsx->>App: dynamic import('./App.tsx')
    App-->>main.tsx: App component
    main.tsx->>Browser: "createRoot().render(<App />)"
    Note over main.tsx,Browser: .catch() logs console.error on any failure
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant main.tsx
    participant initializeGTSPA
    participant addRuntimeCredentials
    participant BrowserI18nCache
    participant App

    Browser->>main.tsx: load module
    main.tsx->>initializeGTSPA: call with gtConfig + loadTranslations
    initializeGTSPA->>addRuntimeCredentials: read VITE_GT_PROJECT_ID / VITE_GT_DEV_API_KEY from import.meta.env
    addRuntimeCredentials-->>initializeGTSPA: merged config
    initializeGTSPA->>BrowserI18nCache: initialize i18n cache
    initializeGTSPA->>initializeGTSPA: getTranslationsSnapshot (await locale)
    initializeGTSPA-->>main.tsx: translations ready
    main.tsx->>App: dynamic import('./App.tsx')
    App-->>main.tsx: App component
    main.tsx->>Browser: "createRoot().render(<App />)"
    Note over main.tsx,Browser: .catch() logs console.error on any failure
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(examples): expose Vercel build envir..."](https://github.com/generaltranslation/gt/commit/3e437ea6e0cecf03182dcf41f117e504099eee8e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44913643)</sub>

<!-- /greptile_comment -->