### PR TITLE
perf(react): lazy-load development translation cache

### DIFF
--- a/.changeset/lazy-dev-cache.md
+++ b/.changeset/lazy-dev-cache.md
@@ -1,0 +1,5 @@
+---
+'gt-react': patch
+---
+
+Lazy-load the development-only localStorage translation cache from the browser entrypoint.

--- a/packages/react/src/__tests__/react-package.test.ts
+++ b/packages/react/src/__tests__/react-package.test.ts
@@ -197,7 +197,7 @@ describe('gt-react package exports', () => {
     const runtimeArtifacts = readdirSync(join(packageRoot, 'dist')).filter(
       (file) => /\.(cjs|mjs)$/.test(file)
     );
-    expect(runtimeArtifacts.filter((file) => !file.includes('-'))).toEqual(
+    expect(runtimeArtifacts).toEqual(
       expect.arrayContaining(runtimeArtifactNames)
     );
 

--- a/packages/react/src/__tests__/react-package.test.ts
+++ b/packages/react/src/__tests__/react-package.test.ts
@@ -193,12 +193,30 @@ describe('gt-react package exports', () => {
     }
   });
 
-  it('emits independent runtime entrypoints without shared chunks', () => {
-    expect(
-      readdirSync(join(packageRoot, 'dist'))
-        .filter((file) => /\.(cjs|mjs)$/.test(file))
-        .sort()
-    ).toEqual(runtimeArtifactNames);
+  it('keeps the dev-only localStorage cache out of the initial client entrypoint', () => {
+    const runtimeArtifacts = readdirSync(join(packageRoot, 'dist')).filter(
+      (file) => /\.(cjs|mjs)$/.test(file)
+    );
+    expect(runtimeArtifacts.filter((file) => !file.includes('-'))).toEqual(
+      expect.arrayContaining(runtimeArtifactNames)
+    );
+
+    const clientEntries = ['dist/index.client.cjs', 'dist/index.client.mjs'];
+    for (const file of clientEntries) {
+      expect(readFileSync(join(packageRoot, file), 'utf8')).not.toContain(
+        'gt:tx:'
+      );
+    }
+
+    const cacheChunks = runtimeArtifacts.filter((file) =>
+      file.startsWith('LocalStorageTranslationCache-')
+    );
+    expect(cacheChunks).toHaveLength(2);
+    for (const file of cacheChunks) {
+      expect(readFileSync(join(packageRoot, 'dist', file), 'utf8')).toContain(
+        'gt:tx:'
+      );
+    }
   });
 
   it('bundles workspace subpath imports in runtime artifacts', () => {

--- a/packages/react/src/i18n-cache/BrowserI18nCache.ts
+++ b/packages/react/src/i18n-cache/BrowserI18nCache.ts
@@ -2,16 +2,22 @@ import type {
   I18nCacheConstructorParams,
   TranslationsLoader,
 } from 'gt-i18n/internal/types';
-import {
-  getI18nConfig,
-  getRuntimeEnvironment,
-  I18nCache,
-} from 'gt-i18n/internal';
+import { getI18nConfig, I18nCache } from 'gt-i18n/internal';
 import type { HtmlTagOptions } from './types';
 import type { Translation } from 'gt-i18n/types';
 import { DEFAULT_HTML_TAG_OPTIONS } from './constants';
-import { LocalStorageTranslationCache } from './LocalStorageTranslationCache';
 import { createDiagnosticMessage } from 'generaltranslation/internal';
+
+type LocalStorageTranslationCache =
+  import('./LocalStorageTranslationCache').LocalStorageTranslationCache;
+type LocalStorageCachePromises = Record<
+  string,
+  Promise<LocalStorageTranslationCache>
+>;
+
+let localStorageCacheModulePromise:
+  | Promise<typeof import('./LocalStorageTranslationCache')>
+  | undefined;
 
 /**
  * The configuration for the BrowserI18nCache
@@ -27,16 +33,13 @@ export class BrowserI18nCache extends I18nCache<Translation> {
   /** Customize browser-related behavior */
   private htmlTagOptions?: HtmlTagOptions;
 
-  /** Per-locale localStorage translation caches (dev mode only) */
-  private _localStorageCaches!: Record<string, LocalStorageTranslationCache>;
-
   /** Whether dev hot reload JSX (Suspense-based <T>) is active */
   private _devHotReloadJsx = false;
 
   constructor(config: BrowserI18nCacheParams) {
     // Must be initialized before super()
     const { htmlTagOptions, ...managerConfig } = config;
-    const localStorageCaches: Record<string, LocalStorageTranslationCache> = {};
+    const localStorageCaches: LocalStorageCachePromises = {};
     const i18nConfig = getI18nConfig();
     const devHotReloadEnabled =
       !!config.loadTranslations && i18nConfig.isDevHotReloadEnabled();
@@ -55,7 +58,6 @@ export class BrowserI18nCache extends I18nCache<Translation> {
       loadTranslations,
     });
 
-    this._localStorageCaches = localStorageCaches;
     this._devHotReloadJsx = devHotReloadEnabled;
 
     this.htmlTagOptions = {
@@ -66,16 +68,11 @@ export class BrowserI18nCache extends I18nCache<Translation> {
     // For dev hot reload, we need to write the translations to the localStorage cache
     if (devHotReloadEnabled) {
       this.onTranslationsCacheMiss = ({ locale, hash, translation }) => {
-        const cache = localStorageCaches[locale];
-        if (cache) {
-          cache.write(hash, translation);
-        } else {
-          localStorageCaches[locale] = new LocalStorageTranslationCache({
-            locale,
-            projectId,
-            init: { [hash]: translation },
-          });
-        }
+        void getOrCreateLocalStorageCache(localStorageCaches, {
+          locale,
+          projectId,
+          init: { [hash]: translation },
+        }).then((cache) => cache.write(hash, translation));
       };
     }
   }
@@ -85,27 +82,6 @@ export class BrowserI18nCache extends I18nCache<Translation> {
    */
   isDevHotReloadJsx(): boolean {
     return this._devHotReloadJsx;
-  }
-
-  /**
-   * Get or create a LocalStorageTranslationCache for the given locale.
-   * Instances are lazily created and cached per locale.
-   * Returns undefined if not in development mode.
-   */
-  getLocalStorageTranslationCache(
-    locale: string,
-    init?: Record<string, Translation>
-  ): LocalStorageTranslationCache | undefined {
-    if (getRuntimeEnvironment() !== 'development') return undefined;
-
-    if (!this._localStorageCaches[locale]) {
-      this._localStorageCaches[locale] = new LocalStorageTranslationCache({
-        locale,
-        projectId: this.config.projectId!,
-        init,
-      });
-    }
-    return this._localStorageCaches[locale];
   }
 
   /**
@@ -161,17 +137,36 @@ export class BrowserI18nCache extends I18nCache<Translation> {
 function wrapLoaderWithLocalStorage(
   originalLoader: TranslationsLoader,
   projectId: string,
-  localStorageCaches: Record<string, LocalStorageTranslationCache>
+  localStorageCaches: LocalStorageCachePromises
 ) {
   return async (locale: string) => {
     const loaderTranslations = await originalLoader(locale);
-    localStorageCaches[locale] ||= new LocalStorageTranslationCache({
+    const cache = await getOrCreateLocalStorageCache(localStorageCaches, {
       locale,
       projectId,
       init: loaderTranslations as Record<string, Translation>,
     });
-    return localStorageCaches[locale].getInternalCache();
+    return cache.getInternalCache();
   };
+}
+
+function getOrCreateLocalStorageCache(
+  localStorageCaches: LocalStorageCachePromises,
+  params: {
+    locale: string;
+    projectId: string;
+    init?: Record<string, Translation>;
+  }
+): Promise<LocalStorageTranslationCache> {
+  return (localStorageCaches[params.locale] ||= loadLocalStorageCache().then(
+    ({ LocalStorageTranslationCache }) =>
+      new LocalStorageTranslationCache(params)
+  ));
+}
+
+function loadLocalStorageCache() {
+  return (localStorageCacheModulePromise ??=
+    import('./LocalStorageTranslationCache'));
 }
 
 const createInvalidLocaleWarning = (locale: string) =>

--- a/packages/react/src/i18n-cache/BrowserI18nCache.ts
+++ b/packages/react/src/i18n-cache/BrowserI18nCache.ts
@@ -15,6 +15,7 @@ type LocalStorageCachePromises = Record<
   Promise<LocalStorageTranslationCache>
 >;
 
+// Share one lazy module import across all BrowserI18nCache instances.
 let localStorageCacheModulePromise:
   | Promise<typeof import('./LocalStorageTranslationCache')>
   | undefined;
@@ -157,6 +158,7 @@ function getOrCreateLocalStorageCache(
     init?: Record<string, Translation>;
   }
 ): Promise<LocalStorageTranslationCache> {
+  // Cache the promise before awaiting it so concurrent calls for a locale share one instance.
   return (localStorageCaches[params.locale] ||= loadLocalStorageCache().then(
     ({ LocalStorageTranslationCache }) =>
       new LocalStorageTranslationCache(params)

--- a/packages/react/src/i18n-cache/BrowserI18nCache.ts
+++ b/packages/react/src/i18n-cache/BrowserI18nCache.ts
@@ -15,7 +15,8 @@ type LocalStorageCachePromises = Record<
   Promise<LocalStorageTranslationCache>
 >;
 
-// Share one lazy module import across all BrowserI18nCache instances.
+// Lazily import the development-only cache so bundlers can keep it out of the initial client chunk.
+// `??=` saves the first import promise, so all cache instances reuse the same lazy module load.
 let localStorageCacheModulePromise:
   | Promise<typeof import('./LocalStorageTranslationCache')>
   | undefined;
@@ -158,7 +159,7 @@ function getOrCreateLocalStorageCache(
     init?: Record<string, Translation>;
   }
 ): Promise<LocalStorageTranslationCache> {
-  // Cache the promise before awaiting it so concurrent calls for a locale share one instance.
+  // `||=` saves the first promise for this locale, so concurrent calls reuse one cache instance.
   return (localStorageCaches[params.locale] ||= loadLocalStorageCache().then(
     ({ LocalStorageTranslationCache }) =>
       new LocalStorageTranslationCache(params)

--- a/packages/react/src/i18n-cache/BrowserI18nCache.ts
+++ b/packages/react/src/i18n-cache/BrowserI18nCache.ts
@@ -71,7 +71,6 @@ export class BrowserI18nCache extends I18nCache<Translation> {
         void getOrCreateLocalStorageCache(localStorageCaches, {
           locale,
           projectId,
-          init: { [hash]: translation },
         }).then((cache) => cache.write(hash, translation));
       };
     }


### PR DESCRIPTION
## TL;DR

Move the development-only localStorage translation cache out of the initial gt-react browser entry.

## Code Changes

- Replace the static cache import with a memoized dynamic import.
- Memoize per-locale cache promises to prevent duplicate initialization.
- Remove the unused synchronous cache accessor that forced static loading.
- Add package-output assertions and a patch changeset for gt-react.

## Notes / Flags

- Validation: gt-react typecheck, build, 11 package export tests, oxlint, and oxfmt.
- The ESM client entry dropped from about 30.0 kB to 23.2 kB; the cache is emitted as a separate 6.7 kB development-only chunk.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR lazy-loads the development-only `LocalStorageTranslationCache` from the browser entry point by replacing a static import with a memoized dynamic `import()`, cutting the initial client ESM bundle from ~30 kB to ~23 kB and emitting the cache as a separate ~6.7 kB chunk.

- **`BrowserI18nCache.ts`**: Per-locale cache entries are now `Promise<LocalStorageTranslationCache>` instead of synchronous instances; a module-level memoized promise (`localStorageCacheModulePromise`) ensures the chunk is fetched once across all instances; the synchronous `getLocalStorageTranslationCache` method (which forced the static import) is removed.
- **`react-package.test.ts`**: The artifact-list assertion is updated to use `arrayContaining` and a new content-inspection test verifies that `gt:tx:` does not appear in the initial client bundles but does appear in exactly two lazily-emitted cache chunks.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is dev-only and restricted to the localStorage cache path, with no impact on production bundles.

The refactoring correctly converts a static import to a memoized dynamic import. The async promise-per-locale design preserves the existing first-write semantics, the synchronous accessor that forced eager loading is cleanly removed, and the updated test verifies both the bundle-content invariant and the chunk-count expectation. No logic regressions were found.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react/src/i18n-cache/BrowserI18nCache.ts | Static LocalStorageTranslationCache import replaced with memoized dynamic import; per-locale caches are now promises; synchronous getLocalStorageTranslationCache removed. Logic is consistent with the previous synchronous behavior. |
| packages/react/src/__tests__/react-package.test.ts | Test updated to assert lazy-loading: verifies gt:tx: is absent from initial client bundles and present in exactly two named cache chunks; uses arrayContaining to tolerate additional build artifacts. |
| .changeset/lazy-dev-cache.md | Patch changeset for gt-react describing the lazy-load optimization. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant App as Browser App
    participant BIC as BrowserI18nCache
    participant Mod as LocalStorageTranslationCache<br/>(lazy chunk)
    participant LS as localStorage

    App->>BIC: new BrowserI18nCache(config)
    Note over BIC: devHotReloadEnabled=true<br/>localStorageCaches = {}

    App->>BIC: loadTranslations("en")
    BIC->>BIC: wrapLoaderWithLocalStorage("en")
    BIC->>BIC: await originalLoader("en") → loaderTranslations
    BIC->>Mod: "import('./LocalStorageTranslationCache')<br/>(first call: fetches chunk)"
    Mod-->>BIC: module (memoized for future calls)
    BIC->>Mod: "new LocalStorageTranslationCache({locale, projectId, init: loaderTranslations})"
    Mod->>LS: initStorage(loaderTranslations)
    BIC->>Mod: getInternalCache()
    Mod->>LS: read
    Mod-->>BIC: merged translations
    BIC-->>App: merged translations

    App->>BIC: "onTranslationsCacheMiss({locale, hash, translation})"
    BIC->>BIC: getOrCreateLocalStorageCache (reuses existing promise)
    BIC->>Mod: cache.write(hash, translation)
    Mod->>LS: debounced flush (500ms)
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(react): avoid duplicate cache writes"](https://github.com/generaltranslation/gt/commit/2c4b26c83ed7c7ae58836b885064618bb086e8bb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46758928)</sub>

<!-- /greptile_comment -->