### PR TITLE
feat(skills): add example app workflow

### DIFF
--- a/.claude/skills/add-example-test-app.md
+++ b/.claude/skills/add-example-test-app.md
@@ -1,0 +1,34 @@
+---
+name: add-example-test-app
+description: Add a new example app or test app to the GT monorepo
+user-invocable: true
+allowed-tools: Bash(pnpm *), Bash(git *), Read, Write, Edit, Glob, Grep
+argument-hint: '<app description>'
+---
+
+Add the example or test app described by `$ARGUMENTS` using the closest
+existing app as the source of current repository and framework conventions.
+
+## Steps
+
+1. Read the repository instructions and inspect the closest sibling app.
+2. Put user-facing demonstrations in `examples/` and focused integration or
+   regression fixtures in `tests/apps/`.
+3. Give the app a unique, descriptive package name and keep it private unless
+   publishing is explicitly requested.
+4. Use workspace versions for GT packages. Declare every imported package as a
+   direct dependency rather than relying on hoisting.
+5. Update the root `.changeset/config.json` in the same change:
+   - Add the app's exact `package.json` `name` to the `ignore` array.
+   - Use the package name, not the directory name, unless they are identical.
+   - Preserve the existing grouping and ensure the name appears exactly once.
+6. Run `pnpm install` after changing manifests and commit the lockfile update.
+7. Run the app's relevant formatting, lint, typecheck, test, and production
+   build commands. For browser apps, start the app and exercise its primary
+   flow in a real browser while checking browser and server logs.
+8. Before finishing, verify that `.changeset/config.json` contains the exact
+   package name. Do not consider a private example or test app complete without
+   this update.
+
+If the new workspace is intentionally publishable, do not add it to `ignore`.
+Create the appropriate changeset instead and explain the exception.


### PR DESCRIPTION
## Summary

- Add a repository-owned skill for creating GT example apps and test apps.
- Require private app package names to be added to `.changeset/config.json` in the same change.
- Include workspace dependency, lockfile, validation, and browser-testing guidance.

## Testing

- Parsed and validated the skill frontmatter with Ruby YAML — passed
- `oxfmt --check .claude/skills/add-example-test-app.md` — passed
- `git diff --check` — passed

## Notes

- Changeset: not required; this adds repository agent workflow documentation only.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a repository-owned workflow for creating example and test apps. The main changes are:

- Defines an invocable app-creation skill.
- Requires direct workspace dependencies and lockfile updates.
- Adds Changesets ignore-list guidance for private apps.
- Requires formatting, tests, builds, and browser checks.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed workflow.
- The dependency and Changesets instructions match the inspected repository conventions.

</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .claude/skills/add-example-test-app.md | Adds an app-creation workflow consistent with the repository's workspace and Changesets conventions. |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(skills): add example app workflow"](https://github.com/generaltranslation/gt/commit/b9c8cc9f10188fd8d323f2a53c27c25c46345a60) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46515033)</sub>

<!-- /greptile_comment -->