### PR TITLE
fix(node): read GT credentials from env in initializeGT

### DIFF
--- a/.changeset/node-env-credentials.md
+++ b/.changeset/node-env-credentials.md
@@ -1,0 +1,5 @@
+---
+'gt-node': patch
+---
+
+`initializeGT()` now reads `GT_PROJECT_ID`, `GT_API_KEY`, and `GT_DEV_API_KEY` from the environment as a fallback when they are not passed explicitly, matching the gt-node quickstart which sets these in `.env`. Explicit params still take precedence.

--- a/packages/node/src/setup/__tests__/runtimeCredentials.test.ts
+++ b/packages/node/src/setup/__tests__/runtimeCredentials.test.ts
@@ -48,6 +48,22 @@ describe('runtime credentials', () => {
     });
   });
 
+  it('treats an empty-string env var as falsy and does not override an explicit param', () => {
+    vi.stubEnv('GT_API_KEY', '');
+
+    expect(addRuntimeCredentials({ apiKey: 'explicit-api-key' })).toMatchObject(
+      { apiKey: 'explicit-api-key' }
+    );
+  });
+
+  it('lets an empty-string explicit param fall back to the env value', () => {
+    vi.stubEnv('GT_API_KEY', 'env-api-key');
+
+    expect(addRuntimeCredentials({ apiKey: '' })).toMatchObject({
+      apiKey: 'env-api-key',
+    });
+  });
+
   it('preserves other config fields when adding credentials', () => {
     vi.stubEnv('GT_PROJECT_ID', 'env-project-id');
 

--- a/packages/node/src/setup/__tests__/runtimeCredentials.test.ts
+++ b/packages/node/src/setup/__tests__/runtimeCredentials.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { addRuntimeCredentials } from '../runtimeCredentials';
+
+describe('runtime credentials', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('reads credentials from the environment for all three variables', () => {
+    vi.stubEnv('GT_PROJECT_ID', 'env-project-id');
+    vi.stubEnv('GT_API_KEY', 'env-api-key');
+    vi.stubEnv('GT_DEV_API_KEY', 'env-dev-api-key');
+
+    expect(addRuntimeCredentials({})).toMatchObject({
+      projectId: 'env-project-id',
+      apiKey: 'env-api-key',
+      devApiKey: 'env-dev-api-key',
+    });
+  });
+
+  it('keeps explicitly supplied credentials over the environment', () => {
+    vi.stubEnv('GT_PROJECT_ID', 'env-project-id');
+    vi.stubEnv('GT_API_KEY', 'env-api-key');
+    vi.stubEnv('GT_DEV_API_KEY', 'env-dev-api-key');
+
+    expect(
+      addRuntimeCredentials({
+        projectId: 'explicit-project-id',
+        apiKey: 'explicit-api-key',
+        devApiKey: 'explicit-dev-api-key',
+      })
+    ).toMatchObject({
+      projectId: 'explicit-project-id',
+      apiKey: 'explicit-api-key',
+      devApiKey: 'explicit-dev-api-key',
+    });
+  });
+
+  it('leaves credentials undefined when neither params nor env are present', () => {
+    vi.stubEnv('GT_PROJECT_ID', undefined);
+    vi.stubEnv('GT_API_KEY', undefined);
+    vi.stubEnv('GT_DEV_API_KEY', undefined);
+
+    expect(addRuntimeCredentials({})).toMatchObject({
+      projectId: undefined,
+      apiKey: undefined,
+      devApiKey: undefined,
+    });
+  });
+
+  it('preserves other config fields when adding credentials', () => {
+    vi.stubEnv('GT_PROJECT_ID', 'env-project-id');
+
+    expect(
+      addRuntimeCredentials({
+        defaultLocale: 'en-US',
+        locales: ['en-US', 'fr'],
+      })
+    ).toMatchObject({
+      defaultLocale: 'en-US',
+      locales: ['en-US', 'fr'],
+      projectId: 'env-project-id',
+    });
+  });
+});

--- a/packages/node/src/setup/initializeGT.ts
+++ b/packages/node/src/setup/initializeGT.ts
@@ -6,6 +6,7 @@ import {
   setI18nCache,
 } from 'gt-i18n/internal';
 import { AsyncConditionStore } from '../async-i18n-cache/AsyncConditionStore';
+import { addRuntimeCredentials } from './runtimeCredentials';
 
 /**
  * Configure GT for node runtime. This must be called to setup GT for node runtime.
@@ -13,9 +14,11 @@ import { AsyncConditionStore } from '../async-i18n-cache/AsyncConditionStore';
  * TODO: auto detect if can find gt.config.json files
  */
 export function initializeGT(params: InitializeGTParams): void {
-  initializeI18nConfig(params);
+  const config = addRuntimeCredentials(params);
 
-  const i18nCache = new I18nCache<string>(params);
+  initializeI18nConfig(config);
+
+  const i18nCache = new I18nCache<string>(config);
   const conditionStore = new AsyncConditionStore();
 
   setI18nCache(i18nCache);

--- a/packages/node/src/setup/runtimeCredentials.ts
+++ b/packages/node/src/setup/runtimeCredentials.ts
@@ -1,0 +1,26 @@
+import type { InitializeGTParams } from './types';
+
+type RuntimeCredentials = Pick<
+  InitializeGTParams,
+  'projectId' | 'apiKey' | 'devApiKey'
+>;
+
+export function addRuntimeCredentials<T extends RuntimeCredentials>(
+  config: T
+): T {
+  const credentials = getRuntimeCredentials();
+  return {
+    ...config,
+    projectId: config.projectId || credentials.projectId,
+    apiKey: config.apiKey || credentials.apiKey,
+    devApiKey: config.devApiKey || credentials.devApiKey,
+  };
+}
+
+function getRuntimeCredentials(): RuntimeCredentials {
+  return {
+    projectId: process.env.GT_PROJECT_ID,
+    apiKey: process.env.GT_API_KEY,
+    devApiKey: process.env.GT_DEV_API_KEY,
+  };
+}


### PR DESCRIPTION
Fixes #1044

## What

`initializeGT()` in `gt-node` now falls back to reading `GT_PROJECT_ID`,
`GT_API_KEY`, and `GT_DEV_API_KEY` from `process.env` when they aren't passed
explicitly. Explicit params still take precedence over the environment.

## Why

The gt-node quickstart tells users to put `GT_API_KEY` / `GT_PROJECT_ID` in a
`.env` file, but `initializeGT()` passes its params straight through with zero
env fallback (`packages/node/src/setup/initializeGT.ts`), and the gt-i18n
pipeline it feeds never reads credential env vars either:
`getTranslationApiType` gates runtime translation on `params.devApiKey ||
params.apiKey`, so with keys only in the environment it silently disables
runtime translation and the app serves untranslated text with nothing in the
logs. (Core's `GTRuntime` does read `GT_API_KEY`/`GT_DEV_API_KEY`/`GT_PROJECT_ID`
from env in its constructor, but `packages/i18n` never constructs it, so that
fallback is unreachable from this path.) When #1044 was filed the same gap
surfaced as an `I18nManager: devApiKey or apiKey is required` warning; after
the I18nCache refactor the failure is quieter, which is arguably worse.

This mirrors the existing pattern in `gt-next`
(`packages/next/src/setup/runtimeCredentials.ts`) and `gt-react`
(`packages/react/src/setup/runtimeCredentials.ts`). Because gt-node is
server-only, the new `packages/node/src/setup/runtimeCredentials.ts` reads plain
`process.env` variables with no `NEXT_PUBLIC_`/`VITE_` prefixes and no
`import.meta` handling. It uses react's `addRuntimeCredentials(config)` merge
shape so explicit config wins (`config.x || credentials.x`).

## Changes

- `packages/node/src/setup/runtimeCredentials.ts` (new): `addRuntimeCredentials()` + `getRuntimeCredentials()`
- `packages/node/src/setup/initializeGT.ts`: merge env credentials before configuring the i18n config and cache
- `packages/node/src/setup/__tests__/runtimeCredentials.test.ts` (new): tests
- `.changeset/node-env-credentials.md`

## Test plan

- TDD: added `runtimeCredentials.test.ts` covering: env fallback for all three
  vars, explicit params winning over env, credentials left `undefined` when
  neither params nor env are present, and other config fields preserved.
- `pnpm --filter gt-node test`: 19 passed (4 files)
- `pnpm --filter gt-node typecheck`: clean

## Caveats

- Env values are read raw (matching gt-next's `getRuntimeCredentials`); empty
  strings are treated as falsy via `||`, so an empty env var falls back to the
  next source rather than overriding an explicit param.
- I didn't add `NEXT_PUBLIC_`/`VITE_` aliases. gt-node is server-only and those
  prefixes are client-bundler concerns.
- One thing worth a team call at some point: gt-node's env merge reads
  `GT_DEV_API_KEY` without a production guard, whereas `packages/next` gates
  dev-key usage on environment (`config.ts:524`). It introduces no new pathway
  here (`devApiKey` was already an accepted `initializeGT` param), but adopting
  next's NODE_ENV gating could be a follow-up.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes `initializeGT()` in `gt-node` so it reads `GT_PROJECT_ID`, `GT_API_KEY`, and `GT_DEV_API_KEY` from `process.env` when they are not passed explicitly, mirroring the already-existing pattern in `gt-next` and `gt-react`. Without this change, users who follow the quickstart (credentials in `.env`) would silently get no runtime translation.

- **`runtimeCredentials.ts`** (new): thin `addRuntimeCredentials` / `getRuntimeCredentials` pair that reads the three plain `process.env` vars and merges them behind explicit config values using `||`.
- **`initializeGT.ts`**: one-line change to apply `addRuntimeCredentials` before forwarding the enriched config to both `initializeI18nConfig` and `I18nCache`.
- **`runtimeCredentials.test.ts`** (new): six vitest cases cover env fallback, explicit-wins, absent-vars, empty-string-falsy, and preservation of unrelated config fields.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is additive and only affects the env-credential fallback path; explicit params continue to win, and the core initializeGT flow is otherwise unchanged.

The new runtimeCredentials.ts is a small, self-contained utility that reads three well-defined env vars and merges them with a simple ||. The integration point in initializeGT.ts is a single-line change that routes the enriched config to both initializeI18nConfig and I18nCache, which is correct. Tests cover all meaningful edge cases including the empty-string falsy behaviour. The pattern is already established in gt-next and gt-react, so there is no novel risk here.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/node/src/setup/runtimeCredentials.ts | New file: reads GT_PROJECT_ID, GT_API_KEY, GT_DEV_API_KEY from process.env and merges them as a fallback behind explicit config values using the same generic-spread pattern as gt-react. |
| packages/node/src/setup/initializeGT.ts | One-line change: applies addRuntimeCredentials before passing config to initializeI18nConfig and I18nCache, correctly routing env-enriched credentials through both downstream callsites. |
| packages/node/src/setup/__tests__/runtimeCredentials.test.ts | New test file with 6 cases covering: env fallback, explicit-wins, undefined when absent, empty-string-as-falsy, empty-string-explicit falls back to env, and preservation of unrelated config fields. |
| .changeset/node-env-credentials.md | Correct patch-level changeset entry describing the env fallback behaviour for gt-node. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant initializeGT
    participant addRuntimeCredentials
    participant process.env
    participant initializeI18nConfig
    participant I18nCache

    Caller->>initializeGT: initializeGT(params)
    initializeGT->>addRuntimeCredentials: addRuntimeCredentials(params)
    addRuntimeCredentials->>process.env: read GT_PROJECT_ID, GT_API_KEY, GT_DEV_API_KEY
    process.env-->>addRuntimeCredentials: env values (fallback)
    Note over addRuntimeCredentials: config.x || credentials.x (explicit params win)
    addRuntimeCredentials-->>initializeGT: enriched config
    initializeGT->>initializeI18nConfig: initializeI18nConfig(config)
    initializeGT->>I18nCache: new I18nCache(config)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant initializeGT
    participant addRuntimeCredentials
    participant process.env
    participant initializeI18nConfig
    participant I18nCache

    Caller->>initializeGT: initializeGT(params)
    initializeGT->>addRuntimeCredentials: addRuntimeCredentials(params)
    addRuntimeCredentials->>process.env: read GT_PROJECT_ID, GT_API_KEY, GT_DEV_API_KEY
    process.env-->>addRuntimeCredentials: env values (fallback)
    Note over addRuntimeCredentials: config.x || credentials.x (explicit params win)
    addRuntimeCredentials-->>initializeGT: enriched config
    initializeGT->>initializeI18nConfig: initializeI18nConfig(config)
    initializeGT->>I18nCache: new I18nCache(config)
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["test(node): cover empty-string env crede..."](https://github.com/generaltranslation/gt/commit/4ffe8f47dcb7f0f94e5c52865c0d65baac8b8f44) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45202041)</sub>

<!-- /greptile_comment -->