### PR TITLE
perf(next): split diagnostics by runtime

### DIFF
--- a/.changeset/split-next-diagnostics.md
+++ b/.changeset/split-next-diagnostics.md
@@ -1,0 +1,5 @@
+---
+'gt-next': patch
+---
+
+Split browser, request, middleware, and loader diagnostics into runtime-specific modules.

--- a/packages/next/src/__tests__/packageExports.test.ts
+++ b/packages/next/src/__tests__/packageExports.test.ts
@@ -52,6 +52,7 @@ describe('gt-next package exports', () => {
   });
 
   const distIt = existsSync(distInitGTServerPath) ? it : it.skip;
+  const distClientIt = existsSync(distClientPath) ? it : it.skip;
 
   distIt('keeps custom request functions visible to bundler aliases', () => {
     const serverBuild = readFileSync(distInitGTServerPath, 'utf8');
@@ -62,13 +63,16 @@ describe('gt-next package exports', () => {
     expect(serverBuild).not.toContain('serverRequire');
   });
 
-  distIt('keeps server diagnostics out of the client module graph', () => {
-    const clientModules = collectStaticModuleGraph(distClientPath);
+  distClientIt(
+    'keeps server diagnostics out of the client module graph',
+    () => {
+      const clientModules = collectStaticModuleGraph(distClientPath);
 
-    expect(clientModules).toContain('dist/errors/client.mjs');
-    expect(clientModules).toContain('dist/errors/request.mjs');
-    expect(clientModules).not.toContain('dist/errors/createErrors.mjs');
-  });
+      expect(clientModules).toContain('dist/errors/client.mjs');
+      expect(clientModules).toContain('dist/errors/request.mjs');
+      expect(clientModules).not.toContain('dist/errors/createErrors.mjs');
+    }
+  );
 
   distIt('initializes custom resolvers from the ESM server build', () => {
     const script = `

--- a/packages/next/src/__tests__/packageExports.test.ts
+++ b/packages/next/src/__tests__/packageExports.test.ts
@@ -1,11 +1,34 @@
 import { existsSync, readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { dirname, join, relative, resolve } from 'node:path';
 import { pathToFileURL, fileURLToPath } from 'node:url';
 import { spawnSync } from 'node:child_process';
 import { describe, expect, it } from 'vitest';
 
 const packageRoot = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
 const distInitGTServerPath = join(packageRoot, 'dist/setup/initGT.server.mjs');
+const distClientPath = join(packageRoot, 'dist/index.client.mjs');
+
+function collectStaticModuleGraph(entryPath: string): Set<string> {
+  const modules = new Set<string>();
+  const pending = [entryPath];
+  const relativeImportPattern =
+    /(?:from\s*|import\s*(?:\(\s*)?)["'](\.[^"']+)["']/g;
+
+  while (pending.length) {
+    const modulePath = pending.pop()!;
+    if (modules.has(modulePath) || !existsSync(modulePath)) continue;
+    modules.add(modulePath);
+
+    const source = readFileSync(modulePath, 'utf8');
+    for (const match of source.matchAll(relativeImportPattern)) {
+      pending.push(resolve(dirname(modulePath), match[1]));
+    }
+  }
+
+  return new Set(
+    [...modules].map((modulePath) => relative(packageRoot, modulePath))
+  );
+}
 
 describe('gt-next package exports', () => {
   it('uses RSC-specific declarations for the react-server condition', () => {
@@ -37,6 +60,14 @@ describe('gt-next package exports', () => {
     expect(serverBuild).toContain('gt-next/internal/_getRegion');
     expect(serverBuild).not.toContain('createRequire');
     expect(serverBuild).not.toContain('serverRequire');
+  });
+
+  distIt('keeps server diagnostics out of the client module graph', () => {
+    const clientModules = collectStaticModuleGraph(distClientPath);
+
+    expect(clientModules).toContain('dist/errors/client.mjs');
+    expect(clientModules).toContain('dist/errors/request.mjs');
+    expect(clientModules).not.toContain('dist/errors/createErrors.mjs');
   });
 
   distIt('initializes custom resolvers from the ESM server build', () => {

--- a/packages/next/src/errors/__tests__/createErrors.test.ts
+++ b/packages/next/src/errors/__tests__/createErrors.test.ts
@@ -1,12 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import {
-  withGTStaticPropsClientError,
-  withGTStaticPropsRscError,
-} from '../createErrors';
+import { createWithGTStaticPropsClientError } from '../client';
+import { withGTStaticPropsRscError } from '../createErrors';
 
 describe('withGTStaticProps errors', () => {
   it('provides an actionable browser diagnostic', () => {
-    expect(withGTStaticPropsClientError).toBe(
+    expect(createWithGTStaticPropsClientError()).toBe(
       'gt-next Error: withGTStaticProps() cannot run in the browser because static props are generated on the server by the Pages Router. Export withGTStaticProps() from a Pages Router page module.'
     );
   });

--- a/packages/next/src/errors/client.ts
+++ b/packages/next/src/errors/client.ts
@@ -1,0 +1,9 @@
+import { createGtNextDiagnostic } from './diagnostics';
+
+export const createWithGTStaticPropsClientError = () =>
+  createGtNextDiagnostic({
+    severity: 'Error',
+    whatHappened: 'withGTStaticProps() cannot run in the browser',
+    why: 'Static props are generated on the server by the Pages Router',
+    fix: 'Export withGTStaticProps() from a Pages Router page module',
+  });

--- a/packages/next/src/errors/createErrors.ts
+++ b/packages/next/src/errors/createErrors.ts
@@ -1,10 +1,8 @@
 // ---- ERRORS ---- //
 
-import { getLocaleProperties } from '@generaltranslation/format';
 import {
   createGtNextDiagnostic,
   createGtNextPluginDiagnostic,
-  formatDiagnosticErrorDetails,
 } from './diagnostics';
 import { BABEL_PLUGIN_SUPPORT, SWC_PLUGIN_SUPPORT } from '../plugin/constants';
 
@@ -58,20 +56,6 @@ export const createDictionarySubsetError = (id: string, functionName: string) =>
     fix: 'Make sure the id maps to the correct subroute of the dictionary',
   });
 
-export const unresolvedCustomLoadDictionaryError = createGtNextDiagnostic({
-  severity: 'Error',
-  whatHappened:
-    'loadDictionary() was found during the build but could not be resolved at runtime',
-  fix: 'Export a loadDictionary() function from the configured file',
-});
-
-export const unresolvedCustomLoadTranslationsError = createGtNextDiagnostic({
-  severity: 'Error',
-  whatHappened:
-    'loadTranslations() was found during the build but could not be resolved at runtime',
-  fix: 'Export a loadTranslations() function from the configured file',
-});
-
 export const unresolvedLoadDictionaryBuildError = (path: string) =>
   createGtNextDiagnostic({
     severity: 'Error',
@@ -106,13 +90,6 @@ export const getTranslationsSnapshotRscError = createGtNextDiagnostic({
   fix: 'Use gt-next build-time translation helpers in the App Router, or call getTranslationsSnapshot() from a Pages Router entry point',
 });
 
-export const withGTStaticPropsClientError = createGtNextDiagnostic({
-  severity: 'Error',
-  whatHappened: 'withGTStaticProps() cannot run in the browser',
-  why: 'Static props are generated on the server by the Pages Router',
-  fix: 'Export withGTStaticProps() from a Pages Router page module',
-});
-
 export const withGTStaticPropsRscError = createGtNextDiagnostic({
   severity: 'Error',
   whatHappened:
@@ -137,28 +114,6 @@ export const invalidCanonicalLocalesError = (locales: string[]) =>
     details: locales,
   });
 
-export const createInvalidRequestLocaleWarning = (
-  locale: string,
-  defaultLocale: string
-) =>
-  createGtNextDiagnostic({
-    severity: 'Warning',
-    whatHappened: `Locale "${locale}" is not valid or is not supported by this app`,
-    wayOut: `The default locale "${defaultLocale}" will be used for this request`,
-    fix: 'Use a valid BCP 47 locale code, add a custom mapping, or configure the locale in gt-next',
-  });
-
-export const createInvalidPathRegexError = (
-  pathRegex: string,
-  error: unknown
-) =>
-  createGtNextDiagnostic({
-    severity: 'Error',
-    whatHappened: `pathRegex "${pathRegex}" is not a valid regular expression`,
-    fix: 'Pass a valid JavaScript regular expression string to withGTConfig()',
-    details: formatDiagnosticErrorDetails(error),
-  });
-
 // ---- WARNINGS ---- //
 
 export const createBadFilepathWarning = (filename: string, dir: string[]) =>
@@ -166,14 +121,6 @@ export const createBadFilepathWarning = (filename: string, dir: string[]) =>
     whatHappened: `${filename} was found in ${dir.join(' or ')}, which is not supported`,
     fix: 'Move it to your project root so gt-next can load it',
   });
-
-export const createUnsupportedLocalesWarning = (locales: string[]) =>
-  `gt-next: The following locales are currently unsupported by our service: ${locales
-    .map((locale) => {
-      const { name } = getLocaleProperties(locale);
-      return `${locale} (${name})`;
-    })
-    .join(', ')}`;
 
 export const projectIdMissingWarn = createGtNextDiagnostic({
   whatHappened: 'Runtime translation needs a project ID',

--- a/packages/next/src/errors/loaders.ts
+++ b/packages/next/src/errors/loaders.ts
@@ -1,0 +1,17 @@
+import { createGtNextDiagnostic } from './diagnostics';
+
+export const createUnresolvedCustomLoadDictionaryError = () =>
+  createGtNextDiagnostic({
+    severity: 'Error',
+    whatHappened:
+      'loadDictionary() was found during the build but could not be resolved at runtime',
+    fix: 'Export a loadDictionary() function from the configured file',
+  });
+
+export const createUnresolvedCustomLoadTranslationsError = () =>
+  createGtNextDiagnostic({
+    severity: 'Error',
+    whatHappened:
+      'loadTranslations() was found during the build but could not be resolved at runtime',
+    fix: 'Export a loadTranslations() function from the configured file',
+  });

--- a/packages/next/src/errors/middleware.ts
+++ b/packages/next/src/errors/middleware.ts
@@ -1,0 +1,9 @@
+import { getLocaleProperties } from '@generaltranslation/format';
+
+export const createUnsupportedLocalesWarning = (locales: string[]) =>
+  `gt-next: The following locales are currently unsupported by our service: ${locales
+    .map((locale) => {
+      const { name } = getLocaleProperties(locale);
+      return `${locale} (${name})`;
+    })
+    .join(', ')}`;

--- a/packages/next/src/errors/pathRegex.ts
+++ b/packages/next/src/errors/pathRegex.ts
@@ -1,0 +1,15 @@
+import {
+  createGtNextDiagnostic,
+  formatDiagnosticErrorDetails,
+} from './diagnostics';
+
+export const createInvalidPathRegexError = (
+  pathRegex: string,
+  error: unknown
+) =>
+  createGtNextDiagnostic({
+    severity: 'Error',
+    whatHappened: `pathRegex "${pathRegex}" is not a valid regular expression`,
+    fix: 'Pass a valid JavaScript regular expression string to withGTConfig()',
+    details: formatDiagnosticErrorDetails(error),
+  });

--- a/packages/next/src/errors/request.ts
+++ b/packages/next/src/errors/request.ts
@@ -1,0 +1,12 @@
+import { createGtNextDiagnostic } from './diagnostics';
+
+export const createInvalidRequestLocaleWarning = (
+  locale: string,
+  defaultLocale: string
+) =>
+  createGtNextDiagnostic({
+    severity: 'Warning',
+    whatHappened: `Locale "${locale}" is not valid or is not supported by this app`,
+    wayOut: `The default locale "${defaultLocale}" will be used for this request`,
+    fix: 'Use a valid BCP 47 locale code, add a custom mapping, or configure the locale in gt-next',
+  });

--- a/packages/next/src/index.client.ts
+++ b/packages/next/src/index.client.ts
@@ -14,7 +14,7 @@ import type {
   WithGTStaticProps,
   WithGTStaticPropsFunction,
 } from './pages-dir/withGTStaticProps';
-import { withGTStaticPropsClientError } from './errors/createErrors';
+import { createWithGTStaticPropsClientError } from './errors/client';
 
 // ===== Unsupported Server APIs ===== //
 export function parseLocale<
@@ -39,7 +39,7 @@ export function withGTServerSideProps<
 }
 
 export const withGTStaticProps: WithGTStaticPropsFunction = () => {
-  throw new Error(withGTStaticPropsClientError);
+  throw new Error(createWithGTStaticPropsClientError());
 };
 
 // ===== Components ===== //

--- a/packages/next/src/middleware-dir/createNextMiddleware.ts
+++ b/packages/next/src/middleware-dir/createNextMiddleware.ts
@@ -1,7 +1,7 @@
 import { isSameDialect, standardizeLocale } from '@generaltranslation/format';
 import { GTRuntime } from 'generaltranslation/runtime';
 import { libraryDefaultLocale } from 'generaltranslation/internal';
-import { createUnsupportedLocalesWarning } from '../errors/createErrors';
+import { createUnsupportedLocalesWarning } from '../errors/middleware';
 import { NextRequest, NextResponse } from 'next/server';
 import {
   defaultLocaleRoutingEnabledCookieName,

--- a/packages/next/src/request/localeValidation.ts
+++ b/packages/next/src/request/localeValidation.ts
@@ -1,5 +1,5 @@
 import { getI18nConfig } from 'gt-i18n/internal';
-import { createInvalidRequestLocaleWarning } from '../errors/createErrors';
+import { createInvalidRequestLocaleWarning } from '../errors/request';
 
 function determineSupportedLocale(locale: unknown): string | undefined {
   if (typeof locale !== 'string' || locale.length === 0) return undefined;

--- a/packages/next/src/resolvers/resolveDictionaryLoader.ts
+++ b/packages/next/src/resolvers/resolveDictionaryLoader.ts
@@ -1,4 +1,4 @@
-import { unresolvedCustomLoadDictionaryError } from '../errors/createErrors';
+import { createUnresolvedCustomLoadDictionaryError } from '../errors/loaders';
 
 type CustomLoader = (locale: string) => Promise<unknown>;
 
@@ -29,6 +29,8 @@ export function resolveDictionaryLoader(): CustomLoader | undefined {
   if (!customLoadDictionary) {
     // So the custom loader doesnt eval to falsey
     customLoadDictionary = async (_: string) => undefined;
+    const unresolvedCustomLoadDictionaryError =
+      createUnresolvedCustomLoadDictionaryError();
 
     // Throw error in dev
     if (process.env.NODE_ENV !== 'production') {

--- a/packages/next/src/resolvers/resolveTranslationLoader.ts
+++ b/packages/next/src/resolvers/resolveTranslationLoader.ts
@@ -1,4 +1,4 @@
-import { unresolvedCustomLoadTranslationsError } from '../errors/createErrors';
+import { createUnresolvedCustomLoadTranslationsError } from '../errors/loaders';
 
 type CustomLoader = (locale: string) => Promise<unknown>;
 
@@ -29,6 +29,8 @@ export function resolveTranslationLoader(): CustomLoader | undefined {
   if (!customLoadTranslations) {
     // So the custom loader doesnt eval to falsey
     customLoadTranslations = async (_: string) => undefined;
+    const unresolvedCustomLoadTranslationsError =
+      createUnresolvedCustomLoadTranslationsError();
 
     // Throw error in dev
     if (process.env.NODE_ENV !== 'production') {

--- a/packages/next/src/utils/pathRegex.ts
+++ b/packages/next/src/utils/pathRegex.ts
@@ -1,4 +1,4 @@
-import { createInvalidPathRegexError } from '../errors/createErrors';
+import { createInvalidPathRegexError } from '../errors/pathRegex';
 
 export function compilePathRegex(pathRegex?: string): RegExp | undefined {
   if (pathRegex === undefined) return undefined;


### PR DESCRIPTION
## TL;DR

Keep unrelated server diagnostics and dependencies out of gt-next client and middleware module graphs.

## Code Changes

- Split client, loader, request, path-regex, and middleware diagnostics into focused modules.
- Defer construction of client and loader diagnostics until their error paths run.
- Add a generated-module-graph assertion that the broad createErrors module is unreachable from the client entry.
- Add a patch changeset for gt-next.

## Notes / Flags

- Validation: gt-next typecheck, dependency build, gt-next build:no-swc-plugin, 28 focused tests, oxlint, and oxfmt.
- The remaining broad diagnostics artifact shrank from 10.35 kB to 8.30 kB and is absent from the client graph.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR splits the monolithic `createErrors.ts` diagnostics module into five focused, runtime-specific modules (`client.ts`, `request.ts`, `middleware.ts`, `pathRegex.ts`, `loaders.ts`) to keep heavy server-side dependencies (notably `@generaltranslation/format`) out of the client and middleware module graphs. It also defers error-string construction inside the resolver files to the point of error, and adds a static module-graph assertion to guard against future regressions.

- **New focused error modules**: `errors/client`, `errors/request`, `errors/middleware`, `errors/pathRegex`, and `errors/loaders` each carry only the diagnostics needed for their runtime, removing the `getLocaleProperties` import from `createErrors.ts` and reducing the client-bundled artifact.
- **Deferred construction in resolvers**: `resolveDictionaryLoader` and `resolveTranslationLoader` now compute the error string only when the error path is actually hit, rather than eagerly at module evaluation time.
- **Regression guard**: A new `collectStaticModuleGraph` crawler test asserts that `dist/errors/client.mjs` and `dist/errors/request.mjs` remain reachable from the client entry while `dist/errors/createErrors.mjs` is not.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a pure refactor that moves diagnostics between files without altering any runtime logic or public API.

All call sites are updated consistently, the new factory functions return the same strings as the old eager constants, and the module-graph regression test correctly guards the core invariant. The deferred construction in the resolver files preserves identical throw/console behaviour.

The collectStaticModuleGraph crawler in packageExports.test.ts silently skips any module whose dist import specifier lacks a .mjs extension; worth keeping in mind if the build config ever changes.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/next/src/__tests__/packageExports.test.ts | Adds collectStaticModuleGraph crawler and distClientIt guard; the regex only matches relative imports with explicit extensions, which is correct for bundled .mjs output but would silently miss modules if the bundler emits extension-less specifiers. |
| packages/next/src/errors/client.ts | New focused module exposing createWithGTStaticPropsClientError(); clean split from createErrors.ts. |
| packages/next/src/errors/loaders.ts | New focused module for dictionary/translation loader diagnostics; factories correctly replace the old eager constants. |
| packages/next/src/errors/middleware.ts | Extracts createUnsupportedLocalesWarning (with @generaltranslation/format dependency) into its own module, keeping it out of client graph. |
| packages/next/src/errors/pathRegex.ts | Extracts createInvalidPathRegexError into a standalone module; clean refactor. |
| packages/next/src/errors/request.ts | Extracts createInvalidRequestLocaleWarning into its own module; correctly imported by localeValidation.ts which is reachable from the client entry. |
| packages/next/src/errors/createErrors.ts | Removes moved symbols and their now-unused imports; remaining server-only diagnostics stay here. |
| packages/next/src/resolvers/resolveDictionaryLoader.ts | Defers error string construction into the error branch; logic and singleton pattern unchanged. |
| packages/next/src/resolvers/resolveTranslationLoader.ts | Same deferred-construction pattern as resolveDictionaryLoader.ts; clean change. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[index.client.ts] -->|imports| B[errors/client.ts]
    A -->|re-exports isLocaleSupported| C[request/localeValidation.ts]
    C -->|imports| D[errors/request.ts]
    B --> DIAG[errors/diagnostics.ts]
    D --> DIAG
    E[middleware-dir/createNextMiddleware.ts] -->|imports| F[errors/middleware.ts]
    G[utils/pathRegex.ts] -->|imports| H[errors/pathRegex.ts]
    H --> DIAG
    I[resolvers/resolveDictionaryLoader.ts] -->|imports| J[errors/loaders.ts]
    K[resolvers/resolveTranslationLoader.ts] -->|imports| J
    J --> DIAG
    CRERR[errors/createErrors.ts - NOT in client graph] --> DIAG
    style A fill:#4ade80,color:#000
    style CRERR fill:#f87171,color:#000
    style DIAG fill:#60a5fa,color:#000
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test(next): guard client artifact checks"](https://github.com/generaltranslation/gt/commit/8d2cae3148f3003baa6c3ab9791f6ac4ad379fbf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46758925)</sub>

<!-- /greptile_comment -->