### PR TITLE
feat(cli): add global --quiet/-q flag to suppress informational output

### DIFF
--- a/.changeset/cli-quiet-flag.md
+++ b/.changeset/cli-quiet-flag.md
@@ -1,0 +1,5 @@
+---
+'gt': minor
+---
+
+Add a global `--quiet` / `-q` flag to the CLI that suppresses informational output. Warnings, errors, exit codes, and machine-readable (`GT_LOG_FORMAT=json`) output are unchanged; only the info/step/success/spinner chatter and the ASCII banner are muted. The flag takes precedence over `GT_LOG_LEVEL` without lowering an already-more-restrictive level, and interactive prompts still run when a command genuinely needs input.

--- a/.changeset/cli-quiet-flag.md
+++ b/.changeset/cli-quiet-flag.md
@@ -2,4 +2,4 @@
 'gt': minor
 ---
 
-Add a global `--quiet` / `-q` flag to the CLI that suppresses informational output. Warnings, errors, exit codes, and machine-readable (`GT_LOG_FORMAT=json`) output are unchanged; only the info/step/success/spinner chatter and the ASCII banner are muted. The flag takes precedence over `GT_LOG_LEVEL` without lowering an already-more-restrictive level, and interactive prompts still run when a command genuinely needs input.
+Add a global `--quiet` / `-q` flag to the CLI that suppresses informational output. Under `--quiet` the CLI drops the info/step/success/spinner chatter and the ASCII banner in both the default and `GT_LOG_FORMAT=json` paths, while warnings, errors, exit codes, and command results stay the same. In JSON mode the remaining output keeps its shape: only info/debug/trace lines are dropped, and warn/error and above still print. The flag takes precedence over `GT_LOG_LEVEL` without lowering an already-more-restrictive level, and interactive prompts still run when a command genuinely needs input.

--- a/packages/cli/src/cli/base.ts
+++ b/packages/cli/src/cli/base.ts
@@ -125,6 +125,17 @@ export class BaseCLI {
       '--suppress-id-compatibility-warning',
       'Suppress the React package ID compatibility warning'
     );
+    this.program.option(
+      '-q, --quiet',
+      'Suppress informational output; only warnings and errors are shown'
+    );
+    // Apply --quiet before any other hook or command action runs so the
+    // singleton logger is muted for the rest of the invocation. The flag is a
+    // global root option, so commander resolves it in any position and for
+    // nested commands (e.g. `gt git setup --quiet`).
+    this.program.hook('preAction', () => {
+      logger.setQuiet(Boolean(this.program.opts().quiet));
+    });
     this.program.hook('preAction', async (thisCommand, actionCommand) => {
       // Nested commands (e.g. `gt git setup`) can share leaf names with
       // translation commands; only direct children of the root qualify

--- a/packages/cli/src/cli/inline.ts
+++ b/packages/cli/src/cli/inline.ts
@@ -8,8 +8,6 @@ import {
 } from './flags.js';
 import { displayHeader, exitSync } from '../console/logging.js';
 import { logger } from '../console/logger.js';
-import { intro } from '@clack/prompts';
-import chalk from 'chalk';
 import { resolveLocaleFiles } from '../fs/config/parseFilesConfig.js';
 import { noFilesError } from '../console/index.js';
 import { saveJSON } from '../fs/saveJSON.js';
@@ -81,8 +79,9 @@ export class InlineCLI extends BaseCLI {
           'Scans the project for a dictionary and/or inline content and validates the project for errors.'
         )
     ).action(async (files: string[], options: Options) => {
-      // intro here since we don't want to show the ascii title
-      intro(chalk.cyan('Validating project...'));
+      // startCommand here since we don't want to show the ascii title; it
+      // renders the same intro while honoring --quiet.
+      logger.startCommand('Validating project...');
       await this.handleValidate(options, files);
       logger.endCommand('Done!');
     });

--- a/packages/cli/src/console/__tests__/quiet.test.ts
+++ b/packages/cli/src/console/__tests__/quiet.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 // Mock @clack/prompts so we can assert exactly which chatter reaches the
 // human (default-format) output path.
@@ -39,7 +40,7 @@ vi.mock('@clack/prompts', () => clack);
 // Mock pino so we can inspect the level the JSON console logger is created
 // with and the level --quiet forces it to.
 const pinoState = vi.hoisted(() => ({
-  instances: [] as Array<{ level?: string }>,
+  instances: [] as Array<{ level?: string; info: Mock }>,
   optionsLog: [] as Array<{ level?: string }>,
 }));
 
@@ -178,6 +179,28 @@ describe('quiet flag: displayHeader banner gating (default format)', () => {
     logger.setQuiet(true);
     displayHeader('Doing a thing...');
     expect(logSpy).not.toHaveBeenCalled();
+
+    logSpy.mockRestore();
+  });
+
+  it('still writes the [START] file-log marker under quiet', async () => {
+    vi.stubEnv('GT_LOG_FILE', '/tmp/gt-quiet-marker-test.log');
+    const { logger } = await import('../logger.js');
+    const { displayHeader } = await import('../logging.js');
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    logger.setQuiet(true);
+    displayHeader('Doing a thing...');
+
+    // Console stays silent: no banner, no clack intro.
+    expect(logSpy).not.toHaveBeenCalled();
+    expect(clack.intro).not.toHaveBeenCalled();
+    // But the file log still gets its [START] marker, so [END] from
+    // endCommand never appears unpaired.
+    const fileInfoCalls = pinoState.instances.flatMap((inst) =>
+      inst.info.mock.calls.map((call) => call[0])
+    );
+    expect(fileInfoCalls).toContain('[START] Doing a thing...');
 
     logSpy.mockRestore();
   });

--- a/packages/cli/src/console/__tests__/quiet.test.ts
+++ b/packages/cli/src/console/__tests__/quiet.test.ts
@@ -1,0 +1,295 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock @clack/prompts so we can assert exactly which chatter reaches the
+// human (default-format) output path.
+const clack = vi.hoisted(() => ({
+  text: vi.fn(),
+  select: vi.fn(),
+  confirm: vi.fn(),
+  multiselect: vi.fn(),
+  isCancel: vi.fn(() => false),
+  cancel: vi.fn(),
+  log: {
+    message: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    success: vi.fn(),
+    step: vi.fn(),
+  },
+  spinner: vi.fn(() => ({
+    start: vi.fn(),
+    stop: vi.fn(),
+    message: vi.fn(),
+    isCancelled: false,
+  })),
+  progress: vi.fn(() => ({
+    start: vi.fn(),
+    stop: vi.fn(),
+    message: vi.fn(),
+    advance: vi.fn(),
+    isCancelled: false,
+  })),
+  intro: vi.fn(),
+  outro: vi.fn(),
+}));
+
+vi.mock('@clack/prompts', () => clack);
+
+// Mock pino so we can inspect the level the JSON console logger is created
+// with and the level --quiet forces it to.
+const pinoState = vi.hoisted(() => ({
+  instances: [] as Array<{ level?: string }>,
+  optionsLog: [] as Array<{ level?: string }>,
+}));
+
+const pinoMock = vi.hoisted(() => {
+  const makeInstance = (opts?: { level?: string }) => {
+    const inst = {
+      level: opts?.level,
+      trace: vi.fn(),
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      fatal: vi.fn(),
+      silent: vi.fn(),
+      flush: vi.fn(),
+    };
+    return inst;
+  };
+  const pino = vi.fn((opts?: { level?: string }) => {
+    pinoState.optionsLog.push({ level: opts?.level });
+    const inst = makeInstance(opts);
+    pinoState.instances.push(inst);
+    return inst;
+  });
+  return { pino, destination: vi.fn(() => ({})) };
+});
+
+vi.mock('pino', () => pinoMock);
+
+function resetPinoState() {
+  pinoState.instances.length = 0;
+  pinoState.optionsLog.length = 0;
+}
+
+describe('quiet flag: clack chatter gating (default format)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    resetPinoState();
+    vi.stubEnv('GT_LOG_FORMAT', 'default');
+    vi.stubEnv('GT_LOG_LEVEL', '');
+    vi.stubEnv('GT_LOG_FILE', '');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('suppresses info/step/success/message chatter under quiet', async () => {
+    const { logger } = await import('../logger.js');
+    logger.setQuiet(true);
+
+    logger.info('an info');
+    logger.step('a step');
+    logger.success('a success');
+    logger.message('a message');
+    logger.debug('a debug');
+    logger.startCommand('start');
+    logger.endCommand('end');
+
+    expect(clack.log.info).not.toHaveBeenCalled();
+    expect(clack.log.step).not.toHaveBeenCalled();
+    expect(clack.log.success).not.toHaveBeenCalled();
+    expect(clack.log.message).not.toHaveBeenCalled();
+    expect(clack.intro).not.toHaveBeenCalled();
+    expect(clack.outro).not.toHaveBeenCalled();
+  });
+
+  it('still emits warnings and errors under quiet', async () => {
+    const { logger } = await import('../logger.js');
+    logger.setQuiet(true);
+
+    logger.warn('a warning');
+    logger.error('an error');
+
+    expect(clack.log.warn).toHaveBeenCalledWith('a warning');
+    expect(clack.log.error).toHaveBeenCalledWith('an error');
+  });
+
+  it('emits chatter normally when not quiet', async () => {
+    const { logger } = await import('../logger.js');
+
+    logger.info('an info');
+    logger.step('a step');
+    logger.success('a success');
+
+    expect(clack.log.info).toHaveBeenCalledWith('an info');
+    expect(clack.log.step).toHaveBeenCalledWith('a step');
+    expect(clack.log.success).toHaveBeenCalledWith('a success');
+  });
+
+  it('returns a silent spinner that emits nothing under quiet', async () => {
+    const { logger } = await import('../logger.js');
+    logger.setQuiet(true);
+
+    const sp = logger.createSpinner();
+    sp.start('working');
+    sp.message('still working');
+    sp.stop('done');
+
+    expect(clack.spinner).not.toHaveBeenCalled();
+    expect(clack.log.info).not.toHaveBeenCalled();
+  });
+
+  it('reports quiet state via isQuiet()', async () => {
+    const { logger } = await import('../logger.js');
+    expect(logger.isQuiet()).toBe(false);
+    logger.setQuiet(true);
+    expect(logger.isQuiet()).toBe(true);
+  });
+});
+
+describe('quiet flag: displayHeader banner gating (default format)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    resetPinoState();
+    vi.stubEnv('GT_LOG_FORMAT', 'default');
+    vi.stubEnv('GT_LOG_LEVEL', '');
+    vi.stubEnv('GT_LOG_FILE', '');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('prints the ASCII banner when not quiet but nothing when quiet', async () => {
+    const { logger } = await import('../logger.js');
+    const { displayHeader } = await import('../logging.js');
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    displayHeader('Doing a thing...');
+    expect(logSpy).toHaveBeenCalled();
+
+    logSpy.mockClear();
+    logger.setQuiet(true);
+    displayHeader('Doing a thing...');
+    expect(logSpy).not.toHaveBeenCalled();
+
+    logSpy.mockRestore();
+  });
+});
+
+describe('quiet flag: pino level gating (json format)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    resetPinoState();
+    vi.stubEnv('GT_LOG_FORMAT', 'json');
+    vi.stubEnv('GT_LOG_FILE', '');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('honors GT_LOG_LEVEL when constructing the console logger', async () => {
+    vi.stubEnv('GT_LOG_LEVEL', 'debug');
+    await import('../logger.js');
+    expect(pinoState.optionsLog[0]?.level).toBe('debug');
+  });
+
+  it('raises the pino level to warn under quiet (quiet wins over GT_LOG_LEVEL=debug)', async () => {
+    vi.stubEnv('GT_LOG_LEVEL', 'debug');
+    const { logger } = await import('../logger.js');
+    expect(pinoState.instances[0]?.level).toBe('debug');
+    logger.setQuiet(true);
+    expect(pinoState.instances[0]?.level).toBe('warn');
+  });
+
+  it('defaults to info then warn under quiet when GT_LOG_LEVEL is unset', async () => {
+    vi.stubEnv('GT_LOG_LEVEL', '');
+    const { logger } = await import('../logger.js');
+    expect(pinoState.instances[0]?.level).toBe('info');
+    logger.setQuiet(true);
+    expect(pinoState.instances[0]?.level).toBe('warn');
+  });
+
+  it('does not lower an already-restrictive level (error stays error under quiet)', async () => {
+    vi.stubEnv('GT_LOG_LEVEL', 'error');
+    const { logger } = await import('../logger.js');
+    logger.setQuiet(true);
+    expect(pinoState.instances[0]?.level).toBe('error');
+  });
+
+  it('still routes warnings and errors to pino under quiet', async () => {
+    vi.stubEnv('GT_LOG_LEVEL', 'debug');
+    const { logger } = await import('../logger.js');
+    logger.setQuiet(true);
+    logger.warn('a warning');
+    logger.error('an error');
+    expect(pinoState.instances[0]?.warn).toHaveBeenCalledWith('a warning');
+    expect(pinoState.instances[0]?.error).toHaveBeenCalledWith('an error');
+  });
+});
+
+describe('quiet flag: parsing (global -q / --quiet)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    resetPinoState();
+    vi.stubEnv('GT_LOG_FORMAT', 'default');
+    vi.stubEnv('GT_LOG_LEVEL', '');
+    vi.stubEnv('GT_LOG_FILE', '');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  async function buildProgram() {
+    const { BaseCLI } = await import('../../cli/base.js');
+    const { Libraries } = await import('../../types/libraries.js');
+    const { Command } = await import('commander');
+    const program = new Command();
+    program.name('gt');
+    new BaseCLI(program, Libraries.GT_REACT);
+    program.exitOverride();
+    program.command('noop').action(() => {});
+    return program;
+  }
+
+  it('registers -q, --quiet on the root program', async () => {
+    const program = await buildProgram();
+    const opt = program.options.find((o) => o.long === '--quiet');
+    expect(opt).toBeTruthy();
+    expect(opt?.short).toBe('-q');
+  });
+
+  it('parses --quiet before the subcommand', async () => {
+    const program = await buildProgram();
+    program.parse(['--quiet', 'noop'], { from: 'user' });
+    expect(program.opts().quiet).toBe(true);
+  });
+
+  it('parses --quiet after the subcommand', async () => {
+    const program = await buildProgram();
+    program.parse(['noop', '--quiet'], { from: 'user' });
+    expect(program.opts().quiet).toBe(true);
+  });
+
+  it('parses -q after the subcommand', async () => {
+    const program = await buildProgram();
+    program.parse(['noop', '-q'], { from: 'user' });
+    expect(program.opts().quiet).toBe(true);
+  });
+
+  it('leaves quiet unset when the flag is absent', async () => {
+    const program = await buildProgram();
+    program.parse(['noop'], { from: 'user' });
+    expect(program.opts().quiet).toBeFalsy();
+  });
+});

--- a/packages/cli/src/console/logger.ts
+++ b/packages/cli/src/console/logger.ts
@@ -42,6 +42,20 @@ function wrapTerminalSessionAware<T extends SpinnerResult | ProgressResult>(
 }
 
 export type LogFormat = 'default' | 'json';
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+// Numeric ordering used to decide the quiet floor without lowering an
+// already-more-restrictive level chosen via GT_LOG_LEVEL.
+const LOG_LEVEL_RANK: Record<LogLevel, number> = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+};
+
+// Under --quiet, informational output is suppressed but warnings and errors
+// still print, so the console never drops below this level.
+const QUIET_FLOOR_LEVEL: LogLevel = 'warn';
 
 // Mock spinner that logs to console instead of updating terminal UI
 class MockSpinner implements SpinnerResult {
@@ -124,6 +138,8 @@ class Logger {
   private pinoLogger: PinoLogger | null = null;
   private fileLogger: PinoLogger | null = null;
   private logFormat: LogFormat;
+  private logLevel: LogLevel;
+  private quiet = false;
 
   private constructor() {
     // Read configuration from environment variables
@@ -148,6 +164,7 @@ class Logger {
     }
 
     this.logFormat = format;
+    this.logLevel = logLevel as LogLevel;
 
     // Console output (stdout) - only for JSON format
     // For 'default' format, we use @clack/prompts directly
@@ -184,35 +201,64 @@ class Logger {
     return Logger.instance;
   }
 
+  /**
+   * Enable or disable quiet mode. When quiet, informational chatter
+   * (info/step/success/message/debug/trace, spinners, progress bars, and
+   * command intro/outro markers) is suppressed on the console, while warnings
+   * and errors still print. Quiet wins over GT_LOG_LEVEL but never lowers an
+   * already-more-restrictive level. File logging is unaffected so an explicit
+   * GT_LOG_FILE still captures everything.
+   */
+  setQuiet(quiet: boolean): void {
+    this.quiet = quiet;
+    if (this.pinoLogger) {
+      this.pinoLogger.level = quiet
+        ? LOG_LEVEL_RANK[this.logLevel] > LOG_LEVEL_RANK[QUIET_FLOOR_LEVEL]
+          ? this.logLevel
+          : QUIET_FLOOR_LEVEL
+        : this.logLevel;
+    }
+  }
+
+  isQuiet(): boolean {
+    return this.quiet;
+  }
+
   // Standard logging methods
   trace(message: string): void {
-    if (this.logFormat === 'default') {
-      endTerminalSession();
-      // @clack/prompts doesn't have trace, use message
-      clackLog.message(message, { symbol: chalk.dim('•') });
-    } else {
-      this.pinoLogger?.trace(message);
+    if (!this.quiet) {
+      if (this.logFormat === 'default') {
+        endTerminalSession();
+        // @clack/prompts doesn't have trace, use message
+        clackLog.message(message, { symbol: chalk.dim('•') });
+      } else {
+        this.pinoLogger?.trace(message);
+      }
     }
     this.fileLogger?.trace(message);
   }
 
   debug(message: string): void {
-    if (this.logFormat === 'default') {
-      endTerminalSession();
-      // @clack/prompts doesn't have debug, use message
-      clackLog.message(message, { symbol: chalk.dim('◆') });
-    } else {
-      this.pinoLogger?.debug(message);
+    if (!this.quiet) {
+      if (this.logFormat === 'default') {
+        endTerminalSession();
+        // @clack/prompts doesn't have debug, use message
+        clackLog.message(message, { symbol: chalk.dim('◆') });
+      } else {
+        this.pinoLogger?.debug(message);
+      }
     }
     this.fileLogger?.debug(message);
   }
 
   info(message: string): void {
-    if (this.logFormat === 'default') {
-      endTerminalSession();
-      clackLog.info(message);
-    } else {
-      this.pinoLogger?.info(message);
+    if (!this.quiet) {
+      if (this.logFormat === 'default') {
+        endTerminalSession();
+        clackLog.info(message);
+      } else {
+        this.pinoLogger?.info(message);
+      }
     }
     this.fileLogger?.info(message);
   }
@@ -254,37 +300,48 @@ class Logger {
 
   // @clack/prompts specific methods (for 'default' format)
   success(message: string): void {
-    if (this.logFormat === 'default') {
-      endTerminalSession();
-      clackLog.success(message);
-    } else {
-      this.pinoLogger?.info(message); // Map to info for non-default formats
+    if (!this.quiet) {
+      if (this.logFormat === 'default') {
+        endTerminalSession();
+        clackLog.success(message);
+      } else {
+        this.pinoLogger?.info(message); // Map to info for non-default formats
+      }
     }
     this.fileLogger?.info(message);
   }
 
   step(message: string): void {
-    if (this.logFormat === 'default') {
-      endTerminalSession();
-      clackLog.step(message);
-    } else {
-      this.pinoLogger?.info(message); // Map to info for non-default formats
+    if (!this.quiet) {
+      if (this.logFormat === 'default') {
+        endTerminalSession();
+        clackLog.step(message);
+      } else {
+        this.pinoLogger?.info(message); // Map to info for non-default formats
+      }
     }
     this.fileLogger?.info(message);
   }
 
   message(message: string, symbol?: string): void {
-    if (this.logFormat === 'default') {
-      endTerminalSession();
-      clackLog.message(message, symbol ? { symbol } : undefined);
-    } else {
-      this.pinoLogger?.info(message); // Map to info for non-default formats
+    if (!this.quiet) {
+      if (this.logFormat === 'default') {
+        endTerminalSession();
+        clackLog.message(message, symbol ? { symbol } : undefined);
+      } else {
+        this.pinoLogger?.info(message); // Map to info for non-default formats
+      }
     }
     this.fileLogger?.info(message);
   }
 
   // Spinner functionality
   createSpinner(indicator: 'dots' | 'timer' = 'timer'): SpinnerResult {
+    // Quiet mode suppresses spinner UI; the mock routes through the gated
+    // info() so nothing reaches the console while file logging is preserved.
+    if (this.quiet) {
+      return new MockSpinner(this);
+    }
     if (this.logFormat === 'default') {
       return wrapTerminalSessionAware(spinner({ indicator }));
     } else {
@@ -294,6 +351,9 @@ class Logger {
 
   // Progress bar functionality
   createProgressBar(total: number): ProgressResult {
+    if (this.quiet) {
+      return new MockProgress(total, this);
+    }
     if (this.logFormat === 'default') {
       return wrapTerminalSessionAware(progress({ max: total }));
     } else {
@@ -303,21 +363,25 @@ class Logger {
 
   // Command start/end markers
   startCommand(message: string): void {
-    if (this.logFormat === 'default') {
-      endTerminalSession();
-      intro(chalk.cyan(message));
-    } else {
-      this.info(`╭─ ${message}`);
+    if (!this.quiet) {
+      if (this.logFormat === 'default') {
+        endTerminalSession();
+        intro(chalk.cyan(message));
+      } else {
+        this.info(`╭─ ${message}`);
+      }
     }
     this.fileLogger?.info(`[START] ${message}`);
   }
 
   endCommand(message: string): void {
-    if (this.logFormat === 'default') {
-      endTerminalSession();
-      outro(chalk.cyan(message));
-    } else {
-      this.info(`╰─ ${message}`);
+    if (!this.quiet) {
+      if (this.logFormat === 'default') {
+        endTerminalSession();
+        outro(chalk.cyan(message));
+      } else {
+        this.info(`╰─ ${message}`);
+      }
     }
     this.fileLogger?.info(`[END] ${message}`);
   }

--- a/packages/cli/src/console/logging.ts
+++ b/packages/cli/src/console/logging.ts
@@ -65,11 +65,13 @@ export function exitSync(code: number): never {
 // GT specific logging
 export function displayHeader(introString?: string) {
   // The ASCII banner is pure chatter and writes to console directly, bypassing
-  // the logger, so gate it here to honor --quiet.
-  if (logger.isQuiet()) return;
-
-  displayAsciiTitle();
-  displayInitializingText();
+  // the logger, so gate it here to honor --quiet. startCommand stays outside
+  // the gate: it is quiet-aware itself and must still run so the file log
+  // gets its [START] marker.
+  if (!logger.isQuiet()) {
+    displayAsciiTitle();
+    displayInitializingText();
+  }
 
   if (introString) {
     logger.startCommand(introString);

--- a/packages/cli/src/console/logging.ts
+++ b/packages/cli/src/console/logging.ts
@@ -64,6 +64,10 @@ export function exitSync(code: number): never {
 
 // GT specific logging
 export function displayHeader(introString?: string) {
+  // The ASCII banner is pure chatter and writes to console directly, bypassing
+  // the logger, so gate it here to honor --quiet.
+  if (logger.isQuiet()) return;
+
   displayAsciiTitle();
   displayInitializingText();
 


### PR DESCRIPTION
Fixes #457

## Summary

- add a global `--quiet`/`-q` flag: drops the informational chatter (banner, intro/outro markers, info/step/success lines, spinners, progress bars) and prints only warnings and errors; exit codes and command results unchanged; works on every command in any position, including nested ones like `gt git setup --quiet`
- both output paths honored: in `GT_LOG_FORMAT=json` mode the info/debug/trace JSON lines drop the same way the human chatter does, and warn/error and above still print with their shape unchanged
- wiring: `-q, --quiet` registered as a root option in `base.ts` next to `--skip-version-check`, applied via a new `setQuiet()` on the logger singleton from a `preAction` hook (the level was previously fixed at import time from `GT_LOG_LEVEL`), matching the existing global-option convention in that file
- `setQuiet()` gates the clack chatter methods (they still write to the file logger) and raises pino's console level to warn without ever lowering an already-stricter level, so `--quiet` wins over `GT_LOG_LEVEL=debug` while `GT_LOG_LEVEL=error` stays `error`; the banner's direct `console.log` is gated and `validate`'s direct `intro()` now goes through `logger.startCommand()`

## Testing

- new `quiet.test.ts`, 16 cases: flag parsing in every position, clack chatter gating, pino level gating, `GT_LOG_LEVEL` precedence, and warnings/errors still emitting
- runtime proof in an offline fixture via `gt git setup --dry-run`: default prints the full chatter plus one warning; `--quiet` and `-q` print only the warning; JSON mode with `GT_LOG_LEVEL=debug` drops the `level:30` lines under the flag and keeps the `level:40` warn; exit 0 throughout
- full gate on `packages/cli`: vitest 2094 passed / 5 skipped, `tsc --noEmit` clean, `oxlint` 0 errors, `oxfmt --check .` clean repo-wide

## Notes

- prompts still run: quiet mutes chatter, not required interaction, and the prompt helpers are not gated; `GT_LOG_FILE` still records everything (it is an explicit debug-capture opt-in)
- scope kept to `--quiet`: a `--log-level` flag and a stricter `--silent` (suppressing warnings too) are reasonable follow-ups; the JSON-mode banner printing without the flag is pre-existing (quiet now suppresses it, fully splitting the banner out of JSON output is a separate cleanup)
- no collision with the status command work (#1914); `displayStatus`/`status.ts` are not on main
- changeset: gt minor

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a global `--quiet` / `-q` flag to the `gt` CLI that suppresses informational output while preserving warnings, errors, and exit codes. The implementation correctly handles both the default (clack) and JSON (pino) output paths, gates the ASCII banner in `displayHeader`, and switches the `validate` command from a direct `intro()` call to `logger.startCommand()` so it respects quiet mode.

- **Logger singleton** gains `setQuiet()` / `isQuiet()` with a `preAction` hook in `base.ts` that fires before any command so the mute is in effect for the entire invocation; `--quiet` wins over `GT_LOG_LEVEL` but never lowers an already-more-restrictive level (e.g. `GT_LOG_LEVEL=error` stays `error`).
- **`displayHeader`** gates only the ASCII banner behind `if (!logger.isQuiet())`; the subsequent `logger.startCommand()` call is left unconditional so the file log's `[START]` marker is always written.
- **Spinners and progress bars** return silent mock implementations in quiet mode that still route through the gated `logger.info()`, keeping file logging intact.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is additive (a new opt-in flag), all existing code paths are unaffected when --quiet is absent, and the file-log [START]/[END] pairing concern from the prior review round is correctly resolved in this version.

The quiet flag is additive and opt-in: every method without --quiet follows the exact same code path as before. The setQuiet() level math is correct for all four valid GT_LOG_LEVEL values, file logging is unconditional throughout, and the displayHeader fix properly keeps startCommand outside the quiet gate. The 16-case test suite covers all advertised behaviors including the [START] file-log marker.

No files require special attention.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/cli/src/console/logger.ts | Core change: adds LogLevel type, LOG_LEVEL_RANK map, quiet field, setQuiet()/isQuiet(), and wraps all informational log methods in `if (!this.quiet)`. Level math in setQuiet is correct; file logging path remains unconditional throughout. |
| packages/cli/src/console/logging.ts | displayHeader gates only the ASCII banner; logger.startCommand() is correctly left outside the quiet gate so [START] file-log markers are always written when introString is provided. |
| packages/cli/src/cli/base.ts | Registers -q/--quiet as a root Commander option and adds a preAction hook that calls logger.setQuiet() before any other hook or command action fires. |
| packages/cli/src/cli/inline.ts | Replaces direct intro() call with logger.startCommand() in the validate command so the intro honors --quiet; chalk and @clack/prompts imports removed as they are now unused. |
| packages/cli/src/console/__tests__/quiet.test.ts | 16-case test suite covering clack chatter gating, banner suppression, [START] file-log marker under quiet, pino level management, GT_LOG_LEVEL precedence, and flag parsing in every position. |

</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/cli/src/console/logging.ts`, line 66-77 ([link](https://github.com/generaltranslation/gt/blob/47f2e34a5f3a98bc366e516cd91b513124afb299/packages/cli/src/console/logging.ts#L66-L77)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`displayHeader` early-return skips file-log `[START]` marker**

   `displayHeader` returns immediately when quiet, bypassing the `logger.startCommand(introString)` call entirely. `startCommand` itself already has an `if (!this.quiet)` guard for console output, but its `this.fileLogger?.info('[START] ...')` call is *outside* that guard, so it's meant to always run. Because `displayHeader` exits before reaching `startCommand`, every command that uses `displayHeader` (setup, stage, translate, git setup, etc.) will write `[END]` to the file log but never `[START]` — directly contradicting the stated design goal that "file logging is untouched" when `--quiet` is active.

   Commands that call `startCommand` directly (e.g., the `validate` command in `inline.ts`) are unaffected because they bypass `displayHeader`; the inconsistency is isolated to the `displayHeader`-based flows.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/cli/src/console/logging.ts
   Line: 66-77

   Comment:
   **`displayHeader` early-return skips file-log `[START]` marker**

   `displayHeader` returns immediately when quiet, bypassing the `logger.startCommand(introString)` call entirely. `startCommand` itself already has an `if (!this.quiet)` guard for console output, but its `this.fileLogger?.info('[START] ...')` call is *outside* that guard, so it's meant to always run. Because `displayHeader` exits before reaching `startCommand`, every command that uses `displayHeader` (setup, stage, translate, git setup, etc.) will write `[END]` to the file log but never `[START]` — directly contradicting the stated design goal that "file logging is untouched" when `--quiet` is active.

   Commands that call `startCommand` directly (e.g., the `validate` command in `inline.ts`) are unaffected because they bypass `displayHeader`; the inconsistency is isolated to the `displayHeader`-based flows.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fcli%2Fsrc%2Fconsole%2Flogging.ts%0ALine%3A%2066-77%0A%0AComment%3A%0A**%60displayHeader%60%20early-return%20skips%20file-log%20%60%5BSTART%5D%60%20marker**%0A%0A%60displayHeader%60%20returns%20immediately%20when%20quiet%2C%20bypassing%20the%20%60logger.startCommand%28introString%29%60%20call%20entirely.%20%60startCommand%60%20itself%20already%20has%20an%20%60if%20%28!this.quiet%29%60%20guard%20for%20console%20output%2C%20but%20its%20%60this.fileLogger%3F.info%28'%5BSTART%5D%20...'%29%60%20call%20is%20*outside*%20that%20guard%2C%20so%20it's%20meant%20to%20always%20run.%20Because%20%60displayHeader%60%20exits%20before%20reaching%20%60startCommand%60%2C%20every%20command%20that%20uses%20%60displayHeader%60%20%28setup%2C%20stage%2C%20translate%2C%20git%20setup%2C%20etc.%29%20will%20write%20%60%5BEND%5D%60%20to%20the%20file%20log%20but%20never%20%60%5BSTART%5D%60%20%E2%80%94%20directly%20contradicting%20the%20stated%20design%20goal%20that%20%22file%20logging%20is%20untouched%22%20when%20%60--quiet%60%20is%20active.%0A%0ACommands%20that%20call%20%60startCommand%60%20directly%20%28e.g.%2C%20the%20%60validate%60%20command%20in%20%60inline.ts%60%29%20are%20unaffected%20because%20they%20bypass%20%60displayHeader%60%3B%20the%20inconsistency%20is%20isolated%20to%20the%20%60displayHeader%60-based%20flows.%0A%0A%60%60%60suggestion%0A%2F%2F%20GT%20specific%20logging%0Aexport%20function%20displayHeader%28introString%3F%3A%20string%29%20%7B%0A%20%20%2F%2F%20The%20ASCII%20banner%20is%20pure%20chatter%20and%20writes%20to%20console%20directly%2C%20bypassing%0A%20%20%2F%2F%20the%20logger%2C%20so%20gate%20it%20here%20to%20honor%20--quiet.%0A%20%20if%20%28!logger.isQuiet%28%29%29%20%7B%0A%20%20%20%20displayAsciiTitle%28%29%3B%0A%20%20%20%20displayInitializingText%28%29%3B%0A%20%20%7D%0A%0A%20%20if%20%28introString%29%20%7B%0A%20%20%20%20%2F%2F%20startCommand%20already%20suppresses%20console%20output%20in%20quiet%20mode%20while%0A%20%20%20%20%2F%2F%20still%20writing%20the%20%5BSTART%5D%20marker%20to%20the%20file%20logger.%0A%20%20%20%20logger.startCommand%28introString%29%3B%0A%20%20%7D%0A%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=generaltranslation%2Fgt&pr=1920&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22feat%2Fcli-quiet-flag%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fcli-quiet-flag%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fcli%2Fsrc%2Fconsole%2Flogging.ts%0ALine%3A%2066-77%0A%0AComment%3A%0A**%60displayHeader%60%20early-return%20skips%20file-log%20%60%5BSTART%5D%60%20marker**%0A%0A%60displayHeader%60%20returns%20immediately%20when%20quiet%2C%20bypassing%20the%20%60logger.startCommand%28introString%29%60%20call%20entirely.%20%60startCommand%60%20itself%20already%20has%20an%20%60if%20%28!this.quiet%29%60%20guard%20for%20console%20output%2C%20but%20its%20%60this.fileLogger%3F.info%28'%5BSTART%5D%20...'%29%60%20call%20is%20*outside*%20that%20guard%2C%20so%20it's%20meant%20to%20always%20run.%20Because%20%60displayHeader%60%20exits%20before%20reaching%20%60startCommand%60%2C%20every%20command%20that%20uses%20%60displayHeader%60%20%28setup%2C%20stage%2C%20translate%2C%20git%20setup%2C%20etc.%29%20will%20write%20%60%5BEND%5D%60%20to%20the%20file%20log%20but%20never%20%60%5BSTART%5D%60%20%E2%80%94%20directly%20contradicting%20the%20stated%20design%20goal%20that%20%22file%20logging%20is%20untouched%22%20when%20%60--quiet%60%20is%20active.%0A%0ACommands%20that%20call%20%60startCommand%60%20directly%20%28e.g.%2C%20the%20%60validate%60%20command%20in%20%60inline.ts%60%29%20are%20unaffected%20because%20they%20bypass%20%60displayHeader%60%3B%20the%20inconsistency%20is%20isolated%20to%20the%20%60displayHeader%60-based%20flows.%0A%0A%60%60%60suggestion%0A%2F%2F%20GT%20specific%20logging%0Aexport%20function%20displayHeader%28introString%3F%3A%20string%29%20%7B%0A%20%20%2F%2F%20The%20ASCII%20banner%20is%20pure%20chatter%20and%20writes%20to%20console%20directly%2C%20bypassing%0A%20%20%2F%2F%20the%20logger%2C%20so%20gate%20it%20here%20to%20honor%20--quiet.%0A%20%20if%20%28!logger.isQuiet%28%29%29%20%7B%0A%20%20%20%20displayAsciiTitle%28%29%3B%0A%20%20%20%20displayInitializingText%28%29%3B%0A%20%20%7D%0A%0A%20%20if%20%28introString%29%20%7B%0A%20%20%20%20%2F%2F%20startCommand%20already%20suppresses%20console%20output%20in%20quiet%20mode%20while%0A%20%20%20%20%2F%2F%20still%20writing%20the%20%5BSTART%5D%20marker%20to%20the%20file%20logger.%0A%20%20%20%20logger.startCommand%28introString%29%3B%0A%20%20%7D%0A%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=generaltranslation%2Fgt&pr=1920&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["fix(cli): keep \[START\] file-log marker w..."](https://github.com/generaltranslation/gt/commit/8c64b3a880ed6c15f8e529fcb2331f4e9d118034) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45191785)</sub>

<!-- /greptile_comment -->
