### PR TITLE
fix(next): support function-form config in withGTConfig

### DIFF
--- a/.changeset/withgtconfig-function-form.md
+++ b/.changeset/withgtconfig-function-form.md
@@ -1,0 +1,5 @@
+---
+"gt-next": patch
+---
+
+Support Next.js's function-form config in `withGTConfig`. When passed a `(phase, context) => NextConfig` function (Next's function config form), `withGTConfig` now calls it and wraps the resolved config instead of spreading the function as a plain object. This lets `withGTConfig` compose with other Next config plugins that return a config function — matching `@sentry/nextjs`'s `withSentryConfig` — for both sync and async config functions.

--- a/packages/next/src/__tests__/config.test.ts
+++ b/packages/next/src/__tests__/config.test.ts
@@ -1632,9 +1632,11 @@ describe('withGTConfig', () => {
   describe('18. Function-form next config', () => {
     it('calls a sync config function and layers GT on the result', async () => {
       const withGTConfig = await getWithGTConfig();
-      const built = withGTConfig((_phase: string): NextConfig => ({
-        reactStrictMode: true,
-      }));
+      const built = withGTConfig(
+        (_phase: string): NextConfig => ({
+          reactStrictMode: true,
+        })
+      );
 
       expect(typeof built).toBe('function');
       const resolved = (

--- a/packages/next/src/__tests__/config.test.ts
+++ b/packages/next/src/__tests__/config.test.ts
@@ -1625,4 +1625,50 @@ describe('withGTConfig', () => {
       expect(result).toHaveProperty('experimental');
     });
   });
+
+  // ==============================
+  // 18. Function-form next config
+  // ==============================
+  describe('18. Function-form next config', () => {
+    it('calls a sync config function and layers GT on the result', async () => {
+      const withGTConfig = await getWithGTConfig();
+      const built = withGTConfig((_phase: string): NextConfig => ({
+        reactStrictMode: true,
+      }));
+
+      expect(typeof built).toBe('function');
+      const resolved = (
+        built as unknown as (
+          phase: string,
+          context: { defaultConfig: NextConfig }
+        ) => NextConfig
+      )('phase-production-build', { defaultConfig: {} });
+
+      expect(resolved.reactStrictMode).toBe(true);
+      expect(resolved).toHaveProperty('env');
+      expect(typeof resolved.webpack).toBe('function');
+      expect(resolved.transpilePackages).toContain('gt-next');
+    });
+
+    it('awaits an async config function and layers GT on the result', async () => {
+      const withGTConfig = await getWithGTConfig();
+      const built = withGTConfig(
+        async (_phase: string): Promise<NextConfig> => ({
+          reactStrictMode: true,
+        })
+      );
+
+      const resolved = await (
+        built as unknown as (
+          phase: string,
+          context: { defaultConfig: NextConfig }
+        ) => Promise<NextConfig>
+      )('phase-production-build', { defaultConfig: {} });
+
+      expect(resolved.reactStrictMode).toBe(true);
+      expect(resolved).toHaveProperty('env');
+      expect(typeof resolved.webpack).toBe('function');
+      expect(resolved.transpilePackages).toContain('gt-next');
+    });
+  });
 });

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -79,6 +79,15 @@ type InternalGTConfigProps = BaseWithGTConfigProps &
 
 type WithGTConfigResult<TNextConfig extends object> = TNextConfig & NextConfig;
 
+function isThenable(value: unknown): value is PromiseLike<NextConfig> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'then' in value &&
+    typeof value.then === 'function'
+  );
+}
+
 /**
  * Initializes General Translation settings for a Next.js application.
  *
@@ -128,6 +137,24 @@ export function withGTConfig<TNextConfig extends object = NextConfig>(
   nextConfig?: TNextConfig,
   props: withGTConfigProps = {}
 ): WithGTConfigResult<TNextConfig> {
+  // Next also accepts the `(phase, context) => config` function form. When given
+  // one, call it and wrap the resolved config so `withGTConfig` composes with
+  // other Next config plugins that return a config function — matching
+  // `@sentry/nextjs`'s `withSentryConfig`. Without this, a function config would
+  // be spread as a plain object below, silently dropping the user's config.
+  if (typeof nextConfig === 'function') {
+    const configFn = nextConfig as (
+      phase: string,
+      context: { defaultConfig: NextConfig }
+    ) => NextConfig | Promise<NextConfig>;
+    return ((phase: string, context: { defaultConfig: NextConfig }) => {
+      const resolved = configFn(phase, context);
+      return isThenable(resolved)
+        ? resolved.then((resolvedConfig) => withGTConfig(resolvedConfig, props))
+        : withGTConfig(resolved, props);
+    }) as unknown as WithGTConfigResult<TNextConfig>;
+  }
+
   const internalNextConfig = (nextConfig ?? {}) as unknown as NextConfig;
 
   // ---------- LOAD GT CONFIG FILE ---------- //

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -77,7 +77,18 @@ type InternalGTConfigProps = BaseWithGTConfigProps &
     _disableDevHotReload?: boolean;
   };
 
-type WithGTConfigResult<TNextConfig extends object> = TNextConfig & NextConfig;
+type WithGTConfigValue<T> =
+  T extends Promise<infer U>
+    ? Promise<U & NextConfig>
+    : T extends PromiseLike<infer U>
+      ? PromiseLike<U & NextConfig>
+      : T & NextConfig;
+
+type WithGTConfigResult<TNextConfig extends object> = TNextConfig extends (
+  ...args: infer A
+) => infer R
+  ? (...args: A) => WithGTConfigValue<R>
+  : TNextConfig & NextConfig;
 
 function isThenable(value: unknown): value is PromiseLike<NextConfig> {
   return (


### PR DESCRIPTION
Next allows a `(phase, context) => NextConfig` config function. withGTConfig now calls it and wraps the resolved config instead of spreading the function as a plain object, which silently dropped the user's config. Mirrors @sentry/nextjs' withSentryConfig; handles sync and async config functions.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This patch teaches `withGTConfig` to handle Next.js's `(phase, context) => NextConfig` function-form config, which was previously spread as a plain object and silently dropped all user config. The fix mirrors the approach used by `@sentry/nextjs`'s `withSentryConfig`.

- `config.ts`: When `nextConfig` is a function, a wrapper function is returned that resolves the inner config (sync or async) and then applies GT settings via a recursive `withGTConfig` call.
- `config.test.ts`: Two new tests verify the sync and async paths round-trip user config properties (`reactStrictMode`, `env`, `webpack`, `transpilePackages`) through the wrapper.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The change is focused, well-tested, and fixes a real silent-failure bug. The only open question is thenable compatibility in the async branch.

The core logic is correct for the native-Promise case that virtually all Next.js configs produce. The instanceof Promise guard would silently mishandle a non-native thenable by treating it as a plain config object, dropping all user keys — but this scenario is unlikely in practice.

The thenable branch in packages/next/src/config.ts (lines 143-145) and the missing transpilePackages assertion in the async test in packages/next/src/__tests__/config.test.ts.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/next/src/config.ts | Adds function-form config support to withGTConfig; correctly short-circuits when nextConfig is a function, resolves sync/async, and recursively applies GT config to the result. |
| packages/next/src/__tests__/config.test.ts | Adds test group 18 covering sync and async config function forms; sync test verifies round-trip properties including transpilePackages, async test is missing that assertion. |
| .changeset/withgtconfig-function-form.md | Patch-level changeset entry accurately describing the fix. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["withGTConfig(nextConfig, props)"] --> B{typeof nextConfig === 'function'?}
    B -- Yes --> C["Cast to configFn"]
    C --> D["Return wrapper function"]
    D --> E["wrapper called by Next.js"]
    E --> F["resolved = configFn(phase, context)"]
    F --> G{resolved instanceof Promise?}
    G -- Yes --> H["resolved.then(withGTConfig)"]
    G -- No --> I["withGTConfig(resolved, props)"]
    B -- No --> J["Apply GT config to plain object"]
    J --> K["NextConfig returned"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["withGTConfig(nextConfig, props)"] --> B{typeof nextConfig === 'function'?}
    B -- Yes --> C["Cast to configFn"]
    C --> D["Return wrapper function"]
    D --> E["wrapper called by Next.js"]
    E --> F["resolved = configFn(phase, context)"]
    F --> G{resolved instanceof Promise?}
    G -- Yes --> H["resolved.then(withGTConfig)"]
    G -- No --> I["withGTConfig(resolved, props)"]
    B -- No --> J["Apply GT config to plain object"]
    J --> K["NextConfig returned"]
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fnext%2Fsrc%2Fconfig.ts%3A143-145%0A%60instanceof%20Promise%60%20misses%20custom%20thenables.%20If%20a%20chained%20Next.js%20plugin%20%28e.g.%20one%20wrapping%20its%20result%20in%20a%20Bluebird%20or%20other%20thenable%29%20returns%20a%20non-native%20Promise%2C%20the%20branch%20falls%20through%20to%20%60withGTConfig%28resolved%2C%20props%29%60%20where%20%60resolved%60%20is%20a%20thenable%20object%20treated%20as%20a%20plain%20config%2C%20silently%20dropping%20all%20user%20config%20keys.%20A%20duck-type%20check%20is%20the%20conventional%20defence%20here.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20return%20resolved%20!%3D%3D%20null%20%26%26%0A%20%20%20%20%20%20%20%20typeof%20%28resolved%20as%20unknown%20as%20%7B%20then%3F%3A%20unknown%20%7D%29.then%20%3D%3D%3D%20'function'%0A%20%20%20%20%20%20%20%20%3F%20%28resolved%20as%20Promise%3CNextConfig%3E%29.then%28%28resolvedConfig%29%20%3D%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20withGTConfig%28resolvedConfig%2C%20props%29%0A%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%3A%20withGTConfig%28resolved%20as%20NextConfig%2C%20props%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fnext%2Fsrc%2F__tests__%2Fconfig.test.ts%3A1668-1673%0AThe%20async%20test%20omits%20the%20%60transpilePackages%60%20assertion%20that%20the%20sync%20test%20includes.%20This%20leaves%20a%20gap%3A%20if%20the%20async%20path%20accidentally%20skipped%20the%20%60transpilePackages%60%20injection%20%28e.g.%20a%20regression%20in%20the%20%60.then%28%29%60%20branch%29%2C%20the%20test%20would%20still%20pass.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20expect%28resolved.reactStrictMode%29.toBe%28true%29%3B%0A%20%20%20%20%20%20expect%28resolved%29.toHaveProperty%28'env'%29%3B%0A%20%20%20%20%20%20expect%28typeof%20resolved.webpack%29.toBe%28'function'%29%3B%0A%20%20%20%20%20%20expect%28resolved.transpilePackages%29.toContain%28'gt-next'%29%3B%0A%20%20%20%20%7D%29%3B%0A%20%20%7D%29%3B%0A%7D%29%3B%0A%60%60%60%0A%0A&repo=generaltranslation%2Fgt&pr=1935&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22fix%2Fwithgtconfig-function-form%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fwithgtconfig-function-form%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fnext%2Fsrc%2Fconfig.ts%3A143-145%0A%60instanceof%20Promise%60%20misses%20custom%20thenables.%20If%20a%20chained%20Next.js%20plugin%20%28e.g.%20one%20wrapping%20its%20result%20in%20a%20Bluebird%20or%20other%20thenable%29%20returns%20a%20non-native%20Promise%2C%20the%20branch%20falls%20through%20to%20%60withGTConfig%28resolved%2C%20props%29%60%20where%20%60resolved%60%20is%20a%20thenable%20object%20treated%20as%20a%20plain%20config%2C%20silently%20dropping%20all%20user%20config%20keys.%20A%20duck-type%20check%20is%20the%20conventional%20defence%20here.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20return%20resolved%20!%3D%3D%20null%20%26%26%0A%20%20%20%20%20%20%20%20typeof%20%28resolved%20as%20unknown%20as%20%7B%20then%3F%3A%20unknown%20%7D%29.then%20%3D%3D%3D%20'function'%0A%20%20%20%20%20%20%20%20%3F%20%28resolved%20as%20Promise%3CNextConfig%3E%29.then%28%28resolvedConfig%29%20%3D%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20withGTConfig%28resolvedConfig%2C%20props%29%0A%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%3A%20withGTConfig%28resolved%20as%20NextConfig%2C%20props%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fnext%2Fsrc%2F__tests__%2Fconfig.test.ts%3A1668-1673%0AThe%20async%20test%20omits%20the%20%60transpilePackages%60%20assertion%20that%20the%20sync%20test%20includes.%20This%20leaves%20a%20gap%3A%20if%20the%20async%20path%20accidentally%20skipped%20the%20%60transpilePackages%60%20injection%20%28e.g.%20a%20regression%20in%20the%20%60.then%28%29%60%20branch%29%2C%20the%20test%20would%20still%20pass.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20expect%28resolved.reactStrictMode%29.toBe%28true%29%3B%0A%20%20%20%20%20%20expect%28resolved%29.toHaveProperty%28'env'%29%3B%0A%20%20%20%20%20%20expect%28typeof%20resolved.webpack%29.toBe%28'function'%29%3B%0A%20%20%20%20%20%20expect%28resolved.transpilePackages%29.toContain%28'gt-next'%29%3B%0A%20%20%20%20%7D%29%3B%0A%20%20%7D%29%3B%0A%7D%29%3B%0A%60%60%60%0A%0A&repo=generaltranslation%2Fgt&pr=1935&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/next/src/config.ts:143-145
`instanceof Promise` misses custom thenables. If a chained Next.js plugin (e.g. one wrapping its result in a Bluebird or other thenable) returns a non-native Promise, the branch falls through to `withGTConfig(resolved, props)` where `resolved` is a thenable object treated as a plain config, silently dropping all user config keys. A duck-type check is the conventional defence here.

```suggestion
      return resolved !== null &&
        typeof (resolved as unknown as { then?: unknown }).then === 'function'
        ? (resolved as Promise<NextConfig>).then((resolvedConfig) =>
            withGTConfig(resolvedConfig, props)
          )
        : withGTConfig(resolved as NextConfig, props);
```

### Issue 2 of 2
packages/next/src/__tests__/config.test.ts:1668-1673
The async test omits the `transpilePackages` assertion that the sync test includes. This leaves a gap: if the async path accidentally skipped the `transpilePackages` injection (e.g. a regression in the `.then()` branch), the test would still pass.

```suggestion
      expect(resolved.reactStrictMode).toBe(true);
      expect(resolved).toHaveProperty('env');
      expect(typeof resolved.webpack).toBe('function');
      expect(resolved.transpilePackages).toContain('gt-next');
    });
  });
});
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(next): support function-form config ..."](https://github.com/generaltranslation/gt/commit/c0758f7ae7976051a57004704051a7650c2837b8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45474866)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->