### PR TITLE
fix(ci): restrict PR alert exclusions to org members

### DIFF
--- a/.github/workflows/community-pr-notification.yml
+++ b/.github/workflows/community-pr-notification.yml
@@ -25,14 +25,21 @@ jobs:
           set -u
 
           status=''
+          # Read the token through stdin so it never appears in process arguments.
           if ! status="$(
-            curl --silent --show-error \
-              --output /dev/null \
-              --write-out '%{http_code}' \
-              --header 'Accept: application/vnd.github+json' \
-              --header "Authorization: Bearer ${ORG_MEMBERS_TOKEN}" \
-              --header 'X-GitHub-Api-Version: 2022-11-28' \
-              "https://api.github.com/orgs/${GITHUB_REPOSITORY_OWNER}/members/${PR_AUTHOR}"
+            curl --config - <<EOF
+          silent
+          show-error
+          proto = "=https"
+          connect-timeout = 10
+          max-time = 30
+          output = "/dev/null"
+          write-out = "%{http_code}"
+          header = "Accept: application/vnd.github+json"
+          header = "Authorization: Bearer ${ORG_MEMBERS_TOKEN}"
+          header = "X-GitHub-Api-Version: 2022-11-28"
+          url = "https://api.github.com/orgs/${GITHUB_REPOSITORY_OWNER}/members/${PR_AUTHOR}"
+          EOF
           )"; then
             echo '::error::Could not query General Translation organization membership.'
             exit 1

--- a/.github/workflows/community-pr-notification.yml
+++ b/.github/workflows/community-pr-notification.yml
@@ -7,12 +7,54 @@ on:
 permissions: {}
 
 jobs:
+  membership:
+    name: Check organization membership
+    if: github.event.pull_request.user.type != 'Bot'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      is_member: ${{ steps.check.outputs.is_member }}
+
+    steps:
+      - name: Check organization membership
+        id: check
+        env:
+          ORG_MEMBERS_TOKEN: ${{ secrets.GT_ORG_MEMBERS_TOKEN }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          set -u
+
+          status=''
+          if ! status="$(
+            curl --silent --show-error \
+              --output /dev/null \
+              --write-out '%{http_code}' \
+              --header 'Accept: application/vnd.github+json' \
+              --header "Authorization: Bearer ${ORG_MEMBERS_TOKEN}" \
+              --header 'X-GitHub-Api-Version: 2022-11-28' \
+              "https://api.github.com/orgs/${GITHUB_REPOSITORY_OWNER}/members/${PR_AUTHOR}"
+          )"; then
+            echo '::error::Could not query General Translation organization membership.'
+            exit 1
+          fi
+
+          case "${status}" in
+            204)
+              echo 'is_member=true' >> "${GITHUB_OUTPUT}"
+              ;;
+            404)
+              echo 'is_member=false' >> "${GITHUB_OUTPUT}"
+              ;;
+            *)
+              echo "::error::Could not verify General Translation organization membership (HTTP ${status}). Check GT_ORG_MEMBERS_TOKEN and its Members: read permission."
+              exit 1
+              ;;
+          esac
+
   notify:
     name: Notify Slack
-    if: >-
-      github.event.pull_request.user.type != 'Bot' &&
-      github.event.pull_request.author_association != 'OWNER' &&
-      github.event.pull_request.author_association != 'MEMBER'
+    needs: membership
+    if: needs.membership.outputs.is_member == 'false'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/community-pr-notification.yml
+++ b/.github/workflows/community-pr-notification.yml
@@ -12,7 +12,7 @@ jobs:
     if: >-
       github.event.pull_request.user.type != 'Bot' &&
       !contains(
-        fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'),
+        fromJSON('["OWNER", "MEMBER"]'),
         github.event.pull_request.author_association
       )
     runs-on: ubuntu-latest

--- a/.github/workflows/community-pr-notification.yml
+++ b/.github/workflows/community-pr-notification.yml
@@ -16,16 +16,25 @@ jobs:
       is_member: ${{ steps.check.outputs.is_member }}
 
     steps:
+      - name: Generate organization membership token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.GT_MEMBERS_APP_CLIENT_ID }}
+          private-key: ${{ secrets.GT_MEMBERS_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          permission-members: read
+
       - name: Check organization membership
         id: check
         env:
-          ORG_MEMBERS_TOKEN: ${{ secrets.GT_ORG_MEMBERS_TOKEN }}
+          ORG_MEMBERS_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
           set -u
 
           status=''
-          # Read the token through stdin so it never appears in process arguments.
+          # Read the short-lived token through stdin so it never appears in process arguments.
           if ! status="$(
             curl -q --config - <<EOF
           silent
@@ -53,7 +62,7 @@ jobs:
               echo 'is_member=false' >> "${GITHUB_OUTPUT}"
               ;;
             *)
-              echo "::error::Could not verify General Translation organization membership (HTTP ${status}). Check GT_ORG_MEMBERS_TOKEN and its Members: read permission."
+              echo "::error::Could not verify General Translation organization membership (HTTP ${status}). Check the GitHub App installation and its Members: read permission."
               exit 1
               ;;
           esac

--- a/.github/workflows/community-pr-notification.yml
+++ b/.github/workflows/community-pr-notification.yml
@@ -27,7 +27,7 @@ jobs:
           status=''
           # Read the token through stdin so it never appears in process arguments.
           if ! status="$(
-            curl --config - <<EOF
+            curl -q --config - <<EOF
           silent
           show-error
           proto = "=https"

--- a/.github/workflows/community-pr-notification.yml
+++ b/.github/workflows/community-pr-notification.yml
@@ -11,10 +11,8 @@ jobs:
     name: Notify Slack
     if: >-
       github.event.pull_request.user.type != 'Bot' &&
-      !contains(
-        fromJSON('["OWNER", "MEMBER"]'),
-        github.event.pull_request.author_association
-      )
+      github.event.pull_request.author_association != 'OWNER' &&
+      github.event.pull_request.author_association != 'MEMBER'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 


### PR DESCRIPTION
## Summary

- verify pull request authors against the General Translation membership API instead of relying on visibility-dependent `author_association` values
- generate a short-lived installation token from an organization-owned GitHub App instead of maintaining an expiring personal access token
- isolate the App credential and membership token from the Slack webhook by running membership verification and notification in separate jobs
- pass the short-lived token to `curl` through standard input, discard the response body, and expose only the membership boolean
- notify only for confirmed non-members; skip bots and fail without notifying when membership cannot be verified

## Testing

- `pnpm exec oxfmt --check .github/workflows/community-pr-notification.yml` — passed
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/community-pr-notification.yml')"` — passed
- extracted membership script syntax check with `bash -n` — passed
- simulated membership API responses: `204` → member, `404` → non-member, `401` → fail closed — passed
- live invalid-credential request exposed no token or response body and failed closed on `401` — passed
- verified the pinned `actions/create-github-app-token` release supports `client-id`, `private-key`, `owner`, and `permission-members` inputs — passed
- `git diff --check origin/main...HEAD` — passed

## Notes

- Changeset: not required; this only adjusts repository automation.
- Requires the `GT_MEMBERS_APP_CLIENT_ID` repository variable and `GT_MEMBERS_APP_PRIVATE_KEY` repository secret for a private, organization-owned GitHub App installed with organization `Members: read` permission.
- The App token is masked and automatically revoked when the membership job finishes.
- Live Actions payloads labeled private organization members as `CONTRIBUTOR`, so `author_association` cannot enforce this policy.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes how community pull request alerts exclude organization members. The main changes are:

- Verifies PR authors through the organization membership API.
- Generates a short-lived token from an organization-owned GitHub App.
- Separates membership verification from the Slack notification job.
- Notifies only for confirmed non-members and skips bots.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the updated workflow.

</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/community-pr-notification.yml | Adds GitHub App authentication, organization membership verification, and output-based Slack notification gating. |

</details>

<sub>Reviews (6): Last reviewed commit: ["fix(ci): use GitHub App for membership c..."](https://github.com/generaltranslation/gt/commit/6da97a88edcd1be7fb220f40e9438fd1e4496499) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45802342)</sub>

<!-- /greptile_comment -->