### PR TITLE
fix(compiler): configure automatic JSX import source

### DIFF
--- a/.changeset/clean-pianos-inject.md
+++ b/.changeset/clean-pianos-inject.md
@@ -1,0 +1,5 @@
+---
+'@generaltranslation/compiler': patch
+---
+
+Allow framework integrations to configure the package used for automatic JSX injection imports.

--- a/packages/compiler/src/config.ts
+++ b/packages/compiler/src/config.ts
@@ -44,6 +44,8 @@ export interface PluginConfig {
   stringTranslationMacro?: string;
   /** Enable Auto Jsx Injection (e.g. <div>Hello</div> -> <div><T>Hello</T></div>) */
   enableAutoJsxInjection?: boolean;
+  /** Package source for components inserted by Auto JSX Injection */
+  autoJsxImportSource?: string;
   /** Automatically treat interpolated/concatenated values as derive() calls */
   autoderive?: boolean | { jsx?: boolean; strings?: boolean };
   /** Emit compiler-injected gt-react imports from gt-react/browser */
@@ -70,6 +72,8 @@ export interface PluginSettings {
   enableMacroImportInjection: boolean;
   /** Enable Auto Jsx Injection (e.g. <div>Hello</div> -> <div><T>Hello</T></div>) */
   enableAutoJsxInjection: boolean;
+  /** Package source for components inserted by Auto JSX Injection */
+  autoJsxImportSource?: string;
   /** Automatically treat interpolated/concatenated values as derive() calls */
   autoderive: { jsx: boolean; strings: boolean };
   /** Emit compiler-injected gt-react imports from gt-react/browser */

--- a/packages/compiler/src/passes/__tests__/jsxInsertionEdgeCases.test.ts
+++ b/packages/compiler/src/passes/__tests__/jsxInsertionEdgeCases.test.ts
@@ -506,6 +506,18 @@ describe('jsxInsertionPass edge cases', () => {
       expect(gtImports).toHaveLength(1);
     });
 
+    it('injects import from a configured source', () => {
+      const code = `
+        import { jsx } from 'react/jsx-runtime';
+        jsx("div", { children: "Hello" });
+      `;
+      const { imports } = transform(code, {
+        autoJsxImportSource: 'gt-next',
+      });
+      const gtImports = imports.filter((i) => i.source.value === 'gt-next');
+      expect(gtImports).toHaveLength(1);
+    });
+
     it('does not inject duplicate import when already imported', () => {
       const code = `
         import { GtInternalTranslateJsx, GtInternalVar } from 'gt-react/browser';
@@ -517,6 +529,19 @@ describe('jsxInsertionPass edge cases', () => {
         (i) => i.source.value === 'gt-react/browser'
       );
       expect(gtImports).toHaveLength(1); // no duplicate
+    });
+
+    it('does not duplicate an import from a configured source', () => {
+      const code = `
+        import { GtInternalTranslateJsx, GtInternalVar } from '@acme/gt';
+        import { jsx } from 'react/jsx-runtime';
+        jsx("div", { children: "Hello" });
+      `;
+      const { imports } = transform(code, {
+        autoJsxImportSource: '@acme/gt',
+      });
+      const gtImports = imports.filter((i) => i.source.value === '@acme/gt');
+      expect(gtImports).toHaveLength(1);
     });
   });
 

--- a/packages/compiler/src/passes/jsxInsertionPass.ts
+++ b/packages/compiler/src/passes/jsxInsertionPass.ts
@@ -28,7 +28,11 @@ export function jsxInsertionPass(state: TransformState): TraverseOptions {
   };
 
   return {
-    ImportDeclaration: processImportDeclaration(onImportFound, calleeInfo),
+    ImportDeclaration: processImportDeclaration(
+      onImportFound,
+      calleeInfo,
+      state.settings.autoJsxImportSource
+    ),
     CallExpression: processCallExpression(state, calleeInfo),
     Program: processProgram({
       state,

--- a/packages/compiler/src/processing/jsx-insertion/processImportDeclaration.ts
+++ b/packages/compiler/src/processing/jsx-insertion/processImportDeclaration.ts
@@ -24,7 +24,8 @@ export interface JsxCalleeInfo {
  */
 export function processImportDeclaration(
   onGtImportFound: () => void,
-  calleeInfo: JsxCalleeInfo
+  calleeInfo: JsxCalleeInfo,
+  autoJsxImportSource?: string
 ): VisitNode<t.Node, t.ImportDeclaration> {
   const targetName = GT_COMPONENT_TYPES.GtInternalTranslateJsx;
 
@@ -32,7 +33,7 @@ export function processImportDeclaration(
     const source = path.node.source.value;
 
     // Check for existing GT import
-    if (isGTImportSource(source)) {
+    if (isGTImportSource(source) || source === autoJsxImportSource) {
       for (const specifier of path.node.specifiers) {
         if (
           t.isImportSpecifier(specifier) &&

--- a/packages/compiler/src/processing/jsx-insertion/processProgram.ts
+++ b/packages/compiler/src/processing/jsx-insertion/processProgram.ts
@@ -32,6 +32,7 @@ export function processProgram({
       if (!isAlreadyImported()) {
         injectJsxInsertionImport(
           path,
+          state.settings.autoJsxImportSource,
           state.settings.legacyGtReactImportSource
         );
       }

--- a/packages/compiler/src/transform/jsx-insertion/injectJsxInsertionImport.ts
+++ b/packages/compiler/src/transform/jsx-insertion/injectJsxInsertionImport.ts
@@ -9,6 +9,7 @@ import { getGtReactImportSource } from '../../utils/constants/gt/helpers';
  */
 export function injectJsxInsertionImport(
   path: NodePath<t.Program>,
+  autoJsxImportSource: string | undefined,
   legacyGtReactImportSource: boolean
 ): void {
   const tName = GT_COMPONENT_TYPES.GtInternalTranslateJsx;
@@ -19,7 +20,9 @@ export function injectJsxInsertionImport(
       t.importSpecifier(t.identifier(tName), t.identifier(tName)),
       t.importSpecifier(t.identifier(varName), t.identifier(varName)),
     ],
-    t.stringLiteral(getGtReactImportSource(legacyGtReactImportSource))
+    t.stringLiteral(
+      autoJsxImportSource ?? getGtReactImportSource(legacyGtReactImportSource)
+    )
   );
 
   path.unshiftContainer('body', importDecl);


### PR DESCRIPTION
## Summary

- make the compiler's automatic JSX component import source configurable for framework integrations
- preserve the existing `gt-react` and `gt-react/browser` defaults
- recognize configured import sources when avoiding duplicate injected imports

## Testing

- `pnpm --filter @generaltranslation/compiler test` — passed (636 tests, 11 skipped)
- `pnpm --filter @generaltranslation/compiler typecheck` — passed
- targeted `oxlint` and `oxfmt --check` on all changed compiler files — passed

## Notes

- Changeset: patch release for `@generaltranslation/compiler`.
- Parent of #1921, which contains all gt-next integration changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes the automatic JSX component injection import source configurable via a new `autoJsxImportSource` option in `PluginConfig`/`PluginSettings`, allowing framework integrations (e.g., `gt-next`) to supply their own package instead of always defaulting to `gt-react`/`gt-react/browser`. The change is backward-compatible: `autoJsxImportSource` is optional and the existing `legacyGtReactImportSource` fallback is preserved.

- Adds `autoJsxImportSource?: string` to both `PluginConfig` and `PluginSettings` in `config.ts`, and threads it through `jsxInsertionPass` → `processImportDeclaration` (deduplication check) and `processProgram` → `injectJsxInsertionImport` (actual import construction).
- Deduplication in `processImportDeclaration` is extended from `isGTImportSource(source)` alone to `isGTImportSource(source) || source === autoJsxImportSource`, preventing a double-inject when the configured source already appears in the file.
- Two new integration tests validate the injection-from-configured-source and no-duplicate-import behaviours.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a well-scoped, backward-compatible extension that only activates when the new optional field is explicitly set.

The new `autoJsxImportSource` option is threaded cleanly through the pipeline with correct nullish-coalescing fallbacks preserving all existing defaults. The deduplication logic is extended correctly, two targeted tests cover both new paths, and no existing behaviour is altered when the field is absent.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/compiler/src/config.ts | Adds optional `autoJsxImportSource?: string` to both `PluginConfig` and `PluginSettings`; no logic changes, clean addition. |
| packages/compiler/src/passes/jsxInsertionPass.ts | Threads `state.settings.autoJsxImportSource` into `processImportDeclaration`; minimal, correct change. |
| packages/compiler/src/processing/jsx-insertion/processImportDeclaration.ts | Extends duplicate-import guard to include `source === autoJsxImportSource`; backward-compatible and well-scoped. |
| packages/compiler/src/processing/jsx-insertion/processProgram.ts | Passes `autoJsxImportSource` to `injectJsxInsertionImport`; straightforward plumbing change. |
| packages/compiler/src/transform/jsx-insertion/injectJsxInsertionImport.ts | Uses `autoJsxImportSource ?? getGtReactImportSource(legacyGtReactImportSource)` to resolve the import string; correct nullish-coalescing precedence preserves legacy defaults. |
| packages/compiler/src/passes/__tests__/jsxInsertionEdgeCases.test.ts | Adds two targeted tests covering injection from a configured source and deduplication; both are well-structured and cover the intended paths. |
| .changeset/clean-pianos-inject.md | Correct patch-level changeset for the `@generaltranslation/compiler` package. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[jsxInsertionPass] -->|autoJsxImportSource| B[processImportDeclaration]
    A -->|state| C[processProgram]

    B --> D{isGTImportSource OR\nsource === autoJsxImportSource?}
    D -->|Yes, has GtInternalTranslateJsx| E[alreadyImported = true]
    D -->|No| F[collect React jsx callee info]

    C --> G{didInsert AND\nnot alreadyImported?}
    G -->|Yes| H[injectJsxInsertionImport]
    G -->|No| I[skip injection]

    H --> J{autoJsxImportSource\ndefined?}
    J -->|Yes| K["inject from autoJsxImportSource\ne.g. 'gt-next'"]
    J -->|No| L["inject from getGtReactImportSource\n(legacyGtReactImportSource)"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[jsxInsertionPass] -->|autoJsxImportSource| B[processImportDeclaration]
    A -->|state| C[processProgram]

    B --> D{isGTImportSource OR\nsource === autoJsxImportSource?}
    D -->|Yes, has GtInternalTranslateJsx| E[alreadyImported = true]
    D -->|No| F[collect React jsx callee info]

    C --> G{didInsert AND\nnot alreadyImported?}
    G -->|Yes| H[injectJsxInsertionImport]
    G -->|No| I[skip injection]

    H --> J{autoJsxImportSource\ndefined?}
    J -->|Yes| K["inject from autoJsxImportSource\ne.g. 'gt-next'"]
    J -->|No| L["inject from getGtReactImportSource\n(legacyGtReactImportSource)"]
```

</a>
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(compiler): configure automatic JSX i..."](https://github.com/generaltranslation/gt/commit/1068cbcf9c990c4077677dd1ef1f3a0d216c2dfa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45189996)</sub>

<!-- /greptile_comment -->