### PR TITLE
test: re-enable POT -> PO transform tests now that the API supports it

### DIFF
--- a/.changeset/enable-pot-po-transform.md
+++ b/.changeset/enable-pot-po-transform.md
@@ -1,5 +1,0 @@
----
-'gt': patch
----
-
-Re-enable the POT -> PO file format transform test coverage. The `files.pot.transformationFormat: "PO"` option in `gt.config.json` shipped in #1248 with its tests skipped, waiting on platform support — which had already landed the same day (gt-cloud #2756). The 8 skipped tests now run and pass; no client code changes were needed.

--- a/.changeset/enable-pot-po-transform.md
+++ b/.changeset/enable-pot-po-transform.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+Re-enable the POT -> PO file format transform test coverage now that the API supports it. The client-side plumbing (`transformationFormat: "PO"` in `gt.config.json`, upload, enqueue, and download-to-`.po` mapping) shipped in #1248 behind skipped tests; the platform support landed the same day, so the tests now run and the transform is verified end-to-end.

--- a/.changeset/enable-pot-po-transform.md
+++ b/.changeset/enable-pot-po-transform.md
@@ -2,4 +2,4 @@
 'gt': patch
 ---
 
-Re-enable the POT -> PO file format transform test coverage now that the API supports it. The client-side plumbing (`transformationFormat: "PO"` in `gt.config.json`, upload, enqueue, and download-to-`.po` mapping) shipped in #1248 behind skipped tests; the platform support landed the same day, so the tests now run and the transform is verified end-to-end.
+Re-enable the POT -> PO file format transform test coverage. The `files.pot.transformationFormat: "PO"` option in `gt.config.json` shipped in #1248 with its tests skipped, waiting on platform support — which had already landed the same day (gt-cloud #2756). The 8 skipped tests now run and pass; no client code changes were needed.

--- a/packages/cli/src/cli/commands/__tests__/translate.test.ts
+++ b/packages/cli/src/cli/commands/__tests__/translate.test.ts
@@ -70,8 +70,7 @@ describe('postProcessTranslations', () => {
     vi.clearAllMocks();
   });
 
-  // TODO: Re-enable when the API supports POT -> PO file format transforms.
-  it.skip('skips postprocessing only for files transformed to another format', async () => {
+  it('skips postprocessing only for files transformed to another format', async () => {
     await postProcessTranslations(
       makeSettings(),
       new Set(['locales/fr/messages.po', 'locales/fr/messages.json'])

--- a/packages/cli/src/config/__tests__/generateSettings.test.ts
+++ b/packages/cli/src/config/__tests__/generateSettings.test.ts
@@ -337,8 +337,7 @@ describe('generateSettings - composite patterns', () => {
     expect(resolveFiles).not.toHaveBeenCalled();
   });
 
-  // TODO: Re-enable when the API supports POT -> PO file format transforms.
-  it.skip('normalizes uppercase file format config keys before resolving files', async () => {
+  it('normalizes uppercase file format config keys before resolving files', async () => {
     const options = {
       files: {
         POT: {

--- a/packages/cli/src/formats/files/__tests__/aggregateFiles.test.ts
+++ b/packages/cli/src/formats/files/__tests__/aggregateFiles.test.ts
@@ -283,8 +283,7 @@ describe('aggregateFiles - Empty File Handling', () => {
       expect(result[0].fileName).toBe('invalid.mdx');
     });
 
-    // TODO: Re-enable when the API supports POT -> PO file format transforms.
-    it.skip('should attach transformFormat for configured POT files', async () => {
+    it('should attach transformFormat for configured POT files', async () => {
       const settings = {
         files: {
           resolvedPaths: {

--- a/packages/cli/src/formats/files/__tests__/fileMapping.test.ts
+++ b/packages/cli/src/formats/files/__tests__/fileMapping.test.ts
@@ -19,8 +19,7 @@ describe('createFileMapping', () => {
     expect(mapping.es[TEMPLATE_FILE_NAME]).toBe('public/gt/es.json');
   });
 
-  // TODO: Re-enable when the API supports POT -> PO file format transforms.
-  it.skip('uses the transformation format extension for mapped output files', () => {
+  it('uses the transformation format extension for mapped output files', () => {
     const sourcePath = path.resolve('locales/en/messages.pot');
     const placeholderPath = path.resolve('locales/[locale]/messages.pot');
 

--- a/packages/cli/src/fs/__tests__/parseFilesConfig.test.ts
+++ b/packages/cli/src/fs/__tests__/parseFilesConfig.test.ts
@@ -251,8 +251,7 @@ describe('parseFilesConfig', () => {
       ]);
     });
 
-    // TODO: Re-enable when the API supports POT -> PO file format transforms.
-    it.skip('should resolve file format transformation options', () => {
+    it('should resolve file format transformation options', () => {
       const files = {
         pot: {
           include: ['locales/[locale]/*.pot'],

--- a/packages/core/src/translate/__tests__/uploadSourceFiles.test.ts
+++ b/packages/core/src/translate/__tests__/uploadSourceFiles.test.ts
@@ -235,8 +235,7 @@ describe.sequential('_uploadSourceFiles', () => {
     );
   });
 
-  // TODO: Re-enable when the API supports POT -> PO file format transforms.
-  it.skip('should upload PO and POT source files', async () => {
+  it('should upload PO and POT source files', async () => {
     const mockFiles = [
       {
         source: createMockFileUpload({

--- a/packages/core/src/translate/__tests__/uploadTranslations.test.ts
+++ b/packages/core/src/translate/__tests__/uploadTranslations.test.ts
@@ -346,8 +346,7 @@ describe.sequential('_uploadTranslations', () => {
     );
   });
 
-  // TODO: Re-enable when the API supports POT -> PO file format transforms.
-  it.skip('should upload POT sources with PO translations', async () => {
+  it('should upload POT sources with PO translations', async () => {
     const mockFiles = [
       {
         source: createMockFileUpload({

--- a/packages/core/src/utils/__tests__/isSupportedFileFormatTransform.test.ts
+++ b/packages/core/src/utils/__tests__/isSupportedFileFormatTransform.test.ts
@@ -24,8 +24,7 @@ describe('isSupportedFileFormatTransform', () => {
     }
   });
 
-  // TODO: Re-enable when the API supports POT -> PO file format transforms.
-  it.skip('supports configured cross-format transforms', () => {
+  it('supports configured cross-format transforms', () => {
     expect(isSupportedFileFormatTransform('POT', 'PO')).toBe(true);
   });
 


### PR DESCRIPTION
Eight tests across core and the CLI sit skipped with the comment "TODO: Re-enable when the API supports POT -> PO file format transforms." The API has supported it since the day the tests were written. This un-skips them.

The timeline, since a wall of skipped tests usually reads as "feature half-done": #1248 wired `transformationFormat` end-to-end on the client (Settings, resolveFiles, createFileMapping, aggregateFiles, upload, enqueue, download) and merged 2026-04-27 at 22:39 UTC with the payoff gated behind these 8 skips, waiting on the platform. The platform side (gt-cloud #2756: `PotToPoTransformAction`, `POT_TO_PO_FORMAT_TRANSFORM`, upload/enqueue validators that accept a POT source with a PO output, with tests) had merged one hour earlier, at 21:38 UTC the same day. The skip comments were stale the moment they landed, and nobody circled back. Meanwhile #1277 and the CLI CHANGELOG have been advertising `transformationFormat` to users since April, and the client guard (`isSupportedFileFormatTransform` with `POT: ['POT', 'PO']`) was never actually closed, so users who configured it got live, untested behavior.

No production code changes. All 8 tests pass unmodified against the current source, which is the point: the client plumbing was finished in April and the tests were only ever waiting on the platform.

I also checked the two halves against each other rather than trusting the skip comment in reverse. The client sends the original `.pot` bytes with `fileFormat: 'POT'` plus `transformFormat: 'PO'` on enqueue; the API validator maps `transformFormat` to its internal `outputFileFormat` and validates the pair against the hardcoded transform table (POT -> PO is the only cross-format entry, no plan gating). On upload-translations the client omits `transformFormat` on translation objects; the validator treats it as optional and stores the translation's own `fileFormat`, so the shapes agree. Download returns `fileFormat: 'PO'` with no fileName, and the client already maps the output path to `.po` via `createFileMapping`.

Testing:

- `pnpm --filter generaltranslation test`: 595 passed, including the 3 re-enabled tests
- `pnpm --filter gt test`: 2083 passed, including the 5 re-enabled tests
- `tsc --noEmit` clean in both packages, `oxlint` 0 errors, repo-wide `oxfmt --check` clean
- End-to-end against a local gt-cloud stack (API + workers + queue infra, repo HEAD): a scratch project with a two-string `messages.pot` and `files.pot.transformationFormat: "PO"` in `gt.config.json`, run through `gtx-cli translate`. The source uploads and is recorded as `file_format: POT`; the enqueue request passes the API validators and the queued job carries `"outputFileFormat": "PO"`; the worker translates it and stores the result as `file_format: PO`; the CLI downloads it and writes `locales/es/messages.po`, a valid PO catalog with a `Language: es` header and real translations (`msgid "Save changes"` / `msgstr "Guardar cambios"`), while the source keeps its `.pot` name and `POT` format.

No changeset: the diff is test-only, so there is nothing to release. (An earlier revision included a patch bump purely for the release note; dropped per review.)

Review agents beat on the diff before this was opened. They confirmed each re-enabled test asserts real behavior against the current source (none pass vacuously), found no other code still gated on the old TODO, and flagged the changeset wording, which was tightened.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR re-enables 8 previously-skipped tests across `packages/core` and `packages/cli` that were blocked by a stale TODO comment ("Re-enable when the API supports POT → PO file format transforms"). No production code is changed — the diff is entirely the removal of `it.skip` calls and their accompanying comments.

- **`packages/core`** (3 tests): Covers `isSupportedFileFormatTransform('POT', 'PO')`, uploading POT source files with `transformFormat: 'PO'`, and uploading POT-source / PO-translation pairs to the API.
- **`packages/cli`** (5 tests): Covers file mapping (`.pot` → `.po` output paths), `transformFormat` attachment in `aggregateFiles`, `transformationFormat` resolution in `parseFilesConfig`, uppercase key normalisation in `generateSettings`, and post-processing skip logic for transformed files in `translate`.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the diff touches only test files and removes stale skip markers; no production logic is modified.

Every change is the removal of an `it.skip` call and its accompanying stale TODO comment. The underlying production code implementing POT→PO transform support was already merged and has been live since April 2026. All 8 tests pass against the current source without any code modifications, confirming the client plumbing was complete when written.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/utils/__tests__/isSupportedFileFormatTransform.test.ts | Re-enables 1 test asserting `isSupportedFileFormatTransform('POT', 'PO')` returns `true`; no production code touched. |
| packages/cli/src/formats/files/__tests__/fileMapping.test.ts | Re-enables 1 test verifying `.pot` source paths map to `.po` output paths when `transformationFormat: "PO"` is configured. |
| packages/core/src/translate/__tests__/uploadSourceFiles.test.ts | Re-enables 1 test checking that POT sources with `transformFormat: 'PO'` are forwarded correctly to the API upload request. |
| packages/core/src/translate/__tests__/uploadTranslations.test.ts | Re-enables 1 test verifying POT source / PO translation pairs are uploaded with the correct file formats. |
| packages/cli/src/formats/files/__tests__/aggregateFiles.test.ts | Re-enables 1 test confirming `transformFormat` is attached to aggregated POT file entries when configured. |
| packages/cli/src/config/__tests__/generateSettings.test.ts | Re-enables 1 test that uppercase file format config keys (e.g. `POT`) are normalised before file resolution. |
| packages/cli/src/fs/__tests__/parseFilesConfig.test.ts | Re-enables 1 test verifying `transformationFormat` options on `pot` config blocks are resolved correctly. |
| packages/cli/src/cli/commands/__tests__/translate.test.ts | Re-enables 1 test asserting that post-processing is skipped for files that were transformed to another format (POT → PO). |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["gt.config.json\nfiles.pot.transformationFormat: 'PO'"] --> B["parseFilesConfig\n(resolves transformationFormat)"]
    B --> C["generateSettings\n(normalises POT key)"]
    C --> D["aggregateFiles\n(attaches transformFormat to file entry)"]
    D --> E["createFileMapping\n(maps .pot source → .po output path)"]
    D --> F["uploadSourceFiles\n(sends fileFormat: POT + transformFormat: PO)"]
    F --> G["API: enqueue\n(validates POT→PO pair, stores outputFileFormat: PO)"]
    G --> H["Worker translates\n(produces PO catalog)"]
    H --> I["uploadTranslations\n(sends fileFormat: PO for each translation)"]
    I --> J["postProcessTranslations\n(skips post-processing for transformed files)"]
    J --> K["Download → writes .po file\nto locale output path"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["gt.config.json\nfiles.pot.transformationFormat: 'PO'"] --> B["parseFilesConfig\n(resolves transformationFormat)"]
    B --> C["generateSettings\n(normalises POT key)"]
    C --> D["aggregateFiles\n(attaches transformFormat to file entry)"]
    D --> E["createFileMapping\n(maps .pot source → .po output path)"]
    D --> F["uploadSourceFiles\n(sends fileFormat: POT + transformFormat: PO)"]
    F --> G["API: enqueue\n(validates POT→PO pair, stores outputFileFormat: PO)"]
    G --> H["Worker translates\n(produces PO catalog)"]
    H --> I["uploadTranslations\n(sends fileFormat: PO for each translation)"]
    I --> J["postProcessTranslations\n(skips post-processing for transformed files)"]
    J --> K["Download → writes .po file\nto locale output path"]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["chore: drop changeset, test-only change ..."](https://github.com/generaltranslation/gt/commit/9bf2694336a620110bb87c49ddff8c243ed9ddb0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45142454)</sub>

<!-- /greptile_comment -->