### PR TITLE
fix(icu): preserve FormatJS edge compatibility

### DIFF
--- a/packages/format/src/formatting/__tests__/format.test.ts
+++ b/packages/format/src/formatting/__tests__/format.test.ts
@@ -75,6 +75,15 @@ describe('_formatMessageICU', () => {
     ).toBe('12.34');
   });
 
+  it('preserves numeric-string precision through the public boundary', () => {
+    expect(
+      publicFormatMessage('{value, number}', {
+        locales: 'en-US',
+        variables: { value: '123456789012345678901234567890' },
+      })
+    ).toBe('123,456,789,012,345,678,901,234,567,890');
+  });
+
   it('passes date skeletons through the package boundary', () => {
     const value = new Date('2020-05-06T14:03:02Z');
     expect(

--- a/packages/icu/src/__tests__/formatter.test.ts
+++ b/packages/icu/src/__tests__/formatter.test.ts
@@ -49,6 +49,29 @@ describe('formatMessage', () => {
     );
   });
 
+  it('does not require the ES2022 Object.hasOwn API', () => {
+    const descriptor = Object.getOwnPropertyDescriptor(Object, 'hasOwn');
+    Object.defineProperty(Object, 'hasOwn', {
+      configurable: true,
+      value: undefined,
+    });
+
+    try {
+      expect(
+        formatMessage('{kind, select, yes {Hi {name}} other {No}}', 'en', {
+          kind: 'yes',
+          name: 'Ada',
+        })
+      ).toBe('Hi Ada');
+    } finally {
+      if (descriptor) {
+        Object.defineProperty(Object, 'hasOwn', descriptor);
+      } else {
+        Reflect.deleteProperty(Object, 'hasOwn');
+      }
+    }
+  });
+
   it('selects exact and fallback branches without prototype collisions', () => {
     const message =
       '{value, select, constructor {ctor} __proto__ {proto} toString {string} other {fallback}}';
@@ -146,6 +169,16 @@ describe('formatMessage', () => {
     ).toBe('123,457');
     expect(formatMessage('{n, number, percent}', 'en-US', { n: 0.56 })).toBe(
       '56%'
+    );
+  });
+
+  it('preserves unscaled numeric-string precision', () => {
+    const value = '123456789012345678901234567890';
+    const expected = '123,456,789,012,345,678,901,234,567,890';
+
+    expect(formatMessage('{n, number}', 'en-US', { n: value })).toBe(expected);
+    expect(formatMessage('{n, number, ::scale/0}', 'en-US', { n: value })).toBe(
+      expected
     );
   });
 

--- a/packages/icu/src/__tests__/parser.test.ts
+++ b/packages/icu/src/__tests__/parser.test.ts
@@ -167,6 +167,32 @@ describe('parse', () => {
     });
   });
 
+  it.each([
+    ['0085', '\u0085'],
+    ['200E', '\u200E'],
+    ['200F', '\u200F'],
+  ])(
+    'parses FormatJS number-skeleton whitespace U+$codePoint',
+    (_codePoint, separator) => {
+      expect(
+        parse(`{amount, number, ::currency/USD${separator}.00}`)[0]
+      ).toMatchObject({
+        style: {
+          tokens: [
+            { stem: 'currency', options: ['USD'] },
+            { stem: '.00', options: [] },
+          ],
+          parsedOptions: {
+            style: 'currency',
+            currency: 'USD',
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2,
+          },
+        },
+      });
+    }
+  );
+
   it.each(['C', 'S', 'A'])(
     'preserves FormatJS parsing of the %s date/time skeleton field',
     (field) => {
@@ -292,6 +318,11 @@ describe('parse', () => {
     ['{n, number, ::}', 'Number skeleton cannot be empty'],
     ['{n, number, ::currency/}', 'Invalid number skeleton token'],
     ['{n, number, ::integer-width/*}', 'Unsupported integer width'],
+    [
+      '{n, number, ::integer-width/*00/foo}',
+      'integer-width stems only accept a single optional option',
+    ],
+    ['{n, number, ::Efoo}', 'Malformed concise eng/scientific notation'],
     ["{n, number, 'unclosed}", 'UNCLOSED_QUOTE_IN_ARGUMENT_STYLE'],
   ])('rejects malformed ICU %j', (message, error) => {
     expect(() => parse(message)).toThrow(error);

--- a/packages/icu/src/formatter.ts
+++ b/packages/icu/src/formatter.ts
@@ -194,8 +194,12 @@ function formatElements(
   return mergeLiteralParts(result);
 }
 
+function hasOwn(object: object, key: PropertyKey): boolean {
+  return Object.prototype.hasOwnProperty.call(object, key);
+}
+
 function requireVariable(variables: MessageVariables, name: string): unknown {
-  if (!Object.hasOwn(variables, name)) {
+  if (!hasOwn(variables, name)) {
     throw new Error(`The ICU message variable "${name}" was not provided.`);
   }
   return variables[name];
@@ -245,20 +249,20 @@ function numberOptions(
   return {};
 }
 
-function applyScale(value: unknown, scale = 1): number | bigint {
+function applyScale(value: unknown, scale?: number): unknown {
   // intl-messageformat treated scale/0 as an absent scale. Preserve that
   // observable behavior for existing messages even though multiplying by zero
   // would follow the ICU skeleton definition more literally.
-  const effectiveScale = scale || 1;
+  if (!scale) return value;
   if (typeof value === 'bigint') {
-    if (!Number.isInteger(effectiveScale)) {
+    if (!Number.isInteger(scale)) {
       throw new RangeError(
-        `Cannot apply fractional scale ${effectiveScale} to a bigint value.`
+        `Cannot apply fractional scale ${scale} to a bigint value.`
       );
     }
-    return value * BigInt(effectiveScale);
+    return value * BigInt(scale);
   }
-  return Number(value) * effectiveScale;
+  return Number(value) * scale;
 }
 
 function getNumberFormat(
@@ -330,7 +334,7 @@ function hasPluralCategoryOption(options: Record<string, unknown>): boolean {
 }
 
 function ownOption<T>(options: Record<string, T>, key: string): T | undefined {
-  return Object.hasOwn(options, key) ? options[key] : undefined;
+  return hasOwn(options, key) ? options[key] : undefined;
 }
 
 function invalidSelection(

--- a/packages/icu/src/skeleton.ts
+++ b/packages/icu/src/skeleton.ts
@@ -8,6 +8,7 @@ import type { ExtendedNumberFormatOptions, NumberSkeletonToken } from './types';
 const FRACTION_PRECISION = /^\.(?:(0+)(\*)?|(#+)|(0+)(#+))$/;
 const SIGNIFICANT_PRECISION = /^(@+)?(\+|#+)?[rs]?$/;
 const INTEGER_WIDTH = /^(?:(\*)(0+)|(#+)(0+)|(0+))$/;
+const NUMBER_SKELETON_WHITE_SPACE = /[\t-\r \x85\u200E\u200F\u2028\u2029]+/u;
 const DATE_TIME_FIELD =
   /(?:[Eec]{1,6}|G{1,5}|[Qq]{1,5}|(?:[yYur]+|U{1,5})|[ML]{1,5}|d{1,2}|D{1,3}|F|[abB]{1,5}|[hHkKjJC]{1,2}|w{1,2}|W|m{1,2}|s{1,2}|[SA]+|[zZOvVxX]{1,4})(?=([^']*'[^']*')*[^']*$)/g;
 
@@ -42,7 +43,9 @@ const ROUNDING_MODES: Record<
 export function parseNumberSkeletonTokens(
   skeleton: string
 ): NumberSkeletonToken[] {
-  const stringTokens = skeleton.trim().split(/\s+/u).filter(Boolean);
+  const stringTokens = skeleton
+    .split(NUMBER_SKELETON_WHITE_SPACE)
+    .filter(Boolean);
   if (stringTokens.length === 0) {
     throw new SyntaxError('Number skeleton cannot be empty.');
   }
@@ -147,6 +150,11 @@ export function parseNumberSkeletonOptions(
         continue;
       case 'integer-width':
         requireOption(token);
+        if (token.options.length > 1) {
+          throw new RangeError(
+            'integer-width stems only accept a single optional option'
+          );
+        }
         applyIntegerWidth(result, option!);
         continue;
     }
@@ -225,8 +233,11 @@ function applyConciseScientific(
   result: ModernNumberFormatOptions,
   source: string
 ): boolean {
+  if (!source.startsWith('E')) return false;
   const match = /^(E{1,2})(\+!|\+\?)?(0+)$/u.exec(source);
-  if (!match) return false;
+  if (!match) {
+    throw new SyntaxError('Malformed concise eng/scientific notation');
+  }
 
   result.notation = match[1] === 'EE' ? 'engineering' : 'scientific';
   if (match[2]) applySign(result, match[2]);


### PR DESCRIPTION
## Summary

- Preserve FormatJS behavior for unscaled numeric strings and `scale/0`, including values beyond JavaScript's safe integer precision.
- Keep own-property checks compatible with older JavaScript runtimes and align number-skeleton whitespace and malformed-token handling with the pinned FormatJS implementation.
- Reproduce the compatibility fixes identified and implemented by @bgub in #1955, applied to the latest #1929 head.

## Testing

- `pnpm install --frozen-lockfile` — passed
- `pnpm exec turbo run build --filter=@generaltranslation/icu --filter=@generaltranslation/format --filter=generaltranslation --filter=gt-i18n --filter=gt --filter=@generaltranslation/react-core-linter` — passed
- `pnpm exec turbo run test --filter=@generaltranslation/icu --filter=@generaltranslation/format --filter=generaltranslation --filter=gt-i18n --filter=gt --filter=@generaltranslation/react-core-linter` — passed
- `pnpm exec turbo run typecheck --filter=@generaltranslation/icu --filter=@generaltranslation/format --filter=generaltranslation --filter=gt-i18n --filter=gt --filter=@generaltranslation/react-core-linter` — passed
- `pnpm lint` — passed with 19 existing warnings and 0 errors
- `pnpm format` — passed

## Notes

- Stack: based on #1929 (`e/multi/replace-formatjs-icu`).
- Changeset: not required because this amends the unreleased ICU package introduced by #1929.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR aligns ICU number formatting and skeleton parsing with FormatJS behavior. The main changes are:

- Preserves precision for unscaled numeric strings and `scale/0`.
- Replaces `Object.hasOwn` with an older-runtime-compatible own-property check.
- Recognizes FormatJS number-skeleton whitespace.
- Rejects malformed scientific and integer-width skeleton tokens.
- Adds formatter, parser, and public-boundary tests.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/icu/src/formatter.ts | Preserves unscaled values before number formatting and removes the ES2022 own-property API dependency. |
| packages/icu/src/skeleton.ts | Updates skeleton whitespace tokenization and malformed-token validation. |
| packages/icu/src/__tests__/formatter.test.ts | Adds tests for older runtimes, numeric-string precision, and `scale/0`. |
| packages/icu/src/__tests__/parser.test.ts | Adds tests for Unicode skeleton whitespace and malformed tokens. |
| packages/format/src/formatting/__tests__/format.test.ts | Verifies numeric-string precision through the public formatting boundary. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(icu): preserve FormatJS edge compati..."](https://github.com/generaltranslation/gt/commit/27544f5ff2a0de0fd8d1fefc162f308dc0b4de9c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46106085)</sub>

<!-- /greptile_comment -->