### PR TITLE
perf(next): remove full runtime from middleware

### DIFF
--- a/.changeset/light-middleware-runtime.md
+++ b/.changeset/light-middleware-runtime.md
@@ -1,0 +1,5 @@
+---
+'gt-next': patch
+---
+
+Remove the full General Translation runtime from the Next.js middleware dependency graph.

--- a/packages/next/src/middleware-dir/__tests__/localeResolution.edge.test.ts
+++ b/packages/next/src/middleware-dir/__tests__/localeResolution.edge.test.ts
@@ -1,8 +1,8 @@
 // @vitest-environment edge-runtime
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { NextRequest } from 'next/server';
-import { GT } from 'generaltranslation';
-import { getLocaleFromRequest } from '../utils';
+import type { CustomMapping } from '@generaltranslation/format/types';
+import { createLocaleResolver, getLocaleFromRequest } from '../utils';
 
 // ---- Cookie Constants ----
 const LOCALE_COOKIE = 'generaltranslation.locale';
@@ -46,9 +46,10 @@ function callGetLocaleFromRequest(
     gtServicesEnabled?: boolean;
     prefixDefaultLocale?: boolean;
     defaultLocalePaths?: string[];
+    customMapping?: CustomMapping;
   } = {}
 ) {
-  const gt = new GT();
+  const localeResolver = createLocaleResolver(overrides.customMapping);
   return getLocaleFromRequest(
     req,
     overrides.defaultLocale ?? DEFAULT_LOCALE,
@@ -60,7 +61,7 @@ function callGetLocaleFromRequest(
     REFERRER_COOKIE,
     LOCALE_COOKIE,
     RESET_COOKIE,
-    gt
+    localeResolver
   );
 }
 
@@ -142,6 +143,22 @@ describe('Locale Resolution (Category 1)', () => {
 
     expect(result.userLocale).toBe('en');
     expect(result.clearResetCookie).toBe(true);
+  });
+
+  it('resolves custom locale aliases without the full runtime', () => {
+    const req = createRequest('/pirate/about');
+    const result = callGetLocaleFromRequest(req, {
+      approvedLocales: ['en', 'pirate'],
+      customMapping: {
+        pirate: {
+          code: 'en-US',
+          name: 'Pirate',
+        },
+      },
+    });
+
+    expect(result.userLocale).toBe('pirate');
+    expect(result.pathnameLocale).toBe('pirate');
   });
 
   it('1.6: Accept-Language: es → userLocale=es', () => {

--- a/packages/next/src/middleware-dir/__tests__/localeResolution.edge.test.ts
+++ b/packages/next/src/middleware-dir/__tests__/localeResolution.edge.test.ts
@@ -151,7 +151,7 @@ describe('Locale Resolution (Category 1)', () => {
       approvedLocales: ['en', 'pirate'],
       customMapping: {
         pirate: {
-          code: 'en-US',
+          code: 'en-us',
           name: 'Pirate',
         },
       },

--- a/packages/next/src/middleware-dir/createNextMiddleware.ts
+++ b/packages/next/src/middleware-dir/createNextMiddleware.ts
@@ -1,5 +1,4 @@
 import { isSameDialect, standardizeLocale } from '@generaltranslation/format';
-import { GTRuntime } from 'generaltranslation/runtime';
 import { libraryDefaultLocale } from 'generaltranslation/internal';
 import { createUnsupportedLocalesWarning } from '../errors/createErrors';
 import { NextRequest, NextResponse } from 'next/server';
@@ -20,6 +19,7 @@ import {
   getLocaleFromRequest,
   getResponse,
   ResponseConfig,
+  createLocaleResolver,
 } from './utils';
 import { defaultLocaleHeaderName } from '../utils/headers';
 import type { CustomMapping } from '@generaltranslation/format/types';
@@ -76,10 +76,7 @@ export function createNextMiddleware({
     }
   }
 
-  // gt instance
-  const gt = new GTRuntime({
-    customMapping: envParams?.customMapping,
-  });
+  const localeResolver = createLocaleResolver(envParams?.customMapping);
 
   // using gt services
   const gtServicesEnabled =
@@ -118,12 +115,14 @@ export function createNextMiddleware({
   const localeHeaderName =
     headersAndCookies?.localeHeaderName || defaultLocaleHeaderName;
 
-  if (!gt.isValidLocale(defaultLocale))
+  if (!localeResolver.isValidLocale(defaultLocale))
     throw new Error(
       `gt-next middleware: defaultLocale "${defaultLocale}" is not a valid locale.`
     );
 
-  const warningLocales = locales.filter((locale) => !gt.isValidLocale(locale));
+  const warningLocales = locales.filter(
+    (locale) => !localeResolver.isValidLocale(locale)
+  );
   if (warningLocales.length)
     console.warn(createUnsupportedLocalesWarning(warningLocales));
 
@@ -199,7 +198,7 @@ export function createNextMiddleware({
       referrerLocaleCookieName,
       localeCookieName,
       resetLocaleCookieName,
-      gt
+      localeResolver
     );
 
     const headerList = new Headers(req.headers);

--- a/packages/next/src/middleware-dir/utils.ts
+++ b/packages/next/src/middleware-dir/utils.ts
@@ -1,6 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { standardizeLocale } from '@generaltranslation/format';
-import { GTRuntime } from 'generaltranslation/runtime';
+import {
+  determineLocale,
+  isValidLocale,
+  resolveAliasLocale,
+  resolveCanonicalLocale,
+  standardizeLocale,
+} from '@generaltranslation/format';
+import type { CustomMapping } from '@generaltranslation/format/types';
 import { NextURL } from 'next/dist/server/web/next-url';
 import { parseAcceptLanguage } from 'gt-i18n/internal';
 
@@ -20,6 +26,45 @@ export type ResponseConfig = {
   resetLocaleCookieName: string;
   localeHeaderName: string;
 };
+
+export type LocaleResolver = {
+  determineLocale: (
+    locales: string | string[],
+    approvedLocales: string[]
+  ) => string | undefined;
+  isValidLocale: (locale: string) => boolean;
+  resolveAliasLocale: (locale: string) => string;
+};
+
+export function createLocaleResolver(
+  customMapping?: CustomMapping
+): LocaleResolver {
+  return {
+    determineLocale(locales, approvedLocales) {
+      const approvedLocalePairs = approvedLocales.map((locale) => ({
+        locale,
+        canonicalLocale: resolveCanonicalLocale(locale, customMapping),
+      }));
+      const resolvedLocale = determineLocale(
+        Array.isArray(locales)
+          ? locales.map((locale) =>
+              resolveCanonicalLocale(locale, customMapping)
+            )
+          : resolveCanonicalLocale(locales, customMapping),
+        approvedLocalePairs.map(({ canonicalLocale }) => canonicalLocale),
+        customMapping
+      );
+      if (!resolvedLocale) return undefined;
+      return (
+        approvedLocalePairs.find(
+          ({ canonicalLocale }) => canonicalLocale === resolvedLocale
+        )?.locale ?? resolveAliasLocale(resolvedLocale, customMapping)
+      );
+    },
+    isValidLocale: (locale) => isValidLocale(locale, customMapping),
+    resolveAliasLocale: (locale) => resolveAliasLocale(locale, customMapping),
+  };
+}
 
 const DYNAMIC_PATH_SEGMENT_PATTERN = '/[^/]+';
 const PATH_REGEX_SLASHES = /[\\/]/g;
@@ -277,7 +322,7 @@ export function getLocaleFromRequest(
   referrerLocaleCookieName: string,
   localeCookieName: string,
   resetLocaleCookieName: string,
-  gt: GTRuntime
+  localeResolver: LocaleResolver
 ): {
   userLocale: string;
   pathnameLocale: string | undefined;
@@ -299,15 +344,15 @@ export function getLocaleFromRequest(
 
     if (
       extractedLocale &&
-      gt.isValidLocale(extractedLocale) &&
-      gt.determineLocale([extractedLocale], approvedLocales)
+      localeResolver.isValidLocale(extractedLocale) &&
+      localeResolver.determineLocale([extractedLocale], approvedLocales)
     ) {
-      const determinedLocale = gt.determineLocale(
+      const determinedLocale = localeResolver.determineLocale(
         [extractedLocale],
         approvedLocales
       );
       if (determinedLocale) {
-        pathnameLocale = gt.resolveAliasLocale(determinedLocale);
+        pathnameLocale = localeResolver.resolveAliasLocale(determinedLocale);
         candidates.push(pathnameLocale);
       }
     }
@@ -325,7 +370,10 @@ export function getLocaleFromRequest(
 
   // Check cookie locale
   const cookieLocale = req.cookies.get(localeCookieName);
-  if (cookieLocale?.value && gt.isValidLocale(cookieLocale?.value)) {
+  if (
+    cookieLocale?.value &&
+    localeResolver.isValidLocale(cookieLocale?.value)
+  ) {
     const resetCookie = req.cookies.get(resetLocaleCookieName);
     if (resetCookie?.value) {
       // Add this back in when we support custom getLocale
@@ -343,11 +391,11 @@ export function getLocaleFromRequest(
   const referrerLocaleCookie = req.cookies.get(referrerLocaleCookieName);
   if (
     referrerLocaleCookie?.value &&
-    gt.isValidLocale(referrerLocaleCookie.value) &&
+    localeResolver.isValidLocale(referrerLocaleCookie.value) &&
     !clearResetCookie
   ) {
     const referrerLocale = referrerLocaleCookie.value;
-    if (gt.determineLocale([referrerLocale], approvedLocales)) {
+    if (localeResolver.determineLocale([referrerLocale], approvedLocales)) {
       candidates.push(referrerLocale);
     }
   }
@@ -362,8 +410,8 @@ export function getLocaleFromRequest(
 
   // determine userLocale
   const unstandardizedUserLocale =
-    gt.determineLocale(
-      candidates.filter((locale) => gt.isValidLocale(locale)),
+    localeResolver.determineLocale(
+      candidates.filter((locale) => localeResolver.isValidLocale(locale)),
       approvedLocales
     ) || defaultLocale;
   const userLocale = gtServicesEnabled

--- a/packages/next/src/middleware-dir/utils.ts
+++ b/packages/next/src/middleware-dir/utils.ts
@@ -33,7 +33,6 @@ export type LocaleResolver = {
     approvedLocales: string[]
   ) => string | undefined;
   isValidLocale: (locale: string) => boolean;
-  resolveAliasLocale: (locale: string) => string;
 };
 
 export function createLocaleResolver(
@@ -43,14 +42,16 @@ export function createLocaleResolver(
     determineLocale(locales, approvedLocales) {
       const approvedLocalePairs = approvedLocales.map((locale) => ({
         locale,
-        canonicalLocale: resolveCanonicalLocale(locale, customMapping),
+        canonicalLocale: standardizeLocale(
+          resolveCanonicalLocale(locale, customMapping)
+        ),
       }));
       const resolvedLocale = determineLocale(
         Array.isArray(locales)
           ? locales.map((locale) =>
-              resolveCanonicalLocale(locale, customMapping)
+              standardizeLocale(resolveCanonicalLocale(locale, customMapping))
             )
-          : resolveCanonicalLocale(locales, customMapping),
+          : standardizeLocale(resolveCanonicalLocale(locales, customMapping)),
         approvedLocalePairs.map(({ canonicalLocale }) => canonicalLocale),
         customMapping
       );
@@ -62,7 +63,6 @@ export function createLocaleResolver(
       );
     },
     isValidLocale: (locale) => isValidLocale(locale, customMapping),
-    resolveAliasLocale: (locale) => resolveAliasLocale(locale, customMapping),
   };
 }
 
@@ -342,19 +342,13 @@ export function getLocaleFromRequest(
       ? standardizeLocale(unstandardizedPathnameLocale || '')
       : unstandardizedPathnameLocale;
 
-    if (
-      extractedLocale &&
-      localeResolver.isValidLocale(extractedLocale) &&
-      localeResolver.determineLocale([extractedLocale], approvedLocales)
-    ) {
-      const determinedLocale = localeResolver.determineLocale(
-        [extractedLocale],
-        approvedLocales
-      );
-      if (determinedLocale) {
-        pathnameLocale = localeResolver.resolveAliasLocale(determinedLocale);
-        candidates.push(pathnameLocale);
-      }
+    const determinedLocale =
+      extractedLocale && localeResolver.isValidLocale(extractedLocale)
+        ? localeResolver.determineLocale([extractedLocale], approvedLocales)
+        : undefined;
+    if (determinedLocale) {
+      pathnameLocale = determinedLocale;
+      candidates.push(pathnameLocale);
     }
   }
 


### PR DESCRIPTION
## TL;DR

Remove GTRuntime from the gt-next Edge middleware dependency graph while preserving locale aliases and custom mappings.

## Code Changes

- Add a narrow locale resolver built from pure format helpers.
- Use it for validation, locale matching, and alias resolution in middleware.
- Add an Edge test for custom locale alias behavior.
- Add a patch changeset for gt-next.

## Notes / Flags

- Validation: 34 Edge tests, gt-next typecheck, dependency build, gt-next build:no-swc-plugin, oxlint, and oxfmt.
- Emitted middleware files contain no generaltranslation/runtime reference.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the heavy `GTRuntime` dependency from the Next.js Edge middleware by introducing a narrow `LocaleResolver` built entirely from pure `@generaltranslation/format` helpers, eliminating any runtime-bundle references in the emitted middleware output.

- **`createLocaleResolver`** in `utils.ts` encapsulates `determineLocale`, `isValidLocale`, alias resolution, and canonicalization; it fixes two previously flagged issues: canonical codes are now standardized on both sides of locale matching, and `determineLocale` is called once with the alias result returned directly (no `resolveAliasLocale` wrapper needed).
- **`createNextMiddleware.ts`** drops the `GTRuntime` import and wires `createLocaleResolver` in its place with no behavioral changes to validation or warning logic.
- **Edge test** adds a regression case for a lowercase `en-us` custom mapping entry resolving to the `pirate` alias, directly covering the canonicalization mismatch that was fixed.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a targeted dependency swap with no new public API surface.

The new createLocaleResolver correctly standardizes canonical codes on both sides of every comparison, calls determineLocale once per resolution path, and returns the alias locale directly without an extra wrapper call. The regression test covers the exact canonicalization edge case that was previously flagged. No behavioral changes to validation, warning, or routing logic were introduced.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/next/src/middleware-dir/utils.ts | Replaces GTRuntime with a lean LocaleResolver; previous double-call and canonicalization issues are resolved; alias mapping logic is correct. |
| packages/next/src/middleware-dir/createNextMiddleware.ts | Drops GTRuntime import; wires createLocaleResolver in its place; validation and locale warning logic unchanged. |
| packages/next/src/middleware-dir/__tests__/localeResolution.edge.test.ts | Migrates test helper to createLocaleResolver; adds regression test covering lowercase custom-mapping alias (pirate→en-us) to prevent canonicalization mismatch regression. |
| .changeset/light-middleware-runtime.md | Patch changeset entry for gt-next correctly scoped; no issues. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant MW as Next.js Middleware
    participant LR as LocaleResolver (new)
    participant FMT as @generaltranslation/format

    Note over MW: createNextMiddleware() init
    MW->>LR: createLocaleResolver(customMapping)
    LR-->>MW: "{ determineLocale, isValidLocale }"

    Note over MW: Per-request handling
    MW->>LR: isValidLocale(defaultLocale)
    LR->>FMT: isValidLocale(locale, customMapping)
    FMT-->>LR: boolean
    LR-->>MW: boolean

    MW->>LR: determineLocale([pathnameLocale], approvedLocales)
    LR->>FMT: resolveCanonicalLocale(locale, customMapping)
    FMT-->>LR: canonical (e.g. en-US for pirate)
    LR->>FMT: standardizeLocale(canonical)
    FMT-->>LR: standardized canonical
    LR->>FMT: determineLocale(canonicalLocales, approvedCanonicals, customMapping)
    FMT-->>LR: resolvedCanonical
    LR->>LR: approvedLocalePairs.find() to alias locale
    LR-->>MW: alias locale (e.g. pirate)
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(next): normalize middleware locale a..."](https://github.com/generaltranslation/gt/commit/1a367b2f784a08c6bfc093d21bd44bdeeab43e82) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46758924)</sub>

<!-- /greptile_comment -->