### PR TITLE
refactor: remove deprecated internal code

### DIFF
--- a/packages/cli/src/react/jsx/utils/stringParsing/derivation/handleDerivation.ts
+++ b/packages/cli/src/react/jsx/utils/stringParsing/derivation/handleDerivation.ts
@@ -21,9 +21,6 @@ import { isDeriveCall } from './isDeriveCall.js';
 const traverse = traverseModule.default || traverseModule;
 const generate = generateModule.default || generateModule;
 
-// Nested arrays of strings (deprecated - kept for backwards compatibility)
-export type StringTree = (string | StringTree)[];
-
 /**
  * Cache for resolved import paths to avoid redundant I/O operations.
  * Key: `${currentFile}::${importPath}`

--- a/packages/compiler/src/state/ScopeTracker.ts
+++ b/packages/compiler/src/state/ScopeTracker.ts
@@ -39,10 +39,6 @@ export interface ScopedVariable {
   canonicalName: string | GT_ALL_FUNCTIONS;
   /** The variable name (t, translationFunction, etc.) */
   aliasName: string;
-  /** Whether the variable is a translation function
-   * @deprecated
-   */
-  isTranslationFunction: boolean;
   type: VariableType;
   /** The identifier for the variable */
   identifier: number;
@@ -156,7 +152,6 @@ export class ScopeTracker {
   trackVariable(
     aliasName: string,
     canonicalName: string,
-    isTranslationFunction: boolean,
     type: VariableType,
     identifier: number
   ): void {
@@ -164,7 +159,6 @@ export class ScopeTracker {
       scopeId: this.currentScope,
       canonicalName,
       aliasName,
-      isTranslationFunction,
       type,
       identifier,
     };
@@ -185,7 +179,6 @@ export class ScopeTracker {
     this.trackVariable(
       aliasName,
       canonicalName,
-      true,
       'generaltranslation',
       identifier
     );
@@ -207,7 +200,6 @@ export class ScopeTracker {
     this.trackVariable(
       aliasName,
       canonicalName,
-      true,
       'generaltranslation',
       identifier
     );
@@ -221,14 +213,14 @@ export class ScopeTracker {
     assignedValue: string,
     identifier: number
   ): void {
-    this.trackVariable(variableName, assignedValue, false, 'react', identifier);
+    this.trackVariable(variableName, assignedValue, 'react', identifier);
   }
 
   /**
    * Track a non-translation variable (convenience method)
    */
   trackRegularVariable(variableName: string, assignedValue: string): void {
-    this.trackVariable(variableName, assignedValue, false, 'other', 0); // 0 because we don't care about the identifier
+    this.trackVariable(variableName, assignedValue, 'other', 0); // 0 because we don't care about the identifier
   }
 
   /* =============================== */

--- a/packages/react/src/i18n-cache/BrowserI18nCache.ts
+++ b/packages/react/src/i18n-cache/BrowserI18nCache.ts
@@ -5,8 +5,6 @@ import type {
 import { getI18nConfig, I18nCache } from 'gt-i18n/internal';
 import type { HtmlTagOptions } from './types';
 import type { Translation } from 'gt-i18n/types';
-import { DEFAULT_HTML_TAG_OPTIONS } from './constants';
-import { createDiagnosticMessage } from 'generaltranslation/internal';
 
 type LocalStorageTranslationCache =
   import('./LocalStorageTranslationCache').LocalStorageTranslationCache;
@@ -32,15 +30,13 @@ export type BrowserI18nCacheParams = I18nCacheConstructorParams & {
  * I18nCache implementation for Browser.
  */
 export class BrowserI18nCache extends I18nCache<Translation> {
-  /** Customize browser-related behavior */
-  private htmlTagOptions?: HtmlTagOptions;
-
   /** Whether dev hot reload JSX (Suspense-based <T>) is active */
   private _devHotReloadJsx = false;
 
   constructor(config: BrowserI18nCacheParams) {
     // Must be initialized before super()
-    const { htmlTagOptions, ...managerConfig } = config;
+    // Keep accepting htmlTagOptions without passing it to the translation cache.
+    const { htmlTagOptions: _htmlTagOptions, ...managerConfig } = config;
     const localStorageCaches: LocalStorageCachePromises = {};
     const i18nConfig = getI18nConfig();
     const devHotReloadEnabled =
@@ -62,11 +58,6 @@ export class BrowserI18nCache extends I18nCache<Translation> {
 
     this._devHotReloadJsx = devHotReloadEnabled;
 
-    this.htmlTagOptions = {
-      ...DEFAULT_HTML_TAG_OPTIONS,
-      ...htmlTagOptions,
-    };
-
     // For dev hot reload, we need to write the translations to the localStorage cache
     if (devHotReloadEnabled) {
       this.onTranslationsCacheMiss = ({ locale, hash, translation }) => {
@@ -83,45 +74,6 @@ export class BrowserI18nCache extends I18nCache<Translation> {
    */
   isDevHotReloadJsx(): boolean {
     return this._devHotReloadJsx;
-  }
-
-  /**
-   * Update the html tag (lang, dir)
-   *
-   * @deprecated, TODO: we should use a different system for managing this html tag
-   * this should just be for managing translations
-   */
-  updateHtmlTag(
-    locale: string,
-    htmlTagOptions?: { lang?: string; dir?: 'ltr' | 'rtl' } & HtmlTagOptions
-  ): void {
-    // Get parameters
-    const htmlLocale = htmlTagOptions?.lang || locale;
-    const i18nConfig = getI18nConfig();
-    const canonicalLocale = i18nConfig.resolveCanonicalLocale(htmlLocale);
-
-    // Validate parameters
-    if (!i18nConfig.isValidLocale(canonicalLocale)) {
-      console.warn(createInvalidLocaleWarning(htmlLocale));
-      return;
-    }
-
-    const localeDirection =
-      htmlTagOptions?.dir || i18nConfig.getLocaleDirection(canonicalLocale);
-
-    // Merge options
-    const mergedHtmlTagOptions = {
-      ...this.htmlTagOptions,
-      ...htmlTagOptions,
-    };
-
-    // Update html tag
-    if (mergedHtmlTagOptions.updateHtmlLangTag) {
-      document.documentElement.lang = canonicalLocale;
-    }
-    if (mergedHtmlTagOptions.updateHtmlDirTag) {
-      document.documentElement.dir = localeDirection;
-    }
   }
 }
 
@@ -150,7 +102,6 @@ function wrapLoaderWithLocalStorage(
     return cache.getInternalCache();
   };
 }
-
 function getOrCreateLocalStorageCache(
   localStorageCaches: LocalStorageCachePromises,
   params: {
@@ -170,11 +121,3 @@ function loadLocalStorageCache() {
   return (localStorageCacheModulePromise ??=
     import('./LocalStorageTranslationCache'));
 }
-
-const createInvalidLocaleWarning = (locale: string) =>
-  createDiagnosticMessage({
-    source: 'gt-react',
-    severity: 'Warning',
-    whatHappened: `Locale "${locale}" is not valid`,
-    fix: 'Use a valid BCP 47 locale code or add a custom mapping',
-  });

--- a/packages/react/src/i18n-cache/constants.ts
+++ b/packages/react/src/i18n-cache/constants.ts
@@ -1,6 +1,0 @@
-import type { HtmlTagOptions } from './types';
-
-export const DEFAULT_HTML_TAG_OPTIONS: HtmlTagOptions = {
-  updateHtmlLangTag: true,
-  updateHtmlDirTag: true,
-};


### PR DESCRIPTION
## TL;DR

Remove deprecated internal code that no longer participates in runtime behavior.

## Code Changes

- Remove the unreachable BrowserI18nCache HTML-tag mutation path and its private defaults while continuing to accept htmlTagOptions for compatibility.
- Remove redundant isTranslationFunction state from compiler scope tracking; the existing variable type remains the discriminator.
- Remove the unused deprecated StringTree CLI type alias.

## Notes / Flags

- No changeset: these are internal implementation cleanups with no supported public API or runtime behavior change.
- Verified with package tests, type checks, and builds for gt-react, @generaltranslation/compiler, and gt.
- Repository lint and format checks pass.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes three pieces of deprecated internal code that were already unreachable or redundant at runtime: the `updateHtmlTag` method in `BrowserI18nCache`, the `isTranslationFunction` boolean in `ScopeTracker`, and the `StringTree` CLI type alias. The `htmlTagOptions` constructor parameter is preserved for API compatibility but is now silently discarded.

- **`BrowserI18nCache.ts` / `constants.ts`**: `updateHtmlTag` and its supporting `htmlTagOptions` private field and `DEFAULT_HTML_TAG_OPTIONS` constant are removed. The constructor still accepts `htmlTagOptions` (destructured as `_htmlTagOptions`) so existing call sites don't break, but the value is unused.
- **`ScopeTracker.ts`**: `isTranslationFunction: boolean` is removed from `ScopedVariable` and the `trackVariable` signature; discrimination is already handled exclusively by `type === 'generaltranslation'` via `isScopedGTFunction`.
- **`handleDerivation.ts`**: The `StringTree` type alias is removed; grep confirms no remaining usages anywhere in the CLI package.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all removed code paths were already unreachable or fully redundant, and no public surface area changed.

Each deletion was confirmed to have zero remaining call sites: updateHtmlTag is not invoked anywhere in the react package, StringTree has no usages in the CLI, and isTranslationFunction was already superseded by the type field discriminator used exclusively by isScopedGTFunction. The constructor continues to accept htmlTagOptions for backward compatibility, just discarding it silently.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react/src/i18n-cache/BrowserI18nCache.ts | Removed deprecated updateHtmlTag method and htmlTagOptions private field; constructor still accepts but discards the option for backward compat. No remaining callers confirmed. |
| packages/react/src/i18n-cache/constants.ts | Deleted — contained only DEFAULT_HTML_TAG_OPTIONS which is no longer referenced after the updateHtmlTag removal. |
| packages/compiler/src/state/ScopeTracker.ts | Removed deprecated isTranslationFunction boolean from ScopedVariable interface and trackVariable signature; all call sites updated consistently and type-based discrimination via isScopedGTFunction is already in place. |
| packages/cli/src/react/jsx/utils/stringParsing/derivation/handleDerivation.ts | Removed the StringTree type alias (marked deprecated); confirmed no remaining usages in the CLI package. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph BrowserI18nCache["BrowserI18nCache (after)"]
        A["constructor(config: BrowserI18nCacheParams)"] --> B["Destructure: htmlTagOptions discarded\n_htmlTagOptions ignored"]
        B --> C["super(managerConfig)"]
        C --> D["_devHotReloadJsx = devHotReloadEnabled"]
        D -->|"devHotReloadEnabled"| E["onTranslationsCacheMiss → write to localStorage"]
        D -->|"not enabled"| F["Ready"]
        E --> F
    end

    subgraph Removed["Removed (deprecated)"]
        R1["updateHtmlTag(locale, options)"]
        R2["htmlTagOptions private field"]
        R3["DEFAULT_HTML_TAG_OPTIONS constant"]
        R4["ScopedVariable.isTranslationFunction boolean"]
        R5["StringTree type alias"]
    end

    subgraph ScopeTracker["ScopeTracker.trackVariable (after)"]
        T1["trackVariable(aliasName, canonicalName, type, identifier)"]
        T1 --> T2["type: 'generaltranslation' | 'react' | 'other'"]
        T2 --> T3["isScopedGTFunction: variable.type === 'generaltranslation'"]
    end

    style Removed fill:#fdd,stroke:#f00
    style BrowserI18nCache fill:#dfd,stroke:#090
    style ScopeTracker fill:#dfd,stroke:#090
```
</details>

<sub>Reviews (2): Last reviewed commit: ["refactor: remove deprecated internal cod..."](https://github.com/generaltranslation/gt/commit/51fb4d7a0567af3bb1d42a8135a45c62894e60b0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46839666)</sub>

<!-- /greptile_comment -->