### PR TITLE
ci: notify Slack of community pull requests

### DIFF
--- a/.github/workflows/community-pr-notification.yml
+++ b/.github/workflows/community-pr-notification.yml
@@ -16,15 +16,16 @@ jobs:
         github.event.pull_request.author_association
       )
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
 
     steps:
       - name: Send Slack notification
-        continue-on-error: true
-        uses: slackapi/slack-github-action@v2.1.1
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
         with:
+          errors: true
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
+          # PR titles are JSON-encoded below. PR bodies are intentionally excluded.
           payload: |
             {
               "text": ${{ toJSON(format('New community pull request #{0}', github.event.pull_request.number)) }},
@@ -62,7 +63,7 @@ jobs:
                         "type": "plain_text",
                         "text": "View Pull Request"
                       },
-                      "url": "${{ github.event.pull_request.html_url }}"
+                      "url": ${{ toJSON(github.event.pull_request.html_url) }}
                     }
                   ]
                 }

--- a/.github/workflows/community-pr-notification.yml
+++ b/.github/workflows/community-pr-notification.yml
@@ -1,0 +1,70 @@
+name: Notify Slack of Community Pull Requests
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions: {}
+
+jobs:
+  notify:
+    name: Notify Slack
+    if: >-
+      github.event.pull_request.user.type != 'Bot' &&
+      !contains(
+        fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'),
+        github.event.pull_request.author_association
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Send Slack notification
+        continue-on-error: true
+        uses: slackapi/slack-github-action@v2.1.1
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": ${{ toJSON(format('New community pull request #{0}', github.event.pull_request.number)) }},
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "🌱 New community pull request"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": ${{ toJSON(format('#{0}: {1}', github.event.pull_request.number, github.event.pull_request.title)) }},
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "mrkdwn",
+                      "text": ${{ toJSON(format('Opened by <{0}|@{1}> • `{2}`', github.event.pull_request.user.html_url, github.event.pull_request.user.login, github.event.pull_request.author_association)) }}
+                    }
+                  ]
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "View Pull Request"
+                      },
+                      "url": "${{ github.event.pull_request.html_url }}"
+                    }
+                  ]
+                }
+              ]
+            }


### PR DESCRIPTION
## Summary

- notify Slack when a user outside the GT organization opens a pull request
- suppress notifications for repository owners, members, collaborators, and bot-authored release automation
- use `pull_request_target` without checking out contributor code so the existing Slack webhook is available safely for forked PRs

## Testing

- `pnpm exec oxfmt --check .github/workflows/community-pr-notification.yml` — passed
- YAML parse with Ruby `YAML.load_file` — passed
- author-association filter matrix for internal users, external contributors, and bots — passed
- `git diff --check origin/main...HEAD` — passed

## Notes

- Changeset: not required; this only adds repository automation.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a GitHub Actions workflow that sends a Slack notification whenever a community contributor (anyone who is not an org owner, member, collaborator, or bot) opens a pull request. It uses `pull_request_target` without checking out contributor code, making secrets available safely for forked PRs.

- **Author-association filter**: bots (`user.type != 'Bot'`) and internal associations (`OWNER`, `MEMBER`, `COLLABORATOR`) are excluded; `CONTRIBUTOR`, `FIRST_TIMER`, `FIRST_TIME_CONTRIBUTOR`, and `NONE` trigger the notification as intended.
- **Payload security**: all user-controlled dynamic values (`PR number`, `title`, `user login`, `author_association`, `html_url`) are passed through `toJSON()` or `format()` + `toJSON()`, preventing JSON injection.
- **Supply-chain hygiene**: the `slackapi/slack-github-action` step is pinned to a full commit SHA (`91efab103c0de0a537f72a35f6b8cda0ee76bf0a`) with a version comment, and `permissions: {}` is set explicitly.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the workflow adds read-only Slack alerting with no checkout, no write permissions, and no exposure of secrets to contributor-controlled code.

The change is a single new workflow file with no production code impact. The pull_request_target trigger is used correctly (no contributor code checkout), all dynamic payload values go through toJSON(), the action is pinned to a commit SHA, and permissions are explicitly empty. No functional or security defects were found.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/community-pr-notification.yml | New workflow notifying Slack on community PRs; uses pull_request_target safely (no checkout), pins action to commit SHA, and wraps all dynamic values in toJSON() |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant C as Community Contributor
    participant GH as GitHub (pull_request_target)
    participant WF as Workflow Runner
    participant S as Slack Webhook

    C->>GH: Opens Pull Request
    GH->>WF: Triggers pull_request_target (opened)
    WF->>WF: "Evaluate if condition:<br/>user.type != Bot AND<br/>author_association NOT IN [OWNER, MEMBER, COLLABORATOR]"
    alt Internal / Bot author
        WF-->>GH: Skip (job skipped)
    else Community contributor
        WF->>S: "POST Slack message (PR #, title, author, URL)"
        S-->>WF: 200 OK
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant C as Community Contributor
    participant GH as GitHub (pull_request_target)
    participant WF as Workflow Runner
    participant S as Slack Webhook

    C->>GH: Opens Pull Request
    GH->>WF: Triggers pull_request_target (opened)
    WF->>WF: "Evaluate if condition:<br/>user.type != Bot AND<br/>author_association NOT IN [OWNER, MEMBER, COLLABORATOR]"
    alt Internal / Bot author
        WF-->>GH: Skip (job skipped)
    else Community contributor
        WF->>S: "POST Slack message (PR #, title, author, URL)"
        S-->>WF: 200 OK
    end
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ci): harden community PR notificatio..."](https://github.com/generaltranslation/gt/commit/258129470a8e98ef137b922a7b86a9b44f61ba25) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45731069)</sub>

<!-- /greptile_comment -->