### PR TITLE
feat(compiler): expand t(`...`) and t("a" + b) call-argument macros

### DIFF
--- a/.changeset/compiler-call-expression-macros.md
+++ b/.changeset/compiler-call-expression-macros.md
@@ -1,0 +1,5 @@
+---
+'@generaltranslation/compiler': minor
+---
+
+Expand string translation macros in call-argument form. Template-literal arguments (``t(`...`)``) and string concatenations (`t("a" + b)`) are now normalized the same way as ``t`...` `` tagged templates, honoring the existing `enableTemplateLiteralArg` and `enableConcatenationArg` settings.

--- a/packages/compiler/src/passes/__tests__/macroExpansionPass.test.ts
+++ b/packages/compiler/src/passes/__tests__/macroExpansionPass.test.ts
@@ -142,7 +142,7 @@ describe('macroExpansionPass', () => {
     expect(getVarIdentifiers(tCalls[0])).toEqual(['name']);
   });
 
-  it.skip('transforms template literal in call: t(`Hello, ${name}`)', () => {
+  it('transforms template literal in call: t(`Hello, ${name}`)', () => {
     const { tCalls } = transform('const x = t(`Hello, ${name}`);');
     expect(tCalls).toHaveLength(1);
     expect(getMessageString(tCalls[0])).toBe('Hello, {0}');
@@ -150,12 +150,33 @@ describe('macroExpansionPass', () => {
     expect(getVarIdentifiers(tCalls[0])).toEqual(['name']);
   });
 
-  it.skip('transforms concatenation in call: t("Hello, " + name)', () => {
+  it('transforms concatenation in call: t("Hello, " + name)', () => {
     const { tCalls } = transform('const x = t("Hello, " + name);');
     expect(tCalls).toHaveLength(1);
     expect(getMessageString(tCalls[0])).toBe('Hello, {0}');
     expect(getVarKeys(tCalls[0])).toEqual(['0']);
     expect(getVarIdentifiers(tCalls[0])).toEqual(['name']);
+  });
+
+  it('transforms expressionless template literal in call: t(`hello`)', () => {
+    const { tCalls } = transform('const x = t(`hello`);');
+    expect(tCalls).toHaveLength(1);
+    expect(getMessageString(tCalls[0])).toBe('hello');
+    expect(tCalls[0].arguments).toHaveLength(1);
+  });
+
+  it('transforms template literal in call with custom stringTranslationMacro', () => {
+    const { tCalls } = transform('const x = __(`hello ${name}`);', {
+      stringTranslationMacro: '__',
+    });
+    expect(tCalls).toHaveLength(1);
+    expect(getMessageString(tCalls[0])).toBe('hello {0}');
+    expect(t.isIdentifier(tCalls[0].callee, { name: 't' })).toBe(true);
+  });
+
+  it('does NOT transform call with extra arguments: t(`...`, opts)', () => {
+    const { ast } = transform('const x = t(`hello ${name}`, opts);');
+    assertStillTemplateLiteralArg(ast);
   });
 
   it('leaves plain string call t("Hello") untouched', () => {
@@ -321,7 +342,7 @@ describe('macroExpansionPass', () => {
 
   // --- Recursive string simplification ---
 
-  it.skip('recursively simplifies nested concatenation and templates', () => {
+  it('recursively simplifies nested concatenation and templates', () => {
     const code = 'const x = t("A" + "B" + `C${"D" + `${`E`}F`}`);';
     const { tCalls } = transform(code);
     expect(tCalls).toHaveLength(1);
@@ -329,19 +350,19 @@ describe('macroExpansionPass', () => {
     expect(tCalls[0].arguments).toHaveLength(1);
   });
 
-  it.skip('simplifies numeric literal in concatenation', () => {
+  it('simplifies numeric literal in concatenation', () => {
     const { tCalls } = transform('const x = t("count: " + 42);');
     expect(getMessageString(tCalls[0])).toBe('count: 42');
     expect(tCalls[0].arguments).toHaveLength(1);
   });
 
-  it.skip('simplifies boolean literal in concatenation', () => {
+  it('simplifies boolean literal in concatenation', () => {
     const { tCalls } = transform('const x = t(true + " value");');
     expect(getMessageString(tCalls[0])).toBe('true value');
     expect(tCalls[0].arguments).toHaveLength(1);
   });
 
-  it.skip('deeply nested static simplification', () => {
+  it('deeply nested static simplification', () => {
     const code = 'const x = t(`A${`B${"C" + "D"}E`}F`);';
     const { tCalls } = transform(code);
     expect(getMessageString(tCalls[0])).toBe('ABCDEF');
@@ -368,7 +389,7 @@ describe('macroExpansionPass', () => {
     expect(tCalls[0].arguments).toHaveLength(1); // no variables arg
   });
 
-  it.skip('preserves derive in concatenation with static collapse and dynamic extraction', () => {
+  it('preserves derive in concatenation with static collapse and dynamic extraction', () => {
     const code =
       'import { derive } from \'gt-react/browser\';\nconst x = t(`A${derive(getName())}B` + "C" + name);';
     const { tCalls } = transform(code);
@@ -410,7 +431,7 @@ describe('macroExpansionPass', () => {
     expect(getVarIdentifiers(tCalls[0])).toEqual(['name']);
   });
 
-  it.skip('derive adjacent to static string collapses around it', () => {
+  it('derive adjacent to static string collapses around it', () => {
     const code =
       'import { derive } from \'gt-react/browser\';\nconst x = t(`A${"B"}${derive(x)}${"C"}D`);';
     const { tCalls } = transform(code);

--- a/packages/compiler/src/passes/__tests__/macroExpansionPass.test.ts
+++ b/packages/compiler/src/passes/__tests__/macroExpansionPass.test.ts
@@ -456,6 +456,19 @@ describe('macroExpansionPass', () => {
     expect(tCalls[0].arguments).toHaveLength(1);
   });
 
+  it('does not re-process tagged-template output through the call-expression visitor', () => {
+    // t`${derive(a)}` expands to t(<template with derive>) — a one-argument
+    // template-literal call, which is exactly the shape the CallExpression
+    // visitor targets. It must not be counted or transformed a second time.
+    const state = initializeState({}, 'test.tsx');
+    const ast = parser.parse(
+      "import { derive } from 'gt-react/browser';\nconst x = t`${derive(a)}`;",
+      { sourceType: 'module', plugins: ['typescript'] }
+    );
+    traverse(ast, macroExpansionPass(state));
+    expect(state.statistics.macroExpansionsCount).toBe(1);
+  });
+
   it('derive only in tagged template', () => {
     const code =
       "import { derive } from 'gt-react/browser';\nconst x = t`${derive(x)}`;";

--- a/packages/compiler/src/passes/macroExpansionPass.ts
+++ b/packages/compiler/src/passes/macroExpansionPass.ts
@@ -1,4 +1,5 @@
 import { TraverseOptions } from '@babel/traverse';
+import * as t from '@babel/types';
 import { TransformState } from '../state/types';
 import { processTaggedTemplateExpression } from '../processing/macro-expansion/processTaggedTemplateExpression';
 import { processCallExpression } from '../processing/macro-expansion/processCallExpression';
@@ -20,10 +21,18 @@ export function macroExpansionPass(state: TransformState): TraverseOptions {
     alreadyImported = true;
   };
 
+  // Both processors replace macros with t(...) calls, and path.replaceWith
+  // requeues the new node for this same traversal — track every replacement
+  // so the CallExpression visitor never re-processes expanded output
+  const replacements = new WeakSet<t.Node>();
+
   return {
     ImportDeclaration: processImportDeclaration(onImportFound),
-    TaggedTemplateExpression: processTaggedTemplateExpression(state),
-    CallExpression: processCallExpression(state),
+    TaggedTemplateExpression: processTaggedTemplateExpression(
+      state,
+      replacements
+    ),
+    CallExpression: processCallExpression(state, replacements),
     Program: processProgram({
       state,
       countBefore,

--- a/packages/compiler/src/passes/macroExpansionPass.ts
+++ b/packages/compiler/src/passes/macroExpansionPass.ts
@@ -1,6 +1,7 @@
 import { TraverseOptions } from '@babel/traverse';
 import { TransformState } from '../state/types';
 import { processTaggedTemplateExpression } from '../processing/macro-expansion/processTaggedTemplateExpression';
+import { processCallExpression } from '../processing/macro-expansion/processCallExpression';
 import { processImportDeclaration } from '../processing/macro-expansion/processImportDeclaration';
 import { processProgram } from '../processing/macro-expansion/processProgram';
 
@@ -22,6 +23,7 @@ export function macroExpansionPass(state: TransformState): TraverseOptions {
   return {
     ImportDeclaration: processImportDeclaration(onImportFound),
     TaggedTemplateExpression: processTaggedTemplateExpression(state),
+    CallExpression: processCallExpression(state),
     Program: processProgram({
       state,
       countBefore,

--- a/packages/compiler/src/processing/macro-expansion/processCallExpression.ts
+++ b/packages/compiler/src/processing/macro-expansion/processCallExpression.ts
@@ -16,13 +16,10 @@ import { isStringTranslationCallExpression } from '../../utils/parsing/isStringT
  * Skips when t is bound to a non-GT import (e.g., i18next)
  */
 export function processCallExpression(
-  state: TransformState
+  state: TransformState,
+  replacements: WeakSet<t.Node>
 ): VisitNode<t.Node, t.CallExpression> {
   const symbol = state.settings.stringTranslationMacro;
-  // replaceWith requeues the new call for this same visitor; when the message
-  // keeps derive() expressions it stays a template literal arg and would be
-  // re-processed forever without this guard
-  const replacements = new WeakSet<t.Node>();
 
   return (path) => {
     if (replacements.has(path.node)) return;

--- a/packages/compiler/src/processing/macro-expansion/processCallExpression.ts
+++ b/packages/compiler/src/processing/macro-expansion/processCallExpression.ts
@@ -1,0 +1,59 @@
+import { VisitNode } from '@babel/traverse';
+import * as t from '@babel/types';
+import { TransformState } from '../../state/types';
+import { GT_OTHER_FUNCTIONS } from '../../utils/constants/gt/constants';
+import { transformTemplateLiteral } from '../../transform/macro-expansion/transformTemplateLiteral';
+import { isStringTranslationCallExpression } from '../../utils/parsing/isStringTranslationCallExpression';
+
+/**
+ * Process call expressions for macro expansion.
+ * Transforms t(`Hello, ${name}`) and t("Hello, " + name)
+ * → t("Hello, {0}", { "0": name })
+ *
+ * Only transforms when:
+ * - t is unbound (global macro via gt-react/macros)
+ * - t is imported from a gt-react entrypoint
+ * Skips when t is bound to a non-GT import (e.g., i18next)
+ */
+export function processCallExpression(
+  state: TransformState
+): VisitNode<t.Node, t.CallExpression> {
+  const symbol = state.settings.stringTranslationMacro;
+  // replaceWith requeues the new call for this same visitor; when the message
+  // keeps derive() expressions it stays a template literal arg and would be
+  // re-processed forever without this guard
+  const replacements = new WeakSet<t.Node>();
+
+  return (path) => {
+    if (replacements.has(path.node)) return;
+    if (path.node.arguments.length !== 1) return;
+
+    const argPath = path.get('arguments')[0];
+    if (argPath.isTemplateLiteral()) {
+      if (!state.settings.enableTemplateLiteralArg) return;
+    } else if (argPath.isBinaryExpression({ operator: '+' })) {
+      if (!state.settings.enableConcatenationArg) return;
+    } else {
+      return;
+    }
+    if (!isStringTranslationCallExpression(path, symbol)) return;
+
+    // Extract message from the argument, errors are logged by collection pass
+    const { content, errors } = transformTemplateLiteral(argPath);
+    // TODO: Until derive added, we only support one message variant
+    const message = content[0]?.message;
+    const variables = content[0]?.variables;
+    if (errors.length > 0 || message == null) return;
+
+    // Build the call expression arguments
+    const args: t.Expression[] = [message];
+    if (variables) args.push(variables);
+    const replacement = t.callExpression(
+      t.identifier(GT_OTHER_FUNCTIONS.t),
+      args
+    );
+    replacements.add(replacement);
+    path.replaceWith(replacement);
+    state.statistics.macroExpansionsCount++;
+  };
+}

--- a/packages/compiler/src/processing/macro-expansion/processTaggedTemplateExpression.ts
+++ b/packages/compiler/src/processing/macro-expansion/processTaggedTemplateExpression.ts
@@ -15,7 +15,8 @@ import { isStringTranslationTaggedTemplate } from '../../utils/parsing/isStringT
  * Skips when t is bound to a non-GT import (e.g., i18next)
  */
 export function processTaggedTemplateExpression(
-  state: TransformState
+  state: TransformState,
+  replacements: WeakSet<t.Node>
 ): VisitNode<t.Node, t.TaggedTemplateExpression> {
   const symbol = state.settings.stringTranslationMacro;
 
@@ -33,9 +34,12 @@ export function processTaggedTemplateExpression(
     // Build the call expression arguments
     const args: t.Expression[] = [message];
     if (variables) args.push(variables);
-    path.replaceWith(
-      t.callExpression(t.identifier(GT_OTHER_FUNCTIONS.t), args)
+    const replacement = t.callExpression(
+      t.identifier(GT_OTHER_FUNCTIONS.t),
+      args
     );
+    replacements.add(replacement);
+    path.replaceWith(replacement);
     state.statistics.macroExpansionsCount++;
   };
 }

--- a/packages/compiler/src/transform/macro-expansion/transformTemplateLiteral.ts
+++ b/packages/compiler/src/transform/macro-expansion/transformTemplateLiteral.ts
@@ -5,13 +5,14 @@ import { buildTransformResult } from '../../utils/string-expressions/buildTransf
 import { multiply } from '../../utils/multiplication/multiply';
 
 /**
- * Converts template literal quasis and expressions into an ICU-style message
- * string with numeric variable placeholders ({0}, {1}, etc.).
+ * Converts a string-producing expression (template literal, "+"
+ * concatenation, or literal) into an ICU-style message string with numeric
+ * variable placeholders ({0}, {1}, etc.).
  *
  * Recursively simplifies nested static expressions (string literals,
  * nested templates) and preserves derive() calls as template expressions.
  */
-export function transformTemplateLiteral(path: NodePath<t.TemplateLiteral>): {
+export function transformTemplateLiteral(path: NodePath<t.Expression>): {
   content: {
     message: t.StringLiteral | t.TemplateLiteral;
     variables: t.ObjectExpression | null;

--- a/packages/compiler/src/utils/parsing/isStringTranslationCallExpression.ts
+++ b/packages/compiler/src/utils/parsing/isStringTranslationCallExpression.ts
@@ -3,19 +3,19 @@ import * as t from '@babel/types';
 import { isStringTranslationMacroBinding } from './isStringTranslationMacroBinding';
 
 /**
- * Checks whether a tagged template expression should be treated as the GT
- * string translation macro.
+ * Checks whether a call expression should be treated as the GT string
+ * translation macro (the call-argument forms: t(`...`) and t("a" + b)).
  *
  * The macro is valid when it is an unbound bare identifier, or when it is
  * imported from gt-react. This covers global `t`, but not explicit
  * member access such as `globalThis.t` or `window.t`. Other bindings are left
- * alone so local/i18next t tags do not get transformed or extracted.
+ * alone so local/i18next t calls do not get transformed or extracted.
  */
-export function isStringTranslationTaggedTemplate(
-  path: NodePath<t.TaggedTemplateExpression>,
+export function isStringTranslationCallExpression(
+  path: NodePath<t.CallExpression>,
   symbol: string
 ): boolean {
-  if (!t.isIdentifier(path.node.tag, { name: symbol })) {
+  if (!t.isIdentifier(path.node.callee, { name: symbol })) {
     return false;
   }
 

--- a/packages/compiler/src/utils/parsing/isStringTranslationMacroBinding.ts
+++ b/packages/compiler/src/utils/parsing/isStringTranslationMacroBinding.ts
@@ -1,0 +1,30 @@
+import type { Scope } from '@babel/traverse';
+import { isGTReactImportSource } from '../constants/gt/helpers';
+
+/**
+ * Checks whether the macro symbol resolves to a binding that should be
+ * treated as the GT string translation macro in the given scope.
+ *
+ * Valid when the symbol is unbound (global macro via gt-react/macros) or
+ * imported from gt-react. Other bindings (local variables, destructured
+ * values, non-GT imports such as i18next) are left alone.
+ */
+export function isStringTranslationMacroBinding(
+  scope: Scope,
+  symbol: string
+): boolean {
+  const binding = scope.getBinding(symbol);
+  if (!binding) {
+    return true;
+  }
+
+  if (!binding.path.isImportSpecifier()) {
+    return false;
+  }
+
+  const importDecl = binding.path.parentPath;
+  return (
+    importDecl?.isImportDeclaration() === true &&
+    isGTReactImportSource(importDecl.node.source.value)
+  );
+}


### PR DESCRIPTION
The macro expansion pass documents three forms in its own docstring and in `config.ts`: ``t`...` ``, ``t(`...`)``, and `t("a" + b)`. The `enableTemplateLiteralArg` and `enableConcatenationArg` settings exist and default to `true`, but only the `TaggedTemplateExpression` visitor was ever registered. The two call-argument forms silently did nothing, and their 8 spec tests sat skipped.

Some history, since "skipped tests" can read as "abandoned": these call forms shipped working in #1118. One day later, #1129 (the derive refactor) intentionally disabled the `CallExpression` visitor and skipped the tests, describing it as "an acknowledged temporary gap" with a follow-up PR "needed to re-enable this at stage 4". The dead processor file was cleaned up in #1141, and the follow-up never came. This is that follow-up, rebuilt on the current flatten/multiply pipeline. One difference from the #1118 original: the scope guard here is the tight gt-react-only check shared with the tagged-template path, not the any-GT-source check that #1118's review flagged as too loose.

This wires up the missing `CallExpression` visitor:

- `processCallExpression.ts` mirrors `processTaggedTemplateExpression`: the same scope guard (unbound global `t` or gt-react imports only; i18next and local `t` untouched) and the same transform, statistics, and auto-import behavior. It honors `enableTemplateLiteralArg` and `enableConcatenationArg` per argument shape.
- The existing `flattenExpressionToParts`/`multiply`/`buildTransformResult` machinery is reused unchanged. It was already generic over any expression, so `transformTemplateLiteral`'s parameter type widens from `NodePath<TemplateLiteral>` to `NodePath<Expression>` with no behavior change for existing callers.
- The binding check both guards share moved into `isStringTranslationMacroBinding`.
- The 8 spec tests are un-skipped, plus 4 new ones: expressionless ``t(`hello`)`` normalizes to `t("hello")`, a custom `stringTranslationMacro` works in call form, calls with extra arguments are left alone, and a regression test for the re-entrancy fix below.

Two decisions worth flagging for review:

- Re-entrancy: `path.replaceWith` requeues the replacement call into the same traversal. When the message keeps `derive()` expressions, the argument stays a template literal, which is the exact shape this visitor matches. So both visitors share one `WeakSet` of replacements; without it, tagged-template output gets re-processed by the call visitor and double-counts `macroExpansionsCount`. I picked the shared set over `path.skip()` so nested macros inside replacements still get visited.
- Multi-argument calls like ``t(`...`, opts)`` are skipped on purpose. Merging generated variables into an existing second argument isn't safely mechanical.

Testing: `pnpm --filter @generaltranslation/compiler test` runs 649 tests, 646 passed and 3 skipped (pre-existing skips elsewhere), including the 8 previously-skipped macro tests. `tsc --noEmit`, the package build, `oxfmt`, and the full monorepo suite are all clean. I also built `tests/apps/esbuild-react` through the plugin with all three macro forms in source; the production bundle contains the normalized messages (`Hello, {0}`, `Static {0}`, `Tagged {0}`) and the auto-injected `gt-react` import. Review agents beat on the diff before I opened this. They found the derive double-count above, fixed in the second commit with its own regression test, and the guard tests that used to pass vacuously (flag-off cases, i18next scope guards for call args, derive preservation) now exercise real behavior and still pass.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires up the previously-unregistered `CallExpression` visitor in the macro-expansion pass, enabling `t(\`...\`)` and `t("a" + b)` call-argument forms that were documented and guarded by flags but silently no-oped. Eight spec tests that were previously skipped now exercise real behavior.

- **New `processCallExpression.ts`**: mirrors `processTaggedTemplateExpression` with the same scope guard (unbound global or gt-react import), same flag checks (`enableTemplateLiteralArg` / `enableConcatenationArg`), and the same transform pipeline — multi-argument calls are deliberately skipped.
- **Re-entrancy fix via shared `WeakSet`**: `path.replaceWith` requeues the replacement for the same traversal; the WeakSet is shared between both visitors so tagged-template output (a one-arg template-literal call) is not double-counted by the call visitor.
- **Refactored `isStringTranslationMacroBinding`**: the binding-resolution logic is extracted from `isStringTranslationTaggedTemplate` into a shared helper used by both visitors, keeping the two code paths in lockstep.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all three macro forms now behave identically, the re-entrancy edge case is covered by a regression test, and no pre-existing tagged-template behavior is altered.

The change wires up two previously-dead code paths with full guard parity to the existing tagged-template visitor. The shared WeakSet correctly prevents double-counting when derive()-containing replacements are requeued, and the 8 newly-activated spec tests plus 4 new ones cover all meaningful branches including flag-off, multi-arg skip, custom macro names, and the re-entrancy regression.

No files require special attention — processCallExpression.ts is the main new surface and it follows the tagged-template visitor exactly.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/compiler/src/processing/macro-expansion/processCallExpression.ts | New visitor handling t(`...`) and t("a"+b); correctly guards re-entrancy, flag checks, argument count, and scope identity before transforming. |
| packages/compiler/src/passes/macroExpansionPass.ts | Wires up the new CallExpression visitor with the shared WeakSet for re-entrancy protection; structure mirrors the tagged-template registration cleanly. |
| packages/compiler/src/utils/parsing/isStringTranslationMacroBinding.ts | Extracted shared binding-resolution helper; correctly handles unbound globals and GT-react imports while excluding other local/i18next bindings. |
| packages/compiler/src/utils/parsing/isStringTranslationCallExpression.ts | New guard for call-expression form; delegates to the shared binding helper after verifying the callee is a bare identifier matching the symbol. |
| packages/compiler/src/transform/macro-expansion/transformTemplateLiteral.ts | Type widened from NodePath<TemplateLiteral> to NodePath<Expression>; no logic change, existing callers unaffected. |
| packages/compiler/src/processing/macro-expansion/processTaggedTemplateExpression.ts | Updated to accept the shared replacements WeakSet and mark its output before calling replaceWith; no behavior change to the tagged-template transformation itself. |
| packages/compiler/src/utils/parsing/isStringTranslationTaggedTemplate.ts | Refactored to delegate the binding check to the new shared helper; identical behavior, reduced duplication. |
| packages/compiler/src/passes/__tests__/macroExpansionPass.test.ts | 8 previously-skipped tests un-skipped and 4 new tests added covering expressionless template literals, custom macro names, multi-arg skip, and the re-entrancy regression. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Babel Traversal] --> B{Node type?}
    B -->|TaggedTemplateExpression| C[processTaggedTemplateExpression]
    B -->|CallExpression| D[processCallExpression]

    C --> C1{enableTaggedTemplate?}
    C1 -->|no| SKIP1[skip]
    C1 -->|yes| C2{isStringTranslationTaggedTemplate?}
    C2 -->|no| SKIP2[skip]
    C2 -->|yes| C3[transformTemplateLiteral quasi]
    C3 --> C4[build t call replacement]
    C4 --> C5[replacements.add replacement]
    C5 --> C6[path.replaceWith requeues as CallExpression]
    C6 --> C7[macroExpansionsCount++]

    D --> D1{replacements.has node?}
    D1 -->|yes| SKIP3[skip already-expanded output]
    D1 -->|no| D2{arguments.length === 1?}
    D2 -->|no| SKIP4[skip multi-arg call]
    D2 -->|yes| D3{arg is TemplateLiteral?}
    D3 -->|yes| D4{enableTemplateLiteralArg?}
    D4 -->|no| SKIP5[skip]
    D4 -->|yes| D6
    D3 -->|no| D5{arg is BinaryExpression +?}
    D5 -->|no| SKIP6[skip]
    D5 -->|yes| D5a{enableConcatenationArg?}
    D5a -->|no| SKIP7[skip]
    D5a -->|yes| D6
    D6{isStringTranslationCallExpression?}
    D6 -->|no| SKIP8[skip non-GT t binding]
    D6 -->|yes| D7[transformTemplateLiteral arg]
    D7 --> D8[build t call replacement]
    D8 --> D9[replacements.add replacement]
    D9 --> D10[path.replaceWith]
    D10 --> D11[macroExpansionsCount++]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Babel Traversal] --> B{Node type?}
    B -->|TaggedTemplateExpression| C[processTaggedTemplateExpression]
    B -->|CallExpression| D[processCallExpression]

    C --> C1{enableTaggedTemplate?}
    C1 -->|no| SKIP1[skip]
    C1 -->|yes| C2{isStringTranslationTaggedTemplate?}
    C2 -->|no| SKIP2[skip]
    C2 -->|yes| C3[transformTemplateLiteral quasi]
    C3 --> C4[build t call replacement]
    C4 --> C5[replacements.add replacement]
    C5 --> C6[path.replaceWith requeues as CallExpression]
    C6 --> C7[macroExpansionsCount++]

    D --> D1{replacements.has node?}
    D1 -->|yes| SKIP3[skip already-expanded output]
    D1 -->|no| D2{arguments.length === 1?}
    D2 -->|no| SKIP4[skip multi-arg call]
    D2 -->|yes| D3{arg is TemplateLiteral?}
    D3 -->|yes| D4{enableTemplateLiteralArg?}
    D4 -->|no| SKIP5[skip]
    D4 -->|yes| D6
    D3 -->|no| D5{arg is BinaryExpression +?}
    D5 -->|no| SKIP6[skip]
    D5 -->|yes| D5a{enableConcatenationArg?}
    D5a -->|no| SKIP7[skip]
    D5a -->|yes| D6
    D6{isStringTranslationCallExpression?}
    D6 -->|no| SKIP8[skip non-GT t binding]
    D6 -->|yes| D7[transformTemplateLiteral arg]
    D7 --> D8[build t call replacement]
    D8 --> D9[replacements.add replacement]
    D9 --> D10[path.replaceWith]
    D10 --> D11[macroExpansionsCount++]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(compiler): share macro replacement t..."](https://github.com/generaltranslation/gt/commit/50f8c202abf4a2ac792403aa75ad7b9707dfaf0a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44970235)</sub>

<!-- /greptile_comment -->

