### PR TITLE
fix(compiler): warn for incompatible dev hot reload

### DIFF
--- a/.changeset/quiet-pandas-warn.md
+++ b/.changeset/quiet-pandas-warn.md
@@ -1,0 +1,5 @@
+---
+'@generaltranslation/compiler': patch
+---
+
+Warn when development hot reload is enabled for CommonJS or pre-ES2022 module output that cannot support its injected top-level await.

--- a/.changeset/quiet-pandas-warn.md
+++ b/.changeset/quiet-pandas-warn.md
@@ -2,4 +2,4 @@
 '@generaltranslation/compiler': patch
 ---
 
-Warn when development hot reload is enabled for CommonJS or pre-ES2022 module output that cannot support its injected top-level await.
+Warn while continuing compilation when development hot reload is enabled for detected CommonJS or unknown module output.

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -42,6 +42,7 @@
     "@babel/types": "^7.23.0",
     "@generaltranslation/format": "workspace:*",
     "generaltranslation": "workspace:*",
+    "get-tsconfig": "^4.13.7",
     "unplugin": "^2.3.10"
   },
   "devDependencies": {

--- a/packages/compiler/src/__tests__/index.test.ts
+++ b/packages/compiler/src/__tests__/index.test.ts
@@ -57,7 +57,8 @@ function writeInvalidGTConfig(cwd: string): string {
 
 async function transformWithPlugin(
   options: GTUnpluginOptions | undefined,
-  cwd: string
+  cwd: string,
+  code = JSX_RUNTIME_CODE
 ): Promise<string | null> {
   const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(cwd);
   const plugin = (() => {
@@ -77,7 +78,7 @@ async function transformWithPlugin(
 
   const result: TransformResult = await transform.call(
     context,
-    JSX_RUNTIME_CODE,
+    code,
     path.join(cwd, 'App.tsx')
   );
   if (!result) {
@@ -319,6 +320,67 @@ describe('gtUnplugin config loading', () => {
       );
       expect(warning).toContain('valid gt.config.json');
       expect(warning).not.toBe(MISSING_GT_CONFIG_WARNING);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+});
+
+describe('gtUnplugin dev hot reload compatibility', () => {
+  afterEach(() => {
+    for (const tempDir of tempDirs.splice(0)) {
+      fs.rmSync(tempDir, { force: true, recursive: true });
+    }
+  });
+
+  it('warns when dev hot reload injects top-level await into CommonJS output', async () => {
+    const cwd = createTempDir();
+    fs.writeFileSync(
+      path.join(cwd, 'tsconfig.json'),
+      JSON.stringify({ compilerOptions: { module: 'commonjs' } })
+    );
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      const output = await transformWithPlugin(
+        { devHotReload: true, gtConfig: {} },
+        cwd,
+        "import { t } from 'gt-react'; t('Hello');"
+      );
+
+      expect(output).toContain('await Promise.all');
+      expect(warnSpy).toHaveBeenCalledOnce();
+      expect(warnSpy.mock.calls[0]?.[0]).toContain(
+        '@generaltranslation/compiler Warning:'
+      );
+      expect(warnSpy.mock.calls[0]?.[0]).toContain(
+        'top-level await, which requires ES2022 modules'
+      );
+      expect(warnSpy.mock.calls[0]?.[0]).toContain(
+        'Detected module type: commonjs.'
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('does not warn for ES2022 module output', async () => {
+    const cwd = createTempDir();
+    fs.writeFileSync(
+      path.join(cwd, 'tsconfig.json'),
+      JSON.stringify({ compilerOptions: { module: 'es2022' } })
+    );
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      const output = await transformWithPlugin(
+        { devHotReload: true, gtConfig: {} },
+        cwd,
+        "import { t } from 'gt-react'; t('Hello');"
+      );
+
+      expect(output).toContain('await Promise.all');
+      expect(warnSpy).not.toHaveBeenCalled();
     } finally {
       warnSpy.mockRestore();
     }

--- a/packages/compiler/src/__tests__/index.test.ts
+++ b/packages/compiler/src/__tests__/index.test.ts
@@ -354,10 +354,10 @@ describe('gtUnplugin dev hot reload compatibility', () => {
         '@generaltranslation/compiler Warning:'
       );
       expect(warnSpy.mock.calls[0]?.[0]).toContain(
-        'top-level await, which requires ES2022 modules'
+        'top-level await, which requires ESM and ES2022-or-newer runtime support'
       );
       expect(warnSpy.mock.calls[0]?.[0]).toContain(
-        'Detected module type: commonjs.'
+        'Module format detection: tsconfig module: commonjs.'
       );
     } finally {
       warnSpy.mockRestore();

--- a/packages/compiler/src/compatibility/__tests__/devHotReload.test.ts
+++ b/packages/compiler/src/compatibility/__tests__/devHotReload.test.ts
@@ -1,0 +1,120 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import * as parser from '@babel/parser';
+import { afterEach, describe, expect, it } from 'vitest';
+import { DevHotReloadCompatibilityResolver } from '../devHotReload';
+
+const tempDirs: string[] = [];
+
+function createProject(
+  module: string | undefined,
+  packageType?: string
+): string {
+  const directory = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'gt-compiler-module-')
+  );
+  tempDirs.push(directory);
+  if (module) {
+    fs.writeFileSync(
+      path.join(directory, 'tsconfig.json'),
+      JSON.stringify({ compilerOptions: { module } })
+    );
+  }
+  if (packageType) {
+    fs.writeFileSync(
+      path.join(directory, 'package.json'),
+      JSON.stringify({ type: packageType })
+    );
+  }
+  return directory;
+}
+
+function parse(code: string) {
+  return parser.parse(code, {
+    sourceType: 'module',
+    plugins: ['jsx', 'typescript'],
+  });
+}
+
+describe('DevHotReloadCompatibilityResolver', () => {
+  afterEach(() => {
+    for (const directory of tempDirs.splice(0)) {
+      fs.rmSync(directory, { force: true, recursive: true });
+    }
+  });
+
+  it.each(['commonjs', 'amd', 'umd'])(
+    'detects the %s TypeScript module format',
+    (module) => {
+      const project = createProject(module);
+      const compatibility = new DevHotReloadCompatibilityResolver().resolve(
+        path.join(project, 'App.tsx'),
+        parse("import { t } from 'gt-react'; t('Hello');")
+      );
+
+      expect(compatibility).toEqual({
+        compatible: false,
+        detectedModuleType: module,
+        reason: 'commonjs',
+      });
+    }
+  );
+
+  it.each([
+    { configured: 'es2015', detected: 'es6' },
+    { configured: 'es2020', detected: 'es2020' },
+  ])(
+    'detects the $configured module format as older ESM',
+    ({ configured, detected }) => {
+      const project = createProject(configured);
+      const compatibility = new DevHotReloadCompatibilityResolver().resolve(
+        path.join(project, 'App.tsx'),
+        parse("import { t } from 'gt-react'; t('Hello');")
+      );
+
+      expect(compatibility).toEqual({
+        compatible: false,
+        detectedModuleType: detected,
+        reason: 'legacy-esm',
+      });
+    }
+  );
+
+  it.each(['es2022', 'esnext', 'preserve'])(
+    'allows the %s module format',
+    (module) => {
+      const project = createProject(module);
+      const compatibility = new DevHotReloadCompatibilityResolver().resolve(
+        path.join(project, 'App.tsx'),
+        parse("import { t } from 'gt-react'; t('Hello');")
+      );
+
+      expect(compatibility).toEqual({ compatible: true });
+    }
+  );
+
+  it('uses package type to resolve Node module formats', () => {
+    const cjsProject = createProject('node16', 'commonjs');
+    const esmProject = createProject('node16', 'module');
+    const resolver = new DevHotReloadCompatibilityResolver();
+    const ast = parse("import { t } from 'gt-react'; t('Hello');");
+
+    expect(
+      resolver.resolve(path.join(cjsProject, 'App.ts'), ast).compatible
+    ).toBe(false);
+    expect(
+      resolver.resolve(path.join(esmProject, 'App.ts'), ast).compatible
+    ).toBe(true);
+  });
+
+  it('falls back to CommonJS syntax when no tsconfig is available', () => {
+    const project = createProject(undefined);
+    const compatibility = new DevHotReloadCompatibilityResolver().resolve(
+      path.join(project, 'App.js'),
+      parse("const { t } = require('gt-react'); t('Hello');")
+    );
+
+    expect(compatibility.compatible).toBe(false);
+  });
+});

--- a/packages/compiler/src/compatibility/__tests__/devHotReload.test.ts
+++ b/packages/compiler/src/compatibility/__tests__/devHotReload.test.ts
@@ -3,14 +3,11 @@ import os from 'node:os';
 import path from 'node:path';
 import * as parser from '@babel/parser';
 import { afterEach, describe, expect, it } from 'vitest';
-import { DevHotReloadCompatibilityResolver } from '../devHotReload';
+import { ModuleFormatResolver } from '../devHotReload';
 
 const tempDirs: string[] = [];
 
-function createProject(
-  module: string | undefined,
-  packageType?: string
-): string {
+function createProject(module?: string): string {
   const directory = fs.mkdtempSync(
     path.join(os.tmpdir(), 'gt-compiler-module-')
   );
@@ -19,12 +16,6 @@ function createProject(
     fs.writeFileSync(
       path.join(directory, 'tsconfig.json'),
       JSON.stringify({ compilerOptions: { module } })
-    );
-  }
-  if (packageType) {
-    fs.writeFileSync(
-      path.join(directory, 'package.json'),
-      JSON.stringify({ type: packageType })
     );
   }
   return directory;
@@ -37,84 +28,87 @@ function parse(code: string) {
   });
 }
 
-describe('DevHotReloadCompatibilityResolver', () => {
+describe('ModuleFormatResolver', () => {
   afterEach(() => {
     for (const directory of tempDirs.splice(0)) {
       fs.rmSync(directory, { force: true, recursive: true });
     }
   });
 
-  it.each(['commonjs', 'amd', 'umd'])(
-    'detects the %s TypeScript module format',
-    (module) => {
-      const project = createProject(module);
-      const compatibility = new DevHotReloadCompatibilityResolver().resolve(
+  it('detects CommonJS from tsconfig', () => {
+    const project = createProject('commonjs');
+
+    expect(
+      new ModuleFormatResolver().resolve(
         path.join(project, 'App.tsx'),
         parse("import { t } from 'gt-react'; t('Hello');")
-      );
+      )
+    ).toEqual({ format: 'cjs', detail: 'tsconfig module: commonjs' });
+  });
 
-      expect(compatibility).toEqual({
-        compatible: false,
-        detectedModuleType: module,
-        reason: 'commonjs',
-      });
+  it.each(['es2015', 'es2020', 'es2022', 'esnext', 'preserve'])(
+    'detects %s as ESM without claiming top-level await support',
+    (module) => {
+      const project = createProject(module);
+
+      expect(
+        new ModuleFormatResolver().resolve(
+          path.join(project, 'App.tsx'),
+          parse("import { t } from 'gt-react'; t('Hello');")
+        ).format
+      ).toBe('esm');
+    }
+  );
+
+  it.each(['node16', 'system', 'umd', 'none'])(
+    'returns unknown for the ambiguous %s module setting',
+    (module) => {
+      const project = createProject(module);
+
+      expect(
+        new ModuleFormatResolver().resolve(
+          path.join(project, 'App.tsx'),
+          parse("import { t } from 'gt-react'; t('Hello');")
+        ).format
+      ).toBe('unknown');
     }
   );
 
   it.each([
-    { configured: 'es2015', detected: 'es6' },
-    { configured: 'es2020', detected: 'es2020' },
-  ])(
-    'detects the $configured module format as older ESM',
-    ({ configured, detected }) => {
-      const project = createProject(configured);
-      const compatibility = new DevHotReloadCompatibilityResolver().resolve(
-        path.join(project, 'App.tsx'),
-        parse("import { t } from 'gt-react'; t('Hello');")
-      );
-
-      expect(compatibility).toEqual({
-        compatible: false,
-        detectedModuleType: detected,
-        reason: 'legacy-esm',
-      });
-    }
-  );
-
-  it.each(['es2022', 'esnext', 'preserve'])(
-    'allows the %s module format',
-    (module) => {
-      const project = createProject(module);
-      const compatibility = new DevHotReloadCompatibilityResolver().resolve(
-        path.join(project, 'App.tsx'),
-        parse("import { t } from 'gt-react'; t('Hello');")
-      );
-
-      expect(compatibility).toEqual({ compatible: true });
-    }
-  );
-
-  it('uses package type to resolve Node module formats', () => {
-    const cjsProject = createProject('node16', 'commonjs');
-    const esmProject = createProject('node16', 'module');
-    const resolver = new DevHotReloadCompatibilityResolver();
-    const ast = parse("import { t } from 'gt-react'; t('Hello');");
+    { extension: '.cjs', format: 'cjs' },
+    { extension: '.cts', format: 'cjs' },
+    { extension: '.mjs', format: 'esm' },
+    { extension: '.mts', format: 'esm' },
+  ] as const)('detects $format from $extension', ({ extension, format }) => {
+    const project = createProject();
 
     expect(
-      resolver.resolve(path.join(cjsProject, 'App.ts'), ast).compatible
-    ).toBe(false);
-    expect(
-      resolver.resolve(path.join(esmProject, 'App.ts'), ast).compatible
-    ).toBe(true);
+      new ModuleFormatResolver().resolve(
+        path.join(project, `App${extension}`),
+        parse('const value = 1;')
+      ).format
+    ).toBe(format);
   });
 
-  it('falls back to CommonJS syntax when no tsconfig is available', () => {
-    const project = createProject(undefined);
-    const compatibility = new DevHotReloadCompatibilityResolver().resolve(
-      path.join(project, 'App.js'),
-      parse("const { t } = require('gt-react'); t('Hello');")
-    );
+  it('falls back to CommonJS syntax without a tsconfig', () => {
+    const project = createProject();
 
-    expect(compatibility.compatible).toBe(false);
+    expect(
+      new ModuleFormatResolver().resolve(
+        path.join(project, 'App.js'),
+        parse("const { t } = require('gt-react'); t('Hello');")
+      ).format
+    ).toBe('cjs');
+  });
+
+  it('returns unknown for mixed module syntax', () => {
+    const project = createProject();
+
+    expect(
+      new ModuleFormatResolver().resolve(
+        path.join(project, 'App.js'),
+        parse("import value from 'value'; require('other');")
+      ).format
+    ).toBe('unknown');
   });
 });

--- a/packages/compiler/src/compatibility/devHotReload.ts
+++ b/packages/compiler/src/compatibility/devHotReload.ts
@@ -1,81 +1,73 @@
-import fs from 'node:fs';
 import path from 'node:path';
 import traverse from '@babel/traverse';
 import * as t from '@babel/types';
 import { getTsconfig, type Cache } from 'get-tsconfig';
 
-export type DevHotReloadModuleCompatibility =
-  | { compatible: true }
-  | {
-      compatible: false;
-      detectedModuleType: string;
-      reason: 'commonjs' | 'legacy-esm';
-    };
+export type ModuleFormat = 'esm' | 'cjs' | 'unknown';
 
-const TOP_LEVEL_AWAIT_MODULE_TYPES = new Set(['es2022', 'esnext', 'preserve']);
-const LEGACY_ESM_MODULE_TYPES = new Set(['es6', 'es2015', 'es2020']);
-const COMMONJS_MODULE_TYPES = new Set(['commonjs', 'node', 'amd', 'umd']);
-const NODE_MODULE_TYPES = new Set(['node16', 'node18', 'node20', 'nodenext']);
+export type ModuleFormatDetection = {
+  format: ModuleFormat;
+  detail: string;
+};
 
-type PackageJson = { type?: string };
+const ESM_MODULE_TYPES = new Set([
+  'es6',
+  'es2015',
+  'es2020',
+  'es2022',
+  'esnext',
+  'preserve',
+]);
 
 function getExtension(filename: string): string {
   return path.extname(filename.split('?')[0]).toLowerCase();
 }
 
-function findPackageType(
-  filename: string,
-  packageTypeCache: Map<string, string | undefined>
-): string | undefined {
-  let directory = path.dirname(filename);
-
-  while (true) {
-    if (packageTypeCache.has(directory)) {
-      return packageTypeCache.get(directory);
-    }
-
-    const packagePath = path.join(directory, 'package.json');
-    if (fs.existsSync(packagePath)) {
-      try {
-        const packageJson = JSON.parse(
-          fs.readFileSync(packagePath, 'utf8')
-        ) as PackageJson;
-        const packageType = packageJson.type?.toLowerCase();
-        packageTypeCache.set(directory, packageType);
-        return packageType;
-      } catch {
-        packageTypeCache.set(directory, undefined);
-        return undefined;
-      }
-    }
-
-    const parent = path.dirname(directory);
-    if (parent === directory) {
-      packageTypeCache.set(directory, undefined);
-      return undefined;
-    }
-    directory = parent;
+function detectFromExtension(filename: string): ModuleFormatDetection | null {
+  const extension = getExtension(filename);
+  if (extension === '.cjs' || extension === '.cts') {
+    return { format: 'cjs', detail: `${extension} file extension` };
   }
+  if (extension === '.mjs' || extension === '.mts') {
+    return { format: 'esm', detail: `${extension} file extension` };
+  }
+  return null;
 }
 
-function usesEsModules(ast: t.File): boolean {
-  return ast.program.body.some(
+function detectFromModuleSetting(moduleSetting: string): ModuleFormatDetection {
+  const normalizedModuleSetting = moduleSetting.toLowerCase();
+  if (normalizedModuleSetting === 'commonjs') {
+    return { format: 'cjs', detail: 'tsconfig module: commonjs' };
+  }
+  if (ESM_MODULE_TYPES.has(normalizedModuleSetting)) {
+    return {
+      format: 'esm',
+      detail: `tsconfig module: ${normalizedModuleSetting}`,
+    };
+  }
+
+  // Node module modes depend on the file extension and nearest package.json,
+  // while AMD, UMD, SystemJS, and script output are neither ESM nor CommonJS.
+  return {
+    format: 'unknown',
+    detail: `tsconfig module: ${normalizedModuleSetting}`,
+  };
+}
+
+function detectFromSyntax(ast: t.File): ModuleFormatDetection {
+  const hasEsmSyntax = ast.program.body.some(
     (statement) =>
       t.isImportDeclaration(statement) ||
       t.isExportNamedDeclaration(statement) ||
       t.isExportDefaultDeclaration(statement) ||
       t.isExportAllDeclaration(statement)
   );
-}
-
-function usesCommonJs(ast: t.File): boolean {
-  let commonJsDetected = false;
+  let hasCommonJsSyntax = false;
 
   traverse(ast, {
     CallExpression(path) {
       if (t.isIdentifier(path.node.callee, { name: 'require' })) {
-        commonJsDetected = true;
-        path.stop();
+        hasCommonJsSyntax = true;
       }
     },
     MemberExpression(path) {
@@ -84,102 +76,52 @@ function usesCommonJs(ast: t.File): boolean {
         (path.node.object.name === 'module' ||
           path.node.object.name === 'exports')
       ) {
-        commonJsDetected = true;
-        path.stop();
+        hasCommonJsSyntax = true;
       }
     },
   });
 
-  return commonJsDetected;
+  if (hasEsmSyntax && !hasCommonJsSyntax) {
+    return { format: 'esm', detail: 'ESM import or export syntax' };
+  }
+  if (hasCommonJsSyntax && !hasEsmSyntax) {
+    return { format: 'cjs', detail: 'CommonJS require or exports syntax' };
+  }
+  return {
+    format: 'unknown',
+    detail: hasEsmSyntax
+      ? 'mixed ESM and CommonJS syntax'
+      : 'no module format signal',
+  };
 }
 
-function isNodeModuleEsm(
-  filename: string,
-  packageTypeCache: Map<string, string | undefined>
-): boolean {
-  const extension = getExtension(filename);
-  if (extension === '.mts' || extension === '.mjs') return true;
-  if (extension === '.cts' || extension === '.cjs') return false;
-  return findPackageType(filename, packageTypeCache) === 'module';
-}
-
-export class DevHotReloadCompatibilityResolver {
+/**
+ * Detects whether a source file is ESM, CommonJS, or unknown.
+ *
+ * This intentionally does not claim that detected ESM supports top-level
+ * await. Top-level await requires ES2022-or-newer runtime support, and a
+ * bundler may choose a different final output format than the source or
+ * tsconfig suggests.
+ */
+export class ModuleFormatResolver {
   private readonly tsconfigCache: Cache = new Map();
-  private readonly packageTypeCache = new Map<string, string | undefined>();
 
-  resolve(filename: string, ast: t.File): DevHotReloadModuleCompatibility {
-    const extension = getExtension(filename);
-    if (extension === '.cts' || extension === '.cjs') {
-      return {
-        compatible: false,
-        detectedModuleType: extension.slice(1),
-        reason: 'commonjs',
-      };
-    }
+  resolve(filename: string, ast: t.File): ModuleFormatDetection {
+    const extensionDetection = detectFromExtension(filename);
+    if (extensionDetection) return extensionDetection;
 
-    let configuredModuleType: string | undefined;
     try {
-      configuredModuleType = getTsconfig(
+      const moduleSetting = getTsconfig(
         filename,
         'tsconfig.json',
         this.tsconfigCache
-      )?.config.compilerOptions?.module?.toLowerCase();
+      )?.config.compilerOptions?.module;
+      if (moduleSetting) return detectFromModuleSetting(moduleSetting);
     } catch {
       // Invalid project configuration is reported by the owning tool. Fall
-      // back to the file syntax so this compatibility check stays non-fatal.
+      // back to syntax detection so this check remains non-fatal.
     }
 
-    if (configuredModuleType) {
-      if (COMMONJS_MODULE_TYPES.has(configuredModuleType)) {
-        return {
-          compatible: false,
-          detectedModuleType: configuredModuleType,
-          reason: 'commonjs',
-        };
-      }
-      if (LEGACY_ESM_MODULE_TYPES.has(configuredModuleType)) {
-        return {
-          compatible: false,
-          detectedModuleType: configuredModuleType,
-          reason: 'legacy-esm',
-        };
-      }
-      if (TOP_LEVEL_AWAIT_MODULE_TYPES.has(configuredModuleType)) {
-        return { compatible: true };
-      }
-      if (NODE_MODULE_TYPES.has(configuredModuleType)) {
-        return isNodeModuleEsm(filename, this.packageTypeCache)
-          ? { compatible: true }
-          : {
-              compatible: false,
-              detectedModuleType: `${configuredModuleType} (CommonJS file)`,
-              reason: 'commonjs',
-            };
-      }
-    }
-
-    const hasEsmSyntax = usesEsModules(ast);
-    const hasCommonJsSyntax = usesCommonJs(ast);
-    if (hasCommonJsSyntax && !hasEsmSyntax) {
-      return {
-        compatible: false,
-        detectedModuleType: 'CommonJS syntax',
-        reason: 'commonjs',
-      };
-    }
-    if (hasEsmSyntax) return { compatible: true };
-
-    if (
-      (extension === '.js' || extension === '.jsx') &&
-      findPackageType(filename, this.packageTypeCache) !== 'module'
-    ) {
-      return {
-        compatible: false,
-        detectedModuleType: 'CommonJS package',
-        reason: 'commonjs',
-      };
-    }
-
-    return { compatible: true };
+    return detectFromSyntax(ast);
   }
 }

--- a/packages/compiler/src/compatibility/devHotReload.ts
+++ b/packages/compiler/src/compatibility/devHotReload.ts
@@ -1,0 +1,185 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import traverse from '@babel/traverse';
+import * as t from '@babel/types';
+import { getTsconfig, type Cache } from 'get-tsconfig';
+
+export type DevHotReloadModuleCompatibility =
+  | { compatible: true }
+  | {
+      compatible: false;
+      detectedModuleType: string;
+      reason: 'commonjs' | 'legacy-esm';
+    };
+
+const TOP_LEVEL_AWAIT_MODULE_TYPES = new Set(['es2022', 'esnext', 'preserve']);
+const LEGACY_ESM_MODULE_TYPES = new Set(['es6', 'es2015', 'es2020']);
+const COMMONJS_MODULE_TYPES = new Set(['commonjs', 'node', 'amd', 'umd']);
+const NODE_MODULE_TYPES = new Set(['node16', 'node18', 'node20', 'nodenext']);
+
+type PackageJson = { type?: string };
+
+function getExtension(filename: string): string {
+  return path.extname(filename.split('?')[0]).toLowerCase();
+}
+
+function findPackageType(
+  filename: string,
+  packageTypeCache: Map<string, string | undefined>
+): string | undefined {
+  let directory = path.dirname(filename);
+
+  while (true) {
+    if (packageTypeCache.has(directory)) {
+      return packageTypeCache.get(directory);
+    }
+
+    const packagePath = path.join(directory, 'package.json');
+    if (fs.existsSync(packagePath)) {
+      try {
+        const packageJson = JSON.parse(
+          fs.readFileSync(packagePath, 'utf8')
+        ) as PackageJson;
+        const packageType = packageJson.type?.toLowerCase();
+        packageTypeCache.set(directory, packageType);
+        return packageType;
+      } catch {
+        packageTypeCache.set(directory, undefined);
+        return undefined;
+      }
+    }
+
+    const parent = path.dirname(directory);
+    if (parent === directory) {
+      packageTypeCache.set(directory, undefined);
+      return undefined;
+    }
+    directory = parent;
+  }
+}
+
+function usesEsModules(ast: t.File): boolean {
+  return ast.program.body.some(
+    (statement) =>
+      t.isImportDeclaration(statement) ||
+      t.isExportNamedDeclaration(statement) ||
+      t.isExportDefaultDeclaration(statement) ||
+      t.isExportAllDeclaration(statement)
+  );
+}
+
+function usesCommonJs(ast: t.File): boolean {
+  let commonJsDetected = false;
+
+  traverse(ast, {
+    CallExpression(path) {
+      if (t.isIdentifier(path.node.callee, { name: 'require' })) {
+        commonJsDetected = true;
+        path.stop();
+      }
+    },
+    MemberExpression(path) {
+      if (
+        t.isIdentifier(path.node.object) &&
+        (path.node.object.name === 'module' ||
+          path.node.object.name === 'exports')
+      ) {
+        commonJsDetected = true;
+        path.stop();
+      }
+    },
+  });
+
+  return commonJsDetected;
+}
+
+function isNodeModuleEsm(
+  filename: string,
+  packageTypeCache: Map<string, string | undefined>
+): boolean {
+  const extension = getExtension(filename);
+  if (extension === '.mts' || extension === '.mjs') return true;
+  if (extension === '.cts' || extension === '.cjs') return false;
+  return findPackageType(filename, packageTypeCache) === 'module';
+}
+
+export class DevHotReloadCompatibilityResolver {
+  private readonly tsconfigCache: Cache = new Map();
+  private readonly packageTypeCache = new Map<string, string | undefined>();
+
+  resolve(filename: string, ast: t.File): DevHotReloadModuleCompatibility {
+    const extension = getExtension(filename);
+    if (extension === '.cts' || extension === '.cjs') {
+      return {
+        compatible: false,
+        detectedModuleType: extension.slice(1),
+        reason: 'commonjs',
+      };
+    }
+
+    let configuredModuleType: string | undefined;
+    try {
+      configuredModuleType = getTsconfig(
+        filename,
+        'tsconfig.json',
+        this.tsconfigCache
+      )?.config.compilerOptions?.module?.toLowerCase();
+    } catch {
+      // Invalid project configuration is reported by the owning tool. Fall
+      // back to the file syntax so this compatibility check stays non-fatal.
+    }
+
+    if (configuredModuleType) {
+      if (COMMONJS_MODULE_TYPES.has(configuredModuleType)) {
+        return {
+          compatible: false,
+          detectedModuleType: configuredModuleType,
+          reason: 'commonjs',
+        };
+      }
+      if (LEGACY_ESM_MODULE_TYPES.has(configuredModuleType)) {
+        return {
+          compatible: false,
+          detectedModuleType: configuredModuleType,
+          reason: 'legacy-esm',
+        };
+      }
+      if (TOP_LEVEL_AWAIT_MODULE_TYPES.has(configuredModuleType)) {
+        return { compatible: true };
+      }
+      if (NODE_MODULE_TYPES.has(configuredModuleType)) {
+        return isNodeModuleEsm(filename, this.packageTypeCache)
+          ? { compatible: true }
+          : {
+              compatible: false,
+              detectedModuleType: `${configuredModuleType} (CommonJS file)`,
+              reason: 'commonjs',
+            };
+      }
+    }
+
+    const hasEsmSyntax = usesEsModules(ast);
+    const hasCommonJsSyntax = usesCommonJs(ast);
+    if (hasCommonJsSyntax && !hasEsmSyntax) {
+      return {
+        compatible: false,
+        detectedModuleType: 'CommonJS syntax',
+        reason: 'commonjs',
+      };
+    }
+    if (hasEsmSyntax) return { compatible: true };
+
+    if (
+      (extension === '.js' || extension === '.jsx') &&
+      findPackageType(filename, this.packageTypeCache) !== 'module'
+    ) {
+      return {
+        compatible: false,
+        detectedModuleType: 'CommonJS package',
+        reason: 'commonjs',
+      };
+    }
+
+    return { compatible: true };
+  }
+}

--- a/packages/compiler/src/diagnostics.ts
+++ b/packages/compiler/src/diagnostics.ts
@@ -1,0 +1,31 @@
+import {
+  createDiagnosticMessage,
+  type DiagnosticMessageInput,
+} from 'generaltranslation/internal';
+import type { DevHotReloadModuleCompatibility } from './compatibility/devHotReload';
+
+type CompilerDiagnosticInput = Omit<DiagnosticMessageInput, 'source'>;
+
+function createCompilerDiagnostic(input: CompilerDiagnosticInput): string {
+  return createDiagnosticMessage({
+    source: '@generaltranslation/compiler',
+    ...input,
+  });
+}
+
+export function createIncompatibleDevHotReloadWarning(
+  compatibility: Exclude<DevHotReloadModuleCompatibility, { compatible: true }>
+): string {
+  return createCompilerDiagnostic({
+    severity: 'Warning',
+    whatHappened:
+      'Development hot reload is enabled for a module format that does not support it',
+    reassurance: 'Production translations are unaffected.',
+    why: 'development hot reload injects top-level await, which requires ES2022 modules',
+    fix: 'Compile the application as ES2022 or ESNext ESM',
+    wayOut: 'disable devHotReload in gt.config.json',
+    details: `Detected module type: ${compatibility.detectedModuleType}`,
+    docsUrl:
+      'https://generaltranslation.com/en/docs/react/guides/developing-spa-translations',
+  });
+}

--- a/packages/compiler/src/diagnostics.ts
+++ b/packages/compiler/src/diagnostics.ts
@@ -2,7 +2,7 @@ import {
   createDiagnosticMessage,
   type DiagnosticMessageInput,
 } from 'generaltranslation/internal';
-import type { DevHotReloadModuleCompatibility } from './compatibility/devHotReload';
+import type { ModuleFormatDetection } from './compatibility/devHotReload';
 
 type CompilerDiagnosticInput = Omit<DiagnosticMessageInput, 'source'>;
 
@@ -13,18 +13,21 @@ function createCompilerDiagnostic(input: CompilerDiagnosticInput): string {
   });
 }
 
-export function createIncompatibleDevHotReloadWarning(
-  compatibility: Exclude<DevHotReloadModuleCompatibility, { compatible: true }>
+export function createDevHotReloadModuleFormatWarning(
+  detection: ModuleFormatDetection
 ): string {
+  const detectedFormat =
+    detection.format === 'cjs' ? 'CommonJS (CJS)' : 'an unknown module format';
+
   return createCompilerDiagnostic({
     severity: 'Warning',
-    whatHappened:
-      'Development hot reload is enabled for a module format that does not support it',
-    reassurance: 'Production translations are unaffected.',
-    why: 'development hot reload injects top-level await, which requires ES2022 modules',
-    fix: 'Compile the application as ES2022 or ESNext ESM',
+    whatHappened: `Development hot reload is enabled while the compiler detected ${detectedFormat}`,
+    reassurance:
+      'The compiler will continue and inject the configured development hot reload calls.',
+    why: 'development hot reload uses top-level await, which requires ESM and ES2022-or-newer runtime support',
+    fix: 'Use ES2022-or-newer ESM',
     wayOut: 'disable devHotReload in gt.config.json',
-    details: `Detected module type: ${compatibility.detectedModuleType}`,
+    details: `Module format detection: ${detection.detail}`,
     docsUrl:
       'https://generaltranslation.com/en/docs/react/guides/developing-spa-translations',
   });

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -16,8 +16,8 @@ import { handleErrors, InvalidLibraryUsageError } from './passes/handleErrors';
 import { initializeState } from './state/utils/initializeState';
 import { jsxInsertionPass } from './passes/jsxInsertionPass';
 import { runtimeTranslatePass } from './passes/runtimeTranslatePass';
-import { DevHotReloadCompatibilityResolver } from './compatibility/devHotReload';
-import { createIncompatibleDevHotReloadWarning } from './diagnostics';
+import { ModuleFormatResolver } from './compatibility/devHotReload';
+import { createDevHotReloadModuleFormatWarning } from './diagnostics';
 
 /**
  * Architecture:
@@ -213,15 +213,19 @@ const gtUnplugin = createUnplugin<GTUnpluginOptions | undefined>(
     const debugManifest = resolvedOptions._debugHashManifest
       ? new Map<string, unknown>()
       : undefined;
-    const devHotReloadCompatibilityResolver =
-      new DevHotReloadCompatibilityResolver();
-    let incompatibleDevHotReloadWarningShown = false;
+    const moduleFormatResolver = new ModuleFormatResolver();
+    let devHotReloadModuleFormatWarningShown = false;
 
     return {
       name: '@generaltranslation/GT_PLUGIN',
       transformInclude(id: string) {
-        // Only transform JavaScript and TypeScript files.
-        return /\.[cm]?[jt]sx?(?:\?.*)?$/.test(id);
+        // Only transform TSX and JSX files
+        return (
+          id.endsWith('.tsx') ||
+          id.endsWith('.jsx') ||
+          id.endsWith('.ts') ||
+          id.endsWith('.js')
+        );
       },
       transform(code: string, id: string) {
         // Initialize processing state
@@ -279,18 +283,13 @@ const gtUnplugin = createUnplugin<GTUnpluginOptions | undefined>(
           if (
             devHotReloadActive &&
             hasCollectionContent &&
-            !incompatibleDevHotReloadWarningShown &&
+            !devHotReloadModuleFormatWarningShown &&
             shouldWarn(state.settings.logLevel)
           ) {
-            const compatibility = devHotReloadCompatibilityResolver.resolve(
-              id,
-              ast
-            );
-            if (!compatibility.compatible) {
-              console.warn(
-                createIncompatibleDevHotReloadWarning(compatibility)
-              );
-              incompatibleDevHotReloadWarningShown = true;
+            const moduleFormat = moduleFormatResolver.resolve(id, ast);
+            if (moduleFormat.format !== 'esm') {
+              console.warn(createDevHotReloadModuleFormatWarning(moduleFormat));
+              devHotReloadModuleFormatWarningShown = true;
             }
           }
           if (devHotReloadActive && hasCollectionContent) {

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -16,6 +16,8 @@ import { handleErrors, InvalidLibraryUsageError } from './passes/handleErrors';
 import { initializeState } from './state/utils/initializeState';
 import { jsxInsertionPass } from './passes/jsxInsertionPass';
 import { runtimeTranslatePass } from './passes/runtimeTranslatePass';
+import { DevHotReloadCompatibilityResolver } from './compatibility/devHotReload';
+import { createIncompatibleDevHotReloadWarning } from './diagnostics';
 
 /**
  * Architecture:
@@ -211,17 +213,15 @@ const gtUnplugin = createUnplugin<GTUnpluginOptions | undefined>(
     const debugManifest = resolvedOptions._debugHashManifest
       ? new Map<string, unknown>()
       : undefined;
+    const devHotReloadCompatibilityResolver =
+      new DevHotReloadCompatibilityResolver();
+    let incompatibleDevHotReloadWarningShown = false;
 
     return {
       name: '@generaltranslation/GT_PLUGIN',
       transformInclude(id: string) {
-        // Only transform TSX and JSX files
-        return (
-          id.endsWith('.tsx') ||
-          id.endsWith('.jsx') ||
-          id.endsWith('.ts') ||
-          id.endsWith('.js')
-        );
+        // Only transform JavaScript and TypeScript files.
+        return /\.[cm]?[jt]sx?(?:\?.*)?$/.test(id);
       },
       transform(code: string, id: string) {
         // Initialize processing state
@@ -276,6 +276,23 @@ const gtUnplugin = createUnplugin<GTUnpluginOptions | undefined>(
           const devHotReloadActive =
             state.settings.devHotReload.strings ||
             state.settings.devHotReload.jsx;
+          if (
+            devHotReloadActive &&
+            hasCollectionContent &&
+            !incompatibleDevHotReloadWarningShown &&
+            shouldWarn(state.settings.logLevel)
+          ) {
+            const compatibility = devHotReloadCompatibilityResolver.resolve(
+              id,
+              ast
+            );
+            if (!compatibility.compatible) {
+              console.warn(
+                createIncompatibleDevHotReloadWarning(compatibility)
+              );
+              incompatibleDevHotReloadWarningShown = true;
+            }
+          }
           if (devHotReloadActive && hasCollectionContent) {
             traverse(ast, runtimeTranslatePass(state));
           }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -796,6 +796,9 @@ importers:
       generaltranslation:
         specifier: workspace:*
         version: link:../core
+      get-tsconfig:
+        specifier: ^4.13.7
+        version: 4.13.7
       unplugin:
         specifier: ^2.3.10
         version: 2.3.10


### PR DESCRIPTION
## Summary

- Detect module format conservatively as ESM, CommonJS, or unknown using file extensions, resolved TypeScript configuration, and source syntax.
- Warn once for CommonJS or unknown formats when development hot reload is enabled, while continuing to inject the configured module-level calls.
- Explain that development hot reload uses top-level `await`, requires ESM with ES2022-or-newer runtime support, and can be disabled through `devHotReload`.

## Testing

- `pnpm --filter @generaltranslation/compiler test` — passed (652 passed, 11 skipped)
- `pnpm --filter @generaltranslation/compiler typecheck` — passed
- `pnpm --filter @generaltranslation/compiler build` — passed
- `pnpm --filter gt-test-rolldown-react build` — passed; no compiler validation errors from library `.mjs` files
- `pnpm --filter @generaltranslation/compiler format` — passed
- `pnpm exec oxlint packages/compiler/src` — passed

## Notes

- Changeset: patch for `@generaltranslation/compiler`.
- Development hot reload remains disabled by default. Explicitly enabling it continues injection after the warning.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a conservative module-format detector (`ModuleFormatResolver`) to the compiler plugin and uses it to emit a one-time `console.warn` when `devHotReload` is enabled but the file appears to be CommonJS or of unknown format — preventing silent runtime failures caused by top-level `await` in non-ESM contexts.

- **Detection priority**: file extension (`.cjs`/`.mjs`/`.cts`/`.mts`) → `tsconfig.json` `module` setting → AST syntax scan. Falls back gracefully on any `getTsconfig` error.
- **Warning behavior**: fires at most once per plugin instance (flag-gated), only when `hasCollectionContent` is true and `logLevel` permits warnings, and continues injection regardless so builds are not blocked.
- **Test coverage**: unit tests cover all three detection layers including mixed-syntax and no-signal edge cases; integration tests verify the warn-and-continue contract end-to-end.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change adds a non-blocking warning and never alters injection behavior; the only finding is a missing entry in the ESM type set that causes a false-positive warning for Vite-with-bundler-module projects.

The detection and warn-once logic are straightforward and well-tested across all three detection layers. The change is purely additive: injection always continues, warnings are gated on both log level and content presence, and the new dependency (get-tsconfig) is a read-only utility with no build-time side effects. The one gap — module: "bundler" producing an unnecessary warning for Vite setups — is a UX nit, not a correctness defect.

packages/compiler/src/compatibility/devHotReload.ts — ESM_MODULE_TYPES is missing "bundler", which is the TypeScript 5.0 mode recommended for Vite projects.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/compiler/src/compatibility/devHotReload.ts | New module format resolver with extension, tsconfig, and syntax-based detection; module: "bundler" (TypeScript 5.0+) falls into unknown and triggers a spurious warning for Vite users |
| packages/compiler/src/index.ts | Integrates ModuleFormatResolver with warn-once flag; warning is correctly gated on devHotReloadActive, hasCollectionContent, shouldWarn, and a per-instance flag |
| packages/compiler/src/diagnostics.ts | New diagnostic helper for CJS/unknown format warning; structured message with actionable fix and docs link |
| packages/compiler/src/compatibility/__tests__/devHotReload.test.ts | Good unit test coverage for extension, tsconfig, and syntax-based detection paths; covers cjs/esm/unknown outcomes and mixed-syntax edge cases |
| packages/compiler/src/__tests__/index.test.ts | New integration tests verify warn-on-CJS and no-warn-on-ES2022 paths through the full plugin transform pipeline |
| .changeset/quiet-pandas-warn.md | Patch changeset for @generaltranslation/compiler; correctly scoped as a non-breaking warning addition |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["transform(code, id)"] --> B{devHotReloadActive\n&& hasCollectionContent\n&& !warningShown\n&& shouldWarn?}
    B -->|No| F[Run runtimeTranslatePass\nif devHotReloadActive]
    B -->|Yes| C[ModuleFormatResolver.resolve]
    C --> D1{Extension\n.cjs/.cts → cjs\n.mjs/.mts → esm}
    D1 -->|Match| E1[Return detection]
    D1 -->|No match| D2{getTsconfig:\nmodule setting?}
    D2 -->|commonjs| E2[format: cjs]
    D2 -->|ESM_MODULE_TYPES| E3[format: esm]
    D2 -->|Other/node16/none| E4[format: unknown]
    D2 -->|Not found| D3[detectFromSyntax]
    D3 -->|import/export only| E5[format: esm]
    D3 -->|require/exports only| E6[format: cjs]
    D3 -->|Mixed or neither| E7[format: unknown]
    E1 --> G{format === esm?}
    E2 --> G
    E3 --> G
    E4 --> G
    E5 --> G
    E6 --> G
    E7 --> G
    G -->|No - cjs/unknown| H[console.warn\nset warningShown=true]
    G -->|Yes - esm| F
    H --> F
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["transform(code, id)"] --> B{devHotReloadActive\n&& hasCollectionContent\n&& !warningShown\n&& shouldWarn?}
    B -->|No| F[Run runtimeTranslatePass\nif devHotReloadActive]
    B -->|Yes| C[ModuleFormatResolver.resolve]
    C --> D1{Extension\n.cjs/.cts → cjs\n.mjs/.mts → esm}
    D1 -->|Match| E1[Return detection]
    D1 -->|No match| D2{getTsconfig:\nmodule setting?}
    D2 -->|commonjs| E2[format: cjs]
    D2 -->|ESM_MODULE_TYPES| E3[format: esm]
    D2 -->|Other/node16/none| E4[format: unknown]
    D2 -->|Not found| D3[detectFromSyntax]
    D3 -->|import/export only| E5[format: esm]
    D3 -->|require/exports only| E6[format: cjs]
    D3 -->|Mixed or neither| E7[format: unknown]
    E1 --> G{format === esm?}
    E2 --> G
    E3 --> G
    E4 --> G
    E5 --> G
    E6 --> G
    E7 --> G
    G -->|No - cjs/unknown| H[console.warn\nset warningShown=true]
    G -->|Yes - esm| F
    H --> F
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(compiler): simplify module format wa..."](https://github.com/generaltranslation/gt/commit/58101ea41592b4d908c31a360469e5290185baf1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45190002)</sub>

<!-- /greptile_comment -->