### PR TITLE
perf(format): isolate custom cutoff cache

### DIFF
--- a/.changeset/slim-intl-cache.md
+++ b/.changeset/slim-intl-cache.md
@@ -1,0 +1,5 @@
+---
+'@generaltranslation/format': patch
+---
+
+Keep the custom cutoff formatter and locale metadata helpers out of native Intl-only bundles.

--- a/packages/format/src/LocaleConfig.ts
+++ b/packages/format/src/LocaleConfig.ts
@@ -8,7 +8,6 @@ import {
   _formatRelativeTime,
   _selectRelativeTimeUnit,
 } from './formatting/format';
-import { intlCache } from './cache/IntlCache';
 import { _requiresTranslation } from './locales/requiresTranslation';
 import { _determineLocale } from './locales/determineLocale';
 import { _isSameLanguage } from './locales/isSameLanguage';
@@ -24,6 +23,7 @@ import type { CustomMapping, FormatVariables } from './types';
 import { _resolveAliasLocale } from './locales/resolveAliasLocale';
 import { _resolveCanonicalLocale } from './locales/resolveCanonicalLocale';
 import type { CutoffFormatOptions } from './formatting/custom-formats/CutoffFormat/types';
+import { cutoffFormatCache } from './formatting/custom-formats/CutoffFormat/CutoffFormatCache';
 import type { StringFormat } from './types-dir/jsx/content';
 
 export type LocaleConfigConstructorParams = {
@@ -158,12 +158,8 @@ export class LocaleConfig {
     options: WithLocales<CutoffFormatOptions> = {}
   ) {
     const { locales, ...formatOptions } = options;
-    return intlCache
-      .get(
-        'CutoffFormat',
-        this.getFormattingLocales(targetLocale, locales),
-        formatOptions
-      )
+    return cutoffFormatCache
+      .get(this.getFormattingLocales(targetLocale, locales), formatOptions)
       .format(value);
   }
 

--- a/packages/format/src/__tests__/format-package.test.ts
+++ b/packages/format/src/__tests__/format-package.test.ts
@@ -1,9 +1,9 @@
 import { execFileSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { beforeAll, describe, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 
 import type { CustomMapping } from '@generaltranslation/format/types';
 
@@ -178,5 +178,18 @@ describe('@generaltranslation/format package export', () => {
       ],
       { stdio: 'pipe' }
     );
+  });
+
+  it('keeps the custom cutoff formatter out of the native Intl cache chunk', () => {
+    const intlCacheArtifacts = readdirSync(join(packageRoot, 'dist')).filter(
+      (artifact) => /^IntlCache-.*\.(?:cjs|mjs)$/.test(artifact)
+    );
+
+    expect(intlCacheArtifacts).toHaveLength(2);
+    for (const artifact of intlCacheArtifacts) {
+      expect(
+        readFileSync(join(packageRoot, 'dist', artifact), 'utf8')
+      ).not.toContain('CutoffFormat');
+    }
   });
 });

--- a/packages/format/src/__tests__/format-package.test.ts
+++ b/packages/format/src/__tests__/format-package.test.ts
@@ -185,7 +185,9 @@ describe('@generaltranslation/format package export', () => {
       (artifact) => /^IntlCache-.*\.(?:cjs|mjs)$/.test(artifact)
     );
 
-    expect(intlCacheArtifacts).toHaveLength(2);
+    expect(
+      new Set(intlCacheArtifacts.map((artifact) => artifact.split('.').at(-1)))
+    ).toEqual(new Set(['cjs', 'mjs']));
     for (const artifact of intlCacheArtifacts) {
       expect(
         readFileSync(join(packageRoot, 'dist', artifact), 'utf8')

--- a/packages/format/src/cache/IntlCache.ts
+++ b/packages/format/src/cache/IntlCache.ts
@@ -1,17 +1,16 @@
 import { libraryDefaultLocale } from '../settings/settings';
-import { CutoffFormatConstructor } from '../formatting/custom-formats/CutoffFormat/CutoffFormat';
 import {
   ConstructorType,
-  CustomIntlConstructors,
-  CustomIntlType,
+  IntlConstructors,
+  IntlConstructorMap,
   IntlCacheObject,
 } from './types';
 
 /**
  * Object mapping constructor names to their respective constructor functions
- * Includes all native Intl constructors plus custom ones like CutoffFormat
+ * Includes the native Intl constructors.
  */
-const CustomIntl: CustomIntlType = {
+const IntlConstructor: IntlConstructorMap = {
   Collator: Intl.Collator,
   DateTimeFormat: Intl.DateTimeFormat,
   DisplayNames: Intl.DisplayNames,
@@ -21,11 +20,10 @@ const CustomIntl: CustomIntlType = {
   PluralRules: Intl.PluralRules,
   RelativeTimeFormat: Intl.RelativeTimeFormat,
   Segmenter: Intl.Segmenter,
-  CutoffFormat: CutoffFormatConstructor,
 };
 
 /**
- * Cache for Intl and custom format instances to avoid repeated instantiation
+ * Cache for native Intl format instances to avoid repeated instantiation
  * Uses a two-level structure: constructor name -> cache key -> instance.
  */
 class IntlCache {
@@ -56,9 +54,9 @@ class IntlCache {
    * @param args Constructor arguments (locales, options).
    * @returns Cached or newly created Intl instance.
    */
-  get<K extends keyof CustomIntlConstructors>(
+  get<K extends keyof IntlConstructors>(
     constructor: K,
-    ...args: ConstructorParameters<CustomIntlConstructors[K]>
+    ...args: ConstructorParameters<IntlConstructors[K]>
   ): InstanceType<ConstructorType<K>> {
     const [locales = libraryDefaultLocale, options = {}] = args;
     const key = this.generateKey(locales, options);
@@ -71,7 +69,7 @@ class IntlCache {
 
     if (intlObject === undefined) {
       // Create new instance and cache it
-      intlObject = new CustomIntl[constructor](...args);
+      intlObject = new IntlConstructor[constructor](...args);
       cache[key] = intlObject;
     }
 

--- a/packages/format/src/cache/types.ts
+++ b/packages/format/src/cache/types.ts
@@ -1,10 +1,8 @@
-import { CutoffFormatConstructor } from '../formatting/custom-formats/CutoffFormat/CutoffFormat';
-
 /**
  * Extracts only the constructor functions from the Intl namespace,
  * filtering out static methods like getCanonicalLocales and supportedValuesOf
  */
-type IntlConstructors = {
+export type IntlConstructors = {
   [K in keyof typeof Intl as (typeof Intl)[K] extends new (
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ...args: any[]
@@ -15,25 +13,18 @@ type IntlConstructors = {
 };
 
 /**
- * Extended interface that includes all native Intl constructors plus custom ones
- */
-export interface CustomIntlConstructors extends IntlConstructors {
-  CutoffFormat: typeof CutoffFormatConstructor;
-}
-
-/**
  * Helper type to represent a constructor function for a given Intl constructor key
  */
-export type ConstructorType<K extends keyof CustomIntlConstructors> = new (
-  ...args: ConstructorParameters<CustomIntlConstructors[K]>
-) => InstanceType<CustomIntlConstructors[K]>;
+export type ConstructorType<K extends keyof IntlConstructors> = new (
+  ...args: ConstructorParameters<IntlConstructors[K]>
+) => InstanceType<IntlConstructors[K]>;
 
 /**
  * Type for the cache object structure - each constructor gets its own Record
  * mapping cache keys to instances of that specific constructor type
  */
 export type IntlCacheObject = {
-  [K in keyof CustomIntlConstructors]?: Record<
+  [K in keyof IntlConstructors]?: Record<
     string,
     InstanceType<ConstructorType<K>>
   >;
@@ -42,6 +33,6 @@ export type IntlCacheObject = {
 /**
  * Type for the CustomIntl object that maps constructor names to constructor functions
  */
-export type CustomIntlType = {
-  [K in keyof CustomIntlConstructors]: ConstructorType<K>;
+export type IntlConstructorMap = {
+  [K in keyof IntlConstructors]: ConstructorType<K>;
 };

--- a/packages/format/src/core.ts
+++ b/packages/format/src/core.ts
@@ -8,8 +8,8 @@ import {
   _formatRelativeTime,
   _selectRelativeTimeUnit,
 } from './formatting/format';
-import { intlCache } from './cache/IntlCache';
 import type { CutoffFormatOptions } from './formatting/custom-formats/CutoffFormat/types';
+import { cutoffFormatCache } from './formatting/custom-formats/CutoffFormat/CutoffFormatCache';
 import { _determineLocale } from './locales/determineLocale';
 import { _getLocaleDirection } from './locales/getLocaleDirection';
 import { _getLocaleEmoji } from './locales/getLocaleEmoji';
@@ -101,7 +101,7 @@ export function formatCutoff(
   options?: LocalesOption & CutoffFormatOptions
 ) {
   const { locales, ...formatOptions } = options ?? {};
-  return intlCache.get('CutoffFormat', locales, formatOptions).format(value);
+  return cutoffFormatCache.get(locales, formatOptions).format(value);
 }
 
 /**

--- a/packages/format/src/formatting/custom-formats/CutoffFormat/CutoffFormatCache.ts
+++ b/packages/format/src/formatting/custom-formats/CutoffFormat/CutoffFormatCache.ts
@@ -1,0 +1,26 @@
+import { libraryDefaultLocale } from '../../../settings/settings';
+import { CutoffFormatConstructor } from './CutoffFormat';
+import type { CutoffFormatOptions } from './types';
+
+class CutoffFormatCache {
+  private cache = new Map<string, CutoffFormatConstructor>();
+
+  get(
+    locales: Intl.LocalesArgument = libraryDefaultLocale,
+    options: CutoffFormatOptions = {}
+  ): CutoffFormatConstructor {
+    const localeKey = Array.isArray(locales)
+      ? locales.map(String).join(',')
+      : String(locales);
+    const optionsKey = JSON.stringify(options, Object.keys(options).sort());
+    const key = `${localeKey}:${optionsKey}`;
+    let formatter = this.cache.get(key);
+    if (!formatter) {
+      formatter = new CutoffFormatConstructor(locales, options);
+      this.cache.set(key, formatter);
+    }
+    return formatter;
+  }
+}
+
+export const cutoffFormatCache = new CutoffFormatCache();

--- a/packages/format/src/locales/__tests__/getLocaleDirection.browser.test.ts
+++ b/packages/format/src/locales/__tests__/getLocaleDirection.browser.test.ts
@@ -51,6 +51,11 @@ describe.sequential('_getLocaleDirection (browser)', () => {
     expect(_getLocaleDirection('az-Latn')).toBe('ltr');
   });
 
+  it('should infer an rtl script when the locale omits its script subtag', () => {
+    mockLocaleWithoutTextInfo();
+    expect(_getLocaleDirection('ks')).toBe('rtl');
+  });
+
   it('should fall back to known rtl languages when Intl.Locale is not available', () => {
     vi.spyOn(intlCache, 'get').mockImplementation(() => {
       throw new Error('Intl.Locale not supported');

--- a/packages/format/src/locales/getLocaleDirection.ts
+++ b/packages/format/src/locales/getLocaleDirection.ts
@@ -1,5 +1,4 @@
 import { intlCache } from '../cache/IntlCache';
-import { _getLocaleProperties } from './getLocaleProperties';
 
 /**
  * Get the text direction for a given locale code using the Intl.Locale API.
@@ -9,6 +8,9 @@ import { _getLocaleProperties } from './getLocaleProperties';
  * @internal
  */
 export function _getLocaleDirection(code: string): 'ltr' | 'rtl' {
+  let languageCode: string | undefined;
+  let scriptCode: string | undefined;
+
   // Extract via textInfo property
   try {
     const locale = intlCache.get('Locale', code);
@@ -16,12 +18,11 @@ export function _getLocaleDirection(code: string): 'ltr' | 'rtl' {
     if (textInfoDirection) {
       return textInfoDirection;
     }
+    languageCode = locale.language;
+    scriptCode = locale.script;
   } catch {
-    // Fall back to language/script heuristics below.
+    ({ languageCode, scriptCode } = extractLocaleParts(code));
   }
-
-  // Fallback to simple heuristics
-  const { scriptCode, languageCode } = _getLocaleProperties(code);
 
   // Handle RTL script or language
   if (scriptCode) {
@@ -88,4 +89,14 @@ function extractDirectionWithTextInfo(locale: Intl.Locale) {
       ? locale.textInfo.direction
       : undefined;
   return direction === 'rtl' || direction === 'ltr' ? direction : undefined;
+}
+
+function extractLocaleParts(code: string): {
+  languageCode?: string;
+  scriptCode?: string;
+} {
+  const parts = code.replaceAll('_', '-').split('-');
+  const languageCode = /^[a-z]{2,3}$/i.test(parts[0]) ? parts[0] : undefined;
+  const scriptCode = parts.find((part) => /^[a-z]{4}$/i.test(part));
+  return { languageCode, scriptCode };
 }

--- a/packages/format/src/locales/getLocaleDirection.ts
+++ b/packages/format/src/locales/getLocaleDirection.ts
@@ -18,8 +18,9 @@ export function _getLocaleDirection(code: string): 'ltr' | 'rtl' {
     if (textInfoDirection) {
       return textInfoDirection;
     }
-    languageCode = locale.language;
-    scriptCode = locale.script;
+    const maximizedLocale = locale.maximize();
+    languageCode = maximizedLocale.language;
+    scriptCode = maximizedLocale.script;
   } catch {
     ({ languageCode, scriptCode } = extractLocaleParts(code));
   }


### PR DESCRIPTION
## TL;DR

Keep CutoffFormat and locale metadata helpers out of native Intl-only bundle paths.

## Code Changes

- Restrict IntlCache to native Intl constructors.
- Add a dedicated cache for CutoffFormat.
- Resolve locale direction from the existing Intl.Locale language and script fields, with a lightweight string fallback.
- Add an emitted-chunk assertion and a patch changeset for @generaltranslation/format.

## Notes / Flags

- Validation: 298 unit tests, 5 package export tests, typecheck, build, oxlint, and oxfmt.
- The native Intl cache ESM chunk shrank from 7.32 kB to 1.95 kB.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR isolates the `CutoffFormat` custom formatter and locale-metadata helpers from the native `Intl`-only bundle chunk, shrinking the `IntlCache` ESM chunk from ~7 kB to ~2 kB. The `getLocaleDirection` fallback now also calls `locale.maximize()` before reading the script subtag, fixing script-inference for locales like `ks` (Kashmiri) that omit their explicit script subtag.

- **`IntlCache`** is narrowed to native `Intl.*` constructors only; `CutoffFormat` is moved to a dedicated `CutoffFormatCache` with an equivalent key-generation strategy.
- **`getLocaleDirection`** maximizes the locale before extracting `language`/`script` in the no-`textInfo` path, and an `extractLocaleParts` fallback is introduced for the (rare) case where `Intl.Locale` itself is unavailable.
- A new build-artifact integration test asserts that `IntlCache-*.cjs/mjs` chunks contain no `CutoffFormat` reference, using extension-set equality to avoid fragility on extra chunk counts.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a clean bundle-boundary refactor with no behavioral regressions; the CutoffFormat and locale-direction paths are both exercised by the existing and new tests.

The CutoffFormat extraction into its own cache is a straightforward structural change with key generation logic consistent with IntlCache. The getLocaleDirection fix correctly handles locales like `ks` by calling maximize() before reading the script subtag, and a new regression test covers that case. No auth, data, or API contract changes are present.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/format/src/cache/IntlCache.ts | Narrowed to native Intl constructors only by removing CutoffFormat; type aliases updated accordingly. Logic is unchanged. |
| packages/format/src/formatting/custom-formats/CutoffFormat/CutoffFormatCache.ts | New dedicated cache for CutoffFormat using a Map; key generation (sorted JSON options + locale string) mirrors IntlCache. Default parameter for undefined locales is handled correctly. |
| packages/format/src/locales/getLocaleDirection.ts | Now calls locale.maximize() before reading language/script in the no-textInfo path, fixing RTL inference for locales like `ks`. The extractLocaleParts fallback is a lightweight string heuristic for when Intl.Locale itself is unavailable. |
| packages/format/src/__tests__/format-package.test.ts | New integration test asserts IntlCache artifacts contain no CutoffFormat string, and uses Set equality on extensions instead of a hardcoded length check. |
| packages/format/src/cache/types.ts | CustomIntlConstructors interface and CutoffFormat import removed; IntlConstructors type is now exported for use in IntlCache. |
| packages/format/src/core.ts | formatCutoff updated to use cutoffFormatCache instead of intlCache; semantically equivalent, no behavioral change. |
| packages/format/src/LocaleConfig.ts | formatCutoff method updated to use cutoffFormatCache.get() with its simpler two-arg signature; correct drop-in. |
| packages/format/src/locales/__tests__/getLocaleDirection.browser.test.ts | Adds regression test for `ks` (Kashmiri) to verify RTL inference when textInfo is absent but Intl.Locale.maximize() is available. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["formatCutoff() / LocaleConfig.formatCutoff()"] --> B["cutoffFormatCache.get(locales, options)"]
    B --> C{Cache hit?}
    C -- Yes --> D["Return cached CutoffFormatConstructor"]
    C -- No --> E["new CutoffFormatConstructor(locales, options)"]
    E --> F["Store in Map cache"]
    F --> D

    G["intlCache.get(constructor, ...)"] --> H{Native Intl constructor?}
    H -- "Collator / DateTimeFormat / Locale / ..." --> I["IntlConstructor map (native only)"]
    H -- "CutoffFormat (removed)" --> X["No longer in IntlCache"]

    J["_getLocaleDirection(code)"] --> K["intlCache.get('Locale', code)"]
    K --> L["extractDirectionWithTextInfo(locale)"]
    L -- "textInfo present" --> M["Return ltr or rtl"]
    L -- "textInfo absent" --> N["locale.maximize()"]
    N --> O["Use maximized language + script"]
    K -- "Intl.Locale throws" --> P["extractLocaleParts string heuristic"]
    O --> Q{scriptCode?}
    P --> Q
    Q -- Yes --> R["RTL_SCRIPTS.has(script)"]
    Q -- No --> S["RTL_LANGUAGES.has(language)"]
    R --> M
    S --> M
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(format): preserve inferred locale di..."](https://github.com/generaltranslation/gt/commit/8c448d20df9c7fd01b59a4bdcabf8ce582ac18c2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46758926)</sub>

<!-- /greptile_comment -->