### PR TITLE
fix(cli): configure server-rendered React setup

### DIFF
--- a/.changeset/modern-react-ssr-setup.md
+++ b/.changeset/modern-react-ssr-setup.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+Configure the gt-react v11 server-rendered runtime automatically for standard React Router projects, while preserving custom loader code with actionable manual setup guidance.

--- a/packages/cli/src/cli/base.ts
+++ b/packages/cli/src/cli/base.ts
@@ -26,11 +26,15 @@ import {
   SetupOptions,
   TranslateFlags,
   SharedFlags,
+  ReactFrameworkObject,
 } from '../types/index.js';
 import { generateSettings } from '../config/generateSettings.js';
 import chalk from 'chalk';
 import { FILE_EXT_TO_EXT_LABEL } from '../formats/files/supportedFiles.js';
-import { handleSetupReactCommand } from '../setup/wizard.js';
+import {
+  completeSetupReactRuntime,
+  handleSetupReactCommand,
+} from '../setup/wizard.js';
 import {
   isPackageInstalled,
   searchForPackageJson,
@@ -610,6 +614,7 @@ export class BaseCLI {
           });
 
           let ranReactSetup = false;
+          let configuredReactFramework: ReactFrameworkObject | undefined;
 
           // so that people can run init in non-js projects
           if (framework.type === 'react') {
@@ -624,7 +629,15 @@ export class BaseCLI {
               logger.info(
                 `${chalk.yellow('[EXPERIMENTAL]')} Configuring project...`
               );
-              await handleSetupReactCommand(options, framework, useDefaults);
+              const configuredFrameworkName = await handleSetupReactCommand(
+                options,
+                framework,
+                useDefaults
+              );
+              configuredReactFramework = {
+                name: configuredFrameworkName,
+                type: 'react',
+              };
               logger.endCommand(
                 `Done! Since this wizard is experimental, please review the changes and make modifications as needed.
 \nNext step: start internationalizing! See the docs for more information: https://generaltranslation.com/docs/react/tutorials/quickstart`
@@ -637,11 +650,20 @@ export class BaseCLI {
             logger.startCommand('Setting up project config...');
           }
           // Configure gt.config.json
-          await this.handleInitCommand(
+          const initResult = await this.handleInitCommand(
             ranReactSetup,
             useDefaults,
-            framework.name === 'vite'
+            (configuredReactFramework ?? framework).name === 'vite'
           );
+
+          if (ranReactSetup && framework.type === 'react') {
+            await completeSetupReactRuntime(
+              options,
+              configuredReactFramework ?? framework,
+              useDefaults,
+              initResult.translationStorage
+            );
+          }
 
           logger.endCommand(
             'Done! Check out our docs for more information on how to use General Translation: https://generaltranslation.com/docs'
@@ -689,7 +711,9 @@ export class BaseCLI {
     ranReactSetup: boolean,
     useDefaults: boolean = false,
     isVite: boolean = false
-  ): Promise<void> {
+  ): Promise<{
+    translationStorage: 'local' | 'remote';
+  }> {
     const { defaultLocale, locales } = await getDesiredLocales(); // Locales should still be asked for even if using defaults
 
     const packageJson = await searchForPackageJson();
@@ -852,6 +876,9 @@ See https://generaltranslation.com/en/docs/next/guides/local-tx`
         await setCredentials(credentials, settings.framework);
       }
     }
+    return {
+      translationStorage: usingCDN ? 'remote' : 'local',
+    };
   }
   protected async handleLoginCommand(options: LoginOptions): Promise<void> {
     const settings = await generateSettings({ config: options.config });

--- a/packages/cli/src/setup/__tests__/reactRuntime.test.ts
+++ b/packages/cli/src/setup/__tests__/reactRuntime.test.ts
@@ -1,0 +1,288 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  detectReactRuntime,
+  setupReactRuntime,
+  updateReactRouterSsrRoot,
+} from '../reactRuntime.js';
+
+const tempDirectories: string[] = [];
+
+function createTempDirectory(): string {
+  const tempDirectory = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'gt-react-runtime-')
+  );
+  tempDirectories.push(tempDirectory);
+  return tempDirectory;
+}
+
+afterEach(() => {
+  for (const tempDirectory of tempDirectories.splice(0)) {
+    fs.rmSync(tempDirectory, { recursive: true, force: true });
+  }
+});
+
+describe('detectReactRuntime', () => {
+  it('distinguishes a React Router SPA from its default SSR mode', () => {
+    const spaDirectory = createTempDirectory();
+    fs.mkdirSync(path.join(spaDirectory, 'app'));
+    fs.writeFileSync(
+      path.join(spaDirectory, 'app/root.tsx'),
+      'export default function App() { return <main />; }'
+    );
+    fs.writeFileSync(
+      path.join(spaDirectory, 'react-router.config.ts'),
+      'export default { ssr: false };'
+    );
+    const packageJson = { devDependencies: { '@react-router/dev': '^7.0.0' } };
+
+    expect(detectReactRuntime('vite', packageJson, spaDirectory)).toEqual({
+      kind: 'spa',
+    });
+
+    fs.writeFileSync(
+      path.join(spaDirectory, 'react-router.config.ts'),
+      'export default { ssr: true };'
+    );
+    expect(detectReactRuntime('vite', packageJson, spaDirectory)).toEqual({
+      kind: 'ssr',
+      framework: 'react-router',
+      rootPath: 'app/root.tsx',
+    });
+
+    fs.rmSync(path.join(spaDirectory, 'react-router.config.ts'));
+    expect(detectReactRuntime('vite', packageJson, spaDirectory)).toEqual({
+      kind: 'ssr',
+      framework: 'react-router',
+      rootPath: 'app/root.tsx',
+    });
+
+    fs.writeFileSync(
+      path.join(spaDirectory, 'react-router.config.ts'),
+      'export default { ssr: process.env.ENABLE_SSR === "true" };'
+    );
+    expect(detectReactRuntime('vite', packageJson, spaDirectory)).toMatchObject(
+      {
+        kind: 'unsupported-ssr',
+        reason: expect.stringContaining('determines ssr dynamically'),
+      }
+    );
+  });
+});
+
+describe('updateReactRouterSsrRoot', () => {
+  it('adds the v11 SSR lifecycle while preserving the root component', () => {
+    const code = `
+import { Links, Outlet, Scripts } from 'react-router';
+
+const preserved = 'user code';
+
+export default function App() {
+  return (
+    <main data-value={preserved}>
+      <Outlet />
+      <Links />
+      <Scripts />
+    </main>
+  );
+}
+`;
+
+    const result = updateReactRouterSsrRoot({
+      code,
+      rootPath: '/project/app/root.tsx',
+      configPath: '/project/gt.config.json',
+      loadTranslationsPath: '/project/loadTranslations.js',
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.warning).toBeUndefined();
+    expect(result.code).toMatch(
+      /import \{ GTProvider, getTranslationsSnapshot, initializeGT, parseLocale \} from ['"]gt-react['"];/
+    );
+    expect(result.code).toMatch(
+      /import gtConfig from ['"]\.\.\/gt\.config\.json['"];/
+    );
+    expect(result.code).toMatch(
+      /import loadTranslations from ['"]\.\.\/loadTranslations\.js['"];/
+    );
+    expect(result.code).toContain('initializeGT({');
+    expect(result.code).toContain('const locale = parseLocale(request);');
+    expect(result.code).toContain(
+      'translations: await getTranslationsSnapshot(locale)'
+    );
+    expect(result.code).toContain('useLoaderData<typeof loader>()');
+    expect(result.code).toContain(
+      '<GTProvider locale={locale} translations={translations}>'
+    );
+    expect(result.code).toContain('<main data-value={preserved}>');
+  });
+
+  it('supports JavaScript roots without adding TypeScript syntax', () => {
+    const result = updateReactRouterSsrRoot({
+      code: `import { Outlet } from 'react-router';
+export default function App() { return <Outlet />; }`,
+      rootPath: '/project/app/root.jsx',
+      configPath: '/project/gt.config.json',
+      loadTranslationsPath: '/project/loadTranslations.js',
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.code).toMatch(
+      /export async function loader\(\{\s*request\s*\}\)/
+    );
+    expect(result.code).not.toContain('request: Request');
+  });
+
+  it('uses the configured CDN when no local translation loader exists', () => {
+    const result = updateReactRouterSsrRoot({
+      code: `import { Outlet } from 'react-router';
+export default function App() { return <Outlet />; }`,
+      rootPath: '/project/app/root.tsx',
+      configPath: '/project/gt.config.json',
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.code).toContain(`initializeGT({
+  ...gtConfig
+});`);
+    expect(result.code).not.toContain('loadTranslations');
+  });
+
+  it('is idempotent after completing the SSR setup', () => {
+    const input = `import { Outlet } from 'react-router';
+export default function App() { return <Outlet />; }`;
+    const first = updateReactRouterSsrRoot({
+      code: input,
+      rootPath: '/project/app/root.tsx',
+      configPath: '/project/gt.config.json',
+      loadTranslationsPath: '/project/loadTranslations.js',
+    });
+    const second = updateReactRouterSsrRoot({
+      code: first.code,
+      rootPath: '/project/app/root.tsx',
+      configPath: '/project/gt.config.json',
+      loadTranslationsPath: '/project/loadTranslations.js',
+    });
+
+    expect(second).toEqual({ code: first.code, changed: false });
+  });
+});
+
+describe('setupReactRuntime fallback behavior', () => {
+  it('preserves an existing root loader and gives actionable SSR guidance', async () => {
+    const cwd = createTempDirectory();
+    fs.mkdirSync(path.join(cwd, 'app'));
+    const rootPath = path.join(cwd, 'app/root.tsx');
+    const originalCode = `import { Outlet } from 'react-router';
+export async function loader() { return { user: 'Ernest' }; }
+export default function App() { return <Outlet />; }`;
+    fs.writeFileSync(rootPath, originalCode);
+    fs.writeFileSync(path.join(cwd, 'gt.config.json'), '{}');
+
+    const result = await setupReactRuntime({
+      framework: 'vite',
+      packageJson: {
+        devDependencies: { '@react-router/dev': '^7.0.0' },
+      },
+      cwd,
+    });
+
+    expect(fs.readFileSync(rootPath, 'utf8')).toBe(originalCode);
+    expect(result.filesUpdated).toEqual([]);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain('already exports a loader');
+    expect(result.warnings[0]).toContain('initializeGT()');
+    expect(result.warnings[0]).toContain('getTranslationsSnapshot(locale)');
+    expect(result.warnings[0]).toContain(
+      'https://generaltranslation.com/docs/react/react-quickstart'
+    );
+  });
+
+  it('preserves root bindings that would conflict with generated data', () => {
+    const code = `import { Outlet } from 'react-router';
+export default function App() {
+  const locale = 'custom';
+  return <Outlet />;
+}`;
+
+    const result = updateReactRouterSsrRoot({
+      code,
+      rootPath: '/project/app/root.tsx',
+      configPath: '/project/gt.config.json',
+    });
+
+    expect(result.changed).toBe(false);
+    expect(result.code).toBe(code);
+    expect(result.warning).toContain('already declares "locale"');
+  });
+
+  it('follows finalized local and remote translation storage', async () => {
+    const createProject = () => {
+      const cwd = createTempDirectory();
+      fs.mkdirSync(path.join(cwd, 'app'));
+      fs.writeFileSync(
+        path.join(cwd, 'app/root.tsx'),
+        `import { Outlet } from 'react-router';
+export default function App() { return <Outlet />; }`
+      );
+      fs.writeFileSync(
+        path.join(cwd, 'gt.config.json'),
+        '{"files":{"gt":{"output":"src/_gt/[locale].json"}}}'
+      );
+      fs.writeFileSync(
+        path.join(cwd, 'loadTranslations.js'),
+        'export default async function loadTranslations() { return {}; }'
+      );
+      return cwd;
+    };
+    const localCwd = createProject();
+    const remoteCwd = createProject();
+    const packageJson = { devDependencies: { '@react-router/dev': '^7.0.0' } };
+
+    await setupReactRuntime({
+      framework: 'vite',
+      packageJson,
+      translationStorage: 'local',
+      cwd: localCwd,
+    });
+    await setupReactRuntime({
+      framework: 'vite',
+      packageJson,
+      translationStorage: 'remote',
+      cwd: remoteCwd,
+    });
+
+    expect(
+      fs.readFileSync(path.join(localCwd, 'app/root.tsx'), 'utf8')
+    ).toContain("import loadTranslations from '../loadTranslations.js';");
+    expect(
+      fs.readFileSync(path.join(remoteCwd, 'app/root.tsx'), 'utf8')
+    ).not.toContain('loadTranslations');
+  });
+
+  it('leaves React Router SPAs untouched without SSR guidance', async () => {
+    const cwd = createTempDirectory();
+    fs.mkdirSync(path.join(cwd, 'app'));
+    fs.writeFileSync(
+      path.join(cwd, 'app/root.tsx'),
+      'export default function App() { return <main />; }'
+    );
+    fs.writeFileSync(
+      path.join(cwd, 'react-router.config.ts'),
+      'export default { ssr: false };'
+    );
+
+    await expect(
+      setupReactRuntime({
+        framework: 'vite',
+        packageJson: {
+          devDependencies: { '@react-router/dev': '^7.0.0' },
+        },
+        cwd,
+      })
+    ).resolves.toEqual({ filesUpdated: [], warnings: [] });
+  });
+});

--- a/packages/cli/src/setup/reactRuntime.ts
+++ b/packages/cli/src/setup/reactRuntime.ts
@@ -1,0 +1,742 @@
+import generateModule from '@babel/generator';
+import { parse } from '@babel/parser';
+import traverseModule, { type NodePath } from '@babel/traverse';
+import * as t from '@babel/types';
+import { createDiagnosticMessage } from 'generaltranslation/internal';
+import fs from 'node:fs';
+import path from 'node:path';
+import type { SupportedReactFrameworks } from '../types/index.js';
+
+const generate = generateModule.default || generateModule;
+const traverse = traverseModule.default || traverseModule;
+
+const REACT_QUICKSTART_URL =
+  'https://generaltranslation.com/docs/react/react-quickstart';
+const REACT_ROUTER_CONFIG_FILES = [
+  'react-router.config.ts',
+  'react-router.config.js',
+  'react-router.config.mts',
+  'react-router.config.mjs',
+  'react-router.config.cts',
+  'react-router.config.cjs',
+];
+const REACT_ROUTER_ROOT_FILES = [
+  'app/root.tsx',
+  'app/root.jsx',
+  'app/root.ts',
+  'app/root.js',
+];
+const CUSTOM_SSR_ENTRY_FILES = [
+  'entry.server.tsx',
+  'entry.server.jsx',
+  'entry-server.tsx',
+  'entry-server.jsx',
+  'src/entry.server.tsx',
+  'src/entry.server.jsx',
+  'src/entry-server.tsx',
+  'src/entry-server.jsx',
+  'app/entry.server.tsx',
+  'app/entry.server.jsx',
+];
+
+type ReactRuntimeDetection =
+  | { kind: 'spa' }
+  | { kind: 'ssr'; framework: 'react-router'; rootPath: string }
+  | { kind: 'unsupported-ssr'; reason: string }
+  | { kind: 'unknown' };
+
+export type SetupReactRuntimeResult = {
+  filesUpdated: string[];
+  warnings: string[];
+};
+
+function hasPackage(
+  packageJson: Record<string, unknown>,
+  packageName: string
+): boolean {
+  const dependencies = {
+    ...(packageJson.dependencies as Record<string, string> | undefined),
+    ...(packageJson.devDependencies as Record<string, string> | undefined),
+  };
+  return packageName in dependencies;
+}
+
+function findExistingFile(cwd: string, candidates: string[]): string | null {
+  for (const candidate of candidates) {
+    if (fs.existsSync(path.join(cwd, candidate))) return candidate;
+  }
+  return null;
+}
+
+function getTranslationStorageMode(
+  configPath: string
+): 'local' | 'remote' | 'unknown' {
+  try {
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8')) as {
+      files?: { gt?: { output?: unknown } };
+    };
+    return typeof config.files?.gt?.output === 'string' ? 'local' : 'remote';
+  } catch {
+    return 'unknown';
+  }
+}
+
+function getConfiguredReactRouterMode(
+  configPath: string
+): 'ssr' | 'spa' | 'default' | 'unknown' {
+  let code: string;
+  try {
+    code = fs.readFileSync(configPath, 'utf8');
+  } catch {
+    return 'unknown';
+  }
+
+  try {
+    const ast = parse(code, {
+      sourceType: 'unambiguous',
+      plugins: ['typescript'],
+    });
+    let mode: 'ssr' | 'spa' | 'default' | 'unknown' = 'default';
+    traverse(ast, {
+      ObjectProperty(propertyPath) {
+        const key = propertyPath.node.key;
+        const isSsrKey =
+          (t.isIdentifier(key) && key.name === 'ssr') ||
+          (t.isStringLiteral(key) && key.value === 'ssr');
+        if (!isSsrKey) return;
+        mode = t.isBooleanLiteral(propertyPath.node.value)
+          ? propertyPath.node.value.value
+            ? 'ssr'
+            : 'spa'
+          : 'unknown';
+        propertyPath.stop();
+      },
+    });
+    return mode;
+  } catch {
+    return 'unknown';
+  }
+}
+
+export function detectReactRuntime(
+  framework: SupportedReactFrameworks,
+  packageJson: Record<string, unknown>,
+  cwd: string = process.cwd()
+): ReactRuntimeDetection {
+  if (framework === 'next-app' || framework === 'next-pages') {
+    return { kind: 'unknown' };
+  }
+
+  if (framework === 'gatsby') {
+    return {
+      kind: 'unsupported-ssr',
+      reason:
+        'Gatsby splits server and browser setup across framework-specific APIs that cannot be updated reliably without inspecting the application lifecycle.',
+    };
+  }
+  if (framework === 'redwood') {
+    return {
+      kind: 'unsupported-ssr',
+      reason:
+        'RedwoodJS owns request loading and application hydration through framework-specific roots that the setup wizard cannot update reliably.',
+    };
+  }
+  if (hasPackage(packageJson, '@remix-run/react')) {
+    return {
+      kind: 'unsupported-ssr',
+      reason:
+        'Remix loader composition varies by route and version, so adding request-locale data to an existing root loader is not safe to automate.',
+    };
+  }
+
+  if (hasPackage(packageJson, '@react-router/dev')) {
+    const config = findExistingFile(cwd, REACT_ROUTER_CONFIG_FILES);
+    if (config) {
+      const configuredMode = getConfiguredReactRouterMode(
+        path.join(cwd, config)
+      );
+      if (configuredMode === 'spa') return { kind: 'spa' };
+      if (configuredMode === 'unknown') {
+        return {
+          kind: 'unsupported-ssr',
+          reason:
+            'The React Router config determines ssr dynamically, so the setup wizard cannot tell whether the application renders on the server or only in the browser.',
+        };
+      }
+    }
+
+    const rootPath = findExistingFile(cwd, REACT_ROUTER_ROOT_FILES);
+    return rootPath
+      ? { kind: 'ssr', framework: 'react-router', rootPath }
+      : {
+          kind: 'unsupported-ssr',
+          reason:
+            'React Router framework mode is server-rendered by default, but no standard app/root file was found.',
+        };
+  }
+
+  if (findExistingFile(cwd, CUSTOM_SSR_ENTRY_FILES)) {
+    return {
+      kind: 'unsupported-ssr',
+      reason:
+        'A server entry point was found, but custom SSR loaders and hydration entry points do not have a standard shape the setup wizard can update safely.',
+    };
+  }
+
+  return framework === 'vite' ? { kind: 'spa' } : { kind: 'unknown' };
+}
+
+function toImportSpecifier(fromFile: string, targetFile: string): string {
+  let relativePath = path
+    .relative(path.dirname(fromFile), targetFile)
+    .split(path.sep)
+    .join(path.posix.sep);
+  if (!relativePath.startsWith('.')) relativePath = `./${relativePath}`;
+  return relativePath;
+}
+
+function addNamedImports(
+  program: t.Program,
+  source: string,
+  importedNames: string[]
+): void {
+  const existingImport = program.body.find(
+    (node): node is t.ImportDeclaration =>
+      t.isImportDeclaration(node) &&
+      node.source.value === source &&
+      !node.specifiers.some((specifier) =>
+        t.isImportNamespaceSpecifier(specifier)
+      )
+  );
+  const existingNames = new Set(
+    existingImport?.specifiers.flatMap((specifier) =>
+      t.isImportSpecifier(specifier) &&
+      t.isIdentifier(specifier.imported) &&
+      specifier.local.name === specifier.imported.name
+        ? [specifier.local.name]
+        : []
+    ) ?? []
+  );
+  const newSpecifiers = importedNames
+    .filter((name) => !existingNames.has(name))
+    .map((name) => t.importSpecifier(t.identifier(name), t.identifier(name)));
+
+  if (existingImport) {
+    existingImport.specifiers.push(...newSpecifiers);
+    return;
+  }
+  program.body.unshift(
+    t.importDeclaration(newSpecifiers, t.stringLiteral(source))
+  );
+}
+
+function hasExportedLoader(program: t.Program): boolean {
+  return program.body.some((node) => {
+    if (!t.isExportNamedDeclaration(node)) return false;
+    if (
+      (t.isFunctionDeclaration(node.declaration) ||
+        t.isVariableDeclaration(node.declaration)) &&
+      node.declaration
+    ) {
+      if (t.isFunctionDeclaration(node.declaration)) {
+        return node.declaration.id?.name === 'loader';
+      }
+      return node.declaration.declarations.some(
+        (declaration) =>
+          t.isIdentifier(declaration.id) && declaration.id.name === 'loader'
+      );
+    }
+    return node.specifiers.some(
+      (specifier) =>
+        t.isExportSpecifier(specifier) &&
+        t.isIdentifier(specifier.exported) &&
+        specifier.exported.name === 'loader'
+    );
+  });
+}
+
+function hasGtSsrMarker(ast: t.File): boolean {
+  let found = false;
+  traverse(ast, {
+    Identifier(identifierPath) {
+      if (
+        [
+          'initializeGT',
+          'getTranslationsSnapshot',
+          'parseLocale',
+          'GTProvider',
+        ].includes(identifierPath.node.name)
+      ) {
+        found = true;
+        identifierPath.stop();
+      }
+    },
+  });
+  return found;
+}
+
+function isCompleteGtSsrSetup(ast: t.File): boolean {
+  const markers = new Set<string>();
+  traverse(ast, {
+    CallExpression(callPath) {
+      if (t.isIdentifier(callPath.node.callee)) {
+        markers.add(`call:${callPath.node.callee.name}`);
+      }
+    },
+    JSXOpeningElement(elementPath) {
+      if (t.isJSXIdentifier(elementPath.node.name, { name: 'GTProvider' })) {
+        markers.add('provider:GTProvider');
+        for (const attribute of elementPath.node.attributes) {
+          if (
+            t.isJSXAttribute(attribute) &&
+            t.isJSXIdentifier(attribute.name)
+          ) {
+            markers.add(`prop:${attribute.name.name}`);
+          }
+        }
+      }
+    },
+  });
+  return [
+    'call:initializeGT',
+    'call:getTranslationsSnapshot',
+    'call:parseLocale',
+    'provider:GTProvider',
+    'prop:locale',
+    'prop:translations',
+  ].every((marker) => markers.has(marker));
+}
+
+function findDefaultRootFunction(
+  ast: t.File
+): NodePath<t.FunctionDeclaration> | null {
+  let rootFunction: NodePath<t.FunctionDeclaration> | null = null;
+  traverse(ast, {
+    ExportDefaultDeclaration(exportPath) {
+      const declarationPath = exportPath.get('declaration');
+      if (declarationPath.isFunctionDeclaration()) {
+        rootFunction = declarationPath;
+        exportPath.stop();
+      }
+    },
+  });
+  return rootFunction;
+}
+
+function findBindingConflict(
+  ast: t.File,
+  rootFunction: NodePath<t.FunctionDeclaration>
+): string | null {
+  let conflict: string | null = null;
+  traverse(ast, {
+    Program(programPath) {
+      for (const name of ['gtConfig', 'loadTranslations', 'loader']) {
+        if (programPath.scope.hasOwnBinding(name)) {
+          conflict = name;
+          programPath.stop();
+          return;
+        }
+      }
+      const useLoaderDataBinding =
+        programPath.scope.getBinding('useLoaderData');
+      const useLoaderDataImport = useLoaderDataBinding?.path.parentPath;
+      if (
+        useLoaderDataBinding &&
+        (!useLoaderDataBinding.path.isImportSpecifier() ||
+          !useLoaderDataImport?.isImportDeclaration() ||
+          useLoaderDataImport.node.source.value !== 'react-router')
+      ) {
+        conflict = 'useLoaderData';
+        programPath.stop();
+      }
+    },
+  });
+  if (conflict) return conflict;
+  for (const name of ['locale', 'translations']) {
+    if (rootFunction.scope.hasOwnBinding(name)) return name;
+  }
+  return null;
+}
+
+function getSingleReturn(
+  functionPath: NodePath<t.FunctionDeclaration>
+): NodePath<t.ReturnStatement> | null {
+  const returns: NodePath<t.ReturnStatement>[] = [];
+  functionPath.traverse({
+    ReturnStatement(returnPath) {
+      if (returnPath.getFunctionParent() === functionPath)
+        returns.push(returnPath);
+    },
+  });
+  return returns.length === 1 ? returns[0] : null;
+}
+
+function createFallbackWarning(reason: string, rootPath?: string): string {
+  return createDiagnosticMessage({
+    source: 'gt',
+    severity: 'Warning',
+    whatHappened:
+      'The setup wizard could not safely automate the server-rendered gt-react runtime setup',
+    why: reason,
+    fix: 'In a root module loaded by both server and client, call initializeGT() with gt.config.json and, for local translation files, loadTranslations; then resolve each request with parseLocale(), load getTranslationsSnapshot(locale) in the framework loader, and pass both locale and translations to GTProvider.',
+    wayOut:
+      'Keep the existing application code unchanged and complete these steps manually.',
+    details: rootPath ? [`Root file: ${rootPath}`] : undefined,
+    docsUrl: REACT_QUICKSTART_URL,
+  });
+}
+
+function createInitializationStatements(
+  configImportPath: string,
+  loaderImportPath?: string
+): t.Statement[] {
+  const statements: t.Statement[] = [
+    t.importDeclaration(
+      [t.importDefaultSpecifier(t.identifier('gtConfig'))],
+      t.stringLiteral(configImportPath)
+    ),
+  ];
+  if (loaderImportPath) {
+    statements.push(
+      t.importDeclaration(
+        [t.importDefaultSpecifier(t.identifier('loadTranslations'))],
+        t.stringLiteral(loaderImportPath)
+      )
+    );
+  }
+  statements.push(
+    t.expressionStatement(
+      t.callExpression(t.identifier('initializeGT'), [
+        t.objectExpression([
+          t.spreadElement(t.identifier('gtConfig')),
+          ...(loaderImportPath
+            ? [
+                t.objectProperty(
+                  t.identifier('loadTranslations'),
+                  t.identifier('loadTranslations'),
+                  false,
+                  true
+                ),
+              ]
+            : []),
+        ]),
+      ])
+    )
+  );
+  return statements;
+}
+
+function createLoaderDeclaration(
+  typescript: boolean
+): t.ExportNamedDeclaration {
+  const requestPattern = t.objectPattern([
+    t.objectProperty(
+      t.identifier('request'),
+      t.identifier('request'),
+      false,
+      true
+    ),
+  ]);
+  if (typescript) {
+    requestPattern.typeAnnotation = t.tsTypeAnnotation(
+      t.tsTypeLiteral([
+        t.tsPropertySignature(
+          t.identifier('request'),
+          t.tsTypeAnnotation(t.tsTypeReference(t.identifier('Request')))
+        ),
+      ])
+    );
+  }
+  const localeDeclaration = t.variableDeclaration('const', [
+    t.variableDeclarator(
+      t.identifier('locale'),
+      t.callExpression(t.identifier('parseLocale'), [t.identifier('request')])
+    ),
+  ]);
+  const returnStatement = t.returnStatement(
+    t.objectExpression([
+      t.objectProperty(
+        t.identifier('locale'),
+        t.identifier('locale'),
+        false,
+        true
+      ),
+      t.objectProperty(
+        t.identifier('translations'),
+        t.awaitExpression(
+          t.callExpression(t.identifier('getTranslationsSnapshot'), [
+            t.identifier('locale'),
+          ])
+        )
+      ),
+    ])
+  );
+  return t.exportNamedDeclaration(
+    t.functionDeclaration(
+      t.identifier('loader'),
+      [requestPattern],
+      t.blockStatement([localeDeclaration, returnStatement]),
+      false,
+      true
+    )
+  );
+}
+
+export function updateReactRouterSsrRoot({
+  code,
+  rootPath,
+  configPath,
+  loadTranslationsPath,
+}: {
+  code: string;
+  rootPath: string;
+  configPath: string;
+  loadTranslationsPath?: string;
+}): { code: string; changed: boolean; warning?: string } {
+  let ast: t.File;
+  try {
+    ast = parse(code, {
+      sourceType: 'module',
+      plugins: ['jsx', 'typescript'],
+    });
+  } catch (error) {
+    return {
+      code,
+      changed: false,
+      warning: createFallbackWarning(
+        `The root module could not be parsed: ${String(error)}`,
+        rootPath
+      ),
+    };
+  }
+
+  if (isCompleteGtSsrSetup(ast)) return { code, changed: false };
+  if (hasGtSsrMarker(ast)) {
+    return {
+      code,
+      changed: false,
+      warning: createFallbackWarning(
+        'The root module already contains part of a gt-react setup, and replacing or completing custom initialization could change application behavior.',
+        rootPath
+      ),
+    };
+  }
+  if (hasExportedLoader(ast.program)) {
+    return {
+      code,
+      changed: false,
+      warning: createFallbackWarning(
+        'The root route already exports a loader, and automatically merging locale resolution into arbitrary loader return data could overwrite user behavior.',
+        rootPath
+      ),
+    };
+  }
+
+  const rootFunction = findDefaultRootFunction(ast);
+  const returnPath = rootFunction ? getSingleReturn(rootFunction) : null;
+  if (!rootFunction || !returnPath || !returnPath.node.argument) {
+    return {
+      code,
+      changed: false,
+      warning: createFallbackWarning(
+        'The default root component is not a function with one explicit return, so the wizard cannot wrap it without risking a semantic change.',
+        rootPath
+      ),
+    };
+  }
+  const bindingConflict = findBindingConflict(ast, rootFunction);
+  if (bindingConflict) {
+    return {
+      code,
+      changed: false,
+      warning: createFallbackWarning(
+        `The root module already declares "${bindingConflict}", which the generated SSR setup would also need to declare.`,
+        rootPath
+      ),
+    };
+  }
+
+  addNamedImports(ast.program, 'gt-react', [
+    'GTProvider',
+    'getTranslationsSnapshot',
+    'initializeGT',
+    'parseLocale',
+  ]);
+  addNamedImports(ast.program, 'react-router', ['useLoaderData']);
+
+  let lastImportIndex = -1;
+  for (const [index, node] of ast.program.body.entries()) {
+    if (t.isImportDeclaration(node)) lastImportIndex = index;
+  }
+  ast.program.body.splice(
+    lastImportIndex + 1,
+    0,
+    ...createInitializationStatements(
+      toImportSpecifier(rootPath, configPath),
+      loadTranslationsPath
+        ? toImportSpecifier(rootPath, loadTranslationsPath)
+        : undefined
+    ),
+    createLoaderDeclaration(/\.[cm]?tsx?$/.test(rootPath))
+  );
+
+  const useLoaderDataCall = t.callExpression(t.identifier('useLoaderData'), []);
+  if (/\.[cm]?tsx?$/.test(rootPath)) {
+    useLoaderDataCall.typeParameters = t.tsTypeParameterInstantiation([
+      t.tsTypeQuery(t.identifier('loader')),
+    ]);
+  }
+  rootFunction.node.body.body.unshift(
+    t.variableDeclaration('const', [
+      t.variableDeclarator(
+        t.objectPattern([
+          t.objectProperty(
+            t.identifier('locale'),
+            t.identifier('locale'),
+            false,
+            true
+          ),
+          t.objectProperty(
+            t.identifier('translations'),
+            t.identifier('translations'),
+            false,
+            true
+          ),
+        ]),
+        useLoaderDataCall
+      ),
+    ])
+  );
+  const previousReturnValue = returnPath.node.argument;
+  returnPath.node.argument = t.jsxElement(
+    t.jsxOpeningElement(
+      t.jsxIdentifier('GTProvider'),
+      [
+        t.jsxAttribute(
+          t.jsxIdentifier('locale'),
+          t.jsxExpressionContainer(t.identifier('locale'))
+        ),
+        t.jsxAttribute(
+          t.jsxIdentifier('translations'),
+          t.jsxExpressionContainer(t.identifier('translations'))
+        ),
+      ],
+      false
+    ),
+    t.jsxClosingElement(t.jsxIdentifier('GTProvider')),
+    t.isJSXElement(previousReturnValue) || t.isJSXFragment(previousReturnValue)
+      ? [previousReturnValue]
+      : [t.jsxExpressionContainer(previousReturnValue)],
+    false
+  );
+
+  return {
+    code: generate(
+      ast,
+      { comments: true, jsescOption: { quotes: 'single' } },
+      code
+    ).code,
+    changed: true,
+  };
+}
+
+export async function setupReactRuntime({
+  framework,
+  packageJson,
+  translationStorage,
+  configPath = 'gt.config.json',
+  cwd = process.cwd(),
+}: {
+  framework: SupportedReactFrameworks;
+  packageJson: Record<string, unknown>;
+  translationStorage?: 'local' | 'remote';
+  configPath?: string;
+  cwd?: string;
+}): Promise<SetupReactRuntimeResult> {
+  const detection = detectReactRuntime(framework, packageJson, cwd);
+  if (detection.kind === 'spa' || detection.kind === 'unknown') {
+    return { filesUpdated: [], warnings: [] };
+  }
+  if (detection.kind === 'unsupported-ssr') {
+    return {
+      filesUpdated: [],
+      warnings: [createFallbackWarning(detection.reason)],
+    };
+  }
+
+  const absoluteRootPath = path.join(cwd, detection.rootPath);
+  const absoluteConfigPath = path.resolve(cwd, configPath);
+  const storageMode =
+    translationStorage ?? getTranslationStorageMode(absoluteConfigPath);
+  if (storageMode === 'unknown') {
+    return {
+      filesUpdated: [],
+      warnings: [
+        createFallbackWarning(
+          `The finalized GT config could not be read at ${configPath}.`,
+          detection.rootPath
+        ),
+      ],
+    };
+  }
+  const expectedLoadTranslationsPath = fs.existsSync(path.join(cwd, 'src'))
+    ? path.join(cwd, 'src', 'loadTranslations.js')
+    : path.join(cwd, 'loadTranslations.js');
+  if (storageMode === 'local' && !fs.existsSync(expectedLoadTranslationsPath)) {
+    return {
+      filesUpdated: [],
+      warnings: [
+        createFallbackWarning(
+          `The GT config uses local translation output, but ${path.relative(
+            cwd,
+            expectedLoadTranslationsPath
+          )} was not found.`,
+          detection.rootPath
+        ),
+      ],
+    };
+  }
+  const loadTranslationsPath =
+    storageMode === 'local' ? expectedLoadTranslationsPath : undefined;
+  let originalCode: string;
+  try {
+    originalCode = await fs.promises.readFile(absoluteRootPath, 'utf8');
+  } catch (error) {
+    return {
+      filesUpdated: [],
+      warnings: [
+        createFallbackWarning(
+          `The root module could not be read: ${String(error)}`,
+          detection.rootPath
+        ),
+      ],
+    };
+  }
+  const result = updateReactRouterSsrRoot({
+    code: originalCode,
+    rootPath: absoluteRootPath,
+    configPath: absoluteConfigPath,
+    loadTranslationsPath,
+  });
+  if (!result.changed) {
+    return {
+      filesUpdated: [],
+      warnings: result.warning ? [result.warning] : [],
+    };
+  }
+
+  try {
+    await fs.promises.writeFile(absoluteRootPath, result.code);
+  } catch (error) {
+    return {
+      filesUpdated: [],
+      warnings: [
+        createFallbackWarning(
+          `The updated root module could not be written: ${String(error)}`,
+          detection.rootPath
+        ),
+      ],
+    };
+  }
+  return { filesUpdated: [detection.rootPath], warnings: [] };
+}

--- a/packages/cli/src/setup/wizard.ts
+++ b/packages/cli/src/setup/wizard.ts
@@ -18,12 +18,13 @@ import { exitSync } from '../console/logging.js';
 import { ReactFrameworkObject } from '../types/index.js';
 import { getFrameworkDisplayName } from './frameworkUtils.js';
 import { Libraries } from '../types/libraries.js';
+import { setupReactRuntime } from './reactRuntime.js';
 
 export async function handleSetupReactCommand(
   options: SetupOptions,
   frameworkObject: ReactFrameworkObject,
   useDefaults: boolean = false
-): Promise<void> {
+): Promise<SupportedReactFrameworks> {
   const frameworkDisplayName = getFrameworkDisplayName(frameworkObject);
 
   // Ask user for confirmation using inquirer
@@ -196,7 +197,7 @@ Please let us know what you would like to see added at https://github.com/genera
   const formatter = await detectFormatter();
 
   if (!formatter || filesUpdated.length === 0) {
-    return;
+    return frameworkType as SupportedReactFrameworks;
   }
 
   const applyFormatting = useDefaults
@@ -209,4 +210,45 @@ Please let us know what you would like to see added at https://github.com/genera
       });
   // Format updated files if formatters are available
   if (applyFormatting) await formatFiles(filesUpdated, formatter);
+  return frameworkType as SupportedReactFrameworks;
+}
+
+export async function completeSetupReactRuntime(
+  options: SetupOptions,
+  frameworkObject: ReactFrameworkObject,
+  useDefaults: boolean = false,
+  translationStorage?: 'local' | 'remote'
+): Promise<void> {
+  if (!['react', 'redwood', 'vite', 'gatsby'].includes(frameworkObject.name)) {
+    return;
+  }
+
+  const packageJson = await getPackageJson();
+  if (!packageJson) return;
+
+  const runtimeSetup = await setupReactRuntime({
+    framework: frameworkObject.name,
+    packageJson,
+    translationStorage,
+    configPath:
+      options.config ||
+      findFilepath(['gt.config.json', 'src/gt.config.json']) ||
+      'gt.config.json',
+  });
+  for (const warning of runtimeSetup.warnings) logger.warn(warning);
+  if (runtimeSetup.filesUpdated.length === 0) return;
+
+  const formatter = await detectFormatter();
+  if (!formatter) return;
+  const applyFormatting =
+    useDefaults ||
+    (await promptConfirm({
+      message: `Would you like the wizard to auto-format the SSR runtime file? ${chalk.dim(
+        `(${formatter})`
+      )}`,
+      defaultValue: true,
+    }));
+  if (applyFormatting) {
+    await formatFiles(runtimeSetup.filesUpdated, formatter);
+  }
 }


### PR DESCRIPTION
## Summary

- add safe React Router SSR detection and gt-react v11 runtime wiring
- initialize the shared runtime and hydrate request locale/translations through `GTProvider`
- preserve custom loader and framework integrations with actionable fallback diagnostics and idempotent reruns

## Testing

- `pnpm --filter gt test -- --reporter=dot` — passed (99 files, 2,092 tests)
- `pnpm --filter gt typecheck` — passed
- `pnpm --filter gt build` — passed
- `pnpm exec oxlint packages/cli/src/setup/reactRuntime.ts packages/cli/src/setup/__tests__/reactRuntime.test.ts packages/cli/src/setup/wizard.ts packages/cli/src/cli/base.ts` — passed (0 warnings, 0 errors)
- `pnpm exec oxfmt --check packages/cli/src/setup/reactRuntime.ts packages/cli/src/setup/__tests__/reactRuntime.test.ts packages/cli/src/setup/wizard.ts packages/cli/src/cli/base.ts` — passed

## Notes

- Added a patch changeset for `gt`.
- Automation is limited to standard React Router roots without an existing loader. Custom SSR lifecycles remain unchanged and receive manual setup guidance.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds automatic gt-react runtime setup for server-rendered React projects. The main changes are:

- Detect React Router SSR and SPA configurations.
- Generate runtime initialization, loader data, and `GTProvider` wiring.
- Run SSR setup after locale and translation storage configuration.
- Preserve custom loaders and emit manual setup guidance.
- Add tests and a patch changeset.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Custom config paths and nested SSR settings can produce an incorrectly configured project.

- Custom `--config` paths can split framework and finalized locale settings across two files.
- An unrelated nested `ssr` property can suppress required runtime generation.
- Standard roots, existing loaders, reruns, and local or remote storage have focused tests.

packages/cli/src/setup/wizard.ts and packages/cli/src/setup/reactRuntime.ts
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/setup/reactRuntime.ts | Adds SSR detection and AST-based React Router runtime generation; nested `ssr` properties can cause incorrect detection. |
| packages/cli/src/setup/wizard.ts | Adds post-init runtime setup and formatting; custom config paths can diverge from the finalized config. |
| packages/cli/src/cli/base.ts | Sequences React setup, config generation, and runtime completion while returning translation storage state. |
| packages/cli/src/setup/__tests__/reactRuntime.test.ts | Covers standard SSR and SPA detection, storage modes, idempotency, conflicts, and custom loaders. |
| .changeset/modern-react-ssr-setup.md | Adds a patch changeset for automatic React SSR runtime configuration. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Run gt init] --> B[Configure React framework]
  B --> C[Finalize locales and storage]
  C --> D[Detect React runtime]
  D -->|SPA or unknown| E[Leave root unchanged]
  D -->|Unsupported SSR| F[Show manual guidance]
  D -->|React Router SSR| G[Update app root]
  G --> H[Initialize GT]
  G --> I[Add request loader]
  G --> J[Wrap root with GTProvider]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
  A[Run gt init] --> B[Configure React framework]
  B --> C[Finalize locales and storage]
  C --> D[Detect React runtime]
  D -->|SPA or unknown| E[Leave root unchanged]
  D -->|Unsupported SSR| F[Show manual guidance]
  D -->|React Router SSR| G[Update app root]
  G --> H[Initialize GT]
  G --> I[Add request loader]
  G --> J[Wrap root with GTProvider]
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fcli%2Fsrc%2Fsetup%2Fwizard.ts%3A233-236%0A**Finalized%20Config%20Path%20Diverges**%0A%0AWhen%20%60gt%20init%20--config%20%3Ccustom-path%3E%60%20runs%2C%20the%20React%20wizard%20writes%20that%20file%2C%20but%20%60handleInitCommand%60%20finalizes%20%60gt.config.json%60%20or%20%60src%2Fgt.config.json%60%20instead.%20This%20code%20then%20imports%20the%20custom%2C%20incomplete%20config%20while%20using%20storage%20state%20from%20the%20other%20file%2C%20so%20the%20generated%20SSR%20runtime%20can%20omit%20the%20selected%20locales%20and%20file%20settings.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fcli%2Fsrc%2Fsetup%2FreactRuntime.ts%3A100-111%0A**Nested%20SSR%20Flag%20Controls%20Detection**%0A%0AThe%20traversal%20stops%20at%20the%20first%20object%20property%20named%20%60ssr%60%20anywhere%20in%20the%20config.%20For%20a%20config%20such%20as%20%60plugin%3A%20%7B%20ssr%3A%20false%20%7D%60%20followed%20by%20the%20top-level%20%60ssr%3A%20true%60%2C%20detection%20reports%20an%20SPA%20and%20silently%20skips%20the%20required%20server%20runtime%20setup.%0A%0A&repo=generaltranslation%2Fgt&pr=1969&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fcli%2Fsetup-ssr-initialization%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fcli%2Fsetup-ssr-initialization%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fcli%2Fsrc%2Fsetup%2Fwizard.ts%3A233-236%0A**Finalized%20Config%20Path%20Diverges**%0A%0AWhen%20%60gt%20init%20--config%20%3Ccustom-path%3E%60%20runs%2C%20the%20React%20wizard%20writes%20that%20file%2C%20but%20%60handleInitCommand%60%20finalizes%20%60gt.config.json%60%20or%20%60src%2Fgt.config.json%60%20instead.%20This%20code%20then%20imports%20the%20custom%2C%20incomplete%20config%20while%20using%20storage%20state%20from%20the%20other%20file%2C%20so%20the%20generated%20SSR%20runtime%20can%20omit%20the%20selected%20locales%20and%20file%20settings.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fcli%2Fsrc%2Fsetup%2FreactRuntime.ts%3A100-111%0A**Nested%20SSR%20Flag%20Controls%20Detection**%0A%0AThe%20traversal%20stops%20at%20the%20first%20object%20property%20named%20%60ssr%60%20anywhere%20in%20the%20config.%20For%20a%20config%20such%20as%20%60plugin%3A%20%7B%20ssr%3A%20false%20%7D%60%20followed%20by%20the%20top-level%20%60ssr%3A%20true%60%2C%20detection%20reports%20an%20SPA%20and%20silently%20skips%20the%20required%20server%20runtime%20setup.%0A%0A&repo=generaltranslation%2Fgt&pr=1969&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/cli/src/setup/wizard.ts:233-236
**Finalized Config Path Diverges**

When `gt init --config <custom-path>` runs, the React wizard writes that file, but `handleInitCommand` finalizes `gt.config.json` or `src/gt.config.json` instead. This code then imports the custom, incomplete config while using storage state from the other file, so the generated SSR runtime can omit the selected locales and file settings.

### Issue 2 of 2
packages/cli/src/setup/reactRuntime.ts:100-111
**Nested SSR Flag Controls Detection**

The traversal stops at the first object property named `ssr` anywhere in the config. For a config such as `plugin: { ssr: false }` followed by the top-level `ssr: true`, detection reports an SPA and silently skips the required server runtime setup.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(cli): configure server-rendered Reac..."](https://github.com/generaltranslation/gt/commit/e36eb1844624389390c9462254103d0de5d3aaf9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46137004)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->