### PR TITLE
test(tanstack-start): stabilize package export setup

### DIFF
--- a/packages/tanstack-start/src/__tests__/packageExports.test.ts
+++ b/packages/tanstack-start/src/__tests__/packageExports.test.ts
@@ -1,11 +1,20 @@
 import { execFileSync } from 'node:child_process';
-import { readdirSync, readFileSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { beforeAll, describe, expect, it } from 'vitest';
 
 const packageRoot = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
+const builtArtifacts = [
+  'index.client.mjs',
+  'index.server.mjs',
+  'server.mjs',
+].map((artifact) => join(packageRoot, 'dist', artifact));
+
+function hasBuiltArtifacts(): boolean {
+  return builtArtifacts.every((artifact) => existsSync(artifact));
+}
 
 function buildPackage(): void {
   const command = process.env.npm_execpath ? process.execPath : 'pnpm';
@@ -25,8 +34,9 @@ function node(args: string[]): void {
 
 describe('gt-tanstack-start package exports', () => {
   beforeAll(() => {
+    if (hasBuiltArtifacts()) return;
     buildPackage();
-  });
+  }, 60_000);
 
   it('publishes ESM-only entrypoints', () => {
     const packageJson = JSON.parse(

--- a/packages/tanstack-start/src/__tests__/packageExports.test.ts
+++ b/packages/tanstack-start/src/__tests__/packageExports.test.ts
@@ -1,20 +1,11 @@
 import { execFileSync } from 'node:child_process';
-import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { beforeAll, describe, expect, it } from 'vitest';
 
 const packageRoot = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
-const builtArtifacts = [
-  'index.client.mjs',
-  'index.server.mjs',
-  'server.mjs',
-].map((artifact) => join(packageRoot, 'dist', artifact));
-
-function hasBuiltArtifacts(): boolean {
-  return builtArtifacts.every((artifact) => existsSync(artifact));
-}
 
 function buildPackage(): void {
   const command = process.env.npm_execpath ? process.execPath : 'pnpm';
@@ -25,6 +16,7 @@ function buildPackage(): void {
   execFileSync(command, args, {
     cwd: packageRoot,
     stdio: 'pipe',
+    timeout: 60_000,
   });
 }
 
@@ -34,9 +26,11 @@ function node(args: string[]): void {
 
 describe('gt-tanstack-start package exports', () => {
   beforeAll(() => {
-    if (hasBuiltArtifacts()) return;
+    // Turbo guarantees this package's build task completes before its test
+    // task. Standalone package tests rebuild so they cannot use stale output.
+    if (process.env.TURBO_HASH) return;
     buildPackage();
-  }, 60_000);
+  }, 65_000);
 
   it('publishes ESM-only entrypoints', () => {
     const packageJson = JSON.parse(


### PR DESCRIPTION
## Summary

- reuse TanStack package artifacts produced by Turbo instead of rebuilding synchronously inside the export-test hook
- rebuild package output on standalone runs with a bounded 60-second child-process timeout

## Testing

- `pnpm exec oxfmt --check packages/tanstack-start/src/__tests__/packageExports.test.ts`
- `pnpm --filter gt-tanstack-start typecheck`
- `pnpm --filter gt-tanstack-start test` — passed (17 tests)
- `pnpm exec turbo run test --filter=gt-tanstack-start --ui=stream` — passed (7 tasks; 17 tests)

## Notes

- No changeset is required because this only stabilizes test setup.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR stabilizes the TanStack Start package-export test setup. The main changes are:

- Reuse package artifacts when tests run through Turbo.
- Rebuild package output during standalone test runs.
- Stop synchronous package builds after 60 seconds.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- Turbo-managed tests wait for the package build before reusing its artifacts.
- Standalone tests rebuild the package output.
- The synchronous build now has a bounded timeout.
- No blocking issues were found in the changed code.


</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/tanstack-start/src/__tests__/packageExports.test.ts | Uses Turbo-built artifacts when available and adds bounded rebuilding for standalone export tests. |

</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/tanstack-start/src/__tests__/packageExports.test.ts`, line 25-28 ([link](https://github.com/generaltranslation/gt/blob/c0ea37820e40113421452ae397c83e2894496c60/packages/tanstack-start/src/__tests__/packageExports.test.ts#L25-L28)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Hook Timeout Cannot Stop Build**

   When artifacts are missing and the synchronous build stalls, `execFileSync` blocks the Vitest worker and has no child-process timeout. The 60-second hook timer cannot interrupt that call, so the test can hang until the outer CI job terminates it.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/tanstack-start/src/__tests__/packageExports.test.ts
   Line: 25-28

   Comment:
   **Hook Timeout Cannot Stop Build**

   When artifacts are missing and the synchronous build stalls, `execFileSync` blocks the Vitest worker and has no child-process timeout. The 60-second hook timer cannot interrupt that call, so the test can hang until the outer CI job terminates it.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Ftanstack-start%2Fsrc%2F__tests__%2FpackageExports.test.ts%0ALine%3A%2025-28%0A%0AComment%3A%0A**Hook%20Timeout%20Cannot%20Stop%20Build**%0A%0AWhen%20artifacts%20are%20missing%20and%20the%20synchronous%20build%20stalls%2C%20%60execFileSync%60%20blocks%20the%20Vitest%20worker%20and%20has%20no%20child-process%20timeout.%20The%2060-second%20hook%20timer%20cannot%20interrupt%20that%20call%2C%20so%20the%20test%20can%20hang%20until%20the%20outer%20CI%20job%20terminates%20it.%0A%0A%60%60%60suggestion%0A%20%20execFileSync%28command%2C%20args%2C%20%7B%0A%20%20%20%20cwd%3A%20packageRoot%2C%0A%20%20%20%20stdio%3A%20'pipe'%2C%0A%20%20%20%20timeout%3A%2060_000%2C%0A%20%20%7D%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=generaltranslation%2Fgt&pr=1957&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Ftanstack-start%2Fstabilize-package-export-test%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Ftanstack-start%2Fstabilize-package-export-test%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Ftanstack-start%2Fsrc%2F__tests__%2FpackageExports.test.ts%0ALine%3A%2025-28%0A%0AComment%3A%0A**Hook%20Timeout%20Cannot%20Stop%20Build**%0A%0AWhen%20artifacts%20are%20missing%20and%20the%20synchronous%20build%20stalls%2C%20%60execFileSync%60%20blocks%20the%20Vitest%20worker%20and%20has%20no%20child-process%20timeout.%20The%2060-second%20hook%20timer%20cannot%20interrupt%20that%20call%2C%20so%20the%20test%20can%20hang%20until%20the%20outer%20CI%20job%20terminates%20it.%0A%0A%60%60%60suggestion%0A%20%20execFileSync%28command%2C%20args%2C%20%7B%0A%20%20%20%20cwd%3A%20packageRoot%2C%0A%20%20%20%20stdio%3A%20'pipe'%2C%0A%20%20%20%20timeout%3A%2060_000%2C%0A%20%20%7D%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=generaltranslation%2Fgt&pr=1957&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["test(tanstack-start): avoid stale export..."](https://github.com/generaltranslation/gt/commit/352c92e6371a125ef4e2e0ac644cf26e870b9914) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46049470)</sub>

<!-- /greptile_comment -->