### PR TITLE
perf(next): keep server config out of client bundles

### DIFF
--- a/.changeset/calm-clients-trim.md
+++ b/.changeset/calm-clients-trim.md
@@ -1,0 +1,5 @@
+---
+'gt-next': patch
+---
+
+Stop inlining server-only configuration and arbitrary metadata into client bundles.

--- a/packages/next/src/__tests__/config.test.ts
+++ b/packages/next/src/__tests__/config.test.ts
@@ -1189,7 +1189,6 @@ describe('withGTConfig', () => {
 
       const expectedKeys = [
         '_GENERALTRANSLATION_I18N_CONFIG_PARAMS',
-        '_GENERALTRANSLATION_CLIENT_I18N_CONFIG_PARAMS',
         '_GENERALTRANSLATION_LOCAL_DICTIONARY_ENABLED',
         '_GENERALTRANSLATION_LOCAL_TRANSLATION_ENABLED',
         '_GENERALTRANSLATION_DEFAULT_LOCALE',
@@ -1254,14 +1253,21 @@ describe('withGTConfig', () => {
           description: 'server-only description',
           loadTranslationsPath: './server-only-loader.ts',
           customMetadata: 'server-only metadata',
+          cacheExpiryTime: 12345,
+          _versionId: 'version-id',
+          _disableDevHotReload: true,
         }
       );
 
       const clientConfig = JSON.parse(
-        result.env!._GENERALTRANSLATION_CLIENT_I18N_CONFIG_PARAMS!
+        result.env!.NEXT_PUBLIC_GENERALTRANSLATION_I18N_CONFIG_PARAMS!
       );
-      expect(clientConfig).toMatchObject({
+      expect(clientConfig).toEqual({
+        defaultLocale: expect.any(String),
+        locales: expect.any(Array),
+        runtimeUrl: expect.any(String),
         cacheUrl: expect.any(String),
+        cacheExpiryTime: 12345,
         maxConcurrentRequests: expect.any(Number),
         maxBatchSize: expect.any(Number),
         batchInterval: expect.any(Number),
@@ -1270,11 +1276,9 @@ describe('withGTConfig', () => {
           localeCookieName: expect.any(String),
           enableI18nCookieName: expect.any(String),
         },
+        _versionId: 'version-id',
+        _disableDevHotReload: true,
       });
-      expect(clientConfig).not.toHaveProperty('description');
-      expect(clientConfig).not.toHaveProperty('loadTranslationsPath');
-      expect(clientConfig).not.toHaveProperty('customMetadata');
-      expect(clientConfig).not.toHaveProperty('experimentalCompilerOptions');
     });
 
     it('boolean flags are string "true"/"false", not booleans', async () => {

--- a/packages/next/src/__tests__/config.test.ts
+++ b/packages/next/src/__tests__/config.test.ts
@@ -1189,6 +1189,7 @@ describe('withGTConfig', () => {
 
       const expectedKeys = [
         '_GENERALTRANSLATION_I18N_CONFIG_PARAMS',
+        '_GENERALTRANSLATION_CLIENT_I18N_CONFIG_PARAMS',
         '_GENERALTRANSLATION_LOCAL_DICTIONARY_ENABLED',
         '_GENERALTRANSLATION_LOCAL_TRANSLATION_ENABLED',
         '_GENERALTRANSLATION_DEFAULT_LOCALE',
@@ -1240,6 +1241,40 @@ describe('withGTConfig', () => {
       expect(parsed.projectId).toBeUndefined();
       expect(parsed.apiKey).toBeUndefined();
       expect(parsed.devApiKey).toBeUndefined();
+    });
+
+    it('limits client config params to runtime fields', async () => {
+      const withGTConfig = await getWithGTConfig();
+      vi.mocked(fs.existsSync).mockImplementation((filepath) =>
+        String(filepath).endsWith('server-only-loader.ts')
+      );
+      const result = withGTConfig(
+        {},
+        {
+          description: 'server-only description',
+          loadTranslationsPath: './server-only-loader.ts',
+          customMetadata: 'server-only metadata',
+        }
+      );
+
+      const clientConfig = JSON.parse(
+        result.env!._GENERALTRANSLATION_CLIENT_I18N_CONFIG_PARAMS!
+      );
+      expect(clientConfig).toMatchObject({
+        cacheUrl: expect.any(String),
+        maxConcurrentRequests: expect.any(Number),
+        maxBatchSize: expect.any(Number),
+        batchInterval: expect.any(Number),
+        renderSettings: { timeout: expect.any(Number) },
+        headersAndCookies: {
+          localeCookieName: expect.any(String),
+          enableI18nCookieName: expect.any(String),
+        },
+      });
+      expect(clientConfig).not.toHaveProperty('description');
+      expect(clientConfig).not.toHaveProperty('loadTranslationsPath');
+      expect(clientConfig).not.toHaveProperty('customMetadata');
+      expect(clientConfig).not.toHaveProperty('experimentalCompilerOptions');
     });
 
     it('boolean flags are string "true"/"false", not booleans', async () => {

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -605,6 +605,23 @@ export function withGTConfig<TNextConfig extends object = NextConfig>(
     customMapping: mergedConfig.customMapping,
     runtimeUrl: mergedConfig.runtimeUrl,
   };
+  const clientI18NConfigParams = {
+    cacheUrl: mergedConfig.cacheUrl,
+    cacheExpiryTime: mergedConfig.cacheExpiryTime,
+    maxConcurrentRequests: mergedConfig.maxConcurrentRequests,
+    maxBatchSize: mergedConfig.maxBatchSize,
+    batchInterval: mergedConfig.batchInterval,
+    renderSettings: {
+      timeout: mergedConfig.renderSettings?.timeout,
+    },
+    headersAndCookies: {
+      localeCookieName: mergedConfig.headersAndCookies?.localeCookieName,
+      enableI18nCookieName:
+        mergedConfig.headersAndCookies?.enableI18nCookieName,
+    },
+    _versionId: mergedConfig._versionId,
+    _disableDevHotReload: mergedConfig._disableDevHotReload,
+  };
 
   const { type: _type, ...compilerOptions } =
     mergedConfig.experimentalCompilerOptions || {};
@@ -667,6 +684,9 @@ export function withGTConfig<TNextConfig extends object = NextConfig>(
       _GENERALTRANSLATION_I18N_CONFIG_PARAMS: I18NConfigParams,
       NEXT_PUBLIC_GENERALTRANSLATION_I18N_CONFIG_PARAMS: JSON.stringify(
         publicI18NConfigParams
+      ),
+      _GENERALTRANSLATION_CLIENT_I18N_CONFIG_PARAMS: JSON.stringify(
+        clientI18NConfigParams
       ),
       ...(resolvedDictionaryFilePathType && {
         _GENERALTRANSLATION_DICTIONARY_FILE_TYPE:

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -45,7 +45,6 @@ import {
   cacheComponentsDevHotReloadDisabledWarning,
   cacheComponentsMissingLoadTranslationsError,
 } from './errors/cacheComponents';
-import { I18nConfigParams } from 'gt-i18n/internal/types';
 import { getRuntimeCredentials } from './setup/runtimeCredentials';
 
 type AutoderiveConfig = boolean | { jsx?: boolean; strings?: boolean };
@@ -596,16 +595,11 @@ export function withGTConfig<TNextConfig extends object = NextConfig>(
     ...privateConfigParams
   } = mergedConfig;
   const I18NConfigParams = JSON.stringify(privateConfigParams);
-  const publicI18NConfigParams: Omit<
-    I18nConfigParams,
-    'projectId' | 'devApiKey' | 'apiKey'
-  > = {
+  const clientI18NConfigParams = {
     defaultLocale: mergedConfig.defaultLocale,
     locales: mergedConfig.locales,
     customMapping: mergedConfig.customMapping,
     runtimeUrl: mergedConfig.runtimeUrl,
-  };
-  const clientI18NConfigParams = {
     cacheUrl: mergedConfig.cacheUrl,
     cacheExpiryTime: mergedConfig.cacheExpiryTime,
     maxConcurrentRequests: mergedConfig.maxConcurrentRequests,
@@ -683,9 +677,6 @@ export function withGTConfig<TNextConfig extends object = NextConfig>(
       ...internalNextConfig.env,
       _GENERALTRANSLATION_I18N_CONFIG_PARAMS: I18NConfigParams,
       NEXT_PUBLIC_GENERALTRANSLATION_I18N_CONFIG_PARAMS: JSON.stringify(
-        publicI18NConfigParams
-      ),
-      _GENERALTRANSLATION_CLIENT_I18N_CONFIG_PARAMS: JSON.stringify(
         clientI18NConfigParams
       ),
       ...(resolvedDictionaryFilePathType && {

--- a/packages/next/src/setup/__tests__/shared.test.ts
+++ b/packages/next/src/setup/__tests__/shared.test.ts
@@ -9,29 +9,28 @@ function setConfigEnv() {
       defaultLocale: 'en',
       locales: ['en', 'fr'],
       runtimeUrl: 'https://runtime.example.com',
+      cacheUrl: 'https://cache.example.com',
+      renderSettings: { timeout: 123 },
+      headersAndCookies: {
+        localeCookieName: 'custom-locale',
+        enableI18nCookieName: 'custom-enable-i18n',
+      },
+      maxConcurrentRequests: 1,
+      maxBatchSize: 2,
+      batchInterval: 3,
+      cacheExpiryTime: 12345,
+      _versionId: 'version-id',
     });
-  process.env._GENERALTRANSLATION_CLIENT_I18N_CONFIG_PARAMS = JSON.stringify({
-    cacheUrl: 'https://cache.example.com',
-    renderSettings: { timeout: 123 },
-    headersAndCookies: {
-      localeCookieName: 'custom-locale',
-      enableI18nCookieName: 'custom-enable-i18n',
-    },
-    maxConcurrentRequests: 1,
-    maxBatchSize: 2,
-    batchInterval: 3,
-    cacheExpiryTime: 12345,
-    _versionId: 'version-id',
-  });
 }
 
-function updatePrivateConfig(config: Record<string, unknown>) {
-  process.env._GENERALTRANSLATION_CLIENT_I18N_CONFIG_PARAMS = JSON.stringify({
-    ...JSON.parse(
-      process.env._GENERALTRANSLATION_CLIENT_I18N_CONFIG_PARAMS || '{}'
-    ),
-    ...config,
-  });
+function updateClientConfig(config: Record<string, unknown>) {
+  process.env.NEXT_PUBLIC_GENERALTRANSLATION_I18N_CONFIG_PARAMS =
+    JSON.stringify({
+      ...JSON.parse(
+        process.env.NEXT_PUBLIC_GENERALTRANSLATION_I18N_CONFIG_PARAMS || '{}'
+      ),
+      ...config,
+    });
 }
 
 describe('getParams', () => {
@@ -81,10 +80,8 @@ describe('getParams', () => {
   });
 
   it('lets the i18n cache choose the remote translation loader', () => {
-    updatePrivateConfig({
-      _cacheComponentsEnabled: true,
+    updateClientConfig({
       _disableDevHotReload: true,
-      loadTranslationsType: 'remote',
       cacheExpiryTime: 0,
     });
 

--- a/packages/next/src/setup/__tests__/shared.test.ts
+++ b/packages/next/src/setup/__tests__/shared.test.ts
@@ -10,7 +10,7 @@ function setConfigEnv() {
       locales: ['en', 'fr'],
       runtimeUrl: 'https://runtime.example.com',
     });
-  process.env._GENERALTRANSLATION_I18N_CONFIG_PARAMS = JSON.stringify({
+  process.env._GENERALTRANSLATION_CLIENT_I18N_CONFIG_PARAMS = JSON.stringify({
     cacheUrl: 'https://cache.example.com',
     renderSettings: { timeout: 123 },
     headersAndCookies: {
@@ -26,8 +26,10 @@ function setConfigEnv() {
 }
 
 function updatePrivateConfig(config: Record<string, unknown>) {
-  process.env._GENERALTRANSLATION_I18N_CONFIG_PARAMS = JSON.stringify({
-    ...JSON.parse(process.env._GENERALTRANSLATION_I18N_CONFIG_PARAMS || '{}'),
+  process.env._GENERALTRANSLATION_CLIENT_I18N_CONFIG_PARAMS = JSON.stringify({
+    ...JSON.parse(
+      process.env._GENERALTRANSLATION_CLIENT_I18N_CONFIG_PARAMS || '{}'
+    ),
     ...config,
   });
 }

--- a/packages/next/src/setup/shared.ts
+++ b/packages/next/src/setup/shared.ts
@@ -17,8 +17,8 @@ export function getParams(): {
   const publicConfig = JSON.parse(
     process.env.NEXT_PUBLIC_GENERALTRANSLATION_I18N_CONFIG_PARAMS || '{}'
   );
-  const privateConfig = JSON.parse(
-    process.env._GENERALTRANSLATION_I18N_CONFIG_PARAMS || '{}'
+  const clientConfig = JSON.parse(
+    process.env._GENERALTRANSLATION_CLIENT_I18N_CONFIG_PARAMS || '{}'
   );
   const { projectId, devApiKey, apiKey } = getRuntimeCredentials();
 
@@ -31,27 +31,27 @@ export function getParams(): {
     projectId,
     devApiKey,
     apiKey,
-    cacheUrl: privateConfig.cacheUrl,
-    _disableDevHotReload: privateConfig._disableDevHotReload,
-    localeCookieName: privateConfig.headersAndCookies?.localeCookieName,
-    enableI18nCookieName: privateConfig.headersAndCookies?.enableI18nCookieName,
+    cacheUrl: clientConfig.cacheUrl,
+    _disableDevHotReload: clientConfig._disableDevHotReload,
+    localeCookieName: clientConfig.headersAndCookies?.localeCookieName,
+    enableI18nCookieName: clientConfig.headersAndCookies?.enableI18nCookieName,
   };
 
   // NextI18nCacheParams
-  const timeout = privateConfig.renderSettings?.timeout;
+  const timeout = clientConfig.renderSettings?.timeout;
   const nextI18nCacheParams: NextI18nCacheParams = {
     apiKey,
     devApiKey,
     projectId,
     runtimeUrl: publicConfig.runtimeUrl,
-    cacheUrl: privateConfig.cacheUrl,
-    _versionId: privateConfig._versionId,
-    cacheExpiryTime: privateConfig.cacheExpiryTime,
+    cacheUrl: clientConfig.cacheUrl,
+    _versionId: clientConfig._versionId,
+    cacheExpiryTime: clientConfig.cacheExpiryTime,
     // batching config
     batchConfig: {
-      maxConcurrentRequests: privateConfig.maxConcurrentRequests,
-      maxBatchSize: privateConfig.maxBatchSize,
-      batchInterval: privateConfig.batchInterval,
+      maxConcurrentRequests: clientConfig.maxConcurrentRequests,
+      maxBatchSize: clientConfig.maxBatchSize,
+      batchInterval: clientConfig.batchInterval,
     },
     // runtime translation config
     runtimeTranslation: {

--- a/packages/next/src/setup/shared.ts
+++ b/packages/next/src/setup/shared.ts
@@ -14,20 +14,17 @@ export function getParams(): {
   nextI18nCacheParams: NextI18nCacheParams;
 } {
   // Read from build output
-  const publicConfig = JSON.parse(
-    process.env.NEXT_PUBLIC_GENERALTRANSLATION_I18N_CONFIG_PARAMS || '{}'
-  );
   const clientConfig = JSON.parse(
-    process.env._GENERALTRANSLATION_CLIENT_I18N_CONFIG_PARAMS || '{}'
+    process.env.NEXT_PUBLIC_GENERALTRANSLATION_I18N_CONFIG_PARAMS || '{}'
   );
   const { projectId, devApiKey, apiKey } = getRuntimeCredentials();
 
   // I18nConfigParams
   const i18nConfigParams: NextSetupI18nConfigParams = {
-    defaultLocale: publicConfig.defaultLocale,
-    locales: publicConfig.locales,
-    customMapping: publicConfig.customMapping,
-    runtimeUrl: publicConfig.runtimeUrl,
+    defaultLocale: clientConfig.defaultLocale,
+    locales: clientConfig.locales,
+    customMapping: clientConfig.customMapping,
+    runtimeUrl: clientConfig.runtimeUrl,
     projectId,
     devApiKey,
     apiKey,
@@ -43,7 +40,7 @@ export function getParams(): {
     apiKey,
     devApiKey,
     projectId,
-    runtimeUrl: publicConfig.runtimeUrl,
+    runtimeUrl: clientConfig.runtimeUrl,
     cacheUrl: clientConfig.cacheUrl,
     _versionId: clientConfig._versionId,
     cacheExpiryTime: clientConfig.cacheExpiryTime,
@@ -58,7 +55,7 @@ export function getParams(): {
       // TODO: reduce redundancy in this config
       timeout,
       metadata: {
-        sourceLocale: publicConfig.defaultLocale,
+        sourceLocale: clientConfig.defaultLocale,
         timeout,
         projectId,
         publish: true,


### PR DESCRIPTION
## TL;DR

Keep server-only gt-next configuration and arbitrary metadata out of browser bundles by extending the existing client-safe runtime config.

## Code Changes

- Add browser runtime fields to the existing public config payload.
- Read one client-safe payload during shared initialization while preserving the full server and middleware config.
- Add exact-shape coverage proving server-only loaders, metadata, and compiler options are omitted.
- Add a patch changeset for gt-next.

## Notes / Flags

- Validation: 112 focused tests, gt-next typecheck, dependency build, gt-next build:no-swc-plugin, oxlint, and oxfmt.
- The existing full private config remains available to server and middleware code.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prevents server-only configuration (`loadTranslationsPath`, `customMetadata`, `description`, compiler options, etc.) from leaking into browser bundles by replacing the loosely-typed public config object with an explicit client-safe allowlist. The `getParams()` helper in `shared.ts` is simplified to read exclusively from the single `NEXT_PUBLIC_*` env var, while server and middleware code continues to consume the full private config unaffected.

- **`clientI18NConfigParams` allowlist** (`config.ts`): An explicit object now enumerates exactly which runtime fields (batching params, cache settings, render timeout, cookie names, `_versionId`, `_disableDevHotReload`) are serialized into `NEXT_PUBLIC_GENERALTRANSLATION_I18N_CONFIG_PARAMS`; anything not listed stays out of the client bundle.
- **`shared.ts` consolidation**: Removes the separate `privateConfig` parse; all values `getParams()` needed from the private config are now present in the extended public config, eliminating the dual-read pattern.
- **Test coverage**: A new exact-shape `toEqual` assertion in `config.test.ts` acts as a compile-time-style guard — any future field accidentally added to the allowlist will immediately break the test.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a well-scoped refactor with no data loss and no new exposure of credentials or sensitive values.

The private config is still written correctly at build time and consumed unchanged by middleware, server-init, and pages-dir code. The only behavioral difference is that `shared.ts` now reads a broader but still credentials-free public env var instead of two separate env vars. The new exact-shape test in `config.test.ts` provides a strong regression guard for the allowlist.

No files require special attention. `config.ts` and `shared.ts` are the load-bearing files, and both read cleanly on inspection.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/next/src/config.ts | Replaces the loosely-typed public config object (based on a type Omit) with an explicit allowlist `clientI18NConfigParams`; server-only fields like `description`, `loadTranslationsPath`, and `customMetadata` are correctly excluded while runtime fields are included. |
| packages/next/src/setup/shared.ts | Drops the separate `privateConfig` parse; all needed runtime fields (`cacheUrl`, `renderSettings`, `headersAndCookies`, batching params, `_versionId`, `_disableDevHotReload`) are now read from the single `NEXT_PUBLIC_*` env var. Server/middleware consumers (`initGT.server.ts`, `parseLocale.ts`, `createNextMiddleware.ts`) continue to read the full private config independently. |
| packages/next/src/__tests__/config.test.ts | Adds a strict exact-shape test (`toEqual`) for the client config allowlist, verifying that `description`, `loadTranslationsPath`, and `customMetadata` are absent while all expected runtime fields are present. |
| packages/next/src/setup/__tests__/shared.test.ts | Consolidates test fixtures to use only the public env var; removes previously-set-but-unused `_cacheComponentsEnabled` and `loadTranslationsType` from the test setup, accurately reflecting that `getParams()` no longer reads those from a private config. |
| .changeset/calm-clients-trim.md | Patch changeset for `gt-next` describing the client-bundle trim. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[withGTConfig at build time] --> B[mergedConfig]
    B --> C["_GENERALTRANSLATION_I18N_CONFIG_PARAMS\n(full config, minus credentials)"]
    B --> D["NEXT_PUBLIC_GENERALTRANSLATION_I18N_CONFIG_PARAMS\nclientI18NConfigParams allowlist"]

    C --> E[createNextMiddleware.ts\nedge runtime]
    C --> F[initGT.server.ts\nserver runtime]
    C --> G[parseLocale.ts\npages-dir]

    D --> H[shared.ts getParams\nreads clientConfig only]
    H --> I[i18nConfigParams\ncacheUrl, cookieNames, ...]
    H --> J[nextI18nCacheParams\nbatching, versionId, ...]

    I --> K[Client + Server i18n init]
    J --> K

    subgraph "NOT in client bundle"
        L[loadTranslationsPath]
        M[customMetadata]
        N[description]
        O[localeHeaderName]
        P[ignoreBrowserLocales]
        Q[experimentalCompilerOptions]
    end

    D -.->|excluded| L
    D -.->|excluded| M
    D -.->|excluded| N
    D -.->|excluded| O
    D -.->|excluded| P
    D -.->|excluded| Q
```
</details>

<sub>Reviews (3): Last reviewed commit: ["refactor(next): reuse client runtime con..."](https://github.com/generaltranslation/gt/commit/a110e7d015be69beaa4a3f88127cfad1272eaa35) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46758927)</sub>

<!-- /greptile_comment -->