### PR TITLE
fix(cli): refresh React setup guidance

### DIFF
--- a/.changeset/fresh-react-setup-guidance.md
+++ b/.changeset/fresh-react-setup-guidance.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+Clarify automated React setup guidance for SPAs and server-rendered apps, and point setup messages to the current React documentation.

--- a/packages/cli/src/cli/base.ts
+++ b/packages/cli/src/cli/base.ts
@@ -73,6 +73,10 @@ import { splitMintlifyLanguageRefs } from '../utils/splitMintlifyLanguageRefs.js
 import { runMergeDriver, type MergeDriverName } from '../git/mergeDrivers.js';
 import { setupGitMergeDrivers } from '../git/setupMergeDrivers.js';
 import { warnReactPackageCompatibility } from '../utils/reactPackageCompatibility.js';
+import {
+  getReactSetupGuidance,
+  LOAD_TRANSLATIONS_SETUP_GUIDANCE,
+} from '../setup/guidance.js';
 
 const ID_COMPATIBILITY_WARNING_COMMANDS = new Set([
   'download',
@@ -583,13 +587,13 @@ export class BaseCLI {
           );
         } else {
           // Get framework display info for the defaults message
-          const frameworkDisplayName =
+          const reactSetup =
             framework.type === 'react'
-              ? getFrameworkDisplayName(framework)
-              : null;
-          const library =
-            framework.type === 'react'
-              ? getReactFrameworkLibrary(framework)
+              ? {
+                  frameworkDisplayName: getFrameworkDisplayName(framework),
+                  library: getReactFrameworkLibrary(framework),
+                  guidance: getReactSetupGuidance(framework),
+                }
               : null;
 
           // Build defaults description based on detected framework
@@ -598,10 +602,9 @@ export class BaseCLI {
               ? DEFAULT_VITE_TRANSLATIONS_DIR
               : DEFAULT_TRANSLATIONS_DIR;
 
-          const defaultsDescription =
-            framework.type === 'react'
-              ? `${library} & GTProvider, ${frameworkDisplayName}, Files saved locally in ${defaultTranslationsDir}`
-              : `Files saved locally in ${defaultTranslationsDir}`;
+          const defaultsDescription = reactSetup
+            ? `${reactSetup.library}, ${reactSetup.frameworkDisplayName}, ${reactSetup.guidance.defaultsDescription}, Files saved locally in ${defaultTranslationsDir}`
+            : `Files saved locally in ${defaultTranslationsDir}`;
 
           // Ask if user wants to use defaults
           const useDefaults = await promptConfirm({
@@ -612,11 +615,11 @@ export class BaseCLI {
           let ranReactSetup = false;
 
           // so that people can run init in non-js projects
-          if (framework.type === 'react') {
+          if (framework.type === 'react' && reactSetup) {
             const wrap = useDefaults
               ? true
               : await promptConfirm({
-                  message: `Would you like to install ${library} and add the GTProvider? See the docs for more information: https://generaltranslation.com/docs/react/tutorials/quickstart`,
+                  message: `Would you like to install ${reactSetup.library} and ${reactSetup.guidance.promptAction}? See the docs for more information: ${reactSetup.guidance.docsUrl}`,
                   defaultValue: true,
                 });
 
@@ -627,7 +630,7 @@ export class BaseCLI {
               await handleSetupReactCommand(options, framework, useDefaults);
               logger.endCommand(
                 `Done! Since this wizard is experimental, please review the changes and make modifications as needed.
-\nNext step: start internationalizing! See the docs for more information: https://generaltranslation.com/docs/react/tutorials/quickstart`
+\n${reactSetup.guidance.completion} See the docs for more information: ${reactSetup.guidance.docsUrl}`
               );
               ranReactSetup = true;
             }
@@ -744,8 +747,7 @@ export class BaseCLI {
       );
       logger.message(
         `Created ${chalk.cyan('loadTranslations.js')} file for local translations.
-Make sure to add this function to your app configuration.
-See https://generaltranslation.com/en/docs/next/guides/local-tx`
+${LOAD_TRANSLATIONS_SETUP_GUIDANCE}`
       );
     }
 

--- a/packages/cli/src/setup/__tests__/guidance.test.ts
+++ b/packages/cli/src/setup/__tests__/guidance.test.ts
@@ -1,0 +1,96 @@
+import fs from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import {
+  getReactSetupGuidance,
+  LOAD_TRANSLATIONS_SETUP_GUIDANCE,
+  NEXT_APP_QUICKSTART_URL,
+  NEXT_PAGES_QUICKSTART_URL,
+  REACT_CONFIGURING_GUIDE_URL,
+  REACT_LOAD_TRANSLATIONS_URL,
+  REACT_SERVER_QUICKSTART_URL,
+  REACT_SPA_QUICKSTART_URL,
+} from '../guidance.js';
+
+describe('getReactSetupGuidance', () => {
+  it('directs Vite SPAs to initializeGTSPA without GTProvider', () => {
+    const guidance = getReactSetupGuidance({ name: 'vite', type: 'react' });
+
+    expect(guidance.promptAction).toContain('initializeGTSPA');
+    expect(guidance.completion).toContain('Do not add a GTProvider');
+    expect(guidance.docsUrl).toBe(REACT_SPA_QUICKSTART_URL);
+  });
+
+  it.each(['gatsby', 'redwood'] as const)(
+    'directs %s apps to initializeGT and hydrate GTProvider',
+    (name) => {
+      const guidance = getReactSetupGuidance({ name, type: 'react' });
+
+      expect(guidance.promptAction).toContain('initializeGT');
+      expect(guidance.completion).toContain(
+        'hydrate GTProvider with both values'
+      );
+      expect(guidance.completion).toContain('locale and translations');
+      expect(guidance.docsUrl).toBe(REACT_SERVER_QUICKSTART_URL);
+    }
+  );
+
+  it('explains both rendering models when generic React is detected', () => {
+    const guidance = getReactSetupGuidance({ name: 'react', type: 'react' });
+
+    expect(guidance.completion).toContain('SPAs call initializeGTSPA');
+    expect(guidance.completion).toContain(
+      'Server-rendered apps call initializeGT'
+    );
+    expect(guidance.docsUrl).toBe(REACT_CONFIGURING_GUIDE_URL);
+  });
+
+  it('uses the current Next.js quickstarts', () => {
+    expect(
+      getReactSetupGuidance({ name: 'next-app', type: 'react' }).docsUrl
+    ).toBe(NEXT_APP_QUICKSTART_URL);
+    expect(
+      getReactSetupGuidance({ name: 'next-pages', type: 'react' }).docsUrl
+    ).toBe(NEXT_PAGES_QUICKSTART_URL);
+  });
+});
+
+describe('setup instruction guidance', () => {
+  it('points loader help to the React loader reference', () => {
+    expect(LOAD_TRANSLATIONS_SETUP_GUIDANCE).toContain('initializeGTSPA');
+    expect(LOAD_TRANSLATIONS_SETUP_GUIDANCE).toContain('initializeGT');
+    expect(LOAD_TRANSLATIONS_SETUP_GUIDANCE).toContain(
+      REACT_LOAD_TRANSLATIONS_URL
+    );
+  });
+
+  it('bundles distinct SPA and server-rendered React instructions', () => {
+    const instructions = fs.readFileSync(
+      new URL('../instructions/gt-react.md', import.meta.url),
+      'utf8'
+    );
+
+    expect(instructions).toContain('SPAs do not need a `GTProvider`');
+    expect(instructions).toContain('initializeGTSPA()');
+    expect(instructions).toContain('initializeGT()');
+    expect(instructions).toContain(
+      '<GTProvider locale={locale} translations={translations}>'
+    );
+    expect(instructions).toContain(REACT_SPA_QUICKSTART_URL);
+    expect(instructions).toContain(REACT_SERVER_QUICKSTART_URL);
+    expect(instructions).not.toContain(
+      'https://generaltranslation.com/docs/react.md'
+    );
+  });
+
+  it('bundles the current Next.js quickstart', () => {
+    const instructions = fs.readFileSync(
+      new URL('../instructions/gt-next.md', import.meta.url),
+      'utf8'
+    );
+
+    expect(instructions).toContain(NEXT_APP_QUICKSTART_URL);
+    expect(instructions).not.toContain(
+      'https://generaltranslation.com/docs/next.md'
+    );
+  });
+});

--- a/packages/cli/src/setup/guidance.ts
+++ b/packages/cli/src/setup/guidance.ts
@@ -1,0 +1,81 @@
+import type { ReactFrameworkObject } from '../types/index.js';
+
+export const REACT_SPA_QUICKSTART_URL =
+  'https://generaltranslation.com/docs/react/react-spa-quickstart';
+export const REACT_SERVER_QUICKSTART_URL =
+  'https://generaltranslation.com/docs/react/react-quickstart';
+export const REACT_CONFIGURING_GUIDE_URL =
+  'https://generaltranslation.com/docs/react/guides/configuring';
+export const REACT_LOAD_TRANSLATIONS_URL =
+  'https://generaltranslation.com/docs/react/reference/functions/load-translations';
+export const NEXT_APP_QUICKSTART_URL =
+  'https://generaltranslation.com/docs/react/nextjs-quickstart';
+export const NEXT_PAGES_QUICKSTART_URL =
+  'https://generaltranslation.com/docs/react/nextjs-pages-router-quickstart';
+
+type ReactSetupGuidance = {
+  defaultsDescription: string;
+  promptAction: string;
+  completion: string;
+  docsUrl: string;
+};
+
+export function getReactSetupGuidance(
+  framework: ReactFrameworkObject
+): ReactSetupGuidance {
+  if (framework.name === 'vite') {
+    return {
+      defaultsDescription:
+        'SPA initialization with initializeGTSPA (no GTProvider)',
+      promptAction:
+        'prepare the SPA setup (after the wizard, call initializeGTSPA before rendering; a GTProvider is not needed)',
+      completion:
+        'Next step: call initializeGTSPA with your config and loadTranslations before rendering. Do not add a GTProvider.',
+      docsUrl: REACT_SPA_QUICKSTART_URL,
+    };
+  }
+
+  if (framework.name === 'next-app') {
+    return {
+      defaultsDescription: 'Next.js App Router setup with GTProvider',
+      promptAction: 'add the GTProvider',
+      completion:
+        'Next step: review the Next.js App Router setup and start internationalizing.',
+      docsUrl: NEXT_APP_QUICKSTART_URL,
+    };
+  }
+
+  if (framework.name === 'next-pages') {
+    return {
+      defaultsDescription: 'Next.js Pages Router setup',
+      promptAction: 'prepare the Next.js Pages Router setup',
+      completion:
+        'Next step: review the Next.js Pages Router setup and start internationalizing.',
+      docsUrl: NEXT_PAGES_QUICKSTART_URL,
+    };
+  }
+
+  if (framework.name === 'gatsby' || framework.name === 'redwood') {
+    return {
+      defaultsDescription:
+        'server-rendered initialization with initializeGT and hydrated GTProvider',
+      promptAction:
+        'prepare the server-rendered setup (after the wizard, call initializeGT and hydrate GTProvider with the locale and translations)',
+      completion:
+        'Next step: call initializeGT at module scope, load the locale and translations on the server, and hydrate GTProvider with both values.',
+      docsUrl: REACT_SERVER_QUICKSTART_URL,
+    };
+  }
+
+  return {
+    defaultsDescription: 'rendering-model-specific React initialization',
+    promptAction:
+      'prepare the React setup (SPAs use initializeGTSPA without GTProvider; server-rendered apps use initializeGT and hydrate GTProvider with the locale and translations)',
+    completion:
+      'Next step: finish setup for your rendering model. SPAs call initializeGTSPA before rendering and do not need GTProvider. Server-rendered apps call initializeGT, load the locale and translations on the server, and hydrate GTProvider with both values.',
+    docsUrl: REACT_CONFIGURING_GUIDE_URL,
+  };
+}
+
+export const LOAD_TRANSLATIONS_SETUP_GUIDANCE = `Connect this loader through the setup for your framework. With gt-react, SPAs pass it to initializeGTSPA; server-rendered apps pass it to initializeGT, then hydrate GTProvider with the locale and translations.
+See ${REACT_LOAD_TRANSLATIONS_URL}`;

--- a/packages/cli/src/setup/instructions/gt-next.md
+++ b/packages/cli/src/setup/instructions/gt-next.md
@@ -104,4 +104,4 @@ const locale = useLocale(); // "en-US"
 
 ## Quickstart
 
-See <https://generaltranslation.com/docs/next.md>
+See <https://generaltranslation.com/docs/react/nextjs-quickstart>

--- a/packages/cli/src/setup/instructions/gt-react.md
+++ b/packages/cli/src/setup/instructions/gt-react.md
@@ -4,7 +4,55 @@ This project is using the `gt-react` internationalization library.
 
 ## gt-react setup
 
-- `GTProvider` must wrap the app in the root layout to provide translation context.
+Choose the setup that matches how the app renders:
+
+- Single-page apps (SPAs), including client-rendered Vite apps, call
+  `initializeGTSPA()` once before rendering. Pass the app configuration and
+  `loadTranslations` to it. SPAs do not need a `GTProvider`.
+- Server-rendered React apps call `initializeGT()` once at module scope. During
+  server rendering, resolve the request locale, load its translations with
+  `getTranslationsSnapshot()`, and hydrate `GTProvider` with both the `locale`
+  and `translations`.
+
+```js
+// SPA entry point
+import { initializeGTSPA } from 'gt-react';
+import config from '../gt.config.json'; // Adjust the relative path as needed.
+import loadTranslations from './loadTranslations';
+
+await initializeGTSPA({ ...config, loadTranslations });
+await import('./main');
+```
+
+```jsx
+// Server-rendered root
+import {
+  GTProvider,
+  getTranslationsSnapshot,
+  initializeGT,
+  parseLocale,
+} from 'gt-react';
+import config from '../gt.config.json'; // Adjust the relative path as needed.
+import loadTranslations from './loadTranslations';
+
+initializeGT({ ...config, loadTranslations });
+
+export async function loadRoot(request) {
+  const locale = parseLocale(request);
+  return {
+    locale,
+    translations: await getTranslationsSnapshot(locale),
+  };
+}
+
+export function Root({ locale, translations }) {
+  return (
+    <GTProvider locale={locale} translations={translations}>
+      <App />
+    </GTProvider>
+  );
+}
+```
 
 ## Translating JSX
 
@@ -95,4 +143,8 @@ const locale = useLocale(); // "en-US"
 
 ## Quickstart
 
-See <https://generaltranslation.com/docs/react.md>
+- SPAs: <https://generaltranslation.com/docs/react/react-spa-quickstart>
+- Server-rendered React:
+  <https://generaltranslation.com/docs/react/react-quickstart>
+- Full configuration guide:
+  <https://generaltranslation.com/docs/react/guides/configuring>


### PR DESCRIPTION
## Summary

- distinguish React SPA setup from server-rendered React across CLI defaults, prompts, completion text, loader guidance, and bundled instructions
- direct SPAs to `initializeGTSPA` without `GTProvider`, and server-rendered apps to `initializeGT` plus locale/translation provider hydration
- replace obsolete React, Next.js, and loader documentation links with current quickstarts and reference pages, backed by focused message/instruction tests

## Testing

- `pnpm --filter gt exec vitest run src/setup/__tests__/guidance.test.ts --config ./vitest.config.ts` — passed (8 tests)
- `pnpm exec turbo run test --filter=gt` — passed (99 test files, 2,091 tests)
- `pnpm exec turbo run typecheck --filter=gt` — passed (11 tasks)
- `pnpm exec oxlint packages/cli` — passed with 0 errors and 9 pre-existing warnings
- `pnpm format` — passed
- `git diff --check origin/main...HEAD` — passed
- `pnpm --filter gt test` — initial direct run could not resolve unbuilt workspace package outputs; the dependency-aware Turbo test graph above built them and passed

## Notes

- Changeset: patch added for `gt`.
- Scope is guidance and user-facing messages only; runtime setup transformations are intentionally unchanged.
- Worktree setup: `pnpm install --force` completed successfully before tests after the neighboring install hit a global-store linking race.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refreshes the CLI guidance for React application setup. The main changes are:

- Separates SPA and server-rendered React initialization guidance.
- Adds framework-specific prompts, completion text, and documentation links.
- Updates the bundled React and Next.js setup instructions.
- Adds focused tests for guidance messages and instruction links.
- Adds a patch changeset for the `gt` package.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/cli/base.ts | Uses centralized, framework-specific guidance in setup prompts, completion messages, and loader instructions. |
| packages/cli/src/setup/guidance.ts | Defines React setup guidance and current documentation links for each detected framework. |
| packages/cli/src/setup/instructions/gt-react.md | Documents separate initialization flows for SPAs and server-rendered React applications. |
| packages/cli/src/setup/instructions/gt-next.md | Replaces the obsolete Next.js documentation link with the current quickstart. |
| packages/cli/src/setup/__tests__/guidance.test.ts | Covers framework mappings, loader guidance, and bundled instruction links. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(cli): refresh React setup guidance"](https://github.com/generaltranslation/gt/commit/905b04fae656adef32acca8e3802229a17dea505) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46136407)</sub>

<!-- /greptile_comment -->