### PR TITLE
feat: support Lottie file translation and project font syncing

### DIFF
--- a/.changeset/lottie-font-support.md
+++ b/.changeset/lottie-font-support.md
@@ -1,0 +1,11 @@
+---
+'generaltranslation': minor
+'gt': minor
+---
+
+Add Lottie file support and project font syncing.
+
+- Support `.lottie` files as a new `LOTTIE` file format. Lottie bundles are binary (zip), so their content is carried base64-encoded end-to-end — including existing translated `.lottie` targets on `gt upload` — and skips the UTF-8 encode/decode and text merge paths (new `isBinaryFileFormat` / `BINARY_FILE_FORMATS` exports). Lottie translations are processed asynchronously and require the `gt stage` + `gt download` flow, so `gt translate` now exits with an error pointing users there when a project has Lottie files and staging isn't enabled. (As before, enabling staging makes `gt translate` download staged results rather than translating inline.)
+- Reject `.lottie` files that use After Effects expressions (executable code): the upload fails and names every offending file, since expression-driven text can't be translated safely.
+- Add `GT.uploadFonts` and a `fonts` config option (include/exclude globs) so project fonts are synced to the API before translating formats that need them (including during `gt stage`, so async Lottie jobs get the real fonts). Globs resolve from the project root. Font sync is idempotent and non-fatal on failure.
+- Keep staged lock entries staged until every configured locale has downloaded, and only require `_versionId` for `gt download` when an inline GTJSON template is part of the download and config IDs aren't omitted (staged downloads resolve versions from `gt-lock.json`, file-only projects never have a `_versionId`, and `omitConfigIds` projects use the GTJSON's own content-derived version).

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ dist/
 CLAUDE.local.md
 tsconfig.tsbuildinfo
 target/
+tmp/
 .rollup.cache
 .mcp.json
 .vscode/mcp.json

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -124,6 +124,7 @@
     "enhanced-resolve": "^5.18.3",
     "esbuild": "^0.27.2",
     "fast-glob": "^3.3.3",
+    "fflate": "^0.8.2",
     "fast-json-stable-stringify": "^2.1.0",
     "generaltranslation": "workspace:*",
     "gt-remark": "workspace:*",

--- a/packages/cli/src/api/downloadFileBatch.ts
+++ b/packages/cli/src/api/downloadFileBatch.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import { isBinaryFileFormat } from 'generaltranslation/types';
 import { logger } from '../console/logger.js';
 import { gt } from '../utils/gt.js';
 import { Settings } from '../types/index.js';
@@ -274,6 +275,53 @@ export async function downloadFileBatch(
             : undefined;
         const fileExists = fs.existsSync(outputPath);
 
+        // Binary formats (e.g. LOTTIE zip bundles) carry base64 content that must
+        // not go through the text merge/sort path — decode straight to bytes and
+        // write. Skip only when an unchanged local translation already exists.
+        if (isBinaryFileFormat(file.fileFormat)) {
+          if (!forceDownload && fileExists && downloadedTranslation) {
+            result.skipped.push(requestedFile);
+            continue;
+          }
+          await fs.promises.writeFile(
+            outputPath,
+            Buffer.from(file.data, 'base64')
+          );
+          recordDownloaded(outputPath, {
+            branchId,
+            fileId,
+            versionId,
+            locale,
+            inputPath,
+          });
+          result.successful.push(requestedFile);
+          if (fileId && versionId && locale) {
+            const entry = findOrCreateEntry(
+              entryMap,
+              downloadedVersions.entries,
+              fileId,
+              versionId
+            );
+            entry.fileName = inputPath;
+            entry.translations[locale] = {
+              updatedAt: new Date().toISOString(),
+              // Store a relative path (matches the text path) so gt-lock.json
+              // stays portable and the skip-on-re-download check matches.
+              fileName: getRelative(outputPath),
+            };
+            // A staged entry tracks the whole file, not one locale. Keep it
+            // staged until every configured locale has downloaded, so a partial
+            // batch (locales still translating) doesn't abandon the rest.
+            if (entry.staged) {
+              entry.staged = !options.locales.every(
+                (l) => entry.translations[l]
+              );
+            }
+            didUpdateDownloadedLock = true;
+          }
+          continue;
+        }
+
         // Composite schema files merge translations into the source file itself,
         // so outputPath always exists and the lock can't tell whether derived
         // split outputs (e.g. {locale}/docs.json) are still on disk. Always
@@ -395,11 +443,16 @@ export async function downloadFileBatch(
             versionId
           );
           entry.fileName = inputPath;
-          entry.staged = false;
           entry.translations[locale] = {
             updatedAt: new Date().toISOString(),
             fileName: getRelative(outputPath),
           };
+          // A staged entry tracks the whole file, not one locale. Keep it
+          // staged until every configured locale has downloaded, so a partial
+          // batch (locales still translating) doesn't abandon the rest.
+          if (entry.staged) {
+            entry.staged = !options.locales.every((l) => entry.translations[l]);
+          }
           didUpdateDownloadedLock = true;
         }
       } catch (error) {

--- a/packages/cli/src/cli/base.ts
+++ b/packages/cli/src/cli/base.ts
@@ -16,6 +16,7 @@ import {
   promptGlobPatterns,
 } from '../console/logging.js';
 import { logger } from '../console/logger.js';
+import { lottieTranslateError } from '../console/index.js';
 import { parseGlobPatterns } from '../console/promptParsing.js';
 import path from 'node:path';
 import fs from 'node:fs';
@@ -451,6 +452,13 @@ export class BaseCLI {
     await processSharedStaticAssets(settings);
 
     if (!settings.stageTranslations) {
+      // Lottie translations finish asynchronously server-side (layout
+      // refinement runs after the translation job completes), so the immediate
+      // translate flow would try to download them before they're ready. Only
+      // the stage + download flow supports them.
+      if (settings.files?.resolvedPaths.lottie?.length) {
+        return logErrorAndExit(lottieTranslateError);
+      }
       const results = await handleStage(
         initOptions,
         settings,

--- a/packages/cli/src/cli/commands/__tests__/download.test.ts
+++ b/packages/cli/src/cli/commands/__tests__/download.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { FileToUpload } from 'generaltranslation/types';
+import type { Settings, TranslateFlags } from '../../../types/index.js';
+import { createMockSettings } from '../../../api/__mocks__/settings.js';
+import {
+  TEMPLATE_FILE_ID,
+  TEMPLATE_FILE_NAME,
+} from '../../../utils/constants.js';
+import { handleDownload } from '../download.js';
+import { collectFiles } from '../../../formats/files/collectFiles.js';
+import { runDownloadWorkflow } from '../../../workflows/download.js';
+import { logErrorAndExit } from '../../../console/logging.js';
+import { noVersionIdError } from '../../../console/index.js';
+
+vi.mock('../../../formats/files/collectFiles.js', () => ({
+  collectFiles: vi.fn(),
+}));
+
+vi.mock('../../../workflows/download.js', () => ({
+  runDownloadWorkflow: vi.fn(),
+}));
+
+vi.mock('../../../fs/config/downloadedVersions.js', () => ({
+  getStagedEntriesFromLockfile: vi.fn(() => ({})),
+}));
+
+vi.mock('../../../formats/files/fileMapping.js', () => ({
+  createFileMapping: vi.fn(() => ({})),
+}));
+
+vi.mock('../utils/validation.js', () => ({
+  hasValidCredentials: vi.fn(() => true),
+  hasValidLocales: vi.fn(() => true),
+}));
+
+vi.mock('../../../console/logging.js', () => ({
+  exitSync: vi.fn(),
+  logErrorAndExit: vi.fn(),
+}));
+
+const gtjsonFile = {
+  fileName: TEMPLATE_FILE_NAME,
+  content: '{}',
+  fileFormat: 'GTJSON',
+  fileId: TEMPLATE_FILE_ID,
+  versionId: 'content-derived-version',
+  locale: 'en',
+} satisfies FileToUpload;
+
+const options = {
+  dryRun: false,
+  timeout: 1,
+} as TranslateFlags;
+
+function settings(overrides: Partial<Settings> = {}): Settings {
+  return createMockSettings({
+    config: '/project/gt.config.json',
+    locales: ['es'],
+    defaultLocale: 'en',
+    stageTranslations: false,
+    ...overrides,
+  });
+}
+
+describe('handleDownload GTJSON versionId guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(collectFiles).mockResolvedValue({
+      files: [gtjsonFile],
+      reactComponents: 1,
+      publishMap: new Map(),
+    });
+  });
+
+  it('does not require _versionId when config ids are omitted (regression)', async () => {
+    // omitConfigIds intentionally never writes _versionId; the collected GTJSON
+    // already carries its own content-derived versionId, so the download must
+    // proceed rather than fail.
+    await handleDownload(
+      options,
+      settings({ omitConfigIds: true }),
+      'gt-react'
+    );
+
+    expect(logErrorAndExit).not.toHaveBeenCalled();
+    expect(runDownloadWorkflow).toHaveBeenCalledOnce();
+  });
+
+  it('still errors for a GTJSON download with config ids but no _versionId', async () => {
+    await handleDownload(
+      options,
+      settings({ omitConfigIds: false }),
+      'gt-react'
+    );
+
+    expect(logErrorAndExit).toHaveBeenCalledWith(noVersionIdError);
+    expect(runDownloadWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('proceeds when a _versionId is present in config-id mode', async () => {
+    await handleDownload(
+      options,
+      settings({ omitConfigIds: false, _versionId: 'staged-version' }),
+      'gt-react'
+    );
+
+    expect(logErrorAndExit).not.toHaveBeenCalled();
+    expect(runDownloadWorkflow).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/cli/src/cli/commands/__tests__/upload.test.ts
+++ b/packages/cli/src/cli/commands/__tests__/upload.test.ts
@@ -20,6 +20,10 @@ vi.mock('../../../fs/findFilepath.js', () => ({
     return files?.[filePath] ?? '';
   }),
   getRelative: vi.fn((filePath: string) => filePath),
+  readBinaryFileBase64: vi.fn((filePath: string) => {
+    const files = (vi as unknown).__mockBinaryFiles;
+    return files?.[filePath] ?? '';
+  }),
 }));
 vi.mock('../../../workflows/upload.js', () => ({
   runUploadFilesWorkflow: vi.fn(async () => ({
@@ -58,7 +62,7 @@ vi.mock('../../../fs/determineFramework/index.js', () => ({
   determineLibrary: vi.fn(() => ({ library: 'base', additionalModules: [] })),
 }));
 
-import { readFile } from '../../../fs/findFilepath.js';
+import { readFile, readBinaryFileBase64 } from '../../../fs/findFilepath.js';
 import { runUploadFilesWorkflow } from '../../../workflows/upload.js';
 import { runPublishWorkflow } from '../../../workflows/publish.js';
 import { createFileMapping } from '../../../formats/files/fileMapping.js';
@@ -68,6 +72,14 @@ import { existsSync, readFileSync } from 'node:fs';
 function setMockFiles(files: Record<string, string>) {
   (vi as unknown).__mockFiles = files;
   vi.mocked(readFile).mockImplementation((filePath: string) => {
+    return files[filePath] ?? '';
+  });
+}
+
+// Binary fixtures are stored base64-encoded, mirroring readBinaryFileBase64.
+function setMockBinaryFiles(files: Record<string, string>) {
+  (vi as unknown).__mockBinaryFiles = files;
+  vi.mocked(readBinaryFileBase64).mockImplementation((filePath: string) => {
     return files[filePath] ?? '';
   });
 }
@@ -199,6 +211,63 @@ describe('upload - Twilio Content JSON', () => {
 
     expect(jsonFile?.source.fileFormat).toBe('JSON');
     expect(twilioFile?.source.fileFormat).toBe('TWILIO_CONTENT_JSON');
+  });
+});
+
+describe('upload - binary (LOTTIE) files', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(existsSync).mockReturnValue(false);
+    vi.mocked(readFileSync).mockReturnValue('');
+    vi.mocked(createFileMapping).mockReturnValue({});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('round-trips source and translation bytes through base64 without UTF-8 decoding', async () => {
+    // Zip magic plus bytes that are invalid UTF-8 — a utf8 read would corrupt them.
+    const sourceBytes = Buffer.from([
+      0x50, 0x4b, 0x03, 0x04, 0x00, 0xff, 0xfe, 0x80,
+    ]);
+    const translatedBytes = Buffer.from([
+      0x50, 0x4b, 0x03, 0x04, 0x01, 0xfd, 0x00, 0x81,
+    ]);
+    setMockFiles({});
+    setMockBinaryFiles({
+      'anim/en.lottie': sourceBytes.toString('base64'),
+      'anim/es.lottie': translatedBytes.toString('base64'),
+    });
+
+    const filePaths: ResolvedFiles = { lottie: ['anim/en.lottie'] };
+    const settings = makeSettings({ locales: ['es'], options: {} });
+
+    vi.mocked(createFileMapping).mockReturnValue({
+      es: { 'anim/en.lottie': 'anim/es.lottie' },
+    });
+    vi.mocked(existsSync).mockReturnValue(true);
+
+    await uploadWithFiles(filePaths, settings);
+
+    expect(runUploadFilesWorkflow).toHaveBeenCalledTimes(1);
+    const call = vi.mocked(runUploadFilesWorkflow).mock.calls[0][0];
+    expect(call.files).toHaveLength(1);
+    const { source, translations } = call.files[0];
+
+    expect(source.fileFormat).toBe('LOTTIE');
+    expect(Buffer.from(source.content, 'base64').equals(sourceBytes)).toBe(
+      true
+    );
+
+    expect(translations).toHaveLength(1);
+    expect(translations[0].locale).toBe('es');
+    expect(translations[0].fileFormat).toBe('LOTTIE');
+    expect(
+      Buffer.from(translations[0].content, 'base64').equals(translatedBytes)
+    ).toBe(true);
+    // The translated bundle must never be read as UTF-8 text.
+    expect(readFileSync).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/cli/src/cli/commands/download.ts
+++ b/packages/cli/src/cli/commands/download.ts
@@ -1,4 +1,4 @@
-import { noFilesError } from '../../console/index.js';
+import { noFilesError, noVersionIdError } from '../../console/index.js';
 import { SupportedLibraries, TranslateFlags } from '../../types/index.js';
 import { Settings } from '../../types/index.js';
 import { createFileMapping } from '../../formats/files/fileMapping.js';
@@ -48,6 +48,19 @@ export async function handleDownload(
     fileVersionData = getStagedEntriesFromLockfile(settings);
   } else {
     const { files } = await collectFiles(options, settings, library);
+    // _versionId is only written by stage when an inline GTJSON template was
+    // staged, so demand it only when a GTJSON is part of this download —
+    // file-only projects never have one and don't need it. (Staged downloads
+    // above resolve all versions from gt-lock.json.) omitConfigIds intentionally
+    // never writes _versionId; in that mode the collected GTJSON template carries
+    // its own content-derived versionId, so skip the guard rather than fail.
+    if (
+      !settings.omitConfigIds &&
+      !settings._versionId &&
+      files.some((file) => file.fileFormat === 'GTJSON')
+    ) {
+      return logErrorAndExit(noVersionIdError);
+    }
     fileVersionData = convertToFileTranslationData(files);
   }
 

--- a/packages/cli/src/cli/commands/upload.ts
+++ b/packages/cli/src/cli/commands/upload.ts
@@ -1,7 +1,12 @@
 import { noDefaultLocaleError } from '../../console/index.js';
 import { exitSync, logErrorAndExit } from '../../console/logging.js';
 import { logger } from '../../console/logger.js';
-import { getRelative, readFile } from '../../fs/findFilepath.js';
+import {
+  getRelative,
+  readFile,
+  readBinaryFileBase64,
+} from '../../fs/findFilepath.js';
+import { isBinaryFileFormat } from 'generaltranslation/types';
 import { Settings } from '../../types/index.js';
 import { UploadOptions } from '../base.js';
 import { extractJson } from '../../formats/json/extractJson.js';
@@ -113,11 +118,16 @@ export async function upload(
         // Non-composite: look for separate translation files
         const translatedFileName = fileMapping[locale]?.[file.fileName];
         if (translatedFileName && existsSync(translatedFileName)) {
-          const translatedContent = readFileSync(translatedFileName, 'utf8');
+          const translationFormat = file.transformFormat ?? file.fileFormat;
+          // Binary formats (e.g. LOTTIE zip bundles) travel base64-encoded;
+          // decoding their bytes as UTF-8 would corrupt the archive.
+          const translatedContent = isBinaryFileFormat(translationFormat)
+            ? readBinaryFileBase64(translatedFileName)
+            : readFileSync(translatedFileName, 'utf8');
           translations.push({
             content: translatedContent,
             fileName: translatedFileName,
-            fileFormat: file.transformFormat ?? file.fileFormat,
+            fileFormat: translationFormat,
             dataFormat: file.dataFormat,
             locale,
             fileId: file.fileId,

--- a/packages/cli/src/console/index.ts
+++ b/packages/cli/src/console/index.ts
@@ -433,8 +433,17 @@ export const noSourceFileError = `No source translation file was found. Check yo
 export const noApiKeyError = `No API key was found. Pass --api-key or set the GT_API_KEY environment variable.`;
 export const devApiKeyError = `Development API keys cannot be used with the General Translation API. Use a production API key instead.\nGenerate a production API key with: npx gt auth -t production`;
 export const noProjectIdError = `No project ID was found. Pass --project-id, add projectId to gt.config.json, or set the GT_PROJECT_ID environment variable.`;
+export const noVersionIdError = `No version ID was found. Pass --version-id or add _versionId to gt.config.json.`;
 export const invalidConfigurationError = `The files configuration cannot be used for this operation. Provide a valid download configuration or set --publish true to upload translations to the CDN.`;
+export const lottieTranslateError = `Lottie translations are processed asynchronously, so the translate command cannot complete them in one run. Use the stage and download flow instead:\n  1. Stage the files for translation: npx gt stage\n  2. Fetch the finished translations: npx gt download\nTranslations that are still processing are skipped, so re-run npx gt download until all of them have been downloaded.`;
 export const branchResolutionError = `The current git branch could not be resolved. Specify a branch explicitly or run the command from a git worktree with branch metadata available.`;
+
+export const lottieExpressionsError = (files: string[]): string =>
+  `The following Lottie file(s) use After Effects expressions, which contain executable code and are not supported yet:\n${files
+    .map((file) => `  - ${file}`)
+    .join(
+      '\n'
+    )}\nRe-export the animation with expressions baked into keyframes (or removed), then try again.`;
 
 export const withOriginalError = (message: string, error: unknown): string =>
   error != null ? `${message} Original error: ${String(error)}` : message;

--- a/packages/cli/src/formats/files/__tests__/collectFonts.test.ts
+++ b/packages/cli/src/formats/files/__tests__/collectFonts.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import type { Settings } from '../../../types/index.js';
+import { collectFonts } from '../collectFonts.js';
+
+describe('collectFonts', () => {
+  let projectRoot: string;
+
+  beforeEach(() => {
+    projectRoot = mkdtempSync(path.join(tmpdir(), 'gt-collect-fonts-'));
+  });
+
+  afterEach(() => {
+    rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  function makeSettings(overrides: Partial<Settings> = {}): Settings {
+    return {
+      // generateSettings always sets configDirectory to `<project root>/.gt`
+      configDirectory: path.join(projectRoot, '.gt'),
+      ...overrides,
+    } as Settings;
+  }
+
+  it('resolves globs from the project root, not the .gt state directory', async () => {
+    mkdirSync(path.join(projectRoot, 'public', 'fonts'), { recursive: true });
+    const bytes = Buffer.from([0x00, 0x01, 0x00, 0x00, 0xff, 0xfe, 0x80]);
+    writeFileSync(
+      path.join(projectRoot, 'public', 'fonts', 'Inter.ttf'),
+      bytes
+    );
+
+    const fonts = await collectFonts(
+      makeSettings({ fonts: { include: ['public/fonts/*.ttf'] } })
+    );
+
+    expect(fonts).toHaveLength(1);
+    expect(fonts[0].fileName).toBe('Inter.ttf');
+    expect(fonts[0].assetType).toBe('FONT');
+    // Byte round-trip: the base64 content must decode to the original bytes.
+    expect(Buffer.from(fonts[0].content, 'base64').equals(bytes)).toBe(true);
+  });
+
+  it('applies exclude globs', async () => {
+    mkdirSync(path.join(projectRoot, 'fonts'), { recursive: true });
+    writeFileSync(
+      path.join(projectRoot, 'fonts', 'Keep.ttf'),
+      Buffer.from([1])
+    );
+    writeFileSync(
+      path.join(projectRoot, 'fonts', 'Skip.ttf'),
+      Buffer.from([2])
+    );
+
+    const fonts = await collectFonts(
+      makeSettings({
+        fonts: { include: ['fonts/*.ttf'], exclude: ['fonts/Skip.ttf'] },
+      })
+    );
+
+    expect(fonts.map((f) => f.fileName)).toEqual(['Keep.ttf']);
+  });
+
+  it('returns no fonts when the config is missing or empty', async () => {
+    expect(await collectFonts(makeSettings())).toEqual([]);
+    expect(
+      await collectFonts(makeSettings({ fonts: { include: [] } }))
+    ).toEqual([]);
+  });
+});

--- a/packages/cli/src/formats/files/__tests__/detectLottieExpressions.test.ts
+++ b/packages/cli/src/formats/files/__tests__/detectLottieExpressions.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { zipSync, strToU8 } from 'fflate';
+
+import { lottieHasExpressions } from '../detectLottieExpressions.js';
+
+// Build a base64 dotLottie ZIP from a map of entry name -> JSON value.
+function dotLottie(entries: { [name: string]: unknown }): string {
+  const files: { [name: string]: Uint8Array } = {};
+  for (const [name, value] of Object.entries(entries)) {
+    files[name] = strToU8(JSON.stringify(value));
+  }
+  return Buffer.from(zipSync(files)).toString('base64');
+}
+
+const manifest = { animations: [{ id: 'anim' }] };
+
+describe('lottieHasExpressions', () => {
+  it('flags a string-valued `x` expression on an animated property', () => {
+    const anim = {
+      layers: [{ ks: { p: { a: 0, k: [0, 0], x: 'wiggle(2,10)' } } }],
+    };
+    const b64 = dotLottie({
+      'manifest.json': manifest,
+      'animations/a.json': anim,
+    });
+    expect(lottieHasExpressions(b64)).toBe(true);
+  });
+
+  it('does NOT flag a split-dimension `x` (object, not a string)', () => {
+    // Separated position: `x` and `y` are nested property OBJECTS, never code.
+    const anim = {
+      layers: [
+        { ks: { p: { s: true, x: { a: 0, k: 0 }, y: { a: 0, k: 0 } } } },
+      ],
+    };
+    const b64 = dotLottie({
+      'manifest.json': manifest,
+      'animations/a.json': anim,
+    });
+    expect(lottieHasExpressions(b64)).toBe(false);
+  });
+
+  it('does not flag an empty-string `x`', () => {
+    const anim = { layers: [{ ks: { o: { a: 0, k: 100, x: '' } } }] };
+    const b64 = dotLottie({ 'animations/a.json': anim });
+    expect(lottieHasExpressions(b64)).toBe(false);
+  });
+
+  it('returns false for a clean animation', () => {
+    const anim = { layers: [{ ks: { p: { a: 0, k: [10, 20] } } }] };
+    const b64 = dotLottie({
+      'manifest.json': manifest,
+      'animations/a.json': anim,
+    });
+    expect(lottieHasExpressions(b64)).toBe(false);
+  });
+
+  it('detects expressions in a bare bodymovin JSON with a .lottie extension', () => {
+    const bare = { layers: [{ ks: { r: { a: 0, k: 0, x: 'time*50' } } }] };
+    const b64 = Buffer.from(JSON.stringify(bare)).toString('base64');
+    expect(lottieHasExpressions(b64)).toBe(true);
+  });
+
+  it('returns false for non-Lottie / unreadable payloads', () => {
+    // Fake ZIP magic that is not a valid archive — must not throw.
+    const notAZip = Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x00, 0xff]).toString(
+      'base64'
+    );
+    expect(lottieHasExpressions(notAZip)).toBe(false);
+    expect(lottieHasExpressions('')).toBe(false);
+  });
+});

--- a/packages/cli/src/formats/files/aggregateFiles.ts
+++ b/packages/cli/src/formats/files/aggregateFiles.ts
@@ -1,6 +1,13 @@
 import { logger } from '../../console/logger.js';
+import { logErrorAndExit } from '../../console/logging.js';
+import { lottieExpressionsError } from '../../console/index.js';
 import { recordWarning } from '../../state/translateWarnings.js';
-import { getRelative, readFile } from '../../fs/findFilepath.js';
+import { lottieHasExpressions } from './detectLottieExpressions.js';
+import {
+  getRelative,
+  readFile,
+  readBinaryFileBase64,
+} from '../../fs/findFilepath.js';
 import { Settings } from '../../types/index.js';
 import type { FileFormat, DataFormat, FileToUpload } from '../../types/data.js';
 import { SUPPORTED_FILE_EXTENSIONS } from './supportedFiles.js';
@@ -346,11 +353,54 @@ export async function aggregateFiles(
     files.push(...twilioContentJsonFiles.filter((file) => file !== null));
   }
 
+  // Process Lottie files (binary zip bundles). Content is read as raw bytes and
+  // carried base64-encoded end-to-end; the downloaded translation is written
+  // back as bytes. No text parsing/merge.
+  if (filePaths.lottie) {
+    // Lottie files carrying After Effects expressions (executable JS) are
+    // rejected outright — collect every offender, then fail once with all of
+    // them named rather than aborting on the first.
+    const expressionOffenders: string[] = [];
+    const lottieFiles = filePaths.lottie
+      .map((filePath) => {
+        const content = readBinaryFileBase64(filePath);
+        const relativePath = getRelative(filePath);
+        if (!content) {
+          logger.warn(`Skipping ${relativePath}: file is empty or unreadable`);
+          recordWarning(
+            'skipped_file',
+            relativePath,
+            'File is empty or unreadable'
+          );
+          return null;
+        }
+        if (lottieHasExpressions(content)) {
+          expressionOffenders.push(relativePath);
+          return null;
+        }
+        return {
+          content,
+          fileName: relativePath,
+          fileFormat: 'LOTTIE' as const,
+          ...getTransformFormatProperty(settings, 'lottie'),
+          fileId: hashStringSync(relativePath),
+          versionId: hashStringSync(content),
+          locale: settings.defaultLocale,
+        } satisfies FileToUpload;
+      })
+      .filter((file) => file !== null);
+    if (expressionOffenders.length > 0) {
+      logErrorAndExit(lottieExpressionsError(expressionOffenders));
+    }
+    files.push(...lottieFiles);
+  }
+
   for (const fileType of SUPPORTED_FILE_EXTENSIONS) {
     if (
       fileType === 'json' ||
       fileType === 'yaml' ||
-      fileType === 'twilioContentJson'
+      fileType === 'twilioContentJson' ||
+      fileType === 'lottie'
     )
       continue;
     if (filePaths[fileType]) {

--- a/packages/cli/src/formats/files/collectFonts.ts
+++ b/packages/cli/src/formats/files/collectFonts.ts
@@ -1,0 +1,47 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import fg from 'fast-glob';
+
+import type { Settings } from '../../types/index.js';
+
+// One font to upload to /v2/project/assets. Structurally matches the SDK's
+// AssetUpload; content is base64 (fonts are binary).
+export type FontUpload = {
+  assetType: 'FONT';
+  fileName: string;
+  content: string;
+};
+
+// Resolve the config's `fonts` globs to base64-encoded font uploads. Fonts are
+// locale-invariant, so there's no [locale] placeholder — just match the files
+// and read them as binary.
+export async function collectFonts(settings: Settings): Promise<FontUpload[]> {
+  const fonts = settings.fonts;
+  if (!fonts?.include?.length) return [];
+
+  // `files.include` globs resolve from the cwd generateSettings ran in, and
+  // configDirectory is always `<cwd>/.gt` — so its parent is that same project
+  // root. Globbing from configDirectory itself would search under `.gt/`.
+  const cwd = settings.configDirectory
+    ? path.dirname(settings.configDirectory)
+    : process.cwd();
+  const matches = await fg(fonts.include, {
+    cwd,
+    ignore: fonts.exclude ?? [],
+    absolute: true,
+    onlyFiles: true,
+    unique: true,
+  });
+
+  const uploads: FontUpload[] = [];
+  for (const absolutePath of matches) {
+    const bytes = await readFile(absolutePath);
+    uploads.push({
+      assetType: 'FONT',
+      fileName: path.basename(absolutePath),
+      content: bytes.toString('base64'),
+    });
+  }
+  return uploads;
+}

--- a/packages/cli/src/formats/files/detectLottieExpressions.ts
+++ b/packages/cli/src/formats/files/detectLottieExpressions.ts
@@ -1,0 +1,60 @@
+import { unzipSync } from 'fflate';
+
+import type { JSONValue } from '../../types/data/json.js';
+
+// After Effects "expressions" are JavaScript strings attached to an animated
+// property at key `x`; the full lottie-web build evaluates them with eval() at
+// render time, so a crafted .lottie is an arbitrary-code-execution vector. Until
+// the renderer strips/sandboxes them, we reject any Lottie that carries one.
+//
+// A split-dimension position ALSO uses `x`, but as an object/array (a nested
+// property) — never a string. So a non-empty string value at key `x` is the
+// unambiguous marker of an expression.
+function hasExpressionNode(node: JSONValue): boolean {
+  if (Array.isArray(node)) {
+    for (const v of node) if (hasExpressionNode(v)) return true;
+    return false;
+  }
+  if (node !== null && typeof node === 'object') {
+    const x = (node as { [key: string]: JSONValue }).x;
+    if (typeof x === 'string' && x.trim() !== '') return true;
+    for (const key in node) {
+      if (hasExpressionNode((node as { [key: string]: JSONValue })[key])) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function jsonHasExpression(text: string): boolean {
+  try {
+    return hasExpressionNode(JSON.parse(text) as JSONValue);
+  } catch {
+    return false; // not JSON — nothing to scan
+  }
+}
+
+/**
+ * Returns true if a base64-encoded Lottie carries any After Effects expression
+ * (executable JavaScript). Handles both the dotLottie ZIP bundle (scans each
+ * `animations/*.json`) and a bare bodymovin JSON that uses the `.lottie`
+ * extension. Best-effort: an unreadable/non-Lottie payload returns false and is
+ * left to the existing upload validation.
+ */
+export function lottieHasExpressions(base64Content: string): boolean {
+  const bytes = Buffer.from(base64Content, 'base64');
+  try {
+    // Only decompress JSON entries — skip embedded images/fonts/audio.
+    const entries = unzipSync(bytes, {
+      filter: (file) => file.name.toLowerCase().endsWith('.json'),
+    });
+    for (const data of Object.values(entries)) {
+      if (jsonHasExpression(Buffer.from(data).toString('utf8'))) return true;
+    }
+    return false;
+  } catch {
+    // Not a valid ZIP — maybe a bare bodymovin JSON with a .lottie extension.
+    return jsonHasExpression(bytes.toString('utf8'));
+  }
+}

--- a/packages/cli/src/formats/files/supportedFiles.ts
+++ b/packages/cli/src/formats/files/supportedFiles.ts
@@ -9,6 +9,7 @@ export const SUPPORTED_FILE_EXTENSIONS = [
   'html',
   'txt',
   'twilioContentJson',
+  'lottie',
 ] as const;
 
 export const FILE_EXT_TO_EXT_LABEL = {
@@ -22,4 +23,5 @@ export const FILE_EXT_TO_EXT_LABEL = {
   html: 'HTML',
   txt: 'Text',
   twilioContentJson: 'Twilio Content JSON',
+  lottie: 'Lottie',
 };

--- a/packages/cli/src/formats/files/transformFormat.ts
+++ b/packages/cli/src/formats/files/transformFormat.ts
@@ -20,6 +20,7 @@ export const CONFIG_FILE_TYPE_TO_FILE_FORMAT = {
   html: 'HTML',
   txt: 'TXT',
   twilioContentJson: 'TWILIO_CONTENT_JSON',
+  lottie: 'LOTTIE',
 } as const satisfies Record<SupportedFileExtension, FileFormat>;
 
 /**
@@ -36,6 +37,7 @@ export const FILE_FORMAT_TO_CONFIG_FILE_TYPE = {
   HTML: 'html',
   TXT: 'txt',
   TWILIO_CONTENT_JSON: 'twilioContentJson',
+  LOTTIE: 'lottie',
 } as const satisfies Partial<Record<FileFormat, SupportedFileExtension>>;
 
 /**
@@ -54,6 +56,7 @@ const FILE_FORMAT_EXTENSIONS = {
   HTML: 'html',
   TXT: 'txt',
   TWILIO_CONTENT_JSON: 'json',
+  LOTTIE: 'lottie',
 } as const satisfies Record<FileFormat, string>;
 
 /**

--- a/packages/cli/src/fs/findFilepath.ts
+++ b/packages/cli/src/fs/findFilepath.ts
@@ -82,6 +82,19 @@ export function readFile(filePath: string): string {
 }
 
 /**
+ * Read a file as raw bytes and return it base64-encoded. Used for binary
+ * formats (e.g. Lottie zip bundles) whose content must not be decoded as UTF-8.
+ * @param {string} filePath - The path to the file to read.
+ * @returns {string} - The base64-encoded contents, or '' if the file is absent.
+ */
+export function readBinaryFileBase64(filePath: string): string {
+  if (fs.existsSync(filePath) && fs.statSync(filePath).isFile()) {
+    return fs.readFileSync(filePath).toString('base64');
+  }
+  return '';
+}
+
+/**
  * Find a file in a directory.
  * @param {string} dir - The directory to search in.
  * @param {string} file - The file to search for.

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -225,6 +225,11 @@ export type FilesOptions = {
 };
 
 // Shared settings between all API-related commands
+export type FontsConfig = {
+  include: string[]; // globs of .ttf/.otf files
+  exclude?: string[];
+};
+
 export type Settings = {
   config: string;
   configDirectory: string;
@@ -263,6 +268,7 @@ export type Settings = {
   version?: string; // for specifying a custom version id to use. Should be unique
   description?: string;
   src?: string[]; // list of glob patterns for source file scanning
+  fonts?: FontsConfig; // fonts to sync to the API before translating
   framework?: SupportedFrameworks;
   options?: AdditionalOptions;
   modelProvider?: string;

--- a/packages/cli/src/workflows/__tests__/stage.test.ts
+++ b/packages/cli/src/workflows/__tests__/stage.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { FileToUpload } from 'generaltranslation/types';
+import type { Settings, TranslateFlags } from '../../types/index.js';
+import { runStageFilesWorkflow } from '../stage.js';
+
+vi.mock('../../console/logger.js', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+vi.mock('../../console/logging.js', () => ({
+  logCollectedFiles: vi.fn(),
+  logErrorAndExit: vi.fn((message: string) => {
+    throw new Error(message);
+  }),
+}));
+vi.mock('../../utils/gt.js', () => ({
+  gt: { uploadFonts: vi.fn(async () => ({ assets: [], count: 2 })) },
+}));
+vi.mock('../../formats/files/collectFonts.js', () => ({
+  collectFonts: vi.fn(async () => []),
+}));
+vi.mock('../steps/BranchStep.js', () => ({
+  BranchStep: vi.fn(() => ({
+    run: vi.fn(async () => ({ currentBranch: { id: 'branch-1' } })),
+    wait: vi.fn(),
+  })),
+}));
+vi.mock('../steps/UploadSourcesStep.js', () => ({
+  UploadSourcesStep: vi.fn(() => ({
+    run: vi.fn(async () => []),
+    wait: vi.fn(),
+  })),
+}));
+vi.mock('../steps/SetupStep.js', () => ({
+  SetupStep: vi.fn(() => ({ run: vi.fn(), wait: vi.fn() })),
+}));
+vi.mock('../steps/EnqueueStep.js', () => ({
+  EnqueueStep: vi.fn(() => ({
+    run: vi.fn(async () => ({ message: 'enqueued', jobData: {} })),
+    wait: vi.fn(),
+  })),
+}));
+vi.mock('../steps/TagStep.js', () => ({
+  TagStep: vi.fn(() => ({ run: vi.fn(), wait: vi.fn() })),
+}));
+vi.mock('../steps/UserEditDiffsStep.js', () => ({
+  UserEditDiffsStep: vi.fn(() => ({ run: vi.fn(), wait: vi.fn() })),
+}));
+vi.mock('../utils/filterFilesForEnqueue.js', () => ({
+  filterFilesForEnqueue: vi.fn(async ({ files }: { files: unknown[] }) => ({
+    filesToEnqueue: files,
+    skippedFiles: [],
+  })),
+}));
+
+import { gt } from '../../utils/gt.js';
+import { collectFonts } from '../../formats/files/collectFonts.js';
+import { logger } from '../../console/logger.js';
+
+const files: FileToUpload[] = [
+  {
+    content: 'aGVsbG8=',
+    fileName: 'src/en/anim.lottie',
+    fileFormat: 'LOTTIE',
+    fileId: 'file-1',
+    versionId: 'version-1',
+    locale: 'en',
+  },
+];
+const options = { timeout: '600' } as TranslateFlags;
+const settings = { locales: ['es'] } as Settings;
+
+describe('runStageFilesWorkflow font sync', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uploads configured fonts before enqueueing', async () => {
+    const fonts = [
+      {
+        assetType: 'FONT' as const,
+        fileName: 'Inter.ttf',
+        content: 'Zm9udA==',
+      },
+    ];
+    vi.mocked(collectFonts).mockResolvedValue(fonts);
+
+    const result = await runStageFilesWorkflow({ files, options, settings });
+
+    expect(collectFonts).toHaveBeenCalledWith(settings);
+    expect(gt.uploadFonts).toHaveBeenCalledWith(fonts);
+    expect(result.enqueueResult).toEqual({ message: 'enqueued', jobData: {} });
+  });
+
+  it('skips the upload when no fonts are configured', async () => {
+    vi.mocked(collectFonts).mockResolvedValue([]);
+
+    await runStageFilesWorkflow({ files, options, settings });
+
+    expect(gt.uploadFonts).not.toHaveBeenCalled();
+  });
+
+  it('continues staging when the font upload fails', async () => {
+    vi.mocked(collectFonts).mockResolvedValue([
+      { assetType: 'FONT', fileName: 'Inter.ttf', content: 'Zm9udA==' },
+    ]);
+    vi.mocked(gt.uploadFonts).mockRejectedValueOnce(new Error('server down'));
+
+    const result = await runStageFilesWorkflow({ files, options, settings });
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Font sync failed')
+    );
+    expect(result.enqueueResult).toEqual({ message: 'enqueued', jobData: {} });
+  });
+});

--- a/packages/cli/src/workflows/enqueue.ts
+++ b/packages/cli/src/workflows/enqueue.ts
@@ -7,6 +7,7 @@ import { EnqueueStep } from './steps/EnqueueStep.js';
 import { BranchStep } from './steps/BranchStep.js';
 import { logger } from '../console/logger.js';
 import { filterFilesForEnqueue } from './utils/filterFilesForEnqueue.js';
+import { syncFonts } from './utils/syncFonts.js';
 
 /**
  * Enqueues translations for a given set of files
@@ -32,6 +33,10 @@ export async function runEnqueueWorkflow({
     logCollectedFiles(files);
 
     logger.debug('Files: ' + JSON.stringify(files, null, 2));
+
+    // Sync fonts before enqueueing so the translation jobs (e.g. Lottie
+    // layout refinement) can use them instead of fallback fonts.
+    await syncFonts(settings);
 
     // Create workflow with steps
     const branchStep = new BranchStep(gt, settings);

--- a/packages/cli/src/workflows/stage.ts
+++ b/packages/cli/src/workflows/stage.ts
@@ -13,6 +13,7 @@ import { UserEditDiffsStep } from './steps/UserEditDiffsStep.js';
 import { BranchData } from '../types/branch.js';
 import { calculateTimeoutMs } from '../utils/calculateTimeoutMs.js';
 import { filterFilesForEnqueue } from './utils/filterFilesForEnqueue.js';
+import { syncFonts } from './utils/syncFonts.js';
 
 /**
  * Sends multiple files for translation to the API using a workflow pattern
@@ -36,6 +37,10 @@ export async function runStageFilesWorkflow({
   try {
     // Log files to be translated
     logCollectedFiles(files);
+
+    // Sync fonts before enqueueing so the translation jobs (e.g. Lottie
+    // layout refinement) can use them instead of fallback fonts.
+    await syncFonts(settings);
 
     // Calculate timeout for setup step
     const timeoutMs = calculateTimeoutMs(options.timeout);

--- a/packages/cli/src/workflows/upload.ts
+++ b/packages/cli/src/workflows/upload.ts
@@ -4,6 +4,7 @@ import { logger } from '../console/logger.js';
 import { logErrorAndExit } from '../console/logging.js';
 import { Settings } from '../types/index.js';
 import { gt } from '../utils/gt.js';
+import { syncFonts } from './utils/syncFonts.js';
 import { BranchStep } from './steps/BranchStep.js';
 import { UploadSourcesStep } from './steps/UploadSourcesStep.js';
 import { UploadTranslationsStep } from './steps/UploadTranslationsStep.js';
@@ -37,6 +38,10 @@ export async function runUploadFilesWorkflow({
           )
           .join('\n')
     );
+
+    // Sync fonts first (locale-invariant) so they're available when
+    // translating formats that need them.
+    await syncFonts(options);
 
     // Create workflow steps
     const branchStep = new BranchStep(gt, options);

--- a/packages/cli/src/workflows/utils/syncFonts.ts
+++ b/packages/cli/src/workflows/utils/syncFonts.ts
@@ -1,0 +1,26 @@
+import { logger } from '../../console/logger.js';
+import { Settings } from '../../types/index.js';
+import { gt } from '../../utils/gt.js';
+import { collectFonts } from '../../formats/files/collectFonts.js';
+
+/**
+ * Syncs configured project fonts to the API so they're available when
+ * translation jobs run (e.g. Lottie layout refinement). Fonts are
+ * locale-invariant and the upload is idempotent server-side, so calling this
+ * from every workflow that triggers jobs is safe. A failure is non-fatal —
+ * translation still proceeds with fallback fonts.
+ */
+export async function syncFonts(settings: Settings): Promise<void> {
+  const fonts = await collectFonts(settings);
+  if (fonts.length === 0) return;
+  try {
+    const result = await gt.uploadFonts(fonts);
+    logger.success(`Synced ${result.count} font(s)`);
+  } catch (error) {
+    logger.warn(
+      `Font sync failed; continuing without provisioned fonts: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -41,6 +41,7 @@ import {
   SubmitUserEditDiffsPayload,
 } from './translate/submitUserEditDiffs';
 import { _uploadSourceFiles } from './translate/uploadSourceFiles';
+import { _uploadFonts } from './translate/uploadFonts';
 import { _uploadTranslations } from './translate/uploadTranslations';
 import {
   FileUpload,
@@ -48,6 +49,11 @@ import {
   UploadFilesOptions,
   UploadFilesResponse,
 } from './types-dir/api/uploadFiles';
+import type {
+  AssetUpload,
+  UploadAssetsOptions,
+  UploadAssetsResponse,
+} from './types-dir/api/uploadAssets';
 import { _querySourceFile } from './translate/querySourceFile';
 import { ProjectData } from './types-dir/api/project';
 import { _getProjectData } from './projects/getProjectData';
@@ -696,6 +702,29 @@ export class GT extends GTRuntime {
       count: result.count,
       message: `Successfully uploaded ${result.count} files in ${result.batchCount} batch(es)`,
     };
+  }
+
+  /**
+   * Uploads fonts used when translating formats that need the source font.
+   * Persistent and reused across translation jobs; idempotent on the server, so
+   * re-running only stores new fonts.
+   * @param {AssetUpload[]} fonts - Fonts to upload (`content` base64-encoded).
+   * @param {UploadAssetsOptions} options - Optional settings (e.g. timeout).
+   * @returns {Promise<UploadAssetsResponse>} The stored/deduped assets.
+   */
+  async uploadFonts(
+    fonts: AssetUpload[],
+    options: UploadAssetsOptions = {}
+  ): Promise<UploadAssetsResponse> {
+    this._validateAuth('uploadFonts');
+
+    const result = await _uploadFonts(
+      fonts,
+      options,
+      this._getTranslationConfig()
+    );
+
+    return { assets: result.data, count: result.count };
   }
 
   /**

--- a/packages/core/src/translate/__tests__/downloadFileBatch.test.ts
+++ b/packages/core/src/translate/__tests__/downloadFileBatch.test.ts
@@ -169,6 +169,38 @@ describe.sequential('_downloadFileBatch', () => {
     expect(result.batchCount).toBe(1);
   });
 
+  it('should keep binary (LOTTIE) content base64-encoded (no decode)', async () => {
+    // Binary bytes that are NOT valid UTF-8; decoding would corrupt them.
+    const zipBytes = Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x00, 0xff, 0x10]);
+    const base64Data = zipBytes.toString('base64');
+    vi.mocked(apiRequest).mockResolvedValue({
+      files: [
+        {
+          id: 'translation-lottie',
+          branchId: 'branch-1',
+          fileId: 'file-lottie',
+          versionId: 'version-lottie',
+          locale: 'es',
+          fileFormat: 'LOTTIE',
+          fileName: 'animation.lottie',
+          data: base64Data,
+          metadata: {},
+        },
+      ],
+      count: 1,
+    });
+
+    const result = await _downloadFileBatch(
+      [{ fileId: 'file-lottie', locale: 'es' }],
+      {},
+      mockConfig
+    );
+
+    // data stays base64 (verbatim), so the writer can recover the exact bytes.
+    expect(result.data[0].data).toBe(base64Data);
+    expect(Buffer.from(result.data[0].data, 'base64')).toEqual(zipBytes);
+  });
+
   it('should use default timeout when not specified', async () => {
     vi.mocked(apiRequest).mockResolvedValue(mockDownloadFileBatchResultBase64);
 

--- a/packages/core/src/translate/__tests__/uploadSourceFiles.test.ts
+++ b/packages/core/src/translate/__tests__/uploadSourceFiles.test.ts
@@ -235,6 +235,36 @@ describe.sequential('_uploadSourceFiles', () => {
     );
   });
 
+  it('should pass binary (LOTTIE) content through without re-encoding', async () => {
+    // Binary formats arrive already base64-encoded; re-encoding would corrupt
+    // the bytes. The content must reach the API verbatim.
+    const zipBytes = Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x00, 0xff, 0x10]); // "PK\x03\x04" zip magic + non-UTF8 bytes
+    const base64Content = zipBytes.toString('base64');
+    const mockFiles = [
+      {
+        source: createMockFileUpload({
+          fileName: 'animation.lottie',
+          fileFormat: 'LOTTIE',
+          content: base64Content,
+        }),
+      },
+    ];
+
+    vi.mocked(apiRequest).mockResolvedValue({ success: true });
+
+    await _uploadSourceFiles(mockFiles, createMockOptions(), mockConfig);
+
+    const sentContent =
+      vi.mocked(apiRequest).mock.calls[0][2].body.data[0].source.content;
+    // Verbatim passthrough — NOT encode(base64Content).
+    expect(sentContent).toBe(base64Content);
+    expect(sentContent).not.toBe(
+      Buffer.from(base64Content, 'utf8').toString('base64')
+    );
+    // Round-trips back to the original bytes.
+    expect(Buffer.from(sentContent, 'base64')).toEqual(zipBytes);
+  });
+
   it('should upload PO and POT source files', async () => {
     const mockFiles = [
       {

--- a/packages/core/src/translate/downloadFileBatch.ts
+++ b/packages/core/src/translate/downloadFileBatch.ts
@@ -6,6 +6,7 @@ import {
 } from '../types-dir/api/downloadFileBatch';
 import { apiRequest } from './utils/apiRequest';
 import { decode } from '../utils/base64';
+import { isBinaryFileFormat } from '../types-dir/api/file';
 import { processBatches } from './utils/batch';
 
 /**
@@ -30,10 +31,13 @@ export async function _downloadFileBatch(
         { body: batch, timeout: options.timeout }
       );
 
-      // convert from base64 to string
+      // convert from base64 to string, except binary formats (e.g. LOTTIE zip
+      // bundles) which stay base64 so their bytes survive to the writer.
       const files = result.files.map((file) => ({
         ...file,
-        data: decode(file.data),
+        data: isBinaryFileFormat(file.fileFormat)
+          ? file.data
+          : decode(file.data),
       }));
 
       return files;

--- a/packages/core/src/translate/uploadFonts.ts
+++ b/packages/core/src/translate/uploadFonts.ts
@@ -1,0 +1,47 @@
+import { TranslationRequestConfig } from '../types';
+import { apiRequest } from './utils/apiRequest';
+import { processBatches } from './utils/batch';
+
+import {
+  AssetUpload,
+  UploadAssetsResponse,
+} from '../types-dir/api/uploadAssets';
+
+// Fonts are large binary payloads (often hundreds of KB each once
+// base64-encoded), so batches are kept smaller than the default of 100 used
+// for text-file uploads to bound the request body size.
+const FONT_UPLOAD_BATCH_SIZE = 50;
+
+/**
+ * @internal
+ * Uploads project fonts to the General Translation API in batches. Idempotent
+ * on the server (re-running only stores genuinely new fonts). `content` is
+ * already base64-encoded by the caller (fonts are binary).
+ */
+export async function _uploadFonts(
+  fonts: AssetUpload[],
+  options: { timeout?: number },
+  config: TranslationRequestConfig
+) {
+  return processBatches(
+    fonts,
+    async (batch) => {
+      const body = {
+        assets: batch.map((font) => ({
+          assetType: font.assetType,
+          content: font.content,
+          fileName: font.fileName,
+        })),
+      };
+
+      const result = await apiRequest<UploadAssetsResponse>(
+        config,
+        '/v2/project/assets',
+        { body, timeout: options.timeout }
+      );
+
+      return result.assets || [];
+    },
+    { batchSize: FONT_UPLOAD_BATCH_SIZE }
+  );
+}

--- a/packages/core/src/translate/uploadSourceFiles.ts
+++ b/packages/core/src/translate/uploadSourceFiles.ts
@@ -2,6 +2,7 @@ import { TranslationRequestConfig } from '../types';
 import { apiRequest } from './utils/apiRequest';
 import { encode } from '../utils/base64';
 import { processBatches } from './utils/batch';
+import { isBinaryFileFormat } from '../types-dir/api/file';
 
 import {
   FileUpload,
@@ -28,7 +29,9 @@ export async function _uploadSourceFiles(
       const body = {
         data: batch.map(({ source }) => ({
           source: {
-            content: encode(source.content),
+            content: isBinaryFileFormat(source.fileFormat)
+              ? source.content
+              : encode(source.content),
             fileName: source.fileName,
             fileFormat: source.fileFormat,
             locale: source.locale,

--- a/packages/core/src/translate/uploadTranslations.ts
+++ b/packages/core/src/translate/uploadTranslations.ts
@@ -8,6 +8,7 @@ import {
   RequiredUploadFilesOptions,
 } from '../types-dir/api/uploadFiles';
 import { encode } from '../utils/base64';
+import { isBinaryFileFormat } from '../types-dir/api/file';
 import { validateFileFormatTransforms } from './utils/validateFileFormatTransform';
 
 /**
@@ -34,7 +35,9 @@ export async function _uploadTranslations(
       const body = {
         data: batch.map(({ source, translations }) => ({
           source: {
-            content: encode(source.content),
+            content: isBinaryFileFormat(source.fileFormat)
+              ? source.content
+              : encode(source.content),
             fileName: source.fileName,
             fileFormat: source.fileFormat,
             transformFormat: source.transformFormat,
@@ -46,7 +49,9 @@ export async function _uploadTranslations(
             branchId: source.branchId,
           },
           translations: translations.map((t) => ({
-            content: encode(t.content),
+            content: isBinaryFileFormat(t.fileFormat)
+              ? t.content
+              : encode(t.content),
             fileName: t.fileName,
             fileFormat: t.fileFormat,
             locale: t.locale,

--- a/packages/core/src/types-dir/api/file.ts
+++ b/packages/core/src/types-dir/api/file.ts
@@ -14,7 +14,25 @@ export type FileFormat =
   | 'JS'
   | 'HTML'
   | 'TXT'
-  | 'TWILIO_CONTENT_JSON';
+  | 'TWILIO_CONTENT_JSON'
+  | 'LOTTIE';
+
+/**
+ * File formats whose content is binary (e.g. zip bundles) rather than text.
+ * Their content travels through the pipeline already base64-encoded, so the
+ * usual UTF-8 encode/decode steps must be skipped to avoid corrupting bytes.
+ */
+export const BINARY_FILE_FORMATS: ReadonlySet<FileFormat> = new Set<FileFormat>(
+  ['LOTTIE']
+);
+
+/**
+ * Whether a file format's content is binary (carried as base64 end-to-end)
+ * rather than a UTF-8 text string.
+ */
+export function isBinaryFileFormat(fileFormat: FileFormat): boolean {
+  return BINARY_FILE_FORMATS.has(fileFormat);
+}
 
 /**
  * Metadata for files or entries.

--- a/packages/core/src/types-dir/api/uploadAssets.ts
+++ b/packages/core/src/types-dir/api/uploadAssets.ts
@@ -1,0 +1,29 @@
+// Project assets (e.g., fonts) uploaded once and reused across translation jobs.
+// Distinct from per-file source uploads (uploadFiles.ts): assets are persistent
+// and locale-invariant, so they go to /v2/project/assets rather than the file
+// upload endpoints.
+
+export type AssetUpload = {
+  assetType: 'FONT';
+  // Base64-encoded asset bytes (fonts are binary, so the caller base64-encodes
+  // them; the SDK sends this through as-is).
+  content: string;
+  fileName: string;
+};
+
+export type UploadAssetsOptions = {
+  timeout?: number;
+};
+
+export type UploadedAsset = {
+  id: string;
+  assetKey: string;
+  fileName: string;
+  // True when this exact asset was already stored, so it wasn't uploaded again.
+  deduped: boolean;
+};
+
+export type UploadAssetsResponse = {
+  assets: UploadedAsset[];
+  count: number;
+};

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -59,6 +59,7 @@ export type {
 export type { DownloadedFile } from './types-dir/api/downloadFileBatch';
 export type { DownloadFileOptions } from './types-dir/api/downloadFile';
 export type { FileFormat } from './types-dir/api/file';
+export { isBinaryFileFormat, BINARY_FILE_FORMATS } from './types-dir/api/file';
 export type { TranslateManyResult } from './types-dir/api/translateMany';
 export type {
   TranslationResult,

--- a/packages/core/src/utils/isSupportedFileFormatTransform.ts
+++ b/packages/core/src/utils/isSupportedFileFormatTransform.ts
@@ -14,6 +14,7 @@ const SUPPORTED_TRANSFORMATIONS = {
   HTML: ['HTML'],
   TXT: ['TXT'],
   TWILIO_CONTENT_JSON: ['TWILIO_CONTENT_JSON'],
+  LOTTIE: ['LOTTIE'],
 } as const satisfies Record<FileFormat, FileFormat[]>;
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ catalogs:
       version: 0.47.0
     oxlint:
       specifier: ^1.62.0
-      version: 1.62.0
+      version: 1.74.0
     tsdown:
       specifier: ^0.21.10
       version: 0.21.10
@@ -67,7 +67,7 @@ importers:
         version: 0.47.0
       oxlint:
         specifier: 'catalog:'
-        version: 1.62.0
+        version: 1.74.0
       postcss:
         specifier: ^8.5.19
         version: 8.5.19
@@ -534,7 +534,7 @@ importers:
         version: link:../../packages/next
       next:
         specifier: latest
-        version: 16.2.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.2.12(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -608,7 +608,7 @@ importers:
         version: link:../../packages/cli
       oxlint:
         specifier: 'catalog:'
-        version: 1.62.0
+        version: 1.74.0
       rollup:
         specifier: ^4.62.2
         version: 4.62.2
@@ -819,6 +819,9 @@ importers:
       fast-json-stable-stringify:
         specifier: ^2.1.0
         version: 2.1.0
+      fflate:
+        specifier: ^0.8.2
+        version: 0.8.3
       generaltranslation:
         specifier: workspace:*
         version: link:../core
@@ -5901,6 +5904,7 @@ packages:
 
   '@modelcontextprotocol/inspector@0.14.3':
     resolution: {integrity: sha512-WtEDqVwXnICveGd39BOF0Q3WxCPQg3MhBzMEDDZp2AZn+pO+eTiRR4bqxTiGkqHUjHODckHkSpu2FQ/A+x5mnQ==}
+    deprecated: 'v1 is deprecated. Upgrade to v2: npm i @modelcontextprotocol/inspector@latest. v1 gets security fixes only, published under the v1-latest tag.'
     hasBin: true
 
   '@modelcontextprotocol/sdk@1.18.2':
@@ -5932,12 +5936,6 @@ packages:
   '@mux/playback-core@0.33.3':
     resolution: {integrity: sha512-96HKZoK3TFUvDU3sDiAei/nAV4+Xx0JCiIjJNcl/ZcAjObL0daHQmM+zgtjvU2T6L5zEaGPxnX3OTfI4OogWzg==}
 
-  '@napi-rs/wasm-runtime@1.1.4':
-    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
-    peerDependencies:
-      '@emnapi/core': ^1.7.1
-      '@emnapi/runtime': ^1.7.1
-
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
     peerDependencies:
@@ -5959,8 +5957,8 @@ packages:
   '@next/env@16.1.6':
     resolution: {integrity: sha512-N1ySLuZjnAtN3kFnwhAwPvZah8RJxKasD7x1f8shFqhncnWZn4JMfg37diLNuoHsLAlrDfM3g4mawVdtAG8XLQ==}
 
-  '@next/env@16.2.11':
-    resolution: {integrity: sha512-0do5A3BJ2gxWr0ZCMcD6BhW+e595jyxdTl3rXTS6lOtD8ektMiW6CO+EPwt1Eca1DBnm90r/7GdiKWBKxH++DA==}
+  '@next/env@16.2.12':
+    resolution: {integrity: sha512-d0Z5Bc13Fa4nR8pFAKx2jay2yhJM16vlfHbTzYnUQAxlNb6B6lmn4hjt69lYNt4kRtyYP6gEM49lPRHNbIyneg==}
 
   '@next/env@16.2.9':
     resolution: {integrity: sha512-ki5VxxXfzD/9TDe13wyeTKIjQTAwBVpnr8KhRDUr8ltMUq1/NBpWNT5tiPoxiGl+PHM4X2ahSOiPk6iAimIzPg==}
@@ -5989,8 +5987,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-arm64@16.2.11':
-    resolution: {integrity: sha512-wryL4pjKmDwGv2ox6+GZDFxvmtSRLqApBR8kL1j4+vhB7Z5vJC/zAnXpiR9Xkfzl0AS8WLMnsuGV/UKI67/rrw==}
+  '@next/swc-darwin-arm64@16.2.12':
+    resolution: {integrity: sha512-0W1R0teHWJrqKX0FH20IzzIWAOuGtBxPGuObrxy1lE8hQvCFj49KE8a3WUg0D7sq6rn6zkM4c7YGUnhudBS6oA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
@@ -6025,8 +6023,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.2.11':
-    resolution: {integrity: sha512-aZl2j4f/fLyjQvOhv0Oe9UaMAQHolYpKhctsoYzplSumKJKPUmgjcf6545aBtysLTcu994TREd0+pSgNE4ohmg==}
+  '@next/swc-darwin-x64@16.2.12':
+    resolution: {integrity: sha512-Hy5Ls099+aFUmOLmIgPfLqNi6iCwhL3uQCssz5rWk+5Nkc6TUKCE83DY5BbNylfm3+mfwcSFnLRfrZDJhVxdtw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
@@ -6065,8 +6063,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-arm64-gnu@16.2.11':
-    resolution: {integrity: sha512-5jEriyEnH/LWFy27L2ZG0XaLlyEJIjhsImEsiS9P563PKEVp2BVups/xfOucIrsvVntp11oNcZwjHvaDPYVB5g==}
+  '@next/swc-linux-arm64-gnu@16.2.12':
+    resolution: {integrity: sha512-+YqU2h1cQkHsGfvjAsrSmst8UIFBibBGm5x3Xgel8NLMiDQtNOM4sM2GOEMvG5YiOBNeN/Ykk8cQC2S0Xrqljg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -6107,8 +6105,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@next/swc-linux-arm64-musl@16.2.11':
-    resolution: {integrity: sha512-eIjcpx2fnnFSSkZDbTxy74KnokUXDjfoLClpWelfgHLf621aTqswhwXQ7GkD5K5rplrS6LZ/Bj+mVuvzluBOEg==}
+  '@next/swc-linux-arm64-musl@16.2.12':
+    resolution: {integrity: sha512-0qjhiYBaKAqF63LA1ZWAAnKTzFUguAaZiRa5etMLGGPj/B6uEVjtIZldIzFEp3wHlB0koK6aTzqPtSdplTCjoA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -6149,8 +6147,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-x64-gnu@16.2.11':
-    resolution: {integrity: sha512-8WgzpaWMs46qJT9kiV47cje86L0x/Mu9t8/Gwj+pnbgW3rETVfCnaScPjlYUwNScpOozdcIMHWmAvuZJUonR2w==}
+  '@next/swc-linux-x64-gnu@16.2.12':
+    resolution: {integrity: sha512-7A3q26W+h7gnA15uqBToNuDqBEFZZcqh0mW2mn4AJh/G5pdg2RVE3n4slzLEliASZFG3NmsbEzng/x2Sh09mBg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -6191,8 +6189,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@next/swc-linux-x64-musl@16.2.11':
-    resolution: {integrity: sha512-I3UgPds7G4ZYnTb/H+5GBGuUT2DhAk6j0mL6A4s63RjFs74wB2hOWP0vaxsK+3NJraExt3eYEPQ/UtT0x/64Nw==}
+  '@next/swc-linux-x64-musl@16.2.12':
+    resolution: {integrity: sha512-qSjL/uppm+cbh21s72Ss8gkiOhQ4dExWHNGOWy6eZV7STj5WsKehgxT61beSsOj+YYQuTplL376lOCdMQU5T8w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -6229,8 +6227,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-arm64-msvc@16.2.11':
-    resolution: {integrity: sha512-n89CjtcThnjrwgJMAiI5xbqwLY51zvwC9tSlArmVndAJLYVl9T9UAdlkXTmZvE++idoXe8KdglQlhNRdUp1c6g==}
+  '@next/swc-win32-arm64-msvc@16.2.12':
+    resolution: {integrity: sha512-X6hzsOUJac/e7AWSbn9gQ9nzHld1xWP5iyjHpYWvud8pufB679O1xg4JDyKr8Xd69Jvd+kM2Der6uftiZCmjYA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
@@ -6265,8 +6263,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.2.11':
-    resolution: {integrity: sha512-md8CLNggS1Dx9pUgApzps5uAf+N8GN9xywzmNx9vHAWo94HtBwCCqkSnhIrdfQe83Dhz8Lfo/20Nb1Zxal092w==}
+  '@next/swc-win32-x64-msvc@16.2.12':
+    resolution: {integrity: sha512-F6fakeHuFTLOPt0bslQJdf+xtT+WIP9DVn/m4y1w1mRnVPyh3D/cNvzlRkxM444xfm+IvvYNSOrKiA2CDJ0Uxw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -6528,22 +6526,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@oxlint/binding-android-arm-eabi@1.62.0':
-    resolution: {integrity: sha512-pKsthNECyvJh8lPTICz6VcwVy2jOqdhhsp1rlxCkhgZR47aKvXPmaRWQDv+zlXpRae4qm1MaaTnutkaOk5aofg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [android]
-
   '@oxlint/binding-android-arm-eabi@1.74.0':
     resolution: {integrity: sha512-+gHd12muVI9ZLBaWLPkHt3Fj7jihFjgQ1MGtBaRL8vWrWrI0P7dLUty/cHrHS0oqPYIRgQUJsPu2CExQuMcwNw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
-    os: [android]
-
-  '@oxlint/binding-android-arm64@1.62.0':
-    resolution: {integrity: sha512-b1AUNViByvgmR2xJDubvLIr+dSuu3uraG7bsAoKo+xrpspPvu6RIn6Fhr2JUhobfep3jwUTy18Huco6GkwdvGQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
     os: [android]
 
   '@oxlint/binding-android-arm64@1.74.0':
@@ -6552,22 +6538,10 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@oxlint/binding-darwin-arm64@1.62.0':
-    resolution: {integrity: sha512-iG+Tvf70UJ6otfwFYIHk36Sjq9cpPP5YLxkoggANNRtzgi3Tj3g8q6Ybqi6AtkU3+yg9QwF7bDCkCS6bbL4PCg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [darwin]
-
   '@oxlint/binding-darwin-arm64@1.74.0':
     resolution: {integrity: sha512-iUK7wvc6sejMKsC+Pt67mntoF5weFcyEunhZfLJceU6gL419mexz5wBkSx/EnkFBExMLNtOi9fnDSc5xfK0IzQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
-    os: [darwin]
-
-  '@oxlint/binding-darwin-x64@1.62.0':
-    resolution: {integrity: sha512-oOWI6YPPr5AJUx+yIDlxmuUbQjS5gZX3OH3QisawYvsZgLiQVvZtR0rPBcJTxLWqt2ClrWg0DlSrlUiG5SQNHg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
     os: [darwin]
 
   '@oxlint/binding-darwin-x64@1.74.0':
@@ -6576,32 +6550,14 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@oxlint/binding-freebsd-x64@1.62.0':
-    resolution: {integrity: sha512-dLP33T7VLCmLVv4cvjkVX+rmkcwNk2UfxmsZPNur/7BQHoQR60zJ7XLiRvNUawlzn0u8ngCa3itjEG73MAMa/w==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [freebsd]
-
   '@oxlint/binding-freebsd-x64@1.74.0':
     resolution: {integrity: sha512-u++dH/43jy9hTLbneaWlS0gla/Bp1JdwJ2zgevCl8nDFUh6qRCGMxcL0f0lb7By3A9p/LfFr+7cG4HU1hG856g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@oxlint/binding-linux-arm-gnueabihf@1.62.0':
-    resolution: {integrity: sha512-fl//LWNks6qo9chNY60UDYyIwtp7a5cEx4Y/rHPjaarhuwqx6jtbzEpD5V5AqmdL4a6Y5D8zeXg5HF2Cr0QmSQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
-
   '@oxlint/binding-linux-arm-gnueabihf@1.74.0':
     resolution: {integrity: sha512-Sj1zmtFDVTPeIbIz4ZfcXAbFHqCmKCXdCUlAJzvTF7I20NTH1RDpoF2PhkqNODutJzVhJYmm3oz0GwgY+tvE2g==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
-
-  '@oxlint/binding-linux-arm-musleabihf@1.62.0':
-    resolution: {integrity: sha512-i5vkAuxvueTODV3J2dL61/TXewDHhMFKvtD156cIsk7GsdfiAu7zW7kY0NJXhKeFHeiMZIh7eFNjkPYH6J47HQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
@@ -6612,26 +6568,12 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@oxlint/binding-linux-arm64-gnu@1.62.0':
-    resolution: {integrity: sha512-QwN19LLuIGuOjEflSeJkZmOTfBdBMlTmW8xbMf8TZhjd//cxVNYQPq75q7oKZBJc6hRx3gY7sX0Egc8cEIFZYg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
   '@oxlint/binding-linux-arm64-gnu@1.74.0':
     resolution: {integrity: sha512-/k1Me+aX2tjuH10K62mLS0y8cLkJBHX6Ce0xPK+eWeel4bSdEGZ8dv4+hYMzg0GrSmjwy4yAYsDPeEeKBft/2w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
-
-  '@oxlint/binding-linux-arm64-musl@1.62.0':
-    resolution: {integrity: sha512-8eCy3FCDuWUM5hWujAv6heMvfZPbcCOU3SdQUAkixZLu5bSzOkNfirJiLGoQFO943xceOKkiQRMQNzH++jM3WA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
 
   '@oxlint/binding-linux-arm64-musl@1.74.0':
     resolution: {integrity: sha512-3tFSjBxc5D8/zvjEuLvOqcA8ZXKD0+6NuaVO/edeamNc49MoAsbfaC9s1UiwODwgF6slGaF8yJA2TPkukd77tg==}
@@ -6640,24 +6582,10 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-linux-ppc64-gnu@1.62.0':
-    resolution: {integrity: sha512-NjQ7K7tpTPDe9J+yq8p/s/J0E7lRCkK2uDBDqvT4XIT6f4Z0tlnr59OBg/WcrmVHER1AbrcfyxhGTXgcG8ytWg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
   '@oxlint/binding-linux-ppc64-gnu@1.74.0':
     resolution: {integrity: sha512-9QggtPkSPXOCTu8Szis7auOK/sC7KdQaN+/TujP7YVVhzCAOhgdRfgv8uEz0r2tk5xdgus5rLYUrCDoZNtiRUw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxlint/binding-linux-riscv64-gnu@1.62.0':
-    resolution: {integrity: sha512-oKZed9gmSwze29dEt3/Wnsv6l/Ygw/FUst+8Kfpv2SGeS/glEoTGZAMQw37SVyzFV76UTHJN2snGgxK2t2+8ow==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
@@ -6668,13 +6596,6 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-riscv64-musl@1.62.0':
-    resolution: {integrity: sha512-gBjBxQ+9lGpAYq+ELqw0w8QXsBnkZclFc7GRX2r0LnEVn3ZTEqeIKpKcGjucmp76Q53bvJD0i4qBWBhcfhSfGA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [musl]
-
   '@oxlint/binding-linux-riscv64-musl@1.74.0':
     resolution: {integrity: sha512-SaDY1gh9rOA592J54g+gu5hkOFFQBZsMmIYHs+NRHG+Uq0OxtuuCXMWQ3vu1830Eugv5uMXyjG+bv2Z9y4IXjw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -6682,24 +6603,10 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-linux-s390x-gnu@1.62.0':
-    resolution: {integrity: sha512-Ew2Kxs9EQ9/mbAIJ2hvocMC0wsOu6YKzStI2eFBDt+Td5O8seVC/oxgRIHqCcl5sf5ratA1nozQBAuv7tphkHg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
   '@oxlint/binding-linux-s390x-gnu@1.74.0':
     resolution: {integrity: sha512-ZATQeHZCyr6MbDveg0obD5sxLHFOghtOdC5jwVwYlvFWqtFOxctgFEG6Ef/64hYvZrWyhyCckB10AelqLopeDA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxlint/binding-linux-x64-gnu@1.62.0':
-    resolution: {integrity: sha512-5z25jcAA0gfKyVwz71A0VXgaPlocPoTAxhlv/hgoK6tlCrfoNuw7haWbDHvGMfjXhdic4EqVXGRv5XsTqFnbRQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
     os: [linux]
     libc: [glibc]
 
@@ -6710,13 +6617,6 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-x64-musl@1.62.0':
-    resolution: {integrity: sha512-IWpHmMB6ZDllPvqWDkG6AmXrN7JF5e/c4g/0PuURsmlK+vHoYZPB70rr4u1bn3I4LsKCSpqqfveyx6UCOC8wdg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
   '@oxlint/binding-linux-x64-musl@1.74.0':
     resolution: {integrity: sha512-XyktaR8lhK2qWiCK0Tk8oYD+/cgn+oHA6ddRnxSSXUKkkojkV78CmShZUxQF+yrBFs0SuW+JBOPG6hecyc/iZg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -6724,23 +6624,11 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-openharmony-arm64@1.62.0':
-    resolution: {integrity: sha512-fjlSxxrD5pA594vkyikCS9MnPRjQawW6/BLgyTYkO+73wwPlYjkcZ7LSd974l0Q2zkHQmu4DPvJFLYA7o8xrxQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [openharmony]
-
   '@oxlint/binding-openharmony-arm64@1.74.0':
     resolution: {integrity: sha512-mzbjrPl4neaVUiJ1fUiEUxTGaSZBoiKtaoB6jmIpz9S+VOA2vDYmJpihQ82w6178V5jxziclTg8Cgj5yF6tTDg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
-
-  '@oxlint/binding-win32-arm64-msvc@1.62.0':
-    resolution: {integrity: sha512-EiFXr8loNS0Ul3Gu80+9nr1T8jRmnKocqmHHg16tj5ZqTgUXyb97l2rrspVHdDluyFn9JfR4PoJFdNzw4paHww==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [win32]
 
   '@oxlint/binding-win32-arm64-msvc@1.74.0':
     resolution: {integrity: sha512-vUAe9okpS2Oa5+lX67lqHMuNUvfkleRKwrUDJ/WJBsgmddvZ1mrsh2HVmuFDRzqFELhaJhFaCNOuR6a7L3rtIA==}
@@ -6748,22 +6636,10 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@oxlint/binding-win32-ia32-msvc@1.62.0':
-    resolution: {integrity: sha512-IgOFvL73li1bFgab+hThXYA0N2Xms2kV2MvZN95cebV+fmrZ9AVui1JSxfeeqRLo3CpPxKZlzhyq4G0cnaAvIw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ia32]
-    os: [win32]
-
   '@oxlint/binding-win32-ia32-msvc@1.74.0':
     resolution: {integrity: sha512-yyXXJyYYSXL4I8K8jAWjJs+J3fa9gH2JmEbo4f5adm+1tNC9itseicBNuwK7BDHvqQ5J534s+yDULu89vYL2ZQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
-    os: [win32]
-
-  '@oxlint/binding-win32-x64-msvc@1.62.0':
-    resolution: {integrity: sha512-6hMpyDWQ2zGA1OXFKBrdYMUveUCO8UJhkO6JdwZPd78xIdHZNhjx+pib+4fC2Cljuhjyl0QwA2F3df/bs4Bp6A==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
     os: [win32]
 
   '@oxlint/binding-win32-x64-msvc@1.74.0':
@@ -9246,9 +9122,6 @@ packages:
 
   '@tsconfig/node16@1.0.4':
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
-
-  '@tybys/wasm-util@0.10.1':
-    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
@@ -12503,6 +12376,9 @@ packages:
   fetchdts@0.1.7:
     resolution: {integrity: sha512-YoZjBdafyLIop9lSxXVI33oLD5kN31q4Td+CasofLLYeLXRFeOsuOw0Uo+XNRi9PZlbfdlN2GmRtm4tCEQ9/KA==}
 
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
+
   figures@3.2.0:
     resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
     engines: {node: '>=8'}
@@ -15311,8 +15187,8 @@ packages:
       sass:
         optional: true
 
-  next@16.2.11:
-    resolution: {integrity: sha512-B339zaqbyK8cmxhoAvLrcwoabwCP1wz21zSzfqxqXAemTu2BXnH7tQnfcglKv1vnMUIDBc+Hth7XODQriTZiRQ==}
+  next@16.2.12:
+    resolution: {integrity: sha512-iD59eYQWmbFcEbX7v/acG5DRym9iw1DdaPoD0WTA920naWsE25wShzJW4+UvAs8MK9EC2kBfIH6vtto1H1PHGw==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -15623,16 +15499,6 @@ packages:
     resolution: {integrity: sha512-OFbkbzxKCpooQEnRmpTDnuwTX8KHXzZTQ4Df/hz85fpS67Pl+lxPEFvUtin56HIIS0B1k4X8oIzTXRZPufA2CA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
-
-  oxlint@1.62.0:
-    resolution: {integrity: sha512-1uFkg6HakjsGIpW9wNdeW4/2LOHW9MEkoWjZUTUfQtIHyLIZPYt00w3Sg+H3lH+206FgBPHBbW5dVE5l2ExECQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      oxlint-tsgolint: '>=0.18.0'
-    peerDependenciesMeta:
-      oxlint-tsgolint:
-        optional: true
 
   oxlint@1.74.0:
     resolution: {integrity: sha512-odGl2s2x5IOJoj3A0v1k0PGBXVFBZeZ2+AK/+K2MJur7Ghi3bkyX5NuLUWHKqa4js1wjep3hJeuTQJOlr+4+dA==}
@@ -18604,6 +18470,7 @@ packages:
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0
@@ -22310,7 +22177,7 @@ snapshots:
       resolve: 1.22.11
       resolve-from: 5.0.0
       resolve.exports: 2.0.3
-      semver: 7.7.4
+      semver: 7.8.5
       send: 0.19.2
       slugify: 1.6.9
       source-map-support: 0.5.21
@@ -22386,7 +22253,7 @@ snapshots:
       resolve: 1.22.11
       resolve-from: 5.0.0
       resolve.exports: 2.0.3
-      semver: 7.7.4
+      semver: 7.8.5
       send: 0.19.2
       slugify: 1.6.9
       source-map-support: 0.5.21
@@ -22421,7 +22288,7 @@ snapshots:
       getenv: 2.0.0
       glob: 13.0.6
       resolve-from: 5.0.0
-      semver: 7.7.4
+      semver: 7.8.5
       slash: 3.0.0
       slugify: 1.6.9
       xcode: 3.0.1
@@ -22443,7 +22310,7 @@ snapshots:
       require-from-string: 2.0.2
       resolve-from: 5.0.0
       resolve-workspace-root: 2.0.1
-      semver: 7.7.4
+      semver: 7.8.5
       slugify: 1.6.9
       sucrase: 3.35.1
     transitivePeerDependencies:
@@ -22492,7 +22359,7 @@ snapshots:
       minimatch: 10.2.5
       p-limit: 3.1.0
       resolve-from: 5.0.0
-      semver: 7.7.4
+      semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
 
@@ -22504,7 +22371,7 @@ snapshots:
       getenv: 2.0.0
       jimp-compact: 0.16.1
       parse-png: 2.1.0
-      semver: 7.7.4
+      semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -22517,7 +22384,7 @@ snapshots:
       getenv: 2.0.0
       jimp-compact: 0.16.1
       parse-png: 2.1.0
-      semver: 7.7.4
+      semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -22643,7 +22510,7 @@ snapshots:
       debug: 4.4.3(supports-color@5.5.0)
       expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.7.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.7.3)
       resolve-from: 5.0.0
-      semver: 7.7.4
+      semver: 7.8.5
       xml2js: 0.6.0
     transitivePeerDependencies:
       - supports-color
@@ -22660,7 +22527,7 @@ snapshots:
       debug: 4.4.3(supports-color@5.5.0)
       expo: 54.0.35(@babel/core@7.29.0)(bufferutil@4.0.9)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3))(@react-native/metro-config@0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       resolve-from: 5.0.0
-      semver: 7.7.4
+      semver: 7.8.5
       xml2js: 0.6.0
     transitivePeerDependencies:
       - supports-color
@@ -23982,18 +23849,11 @@ snapshots:
       hls.js: 1.6.15
       mux-embed: 5.17.10
 
-  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.1
-    optional: true
-
-  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
-    dependencies:
-      '@emnapi/core': 1.11.1
-      '@emnapi/runtime': 1.11.1
-      '@tybys/wasm-util': 0.10.1
+      '@tybys/wasm-util': 0.10.3
     optional: true
 
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
@@ -24015,7 +23875,7 @@ snapshots:
 
   '@next/env@16.1.6': {}
 
-  '@next/env@16.2.11': {}
+  '@next/env@16.2.12': {}
 
   '@next/env@16.2.9': {}
 
@@ -24031,7 +23891,7 @@ snapshots:
   '@next/swc-darwin-arm64@16.1.6':
     optional: true
 
-  '@next/swc-darwin-arm64@16.2.11':
+  '@next/swc-darwin-arm64@16.2.12':
     optional: true
 
   '@next/swc-darwin-arm64@16.2.9':
@@ -24049,7 +23909,7 @@ snapshots:
   '@next/swc-darwin-x64@16.1.6':
     optional: true
 
-  '@next/swc-darwin-x64@16.2.11':
+  '@next/swc-darwin-x64@16.2.12':
     optional: true
 
   '@next/swc-darwin-x64@16.2.9':
@@ -24067,7 +23927,7 @@ snapshots:
   '@next/swc-linux-arm64-gnu@16.1.6':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.2.11':
+  '@next/swc-linux-arm64-gnu@16.2.12':
     optional: true
 
   '@next/swc-linux-arm64-gnu@16.2.9':
@@ -24085,7 +23945,7 @@ snapshots:
   '@next/swc-linux-arm64-musl@16.1.6':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.2.11':
+  '@next/swc-linux-arm64-musl@16.2.12':
     optional: true
 
   '@next/swc-linux-arm64-musl@16.2.9':
@@ -24103,7 +23963,7 @@ snapshots:
   '@next/swc-linux-x64-gnu@16.1.6':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.2.11':
+  '@next/swc-linux-x64-gnu@16.2.12':
     optional: true
 
   '@next/swc-linux-x64-gnu@16.2.9':
@@ -24121,7 +23981,7 @@ snapshots:
   '@next/swc-linux-x64-musl@16.1.6':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.2.11':
+  '@next/swc-linux-x64-musl@16.2.12':
     optional: true
 
   '@next/swc-linux-x64-musl@16.2.9':
@@ -24139,7 +23999,7 @@ snapshots:
   '@next/swc-win32-arm64-msvc@16.1.6':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.2.11':
+  '@next/swc-win32-arm64-msvc@16.2.12':
     optional: true
 
   '@next/swc-win32-arm64-msvc@16.2.9':
@@ -24157,7 +24017,7 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.1.6':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.2.11':
+  '@next/swc-win32-x64-msvc@16.2.12':
     optional: true
 
   '@next/swc-win32-x64-msvc@16.2.9':
@@ -24198,7 +24058,7 @@ snapshots:
       is-wsl: 2.2.0
       lilconfig: 3.1.3
       minimatch: 10.2.5
-      semver: 7.7.4
+      semver: 7.8.5
       string-width: 4.2.3
       supports-color: 8.1.1
       tinyglobby: 0.2.17
@@ -24375,115 +24235,58 @@ snapshots:
   '@oxfmt/binding-win32-x64-msvc@0.47.0':
     optional: true
 
-  '@oxlint/binding-android-arm-eabi@1.62.0':
-    optional: true
-
   '@oxlint/binding-android-arm-eabi@1.74.0':
-    optional: true
-
-  '@oxlint/binding-android-arm64@1.62.0':
     optional: true
 
   '@oxlint/binding-android-arm64@1.74.0':
     optional: true
 
-  '@oxlint/binding-darwin-arm64@1.62.0':
-    optional: true
-
   '@oxlint/binding-darwin-arm64@1.74.0':
-    optional: true
-
-  '@oxlint/binding-darwin-x64@1.62.0':
     optional: true
 
   '@oxlint/binding-darwin-x64@1.74.0':
     optional: true
 
-  '@oxlint/binding-freebsd-x64@1.62.0':
-    optional: true
-
   '@oxlint/binding-freebsd-x64@1.74.0':
-    optional: true
-
-  '@oxlint/binding-linux-arm-gnueabihf@1.62.0':
     optional: true
 
   '@oxlint/binding-linux-arm-gnueabihf@1.74.0':
     optional: true
 
-  '@oxlint/binding-linux-arm-musleabihf@1.62.0':
-    optional: true
-
   '@oxlint/binding-linux-arm-musleabihf@1.74.0':
-    optional: true
-
-  '@oxlint/binding-linux-arm64-gnu@1.62.0':
     optional: true
 
   '@oxlint/binding-linux-arm64-gnu@1.74.0':
     optional: true
 
-  '@oxlint/binding-linux-arm64-musl@1.62.0':
-    optional: true
-
   '@oxlint/binding-linux-arm64-musl@1.74.0':
-    optional: true
-
-  '@oxlint/binding-linux-ppc64-gnu@1.62.0':
     optional: true
 
   '@oxlint/binding-linux-ppc64-gnu@1.74.0':
     optional: true
 
-  '@oxlint/binding-linux-riscv64-gnu@1.62.0':
-    optional: true
-
   '@oxlint/binding-linux-riscv64-gnu@1.74.0':
-    optional: true
-
-  '@oxlint/binding-linux-riscv64-musl@1.62.0':
     optional: true
 
   '@oxlint/binding-linux-riscv64-musl@1.74.0':
     optional: true
 
-  '@oxlint/binding-linux-s390x-gnu@1.62.0':
-    optional: true
-
   '@oxlint/binding-linux-s390x-gnu@1.74.0':
-    optional: true
-
-  '@oxlint/binding-linux-x64-gnu@1.62.0':
     optional: true
 
   '@oxlint/binding-linux-x64-gnu@1.74.0':
     optional: true
 
-  '@oxlint/binding-linux-x64-musl@1.62.0':
-    optional: true
-
   '@oxlint/binding-linux-x64-musl@1.74.0':
-    optional: true
-
-  '@oxlint/binding-openharmony-arm64@1.62.0':
     optional: true
 
   '@oxlint/binding-openharmony-arm64@1.74.0':
     optional: true
 
-  '@oxlint/binding-win32-arm64-msvc@1.62.0':
-    optional: true
-
   '@oxlint/binding-win32-arm64-msvc@1.74.0':
     optional: true
 
-  '@oxlint/binding-win32-ia32-msvc@1.62.0':
-    optional: true
-
   '@oxlint/binding-win32-ia32-msvc@1.74.0':
-    optional: true
-
-  '@oxlint/binding-win32-x64-msvc@1.62.0':
     optional: true
 
   '@oxlint/binding-win32-x64-msvc@1.74.0':
@@ -25866,7 +25669,7 @@ snapshots:
       metro: 0.83.6(bufferutil@4.0.9)
       metro-config: 0.83.6(bufferutil@4.0.9)
       metro-core: 0.83.6
-      semver: 7.7.4
+      semver: 7.8.5
     optionalDependencies:
       '@react-native-community/cli': 20.0.0(bufferutil@4.0.9)(typescript@5.9.3)
       '@react-native/metro-config': 0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9)
@@ -25883,7 +25686,7 @@ snapshots:
       metro: 0.83.6(bufferutil@4.0.9)
       metro-config: 0.83.6(bufferutil@4.0.9)
       metro-core: 0.83.6
-      semver: 7.7.4
+      semver: 7.8.5
     optionalDependencies:
       '@react-native-community/cli': 20.0.0(bufferutil@4.0.9)(typescript@5.7.3)
       '@react-native/metro-config': 0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9)
@@ -25900,7 +25703,7 @@ snapshots:
       metro: 0.83.6(bufferutil@4.0.9)
       metro-config: 0.83.6(bufferutil@4.0.9)
       metro-core: 0.83.6
-      semver: 7.7.4
+      semver: 7.8.5
     optionalDependencies:
       '@react-native-community/cli': 20.0.0(bufferutil@4.0.9)(typescript@5.9.3)
       '@react-native/metro-config': 0.81.1(@babel/core@7.29.0)(bufferutil@4.0.9)
@@ -26125,7 +25928,7 @@ snapshots:
 
   '@rolldown/binding-wasm32-wasi@1.0.0-beta.38(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -26135,7 +25938,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.1.5':
@@ -26673,7 +26476,7 @@ snapshots:
       react-is: 19.2.4
       read-package-up: 12.0.0
       rxjs: 7.8.2
-      semver: 7.7.4
+      semver: 7.8.5
       smol-toml: 1.6.1
       tar: 7.5.13
       tar-fs: 3.1.2
@@ -28036,11 +27839,6 @@ snapshots:
 
   '@tsconfig/node16@1.0.4': {}
 
-  '@tybys/wasm-util@0.10.1':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
   '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
@@ -28397,7 +28195,7 @@ snapshots:
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare-lite: 1.4.0
-      semver: 7.7.4
+      semver: 7.8.5
       tsutils: 3.21.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
@@ -28563,7 +28361,7 @@ snapshots:
       debug: 4.4.3(supports-color@5.5.0)
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.7.4
+      semver: 7.8.5
       tsutils: 3.21.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
@@ -28580,7 +28378,7 @@ snapshots:
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
-      semver: 7.7.4
+      semver: 7.8.5
       ts-api-utils: 2.1.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -28594,7 +28392,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 8.50.1
       debug: 4.4.3(supports-color@5.5.0)
       minimatch: 9.0.5
-      semver: 7.7.4
+      semver: 7.8.5
       tinyglobby: 0.2.17
       ts-api-utils: 2.1.0(typescript@5.9.3)
       typescript: 5.9.3
@@ -28611,7 +28409,7 @@ snapshots:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.9.3)
       eslint: 9.36.0(jiti@2.7.0)
       eslint-scope: 5.1.1
-      semver: 7.7.4
+      semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -28713,7 +28511,7 @@ snapshots:
       '@vanilla-extract/babel-plugin-debug-ids': 1.2.2
       '@vanilla-extract/css': 1.20.1(babel-plugin-macros@3.1.0)
       dedent: 1.7.0(babel-plugin-macros@3.1.0)
-      esbuild: 0.27.4
+      esbuild: 0.28.1
       eval: 0.1.8
       find-up: 5.0.0
       javascript-stringify: 2.1.0
@@ -29944,7 +29742,7 @@ snapshots:
 
   builtins@5.1.0:
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.5
 
   bundle-name@4.1.0:
     dependencies:
@@ -32295,6 +32093,8 @@ snapshots:
 
   fetchdts@0.1.7: {}
 
+  fflate@0.8.3: {}
+
   figures@3.2.0:
     dependencies:
       escape-string-regexp: 1.0.5
@@ -32444,7 +32244,7 @@ snapshots:
       memfs: 3.5.3
       minimatch: 3.1.2
       schema-utils: 2.7.0
-      semver: 7.7.4
+      semver: 7.8.5
       tapable: 1.1.3
       typescript: 5.9.3
       webpack: 5.106.2
@@ -32627,7 +32427,7 @@ snapshots:
       get-it: 8.6.10(debug@4.4.3)
       registry-auth-token: 5.1.0
       registry-url: 5.1.0
-      semver: 7.7.4
+      semver: 7.8.5
     transitivePeerDependencies:
       - debug
 
@@ -32636,7 +32436,7 @@ snapshots:
       get-it: 8.7.0(debug@4.4.3)
       registry-auth-token: 5.1.1
       registry-url: 7.2.0
-      semver: 7.7.4
+      semver: 7.8.5
     transitivePeerDependencies:
       - debug
 
@@ -34013,7 +33813,7 @@ snapshots:
       jest-util: 27.5.1
       natural-compare: 1.4.0
       pretty-format: 27.5.1
-      semver: 7.7.4
+      semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
 
@@ -34715,7 +34515,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.5
 
   make-error@1.3.6: {}
 
@@ -36000,9 +35800,9 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@16.2.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@16.2.12(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
-      '@next/env': 16.2.11
+      '@next/env': 16.2.12
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.13
       caniuse-lite: 1.0.30001754
@@ -36011,14 +35811,14 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
       styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.3)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.2.11
-      '@next/swc-darwin-x64': 16.2.11
-      '@next/swc-linux-arm64-gnu': 16.2.11
-      '@next/swc-linux-arm64-musl': 16.2.11
-      '@next/swc-linux-x64-gnu': 16.2.11
-      '@next/swc-linux-x64-musl': 16.2.11
-      '@next/swc-win32-arm64-msvc': 16.2.11
-      '@next/swc-win32-x64-msvc': 16.2.11
+      '@next/swc-darwin-arm64': 16.2.12
+      '@next/swc-darwin-x64': 16.2.12
+      '@next/swc-linux-arm64-gnu': 16.2.12
+      '@next/swc-linux-arm64-musl': 16.2.12
+      '@next/swc-linux-x64-gnu': 16.2.12
+      '@next/swc-linux-x64-musl': 16.2.12
+      '@next/swc-win32-arm64-msvc': 16.2.12
+      '@next/swc-win32-x64-msvc': 16.2.12
       '@opentelemetry/api': 1.9.0
       '@playwright/test': 1.57.0
       babel-plugin-react-compiler: 1.0.0
@@ -36091,7 +35891,7 @@ snapshots:
       ignore-by-default: 1.0.1
       minimatch: 3.1.2
       pstree.remy: 1.1.8
-      semver: 7.7.4
+      semver: 7.8.5
       simple-update-notifier: 2.0.0
       supports-color: 5.5.0
       touch: 3.1.1
@@ -36108,13 +35908,13 @@ snapshots:
     dependencies:
       hosted-git-info: 4.1.0
       is-core-module: 2.16.1
-      semver: 7.7.4
+      semver: 7.8.5
       validate-npm-package-license: 3.0.4
 
   normalize-package-data@8.0.0:
     dependencies:
       hosted-git-info: 9.0.2
-      semver: 7.7.4
+      semver: 7.8.5
       validate-npm-package-license: 3.0.4
 
   normalize-path@3.0.0: {}
@@ -36131,7 +35931,7 @@ snapshots:
     dependencies:
       hosted-git-info: 7.0.2
       proc-log: 4.2.0
-      semver: 7.7.4
+      semver: 7.8.5
       validate-npm-package-name: 5.0.0
 
   npm-packlist@2.2.2:
@@ -36384,28 +36184,6 @@ snapshots:
       '@oxfmt/binding-win32-arm64-msvc': 0.47.0
       '@oxfmt/binding-win32-ia32-msvc': 0.47.0
       '@oxfmt/binding-win32-x64-msvc': 0.47.0
-
-  oxlint@1.62.0:
-    optionalDependencies:
-      '@oxlint/binding-android-arm-eabi': 1.62.0
-      '@oxlint/binding-android-arm64': 1.62.0
-      '@oxlint/binding-darwin-arm64': 1.62.0
-      '@oxlint/binding-darwin-x64': 1.62.0
-      '@oxlint/binding-freebsd-x64': 1.62.0
-      '@oxlint/binding-linux-arm-gnueabihf': 1.62.0
-      '@oxlint/binding-linux-arm-musleabihf': 1.62.0
-      '@oxlint/binding-linux-arm64-gnu': 1.62.0
-      '@oxlint/binding-linux-arm64-musl': 1.62.0
-      '@oxlint/binding-linux-ppc64-gnu': 1.62.0
-      '@oxlint/binding-linux-riscv64-gnu': 1.62.0
-      '@oxlint/binding-linux-riscv64-musl': 1.62.0
-      '@oxlint/binding-linux-s390x-gnu': 1.62.0
-      '@oxlint/binding-linux-x64-gnu': 1.62.0
-      '@oxlint/binding-linux-x64-musl': 1.62.0
-      '@oxlint/binding-openharmony-arm64': 1.62.0
-      '@oxlint/binding-win32-arm64-msvc': 1.62.0
-      '@oxlint/binding-win32-ia32-msvc': 1.62.0
-      '@oxlint/binding-win32-x64-msvc': 1.62.0
 
   oxlint@1.74.0:
     optionalDependencies:
@@ -39157,7 +38935,7 @@ snapshots:
     dependencies:
       color: 4.2.3
       detect-libc: 2.1.2
-      semver: 7.7.4
+      semver: 7.8.5
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.33.5
       '@img/sharp-darwin-x64': 0.33.5
@@ -39184,7 +38962,7 @@ snapshots:
     dependencies:
       '@img/colour': 1.0.0
       detect-libc: 2.1.2
-      semver: 7.7.4
+      semver: 7.8.5
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.34.5
       '@img/sharp-darwin-x64': 0.34.5
@@ -39284,7 +39062,7 @@ snapshots:
 
   simple-update-notifier@2.0.0:
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.5
 
   simple-wcswidth@1.1.2: {}
 
@@ -39736,7 +39514,7 @@ snapshots:
       lines-and-columns: 1.2.4
       mz: 2.7.0
       pirates: 4.0.7
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       ts-interface-checker: 0.1.13
 
   supports-color@10.2.2: {}
@@ -40216,12 +39994,12 @@ snapshots:
       hookable: 6.1.1
       import-without-cache: 0.3.3
       obug: 2.1.1
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       rolldown: 1.0.0-rc.17
       rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.17)(typescript@5.9.3)
-      semver: 7.7.4
+      semver: 7.8.5
       tinyexec: 1.1.1
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       tree-kill: 1.2.2
       unconfig-core: 7.5.0
       unrun: 0.2.37(synckit@0.11.11)
@@ -40771,7 +40549,7 @@ snapshots:
   vite-node@5.3.0(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       cac: 6.7.14
-      es-module-lexer: 2.0.0
+      es-module-lexer: 2.3.1
       obug: 2.1.1
       pathe: 2.0.3
       vite: 7.3.1(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
@@ -40835,11 +40613,11 @@ snapshots:
   vite@7.3.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       esbuild: 0.27.4
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
       postcss: 8.5.19
       rollup: 4.62.2
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 20.19.17
       fsevents: 2.3.3
@@ -40852,11 +40630,11 @@ snapshots:
   vite@7.3.1(@types/node@22.13.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1):
     dependencies:
       esbuild: 0.27.4
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
       postcss: 8.5.19
       rollup: 4.62.2
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 22.13.10
       fsevents: 2.3.3
@@ -40869,11 +40647,11 @@ snapshots:
   vite@7.3.1(@types/node@22.13.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       esbuild: 0.27.4
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
       postcss: 8.5.19
       rollup: 4.62.2
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 22.13.10
       fsevents: 2.3.3
@@ -40886,11 +40664,11 @@ snapshots:
   vite@7.3.1(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       esbuild: 0.27.4
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
       postcss: 8.5.19
       rollup: 4.62.2
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 24.13.3
       fsevents: 2.3.3
@@ -40903,11 +40681,11 @@ snapshots:
   vite@7.3.1(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       esbuild: 0.27.4
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
       postcss: 8.5.19
       rollup: 4.62.2
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 24.13.3
       fsevents: 2.3.3
@@ -40972,11 +40750,11 @@ snapshots:
       expect-type: 1.2.2
       magic-string: 0.30.21
       pathe: 2.0.3
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       std-env: 3.9.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
       vite: 7.3.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
@@ -41016,11 +40794,11 @@ snapshots:
       expect-type: 1.2.2
       magic-string: 0.30.21
       pathe: 2.0.3
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       std-env: 3.9.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
       vite: 7.3.1(@types/node@22.13.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1)
@@ -41060,11 +40838,11 @@ snapshots:
       expect-type: 1.2.2
       magic-string: 0.30.21
       pathe: 2.0.3
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       std-env: 3.9.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
       vite: 7.3.1(@types/node@22.13.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
@@ -41104,11 +40882,11 @@ snapshots:
       expect-type: 1.2.2
       magic-string: 0.30.21
       pathe: 2.0.3
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       std-env: 3.9.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
       vite: 7.3.1(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `.lottie` binary file support to the translation pipeline and introduces project font syncing. Lottie bundles are treated as opaque binary ZIP archives: content is carried base64-encoded end-to-end and bypasses the normal UTF-8 encode/decode path throughout upload, download, and lock-file recording. Font syncing is a new idempotent pre-translation step that uploads project fonts (matched by user-configured globs) to the API before any enqueue or upload workflow runs.

- **Lottie upload**: files are read with `readBinaryFileBase64`, scanned for After Effects expressions (an XSS/ACE vector), and rejected outright if expressions are found; clean files flow through as base64 with `fileFormat: LOTTIE`.
- **Lottie download**: `isBinaryFileFormat` gates the base64→UTF-8 decode in `_downloadFileBatch`; the CLI writer uses `Buffer.from(data, 'base64')` to reconstruct exact bytes; the lock entry now stores a relative path (fixing the previously-reported portability issue) and stays `staged` until every configured locale has downloaded.
- **Font sync**: `collectFonts` globs files from the project root, `syncFonts` calls `GT.uploadFonts` (backed by `_uploadFonts` + `processBatches`) and silently continues on failure; `gt translate` without staging now exits early with a clear error when Lottie files are present.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — binary content is correctly isolated from the UTF-8 pipeline at every stage, and the previously-reported lock-file portability issue has been fixed.

The Lottie binary path is consistently handled across upload, download, and lock recording. Expression detection is well-tested with clear false-positive/negative cases covered. Font syncing is non-fatal on failure. No regressions introduced to existing text-file paths.

**Files Needing Attention:** collectFonts.ts — using path.basename for the font fileName could silently collide when two fonts share a name across directories; worth verifying the server's deduplication key before this matters in production.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/types-dir/api/file.ts | Adds LOTTIE to FileFormat union, BINARY_FILE_FORMATS set, and isBinaryFileFormat utility — clean and exported correctly. |
| packages/cli/src/formats/files/detectLottieExpressions.ts | New AE-expression scanner: handles both dotLottie ZIPs and bare bodymovin JSON, correctly distinguishes string-valued `x` (expression) from object-valued `x` (split-dimension position). |
| packages/cli/src/formats/files/collectFonts.ts | Resolves font globs from project root (correctly derived from configDirectory), reads files as binary and base64-encodes. Uses only path.basename for fileName, so two fonts sharing a basename from different directories would be uploaded with the same key. |
| packages/cli/src/formats/files/aggregateFiles.ts | Adds Lottie aggregation: collects all offenders before failing (good UX), binary read+expression check+push pattern is sound; logErrorAndExit is typed never so the push after the guard is safe. |
| packages/cli/src/api/downloadFileBatch.ts | Binary download path now correctly stores getRelative(outputPath) in the lock entry (fixing the previously-reported portability issue). Staged-entry logic kept staged until all locales download is consistent with the text path. |
| packages/core/src/translate/uploadFonts.ts | Batches font uploads (size 50, smaller than text-file default of 100 to bound request body size). processBatches return type aligns with what GT.uploadFonts expects. |
| packages/core/src/translate/downloadFileBatch.ts | Binary formats skip the base64→UTF-8 decode step; data stays as base64 so the CLI writer can recover exact bytes via Buffer.from(data, 'base64'). |
| packages/cli/src/cli/commands/download.ts | _versionId is now only required when a GTJSON file is present in the download set, unblocking file-only and Lottie-only projects. |
| packages/cli/src/cli/base.ts | gt translate now exits early with a clear error when Lottie files exist and staging is disabled, guiding users to the stage+download flow. |
| packages/cli/src/workflows/utils/syncFonts.ts | Thin wrapper that calls collectFonts+uploadFonts; errors are caught and logged as warnings so font sync is non-fatal to the broader workflow. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant CLI as gt CLI
    participant FS as File System
    participant API as GT API

    Note over CLI,API: gt stage (Lottie flow)
    CLI->>FS: readBinaryFileBase64(.lottie files)
    CLI->>CLI: lottieHasExpressions(base64) reject if AE expressions found
    CLI->>FS: collectFonts(settings) fast-glob from project root
    CLI->>API: uploadFonts(base64 fonts) /v2/project/assets idempotent
    CLI->>API: uploadSourceFiles(base64 .lottie) isBinaryFileFormat skip UTF-8 encode
    CLI->>API: enqueueTranslation jobs
    CLI->>FS: "write gt-lock.json entry.staged = true"

    Note over CLI,API: gt download (poll until done)
    CLI->>API: downloadFileBatch(fileId, locale)
    API-->>CLI: fileFormat LOTTIE data base64
    CLI->>CLI: isBinaryFileFormat skip base64 to UTF-8 decode
    CLI->>FS: writeFile(outputPath, Buffer.from(data,'base64'))
    CLI->>FS: "update gt-lock.json entry.staged = !locales.every(l => translations[l])"
```
</details>

<sub>Reviews (2): Last reviewed commit: ["feat: support Lottie file translation an..."](https://github.com/generaltranslation/gt/commit/5c9172ba91cddd77aed8c8f4dda27c73128d02ad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48835782)</sub>

<!-- /greptile_comment -->