### PR TITLE
perf: use lightweight hydrated client cache

### DIFF
--- a/.changeset/light-clients-cache.md
+++ b/.changeset/light-clients-cache.md
@@ -1,0 +1,9 @@
+---
+'gt-i18n': patch
+'gt-node': patch
+'@generaltranslation/react-core': patch
+'gt-react': patch
+'gt-next': patch
+---
+
+Replace the full runtime cache on hydrated clients with lightweight snapshot and loading capabilities. Production clients no longer initialize the full resource cache, cache expiry, batching, translation client, or runtime translation; existing cache access and loading APIs remain available through a lightweight compatibility layer. Development hot reload loads its missing-translation resolver only after a miss. Full cache consumers now use the dedicated `gt-i18n/internal/i18n-cache` entrypoint.

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -95,6 +95,46 @@
         "types": "./dist/internal-types.d.mts",
         "default": "./dist/internal-types.mjs"
       }
+    },
+    "./internal/i18n-cache": {
+      "require": {
+        "types": "./dist/I18nCache.d.cts",
+        "default": "./dist/I18nCache.cjs"
+      },
+      "import": {
+        "types": "./dist/I18nCache.d.mts",
+        "default": "./dist/I18nCache.mjs"
+      }
+    },
+    "./internal/snapshot-store": {
+      "require": {
+        "types": "./dist/i18n-cache/SnapshotStore.d.cts",
+        "default": "./dist/i18n-cache/SnapshotStore.cjs"
+      },
+      "import": {
+        "types": "./dist/i18n-cache/SnapshotStore.d.mts",
+        "default": "./dist/i18n-cache/SnapshotStore.mjs"
+      }
+    },
+    "./internal/runtime-translation-resolver": {
+      "require": {
+        "types": "./dist/RuntimeTranslationResolver.d.cts",
+        "default": "./dist/RuntimeTranslationResolver.cjs"
+      },
+      "import": {
+        "types": "./dist/RuntimeTranslationResolver.d.mts",
+        "default": "./dist/RuntimeTranslationResolver.mjs"
+      }
+    },
+    "./internal/translation-loader": {
+      "require": {
+        "types": "./dist/i18n-cache/createTranslationLoader.d.cts",
+        "default": "./dist/i18n-cache/createTranslationLoader.cjs"
+      },
+      "import": {
+        "types": "./dist/i18n-cache/createTranslationLoader.d.mts",
+        "default": "./dist/i18n-cache/createTranslationLoader.mjs"
+      }
     }
   },
   "typesVersions": {
@@ -107,6 +147,18 @@
       ],
       "internal/types": [
         "./dist/internal-types.d.cts"
+      ],
+      "internal/i18n-cache": [
+        "./dist/I18nCache.d.cts"
+      ],
+      "internal/snapshot-store": [
+        "./dist/i18n-cache/SnapshotStore.d.cts"
+      ],
+      "internal/runtime-translation-resolver": [
+        "./dist/RuntimeTranslationResolver.d.cts"
+      ],
+      "internal/translation-loader": [
+        "./dist/i18n-cache/createTranslationLoader.d.cts"
       ]
     }
   }

--- a/packages/i18n/src/helpers/versionId.ts
+++ b/packages/i18n/src/helpers/versionId.ts
@@ -1,4 +1,4 @@
-import { getI18nCache } from '../i18n-cache/singleton-operations';
+import { getI18nConfig } from '../i18n-config/singleton-operations';
 
 /**
  * Get the version ID for the current source
@@ -9,6 +9,5 @@ import { getI18nCache } from '../i18n-cache/singleton-operations';
  * console.log(versionId); // 'abc123'
  */
 export function getVersionId() {
-  const i18nCache = getI18nCache();
-  return i18nCache.getVersionId();
+  return getI18nConfig().getVersionId();
 }

--- a/packages/i18n/src/i18n-cache/I18nCache.ts
+++ b/packages/i18n/src/i18n-cache/I18nCache.ts
@@ -26,11 +26,13 @@ import { resolveDictionaryLookupOptions } from './translations-manager/utils/dic
 import { DictionarySourceNotFoundError } from './translations-manager/utils/DictionarySourceNotFoundError';
 import { getRuntimeEnvironment } from '../utils/getRuntimeEnvironment';
 import { getI18nConfig } from '../i18n-config/singleton-operations';
-
-/**
- * Default translation timeout in milliseconds for a runtime translation request
- */
-const DEFAULT_TRANSLATION_TIMEOUT = 12_000; // 12 seconds
+import {
+  resolveCacheLocale,
+  resolveDictionaryCacheLocale,
+  resolveLookupParams,
+} from './utils/resolveCacheLocale';
+import { defaultRuntimeTranslationTimeout } from './settings';
+import { createGTRuntime } from '../runtime/createGTRuntime';
 
 /**
  * A translation resolver is a function that synchronously resolves a translation
@@ -127,9 +129,6 @@ class I18nCache<TranslationValue extends Translation = Translation> {
 
     this.config = {
       projectId: params.projectId,
-      devApiKey: params.devApiKey,
-      apiKey: params.apiKey,
-      runtimeUrl: params.runtimeUrl,
       modelProvider: params.modelProvider,
       cacheExpiryTime: params.cacheExpiryTime,
       batchConfig: params.batchConfig,
@@ -150,8 +149,9 @@ class I18nCache<TranslationValue extends Translation = Translation> {
     }) as SafeTranslationsLoader<TranslationValue>;
     const loadDictionary = params.loadDictionary ?? (() => Promise.resolve({}));
     this.createTranslateMany = createTranslateManyFactory(
-      getI18nConfig().getGTClass(),
-      this.config.runtimeTranslation?.timeout ?? DEFAULT_TRANSLATION_TIMEOUT,
+      createGTRuntime(getI18nConfig(), params),
+      this.config.runtimeTranslation?.timeout ??
+        defaultRuntimeTranslationTimeout,
       {
         ...(this.config.modelProvider && {
           modelProvider: this.config.modelProvider,
@@ -264,7 +264,7 @@ class I18nCache<TranslationValue extends Translation = Translation> {
   ): Promise<Record<Hash, TranslationValue>> {
     return this.guardAsync({}, async () => {
       // Validate
-      const translationLocale = this._resolveCacheLocale(locale);
+      const translationLocale = resolveCacheLocale(locale);
       if (!translationLocale) {
         return {};
       }
@@ -283,7 +283,7 @@ class I18nCache<TranslationValue extends Translation = Translation> {
   async loadDictionary(locale: string): Promise<Dictionary> {
     return this.guardAsync({}, async () => {
       // Validate
-      const dictionaryLocale = this._resolveCacheLocale(locale);
+      const dictionaryLocale = resolveCacheLocale(locale);
       if (!dictionaryLocale) {
         return this.getDefaultDictionaryCache()?.getInternalCache() ?? {};
       }
@@ -300,9 +300,7 @@ class I18nCache<TranslationValue extends Translation = Translation> {
    */
   lookupDictionary(locale: string, id: string): DictionaryEntry | undefined {
     return this.guard(undefined, () =>
-      this.dictionaries
-        .get(this.resolveDictionaryCacheLocale(locale))
-        ?.getEntry(id)
+      this.dictionaries.get(resolveDictionaryCacheLocale(locale))?.getEntry(id)
     );
   }
 
@@ -314,9 +312,7 @@ class I18nCache<TranslationValue extends Translation = Translation> {
     id: string
   ): DictionaryObject | undefined {
     return this.guard(undefined, () =>
-      this.dictionaries
-        .get(this.resolveDictionaryCacheLocale(locale))
-        ?.getValue(id)
+      this.dictionaries.get(resolveDictionaryCacheLocale(locale))?.getValue(id)
     );
   }
 
@@ -327,7 +323,7 @@ class I18nCache<TranslationValue extends Translation = Translation> {
         lookupDictionaryObj: () => undefined,
       },
       async () => {
-        const asyncBoundaryLocale = this._resolveCacheLocale(locale);
+        const asyncBoundaryLocale = resolveCacheLocale(locale);
         const asyncBoundaryDictionaryCache = asyncBoundaryLocale
           ? await this.dictionaries.getOrLoad(asyncBoundaryLocale)
           : this.getDefaultDictionaryCache();
@@ -350,7 +346,7 @@ class I18nCache<TranslationValue extends Translation = Translation> {
     id: string
   ): Promise<DictionaryEntry | undefined> {
     return this.guardAsync(undefined, async () => {
-      const dictionaryLocale = this._resolveCacheLocale(locale);
+      const dictionaryLocale = resolveCacheLocale(locale);
       if (!dictionaryLocale) {
         return this.getSourceDictionaryEntry(id);
       }
@@ -377,7 +373,7 @@ class I18nCache<TranslationValue extends Translation = Translation> {
     id: string
   ): Promise<DictionaryObject | undefined> {
     return this.guardAsync(undefined, async () => {
-      const dictionaryLocale = this._resolveCacheLocale(locale);
+      const dictionaryLocale = resolveCacheLocale(locale);
 
       if (!dictionaryLocale) {
         return this.getSourceDictionaryObject(id);
@@ -445,12 +441,6 @@ class I18nCache<TranslationValue extends Translation = Translation> {
     return this.dictionaries.get(getI18nConfig().getDefaultLocale());
   }
 
-  private resolveDictionaryCacheLocale(locale: string): Locale {
-    return (
-      this._resolveCacheLocale(locale) ?? getI18nConfig().getDefaultLocale()
-    );
-  }
-
   /**
    * Just lookup a translation
    */
@@ -461,8 +451,10 @@ class I18nCache<TranslationValue extends Translation = Translation> {
   ): T | undefined {
     return this.guard<T | undefined>(undefined, () => {
       // Validate
-      const { translationLocale, options: lookupOptions } =
-        this.resolveLookupParams(locale, options);
+      const { translationLocale, options: lookupOptions } = resolveLookupParams(
+        locale,
+        options
+      );
 
       // Early return if in default locale
       if (!translationLocale) return message;
@@ -507,7 +499,7 @@ class I18nCache<TranslationValue extends Translation = Translation> {
       (message) => message,
       async () => {
         // Locale used for the async load
-        const asyncBoundaryLocale = this._resolveCacheLocale(locale);
+        const asyncBoundaryLocale = resolveCacheLocale(locale);
 
         // Early return if i18n is disabled or default locale
         if (!asyncBoundaryLocale) {
@@ -534,8 +526,8 @@ class I18nCache<TranslationValue extends Translation = Translation> {
               prefetchEntries,
               asyncBoundaryLocale,
               (entryLocale) =>
-                this._resolveCacheLocale(entryLocale) ??
-                this._resolveLocale(entryLocale)
+                resolveCacheLocale(entryLocale) ??
+                getI18nConfig().resolveLocale(entryLocale)
             );
             if (resolvedPrefetchEntries.length !== prefetchEntries.length) {
               logger.warn(
@@ -557,7 +549,7 @@ class I18nCache<TranslationValue extends Translation = Translation> {
           lookupOptions: LookupOptions = {} as LookupOptions
         ) =>
           this.guard(undefined, () => {
-            const { translationLocale, options } = this.resolveLookupParams(
+            const { translationLocale, options } = resolveLookupParams(
               lookupOptions.$locale ?? asyncBoundaryLocale,
               lookupOptions
             );
@@ -624,69 +616,13 @@ class I18nCache<TranslationValue extends Translation = Translation> {
     }
   }
 
-  private _resolveLocale(locale: string) {
-    const i18nConfig = getI18nConfig();
-    const resolvedLocale = i18nConfig.determineLocale(locale);
-    if (!i18nConfig.isValidLocale(locale) || !resolvedLocale) {
-      throw new Error(
-        `Locale "${locale}" is not valid. Use a valid BCP 47 locale code or add a custom mapping.`
-      );
-    }
-    return resolvedLocale;
-  }
-
-  /**
-   * Resolve the locale key used to load/read locale caches.
-   * Returns undefined when the requested locale can use source content.
-   */
-  private _resolveCacheLocale(locale: string) {
-    const resolvedLocale = this._resolveLocale(locale);
-    const i18nConfig = getI18nConfig();
-    if (i18nConfig.requiresTranslation(resolvedLocale)) {
-      return resolvedLocale;
-    }
-
-    const aliasLocale = i18nConfig.resolveAliasLocale(
-      i18nConfig.standardizeLocale(locale)
-    );
-    if (i18nConfig.requiresTranslation(aliasLocale)) {
-      return aliasLocale;
-    }
-
-    return undefined;
-  }
-
-  private resolveLookupParams(locale: string, options: LookupOptions) {
-    const translationLocale = this._resolveCacheLocale(locale);
-    return {
-      translationLocale,
-      options: translationLocale
-        ? this.resolveLookupOptions(options, translationLocale)
-        : options,
-    };
-  }
-
-  private resolveLookupOptions(
-    options: LookupOptions = {} as LookupOptions,
-    translationLocale?: string
-  ): LookupOptions {
-    if (!options.$locale) {
-      return options;
-    }
-    return {
-      ...options,
-      $locale:
-        translationLocale ??
-        this._resolveCacheLocale(options.$locale) ??
-        this._resolveLocale(options.$locale),
-    };
-  }
-
   private async lookupTranslationWithFallbackResolved<
     T extends TranslationValue = TranslationValue,
   >(locale: string, message: T, options: LookupOptions): Promise<T> {
-    const { translationLocale, options: lookupOptions } =
-      this.resolveLookupParams(locale, options);
+    const { translationLocale, options: lookupOptions } = resolveLookupParams(
+      locale,
+      options
+    );
 
     if (!translationLocale) {
       return message;

--- a/packages/i18n/src/i18n-cache/RuntimeTranslationResolver.ts
+++ b/packages/i18n/src/i18n-cache/RuntimeTranslationResolver.ts
@@ -1,0 +1,212 @@
+import { getI18nConfig } from '../i18n-config/singleton-operations';
+import type { LookupOptions } from '../translation-functions/types/options';
+import { DictionaryCache } from './translations-manager/DictionaryCache';
+import { TranslationsCache } from './translations-manager/TranslationsCache';
+import type { Translation } from './translations-manager/utils/types/translation-data';
+import {
+  getDictionaryValue,
+  resolveDictionaryLookupOptions,
+} from './translations-manager/utils/dictionary-helpers';
+import { DictionarySourceNotFoundError } from './translations-manager/utils/DictionarySourceNotFoundError';
+import type {
+  DictionaryEntry,
+  DictionaryObject,
+} from './translations-manager/utils/types/dictionary';
+import { createTranslateManyFactory } from './translations-manager/utils/createTranslateMany';
+import type { I18nCacheConstructorParams } from './types';
+import type { SnapshotStoreInstance } from './SnapshotStore';
+import { defaultRuntimeTranslationTimeout } from './settings';
+import { createGTRuntime } from '../runtime/createGTRuntime';
+import {
+  resolveCacheLocale,
+  resolveLookupParams,
+} from './utils/resolveCacheLocale';
+
+export interface MissingTranslationResolver {
+  lookupTranslationWithFallback<T extends Translation>(
+    locale: string,
+    message: T,
+    options: LookupOptions
+  ): Promise<T | undefined>;
+  lookupDictionaryWithFallback(
+    locale: string,
+    id: string
+  ): Promise<DictionaryEntry | undefined>;
+  lookupDictionaryObjWithFallback(
+    locale: string,
+    id: string
+  ): Promise<DictionaryObject | undefined>;
+}
+
+export type RuntimeTranslationResolverParams = Pick<
+  I18nCacheConstructorParams,
+  | 'projectId'
+  | 'runtimeUrl'
+  | 'apiKey'
+  | 'devApiKey'
+  | 'batchConfig'
+  | 'runtimeTranslation'
+  | 'modelProvider'
+>;
+
+/** Resolves hydrated-client misses without resource loading or cache expiry. */
+export class RuntimeTranslationResolver implements MissingTranslationResolver {
+  private readonly translations = new Map<
+    string,
+    TranslationsCache<Translation>
+  >();
+  private readonly dictionaries = new Map<string, DictionaryCache>();
+  private readonly createTranslateMany;
+
+  constructor(
+    private readonly snapshots: SnapshotStoreInstance,
+    private readonly params: RuntimeTranslationResolverParams
+  ) {
+    this.createTranslateMany = createTranslateManyFactory(
+      createGTRuntime(getI18nConfig(), params),
+      params.runtimeTranslation?.timeout ?? defaultRuntimeTranslationTimeout,
+      {
+        ...(params.modelProvider && { modelProvider: params.modelProvider }),
+        ...params.runtimeTranslation?.metadata,
+      }
+    );
+  }
+
+  async lookupTranslationWithFallback<T extends Translation>(
+    locale: string,
+    message: T,
+    options: LookupOptions
+  ): Promise<T | undefined> {
+    const { translationLocale, options: lookupOptions } = resolveLookupParams(
+      locale,
+      options
+    );
+    if (!translationLocale) return message;
+
+    const translation = this.snapshots.lookupTranslation(
+      translationLocale,
+      message,
+      lookupOptions
+    );
+    if (translation != null) return translation;
+
+    return this.getTranslationsCache(translationLocale).miss({
+      message,
+      options: lookupOptions,
+    });
+  }
+
+  async lookupDictionaryWithFallback(
+    locale: string,
+    id: string
+  ): Promise<DictionaryEntry | undefined> {
+    const dictionaryLocale = resolveCacheLocale(locale);
+    if (!dictionaryLocale) return this.getSourceDictionaryEntry(id);
+
+    const existing = this.snapshots.lookupDictionary(dictionaryLocale, id);
+    if (existing) return existing;
+
+    const entry = await this.getDictionaryCache(
+      dictionaryLocale
+    ).materializeEntry(id, this.getSourceDictionaryEntry(id));
+    this.snapshots.updateDictionaryValue(
+      dictionaryLocale,
+      id,
+      getDictionaryValue(entry)
+    );
+    return entry;
+  }
+
+  async lookupDictionaryObjWithFallback(
+    locale: string,
+    id: string
+  ): Promise<DictionaryObject | undefined> {
+    const dictionaryLocale = resolveCacheLocale(locale);
+    if (!dictionaryLocale) return this.getSourceDictionaryObject(id);
+
+    const targetObject = this.snapshots.lookupDictionaryObj(
+      dictionaryLocale,
+      id
+    );
+    const sourceObject = this.getSourceDictionaryObject(id, false);
+    if (sourceObject === undefined) {
+      if (targetObject !== undefined) return targetObject;
+      throw new DictionarySourceNotFoundError(id);
+    }
+
+    const dictionaryObject = await this.getDictionaryCache(
+      dictionaryLocale
+    ).materializeValue(id, sourceObject, targetObject);
+    this.snapshots.updateDictionaryValue(
+      dictionaryLocale,
+      id,
+      dictionaryObject
+    );
+    return dictionaryObject;
+  }
+
+  private getTranslationsCache(locale: string): TranslationsCache<Translation> {
+    let cache = this.translations.get(locale);
+    if (!cache) {
+      cache = new TranslationsCache({
+        init: {},
+        translateMany: this.createTranslateMany(locale),
+        batchConfig: this.params.batchConfig,
+        onMiss: (hash, translation) => {
+          this.snapshots.updateTranslations({
+            [locale]: { [hash]: translation },
+          });
+        },
+      });
+      this.translations.set(locale, cache);
+    }
+    return cache;
+  }
+
+  private getDictionaryCache(locale: string): DictionaryCache {
+    let cache = this.dictionaries.get(locale);
+    if (!cache) {
+      cache = new DictionaryCache({
+        init: this.snapshots.getDictionary(locale) ?? {},
+        runtimeTranslate: async (id, sourceEntry) => {
+          const translation = await this.lookupTranslationWithFallback(
+            locale,
+            sourceEntry.entry,
+            resolveDictionaryLookupOptions(sourceEntry.options)
+          );
+          if (typeof translation !== 'string') {
+            throw new Error(
+              `Dictionary entry "${id}" could not be translated into a string. Check the source entry and runtime translation output.`
+            );
+          }
+          return translation;
+        },
+      });
+      this.dictionaries.set(locale, cache);
+    }
+    return cache;
+  }
+
+  private getSourceDictionaryEntry(id: string): DictionaryEntry {
+    const entry = this.snapshots.lookupDictionary(
+      getI18nConfig().getDefaultLocale(),
+      id
+    );
+    if (!entry) throw new DictionarySourceNotFoundError(id);
+    return entry;
+  }
+
+  private getSourceDictionaryObject(
+    id: string,
+    throwOnMissing = true
+  ): DictionaryObject | undefined {
+    const object = this.snapshots.lookupDictionaryObj(
+      getI18nConfig().getDefaultLocale(),
+      id
+    );
+    if (object === undefined && throwOnMissing) {
+      throw new DictionarySourceNotFoundError(id);
+    }
+    return object;
+  }
+}

--- a/packages/i18n/src/i18n-cache/SnapshotStore.ts
+++ b/packages/i18n/src/i18n-cache/SnapshotStore.ts
@@ -1,0 +1,117 @@
+import type { LookupOptions } from '../translation-functions/types/options';
+import { hashMessage } from '../utils/hashMessage';
+import { getI18nConfig } from '../i18n-config/singleton-operations';
+import {
+  cloneDictionaryValue,
+  getDictionaryEntry,
+  getDictionaryValueAtPath,
+  isDictionaryValue,
+  setDictionaryValueAtPath,
+} from './translations-manager/utils/dictionary-helpers';
+import type {
+  Dictionary,
+  DictionaryEntry,
+  DictionaryObject,
+  DictionaryValue,
+} from './translations-manager/utils/types/dictionary';
+import type { Hash, Locale } from './translations-manager/TranslationsCache';
+import type { Translation } from './translations-manager/utils/types/translation-data';
+import {
+  resolveDictionaryCacheLocale,
+  resolveLookupParams,
+} from './utils/resolveCacheLocale';
+
+/** Mutable translation snapshots with synchronous locale-aware lookup. */
+export class SnapshotStore {
+  private translations: Record<Locale, Record<Hash, Translation>> = {};
+  private dictionaries: Record<Locale, Dictionary> = {};
+
+  constructor(dictionary?: Dictionary) {
+    if (dictionary) {
+      const defaultLocale = getI18nConfig().getDefaultLocale();
+      this.dictionaries[defaultLocale] = cloneDictionaryValue(dictionary);
+    }
+  }
+
+  updateTranslations(
+    translationsSnapshot: Record<Locale, Record<Hash, Translation>>
+  ): void {
+    for (const [locale, translations] of Object.entries(translationsSnapshot)) {
+      this.translations[locale] = {
+        ...this.translations[locale],
+        ...structuredClone(translations),
+      };
+    }
+  }
+
+  updateDictionaries(dictionarySnapshot: Record<Locale, Dictionary>): void {
+    for (const [locale, dictionary] of Object.entries(dictionarySnapshot)) {
+      this.dictionaries[locale] ??= {};
+      mergeDictionary(this.dictionaries[locale], dictionary);
+    }
+  }
+
+  updateDictionaryValue(
+    locale: Locale,
+    id: string,
+    value: DictionaryValue
+  ): void {
+    this.dictionaries[locale] ??= {};
+    setDictionaryValueAtPath(
+      this.dictionaries[locale],
+      id,
+      cloneDictionaryValue(value)
+    );
+  }
+
+  getTranslations(locale: Locale): Record<Hash, Translation> | undefined {
+    const translations = this.translations[locale];
+    return translations ? structuredClone(translations) : undefined;
+  }
+
+  getDictionary(locale: Locale): Dictionary | undefined {
+    const dictionary = this.dictionaries[locale];
+    return dictionary ? cloneDictionaryValue(dictionary) : undefined;
+  }
+
+  lookupTranslation<T extends Translation>(
+    locale: string,
+    message: T,
+    options: LookupOptions
+  ): T | undefined {
+    const { translationLocale, options: lookupOptions } = resolveLookupParams(
+      locale,
+      options
+    );
+    if (!translationLocale) return message;
+
+    const hash = lookupOptions.$_hash ?? hashMessage(message, lookupOptions);
+    return this.translations[translationLocale]?.[hash] as T | undefined;
+  }
+
+  lookupDictionary(locale: string, id: string): DictionaryEntry | undefined {
+    return getDictionaryEntry(this.lookupDictionaryObj(locale, id));
+  }
+
+  lookupDictionaryObj(
+    locale: string,
+    id: string
+  ): DictionaryObject | undefined {
+    const dictionary = this.dictionaries[resolveDictionaryCacheLocale(locale)];
+    if (!dictionary) return undefined;
+    return cloneDictionaryValue(getDictionaryValueAtPath(dictionary, id));
+  }
+}
+
+export type SnapshotStoreInstance = Pick<SnapshotStore, keyof SnapshotStore>;
+
+function mergeDictionary(target: Dictionary, source: Dictionary): void {
+  for (const [key, value] of Object.entries(source)) {
+    const targetValue = target[key];
+    if (isDictionaryValue(targetValue) && isDictionaryValue(value)) {
+      mergeDictionary(targetValue, value);
+    } else {
+      target[key] = cloneDictionaryValue(value);
+    }
+  }
+}

--- a/packages/i18n/src/i18n-cache/__tests__/RuntimeTranslationResolver.test.ts
+++ b/packages/i18n/src/i18n-cache/__tests__/RuntimeTranslationResolver.test.ts
@@ -1,0 +1,48 @@
+import { GTRuntime } from 'generaltranslation/runtime';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { initializeI18nConfig } from '../../i18n-config/singleton-operations';
+import { hashMessage } from '../../utils/hashMessage';
+import { RuntimeTranslationResolver } from '../RuntimeTranslationResolver';
+import { SnapshotStore } from '../SnapshotStore';
+
+type TestGlobal = typeof globalThis & {
+  __generaltranslation?: unknown;
+};
+
+describe('RuntimeTranslationResolver', () => {
+  beforeEach(() => {
+    Reflect.deleteProperty(globalThis as TestGlobal, '__generaltranslation');
+    vi.restoreAllMocks();
+    initializeI18nConfig({
+      defaultLocale: 'en',
+      locales: ['en', 'fr'],
+      projectId: 'test-project',
+      devApiKey: 'test-dev-key',
+    });
+  });
+
+  it('resolves a miss and writes it into the snapshot store', async () => {
+    const message = 'Hello';
+    const options = { $format: 'ICU' as const };
+    const hash = hashMessage(message, options);
+    const translateMany = vi
+      .spyOn(GTRuntime.prototype, 'translateMany')
+      .mockResolvedValue({
+        [hash]: { success: true, translation: 'Bonjour' },
+      } as never);
+    const snapshots = new SnapshotStore();
+    const resolver = new RuntimeTranslationResolver(snapshots, {
+      batchConfig: { batchInterval: 1 },
+    });
+
+    await expect(
+      resolver.lookupTranslationWithFallback('fr', message, options)
+    ).resolves.toBe('Bonjour');
+    expect(translateMany).toHaveBeenCalledWith(
+      expect.objectContaining({ [hash]: expect.any(Object) }),
+      expect.objectContaining({ targetLocale: 'fr' }),
+      expect.any(Number)
+    );
+    expect(snapshots.lookupTranslation('fr', message, options)).toBe('Bonjour');
+  });
+});

--- a/packages/i18n/src/i18n-cache/__tests__/SnapshotStore.test.ts
+++ b/packages/i18n/src/i18n-cache/__tests__/SnapshotStore.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { initializeI18nConfig } from '../../i18n-config/singleton-operations';
+import { SnapshotStore } from '../SnapshotStore';
+
+type TestGlobal = typeof globalThis & {
+  __generaltranslation?: unknown;
+};
+
+describe('SnapshotStore', () => {
+  beforeEach(() => {
+    Reflect.deleteProperty(globalThis as TestGlobal, '__generaltranslation');
+    initializeI18nConfig({
+      defaultLocale: 'en',
+      locales: ['en', 'fr'],
+    });
+  });
+
+  it('resolves target translations and source messages', () => {
+    const snapshots = new SnapshotStore();
+    snapshots.updateTranslations({ fr: { greeting: 'Bonjour' } });
+
+    expect(
+      snapshots.lookupTranslation('fr', 'Hello', {
+        $_hash: 'greeting',
+        $format: 'ICU',
+      })
+    ).toBe('Bonjour');
+    expect(
+      snapshots.lookupTranslation('en', 'Hello', {
+        $_hash: 'greeting',
+        $format: 'ICU',
+      })
+    ).toBe('Hello');
+  });
+
+  it('merges dictionaries without replacing sibling entries', () => {
+    const snapshots = new SnapshotStore({
+      navigation: { home: 'Home' },
+    });
+    snapshots.updateDictionaries({
+      en: { navigation: { account: 'Account' } },
+      fr: { navigation: { home: 'Accueil' } },
+    });
+
+    expect(snapshots.lookupDictionary('en', 'navigation.home')?.entry).toBe(
+      'Home'
+    );
+    expect(snapshots.lookupDictionary('en', 'navigation.account')?.entry).toBe(
+      'Account'
+    );
+    expect(snapshots.lookupDictionary('fr', 'navigation.home')?.entry).toBe(
+      'Accueil'
+    );
+  });
+
+  it('honors locale overrides supplied to a bound lookup', () => {
+    const snapshots = new SnapshotStore();
+    snapshots.updateTranslations({ fr: { greeting: 'Bonjour' } });
+
+    expect(
+      snapshots.lookupTranslation('fr', 'Hello', {
+        $_hash: 'greeting',
+        $format: 'ICU',
+        $locale: 'fr',
+      })
+    ).toBe('Bonjour');
+  });
+});

--- a/packages/i18n/src/i18n-cache/__tests__/singleton-operations.test.ts
+++ b/packages/i18n/src/i18n-cache/__tests__/singleton-operations.test.ts
@@ -32,8 +32,10 @@ describe('i18n cache singleton operations', () => {
   });
 
   it('throws when the i18n cache has not been initialized', async () => {
-    const { getI18nCache } = await import('../singleton-operations');
+    const { getI18nCache, isI18nCacheInitialized } =
+      await import('../singleton-operations');
 
+    expect(isI18nCacheInitialized()).toBe(false);
     expect(() => getI18nCache()).toThrow(
       'Cannot read I18nCache before it has been initialized'
     );
@@ -46,8 +48,10 @@ describe('i18n cache singleton operations', () => {
     setI18nCache(cache);
 
     vi.resetModules();
-    const { getI18nCache } = await import('../singleton-operations');
+    const { getI18nCache, isI18nCacheInitialized } =
+      await import('../singleton-operations');
 
+    expect(isI18nCacheInitialized()).toBe(true);
     expect(getI18nCache()).toBe(cache);
   });
 

--- a/packages/i18n/src/i18n-cache/createTranslationLoader.ts
+++ b/packages/i18n/src/i18n-cache/createTranslationLoader.ts
@@ -1,0 +1,21 @@
+import { routeCreateTranslationLoader } from './translations-manager/translations-loaders/routeCreateTranslationLoader';
+import type { SafeTranslationsLoader } from './translations-manager/translations-loaders/types';
+import type { Translation } from './translations-manager/utils/types/translation-data';
+import type { I18nCacheConstructorParams } from './types';
+import { getLoadTranslationsType } from './utils/getLoadTranslationsType';
+
+/** Creates the configured loader without constructing a full I18nCache. */
+export function createTranslationLoader(
+  params: I18nCacheConstructorParams
+): SafeTranslationsLoader<Translation> {
+  return routeCreateTranslationLoader({
+    loadTranslations: params.loadTranslations,
+    type: getLoadTranslationsType(params),
+    remoteTranslationLoaderParams: {
+      cacheUrl: params.cacheUrl,
+      projectId: params.projectId,
+      _versionId: params._versionId,
+      _branchId: params._branchId,
+    },
+  }) as SafeTranslationsLoader<Translation>;
+}

--- a/packages/i18n/src/i18n-cache/settings.ts
+++ b/packages/i18n/src/i18n-cache/settings.ts
@@ -1,0 +1,2 @@
+/** Default timeout for runtime translation requests. */
+export const defaultRuntimeTranslationTimeout = 12_000;

--- a/packages/i18n/src/i18n-cache/singleton-operations.ts
+++ b/packages/i18n/src/i18n-cache/singleton-operations.ts
@@ -1,7 +1,12 @@
 import { createDiagnosticMessage } from 'generaltranslation/internal';
 import { createGlobalSingleton } from '../globals/createGlobalSingleton';
-import { I18nCache } from './I18nCache';
+import type { I18nCache } from './I18nCache';
 import { Translation } from './translations-manager/utils/types/translation-data';
+
+/** Public I18nCache methods without the class's nominal protected state. */
+export type I18nCacheInstance<
+  TranslationValue extends Translation = Translation,
+> = Pick<I18nCache<TranslationValue>, keyof I18nCache<TranslationValue>>;
 
 const i18nCacheSingleton = createGlobalSingleton<I18nCache>({
   namespace: 'i18n',
@@ -30,6 +35,10 @@ export function getI18nCache<U extends Translation = Translation>():
   return i18nCacheSingleton.get();
 }
 
+export function isI18nCacheInitialized(): boolean {
+  return i18nCacheSingleton.isInitialized();
+}
+
 /**
  * Configure the singleton instance of I18nCache
  * @param config - The configuration for the I18nCache
@@ -39,7 +48,7 @@ export function getI18nCache<U extends Translation = Translation>():
  * Note: should not be consumed by gt-react, consumers should use a wrapper
  */
 export function setI18nCache<TranslationValue extends Translation>(
-  i18nCacheInstance: I18nCache<TranslationValue>
+  i18nCacheInstance: I18nCacheInstance<TranslationValue>
 ): void {
   i18nCacheSingleton.set(i18nCacheInstance as unknown as I18nCache);
 }

--- a/packages/i18n/src/i18n-cache/types.ts
+++ b/packages/i18n/src/i18n-cache/types.ts
@@ -45,9 +45,6 @@ export type I18nCacheConstructorParams = DictionaryConfig &
  */
 export type I18nCacheConfig = {
   projectId?: string;
-  devApiKey?: string;
-  apiKey?: string;
-  runtimeUrl?: string | null;
   modelProvider?: string;
   /**
    * Locale cache TTL in milliseconds. Undefined uses the default TTL, null

--- a/packages/i18n/src/i18n-cache/utils/resolveCacheLocale.ts
+++ b/packages/i18n/src/i18n-cache/utils/resolveCacheLocale.ts
@@ -1,0 +1,30 @@
+import { getI18nConfig } from '../../i18n-config/singleton-operations';
+import type { LookupOptions } from '../../translation-functions/types/options';
+
+export function resolveCacheLocale(locale: string): string | undefined {
+  const i18nConfig = getI18nConfig();
+  const resolvedLocale = i18nConfig.resolveLocale(locale);
+  if (i18nConfig.requiresTranslation(resolvedLocale)) {
+    return resolvedLocale;
+  }
+
+  const aliasLocale = i18nConfig.resolveAliasLocale(
+    i18nConfig.standardizeLocale(locale)
+  );
+  return i18nConfig.requiresTranslation(aliasLocale) ? aliasLocale : undefined;
+}
+
+export function resolveDictionaryCacheLocale(locale: string): string {
+  return resolveCacheLocale(locale) ?? getI18nConfig().getDefaultLocale();
+}
+
+export function resolveLookupParams(locale: string, options: LookupOptions) {
+  const translationLocale = resolveCacheLocale(locale);
+  return {
+    translationLocale,
+    options:
+      translationLocale && options.$locale
+        ? { ...options, $locale: translationLocale }
+        : options,
+  };
+}

--- a/packages/i18n/src/i18n-config/I18nConfig.ts
+++ b/packages/i18n/src/i18n-config/I18nConfig.ts
@@ -3,7 +3,6 @@ import {
   type LocaleConfigConstructorParams,
 } from '@generaltranslation/format';
 import type { CustomMapping } from '@generaltranslation/format/types';
-import { GTRuntime } from 'generaltranslation/runtime';
 import { libraryDefaultLocale } from 'generaltranslation/internal';
 import type { GTConfig } from '../config/types';
 import {
@@ -33,11 +32,16 @@ export type I18nConfigParams = Pick<
   | 'cacheUrl'
   | 'runtimeUrl'
   | '_disableDevHotReload'
+  | '_versionId'
 >;
 
 type RuntimeConfig = Pick<
   I18nConfigParams,
-  'projectId' | 'devApiKey' | 'apiKey' | 'runtimeUrl' | '_disableDevHotReload'
+  | 'projectId'
+  | 'devApiKey'
+  | 'runtimeUrl'
+  | '_disableDevHotReload'
+  | '_versionId'
 >;
 
 export type LocaleCandidates = string | string[] | undefined;
@@ -53,9 +57,9 @@ export class I18nConfig extends LocaleConfig {
     this.runtimeConfig = {
       projectId: params.projectId,
       devApiKey: params.devApiKey,
-      apiKey: params.apiKey,
       runtimeUrl: params.runtimeUrl,
       _disableDevHotReload: params._disableDevHotReload,
+      _versionId: params._versionId,
     };
     this.gtServicesEnabled = gtServicesEnabled;
     this.logLevel = getGeneralTranslationLogLevel();
@@ -77,16 +81,8 @@ export class I18nConfig extends LocaleConfig {
     return this.runtimeConfig.projectId;
   }
 
-  /**
-   * Get a GT instance bound to the resolved target locale. When omitted, the
-   * instance is locale agnostic.
-   *
-   * TODO: keep a cache to avoid creating new instances unnecessarily.
-   */
-  getGTClass(locale?: string): GTRuntime {
-    return this.getGTClassClean(
-      locale ? this.resolveLocale(locale) : undefined
-    );
+  getVersionId(): string | undefined {
+    return this.runtimeConfig._versionId;
   }
 
   determineLocale(
@@ -150,28 +146,6 @@ export class I18nConfig extends LocaleConfig {
 
   isDebugLoggingEnabled(): boolean {
     return isDebugLogLevel(this.logLevel);
-  }
-
-  /**
-   * Create a GT instance without resolving the target locale first.
-   */
-  private getGTClassClean(locale?: string) {
-    return new GTRuntime({
-      sourceLocale: this.getDefaultLocale(),
-      targetLocale: locale,
-      // GT validates approved locales before constructing its LocaleConfig, so
-      // pass canonical locales here while preserving alias target locales.
-      locales: Array.from(
-        new Set(
-          this.getLocales().map((locale) => this.resolveCanonicalLocale(locale))
-        )
-      ),
-      customMapping: this.getCustomMapping(),
-      projectId: this.runtimeConfig.projectId,
-      baseUrl: this.runtimeConfig.runtimeUrl || undefined,
-      apiKey: this.runtimeConfig.apiKey,
-      devApiKey: this.runtimeConfig.devApiKey,
-    });
   }
 
   private getLocaleConfig(config?: I18nConfigParams): LocaleConfig {

--- a/packages/i18n/src/i18n-config/__tests__/I18nConfig.test.ts
+++ b/packages/i18n/src/i18n-config/__tests__/I18nConfig.test.ts
@@ -24,6 +24,12 @@ describe('I18nConfig', () => {
     expect(config.getLocales()).toEqual(['fr']);
   });
 
+  it('owns the configured source version', () => {
+    const config = new I18nConfig({ _versionId: 'version-1' });
+
+    expect(config.getVersionId()).toBe('version-1');
+  });
+
   it('skips locale validation when GT services are disabled', () => {
     const config = new I18nConfig({
       defaultLocale: 'invalid-locale',

--- a/packages/i18n/src/internal.ts
+++ b/packages/i18n/src/internal.ts
@@ -15,14 +15,18 @@ export {
 export { createLookupOptions } from './translation-functions/internal/helpers';
 export { renderDictionaryEntry } from './translation-functions/internal/renderDictionaryEntry';
 export { renderDictionaryObject } from './translation-functions/internal/renderDictionaryObject';
-export { I18nCache } from './i18n-cache/I18nCache';
-export type { TranslationsCacheMissEvent } from './i18n-cache/I18nCache';
+export { DictionarySourceNotFoundError } from './i18n-cache/translations-manager/utils/DictionarySourceNotFoundError';
 export { ReadonlyConditionStore } from './condition-store/ReadonlyConditionStore';
 export type { ReadonlyConditionStoreParams } from './condition-store/ReadonlyConditionStore';
 export { WritableConditionStore } from './condition-store/WritableConditionStore';
 export type { WritableConditionStoreParams } from './condition-store/WritableConditionStore';
 export type { LocaleCandidates } from './i18n-config/I18nConfig';
-export { getI18nCache, setI18nCache } from './i18n-cache/singleton-operations';
+export {
+  getI18nCache,
+  isI18nCacheInitialized,
+  setI18nCache,
+} from './i18n-cache/singleton-operations';
+export type { I18nCacheInstance } from './i18n-cache/singleton-operations';
 export { getVersionId } from './helpers/versionId';
 export { interpolateMessage } from './translation-functions/utils/interpolation/interpolateMessage';
 export { isEncodedTranslationOptions } from './translation-functions/utils/isEncodedTranslationOptions';
@@ -53,5 +57,7 @@ export { createConditionStoreSingleton } from './condition-store/createCondition
 export { createGlobalSingleton } from './globals/createGlobalSingleton';
 export type { GlobalSingleton } from './globals/createGlobalSingleton';
 export { getRuntimeEnvironment } from './utils/getRuntimeEnvironment';
+export { resolveCacheLocale } from './i18n-cache/utils/resolveCacheLocale';
+export { dedupePending } from './i18n-cache/translations-manager/utils/dedupePending';
 export { hashMessage } from './utils/hashMessage';
 export { getCookieValue, parseAcceptLanguage } from './utils/request';

--- a/packages/i18n/src/runtime/createGTRuntime.ts
+++ b/packages/i18n/src/runtime/createGTRuntime.ts
@@ -1,0 +1,31 @@
+import { GTRuntime } from 'generaltranslation/runtime';
+import type { I18nConfig, I18nConfigParams } from '../i18n-config/I18nConfig';
+
+type GTRuntimeConfig = Pick<
+  I18nConfigParams,
+  'projectId' | 'runtimeUrl' | 'apiKey' | 'devApiKey'
+>;
+
+/** Construct the translation client only inside runtime-translation modules. */
+export function createGTRuntime(
+  config: I18nConfig,
+  runtimeConfig: GTRuntimeConfig
+): GTRuntime {
+  return new GTRuntime({
+    sourceLocale: config.getDefaultLocale(),
+    locales: Array.from(
+      new Set(
+        config
+          .getLocales()
+          .map((configuredLocale) =>
+            config.resolveCanonicalLocale(configuredLocale)
+          )
+      )
+    ),
+    customMapping: config.getCustomMapping(),
+    projectId: runtimeConfig.projectId,
+    baseUrl: runtimeConfig.runtimeUrl || undefined,
+    apiKey: runtimeConfig.apiKey,
+    devApiKey: runtimeConfig.devApiKey,
+  });
+}

--- a/packages/i18n/tsdown.config.mts
+++ b/packages/i18n/tsdown.config.mts
@@ -1,11 +1,27 @@
 import { defineConfig } from 'tsdown';
 import { createTsdownConfig } from '../../tsdown.preset.mts';
 
-export default defineConfig(
-  createTsdownConfig([
-    'src/index.ts',
-    'src/types.ts',
-    'src/internal.ts',
-    'src/internal-types.ts',
-  ])
-);
+const mainEntries = [
+  'src/index.ts',
+  'src/types.ts',
+  'src/internal.ts',
+  'src/internal-types.ts',
+  'src/i18n-cache/SnapshotStore.ts',
+  'src/i18n-cache/createTranslationLoader.ts',
+];
+const [mainCjs, mainEsm] = createTsdownConfig(mainEntries);
+const [cacheCjs, cacheEsm] = createTsdownConfig([
+  'src/i18n-cache/I18nCache.ts',
+]);
+const [runtimeResolverCjs, runtimeResolverEsm] = createTsdownConfig([
+  'src/i18n-cache/RuntimeTranslationResolver.ts',
+]);
+
+export default defineConfig([
+  mainCjs,
+  mainEsm,
+  { ...cacheCjs, clean: false },
+  { ...cacheEsm, clean: false },
+  { ...runtimeResolverCjs, clean: false },
+  { ...runtimeResolverEsm, clean: false },
+]);

--- a/packages/next/src/i18n-cache/NextI18nCache.ts
+++ b/packages/next/src/i18n-cache/NextI18nCache.ts
@@ -1,21 +1,20 @@
-import {
-  getI18nCache,
-  getI18nConfig,
-  setI18nCache,
-  type I18nCache,
-} from 'gt-i18n/internal';
+import { getI18nCache, getI18nConfig } from 'gt-i18n/internal';
 import type { Locale } from 'gt-i18n/internal/types';
-import type { Dictionary, Translation } from 'gt-i18n/types';
-import { ReactI18nCache, type ReactI18nCacheParams } from 'gt-react';
+import type { Dictionary } from 'gt-i18n/types';
+import {
+  ReactI18nCache,
+  setReactI18nCache,
+  type ReactI18nCacheParams,
+} from 'gt-react';
 import { getDictionary } from '../dictionary/getDictionary';
 import { resolveDictionaryLoader } from '../resolvers/resolveDictionaryLoader';
 
 export function getNextI18nCache(): NextI18nCache {
-  return getI18nCache() as NextI18nCache;
+  return getI18nCache() as unknown as NextI18nCache;
 }
 
 export function setNextI18nCache(i18nCache: NextI18nCache): void {
-  setI18nCache(i18nCache as I18nCache<Translation>);
+  setReactI18nCache(i18nCache);
 }
 
 export type NextI18nCacheParams = ReactI18nCacheParams;

--- a/packages/next/src/pages-dir/parseLocale.ts
+++ b/packages/next/src/pages-dir/parseLocale.ts
@@ -36,9 +36,7 @@ export function parseLocale<
   }
 
   return (
-    i18nConfig
-      .getGTClass()
-      .determineLocale(preferredLocales, i18nConfig.getLocales()) ||
+    i18nConfig.determineLocale(preferredLocales, i18nConfig.getLocales()) ||
     i18nConfig.getDefaultLocale()
   );
 }

--- a/packages/next/src/request/getLocaleDirection.ts
+++ b/packages/next/src/request/getLocaleDirection.ts
@@ -18,14 +18,14 @@ export function getLocaleDirection(locale: string): 'ltr' | 'rtl';
 export function getLocaleDirection(): Promise<'ltr' | 'rtl'>;
 // Implementation
 export function getLocaleDirection(locale?: string) {
-  const gtInstance = getI18nConfig().getGTClass();
+  const i18nConfig = getI18nConfig();
   if (typeof locale === 'string') {
     // Synchronous result when locale is given
-    return gtInstance.getLocaleDirection(locale) as 'ltr' | 'rtl';
+    return i18nConfig.getLocaleDirection(locale) as 'ltr' | 'rtl';
   }
   // Asynchronous result when locale is not given
   return getLocale().then((resolvedLocale) =>
-    gtInstance.getLocaleDirection(resolvedLocale)
+    i18nConfig.getLocaleDirection(resolvedLocale)
   ) as Promise<'ltr' | 'rtl'>;
 }
 
@@ -43,5 +43,5 @@ export function getLocaleDirection(locale?: string) {
  */
 export function useLocaleDirection(locale?: string): 'ltr' | 'rtl' {
   locale = locale || useLocale();
-  return getI18nConfig().getGTClass().getLocaleDirection(locale);
+  return getI18nConfig().getLocaleDirection(locale);
 }

--- a/packages/next/src/setup/__tests__/initGT.test.ts
+++ b/packages/next/src/setup/__tests__/initGT.test.ts
@@ -6,7 +6,6 @@ import {
 import {
   getI18nConfig,
   getReactI18nCache,
-  ReactI18nCache,
 } from '@generaltranslation/react-core/pure';
 import { initializeGT } from '../initGT';
 import { initializeGTClient } from '../initGT.client';
@@ -86,7 +85,7 @@ describe('initializeGTClient', () => {
     vi.restoreAllMocks();
   });
 
-  it('uses the client-safe ReactI18nCache', () => {
+  it('provides the legacy cache API without initializing the server cache', () => {
     initializeGTClient({
       i18nConfigParams: {
         defaultLocale: 'en',
@@ -96,7 +95,13 @@ describe('initializeGTClient', () => {
     });
 
     const cache = getReactI18nCache();
-    expect(cache).toBeInstanceOf(ReactI18nCache);
     expect(cache).not.toBeInstanceOf(NextI18nCache);
+    expect(
+      cache.lookupTranslation('en', 'Hello', {
+        $_hash: 'greeting',
+        $format: 'ICU',
+      })
+    ).toBe('Hello');
+    expect(cache.loadTranslations).toBeTypeOf('function');
   });
 });

--- a/packages/next/src/setup/initGT.client.ts
+++ b/packages/next/src/setup/initGT.client.ts
@@ -1,4 +1,4 @@
-import { internalInitializeGTSRA } from '@generaltranslation/react-core/pure';
+import { internalInitializeGTClient } from '@generaltranslation/react-core/pure';
 import { getParams } from './shared';
 import type { NextSetupI18nConfigParams } from './shared';
 import type { NextI18nCacheParams } from '../i18n-cache/NextI18nCache';
@@ -15,14 +15,8 @@ export function initializeGTClient(
     nextI18nCacheParams: NextI18nCacheParams;
   } = getParams()
 ): void {
-  internalInitializeGTSRA({
+  internalInitializeGTClient({
     ...i18nConfigParams,
     ...nextI18nCacheParams,
-    /**
-     * Always disable cache expiry for client-side lookups.
-     * Translations and dictionaries are exclusively passed from server to
-     * client, so the client has no loader to refresh expired entries.
-     */
-    cacheExpiryTime: null,
   });
 }

--- a/packages/next/src/setup/shared.ts
+++ b/packages/next/src/setup/shared.ts
@@ -29,6 +29,7 @@ export function getParams(): {
     devApiKey,
     apiKey,
     cacheUrl: clientConfig.cacheUrl,
+    _versionId: clientConfig._versionId,
     _disableDevHotReload: clientConfig._disableDevHotReload,
     localeCookieName: clientConfig.headersAndCookies?.localeCookieName,
     enableI18nCookieName: clientConfig.headersAndCookies?.enableI18nCookieName,

--- a/packages/node/src/async-i18n-cache/__tests__/AsyncConditionStore.test.ts
+++ b/packages/node/src/async-i18n-cache/__tests__/AsyncConditionStore.test.ts
@@ -1,9 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import {
-  I18nCache,
-  initializeI18nConfig,
-  setI18nCache,
-} from 'gt-i18n/internal';
+import { initializeI18nConfig, setI18nCache } from 'gt-i18n/internal';
+import { I18nCache } from 'gt-i18n/internal/i18n-cache';
 import { AsyncConditionStore } from '../AsyncConditionStore';
 
 type TestGlobal = typeof globalThis & {

--- a/packages/node/src/internal.ts
+++ b/packages/node/src/internal.ts
@@ -3,4 +3,5 @@ export {
   getAsyncConditionStore,
   setAsyncConditionStore,
 } from './async-i18n-cache/singleton-operations';
-export { getI18nCache, setI18nCache, I18nCache } from 'gt-i18n/internal';
+export { getI18nCache, setI18nCache } from 'gt-i18n/internal';
+export { I18nCache } from 'gt-i18n/internal/i18n-cache';

--- a/packages/node/src/setup/initializeGT.ts
+++ b/packages/node/src/setup/initializeGT.ts
@@ -1,10 +1,7 @@
 import { setAsyncConditionStore } from '../async-i18n-cache/singleton-operations';
 import type { InitializeGTParams } from './types';
-import {
-  I18nCache,
-  initializeI18nConfig,
-  setI18nCache,
-} from 'gt-i18n/internal';
+import { initializeI18nConfig, setI18nCache } from 'gt-i18n/internal';
+import { I18nCache } from 'gt-i18n/internal/i18n-cache';
 import { AsyncConditionStore } from '../async-i18n-cache/AsyncConditionStore';
 import { addRuntimeCredentials } from './runtimeCredentials';
 

--- a/packages/react-core/src/components/variables/Currency.shared.ts
+++ b/packages/react-core/src/components/variables/Currency.shared.ts
@@ -33,11 +33,11 @@ function computeCurrency({
     enableI18n: _enableI18n,
     localesProp,
   });
-  const gt = getI18nConfig().getGTClass();
+  const i18nConfig = getI18nConfig();
   if (children == null) return null;
   const parsedNumber =
     typeof children === 'string' ? parseFloat(children) : children;
-  return gt.formatCurrency(parsedNumber, currency, {
+  return i18nConfig.formatCurrency(parsedNumber, currency, undefined, {
     locales,
     ...options,
   });

--- a/packages/react-core/src/components/variables/DateTime.shared.ts
+++ b/packages/react-core/src/components/variables/DateTime.shared.ts
@@ -31,11 +31,10 @@ function computeDateTime({
     enableI18n: _enableI18n,
     localesProp,
   });
-  // TODO: theres a world in which we don't need the i18n cache, if user passes their own params
-  const gt = getI18nConfig().getGTClass();
+  const i18nConfig = getI18nConfig();
   if (children == null) return null;
-  return gt
-    .formatDateTime(children, { locales, ...options })
+  return i18nConfig
+    .formatDateTime(children, undefined, { locales, ...options })
     .replace(/[\u200F\u202B\u202E]/g, '');
 }
 

--- a/packages/react-core/src/components/variables/Num.shared.ts
+++ b/packages/react-core/src/components/variables/Num.shared.ts
@@ -31,11 +31,14 @@ function computeNum({
     enableI18n: _enableI18n,
     localesProp,
   });
-  const gt = getI18nConfig().getGTClass();
+  const i18nConfig = getI18nConfig();
   if (children == null) return null;
   const parsedNumber =
     typeof children === 'string' ? parseFloat(children) : children;
-  return gt.formatNum(parsedNumber, { locales, ...options });
+  return i18nConfig.formatNum(parsedNumber, undefined, {
+    locales,
+    ...options,
+  });
 }
 
 export { computeNum };

--- a/packages/react-core/src/components/variables/RelativeTime.shared.ts
+++ b/packages/react-core/src/components/variables/RelativeTime.shared.ts
@@ -39,7 +39,7 @@ function computeRelativeTime({
     enableI18n: _enableI18n,
     localesProp,
   });
-  const gt = getI18nConfig().getGTClass();
+  const i18nConfig = getI18nConfig();
   const resolvedDate = date ?? children;
 
   if (process.env.NODE_ENV === 'development' && value !== undefined && !unit) {
@@ -50,7 +50,7 @@ function computeRelativeTime({
   }
 
   if (value !== undefined && unit) {
-    return gt.formatRelativeTime(value, unit, {
+    return i18nConfig.formatRelativeTime(value, unit, undefined, {
       locales,
       numeric: options.numeric,
       style: options.style,
@@ -59,7 +59,7 @@ function computeRelativeTime({
   }
 
   if (resolvedDate != null) {
-    return gt.formatRelativeTimeFromDate(resolvedDate, {
+    return i18nConfig.formatRelativeTimeFromDate(resolvedDate, undefined, {
       locales,
       baseDate: baseDate ?? new Date(),
       numeric: options.numeric,

--- a/packages/react-core/src/functions/translation/t.ts
+++ b/packages/react-core/src/functions/translation/t.ts
@@ -11,7 +11,7 @@ import {
   isReadonlyConditionStoreInitialized,
 } from '../../condition-store/singleton-operations';
 import { StringContent, StringFormat } from 'generaltranslation/types';
-import { getReactI18nCache } from '../../i18n-cache/singleton-operations';
+import { getReactI18nCacheInstance } from '../../i18n-cache/singleton-operations';
 import { getShouldTranslate } from '../../hooks/utils/getShouldTranslate';
 import { createDiagnosticMessage } from 'generaltranslation/internal';
 
@@ -60,7 +60,7 @@ export function resolveStringContent(
   content: StringContent,
   options: LookupOptionsFor<StringFormat> = {}
 ): StringContent {
-  const i18nCache = getReactI18nCache();
+  const cache = getReactI18nCacheInstance();
   const defaultLocale = getI18nConfig().getDefaultLocale();
   if (!getShouldTranslate()) {
     return interpolateMessage({
@@ -71,7 +71,7 @@ export function resolveStringContent(
   }
 
   const lookupOptions = createLookupOptions(locale, options, 'ICU');
-  const translation = i18nCache.lookupTranslation(
+  const translation = cache.lookupTranslation(
     lookupOptions.$locale,
     content,
     lookupOptions
@@ -106,8 +106,8 @@ function handleTaggedTemplateLiteralTranslation(
     messageOrStrings,
     values
   );
-  const i18nCache = getReactI18nCache();
-  const translatedInterpolatedTemplate = i18nCache.lookupTranslation(
+  const cache = getReactI18nCacheInstance();
+  const translatedInterpolatedTemplate = cache.lookupTranslation(
     locale,
     interpolatedTemplate,
     { $format: 'STRING' }
@@ -218,22 +218,8 @@ function getLocale(): string {
  * Overloaded type for the `t` function.
  * - Tagged template: t`Hello, ${name}` (transformed by the compiler plugin at build time)
  * - Function call: t("Hello, {name}", { name: "John" })
- *
- * {@link TemplateSyncResolutionFunction}
- * {@link SyncResolutionFunction}
  */
 interface StringOrTemplateSyncResolutionFunction {
   (strings: TemplateStringsArray, ...values: unknown[]): string;
   (message: string, options?: GTTranslationOptions): string;
 }
-
-/**
- * Type for the `t` function when used as a tagged template literal.
- * @param strings - The template strings.
- * @param values - The values to interpolate.
- * @returns The translated message.
- */
-type TemplateSyncResolutionFunction = (
-  strings: TemplateStringsArray,
-  ...values: unknown[]
-) => string;

--- a/packages/react-core/src/hooks/useInternalRegionSelector.ts
+++ b/packages/react-core/src/hooks/useInternalRegionSelector.ts
@@ -1,8 +1,14 @@
 import { useMemo } from 'react';
 import { useCustomMapping, useLocales } from './i18n-config';
 import { useLocale, useRegion } from './condition-store';
-import { getLocaleProperties } from '@generaltranslation/format';
-import { getI18nConfig } from 'gt-i18n/internal';
+import {
+  getLocaleProperties,
+  getRegionProperties,
+} from '@generaltranslation/format';
+import type {
+  CustomMapping,
+  CustomRegionMapping,
+} from '@generaltranslation/format/types';
 
 export type RegionData = {
   code: string;
@@ -58,7 +64,7 @@ export function useInternalRegionSelector({
     regions, // ordered list of ISO 3166 region codes
     regionData, // map of ISO 3166 region codes to region display data, potentially not ordered
   ] = useMemo<[string[], Map<string, RegionData>]>(() => {
-    const gt = getI18nConfig().getGTClass(locale);
+    const localeRegionMapping = getCustomRegionMapping(localeCustomMapping);
     const regionToLocaleMap = new Map(
       contextLocales.map((l) => {
         const lp = getLocaleProperties(l, locale, localeCustomMapping); // has to be directly called so sourceLocale can be in the user's current locale
@@ -76,7 +82,7 @@ export function useInternalRegionSelector({
           r,
           {
             locale: regionToLocaleMap?.get(r)?.code || locale,
-            ...gt.getRegionProperties(r),
+            ...getRegionProperties(r, locale, localeRegionMapping),
             ...(typeof customMapping?.[r] === 'string'
               ? { name: customMapping?.[r] }
               : customMapping?.[r]),
@@ -122,4 +128,24 @@ export function useInternalRegionSelector({
     locale,
     localeRegion,
   };
+}
+
+function getCustomRegionMapping(
+  customMapping: CustomMapping
+): CustomRegionMapping {
+  const regionMapping: CustomRegionMapping = {};
+  for (const [mappedLocale, mapping] of Object.entries(customMapping)) {
+    if (
+      typeof mapping === 'object' &&
+      mapping?.regionCode &&
+      !regionMapping[mapping.regionCode]
+    ) {
+      regionMapping[mapping.regionCode] = {
+        locale: mappedLocale,
+        ...(mapping.regionName && { name: mapping.regionName }),
+        ...(mapping.emoji && { emoji: mapping.emoji }),
+      };
+    }
+  }
+  return regionMapping;
 }

--- a/packages/react-core/src/hooks/utils.ts
+++ b/packages/react-core/src/hooks/utils.ts
@@ -31,17 +31,14 @@ export function useShouldTranslate(): boolean {
 }
 
 export function useLocaleProperties(locale: string): LocaleProperties {
-  return useMemo(
-    () => getI18nConfig().getGTClass().getLocaleProperties(locale),
-    [locale]
-  );
+  return useMemo(() => getI18nConfig().getLocaleProperties(locale), [locale]);
 }
 
 export function useLocaleDirection(locale?: string): 'ltr' | 'rtl' {
   const currentLocale = useLocale();
   const resolvedLocale = locale ?? currentLocale;
   return useMemo(
-    () => getI18nConfig().getGTClass().getLocaleDirection(resolvedLocale),
+    () => getI18nConfig().getLocaleDirection(resolvedLocale),
     [resolvedLocale]
   );
 }

--- a/packages/react-core/src/i18n-cache/HydratedI18nCache.ts
+++ b/packages/react-core/src/i18n-cache/HydratedI18nCache.ts
@@ -1,0 +1,229 @@
+import {
+  dedupePending,
+  DictionarySourceNotFoundError,
+  getI18nConfig,
+  getRuntimeEnvironment,
+  resolveCacheLocale,
+} from 'gt-i18n/internal';
+import type { I18nCacheInstance } from 'gt-i18n/internal';
+import type {
+  I18nCacheConstructorParams,
+  LookupOptions,
+} from 'gt-i18n/internal/types';
+import type { MissingTranslationResolver } from 'gt-i18n/internal/runtime-translation-resolver';
+import { SnapshotStore } from 'gt-i18n/internal/snapshot-store';
+import { createTranslationLoader } from 'gt-i18n/internal/translation-loader';
+import type {
+  Dictionary,
+  DictionaryEntry,
+  DictionaryObject,
+  Translation,
+} from 'gt-i18n/types';
+
+/** Legacy cache API backed by the lightweight hydrated-client capabilities. */
+export class HydratedI18nCache
+  implements I18nCacheInstance<Translation>, MissingTranslationResolver
+{
+  private readonly loadTranslationsFromSource;
+  private readonly pendingTranslationLoads = new Map<
+    string,
+    Promise<Record<string, Translation>>
+  >();
+  private readonly pendingDictionaryLoads = new Map<
+    string,
+    Promise<Dictionary>
+  >();
+
+  constructor(
+    private readonly params: I18nCacheConstructorParams,
+    private readonly snapshots: SnapshotStore,
+    private readonly missingTranslationResolver?: MissingTranslationResolver
+  ) {
+    this.loadTranslationsFromSource = createTranslationLoader(params);
+  }
+
+  getVersionId(): string | undefined {
+    return this.params._versionId;
+  }
+
+  updateTranslations(
+    translations: Record<string, Record<string, Translation>>
+  ): void {
+    this.snapshots.updateTranslations(translations);
+  }
+
+  updateDictionaries(dictionaries: Record<string, Dictionary>): void {
+    this.snapshots.updateDictionaries(dictionaries);
+  }
+
+  async loadTranslations(locale: string): Promise<Record<string, Translation>> {
+    return this.guardAsync({}, async () => {
+      const translationLocale = resolveCacheLocale(locale);
+      if (!translationLocale) return {};
+
+      const existing = this.snapshots.getTranslations(translationLocale);
+      if (existing) return existing;
+
+      return dedupePending(
+        this.pendingTranslationLoads,
+        translationLocale,
+        async () => {
+          const translations =
+            await this.loadTranslationsFromSource(translationLocale);
+          this.snapshots.updateTranslations({
+            [translationLocale]: translations,
+          });
+          return translations;
+        }
+      );
+    });
+  }
+
+  async loadDictionary(locale: string): Promise<Dictionary> {
+    return this.guardAsync({}, async () => {
+      const dictionaryLocale =
+        resolveCacheLocale(locale) ?? getI18nConfig().getDefaultLocale();
+      const existing = this.snapshots.getDictionary(dictionaryLocale);
+      if (existing) return existing;
+
+      const loadDictionary = this.params.loadDictionary;
+      if (!loadDictionary) return {};
+
+      return dedupePending(
+        this.pendingDictionaryLoads,
+        dictionaryLocale,
+        async () => {
+          const dictionary = await loadDictionary(dictionaryLocale);
+          this.snapshots.updateDictionaries({ [dictionaryLocale]: dictionary });
+          return dictionary;
+        }
+      );
+    });
+  }
+
+  lookupTranslation<T extends Translation>(
+    locale: string,
+    message: T,
+    options: LookupOptions
+  ): T | undefined {
+    return this.guard(undefined, () =>
+      this.snapshots.lookupTranslation(locale, message, options)
+    );
+  }
+
+  lookupDictionary(locale: string, id: string): DictionaryEntry | undefined {
+    return this.guard(undefined, () =>
+      this.snapshots.lookupDictionary(locale, id)
+    );
+  }
+
+  lookupDictionaryObj(
+    locale: string,
+    id: string
+  ): DictionaryObject | undefined {
+    return this.guard(undefined, () =>
+      this.snapshots.lookupDictionaryObj(locale, id)
+    );
+  }
+
+  lookupTranslationWithFallback<T extends Translation>(
+    locale: string,
+    message: T,
+    options: LookupOptions
+  ): Promise<T | undefined> {
+    const resolver = this.missingTranslationResolver;
+    return resolver
+      ? this.guardAsync(undefined, () =>
+          resolver.lookupTranslationWithFallback(locale, message, options)
+        )
+      : Promise.resolve(this.lookupTranslation(locale, message, options));
+  }
+
+  lookupDictionaryWithFallback(
+    locale: string,
+    id: string
+  ): Promise<DictionaryEntry | undefined> {
+    const resolver = this.missingTranslationResolver;
+    return resolver
+      ? this.guardAsync(undefined, () =>
+          resolver.lookupDictionaryWithFallback(locale, id)
+        )
+      : this.guardAsync(undefined, async () => {
+          const targetEntry = this.snapshots.lookupDictionary(locale, id);
+          if (targetEntry !== undefined) return targetEntry;
+
+          const sourceEntry = this.snapshots.lookupDictionary(
+            getI18nConfig().getDefaultLocale(),
+            id
+          );
+          if (sourceEntry === undefined) {
+            throw new DictionarySourceNotFoundError(id);
+          }
+          return undefined;
+        });
+  }
+
+  lookupDictionaryObjWithFallback(
+    locale: string,
+    id: string
+  ): Promise<DictionaryObject | undefined> {
+    const resolver = this.missingTranslationResolver;
+    return resolver
+      ? this.guardAsync(undefined, () =>
+          resolver.lookupDictionaryObjWithFallback(locale, id)
+        )
+      : this.guardAsync(undefined, async () => {
+          const targetObject = this.snapshots.lookupDictionaryObj(locale, id);
+          if (targetObject !== undefined) return targetObject;
+
+          const sourceObject = this.snapshots.lookupDictionaryObj(
+            getI18nConfig().getDefaultLocale(),
+            id
+          );
+          if (sourceObject === undefined) {
+            throw new DictionarySourceNotFoundError(id);
+          }
+          return undefined;
+        });
+  }
+
+  async getLookupTranslation(locale: string) {
+    await this.loadTranslations(locale);
+    return <T extends Translation>(
+      message: T,
+      options: LookupOptions = {} as LookupOptions
+    ) => this.lookupTranslation(options.$locale ?? locale, message, options);
+  }
+
+  async getLookupDictionary(locale: string) {
+    await this.loadDictionary(locale);
+    return {
+      lookupDictionary: (id: string) => this.lookupDictionary(locale, id),
+      lookupDictionaryObj: (id: string) => this.lookupDictionaryObj(locale, id),
+    };
+  }
+
+  private guard<T>(fallback: T, fn: () => T): T {
+    try {
+      return fn();
+    } catch (error) {
+      this.handleError(error);
+      return fallback;
+    }
+  }
+
+  private async guardAsync<T>(fallback: T, fn: () => Promise<T>): Promise<T> {
+    try {
+      return await fn();
+    } catch (error) {
+      this.handleError(error);
+      return fallback;
+    }
+  }
+
+  private handleError(error: unknown): void {
+    if (error instanceof DictionarySourceNotFoundError) throw error;
+    if (getRuntimeEnvironment() === 'development') throw error;
+    console.error(`I18nCache: ${String(error)}`);
+  }
+}

--- a/packages/react-core/src/i18n-cache/LazyRuntimeTranslationResolver.ts
+++ b/packages/react-core/src/i18n-cache/LazyRuntimeTranslationResolver.ts
@@ -1,0 +1,59 @@
+import type {
+  MissingTranslationResolver,
+  RuntimeTranslationResolverParams,
+} from 'gt-i18n/internal/runtime-translation-resolver';
+import type { SnapshotStoreInstance } from 'gt-i18n/internal/snapshot-store';
+import type { LookupOptions } from 'gt-i18n/internal/types';
+import type {
+  DictionaryEntry,
+  DictionaryObject,
+  Translation,
+} from 'gt-i18n/types';
+
+/** Loads development runtime translation only after the first client miss. */
+export class LazyRuntimeTranslationResolver implements MissingTranslationResolver {
+  private resolver?: Promise<MissingTranslationResolver>;
+
+  constructor(
+    private readonly snapshots: SnapshotStoreInstance,
+    private readonly params: RuntimeTranslationResolverParams
+  ) {}
+
+  async lookupTranslationWithFallback<T extends Translation>(
+    locale: string,
+    message: T,
+    options: LookupOptions
+  ): Promise<T | undefined> {
+    return (await this.getResolver()).lookupTranslationWithFallback(
+      locale,
+      message,
+      options
+    );
+  }
+
+  async lookupDictionaryWithFallback(
+    locale: string,
+    id: string
+  ): Promise<DictionaryEntry | undefined> {
+    return (await this.getResolver()).lookupDictionaryWithFallback(locale, id);
+  }
+
+  async lookupDictionaryObjWithFallback(
+    locale: string,
+    id: string
+  ): Promise<DictionaryObject | undefined> {
+    return (await this.getResolver()).lookupDictionaryObjWithFallback(
+      locale,
+      id
+    );
+  }
+
+  private getResolver(): Promise<MissingTranslationResolver> {
+    this.resolver ??=
+      import('gt-i18n/internal/runtime-translation-resolver').then(
+        ({ RuntimeTranslationResolver }) =>
+          new RuntimeTranslationResolver(this.snapshots, this.params)
+      );
+    return this.resolver;
+  }
+}

--- a/packages/react-core/src/i18n-cache/ReactI18nCache.ts
+++ b/packages/react-core/src/i18n-cache/ReactI18nCache.ts
@@ -1,4 +1,4 @@
-import { I18nCache } from 'gt-i18n/internal';
+import { I18nCache } from 'gt-i18n/internal/i18n-cache';
 import type { I18nCacheConstructorParams } from 'gt-i18n/internal/types';
 import type { Translation } from 'gt-i18n/types';
 

--- a/packages/react-core/src/i18n-cache/__tests__/HydratedI18nCache.test.ts
+++ b/packages/react-core/src/i18n-cache/__tests__/HydratedI18nCache.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SnapshotStore } from 'gt-i18n/internal/snapshot-store';
+import { HydratedI18nCache } from '../HydratedI18nCache';
+import { initializeI18nConfig } from '../../setup/i18nConfig';
+
+type TestGlobal = typeof globalThis & {
+  __generaltranslation?: unknown;
+};
+
+describe('HydratedI18nCache', () => {
+  beforeEach(() => {
+    Reflect.deleteProperty(globalThis as TestGlobal, '__generaltranslation');
+    initializeI18nConfig(
+      {
+        defaultLocale: 'en',
+        locales: ['en', 'fr'],
+      },
+      'server-render'
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it('preserves synchronous cache lookups over hydrated snapshots', () => {
+    const snapshots = new SnapshotStore();
+    const cache = new HydratedI18nCache({}, snapshots);
+    cache.updateTranslations({ fr: { greeting: 'Bonjour' } });
+
+    expect(
+      cache.lookupTranslation('fr', 'Hello', {
+        $_hash: 'greeting',
+        $format: 'ICU',
+      })
+    ).toBe('Bonjour');
+  });
+
+  it('preserves legacy loading methods without constructing the full cache', async () => {
+    const loadTranslations = vi.fn(async () => ({ greeting: 'Bonjour' }));
+    const cache = new HydratedI18nCache(
+      { cacheUrl: null, loadTranslations },
+      new SnapshotStore()
+    );
+
+    await expect(cache.loadTranslations('fr')).resolves.toEqual({
+      greeting: 'Bonjour',
+    });
+    expect(loadTranslations).toHaveBeenCalledWith('fr');
+    expect(
+      cache.lookupTranslation('fr', 'Hello', {
+        $_hash: 'greeting',
+        $format: 'ICU',
+      })
+    ).toBe('Bonjour');
+  });
+
+  it('deduplicates concurrent translation and dictionary loads by locale', async () => {
+    const loadTranslations = vi.fn(async () => ({ greeting: 'Bonjour' }));
+    const loadDictionary = vi.fn(async () => ({ greeting: 'Bonjour' }));
+    const cache = new HydratedI18nCache(
+      { cacheUrl: null, loadTranslations, loadDictionary },
+      new SnapshotStore({ greeting: 'Hello' })
+    );
+
+    await Promise.all([
+      cache.loadTranslations('fr'),
+      cache.loadTranslations('fr'),
+      cache.loadDictionary('fr'),
+      cache.loadDictionary('fr'),
+    ]);
+
+    expect(loadTranslations).toHaveBeenCalledTimes(1);
+    expect(loadDictionary).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves missing source dictionary errors in production', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    const cache = new HydratedI18nCache(
+      { cacheUrl: null },
+      new SnapshotStore({ greeting: 'Hello' })
+    );
+
+    await expect(
+      cache.lookupDictionaryWithFallback('fr', 'missing')
+    ).rejects.toMatchObject({ name: 'DictionarySourceNotFoundError' });
+    await expect(
+      cache.lookupDictionaryObjWithFallback('fr', 'missing')
+    ).rejects.toMatchObject({ name: 'DictionarySourceNotFoundError' });
+  });
+
+  it('preserves production soft failures for invalid locales', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const cache = new HydratedI18nCache({}, new SnapshotStore());
+
+    await expect(cache.loadTranslations('not a locale')).resolves.toEqual({});
+    expect(
+      cache.lookupTranslation('not a locale', 'Hello', {
+        $format: 'ICU',
+      })
+    ).toBeUndefined();
+    expect(consoleError).toHaveBeenCalled();
+  });
+});

--- a/packages/react-core/src/i18n-cache/singleton-operations.ts
+++ b/packages/react-core/src/i18n-cache/singleton-operations.ts
@@ -1,14 +1,47 @@
-import { getI18nCache, setI18nCache } from 'gt-i18n/internal';
-import type { I18nCache } from 'gt-i18n/internal';
+import {
+  getI18nCache,
+  isI18nCacheInitialized,
+  setI18nCache,
+} from 'gt-i18n/internal';
+import type { I18nCacheInstance } from 'gt-i18n/internal';
 import type { Translation } from 'gt-i18n/types';
+import { createDiagnosticMessage } from 'generaltranslation/internal';
 import type { ReactI18nCache } from './ReactI18nCache';
 
 // ===== I18n Cache ===== //
 
+export type ReactI18nCacheInstance = I18nCacheInstance<Translation>;
+
+const clientNotInitializedDiagnostic = createDiagnosticMessage({
+  source: '@generaltranslation/react-core',
+  severity: 'Error',
+  whatHappened: 'Cannot access the React i18n client before it is initialized',
+  fix: 'Initialize GT before reading or resolving translations.',
+});
+
 export function getReactI18nCache(): ReactI18nCache {
-  return getI18nCache() as ReactI18nCache;
+  return getI18nCache() as unknown as ReactI18nCache;
+}
+
+export function getReactI18nCacheInstance(): ReactI18nCacheInstance {
+  if (!isI18nCacheInitialized()) {
+    throw new Error(clientNotInitializedDiagnostic);
+  }
+  return getI18nCache();
+}
+
+export function getMissingTranslationResolver():
+  | ReactI18nCacheInstance
+  | undefined {
+  return isI18nCacheInitialized() ? getReactI18nCacheInstance() : undefined;
 }
 
 export function setReactI18nCache(i18nCache: ReactI18nCache): void {
-  setI18nCache(i18nCache as I18nCache<Translation>);
+  setReactI18nCacheInstance(i18nCache);
+}
+
+export function setReactI18nCacheInstance(
+  i18nCache: ReactI18nCacheInstance
+): void {
+  setI18nCache(i18nCache);
 }

--- a/packages/react-core/src/i18n-store/I18nStore.ts
+++ b/packages/react-core/src/i18n-store/I18nStore.ts
@@ -12,7 +12,10 @@ import type {
 import type { Dictionary, Translation } from 'gt-i18n/types';
 import { subscribeToSet } from './utils/subscriptions';
 import { Hash, Locale } from 'gt-i18n/internal/types';
-import { getReactI18nCache } from '../i18n-cache/singleton-operations';
+import {
+  getMissingTranslationResolver,
+  getReactI18nCacheInstance,
+} from '../i18n-cache/singleton-operations';
 import { lookupTranslation } from './utils/translations';
 import {
   lookupDictionaryEntry,
@@ -27,8 +30,7 @@ export type DictionaryStoreListener = (event: DictionaryLookup) => void;
  *
  * This is the stateful primitive behind lookup subscriptions and runtime
  * translation requests. It intentionally does not know whether lookups are
- * being served from SPA singletons or SRA provider snapshots; that policy lives
- * in LookupAdapter, not in this store.
+ * being served from a full SPA cache or hydrated snapshots.
  */
 export class I18nStore {
   // ----- Listener Sets ----- //
@@ -37,21 +39,16 @@ export class I18nStore {
   private dictionaryEntryListeners = new Set<DictionaryStoreListener>();
   private dictionaryObjectListeners = new Set<DictionaryStoreListener>();
 
-  /**
-   * I18nCache must be already initialized
-   */
-  constructor() {}
-
   // ========== Translation Updates ========== //
 
   updateTranslations = (
     translations: Record<Locale, Record<Hash, Translation>>
   ): void => {
-    getReactI18nCache().updateTranslations(translations);
+    getReactI18nCacheInstance().updateTranslations(translations);
   };
 
   updateDictionaries = (dictionaries: Record<Locale, Dictionary>): void => {
-    getReactI18nCache().updateDictionaries(dictionaries);
+    getReactI18nCacheInstance().updateDictionaries(dictionaries);
   };
 
   // ========== runtime translation ========== //
@@ -59,8 +56,8 @@ export class I18nStore {
   translate = async <T extends Translation>(
     lookup: TranslateLookup<T>
   ): Promise<void> => {
-    return getReactI18nCache()
-      .lookupTranslationWithFallback(
+    return getMissingTranslationResolver()
+      ?.lookupTranslationWithFallback(
         lookup.locale,
         lookup.message,
         lookup.options
@@ -74,8 +71,8 @@ export class I18nStore {
   };
 
   translateDictionaryEntry = (lookup: DictionaryLookup): void => {
-    getReactI18nCache()
-      .lookupDictionaryWithFallback(lookup.locale, lookup.id)
+    getMissingTranslationResolver()
+      ?.lookupDictionaryWithFallback(lookup.locale, lookup.id)
       .then((dictionaryEntry) => {
         if (dictionaryEntry == null) {
           // TODO: warn about runtime dictionary translation failure
@@ -85,8 +82,8 @@ export class I18nStore {
   };
 
   translateDictionaryObject = (lookup: DictionaryLookup): void => {
-    getReactI18nCache()
-      .lookupDictionaryObjWithFallback(lookup.locale, lookup.id)
+    getMissingTranslationResolver()
+      ?.lookupDictionaryObjWithFallback(lookup.locale, lookup.id)
       .then((dictionaryObject) => {
         if (dictionaryObject == null) {
           // TODO: warn about runtime dictionary translation failure
@@ -140,7 +137,7 @@ export class I18nStore {
   ): TranslateSnapshot<T> => {
     return (
       lookupTranslation(translationsSnapshot, lookup) ??
-      getReactI18nCache().lookupTranslation<T>(
+      getReactI18nCacheInstance().lookupTranslation<T>(
         lookup.locale,
         lookup.message,
         lookup.options
@@ -154,7 +151,7 @@ export class I18nStore {
   ): DictionaryEntrySnapshot => {
     return (
       lookupDictionaryEntry(dictionariesSnapshot, lookup) ??
-      getReactI18nCache().lookupDictionary(lookup.locale, lookup.id)
+      getReactI18nCacheInstance().lookupDictionary(lookup.locale, lookup.id)
     );
   };
 
@@ -164,7 +161,7 @@ export class I18nStore {
   ): DictionaryObjectSnapshot => {
     return (
       lookupDictionaryObject(dictionariesSnapshot, lookup) ??
-      getReactI18nCache().lookupDictionaryObj(lookup.locale, lookup.id)
+      getReactI18nCacheInstance().lookupDictionaryObj(lookup.locale, lookup.id)
     );
   };
 

--- a/packages/react-core/src/pure.ts
+++ b/packages/react-core/src/pure.ts
@@ -45,7 +45,9 @@ export type {
 export {
   internalInitializeGTSRA,
   type ReactInitializeGTParams,
+  type ReactInitializeGTClientParams,
 } from './setup/initializeGTSRA';
+export { internalInitializeGTClient } from './setup/initializeGTClient';
 
 export {
   ReactI18nCache,

--- a/packages/react-core/src/setup/initializeGTClient.ts
+++ b/packages/react-core/src/setup/initializeGTClient.ts
@@ -1,0 +1,28 @@
+import type { ReactInitializeGTClientParams } from './initializeGTSRA';
+import { SnapshotStore } from 'gt-i18n/internal/snapshot-store';
+import { LazyRuntimeTranslationResolver } from '../i18n-cache/LazyRuntimeTranslationResolver';
+import { setReactI18nCacheInstance } from '../i18n-cache/singleton-operations';
+import { initializeI18nConfig } from './i18nConfig';
+import { HydratedI18nCache } from '../i18n-cache/HydratedI18nCache';
+
+/**
+ * Initialize a server-rendered client from hydrated translation snapshots.
+ * Runtime misses are only available through a development-only resolver.
+ */
+export function internalInitializeGTClient(
+  config: ReactInitializeGTClientParams
+): void {
+  const i18nConfig = initializeI18nConfig(config, 'server-render');
+  const snapshots = new SnapshotStore(config.dictionary);
+  const missingTranslationResolver =
+    process.env.NODE_ENV !== 'production' && i18nConfig.isDevHotReloadEnabled()
+      ? new LazyRuntimeTranslationResolver(snapshots, config)
+      : undefined;
+
+  const cache = new HydratedI18nCache(
+    config,
+    snapshots,
+    missingTranslationResolver
+  );
+  setReactI18nCacheInstance(cache);
+}

--- a/packages/react-core/src/setup/initializeGTSRA.ts
+++ b/packages/react-core/src/setup/initializeGTSRA.ts
@@ -6,6 +6,8 @@ import { initializeI18nConfig, type ReactI18nConfigParams } from './i18nConfig';
 export type ReactInitializeGTParams = ReactI18nConfigParams &
   ReactI18nCacheParams;
 
+export type ReactInitializeGTClientParams = ReactInitializeGTParams;
+
 /**
  * Validation and setup for read only properties
  */

--- a/packages/react/src/i18n-cache/BrowserI18nCache.ts
+++ b/packages/react/src/i18n-cache/BrowserI18nCache.ts
@@ -2,7 +2,8 @@ import type {
   I18nCacheConstructorParams,
   TranslationsLoader,
 } from 'gt-i18n/internal/types';
-import { getI18nConfig, I18nCache } from 'gt-i18n/internal';
+import { getI18nConfig } from 'gt-i18n/internal';
+import { I18nCache } from 'gt-i18n/internal/i18n-cache';
 import type { HtmlTagOptions } from './types';
 import type { Translation } from 'gt-i18n/types';
 import { DEFAULT_HTML_TAG_OPTIONS } from './constants';

--- a/packages/react/src/index.rsc.ts
+++ b/packages/react/src/index.rsc.ts
@@ -70,10 +70,10 @@ export function useLocales() {
   return getI18nConfig().getLocales();
 }
 export function useLocaleDirection(locale: string) {
-  return getI18nConfig().getGTClass().getLocaleDirection(locale);
+  return getI18nConfig().getLocaleDirection(locale);
 }
 export function useLocaleProperties(locale: string) {
-  return getI18nConfig().getGTClass().getLocaleProperties(locale);
+  return getI18nConfig().getLocaleProperties(locale);
 }
 export function useDefaultLocale(): string {
   return getI18nConfig().getDefaultLocale();

--- a/packages/react/src/setup/initializeGTSRAClient.ts
+++ b/packages/react/src/setup/initializeGTSRAClient.ts
@@ -1,5 +1,5 @@
 import {
-  internalInitializeGTSRA,
+  internalInitializeGTClient,
   type ReactInitializeGTParams,
 } from '@generaltranslation/react-core/pure';
 import { addRuntimeCredentials } from './runtimeCredentials';
@@ -10,10 +10,5 @@ export type InitializeGTClientParams = ReactInitializeGTParams;
  * Initialize GT for client-side rendering.
  */
 export function initializeGTSRAClient(config: InitializeGTClientParams): void {
-  internalInitializeGTSRA(
-    addRuntimeCredentials({
-      cacheExpiryTime: null,
-      ...config,
-    })
-  );
+  internalInitializeGTClient(addRuntimeCredentials(config));
 }


### PR DESCRIPTION
## TL;DR

Replace the full runtime cache on hydrated React and Next.js clients with a lightweight snapshot-backed compatibility cache. Existing lookup, update, and loading APIs remain available while production clients avoid initializing cache expiry, batching, the translation client, and runtime translation.

## Code Changes

- Add snapshot storage, shared translation loading, and a separately emitted runtime translation resolver in `gt-i18n`.
- Initialize hydrated clients with `HydratedI18nCache` and lazy-load the development resolver only after a translation miss.
- Preserve source dictionary errors, locale resolution, version IDs, singleton behavior, and concurrent loader deduplication.
- Move full-cache consumers to the dedicated `gt-i18n/internal/i18n-cache` entrypoint.
- Update React, Next.js, and Node integrations and add coverage for the lightweight cache and resolver boundaries.
- Add patch changesets for the affected packages.

## Notes / Flags

- `getReactI18nCache()` keeps its existing public return type and method surface, but hydrated clients now return the lightweight compatibility implementation rather than an actual `ReactI18nCache` or `NextI18nCache` instance.
- Development runtime translation is deferred to a lazy chunk and loads only on the first miss.
- Validation: `pnpm format`, `pnpm lint`, `pnpm build`, 308 `gt-i18n` tests, 51 React Core tests, 3 focused gt-next initialization tests, and 11 gt-react package artifact tests.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the full `I18nCache` (with batch fetcher, expiry timers, and translation client) on hydrated React/Next.js clients with a lightweight `HydratedI18nCache` backed by a `SnapshotStore`. The existing public API surface (`lookupTranslation`, `loadTranslations`, `updateTranslations`, etc.) is preserved via structural compatibility, and a `LazyRuntimeTranslationResolver` defers the full development resolver to a dynamically-imported chunk loaded only on the first translation miss.

- **New packages/i18n entrypoints**: `SnapshotStore`, `RuntimeTranslationResolver`, `createTranslationLoader`, and the heavy `I18nCache` are each emitted as separate build outputs so consumers can import only what they need.
- **`internalInitializeGTClient`** replaces `internalInitializeGTSRA` for hydrated clients, wiring the snapshot store and (in dev) the lazy resolver; `GTRuntime` construction is extracted into a standalone `createGTRuntime` helper and removed from `I18nConfig`.
- **`resolveCacheLocale` / `resolveLookupParams`** are extracted from private `I18nCache` methods into shared utilities used by both the full cache and the hydrated cache.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge with minor follow-up; the hydrated cache path is correct and well-tested, and all identified issues are confined to the dev-mode resolver and an edge case in dictionary path lookup.

The core data paths — snapshot loading, deduplication, locale resolution, and the full I18nCache used by SPA clients — are sound and match existing behaviour. Three non-blocking concerns were found: the lazy dev resolver permanently fails after a single dynamic-import error (no reset on rejection), loadDictionary silently falls back to the default locale for unrecognised locales, and cloneDictionaryValue in SnapshotStore.lookupDictionaryObj can receive an undefined value for a missing dictionary path. None of these affect production translation delivery.

LazyRuntimeTranslationResolver.ts (sticky rejected promise) and SnapshotStore.ts (cloneDictionaryValue called with potentially undefined)
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react-core/src/i18n-cache/HydratedI18nCache.ts | New lightweight cache implementation backed by SnapshotStore; minor behavioural difference in loadDictionary for invalid/default locales |
| packages/react-core/src/i18n-cache/LazyRuntimeTranslationResolver.ts | Lazy dev-only resolver; stuck on a rejected promise if the dynamic import fails without a reset path |
| packages/i18n/src/i18n-cache/SnapshotStore.ts | Mutable translation/dictionary snapshot store; potential undefined passed to cloneDictionaryValue in lookupDictionaryObj for missing paths |
| packages/i18n/src/i18n-cache/RuntimeTranslationResolver.ts | New standalone runtime-translation resolver extracted from I18nCache; clean separation, writes resolved translations back to SnapshotStore |
| packages/react-core/src/setup/initializeGTClient.ts | New hydrated-client initializer; wires SnapshotStore, HydratedI18nCache, and (in dev) LazyRuntimeTranslationResolver correctly |
| packages/i18n/src/i18n-cache/utils/resolveCacheLocale.ts | Extracted locale-resolution helpers; behaviour is equivalent to the private methods removed from I18nCache |
| packages/i18n/src/i18n-cache/createTranslationLoader.ts | Thin factory that builds the translation loader without constructing a full I18nCache; straightforward extraction |
| packages/i18n/tsdown.config.mts | Splits build into three separate entry groups (main, i18n-cache, runtime-translation-resolver) with clean:false to avoid clobbering shared output |
| packages/react-core/src/i18n-store/I18nStore.ts | Switches translate/translateDictionary* to use getMissingTranslationResolver() with optional chaining; correctly no-ops before initialization |
| packages/i18n/src/i18n-config/I18nConfig.ts | Removes getGTClass() and adds getVersionId(); GTRuntime construction moved to standalone createGTRuntime helper |
| packages/react/src/setup/initializeGTSRAClient.ts | Switches from internalInitializeGTSRA (with cacheExpiryTime:null) to internalInitializeGTClient; removes the now-unnecessary cache expiry override |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant App as React/Next App
    participant Init as internalInitializeGTClient
    participant SS as SnapshotStore
    participant HC as HydratedI18nCache
    participant Lazy as LazyRuntimeTranslationResolver
    participant RTR as RuntimeTranslationResolver (lazy chunk)
    participant Store as I18nStore

    App->>Init: initializeGTClient(config)
    Init->>SS: new SnapshotStore(config.dictionary)
    Init-->>Lazy: new LazyRuntimeTranslationResolver (dev only)
    Init->>HC: new HydratedI18nCache(params, snapshots, resolver?)
    Init->>Store: setReactI18nCacheInstance(cache)

    App->>Store: translate(lookup)
    Store->>HC: lookupTranslationWithFallback(locale, msg, opts)
    alt snapshot hit
        HC->>SS: lookupTranslation(locale, msg, opts)
        SS-->>HC: translation
        HC-->>Store: translation
    else snapshot miss + dev mode
        HC->>Lazy: lookupTranslationWithFallback(locale, msg, opts)
        Lazy->>RTR: import gt-i18n internal runtime-translation-resolver
        RTR-->>Lazy: RuntimeTranslationResolver instance
        Lazy->>RTR: lookupTranslationWithFallback
        RTR->>SS: updateTranslations(resolved)
        RTR-->>Lazy: translation
        Lazy-->>HC: translation
        HC-->>Store: translation
    else snapshot miss + production
        HC->>SS: lookupTranslation returns undefined
        HC-->>Store: undefined
    end
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Apackages%2Freact-core%2Fsrc%2Fi18n-cache%2FLazyRuntimeTranslationResolver.ts%3A50-57%0A**Sticky%20rejected%20promise%20on%20import%20failure**%0A%0AIf%20the%20dynamic%20import%20of%20%60gt-i18n%2Finternal%2Fruntime-translation-resolver%60%20fails%20%28e.g.%2C%20a%20chunk-load%20error%20in%20a%20dev%20server%29%2C%20%60this.resolver%60%20is%20set%20to%20a%20rejected%20%60Promise%60.%20Because%20a%20rejected%20%60Promise%60%20is%20not%20nullish%2C%20the%20%60%3F%3F%3D%60%20assignment%20on%20the%20next%20call%20returns%20the%20same%20rejected%20promise%20rather%20than%20retrying.%20Every%20subsequent%20translation%20miss%20in%20the%20session%20will%20immediately%20reject%20until%20the%20page%20reloads.%0A%0ACompare%20to%20%60dedupePending%60%20in%20%60gt-i18n%60%2C%20which%20uses%20a%20%60finally%60%20block%20to%20delete%20the%20pending%20key%20on%20both%20success%20and%20failure%2C%20allowing%20retries.%20Resetting%20%60this.resolver%20%3D%20undefined%60%20inside%20a%20%60.catch%28%29%60%20handler%20would%20give%20the%20same%20retry-on-failure%20behaviour%20here.%0A%0A%23%23%23%20Issue%202%20of%203%0Apackages%2Freact-core%2Fsrc%2Fi18n-cache%2FHydratedI18nCache.ts%3A84-99%0A**%60loadDictionary%60%20falls%20back%20to%20default%20locale%20on%20invalid%20locale%2C%20masking%20errors**%0A%0AWhen%20%60resolveCacheLocale%28locale%29%60%20returns%20%60undefined%60%20%28for%20the%20default%20locale%20or%20an%20unrecognised%20locale%29%2C%20the%20fallback%20%60%3F%3F%20getI18nConfig%28%29.getDefaultLocale%28%29%60%20silently%20uses%20the%20default%20locale%20as%20the%20dictionary%20key.%20For%20an%20actually%20invalid%20locale%20this%20means%20the%20load%20succeeds%20%28returning%20the%20default%20locale's%20dictionary%29%20rather%20than%20reporting%20an%20error%2C%20which%20differs%20from%20the%20existing%20%60I18nCache.loadDictionary%60%20behaviour%20where%20the%20same%20path%20returns%20the%20source%20dictionary%20cache%20or%20an%20empty%20object.%0A%0A%23%23%23%20Issue%203%20of%203%0Apackages%2Fi18n%2Fsrc%2Fi18n-cache%2FSnapshotStore.ts%3A103-110%0A**%60cloneDictionaryValue%60%20called%20with%20a%20potentially%20%60undefined%60%20argument**%0A%0A%60getDictionaryValueAtPath%28dictionary%2C%20id%29%60%20can%20return%20%60undefined%60%20when%20the%20path%20does%20not%20exist%20in%20the%20dictionary.%20If%20%60cloneDictionaryValue%60%20does%20not%20accept%20%60undefined%60%20as%20input%20the%20call%20will%20throw%20at%20runtime%20for%20any%20missing%20%60id%60.%20The%20early-return%20guard%20%60if%20%28!dictionary%29%20return%20undefined%60%20only%20protects%20against%20a%20missing%20top-level%20dictionary%2C%20not%20a%20missing%20path%20within%20one.%20Callers%20like%20%60HydratedI18nCache%60%20wrap%20the%20call%20in%20%60guard%28undefined%2C%20%E2%80%A6%29%60%20so%20the%20exception%20is%20swallowed%20in%20production%2C%20but%20it%20bypasses%20any%20listener%20notification%20and%20may%20be%20surprising%20in%20development.%0A%0A&repo=generaltranslation%2Fgt&pr=1992&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22bg%2Flightweight-client-cache%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22bg%2Flightweight-client-cache%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Apackages%2Freact-core%2Fsrc%2Fi18n-cache%2FLazyRuntimeTranslationResolver.ts%3A50-57%0A**Sticky%20rejected%20promise%20on%20import%20failure**%0A%0AIf%20the%20dynamic%20import%20of%20%60gt-i18n%2Finternal%2Fruntime-translation-resolver%60%20fails%20%28e.g.%2C%20a%20chunk-load%20error%20in%20a%20dev%20server%29%2C%20%60this.resolver%60%20is%20set%20to%20a%20rejected%20%60Promise%60.%20Because%20a%20rejected%20%60Promise%60%20is%20not%20nullish%2C%20the%20%60%3F%3F%3D%60%20assignment%20on%20the%20next%20call%20returns%20the%20same%20rejected%20promise%20rather%20than%20retrying.%20Every%20subsequent%20translation%20miss%20in%20the%20session%20will%20immediately%20reject%20until%20the%20page%20reloads.%0A%0ACompare%20to%20%60dedupePending%60%20in%20%60gt-i18n%60%2C%20which%20uses%20a%20%60finally%60%20block%20to%20delete%20the%20pending%20key%20on%20both%20success%20and%20failure%2C%20allowing%20retries.%20Resetting%20%60this.resolver%20%3D%20undefined%60%20inside%20a%20%60.catch%28%29%60%20handler%20would%20give%20the%20same%20retry-on-failure%20behaviour%20here.%0A%0A%23%23%23%20Issue%202%20of%203%0Apackages%2Freact-core%2Fsrc%2Fi18n-cache%2FHydratedI18nCache.ts%3A84-99%0A**%60loadDictionary%60%20falls%20back%20to%20default%20locale%20on%20invalid%20locale%2C%20masking%20errors**%0A%0AWhen%20%60resolveCacheLocale%28locale%29%60%20returns%20%60undefined%60%20%28for%20the%20default%20locale%20or%20an%20unrecognised%20locale%29%2C%20the%20fallback%20%60%3F%3F%20getI18nConfig%28%29.getDefaultLocale%28%29%60%20silently%20uses%20the%20default%20locale%20as%20the%20dictionary%20key.%20For%20an%20actually%20invalid%20locale%20this%20means%20the%20load%20succeeds%20%28returning%20the%20default%20locale's%20dictionary%29%20rather%20than%20reporting%20an%20error%2C%20which%20differs%20from%20the%20existing%20%60I18nCache.loadDictionary%60%20behaviour%20where%20the%20same%20path%20returns%20the%20source%20dictionary%20cache%20or%20an%20empty%20object.%0A%0A%23%23%23%20Issue%203%20of%203%0Apackages%2Fi18n%2Fsrc%2Fi18n-cache%2FSnapshotStore.ts%3A103-110%0A**%60cloneDictionaryValue%60%20called%20with%20a%20potentially%20%60undefined%60%20argument**%0A%0A%60getDictionaryValueAtPath%28dictionary%2C%20id%29%60%20can%20return%20%60undefined%60%20when%20the%20path%20does%20not%20exist%20in%20the%20dictionary.%20If%20%60cloneDictionaryValue%60%20does%20not%20accept%20%60undefined%60%20as%20input%20the%20call%20will%20throw%20at%20runtime%20for%20any%20missing%20%60id%60.%20The%20early-return%20guard%20%60if%20%28!dictionary%29%20return%20undefined%60%20only%20protects%20against%20a%20missing%20top-level%20dictionary%2C%20not%20a%20missing%20path%20within%20one.%20Callers%20like%20%60HydratedI18nCache%60%20wrap%20the%20call%20in%20%60guard%28undefined%2C%20%E2%80%A6%29%60%20so%20the%20exception%20is%20swallowed%20in%20production%2C%20but%20it%20bypasses%20any%20listener%20notification%20and%20may%20be%20surprising%20in%20development.%0A%0A&repo=generaltranslation%2Fgt&pr=1992&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
packages/react-core/src/i18n-cache/LazyRuntimeTranslationResolver.ts:50-57
**Sticky rejected promise on import failure**

If the dynamic import of `gt-i18n/internal/runtime-translation-resolver` fails (e.g., a chunk-load error in a dev server), `this.resolver` is set to a rejected `Promise`. Because a rejected `Promise` is not nullish, the `??=` assignment on the next call returns the same rejected promise rather than retrying. Every subsequent translation miss in the session will immediately reject until the page reloads.

Compare to `dedupePending` in `gt-i18n`, which uses a `finally` block to delete the pending key on both success and failure, allowing retries. Resetting `this.resolver = undefined` inside a `.catch()` handler would give the same retry-on-failure behaviour here.

### Issue 2 of 3
packages/react-core/src/i18n-cache/HydratedI18nCache.ts:84-99
**`loadDictionary` falls back to default locale on invalid locale, masking errors**

When `resolveCacheLocale(locale)` returns `undefined` (for the default locale or an unrecognised locale), the fallback `?? getI18nConfig().getDefaultLocale()` silently uses the default locale as the dictionary key. For an actually invalid locale this means the load succeeds (returning the default locale's dictionary) rather than reporting an error, which differs from the existing `I18nCache.loadDictionary` behaviour where the same path returns the source dictionary cache or an empty object.

### Issue 3 of 3
packages/i18n/src/i18n-cache/SnapshotStore.ts:103-110
**`cloneDictionaryValue` called with a potentially `undefined` argument**

`getDictionaryValueAtPath(dictionary, id)` can return `undefined` when the path does not exist in the dictionary. If `cloneDictionaryValue` does not accept `undefined` as input the call will throw at runtime for any missing `id`. The early-return guard `if (!dictionary) return undefined` only protects against a missing top-level dictionary, not a missing path within one. Callers like `HydratedI18nCache` wrap the call in `guard(undefined, …)` so the exception is swallowed in production, but it bypasses any listener notification and may be surprising in development.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["perf: use lightweight hydrated client ca..."](https://github.com/generaltranslation/gt/commit/7f2b1ee3d63b786c6d8e4ea83207ed68d8b22dc6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46900739)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->