### PR TITLE
feat(next): support automatic JSX injection

### DIFF
--- a/.changeset/clean-pianos-inject.md
+++ b/.changeset/clean-pianos-inject.md
@@ -1,0 +1,5 @@
+---
+'@generaltranslation/compiler': patch
+---
+
+Allow framework integrations to configure the package used for automatic JSX injection imports.

--- a/.changeset/green-pears-inject.md
+++ b/.changeset/green-pears-inject.md
@@ -1,0 +1,5 @@
+---
+'gt-next': patch
+---
+
+Support automatic JSX injection with the webpack compiler and import the injected components from `gt-next`.

--- a/packages/compiler/src/config.ts
+++ b/packages/compiler/src/config.ts
@@ -44,6 +44,8 @@ export interface PluginConfig {
   stringTranslationMacro?: string;
   /** Enable Auto Jsx Injection (e.g. <div>Hello</div> -> <div><T>Hello</T></div>) */
   enableAutoJsxInjection?: boolean;
+  /** Package source for components inserted by Auto JSX Injection */
+  autoJsxImportSource?: string;
   /** Automatically treat interpolated/concatenated values as derive() calls */
   autoderive?: boolean | { jsx?: boolean; strings?: boolean };
   /** Emit compiler-injected gt-react imports from gt-react/browser */
@@ -70,6 +72,8 @@ export interface PluginSettings {
   enableMacroImportInjection: boolean;
   /** Enable Auto Jsx Injection (e.g. <div>Hello</div> -> <div><T>Hello</T></div>) */
   enableAutoJsxInjection: boolean;
+  /** Package source for components inserted by Auto JSX Injection */
+  autoJsxImportSource?: string;
   /** Automatically treat interpolated/concatenated values as derive() calls */
   autoderive: { jsx: boolean; strings: boolean };
   /** Emit compiler-injected gt-react imports from gt-react/browser */

--- a/packages/compiler/src/passes/__tests__/jsxInsertionEdgeCases.test.ts
+++ b/packages/compiler/src/passes/__tests__/jsxInsertionEdgeCases.test.ts
@@ -506,6 +506,18 @@ describe('jsxInsertionPass edge cases', () => {
       expect(gtImports).toHaveLength(1);
     });
 
+    it('injects import from a configured source', () => {
+      const code = `
+        import { jsx } from 'react/jsx-runtime';
+        jsx("div", { children: "Hello" });
+      `;
+      const { imports } = transform(code, {
+        autoJsxImportSource: 'gt-next',
+      });
+      const gtImports = imports.filter((i) => i.source.value === 'gt-next');
+      expect(gtImports).toHaveLength(1);
+    });
+
     it('does not inject duplicate import when already imported', () => {
       const code = `
         import { GtInternalTranslateJsx, GtInternalVar } from 'gt-react/browser';
@@ -517,6 +529,19 @@ describe('jsxInsertionPass edge cases', () => {
         (i) => i.source.value === 'gt-react/browser'
       );
       expect(gtImports).toHaveLength(1); // no duplicate
+    });
+
+    it('does not duplicate an import from a configured source', () => {
+      const code = `
+        import { GtInternalTranslateJsx, GtInternalVar } from '@acme/gt';
+        import { jsx } from 'react/jsx-runtime';
+        jsx("div", { children: "Hello" });
+      `;
+      const { imports } = transform(code, {
+        autoJsxImportSource: '@acme/gt',
+      });
+      const gtImports = imports.filter((i) => i.source.value === '@acme/gt');
+      expect(gtImports).toHaveLength(1);
     });
   });
 

--- a/packages/compiler/src/passes/jsxInsertionPass.ts
+++ b/packages/compiler/src/passes/jsxInsertionPass.ts
@@ -28,7 +28,11 @@ export function jsxInsertionPass(state: TransformState): TraverseOptions {
   };
 
   return {
-    ImportDeclaration: processImportDeclaration(onImportFound, calleeInfo),
+    ImportDeclaration: processImportDeclaration(
+      onImportFound,
+      calleeInfo,
+      state.settings.autoJsxImportSource
+    ),
     CallExpression: processCallExpression(state, calleeInfo),
     Program: processProgram({
       state,

--- a/packages/compiler/src/processing/jsx-insertion/processImportDeclaration.ts
+++ b/packages/compiler/src/processing/jsx-insertion/processImportDeclaration.ts
@@ -24,7 +24,8 @@ export interface JsxCalleeInfo {
  */
 export function processImportDeclaration(
   onGtImportFound: () => void,
-  calleeInfo: JsxCalleeInfo
+  calleeInfo: JsxCalleeInfo,
+  autoJsxImportSource?: string
 ): VisitNode<t.Node, t.ImportDeclaration> {
   const targetName = GT_COMPONENT_TYPES.GtInternalTranslateJsx;
 
@@ -32,7 +33,7 @@ export function processImportDeclaration(
     const source = path.node.source.value;
 
     // Check for existing GT import
-    if (isGTImportSource(source)) {
+    if (isGTImportSource(source) || source === autoJsxImportSource) {
       for (const specifier of path.node.specifiers) {
         if (
           t.isImportSpecifier(specifier) &&

--- a/packages/compiler/src/processing/jsx-insertion/processProgram.ts
+++ b/packages/compiler/src/processing/jsx-insertion/processProgram.ts
@@ -32,6 +32,7 @@ export function processProgram({
       if (!isAlreadyImported()) {
         injectJsxInsertionImport(
           path,
+          state.settings.autoJsxImportSource,
           state.settings.legacyGtReactImportSource
         );
       }

--- a/packages/compiler/src/transform/jsx-insertion/injectJsxInsertionImport.ts
+++ b/packages/compiler/src/transform/jsx-insertion/injectJsxInsertionImport.ts
@@ -9,6 +9,7 @@ import { getGtReactImportSource } from '../../utils/constants/gt/helpers';
  */
 export function injectJsxInsertionImport(
   path: NodePath<t.Program>,
+  autoJsxImportSource: string | undefined,
   legacyGtReactImportSource: boolean
 ): void {
   const tName = GT_COMPONENT_TYPES.GtInternalTranslateJsx;
@@ -19,7 +20,9 @@ export function injectJsxInsertionImport(
       t.importSpecifier(t.identifier(tName), t.identifier(tName)),
       t.importSpecifier(t.identifier(varName), t.identifier(varName)),
     ],
-    t.stringLiteral(getGtReactImportSource(legacyGtReactImportSource))
+    t.stringLiteral(
+      autoJsxImportSource ?? getGtReactImportSource(legacyGtReactImportSource)
+    )
   );
 
   path.unshiftContainer('body', importDecl);

--- a/packages/next/src/__tests__/config.test.ts
+++ b/packages/next/src/__tests__/config.test.ts
@@ -1275,6 +1275,35 @@ describe('withGTConfig', () => {
   // 13. Compiler configuration
   // ==============================
   describe('13. Compiler configuration', () => {
+    it.each(['none', 'swc'] as const)(
+      'warns when automatic JSX injection is used with the %s compiler',
+      async (type) => {
+        const withGTConfig = await getWithGTConfig();
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        withGTConfig(
+          {},
+          {
+            experimentalCompilerOptions: {
+              type,
+              enableAutoJsxInjection: true,
+            },
+          }
+        );
+
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining(
+            'Automatic JSX injection requires the GT webpack compiler'
+          )
+        );
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining(
+            "Set experimentalCompilerOptions.type to 'babel'"
+          )
+        );
+      }
+    );
+
     it('uses a Turbopack-specific babel compiler warning', async () => {
       const withGTConfig = await getWithGTConfig();
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
@@ -1282,7 +1311,12 @@ describe('withGTConfig', () => {
 
       const result = withGTConfig(
         {},
-        { experimentalCompilerOptions: { type: 'babel' } }
+        {
+          experimentalCompilerOptions: {
+            type: 'babel',
+            enableAutoJsxInjection: true,
+          },
+        }
       );
       const params = parseConfigParams(result);
 
@@ -1294,6 +1328,14 @@ describe('withGTConfig', () => {
       );
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining("experimentalCompilerOptions: { type: 'swc' }")
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Automatic JSX injection requires the GT webpack compiler'
+        )
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('build with webpack')
       );
       expect(warnSpy).not.toHaveBeenCalledWith(
         expect.stringContaining('compatible with turbopack or < react')
@@ -1358,6 +1400,33 @@ describe('withGTConfig', () => {
   // 14. Webpack function
   // ==============================
   describe('14. Webpack function', () => {
+    it('passes automatic JSX injection to the webpack compiler', async () => {
+      const compiler = require('@generaltranslation/compiler');
+      const compilerWebpackSpy = vi
+        .spyOn(compiler, 'webpack')
+        .mockReturnValue({});
+      const withGTConfig = await getWithGTConfig();
+      const result = withGTConfig(
+        {},
+        {
+          experimentalCompilerOptions: {
+            type: 'babel',
+            enableAutoJsxInjection: true,
+          },
+        }
+      );
+
+      runWebpack(result, makeWebpackConfig());
+
+      expect(compilerWebpackSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          enableAutoJsxInjection: true,
+          autoJsxImportSource: 'gt-next',
+        })
+      );
+      compilerWebpackSpy.mockRestore();
+    });
+
     it('returns webpack config object', async () => {
       const withGTConfig = await getWithGTConfig();
       const result = withGTConfig();

--- a/packages/next/src/__tests__/rscComponentWrappers.test.tsx
+++ b/packages/next/src/__tests__/rscComponentWrappers.test.tsx
@@ -20,6 +20,7 @@ const { mockComponents, mockGetRequestConditions } = vi.hoisted(() => ({
     getLocaleProperties: vi.fn(),
     getLocales: vi.fn(),
     getVersionId: vi.fn(),
+    GtInternalVar: vi.fn(),
     LocaleSelector: vi.fn(),
     mFallback: vi.fn(),
     msg: vi.fn(),
@@ -87,6 +88,11 @@ describe('rsc component wrappers', () => {
       mockComponents.RelativeTime,
     ],
     ['Var', () => import('../variables/Var'), mockComponents.Var],
+    [
+      'GtInternalVar',
+      () => import('../variables/Var'),
+      mockComponents.GtInternalVar,
+    ],
   ])(
     '%s passes request conditions to gt-react',
     async (componentName, loadComponent, coreComponent) => {
@@ -113,7 +119,13 @@ describe('rsc component wrappers', () => {
 
     expect(module.GTProvider).toBeTypeOf('function');
     expect(module.T).toBeTypeOf('function');
+    expect(module.GtInternalTranslateJsx).toBeTypeOf('function');
+    expect(module.GtInternalTranslateJsx._gtt).toBe(
+      'translate-server-automatic'
+    );
     expect(module.Var).toBeTypeOf('function');
+    expect(module.GtInternalVar).toBeTypeOf('function');
+    expect(module.GtInternalVar._gtt).toBe('variable-variable-automatic');
     expect(module.Num).toBeTypeOf('function');
     expect(module.Currency).toBeTypeOf('function');
     expect(module.DateTime).toBeTypeOf('function');

--- a/packages/next/src/config-dir/props/withGTConfigProps.ts
+++ b/packages/next/src/config-dir/props/withGTConfigProps.ts
@@ -28,6 +28,11 @@ export type CompilerOptions = {
    * @default false
    */
   disableBuildChecks?: boolean;
+  /**
+   * Whether to automatically wrap translatable JSX.
+   * @default false
+   */
+  enableAutoJsxInjection?: boolean;
 };
 
 export type RenderMethod = 'skeleton' | 'replace' | 'default';

--- a/packages/next/src/config-dir/utils/validateCompiler.ts
+++ b/packages/next/src/config-dir/utils/validateCompiler.ts
@@ -1,6 +1,7 @@
 import { type BaseWithGTConfigProps } from '../props/withGTConfigProps';
 import { babelPluginCompatible } from '../../plugin/getStableNextVersionInfo';
 import {
+  autoJsxInjectionCompilerWarning,
   babelCompilerTurbopackUnavailableWarning,
   createGTCompilerUnavailableWarning,
   disablingCompileTimeHashWarning,
@@ -36,5 +37,11 @@ export function validateCompiler(mergedConfig: BaseWithGTConfigProps) {
   if (mergedConfig.experimentalCompilerOptions.compileTimeHash === false) {
     console.warn(disablingCompileTimeHashWarning);
     mergedConfig.experimentalCompilerOptions.type = 'none';
+  }
+  if (
+    mergedConfig.experimentalCompilerOptions.enableAutoJsxInjection &&
+    mergedConfig.experimentalCompilerOptions.type !== 'babel'
+  ) {
+    console.warn(autoJsxInjectionCompilerWarning);
   }
 }

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -704,7 +704,10 @@ export function withGTConfig<TNextConfig extends object = NextConfig>(
               webpack: gtUnplugin,
             } = require('@generaltranslation/compiler');
             webpackConfig.plugins.unshift(
-              gtUnplugin(mergedConfig.experimentalCompilerOptions || {})
+              gtUnplugin({
+                ...mergedConfig.experimentalCompilerOptions,
+                autoJsxImportSource: 'gt-next',
+              })
             );
           } catch (e) {
             mergedConfig.experimentalCompilerOptions.type = 'none';

--- a/packages/next/src/errors/createErrors.ts
+++ b/packages/next/src/errors/createErrors.ts
@@ -201,6 +201,13 @@ export const createGTCompilerUnresolvedWarning = (type: 'babel' | 'swc') =>
     }),
   });
 
+export const autoJsxInjectionCompilerWarning = createGtNextPluginDiagnostic({
+  severity: 'Warning',
+  whatHappened: 'Automatic JSX injection requires the GT webpack compiler',
+  wayOut: 'Automatic JSX injection will be skipped',
+  fix: "Set experimentalCompilerOptions.type to 'babel' in withGTConfig() and build with webpack",
+});
+
 export const customGetLocaleUnresolvedWarning = createGtNextDiagnostic({
   whatHappened: 'Custom getLocale() could not be resolved',
   wayOut: 'gt-next will fall back to default locale detection',

--- a/packages/next/src/index.client.ts
+++ b/packages/next/src/index.client.ts
@@ -49,6 +49,8 @@ export {
   DateTime,
   Derive,
   GTProvider,
+  GtInternalTranslateJsx,
+  GtInternalVar,
   LocaleSelector,
   Num,
   Plural,

--- a/packages/next/src/index.rsc.ts
+++ b/packages/next/src/index.rsc.ts
@@ -26,8 +26,8 @@ export { GTProvider } from './provider/GTProvider';
 export { Num } from './variables/Num';
 export { Plural } from './branches/Plural';
 export { RelativeTime } from './variables/RelativeTime';
-export { T } from './server-dir/buildtime/T';
-export { Var } from './variables/Var';
+export { GtInternalTranslateJsx, T } from './server-dir/buildtime/T';
+export { GtInternalVar, Var } from './variables/Var';
 
 // ===== Hooks ===== //
 export { useLocale } from './request/getLocale';

--- a/packages/next/src/index.server.ts
+++ b/packages/next/src/index.server.ts
@@ -24,6 +24,8 @@ export {
   DateTime,
   Derive,
   GTProvider,
+  GtInternalTranslateJsx,
+  GtInternalVar,
   T,
   LocaleSelector,
   Num,

--- a/packages/next/src/index.types.ts
+++ b/packages/next/src/index.types.ts
@@ -20,6 +20,8 @@ import {
   useLocaleProperties as _useLocaleProperties,
   Currency as _Currency,
   DateTime as _DateTime,
+  GtInternalTranslateJsx as _GtInternalTranslateJsx,
+  GtInternalVar as _GtInternalVar,
   RelativeTime as _RelativeTime,
   Num as _Num,
   Var as _Var,
@@ -114,6 +116,11 @@ export const T: typeof _T = () => {
 };
 /** @internal _gtt - The GT transformation for the component. */
 T._gtt = 'translate';
+
+export const GtInternalTranslateJsx: typeof _GtInternalTranslateJsx = () => {
+  throw new Error(typesFileError);
+};
+GtInternalTranslateJsx._gtt = 'translate-client-automatic';
 
 /**
  * The `<Currency>` component renders a formatted currency string, allowing customization of name, default value, currency type, and formatting options.
@@ -223,6 +230,11 @@ export const Var: typeof _Var = () => {
 };
 /** @internal _gtt - The GT transformation for the component. */
 Var._gtt = 'variable-variable';
+
+export const GtInternalVar: typeof _GtInternalVar = () => {
+  throw new Error(typesFileError);
+};
+GtInternalVar._gtt = 'variable-variable-automatic';
 
 /**
  * Marks JSX children as derivable by the GT compiler and CLI.

--- a/packages/next/src/server-dir/buildtime/T.tsx
+++ b/packages/next/src/server-dir/buildtime/T.tsx
@@ -20,6 +20,16 @@ type TProps = {
  * Build-time translation component that renders its children in the user's given locale.
  */
 export async function T(props: TProps): Promise<ReactNode> {
+  return renderT(props);
+}
+
+export async function GtInternalTranslateJsx(
+  props: TProps
+): Promise<ReactNode> {
+  return renderT(props);
+}
+
+async function renderT(props: TProps): Promise<ReactNode> {
   const conditions = await getRequestConditions();
   return RscT({
     ...props,
@@ -30,3 +40,4 @@ export async function T(props: TProps): Promise<ReactNode> {
 
 /** @internal _gtt - The GT transformation for the component. */
 T._gtt = 'translate-server';
+GtInternalTranslateJsx._gtt = 'translate-server-automatic';

--- a/packages/next/src/variables/Var.tsx
+++ b/packages/next/src/variables/Var.tsx
@@ -1,4 +1,4 @@
-import { Var as CoreVar } from 'gt-react';
+import { GtInternalVar as CoreGtInternalVar, Var as CoreVar } from 'gt-react';
 import { getRequestConditions } from '../request/getRequestConditions';
 import type { ReactNode } from 'react';
 
@@ -9,5 +9,11 @@ export async function Var(props: VarProps): Promise<ReactNode> {
   return <CoreVar {...props} {...conditions} />;
 }
 
+export async function GtInternalVar(props: VarProps): Promise<ReactNode> {
+  const conditions = await getRequestConditions();
+  return <CoreGtInternalVar {...props} {...conditions} />;
+}
+
 /** @internal _gtt - The GT transformation for the component. */
 Var._gtt = 'variable-variable';
+GtInternalVar._gtt = 'variable-variable-automatic';


### PR DESCRIPTION
## Summary

- expose `enableAutoJsxInjection` through `withGTConfig()` and forward it to the webpack compiler
- warn with the standard gt-next diagnostic when automatic JSX injection is enabled without the webpack compiler
- configure webpack injection imports to use `gt-next` and export request-aware injected components across runtime conditions

## Testing

- `pnpm --filter gt-next test:js` — passed (244 tests)
- `pnpm --filter gt-next test:rust` — passed (297 tests)
- `pnpm --filter gt-next typecheck` — passed
- `pnpm --filter gt-next build:no-swc-plugin` — passed
- targeted `oxlint` and `oxfmt --check` on all changed gt-next files — passed
- temporary gt-next App Router production build and Playwright smoke test — passed with server/client injection, hydration, and interaction

## Notes

- Changeset: patch release for `gt-next`.
- Stacked on #1918 (`e/next/support-auto-jsx-injection`), which contains all compiler changes.
- SWC automatic JSX injection remains unsupported; users are directed to the webpack compiler.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires `enableAutoJsxInjection` end-to-end in `gt-next`: the option is exposed through `withGTConfig()`, validated with a standard diagnostic warning when the webpack compiler isn't in use, and forwarded to the webpack plugin with a hardcoded `autoJsxImportSource: 'gt-next'`. Two new request-aware RSC components — `GtInternalTranslateJsx` and `GtInternalVar` — are introduced as the automatic-injection targets and exported from all three entry points (client, RSC, and server).

- **New server components**: `GtInternalTranslateJsx` (delegates to the extracted `renderT` helper) and `GtInternalVar` (mirrors `Var` using `CoreGtInternalVar`) are added in `T.tsx` and `Var.tsx`, with correct `_gtt` tags and parallel exports across `index.client.ts`, `index.rsc.ts`, `index.server.ts`, and the types stub.
- **Config plumbing**: `validateCompiler.ts` emits `autoJsxInjectionCompilerWarning` when `enableAutoJsxInjection` is set without `type: 'babel'`; `config.ts` always passes `autoJsxImportSource: 'gt-next'` to the webpack plugin so the compiler knows which package to import injected components from.
- **Tests**: new `it.each` cases cover the compiler warning for `none`/`swc` and the Turbopack babel path; a separate test verifies `autoJsxImportSource` is forwarded; `rscComponentWrappers` tests are extended for both new components including `_gtt` assertions.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — changes are additive, guarded by an early return for missing compiler options, and covered by new tests.

All new code paths are additive and follow existing patterns. The validateCompiler guard fires after type mutation, which is the correct ordering. The autoJsxImportSource hardcode is intentional. The _gtt discrepancy between the types stub and the server component follows the same convention used for T. Tests pass across JS, Rust, and typecheck pipelines.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/next/src/server-dir/buildtime/T.tsx | Adds GtInternalTranslateJsx as a second async server component that delegates to the shared renderT helper; _gtt correctly set to translate-server-automatic. |
| packages/next/src/variables/Var.tsx | Adds GtInternalVar server component mirroring Var; imports GtInternalVar as CoreGtInternalVar from gt-react and sets _gtt = variable-variable-automatic. |
| packages/next/src/index.types.ts | Adds throw-stubs for GtInternalTranslateJsx and GtInternalVar; _gtt values follow existing convention of using client-flavored tags in the types stub. |
| packages/next/src/config-dir/utils/validateCompiler.ts | New guard warns when enableAutoJsxInjection is true but compiler type is not babel; runs after type-mutation logic so it fires correctly for turbopack and SWC paths too. |
| packages/next/src/config.ts | Hardcodes autoJsxImportSource: gt-next when spreading compiler options into the webpack plugin; enableAutoJsxInjection reaches the compiler via the spread of experimentalCompilerOptions. |
| packages/next/src/index.client.ts | Re-exports GtInternalTranslateJsx and GtInternalVar from gt-react for the client entry point. |
| packages/next/src/index.rsc.ts | Exports GtInternalTranslateJsx from T.tsx and GtInternalVar from Var.tsx for the RSC entry point. |
| packages/next/src/index.server.ts | Exports GtInternalTranslateJsx and GtInternalVar from the server entry point. |
| packages/next/src/__tests__/config.test.ts | Adds tests for the compiler warning when enableAutoJsxInjection is used without webpack, and verifies autoJsxImportSource: gt-next is forwarded to the webpack plugin. |
| packages/next/src/__tests__/rscComponentWrappers.test.tsx | Adds GtInternalVar to mock, extends it.each to cover GtInternalVar, and adds _gtt assertions for both new components. |
| packages/next/src/errors/createErrors.ts | Adds autoJsxInjectionCompilerWarning using the standard diagnostic helper with clear whatHappened/wayOut/fix fields. |
| packages/next/src/config-dir/props/withGTConfigProps.ts | Adds optional enableAutoJsxInjection to CompilerOptions type with JSDoc. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User as next.config.js
    participant WGT as withGTConfig()
    participant VC as validateCompiler()
    participant WP as webpack plugin
    participant RSC as RSC runtime
    participant Client as Client runtime

    User->>WGT: "experimentalCompilerOptions { type, enableAutoJsxInjection }"
    WGT->>VC: validateCompiler(mergedConfig)
    alt "type !== babel && enableAutoJsxInjection"
        VC-->>User: console.warn(autoJsxInjectionCompilerWarning)
    end
    WGT->>WP: gtUnplugin spread compilerOptions plus autoJsxImportSource gt-next
    WP-->>RSC: inject GtInternalTranslateJsx and GtInternalVar from gt-next
    RSC->>RSC: GtInternalTranslateJsx calls renderT then getRequestConditions then RscT
    RSC->>RSC: GtInternalVar calls getRequestConditions then CoreGtInternalVar
    WP-->>Client: inject GtInternalTranslateJsx and GtInternalVar from gt-next
    Client->>Client: GtInternalTranslateJsx and GtInternalVar from gt-react
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User as next.config.js
    participant WGT as withGTConfig()
    participant VC as validateCompiler()
    participant WP as webpack plugin
    participant RSC as RSC runtime
    participant Client as Client runtime

    User->>WGT: "experimentalCompilerOptions { type, enableAutoJsxInjection }"
    WGT->>VC: validateCompiler(mergedConfig)
    alt "type !== babel && enableAutoJsxInjection"
        VC-->>User: console.warn(autoJsxInjectionCompilerWarning)
    end
    WGT->>WP: gtUnplugin spread compilerOptions plus autoJsxImportSource gt-next
    WP-->>RSC: inject GtInternalTranslateJsx and GtInternalVar from gt-next
    RSC->>RSC: GtInternalTranslateJsx calls renderT then getRequestConditions then RscT
    RSC->>RSC: GtInternalVar calls getRequestConditions then CoreGtInternalVar
    WP-->>Client: inject GtInternalTranslateJsx and GtInternalVar from gt-next
    Client->>Client: GtInternalTranslateJsx and GtInternalVar from gt-react
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["feat(next): support automatic JSX inject..."](https://github.com/generaltranslation/gt/commit/b1a806e82a0cca988f862ff2107b58bcdf8f5bb1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45198964)</sub>

<!-- /greptile_comment -->