### PR TITLE
fix(cli): clear locale query after selection

### DIFF
--- a/.changeset/clear-locale-query.md
+++ b/.changeset/clear-locale-query.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+Clear the locale search query after selecting a locale during setup.

--- a/packages/cli/src/console/inkPrompts.tsx
+++ b/packages/cli/src/console/inkPrompts.tsx
@@ -250,6 +250,7 @@ function LocaleMultiPrompt({
       }
       return next;
     });
+    setQuery('');
     setError(undefined);
   };
 


### PR DESCRIPTION
## Summary

- Clear the setup locale search query after a valid locale is selected with space.
- Let users immediately type the next locale without manually deleting the previous search.

## Testing

- `pnpm --filter gt... build` — passed
- `pnpm --filter gt test` — passed (98 test files, 2,083 tests)
- `pnpm --filter gt typecheck` — passed
- `pnpm exec oxfmt --check packages/cli/src/console/inkPrompts.tsx .changeset/clear-locale-query.md` — passed
- Pre-commit oxlint and oxfmt hooks — passed

## Notes

- Changeset: added a patch changeset for `gt`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR resets the locale search after a selection in the CLI setup prompt. The main changes are:

- Clear the query after selecting a valid locale.
- Add a patch changeset for the `gt` package.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- The locale is resolved before the query is cleared.
- The selected locale and empty query are applied on the next render.
- No blocking issues found in the changed code.

</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/console/inkPrompts.tsx | Clears the search query after resolving and selecting a locale. |
| .changeset/clear-locale-query.md | Adds the matching patch release note for the `gt` package. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(cli): clear locale query after selec..."](https://github.com/generaltranslation/gt/commit/321922ceef180bc3dd1a2cf3bf686c458675d1d7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46118454)</sub>

<!-- /greptile_comment -->