### PR TITLE
fix(icu): preserve exact selector compatibility

### DIFF
--- a/packages/core/src/derive/__tests__/condenseVarsPrinterRegression.test.ts
+++ b/packages/core/src/derive/__tests__/condenseVarsPrinterRegression.test.ts
@@ -86,6 +86,11 @@ describe('condenseVars printer regression', () => {
       '{count,plural,offset:2 =0{none} =1{one} other{# left}} {_gt_1}',
     ],
     [
+      'plural with lexically distinct exact matches',
+      '{count, plural, =1 {canonical} =01 {leading} =+1 {positive} other {other}} {_gt_1, select, other {}}',
+      '{count,plural,=1{canonical} =01{leading} =+1{positive} other{other}} {_gt_1}',
+    ],
+    [
       'selectordinal with pound',
       '{place, selectordinal, one {#st} two {#nd} few {#rd} other {#th}} {_gt_1, select, other {}}',
       '{place,selectordinal,one{#st} two{#nd} few{#rd} other{#th}} {_gt_1}',

--- a/packages/format/src/formatting/__tests__/format.test.ts
+++ b/packages/format/src/formatting/__tests__/format.test.ts
@@ -75,6 +75,15 @@ describe('_formatMessageICU', () => {
     ).toBe('12.34');
   });
 
+  it('preserves numeric-string precision through the public boundary', () => {
+    expect(
+      publicFormatMessage('{value, number}', {
+        locales: 'en-US',
+        variables: { value: '123456789012345678901234567890' },
+      })
+    ).toBe('123,456,789,012,345,678,901,234,567,890');
+  });
+
   it('passes date skeletons through the package boundary', () => {
     const value = new Date('2020-05-06T14:03:02Z');
     expect(

--- a/packages/format/src/formatting/__tests__/format.test.ts
+++ b/packages/format/src/formatting/__tests__/format.test.ts
@@ -133,6 +133,23 @@ describe('_formatMessageICU', () => {
     }
   );
 
+  it.each([
+    [1, 'canonical'],
+    ['1', 'canonical'],
+    ['01', 'leading'],
+    ['+1', 'positive'],
+  ])(
+    'preserves exact selector spelling through the public package for %j',
+    (count, expected) => {
+      expect(
+        publicFormatMessage(
+          '{count, plural, =1 {canonical} =01 {leading} =+1 {positive} other {other}}',
+          { locales: 'en-US', variables: { count } }
+        )
+      ).toBe(expected);
+    }
+  );
+
   it('preserves boolean interpolation serialization from the previous runtime', () => {
     const result = publicFormatMessage('before {value} after', {
       variables: { value: true },

--- a/packages/i18n/src/translation-functions/utils/__tests__/formatMessage.test.ts
+++ b/packages/i18n/src/translation-functions/utils/__tests__/formatMessage.test.ts
@@ -18,4 +18,14 @@ describe('formatMessage', () => {
       ).toBe(expected);
     }
   );
+
+  it('preserves raw exact selector matching for string-only interpolation values', () => {
+    expect(
+      formatMessage(
+        '{count, plural, =1 {canonical} =01 {leading} other {# items}}',
+        { count: '01' },
+        'en-US'
+      )
+    ).toBe('leading');
+  });
 });

--- a/packages/icu/package.json
+++ b/packages/icu/package.json
@@ -43,7 +43,9 @@
   },
   "homepage": "https://generaltranslation.com/",
   "devDependencies": {
+    "@formatjs/icu-messageformat-parser": "2.11.4",
     "@types/node": "catalog:",
+    "intl-messageformat": "10.7.16",
     "tsdown": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"

--- a/packages/icu/src/__tests__/formatjs-live-differential.test.ts
+++ b/packages/icu/src/__tests__/formatjs-live-differential.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Live compatibility oracle for the exact FormatJS versions replaced by this
+ * package: intl-messageformat 10.7.16 and
+ * @formatjs/icu-messageformat-parser 2.11.4.
+ *
+ * The upstream implementations and tests are available at:
+ * https://github.com/formatjs/formatjs/tree/75edf1cd6a7045475bb134daf62c686602c92547/packages/intl-messageformat
+ * https://github.com/formatjs/formatjs/tree/75edf1cd6a7045475bb134daf62c686602c92547/packages/icu-messageformat-parser
+ * intl-messageformat is BSD-3-Clause licensed and the parser is MIT licensed.
+ * See ../../THIRD_PARTY_NOTICES.md.
+ *
+ * These dependencies must remain exact-pinned test-only oracles. They must not
+ * be moved to runtime dependencies, where they would undo the bundle reduction.
+ */
+
+import { parse as formatJsParse } from '@formatjs/icu-messageformat-parser';
+import { IntlMessageFormat } from 'intl-messageformat';
+import { describe, expect, it } from 'vitest';
+import { formatMessage, parse, printAST } from '../index';
+
+const PLURAL_LOCALES = [
+  'en',
+  'fr',
+  'ar',
+  'ru',
+  'pl',
+  'cs',
+  'sl',
+  'cy',
+] as const;
+const PLURAL_MESSAGES = [
+  '{value, plural, zero {zero:#} one {one:#} two {two:#} few {few:#} many {many:#} other {other:#}}',
+  '{value, selectordinal, zero {zero:#} one {one:#} two {two:#} few {few:#} many {many:#} other {other:#}}',
+  '{value, plural, =1 {canonical} =01 {leading} =+1 {positive} =0 {zero} =-0 {negative-zero} =-01 {negative-leading} other {other:#}}',
+  '{value, plural, offset:2 =0 {none} =1 {one} one {category-one:#} other {other:#}}',
+] as const;
+const PLURAL_VALUES: Array<number | string> = [
+  ...Array.from({ length: 70 }, (_, index) => index - 5),
+  '-01',
+  '-0',
+  '0',
+  '+1',
+  '01',
+  '1',
+  '2',
+  '2.5',
+  '10',
+  '101',
+];
+
+const PLURAL_RUNTIME_CASES = PLURAL_LOCALES.flatMap((locale) =>
+  PLURAL_MESSAGES.flatMap((message) =>
+    PLURAL_VALUES.map((value) => ({ locale, message, value }))
+  )
+);
+
+const NUMBER_LOCALES = ['en-US', 'fr-FR', 'de-DE'] as const;
+const NUMBER_MESSAGES = [
+  '{value, number}',
+  '{value, number, integer}',
+  '{value, number, percent}',
+  '{value, number, ::scale/0}',
+  '{value, number, ::scale/0.01}',
+  '{value, number, ::currency/USD .00}',
+  '{value, number, ::compact-short}',
+  '{value, number, ::integer-width/*000}',
+] as const;
+const NUMBER_VALUES: Array<number | string> = [
+  -1234.567,
+  -0,
+  0,
+  0.125,
+  1,
+  12.34,
+  1234.567,
+  '2.5',
+  '123456789012345678901234567890',
+];
+
+const NUMBER_RUNTIME_CASES = NUMBER_LOCALES.flatMap((locale) =>
+  NUMBER_MESSAGES.flatMap((message) =>
+    NUMBER_VALUES.map((value) => ({ locale, message, value }))
+  )
+);
+
+const DATE_VALUE = new Date('2020-05-06T14:03:02Z');
+const DATE_RUNTIME_CASES = NUMBER_LOCALES.flatMap((locale) =>
+  [
+    '{value, date}',
+    '{value, date, short}',
+    '{value, time, medium}',
+    '{value, date, ::yyyyMMMdd}',
+    '{value, time, ::HHmmss}',
+    '{value, time, ::C}',
+    '{value, time, ::S}',
+    '{value, time, ::A}',
+  ].map((message) => ({ locale, message, value: DATE_VALUE }))
+);
+
+const SIMPLE_RUNTIME_CASES = [
+  {
+    locale: 'en-US',
+    message: 'Hello {name}',
+    values: { name: 'Ada' },
+  },
+  {
+    locale: 'en-US',
+    message: '{kind, select, yes {Hi {name}} other {No}}',
+    values: { kind: 'yes', name: 'Ada' },
+  },
+  {
+    locale: 'en-US',
+    message:
+      '{kind, select, yes {{count, plural, one {one item} other {# items}}} other {none}}',
+    values: { kind: 'yes', count: '2' },
+  },
+  {
+    locale: 'en-US',
+    message: "This '{isn''t}' {name}'s first test",
+    values: { name: 'Ada' },
+  },
+] as const;
+
+const PARSER_MESSAGES = [
+  'plain text',
+  '}',
+  'Héllo 🎉 {name}',
+  '{first}{second}{third}',
+  '{kind, select, yes {Hi {name}} other {No}}',
+  '{value, plural, =1 {canonical} =01 {leading} =+1 {positive} =0 {zero} =-0 {negative-zero} =-01 {negative-leading} other {other:#}}',
+  '{value, plural, offset:2 =0 {none} one {one:#} other {other:#}}',
+  '{value, selectordinal, one {#st} two {#nd} few {#rd} other {#th}}',
+  '<b>Bold <i>{name}</i></b>',
+  "This '{isn''t}' obvious",
+  "{value, plural, other {'#' #}}",
+  '{value, number, ::currency/USD .00##}',
+  '{value, number, ::scale/0}',
+  '{value, number, ::integer-width/*000}',
+  '{value, date, ::yyyyMMMdd}',
+  '{value, time, ::HHmmss}',
+  '{value, time, ::C}',
+  '{value, time, ::S}',
+  '{value, time, ::A}',
+  ...Array.from(
+    { length: 128 },
+    (_, index) => `prefix ${index} {value${index}} suffix ${127 - index}`
+  ),
+  ...Array.from(
+    { length: 64 },
+    (_, index) =>
+      `{value${index}, plural, offset:${index % 5} =0 {zero} =0${index + 1} {leading} one {one:#} other {other:#}}`
+  ),
+];
+
+const INVALID_MESSAGES = [
+  '{',
+  '{value',
+  '{value,}',
+  '{value, unknown}',
+  '{value, plural}',
+  '{value, plural, one {one}}',
+  '{value, plural, one {one} one {duplicate} other {other}}',
+  '{value, plural, = {empty} other {other}}',
+  '{value, plural, =1.5 {decimal} other {other}}',
+  '{value, plural, offset: {other {other}}}',
+  '{value, select, other {unterminated}',
+  '{value, number, ::}',
+  '{value, date, ::}',
+  '<b>unterminated',
+] as const;
+
+const formatJsFormatters = new Map<string, IntlMessageFormat>();
+
+function formatWithFormatJs(
+  message: string,
+  locale: string,
+  values: Record<string, unknown>
+): unknown {
+  const key = `${locale}\u0000${message}`;
+  let formatter = formatJsFormatters.get(key);
+  if (!formatter) {
+    formatter = new IntlMessageFormat(message, locale);
+    formatJsFormatters.set(key, formatter);
+  }
+  return formatter.format(values as never);
+}
+
+describe('live FormatJS runtime compatibility', () => {
+  it.each(PLURAL_RUNTIME_CASES)(
+    'matches plural formatting for $locale, $value, $message',
+    ({ locale, message, value }) => {
+      const values = { value };
+      expect(formatMessage(message, locale, values)).toEqual(
+        formatWithFormatJs(message, locale, values)
+      );
+    }
+  );
+
+  it.each(NUMBER_RUNTIME_CASES)(
+    'matches number formatting for $locale, $value, $message',
+    ({ locale, message, value }) => {
+      const values = { value };
+      expect(formatMessage(message, locale, values)).toEqual(
+        formatWithFormatJs(message, locale, values)
+      );
+    }
+  );
+
+  it.each(DATE_RUNTIME_CASES)(
+    'matches date/time formatting for $locale and $message',
+    ({ locale, message, value }) => {
+      const values = { value };
+      expect(formatMessage(message, locale, values)).toEqual(
+        formatWithFormatJs(message, locale, values)
+      );
+    }
+  );
+
+  it.each(SIMPLE_RUNTIME_CASES)(
+    'matches argument/select behavior for $message',
+    ({ locale, message, values }) => {
+      expect(formatMessage(message, locale, values)).toEqual(
+        formatWithFormatJs(message, locale, values)
+      );
+    }
+  );
+});
+
+describe('live FormatJS parser compatibility', () => {
+  it.each(PARSER_MESSAGES)('matches the AST for %j', (message) => {
+    expect(parse(message, { captureLocation: false })).toEqual(
+      formatJsParse(message, { captureLocation: false })
+    );
+  });
+
+  it.each(PARSER_MESSAGES)(
+    'preserves the AST through our public parse/print round trip for %j',
+    (message) => {
+      const ast = parse(message, { captureLocation: false });
+      expect(parse(printAST(ast), { captureLocation: false })).toEqual(ast);
+    }
+  );
+
+  it.each(INVALID_MESSAGES)(
+    'matches rejection of invalid input %j',
+    (message) => {
+      expect(() => parse(message)).toThrow();
+      expect(() => formatJsParse(message)).toThrow();
+    }
+  );
+});
+
+// FormatJS printAST is intentionally not used as an oracle: it is not part of
+// the package's public API, and its tag handling historically lost plural
+// context. Public AST equivalence plus our own parse/print round trip protects
+// the supported contract without reproducing that upstream bug.

--- a/packages/icu/src/__tests__/formatter.test.ts
+++ b/packages/icu/src/__tests__/formatter.test.ts
@@ -49,6 +49,29 @@ describe('formatMessage', () => {
     );
   });
 
+  it('does not require the ES2022 Object.hasOwn API', () => {
+    const descriptor = Object.getOwnPropertyDescriptor(Object, 'hasOwn');
+    Object.defineProperty(Object, 'hasOwn', {
+      configurable: true,
+      value: undefined,
+    });
+
+    try {
+      expect(
+        formatMessage('{kind, select, yes {Hi {name}} other {No}}', 'en', {
+          kind: 'yes',
+          name: 'Ada',
+        })
+      ).toBe('Hi Ada');
+    } finally {
+      if (descriptor) {
+        Object.defineProperty(Object, 'hasOwn', descriptor);
+      } else {
+        Reflect.deleteProperty(Object, 'hasOwn');
+      }
+    }
+  });
+
   it('selects exact and fallback branches without prototype collisions', () => {
     const message =
       '{value, select, constructor {ctor} __proto__ {proto} toString {string} other {fallback}}';
@@ -146,6 +169,16 @@ describe('formatMessage', () => {
     ).toBe('123,457');
     expect(formatMessage('{n, number, percent}', 'en-US', { n: 0.56 })).toBe(
       '56%'
+    );
+  });
+
+  it('preserves unscaled numeric-string precision', () => {
+    const value = '123456789012345678901234567890';
+    const expected = '123,456,789,012,345,678,901,234,567,890';
+
+    expect(formatMessage('{n, number}', 'en-US', { n: value })).toBe(expected);
+    expect(formatMessage('{n, number, ::scale/0}', 'en-US', { n: value })).toBe(
+      expected
     );
   });
 

--- a/packages/icu/src/__tests__/formatter.test.ts
+++ b/packages/icu/src/__tests__/formatter.test.ts
@@ -106,6 +106,25 @@ describe('formatMessage', () => {
   });
 
   it.each([
+    [1, 'canonical'],
+    ['1', 'canonical'],
+    ['01', 'leading'],
+    ['+1', 'positive'],
+    [0, 'zero'],
+    ['0', 'zero'],
+    ['-0', 'negative zero'],
+    ['-01', 'negative leading'],
+  ])(
+    'preserves raw exact plural selector matching for %j',
+    (count, expected) => {
+      const message =
+        '{count, plural, =1 {canonical} =01 {leading} =+1 {positive} =0 {zero} =-0 {negative zero} =-01 {negative leading} other {other}}';
+
+      expect(formatMessage(message, 'en', { count })).toBe(expected);
+    }
+  );
+
+  it.each([
     ['2', '{count, plural, =2 {exact} other {# items}}', 'exact'],
     ['02', '{count, plural, =2 {exact} other {# items}}', '2 items'],
     [' 2 ', '{count, plural, =2 {exact} other {# items}}', '2 items'],

--- a/packages/icu/src/__tests__/parser.test.ts
+++ b/packages/icu/src/__tests__/parser.test.ts
@@ -167,6 +167,32 @@ describe('parse', () => {
     });
   });
 
+  it.each([
+    ['0085', '\u0085'],
+    ['200E', '\u200E'],
+    ['200F', '\u200F'],
+  ])(
+    'parses FormatJS number-skeleton whitespace U+$codePoint',
+    (_codePoint, separator) => {
+      expect(
+        parse(`{amount, number, ::currency/USD${separator}.00}`)[0]
+      ).toMatchObject({
+        style: {
+          tokens: [
+            { stem: 'currency', options: ['USD'] },
+            { stem: '.00', options: [] },
+          ],
+          parsedOptions: {
+            style: 'currency',
+            currency: 'USD',
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2,
+          },
+        },
+      });
+    }
+  );
+
   it.each(['C', 'S', 'A'])(
     'preserves FormatJS parsing of the %s date/time skeleton field',
     (field) => {
@@ -292,6 +318,11 @@ describe('parse', () => {
     ['{n, number, ::}', 'Number skeleton cannot be empty'],
     ['{n, number, ::currency/}', 'Invalid number skeleton token'],
     ['{n, number, ::integer-width/*}', 'Unsupported integer width'],
+    [
+      '{n, number, ::integer-width/*00/foo}',
+      'integer-width stems only accept a single optional option',
+    ],
+    ['{n, number, ::Efoo}', 'Malformed concise eng/scientific notation'],
     ["{n, number, 'unclosed}", 'UNCLOSED_QUOTE_IN_ARGUMENT_STYLE'],
   ])('rejects malformed ICU %j', (message, error) => {
     expect(() => parse(message)).toThrow(error);

--- a/packages/icu/src/__tests__/parser.test.ts
+++ b/packages/icu/src/__tests__/parser.test.ts
@@ -122,6 +122,25 @@ describe('parse', () => {
     });
   });
 
+  it('preserves exact plural selector spelling without treating equivalents as duplicates', () => {
+    const [element] = parse(
+      '{count, plural, =1 {canonical} =01 {leading} =+1 {positive} =0 {zero} =-0 {negative zero} =-01 {negative leading} other {other}}'
+    );
+
+    expect(element).toMatchObject({
+      type: TYPE.plural,
+      options: {
+        '=1': {},
+        '=01': {},
+        '=+1': {},
+        '=0': {},
+        '=-0': {},
+        '=-01': {},
+        other: {},
+      },
+    });
+  });
+
   it('parses ordinal plurals', () => {
     expect(
       parse(

--- a/packages/icu/src/__tests__/printer.test.ts
+++ b/packages/icu/src/__tests__/printer.test.ts
@@ -114,6 +114,10 @@ describe('printAST', () => {
       '{count,plural,offset:2 =0{none} one{# item} other{# items}}',
     ],
     [
+      '{count, plural, =1 {canonical} =01 {leading} =+1 {positive} =-0 {negative zero} =-01 {negative leading} other {other}}',
+      '{count,plural,=1{canonical} =01{leading} =+1{positive} =-0{negative zero} =-01{negative leading} other{other}}',
+    ],
+    [
       '{place, selectordinal, one {#st} two {#nd} few {#rd} other {#th}}',
       '{place,selectordinal,one{#st} two{#nd} few{#rd} other{#th}}',
     ],
@@ -139,6 +143,7 @@ describe('printAST', () => {
     '{a}{b}{c}',
     '{status, select, yes {{name} accepted} other {none}}',
     '{count, plural, one {<b># item</b>} other {<b># items</b>}}',
+    '{count, plural, =1 {canonical} =01 {leading} =+1 {positive} =-0 {negative zero} =-01 {negative leading} other {other}}',
     "{count, plural, other {'##' and '{#}'}}",
     "{count, plural, other {<b>'##'</b>}}",
     '{count, plural, one {{status, select, yes {{name}} other {none}}} other {No}}',

--- a/packages/icu/src/formatter.ts
+++ b/packages/icu/src/formatter.ts
@@ -194,8 +194,12 @@ function formatElements(
   return mergeLiteralParts(result);
 }
 
+function hasOwn(object: object, key: PropertyKey): boolean {
+  return Object.prototype.hasOwnProperty.call(object, key);
+}
+
 function requireVariable(variables: MessageVariables, name: string): unknown {
-  if (!Object.hasOwn(variables, name)) {
+  if (!hasOwn(variables, name)) {
     throw new Error(`The ICU message variable "${name}" was not provided.`);
   }
   return variables[name];
@@ -245,20 +249,20 @@ function numberOptions(
   return {};
 }
 
-function applyScale(value: unknown, scale = 1): number | bigint {
+function applyScale(value: unknown, scale?: number): unknown {
   // intl-messageformat treated scale/0 as an absent scale. Preserve that
   // observable behavior for existing messages even though multiplying by zero
   // would follow the ICU skeleton definition more literally.
-  const effectiveScale = scale || 1;
+  if (!scale) return value;
   if (typeof value === 'bigint') {
-    if (!Number.isInteger(effectiveScale)) {
+    if (!Number.isInteger(scale)) {
       throw new RangeError(
-        `Cannot apply fractional scale ${effectiveScale} to a bigint value.`
+        `Cannot apply fractional scale ${scale} to a bigint value.`
       );
     }
-    return value * BigInt(effectiveScale);
+    return value * BigInt(scale);
   }
-  return Number(value) * effectiveScale;
+  return Number(value) * scale;
 }
 
 function getNumberFormat(
@@ -330,7 +334,7 @@ function hasPluralCategoryOption(options: Record<string, unknown>): boolean {
 }
 
 function ownOption<T>(options: Record<string, T>, key: string): T | undefined {
-  return Object.hasOwn(options, key) ? options[key] : undefined;
+  return hasOwn(options, key) ? options[key] : undefined;
 }
 
 function invalidSelection(

--- a/packages/icu/src/parser.ts
+++ b/packages/icu/src/parser.ts
@@ -361,7 +361,13 @@ class IcuParser {
 
     while (selector || (argumentType !== 'select' && this.current() === '=')) {
       if (!selector && this.consume('=')) {
-        selector = `=${this.readInteger('EXPECT_PLURAL_ARGUMENT_SELECTOR')}`;
+        // Exact plural selectors compare against the raw input value before
+        // numeric coercion. Preserve the source token so `=01`, `=+1`, and
+        // `=-0` remain observably distinct from their canonical spellings,
+        // matching FormatJS parsing and runtime behavior.
+        selector = `=${this.readIntegerToken(
+          'EXPECT_PLURAL_ARGUMENT_SELECTOR'
+        )}`;
       }
       if (seen.has(selector)) {
         this.fail(
@@ -428,14 +434,19 @@ class IcuParser {
   }
 
   private readInteger(errorCode: string): number {
+    return Number(this.readIntegerToken(errorCode));
+  }
+
+  private readIntegerToken(errorCode: string): string {
     const start = this.index;
     if (this.current() === '+' || this.current() === '-') this.index += 1;
     const digitStart = this.index;
     while (/\d/u.test(this.current())) this.index += 1;
     if (digitStart === this.index) this.fail(errorCode, start);
-    const value = Number(this.message.slice(start, this.index));
+    const token = this.message.slice(start, this.index);
+    const value = Number(token);
     if (!Number.isSafeInteger(value)) this.fail('INVALID_NUMBER', start);
-    return value;
+    return token;
   }
 
   private readIdentifier(): string {

--- a/packages/icu/src/skeleton.ts
+++ b/packages/icu/src/skeleton.ts
@@ -8,6 +8,7 @@ import type { ExtendedNumberFormatOptions, NumberSkeletonToken } from './types';
 const FRACTION_PRECISION = /^\.(?:(0+)(\*)?|(#+)|(0+)(#+))$/;
 const SIGNIFICANT_PRECISION = /^(@+)?(\+|#+)?[rs]?$/;
 const INTEGER_WIDTH = /^(?:(\*)(0+)|(#+)(0+)|(0+))$/;
+const NUMBER_SKELETON_WHITE_SPACE = /[\t-\r \x85\u200E\u200F\u2028\u2029]+/u;
 const DATE_TIME_FIELD =
   /(?:[Eec]{1,6}|G{1,5}|[Qq]{1,5}|(?:[yYur]+|U{1,5})|[ML]{1,5}|d{1,2}|D{1,3}|F|[abB]{1,5}|[hHkKjJC]{1,2}|w{1,2}|W|m{1,2}|s{1,2}|[SA]+|[zZOvVxX]{1,4})(?=([^']*'[^']*')*[^']*$)/g;
 
@@ -42,7 +43,9 @@ const ROUNDING_MODES: Record<
 export function parseNumberSkeletonTokens(
   skeleton: string
 ): NumberSkeletonToken[] {
-  const stringTokens = skeleton.trim().split(/\s+/u).filter(Boolean);
+  const stringTokens = skeleton
+    .split(NUMBER_SKELETON_WHITE_SPACE)
+    .filter(Boolean);
   if (stringTokens.length === 0) {
     throw new SyntaxError('Number skeleton cannot be empty.');
   }
@@ -147,6 +150,11 @@ export function parseNumberSkeletonOptions(
         continue;
       case 'integer-width':
         requireOption(token);
+        if (token.options.length > 1) {
+          throw new RangeError(
+            'integer-width stems only accept a single optional option'
+          );
+        }
         applyIntegerWidth(result, option!);
         continue;
     }
@@ -225,8 +233,11 @@ function applyConciseScientific(
   result: ModernNumberFormatOptions,
   source: string
 ): boolean {
+  if (!source.startsWith('E')) return false;
   const match = /^(E{1,2})(\+!|\+\?)?(0+)$/u.exec(source);
-  if (!match) return false;
+  if (!match) {
+    throw new SyntaxError('Malformed concise eng/scientific notation');
+  }
 
   result.notation = match[1] === 'EE' ? 'engineering' : 'scientific';
   if (match[2]) applySign(result, match[2]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -976,9 +976,15 @@ importers:
 
   packages/icu:
     devDependencies:
+      '@formatjs/icu-messageformat-parser':
+        specifier: 2.11.4
+        version: 2.11.4
       '@types/node':
         specifier: 'catalog:'
         version: 22.13.10
+      intl-messageformat:
+        specifier: 10.7.16
+        version: 10.7.16
       tsdown:
         specifier: 'catalog:'
         version: 0.21.10(synckit@0.11.11)(typescript@5.9.3)
@@ -4793,11 +4799,26 @@ packages:
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
 
+  '@formatjs/ecma402-abstract@2.3.4':
+    resolution: {integrity: sha512-qrycXDeaORzIqNhBOx0btnhpD1c+/qFIHAN9znofuMJX6QBwtbrmlpWfD4oiUUD2vJUOIYFA/gYtg2KAMGG7sA==}
+
   '@formatjs/ecma402-abstract@2.3.6':
     resolution: {integrity: sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==}
 
   '@formatjs/fast-memoize@2.2.7':
     resolution: {integrity: sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==}
+
+  '@formatjs/icu-messageformat-parser@2.11.2':
+    resolution: {integrity: sha512-AfiMi5NOSo2TQImsYAg8UYddsNJ/vUEv/HaNqiFjnI3ZFfWihUtD5QtuX6kHl8+H+d3qvnE/3HZrfzgdWpsLNA==}
+
+  '@formatjs/icu-messageformat-parser@2.11.4':
+    resolution: {integrity: sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==}
+
+  '@formatjs/icu-skeleton-parser@1.8.14':
+    resolution: {integrity: sha512-i4q4V4qslThK4Ig8SxyD76cp3+QJ3sAqr7f6q9VVfeGtxG9OhiAk3y9XF6Q41OymsKzsGQ6OQQoJNY4/lI8TcQ==}
+
+  '@formatjs/icu-skeleton-parser@1.8.16':
+    resolution: {integrity: sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==}
 
   '@formatjs/intl-datetimeformat@6.18.2':
     resolution: {integrity: sha512-XXGJVOi/vmB+eLtYDs+ggDIvba/+VNmNrDZOtMyol5D0zl+zzuPps6W3TgDflpKfzg4memAEbLnA1wC6/TBSjQ==}
@@ -4817,6 +4838,9 @@ packages:
 
   '@formatjs/intl-locale@4.2.13':
     resolution: {integrity: sha512-Qcs0mP9JhEPCinPfpZ5JKzOa+VYDg94TQSFZozYuqG8R+hEGUTKyoyMqB5xi5QZT/hlB0CSgeNc/0fWMGtTFXA==}
+
+  '@formatjs/intl-localematcher@0.6.1':
+    resolution: {integrity: sha512-ePEgLgVCqi2BBFnTMWPfIghu6FkbZnnBVhO2sSxvLfrdFw7wCHAHiDoM2h4NRgjbaY7+B7HgOLZGkK187pZTZg==}
 
   '@formatjs/intl-localematcher@0.6.2':
     resolution: {integrity: sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==}
@@ -13358,6 +13382,9 @@ packages:
   interpret@3.1.1:
     resolution: {integrity: sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==}
     engines: {node: '>=10.13.0'}
+
+  intl-messageformat@10.7.16:
+    resolution: {integrity: sha512-UmdmHUmp5CIKKjSoE10la5yfU+AYJAaiYLsodbjL4lji83JNvgOQUjGaGhGrpFCb0Uh7sl7qfP1IyILa8Z40ug==}
 
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
@@ -22730,6 +22757,13 @@ snapshots:
 
   '@floating-ui/utils@0.2.10': {}
 
+  '@formatjs/ecma402-abstract@2.3.4':
+    dependencies:
+      '@formatjs/fast-memoize': 2.2.7
+      '@formatjs/intl-localematcher': 0.6.1
+      decimal.js: 10.6.0
+      tslib: 2.8.1
+
   '@formatjs/ecma402-abstract@2.3.6':
     dependencies:
       '@formatjs/fast-memoize': 2.2.7
@@ -22739,6 +22773,28 @@ snapshots:
 
   '@formatjs/fast-memoize@2.2.7':
     dependencies:
+      tslib: 2.8.1
+
+  '@formatjs/icu-messageformat-parser@2.11.2':
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.4
+      '@formatjs/icu-skeleton-parser': 1.8.14
+      tslib: 2.8.1
+
+  '@formatjs/icu-messageformat-parser@2.11.4':
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.6
+      '@formatjs/icu-skeleton-parser': 1.8.16
+      tslib: 2.8.1
+
+  '@formatjs/icu-skeleton-parser@1.8.14':
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.4
+      tslib: 2.8.1
+
+  '@formatjs/icu-skeleton-parser@1.8.16':
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.6
       tslib: 2.8.1
 
   '@formatjs/intl-datetimeformat@6.18.2':
@@ -22774,6 +22830,10 @@ snapshots:
       '@formatjs/ecma402-abstract': 2.3.6
       '@formatjs/intl-enumerator': 1.8.12
       '@formatjs/intl-getcanonicallocales': 2.5.6
+      tslib: 2.8.1
+
+  '@formatjs/intl-localematcher@0.6.1':
+    dependencies:
       tslib: 2.8.1
 
   '@formatjs/intl-localematcher@0.6.2':
@@ -33339,6 +33399,13 @@ snapshots:
       side-channel: 1.1.0
 
   interpret@3.1.1: {}
+
+  intl-messageformat@10.7.16:
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.4
+      '@formatjs/fast-memoize': 2.2.7
+      '@formatjs/icu-messageformat-parser': 2.11.2
+      tslib: 2.8.1
 
   invariant@2.2.4:
     dependencies:


### PR DESCRIPTION
## Stack

- Stack base: #1929
- Layer 1: #1959
- Layer 2: this PR

Review #1959 first, then this PR. This PR's base is the exact #1959 head branch.

## Summary

- preserve the original lexeme for exact plural selectors, keeping =1, =01, =+1, =0, =-0, and =-01 distinct as they were in FormatJS
- cover parsing, formatting, printing, condense/hash serialization, @generaltranslation/format, and gt-i18n public behavior
- add 3,240 live differential and round-trip cases against exact-pinned intl-messageformat 10.7.16 and @formatjs/icu-messageformat-parser 2.11.4
- keep both FormatJS packages test-only dev dependencies, so neither enters published runtime dependencies or client bundles

The live oracle cites the pinned upstream source and licenses. intl-messageformat is BSD-3-Clause and the ICU parser is MIT; the package's existing THIRD_PARTY_NOTICES.md contains the notices.

## Verification

- frozen pnpm install
- focused Turbo builds for ICU, format, core, i18n, CLI, and react-core-linter
- focused Turbo tests: ICU 8,389; format 274; core 479; i18n 302; CLI 2,083; react-core-linter 691
- focused Turbo typechecks for the same package graph
- pnpm lint: 0 errors, 19 pre-existing warnings
- pnpm format
- git diff --check

## Changeset

The parent stack already includes .changeset/quick-cats-format-icu.md for the unreleased ICU replacement. This follow-up intentionally reuses that release entry rather than adding a duplicate bump.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR preserves the source spelling of exact ICU plural selectors. The main changes are:

- Keeps selectors such as `=1`, `=01`, `=+1`, and `=-0` distinct.
- Covers formatting, printing, condensation, and public package behavior.
- Adds differential tests against exact-pinned FormatJS packages.
- Keeps the FormatJS packages as test-only dependencies.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/icu/src/parser.ts | Preserves exact-selector tokens while retaining numeric parsing for plural offsets. |
| packages/icu/src/__tests__/formatjs-live-differential.test.ts | Adds parser, formatter, and round-trip comparisons with pinned FormatJS implementations. |
| packages/icu/package.json | Adds the FormatJS reference packages as exact-pinned development dependencies. |
| pnpm-lock.yaml | Records the new test dependencies and their transitive packages. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test(icu): add live FormatJS compatibili..."](https://github.com/generaltranslation/gt/commit/7ac7e422152ca2b11b3d4efa26b12551776e8179) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46108099)</sub>

<!-- /greptile_comment -->