### PR TITLE
fix(compiler): skip incompatible dev hot reload injection

### DIFF
--- a/.changeset/tidy-dragons-rest.md
+++ b/.changeset/tidy-dragons-rest.md
@@ -1,0 +1,5 @@
+---
+'@generaltranslation/compiler': patch
+---
+
+Skip module-level development hot reload injection when CommonJS or pre-ES2022 module output cannot support top-level await.

--- a/packages/compiler/src/__tests__/index.test.ts
+++ b/packages/compiler/src/__tests__/index.test.ts
@@ -333,7 +333,7 @@ describe('gtUnplugin dev hot reload compatibility', () => {
     }
   });
 
-  it('warns when dev hot reload injects top-level await into CommonJS output', async () => {
+  it('warns and skips module-level dev hot reload for CommonJS output', async () => {
     const cwd = createTempDir();
     fs.writeFileSync(
       path.join(cwd, 'tsconfig.json'),
@@ -348,7 +348,9 @@ describe('gtUnplugin dev hot reload compatibility', () => {
         "import { t } from 'gt-react'; t('Hello');"
       );
 
-      expect(output).toContain('await Promise.all');
+      expect(output).not.toContain('await Promise.all');
+      expect(output).not.toContain('GtInternalRuntimeTranslateString');
+      expect(output).toContain('$_hash');
       expect(warnSpy).toHaveBeenCalledOnce();
       expect(warnSpy.mock.calls[0]?.[0]).toContain(
         '@generaltranslation/compiler Warning:'
@@ -381,6 +383,32 @@ describe('gtUnplugin dev hot reload compatibility', () => {
 
       expect(output).toContain('await Promise.all');
       expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('warns and skips module-level dev hot reload for pre-ES2022 ESM', async () => {
+    const cwd = createTempDir();
+    fs.writeFileSync(
+      path.join(cwd, 'tsconfig.json'),
+      JSON.stringify({ compilerOptions: { module: 'es2020' } })
+    );
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      const output = await transformWithPlugin(
+        { devHotReload: true, gtConfig: {} },
+        cwd,
+        "import { t } from 'gt-react'; t('Hello');"
+      );
+
+      expect(output).not.toContain('await Promise.all');
+      expect(output).not.toContain('GtInternalRuntimeTranslateString');
+      expect(warnSpy).toHaveBeenCalledOnce();
+      expect(warnSpy.mock.calls[0]?.[0]).toContain(
+        'Detected module type: es2020.'
+      );
     } finally {
       warnSpy.mockRestore();
     }

--- a/packages/compiler/src/diagnostics.ts
+++ b/packages/compiler/src/diagnostics.ts
@@ -19,11 +19,11 @@ export function createIncompatibleDevHotReloadWarning(
   return createCompilerDiagnostic({
     severity: 'Warning',
     whatHappened:
-      'Development hot reload is enabled for a module format that does not support it',
-    reassurance: 'Production translations are unaffected.',
+      'Module-level development hot reload was disabled for an incompatible module format',
+    reassurance:
+      'Production translations and the rest of the compilation continue normally.',
     why: 'development hot reload injects top-level await, which requires ES2022 modules',
     fix: 'Compile the application as ES2022 or ESNext ESM',
-    wayOut: 'disable devHotReload in gt.config.json',
     details: `Detected module type: ${compatibility.detectedModuleType}`,
     docsUrl:
       'https://generaltranslation.com/en/docs/react/guides/developing-spa-translations',

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -276,24 +276,28 @@ const gtUnplugin = createUnplugin<GTUnpluginOptions | undefined>(
           const devHotReloadActive =
             state.settings.devHotReload.strings ||
             state.settings.devHotReload.jsx;
+          // The runtime translate pass injects top-level await, so keep the
+          // rest of the pipeline active while skipping only this pass for
+          // output formats that cannot represent it.
+          const devHotReloadCompatibility =
+            devHotReloadActive && hasCollectionContent
+              ? devHotReloadCompatibilityResolver.resolve(id, ast)
+              : { compatible: true as const };
           if (
-            devHotReloadActive &&
-            hasCollectionContent &&
+            !devHotReloadCompatibility.compatible &&
             !incompatibleDevHotReloadWarningShown &&
             shouldWarn(state.settings.logLevel)
           ) {
-            const compatibility = devHotReloadCompatibilityResolver.resolve(
-              id,
-              ast
+            console.warn(
+              createIncompatibleDevHotReloadWarning(devHotReloadCompatibility)
             );
-            if (!compatibility.compatible) {
-              console.warn(
-                createIncompatibleDevHotReloadWarning(compatibility)
-              );
-              incompatibleDevHotReloadWarningShown = true;
-            }
+            incompatibleDevHotReloadWarningShown = true;
           }
-          if (devHotReloadActive && hasCollectionContent) {
+          if (
+            devHotReloadActive &&
+            hasCollectionContent &&
+            devHotReloadCompatibility.compatible
+          ) {
             traverse(ast, runtimeTranslatePass(state));
           }
 


### PR DESCRIPTION
## Summary

- Skip the compiler's module-level runtime translation pass when the resolved module output is CommonJS or older than ES2022.
- Preserve compile-time hashes, ordinary compiler transforms, and production translations while avoiding unsupported top-level `await` output.
- Update the diagnostic to explain that only module-level development hot reload was disabled and compilation continues normally.

## Testing

- `pnpm --filter @generaltranslation/compiler test` — passed (647 passed, 11 skipped)
- `pnpm --filter @generaltranslation/compiler typecheck` — passed
- `pnpm --filter @generaltranslation/compiler build` — passed
- `pnpm --filter @generaltranslation/compiler format` — passed
- `pnpm exec oxlint packages/compiler/src` — passed

## Notes

- Changeset: patch for `@generaltranslation/compiler`.
- Stack: based on #1917, which adds the compatibility resolver and warning. Review this PR as the automatic fallback layer on top of that base.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a defect where the runtime-translate pass (which injects top-level `await`) ran unconditionally whenever `devHotReload` was active, even for CommonJS or pre-ES2022 module output that cannot represent top-level `await`. The fix eagerly resolves module compatibility before the pass and skips only the runtime-translate traversal when incompatible, leaving compile-time hash injection and all other compiler passes intact.

- `index.ts`: compatibility is now resolved once per file transform and both the warning and the pass gate share that result; the shortcut `{ compatible: true }` for the no-op cases is safe because the pass guard still checks `devHotReloadActive && hasCollectionContent`.
- `diagnostics.ts`: warning copy is updated to clarify that compilation continues; the `wayOut` field is removed since the feature now auto-disables.
- `index.test.ts`: CommonJS test is updated to assert the pass is skipped, and a new test covers pre-ES2022 ESM (`es2020`).

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the change correctly gates the runtime-translate traversal and preserves all other compiler passes for incompatible module formats.

The core logic is correct and well-tested. The only gap is that the new es2020 test omits the compile-time hash assertion that the equivalent CJS test includes, leaving the hashes-are-preserved guarantee unverified for the legacy-ESM path.

packages/compiler/src/__tests__/index.test.ts — the es2020 test case could be more thorough
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/compiler/src/index.ts | Refactors Pass 5 to eagerly resolve module compatibility and gates the runtime-translate traversal on that result; fixes the pre-existing defect where the pass ran (and injected top-level await) even on incompatible output formats |
| packages/compiler/src/__tests__/index.test.ts | Updates the CommonJS test to assert the pass is now skipped, and adds a new test for pre-ES2022 ESM (es2020); the es2020 test omits the compile-time hash assertion that the CJS test includes |
| packages/compiler/src/diagnostics.ts | Updates warning copy to reflect that compilation continues; removes the now-unnecessary wayOut field since the feature auto-disables itself |
| .changeset/tidy-dragons-rest.md | Correct patch-level changeset entry for the compiler package |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[transform called for file] --> B{devHotReloadActive AND hasCollectionContent?}
    B -- No --> C[devHotReloadCompatibility = compatible true]
    B -- Yes --> D[resolver.resolve id and ast]
    D --> E{compatible?}
    E -- No --> F[devHotReloadCompatibility = compatible false]
    E -- Yes --> G[devHotReloadCompatibility = compatible true]
    C --> H{not compatible AND not warningShown AND shouldWarn?}
    F --> H
    G --> H
    H -- Yes --> I[emit incompatible dev hot reload warning, set warningShown true]
    H -- No --> J{devHotReloadActive AND hasCollectionContent AND compatible?}
    I --> J
    J -- Yes --> K[traverse runtimeTranslatePass]
    J -- No --> L[skip runtimeTranslatePass, hashes and other passes preserved]
    K --> M[generate code]
    L --> M
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[transform called for file] --> B{devHotReloadActive AND hasCollectionContent?}
    B -- No --> C[devHotReloadCompatibility = compatible true]
    B -- Yes --> D[resolver.resolve id and ast]
    D --> E{compatible?}
    E -- No --> F[devHotReloadCompatibility = compatible false]
    E -- Yes --> G[devHotReloadCompatibility = compatible true]
    C --> H{not compatible AND not warningShown AND shouldWarn?}
    F --> H
    G --> H
    H -- Yes --> I[emit incompatible dev hot reload warning, set warningShown true]
    H -- No --> J{devHotReloadActive AND hasCollectionContent AND compatible?}
    I --> J
    J -- Yes --> K[traverse runtimeTranslatePass]
    J -- No --> L[skip runtimeTranslatePass, hashes and other passes preserved]
    K --> M[generate code]
    L --> M
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fcompiler%2Fsrc%2F__tests__%2Findex.test.ts%3A406-408%0AThe%20new%20%60es2020%60%20test%20doesn't%20assert%20that%20compile-time%20hashes%20are%20still%20emitted%2C%20whereas%20the%20CJS%20test%20at%20line%20353%20does%20%28%60expect%28output%29.toContain%28'%24_hash'%29%60%29.%20The%20PR%20description%20explicitly%20calls%20out%20%22Preserve%20compile-time%20hashes%22%20as%20a%20goal%20for%20both%20skipped%20cases%2C%20so%20the%20assertion%20should%20be%20consistent%20to%20actually%20verify%20that%20invariant.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20expect%28output%29.not.toContain%28'await%20Promise.all'%29%3B%0A%20%20%20%20%20%20expect%28output%29.not.toContain%28'GtInternalRuntimeTranslateString'%29%3B%0A%20%20%20%20%20%20expect%28output%29.toContain%28'%24_hash'%29%3B%0A%20%20%20%20%20%20expect%28warnSpy%29.toHaveBeenCalledOnce%28%29%3B%0A%60%60%60%0A%0A&repo=generaltranslation%2Fgt&pr=1919&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fcompiler%2Fdisable-incompatible-dev-hot-reload%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fcompiler%2Fdisable-incompatible-dev-hot-reload%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fcompiler%2Fsrc%2F__tests__%2Findex.test.ts%3A406-408%0AThe%20new%20%60es2020%60%20test%20doesn't%20assert%20that%20compile-time%20hashes%20are%20still%20emitted%2C%20whereas%20the%20CJS%20test%20at%20line%20353%20does%20%28%60expect%28output%29.toContain%28'%24_hash'%29%60%29.%20The%20PR%20description%20explicitly%20calls%20out%20%22Preserve%20compile-time%20hashes%22%20as%20a%20goal%20for%20both%20skipped%20cases%2C%20so%20the%20assertion%20should%20be%20consistent%20to%20actually%20verify%20that%20invariant.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20expect%28output%29.not.toContain%28'await%20Promise.all'%29%3B%0A%20%20%20%20%20%20expect%28output%29.not.toContain%28'GtInternalRuntimeTranslateString'%29%3B%0A%20%20%20%20%20%20expect%28output%29.toContain%28'%24_hash'%29%3B%0A%20%20%20%20%20%20expect%28warnSpy%29.toHaveBeenCalledOnce%28%29%3B%0A%60%60%60%0A%0A&repo=generaltranslation%2Fgt&pr=1919&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/compiler/src/__tests__/index.test.ts:406-408
The new `es2020` test doesn't assert that compile-time hashes are still emitted, whereas the CJS test at line 353 does (`expect(output).toContain('$_hash')`). The PR description explicitly calls out "Preserve compile-time hashes" as a goal for both skipped cases, so the assertion should be consistent to actually verify that invariant.

```suggestion
      expect(output).not.toContain('await Promise.all');
      expect(output).not.toContain('GtInternalRuntimeTranslateString');
      expect(output).toContain('$_hash');
      expect(warnSpy).toHaveBeenCalledOnce();
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(compiler): skip incompatible dev hot..."](https://github.com/generaltranslation/gt/commit/c16fc84c1cc6ded11343bc7eeb052b28b2c09b8f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45190387)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->