### PR TITLE
fix(cli): upload local translation edits before force retranslation

### DIFF
--- a/.changeset/force-preserve-local-edits.md
+++ b/.changeset/force-preserve-local-edits.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+`gt translate --force` (and `--force-download`) now uploads local translation edits to the platform before retranslating, so local manual edits can be recovered instead of being silently destroyed. If that upload fails, the force run aborts before anything destructive happens. Force runs also print a warning that existing translations, including manual edits, will be overwritten.

--- a/packages/cli/src/cli/flags.ts
+++ b/packages/cli/src/cli/flags.ts
@@ -80,12 +80,12 @@ export function attachTranslateFlags(command: Command) {
     )
     .option(
       '--force',
-      'Force a retranslation, invalidating all existing cached translations if they exist.',
+      'Force a retranslation, invalidating all existing cached translations if they exist. Overwrites existing translations, including manual edits. When the run stages files for translation, local translation edits are uploaded first so they can be recovered.',
       false
     )
     .option(
       '--force-download',
-      'Force download and overwrite local files, bypassing gt-lock.json checks.',
+      'Force download and overwrite local files, bypassing gt-lock.json checks. Overwrites manual edits in local files. When the run stages files for translation, local translation edits are uploaded first so they can be recovered.',
       false
     )
     .option(

--- a/packages/cli/src/workflows/__tests__/stage.test.ts
+++ b/packages/cli/src/workflows/__tests__/stage.test.ts
@@ -1,0 +1,204 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Settings, TranslateFlags } from '../../types/index.js';
+import type { FileToUpload } from 'generaltranslation/types';
+import { logger } from '../../console/logger.js';
+import { runStageFilesWorkflow } from '../stage.js';
+
+const mocks = vi.hoisted(() => ({
+  branchRun: vi.fn(),
+  uploadRun: vi.fn(),
+  userEditDiffsRun: vi.fn(),
+  userEditDiffsFailed: false,
+  setupRun: vi.fn(),
+  enqueueRun: vi.fn(),
+  stepWait: vi.fn(),
+}));
+
+vi.mock('../steps/BranchStep.js', () => ({
+  BranchStep: vi.fn(() => ({ run: mocks.branchRun, wait: mocks.stepWait })),
+}));
+
+vi.mock('../steps/UploadSourcesStep.js', () => ({
+  UploadSourcesStep: vi.fn(() => ({
+    run: mocks.uploadRun,
+    wait: mocks.stepWait,
+  })),
+}));
+
+vi.mock('../steps/UserEditDiffsStep.js', () => ({
+  UserEditDiffsStep: vi.fn(() => ({
+    run: mocks.userEditDiffsRun,
+    wait: mocks.stepWait,
+    get hasFailed() {
+      return mocks.userEditDiffsFailed;
+    },
+  })),
+}));
+
+vi.mock('../steps/SetupStep.js', () => ({
+  SetupStep: vi.fn(() => ({ run: mocks.setupRun, wait: mocks.stepWait })),
+}));
+
+vi.mock('../steps/EnqueueStep.js', () => ({
+  EnqueueStep: vi.fn(() => ({ run: mocks.enqueueRun, wait: mocks.stepWait })),
+}));
+
+vi.mock('../steps/TagStep.js', () => ({
+  TagStep: vi.fn(() => ({ run: vi.fn(), wait: vi.fn() })),
+}));
+
+vi.mock('../utils/filterFilesForEnqueue.js', () => ({
+  filterFilesForEnqueue: vi.fn(
+    async ({ files }: { files: FileToUpload[] }) => ({
+      filesToEnqueue: files,
+      skippedFiles: [],
+    })
+  ),
+}));
+
+vi.mock('../../console/logging.js', () => ({
+  logCollectedFiles: vi.fn(),
+  logErrorAndExit: vi.fn((message: unknown) => {
+    throw new Error(String(message));
+  }),
+}));
+
+vi.mock('../../console/logger.js', () => ({
+  logger: {
+    warn: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+vi.mock('../../utils/gt.js', () => ({
+  gt: {},
+}));
+
+describe('runStageFilesWorkflow', () => {
+  const settings = {
+    locales: ['es'],
+  } as Settings;
+
+  const files = [{ fileName: 'messages/en.json' }] as FileToUpload[];
+
+  const branchData = {
+    currentBranch: { id: 'branch-1', name: 'main' },
+    incomingBranch: null,
+    checkedOutBranch: null,
+  };
+
+  const uploadedFiles = [
+    {
+      fileId: 'file-1',
+      versionId: 'version-1',
+      branchId: 'branch-1',
+      fileName: 'messages/en.json',
+    },
+  ];
+
+  const enqueueResult = {
+    jobData: {},
+    locales: ['es'],
+    message: 'Files enqueued',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.userEditDiffsFailed = false;
+    mocks.branchRun.mockResolvedValue(branchData);
+    mocks.uploadRun.mockResolvedValue(uploadedFiles);
+    mocks.userEditDiffsRun.mockImplementation(async (f) => f);
+    mocks.setupRun.mockImplementation(async (f) => f);
+    mocks.enqueueRun.mockResolvedValue(enqueueResult);
+    mocks.stepWait.mockResolvedValue(undefined);
+  });
+
+  it('skips the user edit diffs step by default', async () => {
+    await runStageFilesWorkflow({
+      files,
+      options: {} as TranslateFlags,
+      settings,
+    });
+
+    expect(mocks.userEditDiffsRun).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('runs the user edit diffs step when saveLocal is set', async () => {
+    await runStageFilesWorkflow({
+      files,
+      options: { saveLocal: true } as TranslateFlags,
+      settings,
+    });
+
+    expect(mocks.userEditDiffsRun).toHaveBeenCalledWith(uploadedFiles);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('uploads user edit diffs before enqueueing when force is set', async () => {
+    await runStageFilesWorkflow({
+      files,
+      options: { force: true } as TranslateFlags,
+      settings,
+    });
+
+    expect(mocks.userEditDiffsRun).toHaveBeenCalledWith(uploadedFiles);
+    expect(mocks.userEditDiffsRun.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.enqueueRun.mock.invocationCallOrder[0]
+    );
+  });
+
+  it('uploads user edit diffs before enqueueing when forceDownload is set', async () => {
+    await runStageFilesWorkflow({
+      files,
+      options: { forceDownload: true } as TranslateFlags,
+      settings,
+    });
+
+    expect(mocks.userEditDiffsRun).toHaveBeenCalledWith(uploadedFiles);
+    expect(mocks.userEditDiffsRun.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.enqueueRun.mock.invocationCallOrder[0]
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('--force-download')
+    );
+  });
+
+  it('aborts the force run before enqueueing when the diff upload fails', async () => {
+    mocks.userEditDiffsFailed = true;
+
+    await expect(
+      runStageFilesWorkflow({
+        files,
+        options: { force: true } as TranslateFlags,
+        settings,
+      })
+    ).rejects.toThrow();
+
+    expect(mocks.enqueueRun).not.toHaveBeenCalled();
+  });
+
+  it('does not abort a saveLocal run when the diff upload fails', async () => {
+    mocks.userEditDiffsFailed = true;
+
+    await runStageFilesWorkflow({
+      files,
+      options: { saveLocal: true } as TranslateFlags,
+      settings,
+    });
+
+    expect(mocks.enqueueRun).toHaveBeenCalled();
+  });
+
+  it('warns that force overwrites existing translations', async () => {
+    await runStageFilesWorkflow({
+      files,
+      options: { force: true } as TranslateFlags,
+      settings,
+    });
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('--force')
+    );
+  });
+});

--- a/packages/cli/src/workflows/__tests__/stage.test.ts
+++ b/packages/cli/src/workflows/__tests__/stage.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   branchRun: vi.fn(),
   uploadRun: vi.fn(),
   userEditDiffsRun: vi.fn(),
+  userEditDiffsAbort: vi.fn(),
   userEditDiffsFailed: false,
   setupRun: vi.fn(),
   enqueueRun: vi.fn(),
@@ -29,6 +30,7 @@ vi.mock('../steps/UserEditDiffsStep.js', () => ({
   UserEditDiffsStep: vi.fn(() => ({
     run: mocks.userEditDiffsRun,
     wait: mocks.stepWait,
+    abort: mocks.userEditDiffsAbort,
     get hasFailed() {
       return mocks.userEditDiffsFailed;
     },
@@ -176,6 +178,7 @@ describe('runStageFilesWorkflow', () => {
     ).rejects.toThrow();
 
     expect(mocks.enqueueRun).not.toHaveBeenCalled();
+    expect(mocks.userEditDiffsAbort).toHaveBeenCalled();
   });
 
   it('does not abort a saveLocal run when the diff upload fails', async () => {
@@ -198,7 +201,7 @@ describe('runStageFilesWorkflow', () => {
     });
 
     expect(logger.warn).toHaveBeenCalledWith(
-      expect.stringContaining('--force')
+      expect.stringContaining('--force overwrites')
     );
   });
 });

--- a/packages/cli/src/workflows/stage.ts
+++ b/packages/cli/src/workflows/stage.ts
@@ -73,14 +73,15 @@ export async function runStageFilesWorkflow({
     }
     if (options?.saveLocal || forceFlag) {
       await userEditDiffsStep.run(uploadedFiles);
-      await userEditDiffsStep.wait();
       // Proceeding after a failed upload would destroy any local edits the
       // upload was meant to protect, so abort before anything irreversible
       if (forceFlag && userEditDiffsStep.hasFailed) {
+        userEditDiffsStep.abort();
         return logErrorAndExit(
           `Could not upload local translation edits. Aborting the ${forceFlag} run to avoid destroying them. Retry once the API is reachable.`
         );
       }
+      await userEditDiffsStep.wait();
     }
 
     // then run the tag step (non-fatal — tagging failure should not block translations)

--- a/packages/cli/src/workflows/stage.ts
+++ b/packages/cli/src/workflows/stage.ts
@@ -59,9 +59,28 @@ export async function runStageFilesWorkflow({
     await uploadStep.wait();
 
     // optionally run the user edit diffs step
-    if (options?.saveLocal) {
+    // Force runs overwrite existing translations (including manual edits), so
+    // upload local edits first. Afterwards they are unrecoverable.
+    const forceFlag = options?.force
+      ? '--force'
+      : options?.forceDownload
+        ? '--force-download'
+        : null;
+    if (forceFlag) {
+      logger.warn(
+        `${forceFlag} overwrites existing translations, including manual edits. Uploading local translation edits first so they can be recovered. Edits made only in the dashboard cannot be preserved.`
+      );
+    }
+    if (options?.saveLocal || forceFlag) {
       await userEditDiffsStep.run(uploadedFiles);
       await userEditDiffsStep.wait();
+      // Proceeding after a failed upload would destroy any local edits the
+      // upload was meant to protect, so abort before anything irreversible
+      if (forceFlag && userEditDiffsStep.hasFailed) {
+        return logErrorAndExit(
+          `Could not upload local translation edits. Aborting the ${forceFlag} run to avoid destroying them. Retry once the API is reachable.`
+        );
+      }
     }
 
     // then run the tag step (non-fatal — tagging failure should not block translations)

--- a/packages/cli/src/workflows/steps/UserEditDiffsStep.ts
+++ b/packages/cli/src/workflows/steps/UserEditDiffsStep.ts
@@ -42,4 +42,10 @@ export class UserEditDiffsStep extends WorkflowStep<
       this.spinner.stop(chalk.yellow('Could not update translations'));
     }
   }
+
+  // Used instead of wait() when the caller treats the failure as fatal, so
+  // the spinner line reads as a hard failure rather than a swallowed one
+  abort(): void {
+    this.spinner.stop(chalk.red('Could not update translations'));
+  }
 }

--- a/packages/cli/src/workflows/steps/UserEditDiffsStep.ts
+++ b/packages/cli/src/workflows/steps/UserEditDiffsStep.ts
@@ -17,6 +17,10 @@ export class UserEditDiffsStep extends WorkflowStep<
     super();
   }
 
+  get hasFailed(): boolean {
+    return this.failed;
+  }
+
   async run(files: FileReference[]): Promise<FileReference[]> {
     this.spinner.start('Updating translations...');
 

--- a/packages/cli/src/workflows/steps/__tests__/UserEditDiffsStep.test.ts
+++ b/packages/cli/src/workflows/steps/__tests__/UserEditDiffsStep.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { FileReference } from 'generaltranslation/types';
 import type { Settings } from '../../../types/index.js';
 import { collectAndSendUserEditDiffs } from '../../../api/collectUserEditDiffs.js';
+import { logger } from '../../../console/logger.js';
 import { UserEditDiffsStep } from '../UserEditDiffsStep.js';
 
 vi.mock('../../../console/logger.js', () => ({
@@ -40,5 +41,21 @@ describe('UserEditDiffsStep', () => {
     await expect(step.run(files)).resolves.toEqual(files);
 
     expect(step.hasFailed).toBe(true);
+  });
+
+  it('abort stops the spinner with a failure message', async () => {
+    vi.mocked(collectAndSendUserEditDiffs).mockRejectedValue(
+      new Error('api down')
+    );
+
+    const step = new UserEditDiffsStep(settings);
+    await step.run(files);
+    step.abort();
+
+    const spinner = vi.mocked(logger.createSpinner).mock.results[0]
+      .value as unknown as { stop: ReturnType<typeof vi.fn> };
+    expect(spinner.stop).toHaveBeenCalledWith(
+      expect.stringContaining('Could not')
+    );
   });
 });

--- a/packages/cli/src/workflows/steps/__tests__/UserEditDiffsStep.test.ts
+++ b/packages/cli/src/workflows/steps/__tests__/UserEditDiffsStep.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { FileReference } from 'generaltranslation/types';
+import type { Settings } from '../../../types/index.js';
+import { collectAndSendUserEditDiffs } from '../../../api/collectUserEditDiffs.js';
+import { UserEditDiffsStep } from '../UserEditDiffsStep.js';
+
+vi.mock('../../../console/logger.js', () => ({
+  logger: {
+    createSpinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn() })),
+  },
+}));
+
+vi.mock('../../../api/collectUserEditDiffs.js', () => ({
+  collectAndSendUserEditDiffs: vi.fn(),
+}));
+
+describe('UserEditDiffsStep', () => {
+  const settings = {} as Settings;
+  const files = [{ fileName: 'messages/en.json' }] as FileReference[];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('reports no failure when the diff upload succeeds', async () => {
+    vi.mocked(collectAndSendUserEditDiffs).mockResolvedValue(true);
+
+    const step = new UserEditDiffsStep(settings);
+    await expect(step.run(files)).resolves.toEqual(files);
+
+    expect(step.hasFailed).toBe(false);
+  });
+
+  it('reports failure without throwing when the diff upload rejects', async () => {
+    vi.mocked(collectAndSendUserEditDiffs).mockRejectedValue(
+      new Error('api down')
+    );
+
+    const step = new UserEditDiffsStep(settings);
+    await expect(step.run(files)).resolves.toEqual(files);
+
+    expect(step.hasFailed).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes #1666

## Problem

`gt translate --force` silently destroys manual translation edits with no recovery path. The sequence from the issue:

1. Make manual edits to translations
2. Run `gt translate --force` to pick up new source keys
3. Everything is retranslated and force-downloaded, and the edits are overwritten locally and on the platform

After that there's no way back. `gt save-local` diffs the local file against the last-downloaded server version, but by then both sides match the new AI output and the diff is empty. `gt upload` only uploads source files.

The upload step for user edits (`UserEditDiffsStep`) already exists in the stage workflow, but it's gated on `options.saveLocal` only, so force runs never hit it. The `--force` help text didn't mention any of this either.

## Fix

`runStageFilesWorkflow` now runs `UserEditDiffsStep` when `force` or `forceDownload` is set, after upload and before enqueue, so local edits reach the platform before the retranslation that would destroy them.

If that upload fails on a force run, the run aborts before enqueueing anything. A failure there basically only happens when there were edits to protect, since with no candidates the collector makes no network calls, and proceeding would destroy exactly what the upload was for. `saveLocal` runs keep the old non-fatal behavior.

Force runs also print a warning that manual edits will be overwritten, and the `--force`/`--force-download` help text now says so. The "when the run stages files" qualifier in the help text is deliberate: those flags are attached to six commands, and only runs that go through the stage workflow get the protection (see limitations).

`--force-download` is included because the issue calls it out as equally destructive, and `--force` already implies it at download time.

## Alternatives I didn't take

Warning only, no behavior change: add the warning and help text, keep the upload gated on `saveLocal`, tell people to run `gt save-local` before forcing. That keeps the flag's old semantics exactly and adds no network call. I didn't go this way because by the time the warning prints, the user is already mid-command. It timestamps the loss instead of preventing it, and the step this change enables is exactly what the warning would tell you to do manually. If warning-only is preferred, the gate change is a one-line revert and the rest stands alone.

Keeping the upload best-effort under force: the first version of this PR did that. But then a network blip during the upload re-creates the exact bug, where we print "uploading your edits", the upload fails quietly, and the retranslation destroys them anyway. Data loss is permanent and a blocked CI run is a retry, so it aborts. Also one line to revert if that tradeoff reads wrong.

## Limitations

- Only local edits are protected. Edits made only in the dashboard produce no local diff, so there's nothing to upload. That half of the issue is a platform-side problem the CLI can't reach, and the warning says so.
- Forcing with an unchanged source regenerates the same version, so the uploaded edits get overwritten platform-side there too; they survive, and feed the new translation as reference, when the source actually changed, which is the issue's scenario.
- On projects with `stageTranslations` set, `gt translate --force` goes straight to the download path and skips this protection. `gt stage --force` is covered. Same story for `gt enqueue --force`, `gt download --force`, and `gt setup --force`. Follow-up material; the help text no longer promises anything for those paths.
- This protects edits going forward. It can't recover edits already lost to past force runs.

## Testing

New tests in `workflows/__tests__/stage.test.ts` and `steps/__tests__/UserEditDiffsStep.test.ts`: the gate (default / saveLocal / force / forceDownload), ordering before enqueue, warning content, abort on failed upload under force, no abort under saveLocal. Tests were written first against the old behavior.

Full suite passes (2087 tests), typecheck clean. Changeset included (`gt` patch).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a silent data-loss bug where `gt translate --force` (and `--force-download`) would overwrite local manual translation edits with no recovery path. The fix gates `UserEditDiffsStep` on `force`/`forceDownload` in addition to the existing `saveLocal` condition, uploads local edits before any destructive retranslation, and aborts the run (rather than continuing) if that upload fails under a force flag.

- **`stage.ts`**: `runStageFilesWorkflow` now runs `UserEditDiffsStep` when `force` or `forceDownload` is set, prints a warning naming the active flag, and calls `logErrorAndExit` before enqueue if the upload fails — preventing the retranslation that would destroy the edits.
- **`UserEditDiffsStep.ts`**: Adds a `hasFailed` getter and an `abort()` method that stops the spinner with a red failure message instead of the yellow non-fatal message from `wait()`.
- **Tests**: New files cover all four gate conditions, call-order ordering before enqueue, warning content per flag, abort-on-failure for force runs, and non-abort for `saveLocal` runs.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The change is additive — it inserts an upload step before a destructive operation and adds a hard abort guard only on the force path, leaving the existing saveLocal and default paths untouched.

Since logErrorAndExit calls process.exit(1) and never returns, the outer catch block is never triggered by the abort path in production. All four gate conditions are tested independently, and the abort/non-abort split on failure is covered. No existing behavior is changed for non-force runs.

No files require special attention.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/cli/src/workflows/stage.ts | Core change: UserEditDiffsStep now runs for force/forceDownload flags before enqueue, with an abort-on-failure guard. Logic is correct and well-structured. |
| packages/cli/src/workflows/steps/UserEditDiffsStep.ts | Adds hasFailed getter and abort() method. The abort() method stops the spinner with a red failure message, contrasting with wait()'s yellow message for non-fatal failures. |
| packages/cli/src/workflows/__tests__/stage.test.ts | New test file covering the gate logic, ordering constraint, abort-on-failure, and warning content for all four cases (default, saveLocal, force, forceDownload). |
| packages/cli/src/workflows/steps/__tests__/UserEditDiffsStep.test.ts | New unit tests for hasFailed and abort(); covers success, failure-without-throw, and abort spinner behavior. |
| packages/cli/src/cli/flags.ts | Help text for --force and --force-download updated to mention overwrite behavior and the edit-preservation mechanism. |
| .changeset/force-preserve-local-edits.md | Patch changeset for the gt package describing the fix. |

</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/cli/src/workflows/steps/UserEditDiffsStep.ts`, line 38-44 ([link](https://github.com/generaltranslation/gt/blob/d6943ae1084964bed24d5ea102d5ef06807e180f/packages/cli/src/workflows/steps/UserEditDiffsStep.ts#L38-L44)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Spinner message implies non-fatal outcome before a fatal abort**

   `wait()` always shows the yellow "Could not update translations" text when `failed` is true, regardless of whether the caller is about to abort or continue. In the force-run path the caller immediately follows this with `logErrorAndExit`, so a user sees a soft-looking yellow warning and then a hard red error for the same event. The yellow signal suggests the failure was swallowed, which is the opposite of what happens. A small improvement would be for the stage workflow to skip calling `wait()` (or call a different method) when it is about to abort, so the terminal output reads as a single decisive failure rather than a contradictory soft-then-hard pair. This is a UX-only concern and does not affect correctness.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/cli/src/workflows/steps/UserEditDiffsStep.ts
   Line: 38-44

   Comment:
   **Spinner message implies non-fatal outcome before a fatal abort**

   `wait()` always shows the yellow "Could not update translations" text when `failed` is true, regardless of whether the caller is about to abort or continue. In the force-run path the caller immediately follows this with `logErrorAndExit`, so a user sees a soft-looking yellow warning and then a hard red error for the same event. The yellow signal suggests the failure was swallowed, which is the opposite of what happens. A small improvement would be for the stage workflow to skip calling `wait()` (or call a different method) when it is about to abort, so the terminal output reads as a single decisive failure rather than a contradictory soft-then-hard pair. This is a UX-only concern and does not affect correctness.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fcli%2Fsrc%2Fworkflows%2Fsteps%2FUserEditDiffsStep.ts%0ALine%3A%2038-44%0A%0AComment%3A%0A**Spinner%20message%20implies%20non-fatal%20outcome%20before%20a%20fatal%20abort**%0A%0A%60wait%28%29%60%20always%20shows%20the%20yellow%20%22Could%20not%20update%20translations%22%20text%20when%20%60failed%60%20is%20true%2C%20regardless%20of%20whether%20the%20caller%20is%20about%20to%20abort%20or%20continue.%20In%20the%20force-run%20path%20the%20caller%20immediately%20follows%20this%20with%20%60logErrorAndExit%60%2C%20so%20a%20user%20sees%20a%20soft-looking%20yellow%20warning%20and%20then%20a%20hard%20red%20error%20for%20the%20same%20event.%20The%20yellow%20signal%20suggests%20the%20failure%20was%20swallowed%2C%20which%20is%20the%20opposite%20of%20what%20happens.%20A%20small%20improvement%20would%20be%20for%20the%20stage%20workflow%20to%20skip%20calling%20%60wait%28%29%60%20%28or%20call%20a%20different%20method%29%20when%20it%20is%20about%20to%20abort%2C%20so%20the%20terminal%20output%20reads%20as%20a%20single%20decisive%20failure%20rather%20than%20a%20contradictory%20soft-then-hard%20pair.%20This%20is%20a%20UX-only%20concern%20and%20does%20not%20affect%20correctness.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=generaltranslation%2Fgt&pr=1912&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22fix%2Fcli-force-preserve-local-edits%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fcli-force-preserve-local-edits%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fcli%2Fsrc%2Fworkflows%2Fsteps%2FUserEditDiffsStep.ts%0ALine%3A%2038-44%0A%0AComment%3A%0A**Spinner%20message%20implies%20non-fatal%20outcome%20before%20a%20fatal%20abort**%0A%0A%60wait%28%29%60%20always%20shows%20the%20yellow%20%22Could%20not%20update%20translations%22%20text%20when%20%60failed%60%20is%20true%2C%20regardless%20of%20whether%20the%20caller%20is%20about%20to%20abort%20or%20continue.%20In%20the%20force-run%20path%20the%20caller%20immediately%20follows%20this%20with%20%60logErrorAndExit%60%2C%20so%20a%20user%20sees%20a%20soft-looking%20yellow%20warning%20and%20then%20a%20hard%20red%20error%20for%20the%20same%20event.%20The%20yellow%20signal%20suggests%20the%20failure%20was%20swallowed%2C%20which%20is%20the%20opposite%20of%20what%20happens.%20A%20small%20improvement%20would%20be%20for%20the%20stage%20workflow%20to%20skip%20calling%20%60wait%28%29%60%20%28or%20call%20a%20different%20method%29%20when%20it%20is%20about%20to%20abort%2C%20so%20the%20terminal%20output%20reads%20as%20a%20single%20decisive%20failure%20rather%20than%20a%20contradictory%20soft-then-hard%20pair.%20This%20is%20a%20UX-only%20concern%20and%20does%20not%20affect%20correctness.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=generaltranslation%2Fgt&pr=1912&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(cli): tighten force warning assertio..."](https://github.com/generaltranslation/gt/commit/366ac19479a938af6ca9a09d1d392e709fe621aa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44973118)</sub>

<!-- /greptile_comment -->
