### PR TITLE
fix(next): use client-safe i18n cache in browser

### DIFF
--- a/.changeset/client-safe-next-cache.md
+++ b/.changeset/client-safe-next-cache.md
@@ -1,0 +1,5 @@
+---
+'gt-next': patch
+---
+
+Use the client-safe React i18n cache in the browser so gt-next only resolves dictionary files and loaders on the server.

--- a/packages/next/src/setup/__tests__/initGT.test.ts
+++ b/packages/next/src/setup/__tests__/initGT.test.ts
@@ -1,7 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { getNextI18nCache } from '../../i18n-cache/NextI18nCache';
-import { getI18nConfig } from '@generaltranslation/react-core/pure';
+import {
+  getNextI18nCache,
+  NextI18nCache,
+} from '../../i18n-cache/NextI18nCache';
+import {
+  getI18nConfig,
+  getReactI18nCache,
+  ReactI18nCache,
+} from '@generaltranslation/react-core/pure';
 import { initializeGT } from '../initGT';
+import { initializeGTClient } from '../initGT.client';
 
 type TestGlobal = typeof globalThis & {
   __generaltranslation?: {
@@ -43,6 +51,7 @@ describe('initializeGT', () => {
 
     initializeGT(params);
     const cache = getNextI18nCache();
+    expect(cache).toBeInstanceOf(NextI18nCache);
 
     initializeGT(params);
 
@@ -68,5 +77,26 @@ describe('initializeGT', () => {
     expect(getI18nConfig().getEnableI18nCookieName()).toBe(
       'custom-enable-i18n'
     );
+  });
+});
+
+describe('initializeGTClient', () => {
+  beforeEach(() => {
+    resetI18nGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('uses the client-safe ReactI18nCache', () => {
+    initializeGTClient({
+      i18nConfigParams: {
+        defaultLocale: 'en',
+        locales: ['en', 'fr'],
+      },
+      nextI18nCacheParams: {},
+    });
+
+    const cache = getReactI18nCache();
+    expect(cache).toBeInstanceOf(ReactI18nCache);
+    expect(cache).not.toBeInstanceOf(NextI18nCache);
   });
 });

--- a/packages/next/src/setup/initGT.client.ts
+++ b/packages/next/src/setup/initGT.client.ts
@@ -1,23 +1,33 @@
-import { initializeGT as coreInitializeGT } from './initGT';
+import {
+  initializeI18nConfig,
+  ReactI18nCache,
+  setReactI18nCache,
+} from '@generaltranslation/react-core/pure';
 import { getParams } from './shared';
+import type { NextSetupI18nConfigParams } from './shared';
+import type { NextI18nCacheParams } from '../i18n-cache/NextI18nCache';
 
 /**
  * Initialize GT for Next.js client entrypoints.
  */
-export function initializeGTClient(): void {
-  const params = getParams();
-
-  coreInitializeGT({
-    ...params,
-    nextI18nCacheParams: {
-      ...params.nextI18nCacheParams,
-      /**
-       * Always disable cache expiry for client-side lookups.
-       * Translations are exclusively passed from server to client, so
-       * if translations ever expire, then the client will have no way
-       * to fetch new translations.
-       */
-      cacheExpiryTime: null,
-    },
+export function initializeGTClient(
+  {
+    i18nConfigParams,
+    nextI18nCacheParams,
+  }: {
+    i18nConfigParams: NextSetupI18nConfigParams;
+    nextI18nCacheParams: NextI18nCacheParams;
+  } = getParams()
+): void {
+  initializeI18nConfig(i18nConfigParams);
+  const i18nCache = new ReactI18nCache({
+    ...nextI18nCacheParams,
+    /**
+     * Always disable cache expiry for client-side lookups.
+     * Translations and dictionaries are exclusively passed from server to
+     * client, so the client has no loader to refresh expired entries.
+     */
+    cacheExpiryTime: null,
   });
+  setReactI18nCache(i18nCache);
 }

--- a/packages/next/src/setup/initGT.client.ts
+++ b/packages/next/src/setup/initGT.client.ts
@@ -1,8 +1,4 @@
-import {
-  initializeI18nConfig,
-  ReactI18nCache,
-  setReactI18nCache,
-} from '@generaltranslation/react-core/pure';
+import { internalInitializeGTSRA } from '@generaltranslation/react-core/pure';
 import { getParams } from './shared';
 import type { NextSetupI18nConfigParams } from './shared';
 import type { NextI18nCacheParams } from '../i18n-cache/NextI18nCache';
@@ -19,8 +15,8 @@ export function initializeGTClient(
     nextI18nCacheParams: NextI18nCacheParams;
   } = getParams()
 ): void {
-  initializeI18nConfig(i18nConfigParams);
-  const i18nCache = new ReactI18nCache({
+  internalInitializeGTSRA({
+    ...i18nConfigParams,
     ...nextI18nCacheParams,
     /**
      * Always disable cache expiry for client-side lookups.
@@ -29,5 +25,4 @@ export function initializeGTClient(
      */
     cacheExpiryTime: null,
   });
-  setReactI18nCache(i18nCache);
 }


### PR DESCRIPTION
## Summary

- initialize gt-next browser entrypoints with the client-safe React Core cache while retaining `NextI18nCache` for server and RSC execution
- keep dictionary files and loaders server-only, preventing the browser from probing them and emitting a false loader-resolution error

## Testing

- `pnpm --filter gt-next test:js` — passed, 25 files and 245 tests
- `pnpm exec turbo run build --filter=gt-next` — passed
- `pnpm exec oxlint packages/next` — passed with zero errors and one pre-existing warning
- `pnpm exec oxfmt --check packages/next/src/setup/initGT.client.ts packages/next/src/setup/__tests__/initGT.test.ts` — passed

## Notes

- Changeset added for a `gt-next` patch release.

<!-- greptile_comment -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This patch replaces `NextI18nCache` with the client-safe `ReactI18nCache` in the browser entry point (`initGT.client.ts`), preventing server-only dictionary/loader resolution code from running in (or being probed by) the browser. The server/RSC path through `initializeGT` is unchanged and continues to use `NextI18nCache`.

- **`initGT.client.ts`**: Switches from delegating to the server-side `initializeGT` (which instantiates `NextI18nCache`, calling `resolveDictionaryLoader()`/`getDictionary()`) to calling `internalInitializeGTSRA` directly, which instantiates `ReactI18nCache` with no server-only dependencies. The `cacheExpiryTime: null` override is preserved.
- **`initGT.test.ts`**: Adds a new `initializeGTClient` test suite verifying the cache is a `ReactI18nCache` and not a `NextI18nCache`; also strengthens the existing `initializeGT` test with an explicit `instanceof` assertion.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is narrowly scoped to the browser entry point and does not touch the server/RSC path.

The client entry point now constructs a `ReactI18nCache` instead of delegating to `NextI18nCache`, removing the only path that could trigger server-only resolver code in the browser. Overlapping fields spread from both param objects have the same env-var source, and `cacheExpiryTime: null` is applied last so it cannot be overridden. The new test suite explicitly validates both the positive case (is `ReactI18nCache`) and the negative case (is not `NextI18nCache`).

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/next/src/setup/initGT.client.ts | Correctly switches to `internalInitializeGTSRA` / `ReactI18nCache` for browser entry points; `cacheExpiryTime: null` is applied last to override any stale value from the spread params. |
| packages/next/src/setup/__tests__/initGT.test.ts | New `initializeGTClient` test suite correctly verifies the client-safe cache is a `ReactI18nCache` and explicitly asserts it is not a `NextI18nCache`; existing test gains an `instanceof` assertion. |
| .changeset/client-safe-next-cache.md | Accurate patch-level changeset entry for gt-next. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant Server/RSC

    note over Browser: initGT.client.ts (changed)
    Browser->>internalInitializeGTSRA: initializeGTClient(params)
    internalInitializeGTSRA->>ReactI18nCache: new ReactI18nCache(config)
    note over ReactI18nCache: client-safe, no loader/dictionary resolution

    note over Server/RSC: initGT.ts (unchanged)
    Server/RSC->>initializeI18nConfig: initializeGT(params)
    Server/RSC->>NextI18nCache: new NextI18nCache(params)
    NextI18nCache->>resolveDictionaryLoader: loads server-only dictionary
    NextI18nCache->>getDictionary: reads dictionary
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant Server/RSC

    note over Browser: initGT.client.ts (changed)
    Browser->>internalInitializeGTSRA: initializeGTClient(params)
    internalInitializeGTSRA->>ReactI18nCache: new ReactI18nCache(config)
    note over ReactI18nCache: client-safe, no loader/dictionary resolution

    note over Server/RSC: initGT.ts (unchanged)
    Server/RSC->>initializeI18nConfig: initializeGT(params)
    Server/RSC->>NextI18nCache: new NextI18nCache(params)
    NextI18nCache->>resolveDictionaryLoader: loads server-only dictionary
    NextI18nCache->>getDictionary: reads dictionary
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["refactor(next): reuse client-safe cache ..."](https://github.com/generaltranslation/gt/commit/dec024af1c0a08b7fa4be50f2a37c0d61c1851fd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45238389)</sub>

<!-- /greptile_comment -->