### PR TITLE
fix(ci): read membership app client ID secret

### DIFF
--- a/.github/workflows/community-pr-notification.yml
+++ b/.github/workflows/community-pr-notification.yml
@@ -20,7 +20,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ vars.GT_MEMBERS_APP_CLIENT_ID }}
+          client-id: ${{ secrets.GT_MEMBERS_APP_CLIENT_ID }}
           private-key: ${{ secrets.GT_MEMBERS_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           permission-members: read


### PR DESCRIPTION
## Summary

- Read `GT_MEMBERS_APP_CLIENT_ID` from repository secrets, where it is configured, instead of the empty repository-variable namespace.
- Restore organization membership checks so newly opened external pull requests can trigger Slack notifications without failing token generation.

## Testing

- `pnpm exec oxfmt --check .github/workflows/community-pr-notification.yml` — passed
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/community-pr-notification.yml')"` — passed
- `git diff --check origin/main...HEAD` — passed
- Pre-commit oxfmt hook — passed

## Notes

- Changeset: not required; this only fixes repository automation.
- The workflow remains limited to `pull_request_target` events with `types: [opened]`.
- Confirmed that `GT_MEMBERS_APP_CLIENT_ID`, `GT_MEMBERS_APP_PRIVATE_KEY`, and `SLACK_WEBHOOK_URL` are configured as repository secrets.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores GitHub App authentication in the community PR notification workflow. The main change is:

- Read `GT_MEMBERS_APP_CLIENT_ID` from the configured repository secret instead of the repository-variable namespace.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.
- The named secret is configured, so the workflow can supply the client ID during `pull_request_target` runs.
- The generated app token remains limited to organization membership reads.

</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/community-pr-notification.yml | Uses the configured repository secret for the membership app client ID while preserving the existing trigger, permissions, token scope, and notification flow. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): read membership app client ID s..."](https://github.com/generaltranslation/gt/commit/6a1a9f512756a70faf3a7906142b5cd571ab0c7c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46121166)</sub>

<!-- /greptile_comment -->