### PR TITLE
fix(cli): configure Next.js Pages Router with gt-next

### DIFF
--- a/.changeset/bright-pages-setup.md
+++ b/.changeset/bright-pages-setup.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+Configure Next.js Pages Router projects with `gt-next`, including `withGTConfig`, local translation output, per-page locale and translation props, and `GTProvider` wiring in the custom App. Existing config and page logic are preserved, repeated setup runs are idempotent, and unsupported data-fetching exports receive manual setup guidance.

--- a/packages/cli/src/cli/base.ts
+++ b/packages/cli/src/cli/base.ts
@@ -24,6 +24,7 @@ import {
   Settings,
   SupportedLibraries,
   SetupOptions,
+  SupportedFrameworks,
   TranslateFlags,
   SharedFlags,
 } from '../types/index.js';
@@ -640,7 +641,8 @@ export class BaseCLI {
           await this.handleInitCommand(
             ranReactSetup,
             useDefaults,
-            framework.name === 'vite'
+            framework.name,
+            options.config
           );
 
           logger.endCommand(
@@ -665,7 +667,7 @@ export class BaseCLI {
 
         // Configure gt.config.json
         const framework = await detectFramework();
-        await this.handleInitCommand(false, false, framework.name === 'vite');
+        await this.handleInitCommand(false, false, framework.name);
 
         logger.endCommand(
           'Done! Make sure you have an API key and project ID to use General Translation. Get them on the dashboard: https://generaltranslation.com/dashboard'
@@ -688,7 +690,8 @@ export class BaseCLI {
   protected async handleInitCommand(
     ranReactSetup: boolean,
     useDefaults: boolean = false,
-    isVite: boolean = false
+    framework?: SupportedFrameworks,
+    requestedConfigFilepath?: string
   ): Promise<void> {
     const { defaultLocale, locales } = await getDesiredLocales(); // Locales should still be asked for even if using defaults
 
@@ -715,9 +718,10 @@ export class BaseCLI {
       return selectedValue === 'cdn';
     })();
 
-    const defaultTranslationsDir = isVite
-      ? DEFAULT_VITE_TRANSLATIONS_DIR
-      : DEFAULT_TRANSLATIONS_DIR;
+    const defaultTranslationsDir =
+      framework === 'vite'
+        ? DEFAULT_VITE_TRANSLATIONS_DIR
+        : DEFAULT_TRANSLATIONS_DIR;
 
     // Ask where the translations are stored
     const translationsDir =
@@ -742,8 +746,30 @@ export class BaseCLI {
         finalTranslationsDir,
         locales
       );
+      if (framework === 'next-pages') {
+        const gitignorePath = path.join(process.cwd(), '.gitignore');
+        const ignoredDirectory = `${finalTranslationsDir
+          .replace(/^\.\//, '')
+          .replace(/\/$/, '')}/`;
+        const gitignoreContents = fs.existsSync(gitignorePath)
+          ? await fs.promises.readFile(gitignorePath, 'utf8')
+          : '';
+        const ignoredPaths = gitignoreContents.split(/\r?\n/);
+        if (!ignoredPaths.includes(ignoredDirectory)) {
+          const separator =
+            gitignoreContents && !gitignoreContents.endsWith('\n') ? '\n' : '';
+          await fs.promises.appendFile(
+            gitignorePath,
+            `${separator}${ignoredDirectory}\n`,
+            'utf8'
+          );
+        }
+      }
       logger.message(
-        `Created ${chalk.cyan('loadTranslations.js')} file for local translations.
+        framework === 'next-pages'
+          ? `Created ${chalk.cyan('loadTranslations.js')} for local translations. ${chalk.cyan('withGTConfig')} will detect it automatically.
+See https://generaltranslation.com/docs/react/nextjs-pages-router-quickstart`
+          : `Created ${chalk.cyan('loadTranslations.js')} file for local translations.
 Make sure to add this function to your app configuration.
 See https://generaltranslation.com/en/docs/next/guides/local-tx`
       );
@@ -792,8 +818,8 @@ See https://generaltranslation.com/en/docs/next/guides/local-tx`
       };
     }
 
-    let configFilepath = 'gt.config.json';
-    if (fs.existsSync('src/gt.config.json')) {
+    let configFilepath = requestedConfigFilepath || 'gt.config.json';
+    if (!requestedConfigFilepath && fs.existsSync('src/gt.config.json')) {
       configFilepath = 'src/gt.config.json';
     }
 

--- a/packages/cli/src/fs/config/__tests__/setupConfig.test.ts
+++ b/packages/cli/src/fs/config/__tests__/setupConfig.test.ts
@@ -1,0 +1,50 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createOrUpdateConfig } from '../setupConfig.js';
+
+describe('createOrUpdateConfig', () => {
+  const temporaryDirectories: string[] = [];
+
+  afterEach(() => {
+    for (const directory of temporaryDirectories.splice(0)) {
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves existing file config while adding local GT output', async () => {
+    const directory = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'gt-setup-config-')
+    );
+    temporaryDirectories.push(directory);
+    const configPath = path.join(directory, 'gt.config.json');
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({
+        customSetting: true,
+        files: {
+          json: { include: ['locales/[locale].json'] },
+          gt: { parsingFlags: { jsx: true } },
+        },
+      })
+    );
+
+    await createOrUpdateConfig(configPath, {
+      framework: 'next-pages',
+      files: {
+        gt: { output: 'public/_gt/[locale].json' },
+      },
+    });
+
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    expect(config.customSetting).toBe(true);
+    expect(config.files.json).toEqual({
+      include: ['locales/[locale].json'],
+    });
+    expect(config.files.gt).toEqual({
+      parsingFlags: { jsx: true },
+      output: 'public/_gt/[locale].json',
+    });
+  });
+});

--- a/packages/cli/src/fs/config/setupConfig.ts
+++ b/packages/cli/src/fs/config/setupConfig.ts
@@ -27,7 +27,6 @@ export async function createOrUpdateConfig(
   const newContent = {
     ...(options.projectId && { projectId: options.projectId }),
     ...(options.defaultLocale && { defaultLocale: options.defaultLocale }),
-    ...(options.files && { files: options.files }),
     ...(options.framework && { framework: options.framework }),
     ...(options.baseUrl && { baseUrl: options.baseUrl }),
     ...(options.publish && { publish: options.publish }),
@@ -46,10 +45,32 @@ export async function createOrUpdateConfig(
     }
 
     // merge old and new content
+    const oldFiles =
+      typeof oldContent.files === 'object' && oldContent.files !== null
+        ? (oldContent.files as Record<string, unknown>)
+        : {};
+    const mergedFiles = options.files
+      ? Object.fromEntries(
+          Object.entries(options.files).map(([format, formatOptions]) => [
+            format,
+            typeof oldFiles[format] === 'object' &&
+            oldFiles[format] !== null &&
+            typeof formatOptions === 'object' &&
+            formatOptions !== null
+              ? {
+                  ...(oldFiles[format] as Record<string, unknown>),
+                  ...formatOptions,
+                }
+              : formatOptions,
+          ])
+        )
+      : undefined;
+
     const mergedContent = {
       $schema: GT_CONFIG_SCHEMA_URL,
       ...oldContent,
       ...newContent,
+      ...(mergedFiles && { files: { ...oldFiles, ...mergedFiles } }),
     } as Record<string, unknown> & { locales?: string[] };
 
     // Add locales to mergedContent if they exist

--- a/packages/cli/src/next/parse/__tests__/handleInitGT.test.ts
+++ b/packages/cli/src/next/parse/__tests__/handleInitGT.test.ts
@@ -215,6 +215,28 @@ export default nextConfig;
   });
 
   describe('JavaScript file type detection', () => {
+    it('uses CommonJS and wraps module.exports in a .cjs config', async () => {
+      const filepath = '/test/next.config.cjs';
+      const { errors, warnings, filesUpdated } = createTestArrays();
+      const code = `const nextConfig = { reactStrictMode: true };\nmodule.exports = nextConfig;`;
+
+      vi.mocked(fs.promises.readFile).mockResolvedValue(code);
+      vi.mocked(fs.promises.writeFile).mockResolvedValue(undefined);
+
+      await handleInitGT(filepath, errors, warnings, filesUpdated);
+
+      expect(vi.mocked(fs.promises.writeFile)).toHaveBeenCalledWith(
+        filepath,
+        expect.stringContaining(
+          'const withGTConfig = require("gt-next/config").withGTConfig'
+        )
+      );
+      expect(vi.mocked(fs.promises.writeFile)).toHaveBeenCalledWith(
+        filepath,
+        expect.stringContaining('module.exports = withGTConfig(nextConfig, {})')
+      );
+    });
+
     it('should use CommonJS for .js files when package.json type is not module', async () => {
       const filepath = '/test/next.config.js';
       const { errors, warnings, filesUpdated } = createTestArrays();
@@ -267,7 +289,7 @@ export default nextConfig;
   });
 
   describe('existing imports detection', () => {
-    it('should not add import if withGTConfig is already imported', async () => {
+    it('should apply an existing withGTConfig import when it is not called', async () => {
       const filepath = '/test/next.config.js';
       const { errors, warnings, filesUpdated } = createTestArrays();
       const packageJson = createMockPackageJson();
@@ -287,8 +309,11 @@ export default nextConfig;
 
       await handleInitGT(filepath, errors, warnings, filesUpdated, packageJson);
 
-      expect(vi.mocked(fs.promises.writeFile)).not.toHaveBeenCalled();
-      expect(filesUpdated).toHaveLength(0);
+      expect(vi.mocked(fs.promises.writeFile)).toHaveBeenCalledWith(
+        filepath,
+        expect.stringContaining('export default withGTConfig(nextConfig, {})')
+      );
+      expect(filesUpdated).toEqual([filepath]);
     });
 
     it('should not add import if withGTConfig is already required (destructuring)', async () => {
@@ -784,6 +809,36 @@ export default nextConfig;
   });
 
   describe('file mutation tracking', () => {
+    it('passes a custom GT config path without replacing Next config', async () => {
+      const filepath = '/test/next.config.ts';
+      const { errors, warnings, filesUpdated } = createTestArrays();
+      const code = `const nextConfig = { reactStrictMode: true };\nexport default nextConfig;`;
+
+      vi.mocked(fs.promises.readFile).mockResolvedValue(code);
+      vi.mocked(fs.promises.writeFile).mockResolvedValue(undefined);
+
+      await handleInitGT(
+        filepath,
+        errors,
+        warnings,
+        filesUpdated,
+        { type: 'module' },
+        undefined,
+        'src/gt.config.json'
+      );
+
+      expect(vi.mocked(fs.promises.writeFile)).toHaveBeenCalledWith(
+        filepath,
+        expect.stringContaining(
+          'withGTConfig(nextConfig, { config: "src/gt.config.json" })'
+        )
+      );
+      expect(vi.mocked(fs.promises.writeFile)).toHaveBeenCalledWith(
+        filepath,
+        expect.stringContaining('reactStrictMode: true')
+      );
+    });
+
     it('should add filepath to filesUpdated array when file is modified', async () => {
       const filepath = '/test/next.config.js';
       const { errors, warnings, filesUpdated } = createTestArrays();

--- a/packages/cli/src/next/parse/__tests__/setupPagesRouter.test.ts
+++ b/packages/cli/src/next/parse/__tests__/setupPagesRouter.test.ts
@@ -1,0 +1,317 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  hasPagesRouterLocaleRouting,
+  setupPagesRouter,
+  transformPagesRouterApp,
+  transformPagesRouterPage,
+} from '../setupPagesRouter.js';
+
+const temporaryDirectories: string[] = [];
+const originalCwd = process.cwd();
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe('hasPagesRouterLocaleRouting', () => {
+  it('confirms complete i18n routing in exported ESM and CommonJS configs', () => {
+    expect(
+      hasPagesRouterLocaleRouting(`
+const i18n = { locales: ['en', 'es'], defaultLocale: 'en' };
+const nextConfig = { reactStrictMode: true, i18n };
+export default withGTConfig(nextConfig, {});
+`)
+    ).toBe(true);
+    expect(
+      hasPagesRouterLocaleRouting(`
+module.exports = { i18n: { locales: ['en'], defaultLocale: 'en' } };
+`)
+    ).toBe(true);
+  });
+
+  it('rejects comments and incomplete or ambiguous i18n configs', () => {
+    expect(
+      hasPagesRouterLocaleRouting(`
+// i18n: { locales: ['en'], defaultLocale: 'en' }
+export default { reactStrictMode: true };
+`)
+    ).toBe(false);
+    expect(
+      hasPagesRouterLocaleRouting(
+        `export default { i18n: { locales: ['en'] } };`
+      )
+    ).toBe(false);
+    expect(
+      hasPagesRouterLocaleRouting(`export default createConfig({ i18n });`)
+    ).toBe(false);
+  });
+});
+
+describe('transformPagesRouterApp', () => {
+  it('wires gt-next provider props while preserving custom App code', () => {
+    const source = `
+import type { AppProps } from 'next/app';
+import '../styles/globals.css';
+
+type CustomPageProps = { theme: string };
+
+export default function CustomApp({ Component, pageProps }: AppProps<CustomPageProps>) {
+  return <main><Component {...pageProps} /></main>;
+}
+`;
+
+    const result = transformPagesRouterApp(source, 'pages/_app.tsx');
+
+    expect(result.warning).toBeUndefined();
+    expect(result.modified).toBe(true);
+    expect(result.code).toContain(
+      'import { GTProvider, type WithGTServerSideProps } from "gt-next"'
+    );
+    expect(result.code).toContain(
+      'AppProps<CustomPageProps & WithGTServerSideProps>'
+    );
+    expect(result.code).toContain(
+      'const { locale, translations, ...restPageProps } = pageProps'
+    );
+    expect(result.code).toContain(
+      '<GTProvider locale={locale} translations={translations}>'
+    );
+    expect(result.code).toContain('<Component {...restPageProps} />');
+    expect(result.code).toContain('<main>');
+    expect(result.code).toContain("import '../styles/globals.css'");
+  });
+
+  it('upgrades the legacy gt-react config-spread provider and is idempotent', () => {
+    const source = `
+import type { AppProps } from 'next/app';
+import { GTProvider } from 'gt-react';
+import gtConfig from '../gt.config.json';
+
+export default function App({ Component, pageProps }: AppProps) {
+  return <GTProvider {...gtConfig}><Component {...pageProps} /></GTProvider>;
+}
+`;
+
+    const first = transformPagesRouterApp(source, 'pages/_app.tsx');
+    const second = transformPagesRouterApp(first.code, 'pages/_app.tsx');
+
+    expect(first.code).toContain('from "gt-next"');
+    expect(first.code).not.toContain('gt-react');
+    expect(first.code).not.toContain('gtConfig');
+    expect(first.code).toContain('AppProps<WithGTServerSideProps>');
+    expect(second.warning).toBeUndefined();
+    expect(second.modified).toBe(false);
+    expect(second.code).toBe(first.code);
+  });
+
+  it('returns actionable guidance for an unsupported custom App shape', () => {
+    const source = `export default class App { render() { return null; } }`;
+
+    const result = transformPagesRouterApp(source, 'pages/_app.tsx');
+
+    expect(result.modified).toBe(false);
+    expect(result.code).toBe(source);
+    expect(result.warning).toContain('could not safely wire GTProvider');
+    expect(result.warning).toContain('pages/_app');
+    expect(result.warning).toContain('Learn more:');
+  });
+
+  it('preserves a custom App when the generated prop bindings would collide', () => {
+    const source = `
+export default function App({ Component, pageProps }) {
+  const locale = 'application-locale';
+  return <Component locale={locale} {...pageProps} />;
+}
+`;
+
+    const result = transformPagesRouterApp(source, 'pages/_app.tsx');
+
+    expect(result.modified).toBe(false);
+    expect(result.code).toBe(source);
+    expect(result.warning).toContain('already defines locale');
+    expect(result.warning).toContain('could change application behavior');
+  });
+});
+
+describe('transformPagesRouterPage', () => {
+  it('adds server-side GT props to a page without data fetching', () => {
+    const source = `export default function Home() { return <h1>Hello</h1>; }`;
+
+    const first = transformPagesRouterPage(source, 'pages/index.tsx');
+    const second = transformPagesRouterPage(first.code, 'pages/index.tsx');
+
+    expect(first.code).toContain(
+      'import { withGTServerSideProps } from "gt-next"'
+    );
+    expect(first.code).toContain(
+      'export const getServerSideProps = withGTServerSideProps()'
+    );
+    expect(second.modified).toBe(false);
+    expect(second.code).toBe(first.code);
+  });
+
+  it('aliases the generated helper import when the preferred name is taken', () => {
+    const source = `
+const withGTServerSideProps = 'application value';
+export default function Home() { return <h1>{withGTServerSideProps}</h1>; }
+`;
+
+    const result = transformPagesRouterPage(source, 'pages/index.tsx');
+
+    expect(result.warning).toBeUndefined();
+    expect(result.code).toContain(
+      'import { withGTServerSideProps as GTwithGTServerSideProps } from "gt-next"'
+    );
+    expect(result.code).toContain(
+      'export const getServerSideProps = GTwithGTServerSideProps()'
+    );
+  });
+
+  it('wraps an existing getServerSideProps without changing its body', () => {
+    const source = `
+import type { GetServerSideProps } from 'next';
+
+export const getServerSideProps: GetServerSideProps = async (context) => ({
+  props: { slug: context.params?.slug ?? null },
+});
+
+export default function Page() { return null; }
+`;
+
+    const result = transformPagesRouterPage(source, 'pages/[slug].tsx');
+
+    expect(result.warning).toBeUndefined();
+    expect(result.code).toContain(
+      'getServerSideProps: GetServerSideProps = withGTServerSideProps(async (context) => ({'
+    );
+    expect(result.code).toContain('slug: context.params?.slug ?? null');
+  });
+
+  it('wraps an existing getStaticProps with the static helper', () => {
+    const source = `
+export const getStaticProps = async () => ({ props: { built: true } });
+export default function Page() { return null; }
+`;
+
+    const result = transformPagesRouterPage(source, 'pages/about.tsx', {
+      hasStaticLocaleRouting: true,
+    });
+
+    expect(result.warning).toBeUndefined();
+    expect(result.code).toContain(
+      'import { withGTStaticProps } from "gt-next"'
+    );
+    expect(result.code).toContain(
+      'getStaticProps = withGTStaticProps(async () => ({ props: { built: true } }))'
+    );
+  });
+
+  it('preserves static props and explains locale routing when it is not configured', () => {
+    const source = `
+export const getStaticProps = async () => ({ props: { built: true } });
+export default function Page() { return null; }
+`;
+
+    const result = transformPagesRouterPage(source, 'pages/about.tsx');
+
+    expect(result.modified).toBe(false);
+    expect(result.code).toBe(source);
+    expect(result.warning).toContain(
+      'requires Pages Router locale routing, which the wizard could not confirm'
+    );
+    expect(result.warning).toContain('withGTStaticProps');
+    expect(result.warning).toContain('pages-router-static-site-generation');
+  });
+
+  it('keeps custom error pages static and requires confirmed locale routing', () => {
+    const source = `export default function NotFound() { return <h1>Missing</h1>; }`;
+
+    const unsafeResult = transformPagesRouterPage(source, 'pages/404.tsx', {
+      requiresStaticGeneration: true,
+    });
+    const configuredResult = transformPagesRouterPage(source, 'pages/404.tsx', {
+      requiresStaticGeneration: true,
+      hasStaticLocaleRouting: true,
+    });
+
+    expect(unsafeResult.modified).toBe(false);
+    expect(unsafeResult.code).toBe(source);
+    expect(unsafeResult.warning).toContain('must remain statically generated');
+    expect(configuredResult.code).toContain(
+      'export const getStaticProps = withGTStaticProps()'
+    );
+    expect(configuredResult.code).not.toContain('getServerSideProps');
+  });
+
+  it('leaves function exports untouched and gives a manual fallback', () => {
+    const source = `
+export async function getServerSideProps() {
+  return { props: { preserved: true } };
+}
+export default function Page() { return null; }
+`;
+
+    const result = transformPagesRouterPage(source, 'pages/custom.tsx');
+
+    expect(result.modified).toBe(false);
+    expect(result.code).toBe(source);
+    expect(result.warning).toContain('could not safely add GT locale');
+    expect(result.warning).toContain('withGTServerSideProps');
+    expect(result.warning).toContain('Learn more:');
+  });
+});
+
+describe('setupPagesRouter', () => {
+  it('creates the custom App, skips API routes, and makes reruns no-ops', async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'gt-pages-setup-'));
+    temporaryDirectories.push(directory);
+    const pagesDirectory = path.join(directory, 'pages');
+    const apiDirectory = path.join(pagesDirectory, 'api');
+    fs.mkdirSync(apiDirectory, { recursive: true });
+    fs.writeFileSync(path.join(directory, 'tsconfig.json'), '{}');
+    fs.writeFileSync(
+      path.join(pagesDirectory, 'index.tsx'),
+      'export default function Home() { return <h1>Hello</h1>; }'
+    );
+    const apiSource =
+      'export default function handler(_request, response) { response.status(200).json({ ok: true }); }';
+    fs.writeFileSync(path.join(apiDirectory, 'health.ts'), apiSource);
+    process.chdir(directory);
+
+    const firstErrors: string[] = [];
+    const firstWarnings: string[] = [];
+    const first = await setupPagesRouter(
+      pagesDirectory,
+      firstErrors,
+      firstWarnings
+    );
+    const secondErrors: string[] = [];
+    const secondWarnings: string[] = [];
+    const second = await setupPagesRouter(
+      pagesDirectory,
+      secondErrors,
+      secondWarnings
+    );
+
+    expect(firstErrors).toEqual([]);
+    expect(firstWarnings).toEqual([]);
+    expect(first.filesUpdated).toEqual(
+      expect.arrayContaining([
+        path.join(pagesDirectory, '_app.tsx'),
+        path.join(pagesDirectory, 'index.tsx'),
+      ])
+    );
+    expect(second).toEqual({ filesUpdated: [] });
+    expect(secondErrors).toEqual([]);
+    expect(secondWarnings).toEqual([]);
+    expect(fs.readFileSync(path.join(apiDirectory, 'health.ts'), 'utf8')).toBe(
+      apiSource
+    );
+  });
+});

--- a/packages/cli/src/next/parse/handleInitGT.ts
+++ b/packages/cli/src/next/parse/handleInitGT.ts
@@ -10,6 +10,7 @@ const generate = generateModule.default || generateModule;
 import * as t from '@babel/types';
 import { logger } from '../../console/logger.js';
 import { needsCJS } from '../../utils/parse/needsCJS.js';
+import { createDiagnosticMessage } from 'generaltranslation/internal';
 
 export async function handleInitGT(
   filepath: string,
@@ -17,7 +18,8 @@ export async function handleInitGT(
   warnings: string[],
   filesUpdated: string[],
   packageJson?: { type?: string },
-  tsconfigJson?: { compilerOptions?: { module?: string } }
+  tsconfigJson?: { compilerOptions?: { module?: string } },
+  gtConfigPath?: string
 ) {
   const code = await fs.promises.readFile(filepath, 'utf8');
 
@@ -39,14 +41,19 @@ export async function handleInitGT(
       tsconfigJson,
     });
 
-    // Check if withGTConfig is already imported/required
-    let hasGTConfig = false;
+    // Check if withGTConfig is already imported/required and applied. Keeping
+    // these checks separate lets the wizard repair a config that imported the
+    // helper but never wrapped its export.
+    let hasGTConfigImport = false;
+    let hasGTConfigCall = false;
     traverse(ast, {
       ImportDeclaration(path) {
         if (path.node.source.value === 'gt-next/config') {
           path.node.specifiers.forEach((spec) => {
             if (t.isImportSpecifier(spec)) {
-              if (spec.local.name === 'withGTConfig') hasGTConfig = true;
+              if (spec.local.name === 'withGTConfig') {
+                hasGTConfigImport = true;
+              }
             }
           });
         }
@@ -64,7 +71,7 @@ export async function handleInitGT(
             ) {
               // Handle simple assignment: const withGTConfig = require(...)
               if (t.isIdentifier(dec.id, { name: 'withGTConfig' }))
-                hasGTConfig = true;
+                hasGTConfigImport = true;
 
               // Handle destructuring: const { withGTConfig } = require(...)
               if (t.isObjectPattern(dec.id)) {
@@ -74,7 +81,9 @@ export async function handleInitGT(
                     t.isIdentifier(prop.key) &&
                     t.isIdentifier(prop.value)
                   ) {
-                    if (prop.key.name === 'withGTConfig') hasGTConfig = true;
+                    if (prop.key.name === 'withGTConfig') {
+                      hasGTConfigImport = true;
+                    }
                   }
                 });
               }
@@ -92,44 +101,52 @@ export async function handleInitGT(
                 t.isIdentifier(dec.id, { name: 'withGTConfig' }) &&
                 t.isIdentifier(dec.init.property, { name: 'withGTConfig' })
               ) {
-                hasGTConfig = true;
+                hasGTConfigImport = true;
               }
             }
           }
         });
       },
+      CallExpression(path) {
+        if (t.isIdentifier(path.node.callee, { name: 'withGTConfig' })) {
+          hasGTConfigCall = true;
+        }
+      },
     });
 
-    // Return early if withGTConfig is already present
-    if (hasGTConfig) {
+    // Return early only when withGTConfig is both available and applied.
+    if (hasGTConfigImport && hasGTConfigCall) {
       return;
     }
 
-    ast.program.body.unshift(
-      cjsEnabled
-        ? t.variableDeclaration('const', [
-            t.variableDeclarator(
-              t.identifier('withGTConfig'),
-              t.memberExpression(
-                t.callExpression(t.identifier('require'), [
-                  t.stringLiteral('gt-next/config'),
-                ]),
-                t.identifier('withGTConfig')
-              )
-            ),
-          ])
-        : t.importDeclaration(
-            [
-              t.importSpecifier(
+    if (!hasGTConfigImport) {
+      ast.program.body.unshift(
+        cjsEnabled
+          ? t.variableDeclaration('const', [
+              t.variableDeclarator(
                 t.identifier('withGTConfig'),
-                t.identifier('withGTConfig')
+                t.memberExpression(
+                  t.callExpression(t.identifier('require'), [
+                    t.stringLiteral('gt-next/config'),
+                  ]),
+                  t.identifier('withGTConfig')
+                )
               ),
-            ],
-            t.stringLiteral('gt-next/config')
-          )
-    );
+            ])
+          : t.importDeclaration(
+              [
+                t.importSpecifier(
+                  t.identifier('withGTConfig'),
+                  t.identifier('withGTConfig')
+                ),
+              ],
+              t.stringLiteral('gt-next/config')
+            )
+      );
+    }
 
     // Find and transform the default export
+    let transformedExport = false;
     traverse(ast, {
       ExportDefaultDeclaration(path) {
         const oldExport = path.node.declaration;
@@ -180,10 +197,41 @@ export async function handleInitGT(
 
         path.node.declaration = t.callExpression(t.identifier('withGTConfig'), [
           exportExpression,
-          t.objectExpression([]),
+          createGTConfigOptions(gtConfigPath),
         ]);
+        transformedExport = true;
+        path.skip();
+      },
+      AssignmentExpression(path) {
+        if (
+          !t.isMemberExpression(path.node.left) ||
+          !t.isIdentifier(path.node.left.object, { name: 'module' }) ||
+          !t.isIdentifier(path.node.left.property, { name: 'exports' }) ||
+          !t.isExpression(path.node.right)
+        ) {
+          return;
+        }
+        path.node.right = t.callExpression(t.identifier('withGTConfig'), [
+          path.node.right,
+          createGTConfigOptions(gtConfigPath),
+        ]);
+        transformedExport = true;
+        path.skip();
       },
     });
+
+    if (!transformedExport) {
+      warnings.push(
+        createDiagnosticMessage({
+          whatHappened: `The setup wizard could not apply withGTConfig in ${filepath}`,
+          why: 'the file does not have a default export or module.exports assignment the wizard can wrap safely',
+          fix: 'Wrap the existing Next.js config export with withGTConfig manually',
+          docsUrl:
+            'https://generaltranslation.com/docs/react/nextjs-pages-router-quickstart',
+        })
+      );
+      return;
+    }
 
     // Generate the modified code
     const output = generate(
@@ -212,4 +260,13 @@ export async function handleInitGT(
     logger.error(`Error parsing file ${filepath}: ${error}`);
     errors.push(`Failed to parse ${filepath}: ${error}`);
   }
+}
+
+function createGTConfigOptions(gtConfigPath?: string): t.ObjectExpression {
+  if (!gtConfigPath || gtConfigPath === 'gt.config.json') {
+    return t.objectExpression([]);
+  }
+  return t.objectExpression([
+    t.objectProperty(t.identifier('config'), t.stringLiteral(gtConfigPath)),
+  ]);
 }

--- a/packages/cli/src/next/parse/setupPagesRouter.ts
+++ b/packages/cli/src/next/parse/setupPagesRouter.ts
@@ -1,0 +1,963 @@
+import generateModule from '@babel/generator';
+import { parse } from '@babel/parser';
+import traverseModule, { type NodePath } from '@babel/traverse';
+import * as t from '@babel/types';
+import {
+  createDiagnosticMessage,
+  formatDiagnosticErrorDetails,
+} from 'generaltranslation/internal';
+import fs from 'node:fs';
+import path from 'node:path';
+import { matchFiles } from '../../fs/matchFiles.js';
+
+const traverse = traverseModule.default || traverseModule;
+const generate = generateModule.default || generateModule;
+
+const PAGES_ROUTER_QUICKSTART_URL =
+  'https://generaltranslation.com/docs/react/nextjs-pages-router-quickstart';
+const PAGES_ROUTER_SSG_URL =
+  'https://generaltranslation.com/docs/react/nextjs/pages-router-static-site-generation';
+
+type TransformResult = {
+  code: string;
+  modified: boolean;
+  warning?: string;
+};
+
+type DataFetchingExport = 'getServerSideProps' | 'getStaticProps';
+
+const DATA_FETCHING_HELPERS: Record<DataFetchingExport, string> = {
+  getServerSideProps: 'withGTServerSideProps',
+  getStaticProps: 'withGTStaticProps',
+};
+
+function parseModule(code: string) {
+  return parse(code, {
+    sourceType: 'module',
+    plugins: ['jsx', 'typescript'],
+    tokens: true,
+    createParenthesizedExpressions: true,
+  });
+}
+
+function printModule(ast: ReturnType<typeof parse>, code: string): string {
+  return generate(
+    ast,
+    {
+      retainLines: true,
+      retainFunctionParens: true,
+      comments: true,
+      compact: 'auto',
+    },
+    code
+  ).code;
+}
+
+/**
+ * Conservatively confirm that an exported Next.js config enables Pages Router
+ * locale routing. Ambiguous wrapper functions and imported config values are
+ * intentionally left for manual review before getStaticProps is changed.
+ */
+export function hasPagesRouterLocaleRouting(code: string): boolean {
+  let ast: ReturnType<typeof parse>;
+  try {
+    ast = parseModule(code);
+  } catch {
+    return false;
+  }
+
+  const initializers = new Map<string, t.Expression>();
+  for (const statement of ast.program.body) {
+    if (!t.isVariableDeclaration(statement)) continue;
+    for (const declaration of statement.declarations) {
+      if (
+        t.isIdentifier(declaration.id) &&
+        declaration.init &&
+        t.isExpression(declaration.init)
+      ) {
+        initializers.set(declaration.id.name, declaration.init);
+      }
+    }
+  }
+
+  const resolveObject = (
+    expression: t.Expression,
+    seen = new Set<string>()
+  ): t.ObjectExpression | undefined => {
+    let current = expression;
+    while (
+      t.isParenthesizedExpression(current) ||
+      t.isTSAsExpression(current) ||
+      t.isTSSatisfiesExpression(current) ||
+      t.isTypeCastExpression(current)
+    ) {
+      current = current.expression;
+    }
+    if (t.isObjectExpression(current)) return current;
+    if (t.isIdentifier(current)) {
+      if (seen.has(current.name)) return undefined;
+      const initializer = initializers.get(current.name);
+      if (!initializer) return undefined;
+      return resolveObject(initializer, new Set([...seen, current.name]));
+    }
+    if (
+      t.isCallExpression(current) &&
+      t.isIdentifier(current.callee, { name: 'withGTConfig' }) &&
+      current.arguments[0] &&
+      t.isExpression(current.arguments[0])
+    ) {
+      return resolveObject(current.arguments[0], seen);
+    }
+    return undefined;
+  };
+
+  const exportedExpressions: t.Expression[] = [];
+  for (const statement of ast.program.body) {
+    if (
+      t.isExportDefaultDeclaration(statement) &&
+      t.isExpression(statement.declaration)
+    ) {
+      exportedExpressions.push(statement.declaration);
+    }
+    if (
+      t.isExpressionStatement(statement) &&
+      t.isAssignmentExpression(statement.expression) &&
+      t.isMemberExpression(statement.expression.left) &&
+      t.isIdentifier(statement.expression.left.object, { name: 'module' }) &&
+      t.isIdentifier(statement.expression.left.property, { name: 'exports' }) &&
+      t.isExpression(statement.expression.right)
+    ) {
+      exportedExpressions.push(statement.expression.right);
+    }
+  }
+
+  return exportedExpressions.some((expression) => {
+    const config = resolveObject(expression);
+    if (!config) return false;
+    const i18nProperty = config.properties.find(
+      (property): property is t.ObjectProperty =>
+        t.isObjectProperty(property) &&
+        ((t.isIdentifier(property.key) && property.key.name === 'i18n') ||
+          (t.isStringLiteral(property.key) && property.key.value === 'i18n'))
+    );
+    if (!i18nProperty || !t.isExpression(i18nProperty.value)) return false;
+    const i18nConfig = resolveObject(i18nProperty.value);
+    if (!i18nConfig) return false;
+    const keys = new Set(
+      i18nConfig.properties.flatMap((property) => {
+        if (!t.isObjectProperty(property)) return [];
+        if (t.isIdentifier(property.key)) return [property.key.name];
+        if (t.isStringLiteral(property.key)) return [property.key.value];
+        return [];
+      })
+    );
+    return keys.has('locales') && keys.has('defaultLocale');
+  });
+}
+
+function importedName(specifier: t.ImportSpecifier): string {
+  return t.isIdentifier(specifier.imported)
+    ? specifier.imported.name
+    : specifier.imported.value;
+}
+
+function findNamedImport(
+  ast: ReturnType<typeof parse>,
+  source: string,
+  name: string
+): t.ImportSpecifier | undefined {
+  for (const statement of ast.program.body) {
+    if (
+      !t.isImportDeclaration(statement) ||
+      statement.source.value !== source
+    ) {
+      continue;
+    }
+    const specifier = statement.specifiers.find(
+      (candidate): candidate is t.ImportSpecifier =>
+        t.isImportSpecifier(candidate) && importedName(candidate) === name
+    );
+    if (specifier) return specifier;
+  }
+  return undefined;
+}
+
+function hasProgramBinding(
+  ast: ReturnType<typeof parse>,
+  name: string
+): boolean {
+  let hasBinding = false;
+  traverse(ast, {
+    Program(programPath) {
+      hasBinding = programPath.scope.hasBinding(name);
+      programPath.stop();
+    },
+  });
+  return hasBinding;
+}
+
+function getAvailableLocalName(
+  ast: ReturnType<typeof parse>,
+  preferredName: string
+): string {
+  if (!hasProgramBinding(ast, preferredName)) return preferredName;
+  const baseName = `GT${preferredName}`;
+  let candidate = baseName;
+  let suffix = 2;
+  while (hasProgramBinding(ast, candidate)) {
+    candidate = `${baseName}${suffix}`;
+    suffix += 1;
+  }
+  return candidate;
+}
+
+function ensureNamedImport(
+  ast: ReturnType<typeof parse>,
+  source: string,
+  name: string,
+  options: { typeOnly?: boolean; preferredLocalName?: string } = {}
+): string {
+  const existing = findNamedImport(ast, source, name);
+  if (existing) return existing.local.name;
+
+  const localName = getAvailableLocalName(
+    ast,
+    options.preferredLocalName || name
+  );
+  const specifier = t.importSpecifier(
+    t.identifier(localName),
+    t.identifier(name)
+  );
+  if (options.typeOnly) specifier.importKind = 'type';
+
+  const declaration = ast.program.body.find(
+    (statement): statement is t.ImportDeclaration =>
+      t.isImportDeclaration(statement) && statement.source.value === source
+  );
+  if (declaration) {
+    declaration.specifiers.push(specifier);
+  } else {
+    const importDeclaration = t.importDeclaration(
+      [specifier],
+      t.stringLiteral(source)
+    );
+    let lastImportIndex = -1;
+    ast.program.body.forEach((statement, index) => {
+      if (t.isImportDeclaration(statement)) lastImportIndex = index;
+    });
+    ast.program.body.splice(lastImportIndex + 1, 0, importDeclaration);
+  }
+  return localName;
+}
+
+function migrateLegacyProviderImport(
+  ast: ReturnType<typeof parse>
+): string | undefined {
+  for (const statement of ast.program.body) {
+    if (
+      !t.isImportDeclaration(statement) ||
+      statement.source.value !== 'gt-react'
+    ) {
+      continue;
+    }
+    const providerSpecifier = statement.specifiers.find(
+      (specifier): specifier is t.ImportSpecifier =>
+        t.isImportSpecifier(specifier) &&
+        importedName(specifier) === 'GTProvider'
+    );
+    if (!providerSpecifier) continue;
+
+    statement.specifiers = statement.specifiers.filter(
+      (specifier) => specifier !== providerSpecifier
+    );
+    if (statement.specifiers.length === 0) {
+      ast.program.body = ast.program.body.filter(
+        (candidate) => candidate !== statement
+      );
+    }
+    return ensureNamedImport(ast, 'gt-next', 'GTProvider', {
+      preferredLocalName: providerSpecifier.local.name,
+    });
+  }
+  return undefined;
+}
+
+function getJsxName(element: t.JSXElement): string | undefined {
+  return t.isJSXIdentifier(element.openingElement.name)
+    ? element.openingElement.name.name
+    : undefined;
+}
+
+function hasJsxAttribute(element: t.JSXElement, name: string): boolean {
+  return element.openingElement.attributes.some(
+    (attribute) =>
+      t.isJSXAttribute(attribute) && t.isJSXIdentifier(attribute.name, { name })
+  );
+}
+
+function addExpressionAttribute(
+  element: t.JSXElement,
+  name: string,
+  value: string
+): void {
+  if (hasJsxAttribute(element, name)) return;
+  element.openingElement.attributes.push(
+    t.jsxAttribute(
+      t.jsxIdentifier(name),
+      t.jsxExpressionContainer(t.identifier(value))
+    )
+  );
+}
+
+function containsTypeReference(node: t.TSType, name: string): boolean {
+  if (t.isTSTypeReference(node) && t.isIdentifier(node.typeName, { name })) {
+    return true;
+  }
+  if (t.isTSIntersectionType(node) || t.isTSUnionType(node)) {
+    return node.types.some((part) => containsTypeReference(part, name));
+  }
+  return false;
+}
+
+function addPagePropsType(
+  ast: ReturnType<typeof parse>,
+  injectedTypeName: string
+): boolean {
+  let modified = false;
+  traverse(ast, {
+    TSTypeReference(referencePath) {
+      if (!t.isIdentifier(referencePath.node.typeName, { name: 'AppProps' })) {
+        return;
+      }
+      const injectedType = t.tsTypeReference(t.identifier(injectedTypeName));
+      const existingType = referencePath.node.typeParameters?.params[0];
+      if (!existingType) {
+        referencePath.node.typeParameters = t.tsTypeParameterInstantiation([
+          injectedType,
+        ]);
+        modified = true;
+        return;
+      }
+      if (containsTypeReference(existingType, injectedTypeName)) return;
+      referencePath.node.typeParameters = t.tsTypeParameterInstantiation([
+        t.tsIntersectionType([existingType, injectedType]),
+      ]);
+      modified = true;
+    },
+  });
+  return modified;
+}
+
+function removeLegacyConfigSpread(
+  ast: ReturnType<typeof parse>,
+  providerElement: t.JSXElement
+): void {
+  const removedNames = new Set<string>();
+  providerElement.openingElement.attributes =
+    providerElement.openingElement.attributes.filter((attribute) => {
+      if (
+        t.isJSXSpreadAttribute(attribute) &&
+        t.isIdentifier(attribute.argument)
+      ) {
+        const bindingName = attribute.argument.name;
+        const isConfigImport = ast.program.body.some(
+          (statement) =>
+            t.isImportDeclaration(statement) &&
+            /(?:^|\/)gt\.config\.json$/.test(statement.source.value) &&
+            statement.specifiers.some(
+              (specifier) =>
+                t.isImportDefaultSpecifier(specifier) &&
+                specifier.local.name === bindingName
+            )
+        );
+        if (isConfigImport) {
+          removedNames.add(bindingName);
+          return false;
+        }
+      }
+      return true;
+    });
+
+  if (removedNames.size === 0) return;
+  const stillReferenced = new Set<string>();
+  traverse(ast, {
+    ReferencedIdentifier(identifierPath) {
+      if (removedNames.has(identifierPath.node.name)) {
+        stillReferenced.add(identifierPath.node.name);
+      }
+    },
+  });
+  ast.program.body = ast.program.body.filter((statement) => {
+    if (
+      !t.isImportDeclaration(statement) ||
+      !/(?:^|\/)gt\.config\.json$/.test(statement.source.value)
+    ) {
+      return true;
+    }
+    statement.specifiers = statement.specifiers.filter(
+      (specifier) =>
+        !removedNames.has(specifier.local.name) ||
+        stillReferenced.has(specifier.local.name)
+    );
+    return statement.specifiers.length > 0;
+  });
+}
+
+function createAppWarning(filepath: string, why: string): string {
+  return createDiagnosticMessage({
+    whatHappened: `The setup wizard could not safely wire GTProvider in ${filepath}`,
+    why,
+    fix: 'Update pages/_app so it passes pageProps.locale and pageProps.translations to GTProvider from gt-next, then pass the remaining page props to Component',
+    docsUrl: PAGES_ROUTER_QUICKSTART_URL,
+  });
+}
+
+function createPageWarning(
+  filepath: string,
+  exportName: DataFetchingExport | 'getInitialProps',
+  why: string
+): string {
+  const helper =
+    exportName === 'getInitialProps'
+      ? 'withGTServerSideProps'
+      : DATA_FETCHING_HELPERS[exportName];
+  const dataFetchingName =
+    exportName === 'getInitialProps' ? 'the page data loader' : exportName;
+  return createDiagnosticMessage({
+    whatHappened: `The setup wizard could not safely add GT locale and translation props to ${filepath}`,
+    why,
+    fix: `Wrap ${dataFetchingName} with ${helper} and export the wrapped result from this page`,
+    docsUrl:
+      exportName === 'getStaticProps'
+        ? PAGES_ROUTER_SSG_URL
+        : PAGES_ROUTER_QUICKSTART_URL,
+  });
+}
+
+/**
+ * Wire a Pages Router custom App to the locale and translation props injected by
+ * gt-next's data-fetching helpers. Returns a warning instead of guessing when
+ * the App does not use the conventional Component/pageProps shape.
+ */
+export function transformPagesRouterApp(
+  code: string,
+  filepath: string
+): TransformResult {
+  const ast = parseModule(code);
+  const legacyProviderLocalName = migrateLegacyProviderImport(ast);
+  const providerLocalName =
+    legacyProviderLocalName ||
+    findNamedImport(ast, 'gt-next', 'GTProvider')?.local.name ||
+    getAvailableLocalName(ast, 'GTProvider');
+
+  let componentPath: NodePath<t.JSXElement> | undefined;
+  let appFunctionPath: NodePath<t.Function> | undefined;
+  let componentUsesRestPageProps = false;
+  traverse(ast, {
+    JSXElement(jsxPath) {
+      if (componentPath || getJsxName(jsxPath.node) !== 'Component') return;
+      const pagePropsSpread = jsxPath.node.openingElement.attributes.some(
+        (attribute) =>
+          t.isJSXSpreadAttribute(attribute) &&
+          t.isIdentifier(attribute.argument) &&
+          (attribute.argument.name === 'pageProps' ||
+            attribute.argument.name === 'restPageProps')
+      );
+      if (!pagePropsSpread) return;
+      componentUsesRestPageProps = jsxPath.node.openingElement.attributes.some(
+        (attribute) =>
+          t.isJSXSpreadAttribute(attribute) &&
+          t.isIdentifier(attribute.argument, { name: 'restPageProps' })
+      );
+      const functionPath = jsxPath.findParent((candidate) =>
+        candidate.isFunction()
+      ) as NodePath<t.Function> | null;
+      if (!functionPath) return;
+      componentPath = jsxPath;
+      appFunctionPath = functionPath;
+    },
+  });
+
+  if (!componentPath || !appFunctionPath) {
+    return {
+      code,
+      modified: false,
+      warning: createAppWarning(
+        filepath,
+        'the custom App does not render <Component {...pageProps} /> inside a function component'
+      ),
+    };
+  }
+  if (!t.isBlockStatement(appFunctionPath.node.body)) {
+    return {
+      code,
+      modified: false,
+      warning: createAppWarning(
+        filepath,
+        'the custom App uses an implicit-return function that cannot be extended without restructuring application code'
+      ),
+    };
+  }
+
+  const hasPagePropsBinding = Boolean(
+    appFunctionPath.scope.getBinding('pageProps')
+  );
+  if (!hasPagePropsBinding) {
+    return {
+      code,
+      modified: false,
+      warning: createAppWarning(
+        filepath,
+        'pageProps is not a local binding in the component that renders the page'
+      ),
+    };
+  }
+
+  let hasPropsDeclaration = false;
+  for (const statement of appFunctionPath.node.body.body) {
+    if (!t.isVariableDeclaration(statement)) continue;
+    for (const declaration of statement.declarations) {
+      if (!t.isObjectPattern(declaration.id)) continue;
+      const names = declaration.id.properties.map((property) => {
+        if (t.isRestElement(property) && t.isIdentifier(property.argument)) {
+          return property.argument.name;
+        }
+        return t.isObjectProperty(property) && t.isIdentifier(property.key)
+          ? property.key.name
+          : undefined;
+      });
+      if (
+        t.isIdentifier(declaration.init, { name: 'pageProps' }) &&
+        names.includes('locale') &&
+        names.includes('translations') &&
+        names.includes('restPageProps')
+      ) {
+        hasPropsDeclaration = true;
+      }
+    }
+  }
+
+  const existingProviderPath = componentPath.findParent(
+    (candidate) =>
+      candidate.isJSXElement() &&
+      getJsxName(candidate.node) === providerLocalName
+  ) as NodePath<t.JSXElement> | null;
+  if (
+    !legacyProviderLocalName &&
+    componentUsesRestPageProps &&
+    hasPropsDeclaration &&
+    existingProviderPath &&
+    hasJsxAttribute(existingProviderPath.node, 'locale') &&
+    hasJsxAttribute(existingProviderPath.node, 'translations') &&
+    findNamedImport(ast, 'gt-next', 'GTProvider')
+  ) {
+    return { code, modified: false };
+  }
+
+  if (!hasPropsDeclaration) {
+    const appFunctionScope = appFunctionPath.scope;
+    const conflictingBinding = ['locale', 'translations', 'restPageProps'].find(
+      (name) => appFunctionScope.hasBinding(name)
+    );
+    if (conflictingBinding) {
+      return {
+        code,
+        modified: false,
+        warning: createAppWarning(
+          filepath,
+          `the custom App already defines ${conflictingBinding}, so adding the standard page-props bindings could change application behavior`
+        ),
+      };
+    }
+    appFunctionPath.node.body.body.unshift(
+      t.variableDeclaration('const', [
+        t.variableDeclarator(
+          t.objectPattern([
+            t.objectProperty(
+              t.identifier('locale'),
+              t.identifier('locale'),
+              false,
+              true
+            ),
+            t.objectProperty(
+              t.identifier('translations'),
+              t.identifier('translations'),
+              false,
+              true
+            ),
+            t.restElement(t.identifier('restPageProps')),
+          ]),
+          t.identifier('pageProps')
+        ),
+      ])
+    );
+  }
+
+  componentPath.node.openingElement.attributes =
+    componentPath.node.openingElement.attributes.map((attribute) =>
+      t.isJSXSpreadAttribute(attribute) &&
+      t.isIdentifier(attribute.argument, { name: 'pageProps' })
+        ? t.jsxSpreadAttribute(t.identifier('restPageProps'))
+        : attribute
+    );
+
+  let providerElement: t.JSXElement;
+  if (existingProviderPath) {
+    providerElement = existingProviderPath.node;
+  } else {
+    providerElement = t.jsxElement(
+      t.jsxOpeningElement(t.jsxIdentifier(providerLocalName), [], false),
+      t.jsxClosingElement(t.jsxIdentifier(providerLocalName)),
+      [t.cloneNode(componentPath.node, true)],
+      false
+    );
+    componentPath.replaceWith(providerElement);
+  }
+  removeLegacyConfigSpread(ast, providerElement);
+  addExpressionAttribute(providerElement, 'locale', 'locale');
+  addExpressionAttribute(providerElement, 'translations', 'translations');
+
+  ensureNamedImport(ast, 'gt-next', 'GTProvider', {
+    preferredLocalName: providerLocalName,
+  });
+  const injectedTypeName =
+    findNamedImport(ast, 'gt-next', 'WithGTServerSideProps')?.local.name ||
+    getAvailableLocalName(ast, 'WithGTServerSideProps');
+  const appPropsTypeAdded = addPagePropsType(ast, injectedTypeName);
+  if (appPropsTypeAdded) {
+    ensureNamedImport(ast, 'gt-next', 'WithGTServerSideProps', {
+      typeOnly: true,
+      preferredLocalName: injectedTypeName,
+    });
+  }
+
+  const transformedCode = printModule(ast, code);
+  return {
+    code: transformedCode,
+    modified: transformedCode !== code,
+  };
+}
+
+function getExportedDataFetchingDeclarations(
+  ast: ReturnType<typeof parse>
+): Map<DataFetchingExport, NodePath<t.ExportNamedDeclaration>> {
+  const exports = new Map<
+    DataFetchingExport,
+    NodePath<t.ExportNamedDeclaration>
+  >();
+  traverse(ast, {
+    ExportNamedDeclaration(exportPath) {
+      const declaration = exportPath.node.declaration;
+      if (t.isFunctionDeclaration(declaration) && declaration.id) {
+        if (
+          declaration.id.name === 'getServerSideProps' ||
+          declaration.id.name === 'getStaticProps'
+        ) {
+          exports.set(declaration.id.name, exportPath);
+        }
+        return;
+      }
+      if (t.isVariableDeclaration(declaration)) {
+        for (const variable of declaration.declarations) {
+          if (
+            t.isIdentifier(variable.id) &&
+            (variable.id.name === 'getServerSideProps' ||
+              variable.id.name === 'getStaticProps')
+          ) {
+            exports.set(variable.id.name, exportPath);
+          }
+        }
+      }
+      for (const specifier of exportPath.node.specifiers) {
+        if (
+          t.isExportSpecifier(specifier) &&
+          t.isIdentifier(specifier.exported) &&
+          (specifier.exported.name === 'getServerSideProps' ||
+            specifier.exported.name === 'getStaticProps')
+        ) {
+          exports.set(specifier.exported.name, exportPath);
+        }
+      }
+    },
+  });
+  return exports;
+}
+
+function isHelperCall(
+  expression: t.Expression,
+  helperName: string,
+  helperLocalName: string | undefined
+): boolean {
+  return (
+    t.isCallExpression(expression) &&
+    t.isIdentifier(expression.callee) &&
+    (expression.callee.name === helperName ||
+      expression.callee.name === helperLocalName)
+  );
+}
+
+function hasGetInitialProps(ast: ReturnType<typeof parse>): boolean {
+  let found = false;
+  traverse(ast, {
+    AssignmentExpression(assignmentPath) {
+      if (
+        t.isMemberExpression(assignmentPath.node.left) &&
+        t.isIdentifier(assignmentPath.node.left.property, {
+          name: 'getInitialProps',
+        })
+      ) {
+        found = true;
+        assignmentPath.stop();
+      }
+    },
+  });
+  return found;
+}
+
+/** Add the appropriate gt-next wrapper to one Pages Router page module. */
+export function transformPagesRouterPage(
+  code: string,
+  filepath: string,
+  options: {
+    hasStaticLocaleRouting?: boolean;
+    requiresStaticGeneration?: boolean;
+  } = {}
+): TransformResult {
+  const ast = parseModule(code);
+  const dataFetchingExports = getExportedDataFetchingDeclarations(ast);
+  if (dataFetchingExports.size > 1) {
+    return {
+      code,
+      modified: false,
+      warning: createPageWarning(
+        filepath,
+        'getServerSideProps',
+        'the page exports both getServerSideProps and getStaticProps'
+      ),
+    };
+  }
+
+  const entry = dataFetchingExports.entries().next().value as
+    | [DataFetchingExport, NodePath<t.ExportNamedDeclaration>]
+    | undefined;
+  if (!entry) {
+    if (hasGetInitialProps(ast)) {
+      return {
+        code,
+        modified: false,
+        warning: createPageWarning(
+          filepath,
+          'getInitialProps',
+          'the page uses legacy getInitialProps, whose lifecycle cannot be replaced automatically'
+        ),
+      };
+    }
+    if (options.requiresStaticGeneration && !options.hasStaticLocaleRouting) {
+      return {
+        code,
+        modified: false,
+        warning: createPageWarning(
+          filepath,
+          'getStaticProps',
+          'custom 404 and 500 pages must remain statically generated, but the wizard could not confirm Pages Router locale routing in the existing Next.js config'
+        ),
+      };
+    }
+    const exportName = options.requiresStaticGeneration
+      ? 'getStaticProps'
+      : 'getServerSideProps';
+    const helperLocalName = ensureNamedImport(
+      ast,
+      'gt-next',
+      DATA_FETCHING_HELPERS[exportName]
+    );
+    ast.program.body.push(
+      t.exportNamedDeclaration(
+        t.variableDeclaration('const', [
+          t.variableDeclarator(
+            t.identifier(exportName),
+            t.callExpression(t.identifier(helperLocalName), [])
+          ),
+        ])
+      )
+    );
+    return { code: printModule(ast, code), modified: true };
+  }
+
+  const [exportName, exportPath] = entry;
+  const helperName = DATA_FETCHING_HELPERS[exportName];
+  const existingHelperLocalName = findNamedImport(ast, 'gt-next', helperName)
+    ?.local.name;
+  const declaration = exportPath.node.declaration;
+  if (!t.isVariableDeclaration(declaration)) {
+    return {
+      code,
+      modified: false,
+      warning: createPageWarning(
+        filepath,
+        exportName,
+        `${exportName} is not an initialized exported const`
+      ),
+    };
+  }
+  const variable = declaration.declarations.find(
+    (candidate) =>
+      t.isIdentifier(candidate.id) && candidate.id.name === exportName
+  );
+  if (!variable?.init || !t.isExpression(variable.init)) {
+    return {
+      code,
+      modified: false,
+      warning: createPageWarning(
+        filepath,
+        exportName,
+        `${exportName} does not have an expression the wizard can wrap without restructuring the module`
+      ),
+    };
+  }
+  if (isHelperCall(variable.init, helperName, existingHelperLocalName)) {
+    return { code, modified: false };
+  }
+  if (exportName === 'getStaticProps' && !options.hasStaticLocaleRouting) {
+    return {
+      code,
+      modified: false,
+      warning: createPageWarning(
+        filepath,
+        exportName,
+        'withGTStaticProps requires Pages Router locale routing, which the wizard could not confirm in the existing Next.js config'
+      ),
+    };
+  }
+
+  const helperLocalName = ensureNamedImport(ast, 'gt-next', helperName);
+  variable.init = t.callExpression(t.identifier(helperLocalName), [
+    variable.init,
+  ]);
+  return { code: printModule(ast, code), modified: true };
+}
+
+function isSpecialPagesFile(filepath: string, pagesDirectory: string): boolean {
+  const relativePath = path.relative(pagesDirectory, filepath);
+  const segments = relativePath.split(path.sep);
+  return (
+    segments[0] === 'api' ||
+    path.basename(filepath).startsWith('_') ||
+    filepath.endsWith('.d.ts')
+  );
+}
+
+function isCustomErrorPage(filepath: string, pagesDirectory: string): boolean {
+  const relativePath = path.relative(pagesDirectory, filepath);
+  return (
+    !relativePath.includes(path.sep) &&
+    ['404', '500'].includes(path.parse(relativePath).name)
+  );
+}
+
+function defaultAppContents(useTypeScript: boolean): string {
+  if (!useTypeScript) {
+    return `import { GTProvider } from 'gt-next';
+
+export default function App({ Component, pageProps }) {
+  const { locale, translations, ...restPageProps } = pageProps;
+
+  return (
+    <GTProvider locale={locale} translations={translations}>
+      <Component {...restPageProps} />
+    </GTProvider>
+  );
+}
+`;
+  }
+  return `import type { AppProps } from 'next/app';
+import { GTProvider, type WithGTServerSideProps } from 'gt-next';
+
+export default function App({
+  Component,
+  pageProps,
+}: AppProps<WithGTServerSideProps>) {
+  const { locale, translations, ...restPageProps } = pageProps;
+
+  return (
+    <GTProvider locale={locale} translations={translations}>
+      <Component {...restPageProps} />
+    </GTProvider>
+  );
+}
+`;
+}
+
+export async function setupPagesRouter(
+  pagesDirectory: string,
+  errors: string[],
+  warnings: string[],
+  options: { hasStaticLocaleRouting?: boolean } = {}
+): Promise<{ filesUpdated: string[] }> {
+  const filesUpdated: string[] = [];
+  const appCandidates = ['_app.tsx', '_app.ts', '_app.jsx', '_app.js'].map(
+    (filename) => path.join(pagesDirectory, filename)
+  );
+  let appPath = appCandidates.find((candidate) => fs.existsSync(candidate));
+
+  try {
+    if (!appPath) {
+      const useTypeScript = fs.existsSync(
+        path.join(process.cwd(), 'tsconfig.json')
+      );
+      appPath = path.join(
+        pagesDirectory,
+        useTypeScript ? '_app.tsx' : '_app.jsx'
+      );
+      await fs.promises.writeFile(appPath, defaultAppContents(useTypeScript));
+      filesUpdated.push(appPath);
+    } else {
+      const original = await fs.promises.readFile(appPath, 'utf8');
+      const result = transformPagesRouterApp(original, appPath);
+      if (result.warning) warnings.push(result.warning);
+      if (result.modified && result.code !== original) {
+        await fs.promises.writeFile(appPath, result.code);
+        filesUpdated.push(appPath);
+      }
+    }
+  } catch (error) {
+    errors.push(
+      createDiagnosticMessage({
+        whatHappened: `The setup wizard could not update ${appPath || 'pages/_app'}`,
+        fix: 'Update the custom App manually using the Pages Router quickstart',
+        details: formatDiagnosticErrorDetails(error),
+        docsUrl: PAGES_ROUTER_QUICKSTART_URL,
+      })
+    );
+  }
+
+  const pageFiles = matchFiles(pagesDirectory, ['**/*.{js,jsx,ts,tsx}']);
+  for (const filepath of pageFiles) {
+    if (filepath === appPath || isSpecialPagesFile(filepath, pagesDirectory)) {
+      continue;
+    }
+    try {
+      const original = await fs.promises.readFile(filepath, 'utf8');
+      const result = transformPagesRouterPage(original, filepath, {
+        ...options,
+        requiresStaticGeneration: isCustomErrorPage(filepath, pagesDirectory),
+      });
+      if (result.warning) warnings.push(result.warning);
+      if (result.modified && result.code !== original) {
+        await fs.promises.writeFile(filepath, result.code);
+        filesUpdated.push(filepath);
+      }
+    } catch (error) {
+      errors.push(
+        createDiagnosticMessage({
+          whatHappened: `The setup wizard could not update ${filepath}`,
+          fix: 'Wrap the page data-fetching export manually with the matching gt-next helper',
+          details: formatDiagnosticErrorDetails(error),
+          docsUrl: PAGES_ROUTER_QUICKSTART_URL,
+        })
+      );
+    }
+  }
+
+  return { filesUpdated };
+}

--- a/packages/cli/src/setup/__tests__/frameworkUtils.test.ts
+++ b/packages/cli/src/setup/__tests__/frameworkUtils.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { getReactFrameworkLibrary } from '../frameworkUtils.js';
+
+describe('getReactFrameworkLibrary', () => {
+  it.each(['next-app', 'next-pages'] as const)(
+    'selects gt-next for %s',
+    (name) => {
+      expect(getReactFrameworkLibrary({ name, type: 'react' })).toBe('gt-next');
+    }
+  );
+
+  it('keeps generic React frameworks on gt-react', () => {
+    expect(getReactFrameworkLibrary({ name: 'vite', type: 'react' })).toBe(
+      'gt-react'
+    );
+  });
+});

--- a/packages/cli/src/setup/frameworkUtils.ts
+++ b/packages/cli/src/setup/frameworkUtils.ts
@@ -31,7 +31,8 @@ export function getFrameworkDisplayName(
 export function getReactFrameworkLibrary(
   frameworkObject: ReactFrameworkObject
 ): string {
-  return frameworkObject.name === 'next-app'
+  return frameworkObject.name === 'next-app' ||
+    frameworkObject.name === 'next-pages'
     ? Libraries.GT_NEXT
     : Libraries.GT_REACT;
 }

--- a/packages/cli/src/setup/wizard.ts
+++ b/packages/cli/src/setup/wizard.ts
@@ -16,8 +16,18 @@ import { loadConfig } from '../fs/config/loadConfig.js';
 import { addVitePlugin } from '../react/parse/addVitePlugin/index.js';
 import { exitSync } from '../console/logging.js';
 import { ReactFrameworkObject } from '../types/index.js';
-import { getFrameworkDisplayName } from './frameworkUtils.js';
+import {
+  getFrameworkDisplayName,
+  getReactFrameworkLibrary,
+} from './frameworkUtils.js';
 import { Libraries } from '../types/libraries.js';
+import path from 'node:path';
+import fs from 'node:fs';
+import {
+  hasPagesRouterLocaleRouting,
+  setupPagesRouter,
+} from '../next/parse/setupPagesRouter.js';
+import { createDiagnosticMessage } from 'generaltranslation/internal';
 
 export async function handleSetupReactCommand(
   options: SetupOptions,
@@ -70,8 +80,14 @@ Please let us know what you would like to see added at https://github.com/genera
     exitSync(0);
   }
 
+  const gtConfigPath =
+    options.config ||
+    (fs.existsSync('src/gt.config.json')
+      ? 'src/gt.config.json'
+      : 'gt.config.json');
+
   // ----- Create a starter gt.config.json file -----
-  await createOrUpdateConfig(options.config || 'gt.config.json', {
+  await createOrUpdateConfig(gtConfigPath, {
     framework: frameworkType as SupportedReactFrameworks,
   });
 
@@ -84,31 +100,18 @@ Please let us know what you would like to see added at https://github.com/genera
     );
     exitSync(1);
   }
-  // Check if gt-next or gt-react is installed
-  if (
-    frameworkType === 'next-app' &&
-    !isPackageInstalled(Libraries.GT_NEXT, packageJson)
-  ) {
+  const frameworkLibrary = getReactFrameworkLibrary({
+    name: frameworkType,
+    type: 'react',
+  });
+  if (!isPackageInstalled(frameworkLibrary, packageJson)) {
     const packageManager = await getPackageManager();
     const spinner = logger.createSpinner('timer');
     spinner.start(
-      `Installing ${Libraries.GT_NEXT} with ${packageManager.name}...`
+      `Installing ${frameworkLibrary} with ${packageManager.name}...`
     );
-    await installPackage(Libraries.GT_NEXT, packageManager);
-    spinner.stop(chalk.green(`Automatically installed ${Libraries.GT_NEXT}.`));
-  } else if (
-    ['next-pages', 'react', 'redwood', 'vite', 'gatsby'].includes(
-      frameworkType
-    ) &&
-    !isPackageInstalled(Libraries.GT_REACT, packageJson)
-  ) {
-    const packageManager = await getPackageManager();
-    const spinner = logger.createSpinner('timer');
-    spinner.start(
-      `Installing ${Libraries.GT_REACT} with ${packageManager.name}...`
-    );
-    await installPackage(Libraries.GT_REACT, packageManager);
-    spinner.stop(chalk.green(`Automatically installed ${Libraries.GT_REACT}.`));
+    await installPackage(frameworkLibrary, packageManager);
+    spinner.stop(chalk.green(`Automatically installed ${frameworkLibrary}.`));
   }
 
   const errors: string[] = [];
@@ -119,42 +122,88 @@ Please let us know what you would like to see added at https://github.com/genera
   const tsconfigPath = findFilepath(['tsconfig.json']);
   const tsconfigJson = tsconfigPath ? loadConfig(tsconfigPath) : undefined;
 
-  if (frameworkType === 'next-app') {
+  if (frameworkType === 'next-app' || frameworkType === 'next-pages') {
     // Check if they have a next.config.js file
     const nextConfigPath = findFilepath([
       './next.config.js',
       './next.config.ts',
       './next.config.mjs',
       './next.config.mts',
+      './next.config.cjs',
     ]);
     if (!nextConfigPath) {
-      logger.error('No next.config.[js|ts|mjs|mts] file found.');
+      logger.error(
+        createDiagnosticMessage({
+          source: 'gt',
+          severity: 'Error',
+          whatHappened: 'No Next.js configuration file was found',
+          fix: 'Add a next.config.js, next.config.ts, next.config.mjs, next.config.mts, or next.config.cjs file at the project root and rerun setup',
+          docsUrl:
+            'https://generaltranslation.com/docs/react/nextjs-pages-router-quickstart',
+        })
+      );
       exitSync(1);
     }
 
-    const mergeOptions = {
-      ...options,
-      disableIds: true,
-      disableFormatting: true,
-      skipTs: true,
-      addGTProvider: true,
-    };
-    const spinner = logger.createSpinner();
-    spinner.start('Wrapping JSX content with <T> tags...');
-    // Wrap all JSX elements in the src directory with a <T> tag, with unique ids
-    const { filesUpdated: filesUpdatedNext } = await wrapContentNext(
-      mergeOptions,
-      Libraries.GT_NEXT,
-      errors,
-      warnings
-    );
-    filesUpdated = [...filesUpdated, ...filesUpdatedNext];
+    if (frameworkType === 'next-app') {
+      const mergeOptions = {
+        ...options,
+        disableIds: true,
+        disableFormatting: true,
+        skipTs: true,
+        addGTProvider: true,
+      };
+      const spinner = logger.createSpinner();
+      spinner.start('Wrapping JSX content with <T> tags...');
+      // Wrap all JSX elements in the src directory with a <T> tag, with unique ids
+      const { filesUpdated: filesUpdatedNext } = await wrapContentNext(
+        mergeOptions,
+        Libraries.GT_NEXT,
+        errors,
+        warnings
+      );
+      filesUpdated = [...filesUpdated, ...filesUpdatedNext];
 
-    spinner.stop(
-      chalk.green(
-        `Success! Updated ${chalk.bold.cyan(filesUpdated.length)} files:\n`
-      ) + filesUpdated.map((file) => `${chalk.green('-')} ${file}`).join('\n')
-    );
+      spinner.stop(
+        chalk.green(
+          `Success! Updated ${chalk.bold.cyan(filesUpdated.length)} files:\n`
+        ) + filesUpdated.map((file) => `${chalk.green('-')} ${file}`).join('\n')
+      );
+    } else {
+      const pagesDirectory = [
+        path.join(process.cwd(), 'pages'),
+        path.join(process.cwd(), 'src', 'pages'),
+      ].find((candidate) => fs.existsSync(candidate));
+      if (!pagesDirectory) {
+        logger.error(
+          createDiagnosticMessage({
+            source: 'gt',
+            severity: 'Error',
+            whatHappened: 'No Pages Router directory was found',
+            fix: 'Run the setup wizard from a Next.js project containing pages or src/pages',
+            docsUrl:
+              'https://generaltranslation.com/docs/react/nextjs-pages-router-quickstart',
+          })
+        );
+        exitSync(1);
+      }
+      const { filesUpdated: pagesFilesUpdated } = await setupPagesRouter(
+        pagesDirectory,
+        errors,
+        warnings,
+        {
+          hasStaticLocaleRouting: hasPagesRouterLocaleRouting(
+            await fs.promises.readFile(nextConfigPath, 'utf8')
+          ),
+        }
+      );
+      filesUpdated = [...filesUpdated, ...pagesFilesUpdated];
+      logger.step(
+        chalk.green(
+          `Configured ${chalk.bold.cyan(pagesFilesUpdated.length)} Pages Router files for gt-next.`
+        )
+      );
+    }
 
     // Add the withGTConfig() function to the next.config.js file
     await handleInitGT(
@@ -163,7 +212,8 @@ Please let us know what you would like to see added at https://github.com/genera
       warnings,
       filesUpdated,
       packageJson,
-      tsconfigJson
+      tsconfigJson,
+      gtConfigPath
     );
     logger.step(
       chalk.green(`Added withGTConfig() to your ${nextConfigPath} file.`)

--- a/packages/cli/src/utils/__tests__/credentials.test.ts
+++ b/packages/cli/src/utils/__tests__/credentials.test.ts
@@ -1,0 +1,51 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { setCredentials } from '../credentials.js';
+
+describe('setCredentials for Next.js Pages Router', () => {
+  const temporaryDirectories: string[] = [];
+
+  afterEach(() => {
+    for (const directory of temporaryDirectories.splice(0)) {
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps credentials server-only and replaces them on rerun', async () => {
+    const directory = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'gt-pages-credentials-')
+    );
+    temporaryDirectories.push(directory);
+    fs.writeFileSync(
+      path.join(directory, '.env.local'),
+      'CUSTOM_VALUE=preserved\nNEXT_PUBLIC_GT_PROJECT_ID=legacy\n'
+    );
+
+    await setCredentials(
+      {
+        projectId: 'first-project',
+        apiKeys: [{ type: 'development', key: 'first-key' }],
+      },
+      'next-pages',
+      directory
+    );
+    await setCredentials(
+      {
+        projectId: 'final-project',
+        apiKeys: [{ type: 'development', key: 'final-key' }],
+      },
+      'next-pages',
+      directory
+    );
+
+    const env = fs.readFileSync(path.join(directory, '.env.local'), 'utf8');
+    expect(env).toContain('CUSTOM_VALUE=preserved');
+    expect(env).toContain('GT_PROJECT_ID=final-project');
+    expect(env).toContain('GT_DEV_API_KEY=final-key');
+    expect(env).not.toContain('NEXT_PUBLIC_');
+    expect(env.match(/^GT_PROJECT_ID=/gm)).toHaveLength(1);
+    expect(env.match(/^GT_DEV_API_KEY=/gm)).toHaveLength(1);
+  });
+});

--- a/packages/cli/src/utils/credentials.ts
+++ b/packages/cli/src/utils/credentials.ts
@@ -139,9 +139,7 @@ export async function setCredentials(
 
   // Always append the credentials to the file
   let prefix = '';
-  if (framework === 'next-pages') {
-    prefix = 'NEXT_PUBLIC_';
-  } else if (framework === 'vite') {
+  if (framework === 'vite') {
     prefix = 'VITE_';
   } else if (framework === 'gatsby') {
     prefix = 'GATSBY_';
@@ -151,15 +149,28 @@ export async function setCredentials(
     prefix = 'REDWOOD_ENV_';
   }
 
-  envContent += `\n${prefix}GT_PROJECT_ID=${credentials.projectId}\n`;
-
-  for (const apiKey of credentials.apiKeys) {
-    if (apiKey.type === 'development') {
-      envContent += `${prefix || ''}GT_DEV_API_KEY=${apiKey.key}\n`;
-    } else {
-      envContent += `GT_API_KEY=${apiKey.key}\n`;
-    }
+  const credentialLines = [
+    `${prefix}GT_PROJECT_ID=${credentials.projectId}`,
+    ...credentials.apiKeys.map((apiKey) =>
+      apiKey.type === 'development'
+        ? `${prefix}GT_DEV_API_KEY=${apiKey.key}`
+        : `GT_API_KEY=${apiKey.key}`
+    ),
+  ];
+  if (framework === 'next-pages') {
+    const managedKeys = new Set([
+      'GT_PROJECT_ID',
+      'GT_DEV_API_KEY',
+      'GT_API_KEY',
+      'NEXT_PUBLIC_GT_PROJECT_ID',
+      'NEXT_PUBLIC_GT_DEV_API_KEY',
+    ]);
+    envContent = envContent
+      .split(/\r?\n/)
+      .filter((line) => !managedKeys.has(line.split('=', 1)[0]))
+      .join('\n');
   }
+  envContent += `\n${credentialLines.join('\n')}\n`;
 
   // Ensure we don't have excessive newlines
   envContent = envContent.replace(/\n{3,}/g, '\n\n').trim() + '\n';

--- a/packages/cli/src/utils/parse/needsCJS.ts
+++ b/packages/cli/src/utils/parse/needsCJS.ts
@@ -55,7 +55,11 @@ export function needsCJS({
     needsCJS = false;
   } else {
     // No imports/requires found, fall back to configuration-based logic
-    if (filepath.endsWith('.ts') || filepath.endsWith('.tsx')) {
+    if (filepath.endsWith('.cjs') || filepath.endsWith('.cts')) {
+      needsCJS = true;
+    } else if (filepath.endsWith('.mjs') || filepath.endsWith('.mts')) {
+      needsCJS = false;
+    } else if (filepath.endsWith('.ts') || filepath.endsWith('.tsx')) {
       // For TypeScript files, check tsconfig.json compilerOptions.module
       const moduleSetting = tsconfigJson?.compilerOptions?.module;
       if (moduleSetting === 'commonjs' || moduleSetting === 'node') {


### PR DESCRIPTION
## Summary

- route Next.js Pages Router setup through `gt-next`, configure `withGTConfig`, local translation output, and server-only credentials
- safely wire `GTProvider` and per-page locale/translation props while preserving existing config and application logic
- keep reruns idempotent and provide focused fallback guidance for unsupported data loaders, ambiguous SSG routing, and custom error pages

## Testing

- `pnpm --filter gt... build`
- `pnpm --filter gt test` (2,104 tests)
- focused Pages Router/setup tests (49 tests)
- `pnpm --filter gt typecheck`
- `pnpm lint`
- `pnpm format`

## Release

- added a patch changeset for `gt`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds first-class `gt-next` setup for Next.js Pages Router projects. The main changes are:

- Installs and configures `gt-next` for Pages Router projects.
- Wires `GTProvider` and page data-loading helpers.
- Preserves existing GT file configuration during updates.
- Migrates Pages Router credentials to server-only variables.
- Adds idempotence checks, diagnostics, and focused tests.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The Next.js config transformation needs fixes before merging.

- Aliased CommonJS imports can produce an undefined helper reference.
- An unrelated helper call can leave the exported Next.js config unwrapped.
- The remaining Pages Router setup changes use conservative fallbacks and focused tests.

packages/cli/src/next/parse/handleInitGT.ts
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/next/parse/handleInitGT.ts | Adds CommonJS and custom config-path support, but helper binding and application detection can generate or preserve an invalid Next.js config. |
| packages/cli/src/next/parse/setupPagesRouter.ts | Adds conservative AST transforms for custom Apps and page data loaders, with manual guidance for unsupported forms. |
| packages/cli/src/setup/wizard.ts | Routes Pages Router setup through `gt-next` and coordinates config, App, and page transformations. |
| packages/cli/src/fs/config/setupConfig.ts | Merges new per-format file options while preserving existing formats and settings. |
| packages/cli/src/utils/credentials.ts | Replaces legacy public Pages Router credentials with idempotent server-only entries. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fcli%2Fsrc%2Fnext%2Fparse%2FhandleInitGT.ts%3A84-86%0A**Aliased%20Import%20Generates%20Missing%20Binding**%0A%0AWhen%20a%20config%20uses%20%60const%20%7B%20withGTConfig%3A%20configureGT%20%7D%20%3D%20require%28'gt-next%2Fconfig'%29%60%2C%20this%20branch%20records%20that%20the%20helper%20is%20imported%20but%20discards%20its%20local%20name.%20Setup%20then%20wraps%20%60module.exports%60%20with%20an%20undefined%20%60withGTConfig%60%20identifier%2C%20so%20loading%20the%20generated%20Next.js%20config%20throws.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fcli%2Fsrc%2Fnext%2Fparse%2FhandleInitGT.ts%3A110-113%0A**Unrelated%20Call%20Suppresses%20Config%20Wrapping**%0A%0AAny%20call%20named%20%60withGTConfig%60%20makes%20this%20branch%20return%2C%20even%20when%20the%20exported%20Next.js%20config%20is%20not%20the%20call's%20result.%20For%20example%2C%20calling%20the%20helper%20for%20another%20value%20before%20%60export%20default%20nextConfig%60%20leaves%20%60nextConfig%60%20unwrapped%20while%20setup%20reports%20success%2C%20so%20the%20generated%20project%20never%20enables%20GT%20configuration.%0A%0A&repo=generaltranslation%2Fgt&pr=1970&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fcli%2Ffix-next-pages-setup%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fcli%2Ffix-next-pages-setup%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fcli%2Fsrc%2Fnext%2Fparse%2FhandleInitGT.ts%3A84-86%0A**Aliased%20Import%20Generates%20Missing%20Binding**%0A%0AWhen%20a%20config%20uses%20%60const%20%7B%20withGTConfig%3A%20configureGT%20%7D%20%3D%20require%28'gt-next%2Fconfig'%29%60%2C%20this%20branch%20records%20that%20the%20helper%20is%20imported%20but%20discards%20its%20local%20name.%20Setup%20then%20wraps%20%60module.exports%60%20with%20an%20undefined%20%60withGTConfig%60%20identifier%2C%20so%20loading%20the%20generated%20Next.js%20config%20throws.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fcli%2Fsrc%2Fnext%2Fparse%2FhandleInitGT.ts%3A110-113%0A**Unrelated%20Call%20Suppresses%20Config%20Wrapping**%0A%0AAny%20call%20named%20%60withGTConfig%60%20makes%20this%20branch%20return%2C%20even%20when%20the%20exported%20Next.js%20config%20is%20not%20the%20call's%20result.%20For%20example%2C%20calling%20the%20helper%20for%20another%20value%20before%20%60export%20default%20nextConfig%60%20leaves%20%60nextConfig%60%20unwrapped%20while%20setup%20reports%20success%2C%20so%20the%20generated%20project%20never%20enables%20GT%20configuration.%0A%0A&repo=generaltranslation%2Fgt&pr=1970&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/cli/src/next/parse/handleInitGT.ts:84-86
**Aliased Import Generates Missing Binding**

When a config uses `const { withGTConfig: configureGT } = require('gt-next/config')`, this branch records that the helper is imported but discards its local name. Setup then wraps `module.exports` with an undefined `withGTConfig` identifier, so loading the generated Next.js config throws.

### Issue 2 of 2
packages/cli/src/next/parse/handleInitGT.ts:110-113
**Unrelated Call Suppresses Config Wrapping**

Any call named `withGTConfig` makes this branch return, even when the exported Next.js config is not the call's result. For example, calling the helper for another value before `export default nextConfig` leaves `nextConfig` unwrapped while setup reports success, so the generated project never enables GT configuration.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(cli): configure Next.js Pages Router..."](https://github.com/generaltranslation/gt/commit/a2ca0e4587578af447b5bd4e2f550fb3f5056b50) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46138580)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->