### PR TITLE
fix(icu): harden parser and formatter edge cases

### DIFF
--- a/packages/core/src/derive/__tests__/condenseVarsPrinterRegression.test.ts
+++ b/packages/core/src/derive/__tests__/condenseVarsPrinterRegression.test.ts
@@ -2,10 +2,10 @@ import { describe, it, expect } from 'vitest';
 import { parse } from '@generaltranslation/icu';
 import { condenseVars } from '../condenseVars';
 
-// Pins the exact serialized output produced by the FormatJS `printAST`
-// implementation that condenseVars historically used. The vendored printer
-// must keep every one of these outputs byte-identical, because the condensed
-// strings feed into hashing.
+// Pins the serialized output used by condenseVars. Existing FormatJS output
+// stays byte-identical unless it was not safely reparseable; corrected cases
+// use the canonical, round-trippable form because condensed strings feed into
+// hashing and later parsing.
 describe('condenseVars printer regression', () => {
   it.each([
     ['single indexed select', '{_gt_1, select, other {}}', '{_gt_1}'],
@@ -119,6 +119,11 @@ describe('condenseVars printer regression', () => {
       'quoted brace run',
       "Show '{'raw'}' and '}' {_gt_1, select, other {}}",
       "Show '{raw} and }' {_gt_1}",
+    ],
+    [
+      'apostrophe inside quoted braces',
+      "'{isn''t}' {_gt_1, select, other {}}",
+      "'{isn''t}' {_gt_1}",
     ],
     [
       'escaped apostrophes',

--- a/packages/icu/src/__tests__/formatter.test.ts
+++ b/packages/icu/src/__tests__/formatter.test.ts
@@ -196,6 +196,21 @@ describe('formatMessage', () => {
     ).toThrow('Cannot apply fractional scale');
   });
 
+  it('rejects unsafe bigint plural selection instead of losing precision', () => {
+    const count = 1000000000000000001n;
+    expect(
+      formatMessage('{count, plural, other {# items}}', 'ru', { count })
+    ).toBe(`${new Intl.NumberFormat('ru').format(count)} items`);
+
+    expect(() =>
+      formatMessage(
+        '{count, plural, one {one} few {few} many {many} other {other}}',
+        'ru',
+        { count }
+      )
+    ).toThrow('outside the safe integer range');
+  });
+
   it('formats date and time named styles', () => {
     const value = new Date('2020-05-06T14:03:02Z');
     expect(formatMessage('{d, date, full}', 'en-US', { d: value })).toBe(

--- a/packages/icu/src/__tests__/parser.test.ts
+++ b/packages/icu/src/__tests__/parser.test.ts
@@ -212,6 +212,19 @@ describe('parse', () => {
     ]);
   });
 
+  it.each(['<a\u0301>x</a\u0301>', '<a\u203f>x</a\u203f>'])(
+    'parses FormatJS-compatible Unicode tag names in %j',
+    (message) => {
+      expect(parse(message)).toEqual([
+        {
+          type: TYPE.tag,
+          value: message.slice(1, message.indexOf('>')),
+          children: [{ type: TYPE.literal, value: 'x' }],
+        },
+      ]);
+    }
+  );
+
   it('can treat tags as plain text', () => {
     expect(parse('<b>{name}</b>', { ignoreTag: true })).toEqual([
       { type: TYPE.literal, value: '<b>' },

--- a/packages/icu/src/__tests__/printer.test.ts
+++ b/packages/icu/src/__tests__/printer.test.ts
@@ -97,11 +97,11 @@ describe('printAST', () => {
     ],
     ['<b>Bold <i>{name}</i></b>', '<b>Bold <i>{name}</i></b>'],
     ["Cost: '{'price'}'", "Cost: '{price}'"],
-    ["'{isn''t}'", "'{isn't}'"],
+    ["'{isn''t}'", "'{isn''t}'"],
     ["It''s {name} o''clock", "It's {name} o'clock"],
     ["{name}'s book", "{name}''s book"],
     ["{count, plural, other {'#' #}}", "{count,plural,other{'#' #}}"],
-  ])('prints %j with stable historical bytes', (message, expected) => {
+  ])('prints %j with stable canonical bytes', (message, expected) => {
     expect(printAST(parse(message))).toBe(expected);
   });
 
@@ -112,8 +112,10 @@ describe('printAST', () => {
     '{status, select, yes {{name} accepted} other {none}}',
     '{count, plural, one {<b># item</b>} other {<b># items</b>}}',
     '{count, plural, one {{status, select, yes {{name}} other {none}}} other {No}}',
-  ])('produces reparseable output for %j', (message) => {
-    expect(() => parse(printAST(parse(message)))).not.toThrow();
+    "'{isn''t}'",
+  ])('preserves the AST through print and reparse for %j', (message) => {
+    const original = parse(message);
+    expect(parse(printAST(original))).toEqual(original);
   });
 
   it.each(GENERATED_ROUND_TRIP_MESSAGES)(

--- a/packages/icu/src/formatter.ts
+++ b/packages/icu/src/formatter.ts
@@ -143,13 +143,13 @@ function formatElements(
         let option = ownOption(element.options, exactSelector);
         const value = coercePluralValue(rawValue);
         const adjustedValue = subtractOffset(value, element.offset);
-        if (!option) {
+        if (!option && hasPluralCategoryOption(element.options)) {
           const category = new Intl.PluralRules(locales, {
             type: element.pluralType,
-          }).select(Number(adjustedValue));
-          option =
-            ownOption(element.options, category) ?? element.options.other;
+          }).select(toPluralRulesNumber(adjustedValue));
+          option = ownOption(element.options, category);
         }
+        option ??= element.options.other;
         if (!option) {
           throw invalidSelection(element.value, rawValue, element.options);
         }
@@ -256,6 +256,22 @@ function coercePluralValue(value: unknown): PluralValue {
 
 function subtractOffset(value: PluralValue, offset: number): PluralValue {
   return typeof value === 'bigint' ? value - BigInt(offset) : value - offset;
+}
+
+function toPluralRulesNumber(value: PluralValue): number {
+  const numberValue = Number(value);
+  if (typeof value === 'bigint' && !Number.isSafeInteger(numberValue)) {
+    throw new RangeError(
+      `Cannot select a plural category for bigint ${value} outside the safe integer range.`
+    );
+  }
+  return numberValue;
+}
+
+function hasPluralCategoryOption(options: Record<string, unknown>): boolean {
+  return Object.keys(options).some(
+    (selector) => selector !== 'other' && !selector.startsWith('=')
+  );
 }
 
 function ownOption<T>(options: Record<string, T>, key: string): T | undefined {

--- a/packages/icu/src/parser.ts
+++ b/packages/icu/src/parser.ts
@@ -23,7 +23,6 @@ import {
 
 const WHITE_SPACE = /[\p{White_Space}\u200E\u200F]/u;
 const IDENTIFIER_BOUNDARY = /[\p{White_Space}\p{Pattern_Syntax}]/u;
-const TAG_NAME_CHARACTER = /^[\p{L}\p{N}_.\-·\u200C\u200D]$/u;
 
 type PositionIndex = {
   lines: Uint32Array;
@@ -190,7 +189,7 @@ class IcuParser {
     const start = this.index;
     if (!isAsciiLetter(this.current())) this.fail('INVALID_TAG', start);
     this.index += 1;
-    while (!this.atEnd() && TAG_NAME_CHARACTER.test(this.current())) {
+    while (!this.atEnd() && isTagNameCharacter(this.current())) {
       this.index += this.current().length;
     }
     return this.message.slice(start, this.index);
@@ -505,6 +504,37 @@ class IcuParser {
 
 function isAsciiLetter(character: string): boolean {
   return /^[A-Za-z]$/u.test(character);
+}
+
+/**
+ * Matches the PENChar ranges used by FormatJS and the custom-element-name
+ * grammar, while allowing ASCII uppercase characters and names without a dash.
+ */
+function isTagNameCharacter(character: string): boolean {
+  const codePoint = character.codePointAt(0);
+  if (codePoint === undefined) return false;
+
+  return (
+    codePoint === 0x2d ||
+    codePoint === 0x2e ||
+    (codePoint >= 0x30 && codePoint <= 0x39) ||
+    codePoint === 0x5f ||
+    (codePoint >= 0x41 && codePoint <= 0x5a) ||
+    (codePoint >= 0x61 && codePoint <= 0x7a) ||
+    codePoint === 0xb7 ||
+    (codePoint >= 0xc0 && codePoint <= 0xd6) ||
+    (codePoint >= 0xd8 && codePoint <= 0xf6) ||
+    (codePoint >= 0xf8 && codePoint <= 0x37d) ||
+    (codePoint >= 0x37f && codePoint <= 0x1fff) ||
+    (codePoint >= 0x200c && codePoint <= 0x200d) ||
+    (codePoint >= 0x203f && codePoint <= 0x2040) ||
+    (codePoint >= 0x2070 && codePoint <= 0x218f) ||
+    (codePoint >= 0x2c00 && codePoint <= 0x2fef) ||
+    (codePoint >= 0x3001 && codePoint <= 0xd7ff) ||
+    (codePoint >= 0xf900 && codePoint <= 0xfdcf) ||
+    (codePoint >= 0xfdf0 && codePoint <= 0xfffd) ||
+    (codePoint >= 0x10000 && codePoint <= 0xeffff)
+  );
 }
 
 function buildPositionIndex(message: string): PositionIndex {

--- a/packages/icu/src/printer.ts
+++ b/packages/icu/src/printer.ts
@@ -57,7 +57,9 @@ function printElements(
 }
 
 function escapeMessage(message: string): string {
-  return message.replace(/([{}](?:[\s\S]*[{}])?)/, "'$1'");
+  return message.replace(/([{}](?:[\s\S]*[{}])?)/, (matched) => {
+    return `'${matched.replace(/'/g, "''")}'`;
+  });
 }
 
 function printLiteral(


### PR DESCRIPTION
## TL;DR

Fixes the ICU compatibility edge cases found while reviewing #1929.

## Code Changes

- Restore FormatJS-compatible Unicode PENChar tag-name parsing.
- Preserve apostrophes when printing brace-escaped literals and add core condense round-trip coverage.
- Avoid lossy BigInt plural-category selection: retain exact `other`-only formatting and reject unsafe locale-category selection.
- Add focused parser, printer, formatter, and core regression tests.

## Notes / Flags

- Stacked on #1929; the base branch is `e/multi/replace-formatjs-icu`.
- No new changeset: these fixes amend the unreleased ICU package introduced by the parent PR.
- `Intl.PluralRules` does not accept arbitrary BigInts; unsafe values now throw only when a locale category must be computed.
- Verification:
  - `pnpm --filter @generaltranslation/icu test` — passed (4,532 tests).
  - `pnpm --filter generaltranslation test` — passed (473 passed, 3 skipped).
  - `pnpm --filter @generaltranslation/format test` — passed (269 tests).
  - `pnpm --filter gt test` — passed (2,078 passed, 5 skipped).
  - `pnpm --filter @generaltranslation/react-core-linter test` — passed (691 tests).
  - `pnpm --filter gt-i18n test` — passed (300 tests).
  - `pnpm --filter @generaltranslation/icu build` — passed.
  - `pnpm --filter @generaltranslation/icu typecheck`, `pnpm --filter generaltranslation typecheck`, `pnpm --filter @generaltranslation/format typecheck`, `pnpm --filter gt typecheck`, `pnpm --filter @generaltranslation/react-core-linter typecheck`, and `pnpm --filter gt-i18n typecheck` — passed.
  - `pnpm lint` — passed, including formatting checks.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens edge cases in the ICU message format parser, printer, and formatter stacked on #1929. The four targeted fixes are: restoring FormatJS-compatible PENChar Unicode ranges for tag-name parsing, preserving apostrophes when `escapeMessage` re-escapes brace-containing literals, avoiding a lossy `BigInt → Number` cast when plural category selection is unnecessary, and throwing clearly on unsafe BigInt values when category lookup is required.

- **parser.ts**: replaces the `TAG_NAME_CHARACTER` regex with an explicit `isTagNameCharacter` function using the same PENChar code-point ranges as FormatJS, enabling characters like U+0301 and U+203F in tag names.
- **printer.ts**: `escapeMessage` now doubles internal apostrophes before wrapping brace content in quotes, fixing a round-trip regression where `{isn't}` was printed as `'{isn't}'` (closes the quote early) instead of the correct `'{isn''t}'`.
- **formatter.ts**: introduces `hasPluralCategoryOption` to skip the `Intl.PluralRules.select()` call when options contain only `other` or exact `=N` selectors, and `toPluralRulesNumber` to throw a `RangeError` for unsafe BigInts only when locale-category lookup is actually needed.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

All three source changes are narrowly targeted and fully covered by new regression tests; no existing behaviour is removed, only incorrect edge-case paths are corrected.

The printer apostrophe fix, the PENChar parser expansion, and the BigInt plural guard each touch a small, isolated code path. The test suite was run across six packages and passed. The formatter change replaces a single compound expression with two guarded steps that preserve the same fallback semantics in every reachable case.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/icu/src/formatter.ts | Adds hasPluralCategoryOption guard and toPluralRulesNumber to fix lossy BigInt-to-Number conversion; logic and fallback semantics are preserved correctly. |
| packages/icu/src/printer.ts | escapeMessage now doubles apostrophes inside brace-escaped segments, fixing the round-trip regression for values like {isn't}. |
| packages/icu/src/parser.ts | TAG_NAME_CHARACTER regex replaced by isTagNameCharacter with explicit PENChar ranges; surrogate-pair advancement is correct via this.current().length. |
| packages/icu/src/__tests__/formatter.test.ts | Adds two-part BigInt test: safe path (other-only plural formats without throwing) and unsafe path (category lookup required, RangeError thrown). |
| packages/icu/src/__tests__/printer.test.ts | Corrects the expected printer output for '{isn''t}' and upgrades the round-trip test to also assert AST equality, not just no-throw. |
| packages/icu/src/__tests__/parser.test.ts | Adds parameterised tests for U+0301 and U+203F tag-name characters, covering the new PENChar ranges. |
| packages/core/src/derive/__tests__/condenseVarsPrinterRegression.test.ts | Adds apostrophe-inside-quoted-braces regression case and updates the comment to reflect that corrected (non-lossy) forms are now canonical. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[plural element\nrawValue provided] --> B{exact match\n=N in options?}
    B -- yes --> G[use exact option]
    B -- no --> C{hasPluralCategoryOption?\none/few/many/zero/two present}
    C -- no --> D[option ??= other\nskip Intl.PluralRules entirely]
    C -- yes --> E{toPluralRulesNumber\nBigInt safe?}
    E -- unsafe BigInt --> F[throw RangeError\nunsafe integer range]
    E -- safe / number --> H[Intl.PluralRules.select\ncategory lookup]
    H --> I{category match\nfound?}
    I -- yes --> G
    I -- no --> D
    D --> J[format option value]
    G --> J
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[plural element\nrawValue provided] --> B{exact match\n=N in options?}
    B -- yes --> G[use exact option]
    B -- no --> C{hasPluralCategoryOption?\none/few/many/zero/two present}
    C -- no --> D[option ??= other\nskip Intl.PluralRules entirely]
    C -- yes --> E{toPluralRulesNumber\nBigInt safe?}
    E -- unsafe BigInt --> F[throw RangeError\nunsafe integer range]
    E -- safe / number --> H[Intl.PluralRules.select\ncategory lookup]
    H --> I{category match\nfound?}
    I -- yes --> G
    I -- no --> D
    D --> J[format option value]
    G --> J
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(icu): harden parser and formatter ed..."](https://github.com/generaltranslation/gt/commit/f1aa397667b86f96cd6cd5cb89a85e791d47c55c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45746064)</sub>

<!-- /greptile_comment -->