### PR TITLE
fix(cli): modernize React provider setup

### DIFF
--- a/.changeset/modern-react-provider-setup.md
+++ b/.changeset/modern-react-provider-setup.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+Make React setup rendering-mode aware and stop generating legacy `GTProvider` configuration props.

--- a/packages/cli/src/cli/base.ts
+++ b/packages/cli/src/cli/base.ts
@@ -64,8 +64,12 @@ import processSharedStaticAssets, {
 import { setupLocadex } from '../locadex/setupFlow.js';
 import { detectFramework } from '../setup/detectFramework.js';
 import {
+  getDefaultReactRenderingMode,
   getFrameworkDisplayName,
+  getLoadTranslationsSetupInstruction,
   getReactFrameworkLibrary,
+  getReactSetupSummary,
+  type ReactSetupContext,
 } from '../setup/frameworkUtils.js';
 import { INLINE_LIBRARIES } from '../types/libraries.js';
 import { handleEnqueue } from './commands/enqueue.js';
@@ -587,10 +591,6 @@ export class BaseCLI {
             framework.type === 'react'
               ? getFrameworkDisplayName(framework)
               : null;
-          const library =
-            framework.type === 'react'
-              ? getReactFrameworkLibrary(framework)
-              : null;
 
           // Build defaults description based on detected framework
           const defaultTranslationsDir =
@@ -600,7 +600,7 @@ export class BaseCLI {
 
           const defaultsDescription =
             framework.type === 'react'
-              ? `${library} & GTProvider, ${frameworkDisplayName}, Files saved locally in ${defaultTranslationsDir}`
+              ? `${getReactSetupSummary(framework)}, ${frameworkDisplayName}, Files saved locally in ${defaultTranslationsDir}`
               : `Files saved locally in ${defaultTranslationsDir}`;
 
           // Ask if user wants to use defaults
@@ -610,13 +610,18 @@ export class BaseCLI {
           });
 
           let ranReactSetup = false;
+          let reactSetupContext: ReactSetupContext | undefined;
 
           // so that people can run init in non-js projects
           if (framework.type === 'react') {
+            const setupPromptDescription =
+              framework.name === 'next-app'
+                ? getReactSetupSummary(framework)
+                : `${getReactFrameworkLibrary(framework)} for React (choose SPA or server rendering next)`;
             const wrap = useDefaults
               ? true
               : await promptConfirm({
-                  message: `Would you like to install ${library} and add the GTProvider? See the docs for more information: https://generaltranslation.com/docs/react/tutorials/quickstart`,
+                  message: `Would you like to configure ${setupPromptDescription}? See the docs for more information: https://generaltranslation.com/docs/react/guides/configuring`,
                   defaultValue: true,
                 });
 
@@ -624,7 +629,11 @@ export class BaseCLI {
               logger.info(
                 `${chalk.yellow('[EXPERIMENTAL]')} Configuring project...`
               );
-              await handleSetupReactCommand(options, framework, useDefaults);
+              reactSetupContext = await handleSetupReactCommand(
+                options,
+                framework,
+                useDefaults
+              );
               logger.endCommand(
                 `Done! Since this wizard is experimental, please review the changes and make modifications as needed.
 \nNext step: start internationalizing! See the docs for more information: https://generaltranslation.com/docs/react/tutorials/quickstart`
@@ -640,7 +649,9 @@ export class BaseCLI {
           await this.handleInitCommand(
             ranReactSetup,
             useDefaults,
-            framework.name === 'vite'
+            reactSetupContext?.framework === 'vite' ||
+              framework.name === 'vite',
+            reactSetupContext
           );
 
           logger.endCommand(
@@ -665,7 +676,18 @@ export class BaseCLI {
 
         // Configure gt.config.json
         const framework = await detectFramework();
-        await this.handleInitCommand(false, false, framework.name === 'vite');
+        const renderingMode =
+          framework.type === 'react'
+            ? getDefaultReactRenderingMode(framework)
+            : undefined;
+        await this.handleInitCommand(
+          false,
+          false,
+          framework.name === 'vite',
+          framework.type === 'react' && renderingMode
+            ? { framework: framework.name, renderingMode }
+            : undefined
+        );
 
         logger.endCommand(
           'Done! Make sure you have an API key and project ID to use General Translation. Get them on the dashboard: https://generaltranslation.com/dashboard'
@@ -688,7 +710,8 @@ export class BaseCLI {
   protected async handleInitCommand(
     ranReactSetup: boolean,
     useDefaults: boolean = false,
-    isVite: boolean = false
+    isVite: boolean = false,
+    reactSetupContext?: ReactSetupContext
   ): Promise<void> {
     const { defaultLocale, locales } = await getDesiredLocales(); // Locales should still be asked for even if using defaults
 
@@ -744,8 +767,8 @@ export class BaseCLI {
       );
       logger.message(
         `Created ${chalk.cyan('loadTranslations.js')} file for local translations.
-Make sure to add this function to your app configuration.
-See https://generaltranslation.com/en/docs/next/guides/local-tx`
+${getLoadTranslationsSetupInstruction(reactSetupContext)}
+See https://generaltranslation.com/docs/react/guides/configuring`
       );
     }
 

--- a/packages/cli/src/react/parse/__tests__/wrapContentProvider.test.ts
+++ b/packages/cli/src/react/parse/__tests__/wrapContentProvider.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { wrapContentReact } from '../wrapContent.js';
+import { Libraries } from '../../../types/libraries.js';
+
+describe('wrapContentReact provider behavior', () => {
+  let originalCwd: string;
+  let tempDirectory: string;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    tempDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'gt-wrap-provider-'));
+    process.chdir(tempDirectory);
+    fs.mkdirSync('pages');
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(tempDirectory, { recursive: true, force: true });
+  });
+
+  it('does not inject the legacy config-backed provider into Next Pages', async () => {
+    const source = `
+export default function App({ Component, pageProps }) {
+  return <Component {...pageProps} />;
+}
+`;
+    const filePath = path.join(tempDirectory, 'pages', '_app.tsx');
+    fs.writeFileSync(filePath, source);
+
+    const errors: string[] = [];
+    const warnings: string[] = [];
+    const result = await wrapContentReact(
+      {
+        src: ['pages/_app.tsx'],
+        config: 'gt.config.json',
+        skipTs: true,
+        disableIds: true,
+        disableFormatting: true,
+        addGTProvider: true,
+      },
+      Libraries.GT_REACT,
+      'next-pages',
+      errors,
+      warnings
+    );
+
+    expect(errors).toEqual([]);
+    expect(warnings).toEqual([]);
+    expect(result.filesUpdated).toEqual([]);
+    const transformedSource = fs.readFileSync(filePath, 'utf8');
+    expect(transformedSource).toBe(source);
+    expect(transformedSource).not.toContain('GTProvider');
+    expect(transformedSource).not.toContain('gtConfig');
+  });
+});

--- a/packages/cli/src/react/parse/wrapContent.ts
+++ b/packages/cli/src/react/parse/wrapContent.ts
@@ -1,11 +1,9 @@
 import fs from 'node:fs';
-import path from 'node:path';
 import { SupportedFrameworks, WrapOptions } from '../../types/index.js';
 import * as t from '@babel/types';
 import { parse } from '@babel/parser';
 import traverseModule from '@babel/traverse';
 import generateModule from '@babel/generator';
-import { NodePath } from '@babel/traverse';
 
 // Handle CommonJS/ESM interop
 const traverse = traverseModule.default || traverseModule;
@@ -27,7 +25,6 @@ const IMPORT_MAP = {
   Var: { name: 'Var', source: Libraries.GT_REACT },
   GTT: { name: 'T', source: Libraries.GT_REACT },
   GTVar: { name: 'Var', source: Libraries.GT_REACT },
-  GTProvider: { name: 'GTProvider', source: Libraries.GT_REACT },
 };
 
 /**
@@ -40,7 +37,7 @@ const IMPORT_MAP = {
 export async function wrapContentReact(
   options: WrapOptions,
   pkg: `${typeof Libraries.GT_REACT}`,
-  framework: SupportedFrameworks,
+  _framework: SupportedFrameworks,
   errors: string[],
   warnings: string[]
 ): Promise<{ filesUpdated: string[] }> {
@@ -50,17 +47,6 @@ export async function wrapContentReact(
   const filesUpdated = [];
 
   for (const file of files) {
-    const baseFileName = path.basename(file);
-    const configPath = path.relative(
-      path.dirname(file),
-      path.resolve(process.cwd(), options.config)
-    );
-
-    // Ensure the path starts with ./ or ../
-    const normalizedConfigPath = configPath.startsWith('.')
-      ? configPath
-      : './' + configPath;
-
     const code = await fs.promises.readFile(file, 'utf8');
 
     // Create relative path from src directory and remove extension
@@ -92,68 +78,6 @@ export async function wrapContentReact(
     let globalId = 0;
     traverse(ast, {
       JSXElement(path) {
-        if (
-          framework === 'next-pages' &&
-          options.addGTProvider &&
-          (baseFileName === '_app.tsx' || baseFileName === '_app.jsx')
-        ) {
-          // Check if this is the Component element with pageProps
-          const isComponentWithPageProps =
-            t.isJSXElement(path.node) &&
-            t.isJSXIdentifier(path.node.openingElement.name) &&
-            path.node.openingElement.name.name === 'Component' &&
-            path.node.openingElement.attributes.some(
-              (attr) =>
-                t.isJSXSpreadAttribute(attr) &&
-                t.isIdentifier(attr.argument) &&
-                attr.argument.name === 'pageProps'
-            );
-
-          if (!isComponentWithPageProps) {
-            return;
-          }
-
-          // Check if GTProvider already exists in the ancestors
-          let hasGTProvider = false;
-          let currentPath: NodePath = path;
-
-          while (currentPath.parentPath) {
-            if (
-              t.isJSXElement(currentPath.node) &&
-              t.isJSXIdentifier(currentPath.node.openingElement.name) &&
-              currentPath.node.openingElement.name.name === 'GTProvider'
-            ) {
-              hasGTProvider = true;
-              break;
-            }
-            currentPath = currentPath.parentPath;
-          }
-
-          if (!hasGTProvider) {
-            // Wrap the Component element with GTProvider
-            const gtProviderJsx = t.jsxElement(
-              t.jsxOpeningElement(
-                t.jsxIdentifier('GTProvider'),
-                [t.jsxSpreadAttribute(t.identifier('gtConfig'))],
-                false
-              ),
-              t.jsxClosingElement(t.jsxIdentifier('GTProvider')),
-              [path.node]
-            );
-
-            path.replaceWith(gtProviderJsx);
-            usedImports.push('GTProvider');
-            usedImports.push({
-              local: 'gtConfig',
-              imported: 'default',
-              source: normalizedConfigPath,
-            });
-            modified = true;
-            path.skip();
-            return;
-          }
-        }
-
         // Check if this JSX element has any JSX element ancestors
         if (
           t.isJSXElement(path.parentPath?.node) ||

--- a/packages/cli/src/setup/__tests__/frameworkUtils.test.ts
+++ b/packages/cli/src/setup/__tests__/frameworkUtils.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getDefaultReactRenderingMode,
+  getLoadTranslationsSetupInstruction,
+  getReactSetupSummary,
+  type ReactRenderingMode,
+} from '../frameworkUtils.js';
+import type { ReactFrameworkObject } from '../../types/index.js';
+
+function reactFramework(
+  name: ReactFrameworkObject['name']
+): ReactFrameworkObject {
+  return { name, type: 'react' };
+}
+
+describe('React setup rendering modes', () => {
+  it.each([
+    ['vite', 'spa'],
+    ['next-app', 'ssr'],
+    ['next-pages', 'ssr'],
+    ['gatsby', 'ssr'],
+    ['redwood', 'ssr'],
+  ] as const)('defaults %s projects to %s rendering', (name, mode) => {
+    expect(getDefaultReactRenderingMode(reactFramework(name))).toBe(mode);
+  });
+
+  it('leaves generic React rendering mode for the user to choose', () => {
+    expect(getDefaultReactRenderingMode(reactFramework('react'))).toBe(
+      undefined
+    );
+  });
+
+  it('describes SPA setup without a provider', () => {
+    expect(getReactSetupSummary(reactFramework('vite'))).toContain(
+      'no GTProvider'
+    );
+  });
+
+  it('limits the server-rendered provider to resolved runtime data', () => {
+    expect(getReactSetupSummary(reactFramework('react'), 'ssr')).toContain(
+      'GTProvider receives only locale and translations'
+    );
+  });
+});
+
+describe('loadTranslations setup instructions', () => {
+  const context = (
+    renderingMode: ReactRenderingMode
+  ): { framework: 'react'; renderingMode: ReactRenderingMode } => ({
+    framework: 'react',
+    renderingMode,
+  });
+
+  it('directs SPAs to initialization instead of a provider', () => {
+    const instruction = getLoadTranslationsSetupInstruction(context('spa'));
+
+    expect(instruction).toContain('initializeGTSPA()');
+    expect(instruction).toContain('do not use GTProvider');
+  });
+
+  it('keeps loaders off the server-rendered provider', () => {
+    const instruction = getLoadTranslationsSetupInstruction(context('ssr'));
+
+    expect(instruction).toContain('initializeGT()');
+    expect(instruction).toContain('only the resolved locale and translations');
+  });
+});

--- a/packages/cli/src/setup/frameworkUtils.ts
+++ b/packages/cli/src/setup/frameworkUtils.ts
@@ -1,5 +1,16 @@
-import { FrameworkObject, ReactFrameworkObject } from '../types/index.js';
+import {
+  FrameworkObject,
+  ReactFrameworkObject,
+  SupportedReactFrameworks,
+} from '../types/index.js';
 import { Libraries } from '../types/libraries.js';
+
+export type ReactRenderingMode = 'spa' | 'ssr';
+
+export type ReactSetupContext = {
+  framework: SupportedReactFrameworks;
+  renderingMode: ReactRenderingMode;
+};
 
 export function getFrameworkDisplayName(
   frameworkObject: FrameworkObject
@@ -34,4 +45,49 @@ export function getReactFrameworkLibrary(
   return frameworkObject.name === 'next-app'
     ? Libraries.GT_NEXT
     : Libraries.GT_REACT;
+}
+
+export function getDefaultReactRenderingMode(
+  frameworkObject: ReactFrameworkObject
+): ReactRenderingMode | undefined {
+  if (frameworkObject.name === 'vite') {
+    return 'spa';
+  }
+  if (frameworkObject.name === 'react') {
+    return undefined;
+  }
+  return 'ssr';
+}
+
+export function getReactSetupSummary(
+  frameworkObject: ReactFrameworkObject,
+  renderingMode = getDefaultReactRenderingMode(frameworkObject)
+): string {
+  const library = getReactFrameworkLibrary(frameworkObject);
+
+  if (frameworkObject.name === 'next-app') {
+    return `${library} with GTProvider`;
+  }
+  if (renderingMode === 'spa') {
+    return `${library} for a browser-rendered SPA (no GTProvider)`;
+  }
+  if (renderingMode === 'ssr') {
+    return `${library} for server-rendered React (GTProvider receives only locale and translations)`;
+  }
+  return `${library} for React (choose SPA or server rendering during setup)`;
+}
+
+export function getLoadTranslationsSetupInstruction(
+  setupContext?: ReactSetupContext
+): string {
+  if (setupContext?.renderingMode === 'spa') {
+    return 'Pass this function to initializeGTSPA(). SPAs do not use GTProvider.';
+  }
+  if (
+    setupContext?.renderingMode === 'ssr' &&
+    setupContext.framework !== 'next-app'
+  ) {
+    return 'Pass this function to initializeGT(). GTProvider should receive only the resolved locale and translations.';
+  }
+  return 'Connect this function through your library or framework initialization, not through GTProvider.';
 }

--- a/packages/cli/src/setup/wizard.ts
+++ b/packages/cli/src/setup/wizard.ts
@@ -16,14 +16,19 @@ import { loadConfig } from '../fs/config/loadConfig.js';
 import { addVitePlugin } from '../react/parse/addVitePlugin/index.js';
 import { exitSync } from '../console/logging.js';
 import { ReactFrameworkObject } from '../types/index.js';
-import { getFrameworkDisplayName } from './frameworkUtils.js';
+import {
+  getDefaultReactRenderingMode,
+  getFrameworkDisplayName,
+  type ReactRenderingMode,
+  type ReactSetupContext,
+} from './frameworkUtils.js';
 import { Libraries } from '../types/libraries.js';
 
 export async function handleSetupReactCommand(
   options: SetupOptions,
   frameworkObject: ReactFrameworkObject,
   useDefaults: boolean = false
-): Promise<void> {
+): Promise<ReactSetupContext> {
   const frameworkDisplayName = getFrameworkDisplayName(frameworkObject);
 
   // Ask user for confirmation using inquirer
@@ -69,6 +74,35 @@ Please let us know what you would like to see added at https://github.com/genera
     );
     exitSync(0);
   }
+
+  const selectedFramework = {
+    name: frameworkType,
+    type: 'react',
+  } satisfies ReactFrameworkObject;
+  const defaultRenderingMode =
+    getDefaultReactRenderingMode(selectedFramework) || 'spa';
+  const renderingMode =
+    frameworkType === 'next-app' || (useDefaults && frameworkType !== 'react')
+      ? defaultRenderingMode
+      : await promptSelect<ReactRenderingMode>({
+          message: 'How is your React app rendered?',
+          options: [
+            {
+              value: 'spa',
+              label: 'Single-page app (browser-rendered, no GTProvider)',
+            },
+            {
+              value: 'ssr',
+              label:
+                'Server-rendered app (GTProvider gets locale and translations)',
+            },
+          ],
+          defaultValue: defaultRenderingMode,
+        });
+  const setupContext: ReactSetupContext = {
+    framework: frameworkType,
+    renderingMode,
+  };
 
   // ----- Create a starter gt.config.json file -----
   await createOrUpdateConfig(options.config || 'gt.config.json', {
@@ -137,7 +171,7 @@ Please let us know what you would like to see added at https://github.com/genera
       disableIds: true,
       disableFormatting: true,
       skipTs: true,
-      addGTProvider: true,
+      addGTProvider: renderingMode === 'ssr',
     };
     const spinner = logger.createSpinner();
     spinner.start('Wrapping JSX content with <T> tags...');
@@ -196,7 +230,7 @@ Please let us know what you would like to see added at https://github.com/genera
   const formatter = await detectFormatter();
 
   if (!formatter || filesUpdated.length === 0) {
-    return;
+    return setupContext;
   }
 
   const applyFormatting = useDefaults
@@ -209,4 +243,6 @@ Please let us know what you would like to see added at https://github.com/genera
       });
   // Format updated files if formatters are available
   if (applyFormatting) await formatFiles(filesUpdated, formatter);
+
+  return setupContext;
 }


### PR DESCRIPTION
## Summary

- make React setup prompts distinguish browser-rendered SPAs from server-rendered apps, with no provider for SPAs and only resolved locale/translations on the server-rendered provider
- remove the dormant v10-era Next Pages transform that spread `gt.config.json` into `GTProvider`, and direct generated translation loaders to initialization instead

## Testing

- `pnpm install --force` — passed
- `pnpm --filter gt... run build` — passed
- `pnpm --filter gt test` — passed (100 files, 2,094 tests)
- `pnpm --filter gt typecheck` — passed
- `pnpm exec oxlint packages/cli` — passed with 0 errors (9 pre-existing warnings)
- `pnpm exec oxfmt --check <changed files>` — passed
- `git diff --check origin/main...HEAD` — passed

## Notes

- Changeset: patch release for `gt`.
- Scope is limited to provider semantics and setup UX; SPA bootstrapping, SSR framework integration, and Next Pages migration remain separate work.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes React CLI setup aware of browser and server rendering modes. The main changes are:

- Adds SPA and SSR setup descriptions and initialization guidance.
- Carries the selected rendering mode into the init flow.
- Avoids generating `GTProvider` setup for SPAs.
- Removes the dormant Next Pages config-backed provider transform.
- Adds focused tests for provider and rendering-mode behavior.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/cli/base.ts | Propagates React rendering context into setup prompts and translation-loader guidance. |
| packages/cli/src/setup/frameworkUtils.ts | Defines rendering-mode defaults, setup summaries, and mode-specific initialization instructions. |
| packages/cli/src/setup/wizard.ts | Adds SPA or SSR selection and restricts provider generation to server-rendered setup. |
| packages/cli/src/react/parse/wrapContent.ts | Removes the unused Next Pages provider and configuration injection. |
| packages/cli/src/react/parse/__tests__/wrapContentProvider.test.ts | Confirms that Next Pages files no longer receive the legacy provider transform. |
| packages/cli/src/setup/__tests__/frameworkUtils.test.ts | Covers framework defaults and SPA or SSR initialization guidance. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(cli): modernize React provider setup"](https://github.com/generaltranslation/gt/commit/cce53bbad6fd486220f3830391d0bbdbba8fd444) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46136667)</sub>

<!-- /greptile_comment -->