### PR TITLE
feat(sanity): save user edits

### DIFF
--- a/.changeset/preserve-existing-sanity-translations.md
+++ b/.changeset/preserve-existing-sanity-translations.md
@@ -1,0 +1,9 @@
+---
+'gt-sanity': minor
+---
+
+Preserve human-edited translations across source changes. Before a translation run uploads a new source revision, gt-sanity now sends the translations Sanity already holds back to General Translation as the stored translation for the source version it has, so content whose source did not change keeps its existing wording instead of being regenerated. Translated documents (via `translation.metadata`, preferring drafts) and internationalized-array locale values are both covered. Previously every translation run discarded manual edits.
+
+Existing translations can also be uploaded on their own via the "Upload Existing" action, without enqueueing a translation.
+
+Adds a "Retranslate from scratch" option to the Translate All dialog for deliberately regenerating translations — the plugin previously had no way to force a retranslation — and a `preserveExistingTranslations: false` escape hatch to restore the old behavior.

--- a/.changeset/preserve-existing-sanity-translations.md
+++ b/.changeset/preserve-existing-sanity-translations.md
@@ -2,8 +2,8 @@
 'gt-sanity': minor
 ---
 
-Preserve human-edited translations across source changes. Before a translation run uploads a new source revision, gt-sanity now sends the translations Sanity already holds back to General Translation as the stored translation for the source version it has, so content whose source did not change keeps its existing wording instead of being regenerated. Translated documents (via `translation.metadata`, preferring drafts) and internationalized-array locale values are both covered. Previously every translation run discarded manual edits.
+Add opt-in preservation of human-edited translations. With the new **Save local edits** toggle enabled, the translations Sanity already holds are uploaded to General Translation before a translation run, so content whose source text did not change keeps its existing wording instead of being regenerated. Translated documents (via `translation.metadata`, preferring drafts) and internationalized-array locale values are both covered.
 
-Existing translations can also be uploaded on their own via the "Upload Existing" action, without enqueueing a translation.
+The toggle is off by default and shows an explanation before it can be enabled — turning it on means local content overwrites whatever General Translation holds for that source version, including a completed translation that has not been imported yet. Its initial state can be set with the `preserveExistingTranslations` plugin option.
 
-Adds a "Retranslate from scratch" option to the Translate All dialog for deliberately regenerating translations — the plugin previously had no way to force a retranslation — and a `preserveExistingTranslations: false` escape hatch to restore the old behavior.
+Also adds a **Save Local Edits** action, which uploads the translations already in Sanity (seeding source files as needed) without enqueueing a translation, and a **Retranslate from scratch** option in the Translate All dialog for deliberately regenerating translations — the plugin previously had no way to force a retranslation.

--- a/packages/sanity/README.md
+++ b/packages/sanity/README.md
@@ -129,27 +129,31 @@ cross-document rules (e.g. slug deduplication), the plugin-level
 ## Preserving Edits to Translations
 
 Translated content often gets touched up in the Studio after it comes back from
-General Translation. By default gt-sanity keeps those edits: before a
-translation run uploads a new revision of a source document, it reads the
-translation each target locale currently holds in Sanity and sends it back to
-GT as the translation of record for the revision it was produced from. Content
-whose source text has not changed is then reused from that edited version
-instead of being regenerated, so the edit survives.
+General Translation, and a later translation run would normally regenerate it.
+The **Save local edits** toggle in the Translations tool changes that:
+with it on, the translations currently in Sanity are uploaded to General
+Translation before a translation run, so content whose source text has not
+changed is reused from the Sanity version instead of being regenerated.
 
-This is on by default and there is nothing to configure. To regenerate
-translations and deliberately discard those edits for a single run, use
-**Retranslate from scratch** in the Translate All dialog.
+This is **off by default**; turning it on shows an explanation of the trade-off
+first, and the choice lasts for the Studio session. Turning it on means local
+content overwrites whatever General Translation holds for that source version —
+including a completed translation that has not been imported into Sanity yet.
+Import pending translations before enabling it if that matters to you.
 
-To seed General Translation with the translations already in Sanity without
-starting a translation run — useful when adopting the plugin on a project that
-was translated elsewhere — use **Upload Existing**.
-
-The behavior can be disabled entirely, but this is an escape hatch rather than
-a preference — with it off, every translation run overwrites manual edits:
+Set the initial state of the toggle from plugin config:
 
 ```ts
 gtPlugin({
   // ...
-  preserveExistingTranslations: false,
+  preserveExistingTranslations: true,
 });
 ```
+
+To upload the translations already in Sanity without starting a translation run
+— useful when adopting the plugin on a project that was translated elsewhere —
+use **Save Local Edits**. It uploads the source files it needs, but does not
+enqueue any translation.
+
+To regenerate translations and deliberately discard existing ones for a single
+run, use **Retranslate from scratch** in the Translate All dialog.

--- a/packages/sanity/README.md
+++ b/packages/sanity/README.md
@@ -125,3 +125,31 @@ occurrence of that type (matching the native plugins' "field or type"
 semantics). The legacy `localize: false` field property is still supported. For id-based or
 cross-document rules (e.g. slug deduplication), the plugin-level
 `ignoreFields` / `skipFields` / `dedupeFields` options remain available.
+
+## Preserving Edits to Translations
+
+Translated content often gets touched up in the Studio after it comes back from
+General Translation. By default gt-sanity keeps those edits: before a
+translation run uploads a new revision of a source document, it reads the
+translation each target locale currently holds in Sanity and sends it back to
+GT as the translation of record for the revision it was produced from. Content
+whose source text has not changed is then reused from that edited version
+instead of being regenerated, so the edit survives.
+
+This is on by default and there is nothing to configure. To regenerate
+translations and deliberately discard those edits for a single run, use
+**Retranslate from scratch** in the Translate All dialog.
+
+To seed General Translation with the translations already in Sanity without
+starting a translation run — useful when adopting the plugin on a project that
+was translated elsewhere — use **Upload Existing**.
+
+The behavior can be disabled entirely, but this is an escape hatch rather than
+a preference — with it off, every translation run overwrites manual edits:
+
+```ts
+gtPlugin({
+  // ...
+  preserveExistingTranslations: false,
+});
+```

--- a/packages/sanity/src/adapter/core.ts
+++ b/packages/sanity/src/adapter/core.ts
@@ -37,6 +37,7 @@ export class GTConfig {
   additionalBlockDeserializers: unknown[];
   translationLevel: FieldLevelTranslationMode;
   fieldLevelDocuments: TranslateDocumentFilter[];
+  preserveExistingTranslations: boolean;
 
   private static instance: GTConfig;
   constructor(
@@ -55,7 +56,8 @@ export class GTConfig {
     additionalDeserializers: CustomDeserializers = { types: {} },
     additionalBlockDeserializers: unknown[] = [],
     translationLevel: FieldLevelTranslationMode = 'document',
-    fieldLevelDocuments: TranslateDocumentFilter[] = []
+    fieldLevelDocuments: TranslateDocumentFilter[] = [],
+    preserveExistingTranslations: boolean = true
   ) {
     this.secretsNamespace = secretsNamespace;
     this.languageField = languageField;
@@ -73,6 +75,7 @@ export class GTConfig {
     this.additionalBlockDeserializers = additionalBlockDeserializers;
     this.translationLevel = translationLevel;
     this.fieldLevelDocuments = fieldLevelDocuments;
+    this.preserveExistingTranslations = preserveExistingTranslations;
   }
 
   static getInstance() {
@@ -113,7 +116,8 @@ export class GTConfig {
     additionalDeserializers: CustomDeserializers = { types: {} },
     additionalBlockDeserializers: unknown[] = [],
     translationLevel: FieldLevelTranslationMode = 'document',
-    fieldLevelDocuments: TranslateDocumentFilter[] = []
+    fieldLevelDocuments: TranslateDocumentFilter[] = [],
+    preserveExistingTranslations: boolean = true
   ) {
     this.secretsNamespace = secretsNamespace;
     this.languageField = languageField;
@@ -131,6 +135,7 @@ export class GTConfig {
     this.additionalBlockDeserializers = additionalBlockDeserializers;
     this.translationLevel = translationLevel;
     this.fieldLevelDocuments = fieldLevelDocuments;
+    this.preserveExistingTranslations = preserveExistingTranslations;
   }
 
   getSecretsNamespace() {
@@ -182,6 +187,9 @@ export class GTConfig {
   }
   getFieldLevelDocuments() {
     return this.fieldLevelDocuments;
+  }
+  getPreserveExistingTranslations() {
+    return this.preserveExistingTranslations;
   }
 }
 export const pluginConfig = GTConfig.getInstance();

--- a/packages/sanity/src/adapter/core.ts
+++ b/packages/sanity/src/adapter/core.ts
@@ -57,7 +57,7 @@ export class GTConfig {
     additionalBlockDeserializers: unknown[] = [],
     translationLevel: FieldLevelTranslationMode = 'document',
     fieldLevelDocuments: TranslateDocumentFilter[] = [],
-    preserveExistingTranslations: boolean = true
+    preserveExistingTranslations: boolean = false
   ) {
     this.secretsNamespace = secretsNamespace;
     this.languageField = languageField;
@@ -117,7 +117,7 @@ export class GTConfig {
     additionalBlockDeserializers: unknown[] = [],
     translationLevel: FieldLevelTranslationMode = 'document',
     fieldLevelDocuments: TranslateDocumentFilter[] = [],
-    preserveExistingTranslations: boolean = true
+    preserveExistingTranslations: boolean = false
   ) {
     this.secretsNamespace = secretsNamespace;
     this.languageField = languageField;

--- a/packages/sanity/src/components/TranslationsProvider.tsx
+++ b/packages/sanity/src/components/TranslationsProvider.tsx
@@ -87,6 +87,7 @@ interface TranslationsContextType {
   autoImport: boolean;
   autoPatchReferences: boolean;
   autoPublish: boolean;
+  preserveExistingTranslations: boolean;
   loadingDocuments: boolean;
   importProgress: ImportProgress;
   importedTranslations: Set<string>;
@@ -109,6 +110,7 @@ interface TranslationsContextType {
   setAutoImport: (value: boolean) => void;
   setAutoPatchReferences: (value: boolean) => void;
   setAutoPublish: (value: boolean) => void;
+  setPreserveExistingTranslations: (value: boolean) => void;
   handleTranslateAll: (options?: TranslateAllOptions) => Promise<void>;
   handleUploadExistingTranslations: () => Promise<void>;
   handleImportAll: () => Promise<void>;
@@ -194,6 +196,10 @@ export const TranslationsProvider: React.FC<TranslationsProviderProps> = ({
   const [autoImport, setAutoImport] = useState(false);
   const [autoPatchReferences, setAutoPatchReferences] = useState(false);
   const [autoPublish, setAutoPublish] = useState(false);
+  // Seeded from plugin config; opt-in because uploading local translations
+  // overwrites whatever General Translation holds for that source version.
+  const [preserveExistingTranslations, setPreserveExistingTranslations] =
+    useState(() => pluginConfig.getPreserveExistingTranslations());
   const [loadingDocuments, setLoadingDocuments] = useState(false);
   const [importProgress, setImportProgress] = useState<ImportProgress>({
     current: 0,
@@ -406,7 +412,7 @@ export const TranslationsProvider: React.FC<TranslationsProviderProps> = ({
         // the upload below, which makes the new revision the latest version and
         // would leave the edits attached to nothing. Best-effort: a failure here
         // costs edit preservation, and must not block the translation itself.
-        if (pluginConfig.getPreserveExistingTranslations() && !force) {
+        if (preserveExistingTranslations && !force) {
           try {
             const captured = await captureExistingTranslations({
               documents,
@@ -480,6 +486,8 @@ export const TranslationsProvider: React.FC<TranslationsProviderProps> = ({
       schema,
       client,
       branchId,
+      preserveExistingTranslations,
+      serializeSourceDocuments,
       uploadedVersions,
       uploadedVersionsStorageKey,
     ]
@@ -1227,6 +1235,7 @@ export const TranslationsProvider: React.FC<TranslationsProviderProps> = ({
     autoImport,
     autoPatchReferences,
     autoPublish,
+    preserveExistingTranslations,
     loadingDocuments,
     importProgress,
     importedTranslations,
@@ -1245,6 +1254,7 @@ export const TranslationsProvider: React.FC<TranslationsProviderProps> = ({
     setAutoImport,
     setAutoPatchReferences,
     setAutoPublish,
+    setPreserveExistingTranslations,
     handleTranslateAll,
     handleUploadExistingTranslations,
     handleImportAll,

--- a/packages/sanity/src/components/TranslationsProvider.tsx
+++ b/packages/sanity/src/components/TranslationsProvider.tsx
@@ -514,7 +514,7 @@ export const TranslationsProvider: React.FC<TranslationsProviderProps> = ({
     } finally {
       setIsBusy(false);
     }
-  }, [secrets, documents, locales, translationContext, branchId]);
+  }, [secrets, documents, locales, client, schema, branchId]);
 
   const handleImportAll = useCallback(async () => {
     if (!secrets || documents.length === 0 || !branchId) return;

--- a/packages/sanity/src/components/TranslationsProvider.tsx
+++ b/packages/sanity/src/components/TranslationsProvider.tsx
@@ -23,6 +23,8 @@ import { uploadFiles } from '../translation/uploadFiles';
 import { initProject } from '../translation/initProject';
 import { createJobs } from '../translation/createJobs';
 import { captureExistingTranslations } from '../translation/captureExistingTranslations';
+import { collectExistingTranslations } from '../translation/collectExistingTranslations';
+import { uploadTranslations } from '../translation/uploadTranslations';
 import { downloadTranslations } from '../translation/downloadTranslations';
 import { checkTranslationStatus } from '../translation/checkTranslationStatus';
 import { importDocument } from '../translation/importDocument';
@@ -360,6 +362,34 @@ export const TranslationsProvider: React.FC<TranslationsProviderProps> = ({
     }
   }, [documents, locales, client]);
 
+  const serializeSourceDocuments = useCallback(
+    () =>
+      documents
+        .map((doc) => {
+          const { [pluginConfig.getLanguageField()]: _, ...cleanDoc } = doc;
+          const baseLanguage = pluginConfig.getSourceLocale();
+          try {
+            const strategy = getTranslationStrategy(doc);
+            return {
+              info: {
+                documentId: getDocumentPublishedId(doc),
+                versionId: doc._rev,
+              },
+              serializedDocument: strategy.serialize(
+                cleanDoc as typeof doc,
+                schema,
+                baseLanguage
+              ),
+            };
+          } catch (error) {
+            console.error('Error transforming document', doc._id, error);
+          }
+          return null;
+        })
+        .filter((doc) => doc !== null),
+    [documents, schema]
+  );
+
   const handleTranslateAll = useCallback(
     async ({ force = false }: TranslateAllOptions = {}) => {
       if (!secrets || documents.length === 0) return;
@@ -406,30 +436,7 @@ export const TranslationsProvider: React.FC<TranslationsProviderProps> = ({
           }
         }
 
-        const transformedDocuments = documents
-          .map((doc) => {
-            const { [pluginConfig.getLanguageField()]: _, ...cleanDoc } = doc;
-            const baseLanguage = pluginConfig.getSourceLocale();
-            try {
-              const strategy = getTranslationStrategy(doc);
-              const serialized = strategy.serialize(
-                cleanDoc as typeof doc,
-                schema,
-                baseLanguage
-              );
-              return {
-                info: {
-                  documentId: getDocumentPublishedId(doc),
-                  versionId: doc._rev,
-                },
-                serializedDocument: serialized,
-              };
-            } catch (error) {
-              console.error('Error transforming document', doc._id, error);
-            }
-            return null;
-          })
-          .filter((doc) => doc !== null);
+        const transformedDocuments = serializeSourceDocuments();
 
         const uploadResult = await uploadFiles(transformedDocuments, secrets);
         await initProject(uploadResult, { timeout: 600 }, secrets);
@@ -487,20 +494,35 @@ export const TranslationsProvider: React.FC<TranslationsProviderProps> = ({
         .filter((locale) => locale.enabled !== false)
         .map((locale) => locale.localeId);
 
-      const result = await captureExistingTranslations({
+      const transformedDocuments = serializeSourceDocuments();
+
+      // Seed the source files first. uploadTranslations requires the source to
+      // exist, and this action exists for projects whose translations predate
+      // General Translation, where no source has been uploaded yet. Enqueueing
+      // is deliberately skipped so nothing is retranslated.
+      await uploadFiles(transformedDocuments, secrets);
+
+      const existing = await collectExistingTranslations(
         documents,
-        localeIds: availableLocaleIds,
-        secrets,
-        context: translationContext,
-        branchId,
-      });
+        availableLocaleIds,
+        translationContext
+      );
+      const withTranslations = transformedDocuments
+        .map((document) => ({
+          ...document,
+          translations: existing.get(document.info.documentId) ?? [],
+        }))
+        .filter((document) => document.translations.length > 0);
+
+      const response = await uploadTranslations(withTranslations, secrets);
+      const count = response?.uploadedFiles.length ?? 0;
 
       toast.push({
         title:
-          result.capturedCount > 0
-            ? `Uploaded ${result.capturedCount} existing translation(s) across ${result.documentCount} document(s)`
+          count > 0
+            ? `Uploaded ${count} existing translation(s) across ${withTranslations.length} document(s)`
             : 'No existing translations found to upload',
-        status: result.capturedCount > 0 ? 'success' : 'warning',
+        status: count > 0 ? 'success' : 'warning',
         closable: true,
       });
     } catch (error) {
@@ -514,7 +536,7 @@ export const TranslationsProvider: React.FC<TranslationsProviderProps> = ({
     } finally {
       setIsBusy(false);
     }
-  }, [secrets, documents, locales, client, schema, branchId]);
+  }, [secrets, documents, locales, client, schema, serializeSourceDocuments]);
 
   const handleImportAll = useCallback(async () => {
     if (!secrets || documents.length === 0 || !branchId) return;

--- a/packages/sanity/src/components/TranslationsProvider.tsx
+++ b/packages/sanity/src/components/TranslationsProvider.tsx
@@ -22,6 +22,7 @@ import { getTranslationStrategy } from '../translation/strategy';
 import { uploadFiles } from '../translation/uploadFiles';
 import { initProject } from '../translation/initProject';
 import { createJobs } from '../translation/createJobs';
+import { captureExistingTranslations } from '../translation/captureExistingTranslations';
 import { downloadTranslations } from '../translation/downloadTranslations';
 import { checkTranslationStatus } from '../translation/checkTranslationStatus';
 import { importDocument } from '../translation/importDocument';
@@ -65,6 +66,16 @@ type TranslationDocumentMetadata = {
   translationDocs?: { docId?: string }[];
 };
 
+export type TranslateAllOptions = {
+  /**
+   * Discard the translations GT already holds and retranslate from source.
+   * Also skips capturing Studio-side edits — capturing them would immediately
+   * be reused as the baseline, which is the opposite of what a retranslate is
+   * asking for.
+   */
+  force?: boolean;
+};
+
 interface TranslationsContextType {
   // State
   isBusy: boolean;
@@ -96,7 +107,8 @@ interface TranslationsContextType {
   setAutoImport: (value: boolean) => void;
   setAutoPatchReferences: (value: boolean) => void;
   setAutoPublish: (value: boolean) => void;
-  handleTranslateAll: () => Promise<void>;
+  handleTranslateAll: (options?: TranslateAllOptions) => Promise<void>;
+  handleUploadExistingTranslations: () => Promise<void>;
   handleImportAll: () => Promise<void>;
   handleImportMissing: () => Promise<void>;
   handleRefreshAll: () => Promise<void>;
@@ -348,81 +360,161 @@ export const TranslationsProvider: React.FC<TranslationsProviderProps> = ({
     }
   }, [documents, locales, client]);
 
-  const handleTranslateAll = useCallback(async () => {
+  const handleTranslateAll = useCallback(
+    async ({ force = false }: TranslateAllOptions = {}) => {
+      if (!secrets || documents.length === 0) return;
+
+      setIsBusy(true);
+
+      try {
+        const availableLocaleIds = locales
+          .filter((locale) => locale.enabled !== false)
+          .map((locale) => locale.localeId);
+
+        // Send any Studio-side edits to existing translations back to GT first,
+        // pinned to the source version they belong to. This has to happen before
+        // the upload below, which makes the new revision the latest version and
+        // would leave the edits attached to nothing. Best-effort: a failure here
+        // costs edit preservation, and must not block the translation itself.
+        if (pluginConfig.getPreserveExistingTranslations() && !force) {
+          try {
+            const captured = await captureExistingTranslations({
+              documents,
+              localeIds: availableLocaleIds,
+              secrets,
+              context: translationContext,
+              branchId,
+            });
+            if (captured.capturedCount > 0) {
+              toast.push({
+                title: `Preserved ${captured.capturedCount} existing translation(s) across ${captured.documentCount} document(s)`,
+                status: 'info',
+                closable: true,
+              });
+            }
+          } catch (error) {
+            console.error(
+              'Could not preserve existing translations. Continuing — edits made to translated documents may be overwritten by this run.',
+              error
+            );
+            toast.push({
+              title:
+                'Existing translations could not be preserved. Translation is continuing, but edits made to translated documents may be overwritten.',
+              status: 'warning',
+              closable: true,
+            });
+          }
+        }
+
+        const transformedDocuments = documents
+          .map((doc) => {
+            const { [pluginConfig.getLanguageField()]: _, ...cleanDoc } = doc;
+            const baseLanguage = pluginConfig.getSourceLocale();
+            try {
+              const strategy = getTranslationStrategy(doc);
+              const serialized = strategy.serialize(
+                cleanDoc as typeof doc,
+                schema,
+                baseLanguage
+              );
+              return {
+                info: {
+                  documentId: getDocumentPublishedId(doc),
+                  versionId: doc._rev,
+                },
+                serializedDocument: serialized,
+              };
+            } catch (error) {
+              console.error('Error transforming document', doc._id, error);
+            }
+            return null;
+          })
+          .filter((doc) => doc !== null);
+
+        const uploadResult = await uploadFiles(transformedDocuments, secrets);
+        await initProject(uploadResult, { timeout: 600 }, secrets);
+        await createJobs(uploadResult, availableLocaleIds, secrets, force);
+
+        // Pin the _rev each file was uploaded under. GT status queries need the
+        // exact uploaded versionId, and the live _rev moves on (in-place array
+        // imports bump it), so status lookups go through getVersionId instead.
+        // Persisted to sessionStorage so the pins survive a page refresh.
+        const nextUploadedVersions = new Map(uploadedVersions);
+        for (const { info } of transformedDocuments) {
+          if (info.versionId) {
+            nextUploadedVersions.set(info.documentId, info.versionId);
+          }
+        }
+        writeUploadedVersions(uploadedVersionsStorageKey, nextUploadedVersions);
+        setUploadedVersions(nextUploadedVersions);
+
+        toast.push({
+          title: force
+            ? `Retranslating ${documents.length} documents from scratch`
+            : `Translation tasks created for ${documents.length} documents`,
+          status: 'success',
+          closable: true,
+        });
+      } catch {
+        toast.push({
+          title:
+            'Translation tasks could not be created. No documents were changed. Try again or check the console for details.',
+          status: 'error',
+          closable: true,
+        });
+      } finally {
+        setIsBusy(false);
+      }
+    },
+    [
+      secrets,
+      documents,
+      locales,
+      schema,
+      client,
+      branchId,
+      uploadedVersions,
+      uploadedVersionsStorageKey,
+    ]
+  );
+
+  const handleUploadExistingTranslations = useCallback(async () => {
     if (!secrets || documents.length === 0) return;
 
     setIsBusy(true);
-
     try {
       const availableLocaleIds = locales
         .filter((locale) => locale.enabled !== false)
         .map((locale) => locale.localeId);
 
-      const transformedDocuments = documents
-        .map((doc) => {
-          const { [pluginConfig.getLanguageField()]: _, ...cleanDoc } = doc;
-          const baseLanguage = pluginConfig.getSourceLocale();
-          try {
-            const strategy = getTranslationStrategy(doc);
-            const serialized = strategy.serialize(
-              cleanDoc as typeof doc,
-              schema,
-              baseLanguage
-            );
-            return {
-              info: {
-                documentId: getDocumentPublishedId(doc),
-                versionId: doc._rev,
-              },
-              serializedDocument: serialized,
-            };
-          } catch (error) {
-            console.error('Error transforming document', doc._id, error);
-          }
-          return null;
-        })
-        .filter((doc) => doc !== null);
-
-      const uploadResult = await uploadFiles(transformedDocuments, secrets);
-      await initProject(uploadResult, { timeout: 600 }, secrets);
-      await createJobs(uploadResult, availableLocaleIds, secrets);
-
-      // Pin the _rev each file was uploaded under. GT status queries need the
-      // exact uploaded versionId, and the live _rev moves on (in-place array
-      // imports bump it), so status lookups go through getVersionId instead.
-      // Persisted to sessionStorage so the pins survive a page refresh.
-      const nextUploadedVersions = new Map(uploadedVersions);
-      for (const { info } of transformedDocuments) {
-        if (info.versionId) {
-          nextUploadedVersions.set(info.documentId, info.versionId);
-        }
-      }
-      writeUploadedVersions(uploadedVersionsStorageKey, nextUploadedVersions);
-      setUploadedVersions(nextUploadedVersions);
-
-      toast.push({
-        title: `Translation tasks created for ${documents.length} documents`,
-        status: 'success',
-        closable: true,
+      const result = await captureExistingTranslations({
+        documents,
+        localeIds: availableLocaleIds,
+        secrets,
+        context: translationContext,
+        branchId,
       });
-    } catch {
+
       toast.push({
         title:
-          'Translation tasks could not be created. No documents were changed. Try again or check the console for details.',
+          result.capturedCount > 0
+            ? `Uploaded ${result.capturedCount} existing translation(s) across ${result.documentCount} document(s)`
+            : 'No existing translations found to upload',
+        status: result.capturedCount > 0 ? 'success' : 'warning',
+        closable: true,
+      });
+    } catch (error) {
+      console.error('Error uploading existing translations:', error);
+      toast.push({
+        title:
+          'Existing translations could not be uploaded. No documents were changed. Try again or check the console for details.',
         status: 'error',
         closable: true,
       });
     } finally {
       setIsBusy(false);
     }
-  }, [
-    secrets,
-    documents,
-    locales,
-    schema,
-    uploadedVersions,
-    uploadedVersionsStorageKey,
-  ]);
+  }, [secrets, documents, locales, translationContext, branchId]);
 
   const handleImportAll = useCallback(async () => {
     if (!secrets || documents.length === 0 || !branchId) return;
@@ -1132,6 +1224,7 @@ export const TranslationsProvider: React.FC<TranslationsProviderProps> = ({
     setAutoPatchReferences,
     setAutoPublish,
     handleTranslateAll,
+    handleUploadExistingTranslations,
     handleImportAll,
     handleImportMissing,
     handleRefreshAll,

--- a/packages/sanity/src/components/page/SaveLocalTranslationsDialog.tsx
+++ b/packages/sanity/src/components/page/SaveLocalTranslationsDialog.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { Box, Button, Card, Dialog, Flex, Stack, Text } from '@sanity/ui';
+
+interface SaveLocalTranslationsDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+export const SaveLocalTranslationsDialog: React.FC<
+  SaveLocalTranslationsDialogProps
+> = ({ isOpen, onClose, onConfirm }) => {
+  if (!isOpen) return null;
+
+  return (
+    <Dialog
+      header='Save local edits'
+      id='save-local-translations-dialog'
+      onClose={onClose}
+      footer={
+        <Box padding={3}>
+          <Flex gap={2}>
+            <Button text='Cancel' mode='ghost' onClick={onClose} />
+            <Button text='Turn on' tone='primary' onClick={onConfirm} />
+          </Flex>
+        </Box>
+      }
+    >
+      <Box padding={4}>
+        <Stack space={4}>
+          <Text>
+            Before each translation run, the translations currently in Sanity
+            are sent to General Translation. Content whose source text has not
+            changed is then reused from Sanity instead of being translated
+            again, so edits made here are kept.
+          </Text>
+
+          <Card padding={3} radius={2} tone='caution' border>
+            <Stack space={3}>
+              <Text size={1} weight='medium'>
+                Sanity becomes the source of truth
+              </Text>
+              <Text size={1}>
+                What is in Sanity replaces whatever General Translation holds
+                for that version of the document — including a translation that
+                has finished but has not been imported yet. Import any pending
+                translations before turning this on.
+              </Text>
+            </Stack>
+          </Card>
+
+          <Text size={1} muted>
+            This applies to translation runs started from this Studio session.
+            To send them without starting a run, use Save Local Edits.
+          </Text>
+        </Stack>
+      </Box>
+    </Dialog>
+  );
+};

--- a/packages/sanity/src/components/page/TranslateAllDialog.tsx
+++ b/packages/sanity/src/components/page/TranslateAllDialog.tsx
@@ -1,5 +1,14 @@
-import React from 'react';
-import { Box, Button, Dialog, Flex, Stack, Text } from '@sanity/ui';
+import React, { useState } from 'react';
+import {
+  Box,
+  Button,
+  Card,
+  Checkbox,
+  Dialog,
+  Flex,
+  Stack,
+  Text,
+} from '@sanity/ui';
 import { useTranslations } from '../TranslationsProvider';
 
 interface TranslateAllDialogProps {
@@ -12,10 +21,17 @@ export const TranslateAllDialog: React.FC<TranslateAllDialogProps> = ({
   onClose,
 }) => {
   const { documents, handleTranslateAll } = useTranslations();
+  const [force, setForce] = useState(false);
 
   const handleConfirm = async () => {
     onClose();
-    await handleTranslateAll();
+    setForce(false);
+    await handleTranslateAll({ force });
+  };
+
+  const handleCancel = () => {
+    setForce(false);
+    onClose();
   };
 
   if (!isOpen) return null;
@@ -24,26 +40,61 @@ export const TranslateAllDialog: React.FC<TranslateAllDialogProps> = ({
     <Dialog
       header='Confirm Translation'
       id='translate-all-dialog'
-      onClose={onClose}
+      onClose={handleCancel}
       footer={
         <Box padding={3}>
           <Flex gap={2}>
-            <Button text='Cancel' mode='ghost' onClick={onClose} />
-            <Button text='Translate All' onClick={handleConfirm} />
+            <Button text='Cancel' mode='ghost' onClick={handleCancel} />
+            <Button
+              text={force ? 'Retranslate All' : 'Translate All'}
+              tone={force ? 'caution' : 'default'}
+              onClick={handleConfirm}
+            />
           </Flex>
         </Box>
       }
     >
       <Box padding={4}>
-        <Stack space={3}>
-          <Text>
-            Are you sure you want to create translations for all{' '}
-            {documents.length} documents?
-          </Text>
-          <Text size={1} muted>
-            This will submit all documents to General Translation for
-            processing.
-          </Text>
+        <Stack space={4}>
+          <Stack space={3}>
+            <Text>
+              Are you sure you want to create translations for all{' '}
+              {documents.length} documents?
+            </Text>
+            <Text size={1} muted>
+              This will submit all documents to General Translation for
+              processing.
+            </Text>
+          </Stack>
+
+          <Card
+            padding={3}
+            radius={2}
+            tone={force ? 'caution' : 'transparent'}
+            border
+          >
+            <Flex align='flex-start' gap={3}>
+              <Checkbox
+                id='translate-all-force'
+                checked={force}
+                onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+                  setForce(event.currentTarget.checked)
+                }
+              />
+              <Stack space={2} flex={1}>
+                <Text size={1} weight='medium'>
+                  <label htmlFor='translate-all-force'>
+                    Retranslate from scratch
+                  </label>
+                </Text>
+                <Text size={1} muted>
+                  {force
+                    ? 'Existing translations will be discarded and regenerated. Edits made to translated documents will be lost.'
+                    : 'Leave unchecked to reuse existing translations, including edits made to translated documents in the Studio.'}
+                </Text>
+              </Stack>
+            </Flex>
+          </Card>
         </Stack>
       </Box>
     </Dialog>

--- a/packages/sanity/src/components/page/TranslationsTool.tsx
+++ b/packages/sanity/src/components/page/TranslationsTool.tsx
@@ -19,6 +19,7 @@ import {
   PublishIcon,
   RefreshIcon,
   TranslateIcon,
+  UploadIcon,
 } from '@sanity/icons';
 import { Link } from 'sanity/router';
 import { BaseTranslationWrapper } from '../shared/BaseTranslationWrapper';
@@ -27,6 +28,7 @@ import { TranslationsTable } from './TranslationsTable';
 import { TranslateAllDialog } from './TranslateAllDialog';
 import { ImportAllDialog } from './ImportAllDialog';
 import { ImportMissingDialog } from './ImportMissingDialog';
+import { UploadExistingDialog } from './UploadExistingDialog';
 import { BatchProgress } from './BatchProgress';
 
 const TranslationsToolContent: React.FC = () => {
@@ -34,6 +36,8 @@ const TranslationsToolContent: React.FC = () => {
     useState(false);
   const [isImportAllDialogOpen, setIsImportAllDialogOpen] = useState(false);
   const [isImportMissingDialogOpen, setIsImportMissingDialogOpen] =
+    useState(false);
+  const [isUploadExistingDialogOpen, setIsUploadExistingDialogOpen] =
     useState(false);
 
   const {
@@ -60,6 +64,8 @@ const TranslationsToolContent: React.FC = () => {
         return 'Importing';
       case 'Import Missing':
         return 'Importing missing';
+      case 'Upload Existing':
+        return 'Uploading existing';
       case 'Patch References':
         return 'Patching';
       case 'Publish Translations':
@@ -182,6 +188,23 @@ const TranslationsToolContent: React.FC = () => {
                 </Tooltip>
                 <Tooltip
                   placement='top'
+                  content='Uploads the translations already in Sanity to General Translation, preserving human edits'
+                >
+                  <Button
+                    mode='ghost'
+                    fontSize={1}
+                    onClick={() => {
+                      setCurrentOperation('Upload Existing');
+                      setIsUploadExistingDialogOpen(true);
+                    }}
+                    text='Upload Existing'
+                    loading={isBusy && currentOperation === 'Upload Existing'}
+                    icon={UploadIcon}
+                    disabled={actionsDisabled}
+                  />
+                </Tooltip>
+                <Tooltip
+                  placement='top'
                   content='Replaces references in documents with the corresponding translated document reference'
                 >
                   <Button
@@ -266,6 +289,10 @@ const TranslationsToolContent: React.FC = () => {
       <ImportMissingDialog
         isOpen={isImportMissingDialogOpen}
         onClose={() => setIsImportMissingDialogOpen(false)}
+      />
+      <UploadExistingDialog
+        isOpen={isUploadExistingDialogOpen}
+        onClose={() => setIsUploadExistingDialogOpen(false)}
       />
     </Container>
   );

--- a/packages/sanity/src/components/page/TranslationsTool.tsx
+++ b/packages/sanity/src/components/page/TranslationsTool.tsx
@@ -29,6 +29,7 @@ import { TranslateAllDialog } from './TranslateAllDialog';
 import { ImportAllDialog } from './ImportAllDialog';
 import { ImportMissingDialog } from './ImportMissingDialog';
 import { UploadExistingDialog } from './UploadExistingDialog';
+import { SaveLocalTranslationsDialog } from './SaveLocalTranslationsDialog';
 import { BatchProgress } from './BatchProgress';
 
 const TranslationsToolContent: React.FC = () => {
@@ -39,6 +40,7 @@ const TranslationsToolContent: React.FC = () => {
     useState(false);
   const [isUploadExistingDialogOpen, setIsUploadExistingDialogOpen] =
     useState(false);
+  const [isSaveLocalDialogOpen, setIsSaveLocalDialogOpen] = useState(false);
 
   const {
     isBusy,
@@ -50,6 +52,8 @@ const TranslationsToolContent: React.FC = () => {
     importedTranslations,
     isRefreshing,
     setAutoRefresh,
+    preserveExistingTranslations,
+    setPreserveExistingTranslations,
     handleRefreshAll,
     handlePatchDocumentReferences,
     handlePublishAllTranslations,
@@ -64,7 +68,7 @@ const TranslationsToolContent: React.FC = () => {
         return 'Importing';
       case 'Import Missing':
         return 'Importing missing';
-      case 'Upload Existing':
+      case 'Save Local Edits':
         return 'Uploading existing';
       case 'Patch References':
         return 'Patching';
@@ -124,6 +128,23 @@ const TranslationsToolContent: React.FC = () => {
               </Text>
 
               <Flex gap={3} align='center'>
+                <Flex gap={2} align='center'>
+                  <Text size={1} muted>
+                    Save local edits
+                  </Text>
+                  <Switch
+                    checked={preserveExistingTranslations}
+                    onChange={() => {
+                      // Turning it on changes what wins on a conflict, so
+                      // explain before enabling; turning it off is safe.
+                      if (preserveExistingTranslations) {
+                        setPreserveExistingTranslations(false);
+                      } else {
+                        setIsSaveLocalDialogOpen(true);
+                      }
+                    }}
+                  />
+                </Flex>
                 <Flex gap={2} align='center'>
                   <Text size={1} muted>
                     Auto-refresh
@@ -194,11 +215,11 @@ const TranslationsToolContent: React.FC = () => {
                     mode='ghost'
                     fontSize={1}
                     onClick={() => {
-                      setCurrentOperation('Upload Existing');
+                      setCurrentOperation('Save Local Edits');
                       setIsUploadExistingDialogOpen(true);
                     }}
-                    text='Upload Existing'
-                    loading={isBusy && currentOperation === 'Upload Existing'}
+                    text='Save Local Edits'
+                    loading={isBusy && currentOperation === 'Save Local Edits'}
                     icon={UploadIcon}
                     disabled={actionsDisabled}
                   />
@@ -289,6 +310,14 @@ const TranslationsToolContent: React.FC = () => {
       <ImportMissingDialog
         isOpen={isImportMissingDialogOpen}
         onClose={() => setIsImportMissingDialogOpen(false)}
+      />
+      <SaveLocalTranslationsDialog
+        isOpen={isSaveLocalDialogOpen}
+        onClose={() => setIsSaveLocalDialogOpen(false)}
+        onConfirm={() => {
+          setPreserveExistingTranslations(true);
+          setIsSaveLocalDialogOpen(false);
+        }}
       />
       <UploadExistingDialog
         isOpen={isUploadExistingDialogOpen}

--- a/packages/sanity/src/components/page/UploadExistingDialog.tsx
+++ b/packages/sanity/src/components/page/UploadExistingDialog.tsx
@@ -22,14 +22,14 @@ export const UploadExistingDialog: React.FC<UploadExistingDialogProps> = ({
 
   return (
     <Dialog
-      header='Upload Existing Translations'
+      header='Save local edits'
       id='upload-existing-dialog'
       onClose={onClose}
       footer={
         <Box padding={3}>
           <Flex gap={2}>
             <Button text='Cancel' mode='ghost' onClick={onClose} />
-            <Button text='Upload Existing' onClick={handleConfirm} />
+            <Button text='Save Local Edits' onClick={handleConfirm} />
           </Flex>
         </Box>
       }
@@ -37,13 +37,13 @@ export const UploadExistingDialog: React.FC<UploadExistingDialogProps> = ({
       <Box padding={4}>
         <Stack space={3}>
           <Text>
-            Upload the translations already in Sanity for all {documents.length}{' '}
-            documents?
+            Save the translations currently in Sanity for all {documents.length}{' '}
+            documents to General Translation?
           </Text>
           <Text size={1} muted>
-            The translated content currently in Sanity will be stored on General
-            Translation as the translation for each locale, preserving human
-            edits. Existing translations on the platform are overwritten.
+            They become the stored translation for each locale, so later
+            translation runs reuse them. Anything General Translation already
+            holds for those versions is replaced. No translation is started.
           </Text>
         </Stack>
       </Box>

--- a/packages/sanity/src/components/page/UploadExistingDialog.tsx
+++ b/packages/sanity/src/components/page/UploadExistingDialog.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Box, Button, Dialog, Flex, Stack, Text } from '@sanity/ui';
+import { useTranslations } from '../TranslationsProvider';
+
+interface UploadExistingDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export const UploadExistingDialog: React.FC<UploadExistingDialogProps> = ({
+  isOpen,
+  onClose,
+}) => {
+  const { documents, handleUploadExistingTranslations } = useTranslations();
+
+  const handleConfirm = async () => {
+    onClose();
+    await handleUploadExistingTranslations();
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <Dialog
+      header='Upload Existing Translations'
+      id='upload-existing-dialog'
+      onClose={onClose}
+      footer={
+        <Box padding={3}>
+          <Flex gap={2}>
+            <Button text='Cancel' mode='ghost' onClick={onClose} />
+            <Button text='Upload Existing' onClick={handleConfirm} />
+          </Flex>
+        </Box>
+      }
+    >
+      <Box padding={4}>
+        <Stack space={3}>
+          <Text>
+            Upload the translations already in Sanity for all {documents.length}{' '}
+            documents?
+          </Text>
+          <Text size={1} muted>
+            The translated content currently in Sanity will be stored on General
+            Translation as the translation for each locale, preserving human
+            edits. Existing translations on the platform are overwritten.
+          </Text>
+        </Stack>
+      </Box>
+    </Dialog>
+  );
+};

--- a/packages/sanity/src/components/tab/TranslationView.tsx
+++ b/packages/sanity/src/components/tab/TranslationView.tsx
@@ -17,6 +17,7 @@ import {
   useToast,
 } from '@sanity/ui';
 import { pluginConfig } from '../../adapter/core';
+import { SaveLocalTranslationsDialog } from '../page/SaveLocalTranslationsDialog';
 import { useTranslations } from '../TranslationsProvider';
 import { LanguageStatus } from '../shared/LanguageStatus';
 import { LocaleCheckbox } from '../shared/LocaleCheckbox';
@@ -26,6 +27,7 @@ import {
   PublishIcon,
   RefreshIcon,
   TranslateIcon,
+  UploadIcon,
 } from '@sanity/icons';
 import {
   createTranslationStatusKey,
@@ -40,6 +42,7 @@ export const TranslationView = () => {
     branchId,
     isBusy,
     handleTranslateAll,
+    handleUploadExistingTranslations,
     handleImportDocument,
     handleRefreshAll,
     isRefreshing,
@@ -55,11 +58,15 @@ export const TranslationView = () => {
     setAutoPatchReferences,
     autoPublish,
     setAutoPublish,
+    preserveExistingTranslations,
+    setPreserveExistingTranslations,
     getVersionId,
   } = useTranslations();
 
   const [isImporting, setIsImporting] = useState(false);
   const [isPublishing, setIsPublishing] = useState(false);
+  const [isUploadingExisting, setIsUploadingExisting] = useState(false);
+  const [isSaveLocalDialogOpen, setIsSaveLocalDialogOpen] = useState(false);
 
   const toast = useToast();
 
@@ -282,9 +289,18 @@ export const TranslationView = () => {
           disabled={isBusy || !availableLocales.length}
           icon={TranslateIcon}
           text='Translate'
-          loading={isBusy}
+          loading={isBusy && !isUploadingExisting}
         />
       </Stack>
+
+      <SaveLocalTranslationsDialog
+        isOpen={isSaveLocalDialogOpen}
+        onClose={() => setIsSaveLocalDialogOpen(false)}
+        onConfirm={() => {
+          setPreserveExistingTranslations(true);
+          setIsSaveLocalDialogOpen(false);
+        }}
+      />
 
       {/* Translation Status Section */}
       {documentId && versionId && statusLocales.length > 0 && (
@@ -348,6 +364,39 @@ export const TranslationView = () => {
 
           {/* Import Controls */}
           <Stack space={3}>
+            <Flex gap={2} align='center' justify='flex-start'>
+              <Button
+                mode='ghost'
+                onClick={async () => {
+                  setIsUploadingExisting(true);
+                  try {
+                    await handleUploadExistingTranslations();
+                  } finally {
+                    setIsUploadingExisting(false);
+                  }
+                }}
+                disabled={isBusy || !availableLocales.length}
+                icon={UploadIcon}
+                text='Save Local Edits'
+                loading={isUploadingExisting}
+                style={{ minWidth: '180px' }}
+              />
+              <Flex gap={2} align='center'>
+                <Switch
+                  checked={preserveExistingTranslations}
+                  onChange={() => {
+                    // Turning it on changes what wins on a conflict, so explain
+                    // before enabling; turning it off is safe.
+                    if (preserveExistingTranslations) {
+                      setPreserveExistingTranslations(false);
+                    } else {
+                      setIsSaveLocalDialogOpen(true);
+                    }
+                  }}
+                />
+                <Text size={1}>Save local edits before translating</Text>
+              </Flex>
+            </Flex>
             <Flex gap={3} align='center' justify='space-between'>
               <Flex gap={2} align='center'>
                 <Button

--- a/packages/sanity/src/configuration/baseDocumentLevelConfig/helpers/createI18nDocAndPatchMetadata.ts
+++ b/packages/sanity/src/configuration/baseDocumentLevelConfig/helpers/createI18nDocAndPatchMetadata.ts
@@ -5,6 +5,7 @@ import { pluginConfig } from '../../../adapter/core';
 import { applyDocuments } from '../../../utils/applyDocuments';
 import { getPublishedId } from '../../../utils/documentIds';
 import { randomKey } from '../../../utils/randomKey';
+import { metadataTranslations } from '../../../utils/translationMetadata';
 
 export async function createI18nDocAndPatchMetadata(
   sourceDocument: SanityDocumentLike,
@@ -26,7 +27,7 @@ export async function createI18nDocAndPatchMetadata(
   );
   const operation = existingLocaleKey ? 'replace' : 'after';
   const location = existingLocaleKey
-    ? `translations[language == "${localeId}"]`
+    ? metadataTranslations(`== "${localeId}"`)
     : 'translations[-1]';
 
   //remove system fields

--- a/packages/sanity/src/configuration/baseDocumentLevelConfig/helpers/createTranslationMetadata.ts
+++ b/packages/sanity/src/configuration/baseDocumentLevelConfig/helpers/createTranslationMetadata.ts
@@ -8,6 +8,7 @@ import {
 } from 'sanity';
 import { randomKey } from '../../../utils/randomKey';
 import { getPublishedId } from '../../../utils/documentIds';
+import { TRANSLATION_METADATA_TYPE } from '../../../utils/translationMetadata';
 
 type TranslationReference = KeyedObject & {
   _type: 'internationalizedArrayReferenceValue';
@@ -42,7 +43,7 @@ export const createTranslationMetadata = (
   }
 
   return client.create({
-    _type: 'translation.metadata',
+    _type: TRANSLATION_METADATA_TYPE,
     translations: [baseLangEntry],
   });
 };

--- a/packages/sanity/src/configuration/baseDocumentLevelConfig/helpers/getOrCreateTranslationMetadata.ts
+++ b/packages/sanity/src/configuration/baseDocumentLevelConfig/helpers/getOrCreateTranslationMetadata.ts
@@ -8,6 +8,11 @@ import {
 } from 'sanity';
 import { randomKey } from '../../../utils/randomKey';
 import { getPublishedId } from '../../../utils/documentIds';
+import {
+  metadataTranslationRef,
+  translationMetadataId,
+  TRANSLATION_METADATA_TYPE,
+} from '../../../utils/translationMetadata';
 
 type TranslationReference = KeyedObject & {
   _type: 'internationalizedArrayReferenceValue';
@@ -25,8 +30,8 @@ export const getOrCreateTranslationMetadata = async (
   // First, try to get existing metadata
   const existingMetadata = await client.fetch(
     `*[
-        _type == 'translation.metadata' &&
-        translations[language == $baseLanguage][0].value._ref == $id
+        _type == '${TRANSLATION_METADATA_TYPE}' &&
+        ${metadataTranslationRef('$baseLanguage')} == $id
       ][0]`,
     { baseLanguage, id: publishedId }
   );
@@ -61,16 +66,16 @@ export const getOrCreateTranslationMetadata = async (
   try {
     // Use createIfNotExists to handle race conditions
     return await client.createIfNotExists({
-      _id: `translation.metadata.${publishedId}`,
-      _type: 'translation.metadata',
+      _id: translationMetadataId(publishedId),
+      _type: TRANSLATION_METADATA_TYPE,
       translations: [baseLangEntry],
     });
   } catch (error) {
     // If creation fails due to race condition, fetch the existing document
     const metadata = await client.fetch(
       `*[
-          _type == 'translation.metadata' &&
-          translations[language == $baseLanguage][0].value._ref == $id
+          _type == '${TRANSLATION_METADATA_TYPE}' &&
+          ${metadataTranslationRef('$baseLanguage')} == $id
         ][0]`,
       { baseLanguage, id: publishedId }
     );

--- a/packages/sanity/src/configuration/baseDocumentLevelConfig/helpers/getTranslationMetadata.ts
+++ b/packages/sanity/src/configuration/baseDocumentLevelConfig/helpers/getTranslationMetadata.ts
@@ -2,6 +2,10 @@
 
 import { SanityClient, SanityDocumentLike } from 'sanity';
 import { getPublishedId } from '../../../utils/documentIds';
+import {
+  metadataTranslationRef,
+  TRANSLATION_METADATA_TYPE,
+} from '../../../utils/translationMetadata';
 
 export const getTranslationMetadata = (
   id: string,
@@ -10,8 +14,8 @@ export const getTranslationMetadata = (
 ): Promise<SanityDocumentLike | null> => {
   return client.fetch(
     `*[
-        _type == 'translation.metadata' &&
-        translations[language == $baseLanguage][0].value._ref == $id
+        _type == '${TRANSLATION_METADATA_TYPE}' &&
+        ${metadataTranslationRef('$baseLanguage')} == $id
       ][0]`,
     { baseLanguage, id: getPublishedId(id) }
   );

--- a/packages/sanity/src/index.ts
+++ b/packages/sanity/src/index.ts
@@ -122,13 +122,12 @@ export type GTPluginConfig = Omit<
   // In 'mixed' mode, the document types that use the internationalized-array
   // strategy; everything else stays document-level.
   fieldLevelDocuments?: TranslateDocumentFilter[] | string[];
-  // When true (default), edits made to translated content inside the Studio are
-  // captured and sent back to General Translation as the translation of record
-  // for the previously translated source version, so they survive the next
-  // translation run instead of being overwritten. Escape hatch only — turning
-  // this off restores the old behavior, where every run discards manual edits.
-  // To deliberately discard them for a single run, use "Retranslate from
-  // scratch" (force) instead of disabling this.
+  // Sets the initial state of the "Local translations win" toggle. When on,
+  // the translations currently in Sanity are uploaded to General Translation
+  // before a translation run, so they become the baseline the next translation
+  // reuses. Local content overwrites whatever General Translation holds for
+  // that source version, including a completed translation that has not been
+  // imported yet. Off by default; the toggle can be flipped per session.
   preserveExistingTranslations?: boolean;
 };
 
@@ -170,7 +169,7 @@ export const gtPlugin = definePlugin<GTPluginConfig>(
     fieldLevelLocalization,
     translationLevel = 'document',
     fieldLevelDocuments,
-    preserveExistingTranslations = true,
+    preserveExistingTranslations = false,
   }) => {
     // Resolve sourceLocale: explicit sourceLocale > defaultLocale (from gt.config.json) > library default
     const resolvedSourceLocale =

--- a/packages/sanity/src/index.ts
+++ b/packages/sanity/src/index.ts
@@ -122,6 +122,14 @@ export type GTPluginConfig = Omit<
   // In 'mixed' mode, the document types that use the internationalized-array
   // strategy; everything else stays document-level.
   fieldLevelDocuments?: TranslateDocumentFilter[] | string[];
+  // When true (default), edits made to translated content inside the Studio are
+  // captured and sent back to General Translation as the translation of record
+  // for the previously translated source version, so they survive the next
+  // translation run instead of being overwritten. Escape hatch only — turning
+  // this off restores the old behavior, where every run discards manual edits.
+  // To deliberately discard them for a single run, use "Retranslate from
+  // scratch" (force) instead of disabling this.
+  preserveExistingTranslations?: boolean;
 };
 
 /**
@@ -162,6 +170,7 @@ export const gtPlugin = definePlugin<GTPluginConfig>(
     fieldLevelLocalization,
     translationLevel = 'document',
     fieldLevelDocuments,
+    preserveExistingTranslations = true,
   }) => {
     // Resolve sourceLocale: explicit sourceLocale > defaultLocale (from gt.config.json) > library default
     const resolvedSourceLocale =
@@ -203,7 +212,8 @@ export const gtPlugin = definePlugin<GTPluginConfig>(
       additionalDeserializers,
       additionalBlockDeserializers,
       translationLevel,
-      normalizedFieldLevelDocuments
+      normalizedFieldLevelDocuments,
+      preserveExistingTranslations
     );
     gt.setConfig({
       sourceLocale: resolvedSourceLocale,

--- a/packages/sanity/src/sanity-api/resolveRefs.ts
+++ b/packages/sanity/src/sanity-api/resolveRefs.ts
@@ -1,5 +1,10 @@
 import { SanityClient, SanityDocument } from 'sanity';
 import { pluginConfig } from '../adapter/core';
+import {
+  metadataTranslationRef,
+  metadataTranslations,
+  TRANSLATION_METADATA_TYPE,
+} from '../utils/translationMetadata';
 
 interface Reference {
   _type: 'reference';
@@ -88,9 +93,9 @@ async function resolveTranslatedReferences(
   const sourceLocale = pluginConfig.getSourceLocale();
 
   // Optimized GROQ query that directly returns only the needed translation pairs
-  const query = `*[_type == "translation.metadata" && count(translations[language == $sourceLocale && value._ref in $refIds]) > 0] {
-    "originalRef": translations[language == $sourceLocale][0].value._ref,
-    "translatedRefs": translations[language == $locale].value._ref
+  const query = `*[_type == "${TRANSLATION_METADATA_TYPE}" && count(${metadataTranslations('== $sourceLocale', 'value._ref in $refIds')}) > 0] {
+    "originalRef": ${metadataTranslationRef('$sourceLocale')},
+    "translatedRefs": ${metadataTranslations('== $locale')}.value._ref
   }[defined(originalRef) && count(translatedRefs) > 0]`;
 
   const translationPairs: { originalRef: string; translatedRefs: string[] }[] =

--- a/packages/sanity/src/serialization/internationalizedArray/detect.ts
+++ b/packages/sanity/src/serialization/internationalizedArray/detect.ts
@@ -67,3 +67,24 @@ export function findLocaleItem(
 ): InternationalizedArrayItem | undefined {
   return field.find((item) => item.language === locale);
 }
+
+/**
+ * Whether any internationalized-array field anywhere in the value has an item
+ * for the given locale. Used to skip locales with no existing content instead
+ * of uploading an empty translation.
+ */
+export function hasLocaleContent(value: unknown, locale: string): boolean {
+  if (isInternationalizedArrayField(value)) {
+    return findLocaleItem(value, locale) !== undefined;
+  }
+
+  if (Array.isArray(value)) {
+    return value.some((item) => hasLocaleContent(item, locale));
+  }
+
+  if (isRecord(value)) {
+    return Object.values(value).some((item) => hasLocaleContent(item, locale));
+  }
+
+  return false;
+}

--- a/packages/sanity/src/translation/__tests__/captureExistingTranslations.test.ts
+++ b/packages/sanity/src/translation/__tests__/captureExistingTranslations.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import type { SanityClient, SanityDocument, Schema } from 'sanity';
+
+const downloadFileBatch = vi.fn();
+const uploadTranslations = vi.fn();
+const collectExistingTranslations = vi.fn();
+
+vi.mock('../../adapter/core', async () => {
+  const actual =
+    await vi.importActual<typeof import('../../adapter/core')>(
+      '../../adapter/core'
+    );
+  return {
+    ...actual,
+    gt: {
+      sourceLocale: 'en',
+      downloadFileBatch: (...args: unknown[]) => downloadFileBatch(...args),
+      uploadTranslations: (...args: unknown[]) => uploadTranslations(...args),
+    },
+    overrideConfig: vi.fn(),
+  };
+});
+
+vi.mock('../collectExistingTranslations', () => ({
+  collectExistingTranslations: (...args: unknown[]) =>
+    collectExistingTranslations(...args),
+}));
+
+const { captureExistingTranslations } =
+  await import('../captureExistingTranslations');
+
+const doc = (id: string, rev: string) =>
+  ({ _id: id, _type: 'page', _rev: rev }) as unknown as SanityDocument;
+
+const context = {
+  client: {} as SanityClient,
+  schema: {} as Schema,
+};
+
+const seedFile = (fileId: string, versionId: string) => ({
+  id: 'row-1',
+  fileId,
+  versionId,
+  branchId: 'branch-1',
+  fileName: `sanity/${fileId}`,
+  data: '<html><body>source</body></html>',
+  metadata: {},
+  fileFormat: 'HTML' as const,
+});
+
+const run = (documents: SanityDocument[], localeIds = ['es']) =>
+  captureExistingTranslations({
+    documents,
+    localeIds,
+    secrets: { organization: 'o', project: 'p' },
+    context,
+    branchId: 'branch-1',
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  uploadTranslations.mockResolvedValue({ uploadedFiles: [], count: 0 });
+  collectExistingTranslations.mockResolvedValue(new Map());
+});
+
+describe('captureExistingTranslations', () => {
+  test('does nothing without documents or locales', async () => {
+    expect(await run([])).toMatchObject({ capturedCount: 0 });
+    expect(await run([doc('a', 'rev-1')], [])).toMatchObject({
+      capturedCount: 0,
+    });
+    expect(downloadFileBatch).not.toHaveBeenCalled();
+  });
+
+  test('pins translations to the version GT already has, not the live _rev', async () => {
+    // The live document has moved on to rev-new, but GT still holds rev-old.
+    // Pinning to rev-new would mark the not-yet-uploaded version as already
+    // translated, and the worker would abandon the job instead of translating.
+    downloadFileBatch.mockResolvedValue({
+      files: [seedFile('a', 'rev-old')],
+      count: 1,
+    });
+    collectExistingTranslations.mockResolvedValue(
+      new Map([['a', [{ locale: 'es', content: '<html>hola</html>' }]]])
+    );
+
+    const result = await run([doc('a', 'rev-new')]);
+
+    expect(result).toMatchObject({ capturedCount: 1, documentCount: 1 });
+
+    const [files, options] = uploadTranslations.mock.calls[0];
+    expect(options).toEqual({ sourceLocale: 'en' });
+    expect(files[0].source).toMatchObject({
+      fileId: 'a',
+      versionId: 'rev-old',
+      branchId: 'branch-1',
+    });
+    expect(files[0].translations[0]).toMatchObject({
+      locale: 'es',
+      fileId: 'a',
+      versionId: 'rev-old',
+      branchId: 'branch-1',
+    });
+  });
+
+  test('asks GT for the latest version rather than naming one', async () => {
+    downloadFileBatch.mockResolvedValue({ files: [], count: 0 });
+    await run([doc('a', 'rev-new')]);
+
+    expect(downloadFileBatch).toHaveBeenCalledWith([
+      { fileId: 'a', branchId: 'branch-1' },
+    ]);
+  });
+
+  test('skips documents GT has no source file for', async () => {
+    downloadFileBatch.mockResolvedValue({ files: [], count: 0 });
+
+    await run([doc('a', 'rev-1')]);
+
+    expect(uploadTranslations).not.toHaveBeenCalled();
+    // Documents with no source file must not reach the collector either.
+    expect(collectExistingTranslations).toHaveBeenCalledWith(
+      [],
+      ['es'],
+      context
+    );
+  });
+
+  test('uploads nothing when Sanity has no existing translations', async () => {
+    downloadFileBatch.mockResolvedValue({
+      files: [seedFile('a', 'rev-old')],
+      count: 1,
+    });
+    collectExistingTranslations.mockResolvedValue(new Map());
+
+    const result = await run([doc('a', 'rev-1')]);
+
+    expect(result.capturedCount).toBe(0);
+    expect(uploadTranslations).not.toHaveBeenCalled();
+  });
+
+  test('carries every collected locale for a document', async () => {
+    downloadFileBatch.mockResolvedValue({
+      files: [seedFile('a', 'rev-old')],
+      count: 1,
+    });
+    collectExistingTranslations.mockResolvedValue(
+      new Map([
+        [
+          'a',
+          [
+            { locale: 'es', content: '<html>hola</html>' },
+            { locale: 'fr', content: '<html>bonjour</html>' },
+          ],
+        ],
+      ])
+    );
+
+    const result = await run([doc('a', 'rev-1')], ['es', 'fr']);
+
+    expect(result).toMatchObject({ capturedCount: 2, documentCount: 1 });
+    const [files] = uploadTranslations.mock.calls[0];
+    expect(
+      files[0].translations.map((t: { locale: string }) => t.locale)
+    ).toEqual(['es', 'fr']);
+  });
+});

--- a/packages/sanity/src/translation/__tests__/collectExistingTranslations.test.ts
+++ b/packages/sanity/src/translation/__tests__/collectExistingTranslations.test.ts
@@ -1,0 +1,231 @@
+import { Schema } from '@sanity/schema';
+import type { SanityClient, SanityDocument } from 'sanity';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { pluginConfig } from '../../adapter/core';
+import { hasLocaleContent } from '../../serialization/internationalizedArray/detect';
+import type { TranslationFunctionContext } from '../../types';
+import { collectExistingTranslations } from '../collectExistingTranslations';
+
+// Minimal stand-ins for the types sanity-plugin-internationalized-array
+// registers: an array of `{ _key, _type, language, value }` objects.
+const internationalizedArrayType = (fieldType: 'string' | 'text') => {
+  const capitalized = fieldType.charAt(0).toUpperCase() + fieldType.slice(1);
+  const valueTypeName = `internationalizedArray${capitalized}Value`;
+  return [
+    {
+      name: valueTypeName,
+      type: 'object',
+      fields: [
+        { name: 'language', type: 'string' },
+        { name: 'value', type: fieldType },
+      ],
+    },
+    {
+      name: `internationalizedArray${capitalized}`,
+      type: 'array',
+      of: [{ type: valueTypeName }],
+    },
+  ];
+};
+
+const postType = {
+  name: 'post',
+  title: 'Post',
+  type: 'document',
+  fields: [
+    { name: 'title', title: 'Title', type: 'internationalizedArrayString' },
+    {
+      name: 'description',
+      title: 'Description',
+      type: 'internationalizedArrayText',
+    },
+  ],
+};
+
+const pageType = {
+  name: 'page',
+  title: 'Page',
+  type: 'document',
+  fields: [{ name: 'title', title: 'Title', type: 'string' }],
+};
+
+const schema: InstanceType<typeof Schema> = new Schema({
+  name: 'test',
+  types: [
+    ...internationalizedArrayType('string'),
+    ...internationalizedArrayType('text'),
+    postType,
+    pageType,
+  ] as never,
+});
+
+const item = (type: string, language: string, value: unknown) => ({
+  _key: `key-${language}`,
+  _type: type,
+  language,
+  value,
+});
+
+const contextWith = (client: Partial<SanityClient>) =>
+  ({ client, schema }) as unknown as TranslationFunctionContext;
+
+afterEach(() => {
+  pluginConfig.translationLevel = 'document';
+  pluginConfig.fieldLevelDocuments = [];
+  pluginConfig.sourceLocale = 'en';
+});
+
+describe('hasLocaleContent', () => {
+  const field = [
+    item('internationalizedArrayStringValue', 'en', 'Hello'),
+    item('internationalizedArrayStringValue', 'es', 'Hola'),
+  ];
+
+  test('detects a locale item on a top-level field', () => {
+    expect(hasLocaleContent({ title: field }, 'es')).toBe(true);
+    expect(hasLocaleContent({ title: field }, 'fr')).toBe(false);
+  });
+
+  test('detects a locale item nested in objects and arrays', () => {
+    const doc = { sections: [{ heading: { inner: field } }] };
+    expect(hasLocaleContent(doc, 'es')).toBe(true);
+    expect(hasLocaleContent(doc, 'fr')).toBe(false);
+  });
+
+  test('returns false for documents without internationalized arrays', () => {
+    expect(hasLocaleContent({ title: 'Hello', tags: ['a'] }, 'es')).toBe(false);
+  });
+});
+
+describe('collectExistingTranslations (internationalized array)', () => {
+  test('collapses each locale with content and skips locales without', async () => {
+    pluginConfig.translationLevel = 'internationalizedArray';
+    pluginConfig.sourceLocale = 'en';
+
+    const doc = {
+      _id: 'drafts.post-1',
+      _type: 'post',
+      _rev: 'rev-1',
+      title: [
+        item('internationalizedArrayStringValue', 'en', 'Hello'),
+        item('internationalizedArrayStringValue', 'es', 'Hola'),
+      ],
+      description: [
+        item('internationalizedArrayTextValue', 'en', 'A description'),
+      ],
+    } as unknown as SanityDocument;
+
+    const fetchMock = vi.fn();
+    const existing = await collectExistingTranslations(
+      [doc],
+      ['es', 'fr'],
+      contextWith({ fetch: fetchMock as SanityClient['fetch'] })
+    );
+
+    // Translations live in the document itself, so no queries are needed.
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    const translations = existing.get('post-1');
+    expect(translations).toHaveLength(1);
+    expect(translations?.[0].locale).toBe('es');
+    expect(translations?.[0].content).toContain('Hola');
+    expect(translations?.[0].content).not.toContain('Hello');
+    expect(existing.size).toBe(1);
+  });
+
+  test('omits documents with no target-locale content', async () => {
+    pluginConfig.translationLevel = 'internationalizedArray';
+
+    const doc = {
+      _id: 'post-2',
+      _type: 'post',
+      _rev: 'rev-1',
+      title: [item('internationalizedArrayStringValue', 'en', 'Hello')],
+    } as unknown as SanityDocument;
+
+    const existing = await collectExistingTranslations(
+      [doc],
+      ['es'],
+      contextWith({ fetch: vi.fn() as SanityClient['fetch'] })
+    );
+
+    expect(existing.size).toBe(0);
+  });
+});
+
+describe('collectExistingTranslations (document level)', () => {
+  const sourceDoc = {
+    _id: 'page-1',
+    _type: 'page',
+    _rev: 'rev-1',
+    title: 'Hello',
+  } as unknown as SanityDocument;
+
+  test('serializes the linked translated documents, preferring drafts', async () => {
+    const fetchMock = vi
+      .fn()
+      // translation.metadata rows
+      .mockResolvedValueOnce([
+        {
+          sourceDocId: 'page-1',
+          translations: [{ language: 'es', docId: 'page-1-es' }],
+        },
+      ])
+      // translated documents: published and draft versions
+      .mockResolvedValueOnce([
+        {
+          _id: 'page-1-es',
+          _type: 'page',
+          _rev: 'rev-es-1',
+          language: 'es',
+          title: 'Hola publicado',
+        },
+        {
+          _id: 'drafts.page-1-es',
+          _type: 'page',
+          _rev: 'rev-es-2',
+          language: 'es',
+          title: 'Hola borrador',
+        },
+      ]);
+
+    const existing = await collectExistingTranslations(
+      [sourceDoc],
+      ['es'],
+      contextWith({ fetch: fetchMock as SanityClient['fetch'] })
+    );
+
+    const translations = existing.get('page-1');
+    expect(translations).toHaveLength(1);
+    expect(translations?.[0].locale).toBe('es');
+    expect(translations?.[0].content).toContain('Hola borrador');
+    expect(translations?.[0].content).not.toContain('Hola publicado');
+  });
+
+  test('returns nothing when no translated documents are linked', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce([]);
+
+    const existing = await collectExistingTranslations(
+      [sourceDoc],
+      ['es'],
+      contextWith({ fetch: fetchMock as SanityClient['fetch'] })
+    );
+
+    expect(existing.size).toBe(0);
+    // Only the metadata query runs; there are no documents to fetch.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('never uploads the source locale even if requested', async () => {
+    const fetchMock = vi.fn();
+
+    const existing = await collectExistingTranslations(
+      [sourceDoc],
+      ['en'],
+      contextWith({ fetch: fetchMock as SanityClient['fetch'] })
+    );
+
+    expect(existing.size).toBe(0);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/sanity/src/translation/captureExistingTranslations.ts
+++ b/packages/sanity/src/translation/captureExistingTranslations.ts
@@ -1,0 +1,111 @@
+import type { SanityDocument } from 'sanity';
+import { libraryDefaultLocale } from 'generaltranslation/internal';
+import { gt, overrideConfig } from '../adapter/core';
+import { getDocumentPublishedId } from '../utils/documentIds';
+import { collectExistingTranslations } from './collectExistingTranslations';
+
+import type { Secrets, TranslationFunctionContext } from '../types';
+
+export type CaptureExistingTranslationsInput = {
+  documents: SanityDocument[];
+  localeIds: string[];
+  secrets: Secrets;
+  context: TranslationFunctionContext;
+  branchId?: string;
+};
+
+export type CaptureExistingTranslationsResult = {
+  /** Number of (document, locale) translations uploaded. */
+  capturedCount: number;
+  /** Number of documents that had at least one translation uploaded. */
+  documentCount: number;
+};
+
+const EMPTY_RESULT: CaptureExistingTranslationsResult = {
+  capturedCount: 0,
+  documentCount: 0,
+};
+
+/**
+ * Upload the translations Sanity currently holds as the stored translation for
+ * the source version General Translation already has, so a later translation of
+ * a newer source version reuses them instead of regenerating.
+ *
+ * Must run before the current source revision is uploaded: the target version is
+ * whatever General Translation holds now, which the upload would advance.
+ * Documents with no source file there yet are skipped.
+ */
+export async function captureExistingTranslations({
+  documents,
+  localeIds,
+  secrets,
+  context,
+  branchId,
+}: CaptureExistingTranslationsInput): Promise<CaptureExistingTranslationsResult> {
+  if (documents.length === 0 || localeIds.length === 0) {
+    return EMPTY_RESULT;
+  }
+
+  overrideConfig(secrets);
+  const sourceLocale = gt.sourceLocale || libraryDefaultLocale;
+
+  const seedFiles = await gt.downloadFileBatch(
+    documents.map((document) => ({
+      fileId: getDocumentPublishedId(document),
+      branchId,
+    }))
+  );
+  const seedByFileId = new Map(
+    (seedFiles.files ?? []).map((file) => [file.fileId, file])
+  );
+
+  const existing = await collectExistingTranslations(
+    documents.filter((document) =>
+      seedByFileId.has(getDocumentPublishedId(document))
+    ),
+    localeIds,
+    context
+  );
+
+  const files = Array.from(existing.entries()).flatMap(
+    ([documentId, translations]) => {
+      const seed = seedByFileId.get(documentId);
+      if (!seed || translations.length === 0) {
+        return [];
+      }
+      const fileName = seed.fileName ?? `sanity/${documentId}`;
+      const reference = {
+        fileName,
+        fileFormat: 'HTML' as const,
+        fileId: seed.fileId,
+        versionId: seed.versionId,
+        branchId: seed.branchId,
+      };
+
+      return [
+        {
+          source: { ...reference, content: seed.data, locale: sourceLocale },
+          translations: translations.map(({ locale, content }) => ({
+            ...reference,
+            content,
+            locale,
+          })),
+        },
+      ];
+    }
+  );
+
+  if (files.length === 0) {
+    return EMPTY_RESULT;
+  }
+
+  await gt.uploadTranslations(files, { sourceLocale });
+
+  return {
+    capturedCount: files.reduce(
+      (total, file) => total + file.translations.length,
+      0
+    ),
+    documentCount: files.length,
+  };
+}

--- a/packages/sanity/src/translation/collectExistingTranslations.ts
+++ b/packages/sanity/src/translation/collectExistingTranslations.ts
@@ -1,0 +1,199 @@
+import type { SanityClient, SanityDocument } from 'sanity';
+import { pluginConfig } from '../adapter/core';
+import { hasLocaleContent } from '../serialization/internationalizedArray/detect';
+import type { TranslationFunctionContext } from '../types';
+import {
+  dedupeDocumentsPreferDraft,
+  getDocumentPublishedId,
+} from '../utils/documentIds';
+import {
+  metadataTranslationRef,
+  metadataTranslations,
+  TRANSLATION_METADATA_TYPE,
+} from '../utils/translationMetadata';
+import { serializeDocument } from '../utils/serialize';
+import { getTranslationStrategy } from './strategy';
+
+/**
+ * A translation that already exists in Sanity (a human-edited translated
+ * document or a translated internationalized-array item), serialized to the
+ * same HTML format the source document is uploaded in.
+ */
+export type ExistingTranslation = {
+  locale: string;
+  content: string;
+};
+
+type TranslationMetadataRow = {
+  sourceDocId?: string;
+  translations?: { language?: string; docId?: string }[];
+};
+
+/**
+ * Collect and serialize the translations that already exist in Sanity for the
+ * given source documents, keyed by the source document's published id.
+ *
+ * - Document-level types: the translated documents linked through
+ *   `translation.metadata`, preferring drafts so unpublished human edits are
+ *   also preserved.
+ * - Internationalized-array types: the target-locale items stored in the
+ *   source document itself, collapsed per locale.
+ *
+ * Locales without existing content are omitted, so callers only upload
+ * translations that a human could actually have edited.
+ */
+export async function collectExistingTranslations(
+  documents: SanityDocument[],
+  targetLocaleIds: string[],
+  { client, schema }: TranslationFunctionContext
+): Promise<Map<string, ExistingTranslation[]>> {
+  const existing = new Map<string, ExistingTranslation[]>();
+  if (documents.length === 0 || targetLocaleIds.length === 0) {
+    return existing;
+  }
+
+  const sourceLocale = pluginConfig.getSourceLocale();
+  const languageField = pluginConfig.getLanguageField();
+  const localeIds = targetLocaleIds.filter(
+    (localeId) => localeId !== sourceLocale
+  );
+  if (localeIds.length === 0) {
+    return existing;
+  }
+
+  const documentLevelDocs: SanityDocument[] = [];
+  for (const doc of documents) {
+    const strategy = getTranslationStrategy(doc);
+    if (strategy.level !== 'internationalizedArray') {
+      documentLevelDocs.push(doc);
+      continue;
+    }
+
+    // Array-level translations live in the source document itself. Collapsing
+    // to the target locale reuses the source serialization path: fields with
+    // no item for that locale are dropped, so only translated content ships.
+    const { [languageField]: _language, ...cleanDoc } = doc;
+    const translations: ExistingTranslation[] = [];
+    for (const localeId of localeIds) {
+      if (!hasLocaleContent(cleanDoc, localeId)) continue;
+      const serialized = serializeDocument(
+        cleanDoc as SanityDocument,
+        schema,
+        localeId,
+        'internationalizedArray'
+      );
+      translations.push({ locale: localeId, content: serialized.content });
+    }
+    if (translations.length > 0) {
+      existing.set(getDocumentPublishedId(doc), translations);
+    }
+  }
+
+  if (documentLevelDocs.length > 0) {
+    const documentLevel = await collectDocumentLevelTranslations(
+      documentLevelDocs,
+      localeIds,
+      sourceLocale,
+      languageField,
+      client,
+      schema
+    );
+    for (const [sourceDocId, translations] of documentLevel) {
+      existing.set(sourceDocId, translations);
+    }
+  }
+
+  return existing;
+}
+
+async function collectDocumentLevelTranslations(
+  documents: SanityDocument[],
+  localeIds: string[],
+  sourceLocale: string,
+  languageField: string,
+  client: SanityClient,
+  schema: TranslationFunctionContext['schema']
+): Promise<Map<string, ExistingTranslation[]>> {
+  const existing = new Map<string, ExistingTranslation[]>();
+  const sourceDocIds = documents.map(getDocumentPublishedId);
+
+  const query = `*[
+    _type == '${TRANSLATION_METADATA_TYPE}' &&
+    ${metadataTranslationRef('$sourceLocale')} in $sourceDocIds
+  ] {
+    'sourceDocId': ${metadataTranslationRef('$sourceLocale')},
+    'translations': ${metadataTranslations('in $localeIds', 'defined(value._ref)')}{
+      language,
+      'docId': value._ref
+    }
+  }`;
+
+  const metadataRows = await client.fetch<TranslationMetadataRow[]>(query, {
+    sourceLocale,
+    sourceDocIds,
+    localeIds,
+  });
+
+  // Use the last entry per locale defensively: older plugin versions could
+  // create duplicate locale entries when bulk imports raced.
+  const refsBySource = new Map<string, Map<string, string>>();
+  for (const row of metadataRows) {
+    if (!row.sourceDocId) continue;
+    const localeRefs =
+      refsBySource.get(row.sourceDocId) ?? new Map<string, string>();
+    for (const translation of row.translations ?? []) {
+      if (translation.language && translation.docId) {
+        localeRefs.set(translation.language, translation.docId);
+      }
+    }
+    refsBySource.set(row.sourceDocId, localeRefs);
+  }
+
+  const translatedDocIds = Array.from(
+    new Set(
+      Array.from(refsBySource.values()).flatMap((localeRefs) =>
+        Array.from(localeRefs.values())
+      )
+    )
+  );
+  if (translatedDocIds.length === 0) {
+    return existing;
+  }
+
+  // Fetch published and draft versions in one query, preferring drafts so
+  // unpublished human edits are included.
+  const translatedDocs = await client.fetch<SanityDocument[]>(
+    `*[_id in $ids || _id in $draftIds]`,
+    {
+      ids: translatedDocIds,
+      draftIds: translatedDocIds.map((id) => `drafts.${id}`),
+    }
+  );
+  const translatedById = new Map(
+    dedupeDocumentsPreferDraft(translatedDocs).map((doc) => [
+      getDocumentPublishedId(doc),
+      doc,
+    ])
+  );
+
+  for (const [sourceDocId, localeRefs] of refsBySource) {
+    const translations: ExistingTranslation[] = [];
+    for (const [localeId, translatedDocId] of localeRefs) {
+      const translatedDoc = translatedById.get(translatedDocId);
+      if (!translatedDoc) continue;
+      const { [languageField]: _language, ...cleanDoc } = translatedDoc;
+      const serialized = serializeDocument(
+        cleanDoc as SanityDocument,
+        schema,
+        sourceLocale,
+        'document'
+      );
+      translations.push({ locale: localeId, content: serialized.content });
+    }
+    if (translations.length > 0) {
+      existing.set(sourceDocId, translations);
+    }
+  }
+
+  return existing;
+}

--- a/packages/sanity/src/translation/createJobs.ts
+++ b/packages/sanity/src/translation/createJobs.ts
@@ -5,12 +5,18 @@ import type { Secrets } from '../types';
 export async function createJobs(
   uploadResult: Awaited<ReturnType<typeof gt.uploadSourceFiles>>,
   localeIds: string[],
-  secrets: Secrets
+  secrets: Secrets,
+  // Discard any translation GT already holds for these files and retranslate
+  // from source. Without this, GT reuses unchanged content — including
+  // translations captured from the Studio — so a bad translation can never be
+  // regenerated.
+  force: boolean = false
 ): Promise<Awaited<ReturnType<typeof gt.enqueueFiles>>> {
   overrideConfig(secrets);
   const enqueueResult = await gt.enqueueFiles(uploadResult.uploadedFiles, {
     sourceLocale: gt.sourceLocale || libraryDefaultLocale,
     targetLocales: localeIds,
+    force,
   });
   return enqueueResult;
 }

--- a/packages/sanity/src/translation/uploadTranslations.ts
+++ b/packages/sanity/src/translation/uploadTranslations.ts
@@ -1,0 +1,54 @@
+import type { GTFile, Secrets } from '../types';
+import { gt, overrideConfig } from '../adapter/core';
+import { libraryDefaultLocale } from 'generaltranslation/internal';
+import type { SerializedDocument } from '../serialization/types';
+import type { ExistingTranslation } from './collectExistingTranslations';
+
+/**
+ * Upload translations that already exist in Sanity for previously serialized
+ * source documents. The endpoint is an upsert, so the Sanity content becomes
+ * the stored translation for the source's fileId/versionId — this is how
+ * human edits are preserved before (re-)enqueueing machine translation.
+ *
+ * Mirrors the CLI's upload workflow: each translation reuses the source
+ * document's fileId and versionId and differs only by locale.
+ */
+export async function uploadTranslations(
+  documents: {
+    info: GTFile;
+    serializedDocument: SerializedDocument;
+    translations: ExistingTranslation[];
+  }[],
+  secrets: Secrets | null
+): Promise<Awaited<ReturnType<typeof gt.uploadTranslations>> | null> {
+  const withTranslations = documents.filter(
+    (document) => document.translations.length > 0
+  );
+  if (withTranslations.length === 0) {
+    return null;
+  }
+
+  overrideConfig(secrets);
+  const sourceLocale = gt.sourceLocale || libraryDefaultLocale;
+  return await gt.uploadTranslations(
+    withTranslations.map(({ info, serializedDocument, translations }) => ({
+      source: {
+        content: serializedDocument.content,
+        fileName: `sanity/${info.documentId}`,
+        fileId: info.documentId,
+        fileFormat: 'HTML' as const,
+        locale: sourceLocale,
+        versionId: info.versionId || undefined,
+      },
+      translations: translations.map(({ locale, content }) => ({
+        content,
+        fileName: `sanity/${info.documentId}`,
+        fileId: info.documentId,
+        fileFormat: 'HTML' as const,
+        locale,
+        versionId: info.versionId || undefined,
+      })),
+    })),
+    { sourceLocale }
+  );
+}

--- a/packages/sanity/src/utils/translationMetadata.ts
+++ b/packages/sanity/src/utils/translationMetadata.ts
@@ -1,0 +1,38 @@
+/**
+ * GROQ fragments for reading `translation.metadata` documents, single-sourced
+ * so every query stays in sync with the write path
+ * (`createI18nDocAndPatchMetadata` / `getOrCreateTranslationMetadata`).
+ *
+ * The locale of each `translations[]` entry lives in its literal `language`
+ * property. That is the storage shape of the metadata document itself and is
+ * unrelated to the configurable `languageField` option, which only renames
+ * the language field on content documents.
+ */
+export const TRANSLATION_METADATA_TYPE = 'translation.metadata';
+
+/** Deterministic metadata document id for a source document. */
+export function translationMetadataId(publishedDocumentId: string): string {
+  return `${TRANSLATION_METADATA_TYPE}.${publishedDocumentId}`;
+}
+
+/**
+ * `translations[]` entries whose `language` matches a GROQ condition, e.g.
+ * `metadataTranslations('== $sourceLocale')` or
+ * `metadataTranslations('in $localeIds', 'defined(value._ref)')`.
+ */
+export function metadataTranslations(
+  languageCondition: string,
+  extraCondition?: string
+): string {
+  return `translations[language ${languageCondition}${
+    extraCondition ? ` && ${extraCondition}` : ''
+  }]`;
+}
+
+/**
+ * The `_ref` of the document recorded for a language, e.g.
+ * `metadataTranslationRef('$sourceLocale')`.
+ */
+export function metadataTranslationRef(languageExpression: string): string {
+  return `${metadataTranslations(`== ${languageExpression}`)}[0].value._ref`;
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a "preserve human edits" feature to `gt-sanity`: before uploading a new source revision to GT, the plugin now reads back any translated documents already in Sanity and sends them to GT as the stored translation for the version GT currently holds. It also exposes an "Upload Existing" action (without a translation run) and a "Retranslate from scratch" checkbox to deliberately discard saved edits for a single run.

- **New files** `captureExistingTranslations.ts` and `collectExistingTranslations.ts` handle fetching GT seed files, serializing existing Sanity translations, and uploading them; both internationalized-array and document-level strategies are covered, with drafts preferred over published docs.
- **`TranslationsProvider`** gains `handleUploadExistingTranslations` and reworks `handleTranslateAll` to accept `{ force }`, with the capture step wrapped in a best-effort inner try so a failure there never blocks the translation job itself.
- **`translationMetadata.ts`** centralizes GROQ fragments for `translation.metadata` queries, reducing duplication across four call sites.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge after confirming the document-level serialization locale bug; the capture step is best-effort so a wrong serialization silently produces bad HTML rather than blocking translations.

In collectDocumentLevelTranslations, serializeDocument is called with sourceLocale instead of the target localeId for translated documents. The internationalized-array path one function up passes localeId correctly, making the asymmetry clearly unintentional. If BaseDocumentSerializer embeds the language in the serialized HTML, the uploaded content will be mis-tagged and GT may fail to associate it with the correct target locale when reusing translations.

**Files Needing Attention:** packages/sanity/src/translation/collectExistingTranslations.ts — the document-level serialization call at line 185 passes sourceLocale instead of localeId
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/sanity/src/translation/collectExistingTranslations.ts | New file: serializes existing Sanity translations for capture. Document-level path passes sourceLocale instead of the target localeId to serializeDocument, which is semantically wrong and mirrors the correct localeId usage in the adjacent internationalized-array path. |
| packages/sanity/src/translation/captureExistingTranslations.ts | New file: orchestrates download of GT seed files, collection of Sanity translations, and upload of existing translations. Logic is sound — filters by GT source file existence, pins to GT's held version not the live _rev. |
| packages/sanity/src/components/TranslationsProvider.tsx | Adds handleUploadExistingTranslations callback and reworks handleTranslateAll to support force-retranslate and pre-translate capture. Deps are correctly structured (client/schema listed instead of translationContext); best-effort inner try for capture is sound. |
| packages/sanity/src/components/page/TranslateAllDialog.tsx | Adds 'Retranslate from scratch' checkbox with caution tone; state is reset on cancel/confirm, dialog tone changes with force state. Looks correct. |
| packages/sanity/src/components/page/UploadExistingDialog.tsx | New dialog for Upload Existing action; straightforward confirmation pattern matching existing dialogs. |
| packages/sanity/src/utils/translationMetadata.ts | New utility: centralizes GROQ fragments for translation.metadata documents. All functions produce parameterized GROQ (no injection risk); consistent across all consumers. |
| packages/sanity/src/translation/createJobs.ts | Adds optional force parameter forwarded to gt.enqueueFiles. Backward-compatible default of false. |
| packages/sanity/src/serialization/internationalizedArray/detect.ts | Adds hasLocaleContent helper for recursive detection of locale items in a document tree. Logic is correct and well-tested. |
| packages/sanity/src/adapter/core.ts | Adds preserveExistingTranslations flag to GTConfig with default true; threaded through both constructors and exposed via getter. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apackages%2Fsanity%2Fsrc%2Ftranslation%2FcollectExistingTranslations.ts%3A185-190%0A**Wrong%20locale%20passed%20to%20serializer%20for%20translated%20documents**%0A%0A%60serializeDocument%60%20is%20called%20with%20%60sourceLocale%60%20instead%20of%20%60localeId%60%20for%20every%20translated%20document.%20The%20third%20argument%2C%20%60baseLanguage%60%2C%20tells%20the%20serializer%20which%20locale%20the%20document%20belongs%20to%20%E2%80%94%20passing%20the%20source%20locale%20%28e.g.%20%60'en'%60%29%20when%20serializing%20a%20Spanish%20document%20means%20any%20locale-aware%20processing%20inside%20%60BaseDocumentSerializer.serializeDocument%60%20operates%20on%20the%20wrong%20language.%20The%20internationalized-array%20branch%20directly%20above%20%28line%2082%29%20correctly%20passes%20%60localeId%60%20here%3B%20this%20path%20should%20match.%20A%20concrete%20breakage%3A%20if%20GT%20or%20the%20serializer%20embeds%20a%20%60lang%60%20attribute%20in%20the%20serialized%20HTML%2C%20content%20will%20be%20mis-tagged%2C%20causing%20a%20locale%20mismatch%20when%20GT%20tries%20to%20associate%20uploaded%20translations%20with%20their%20target%20locale.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=generaltranslation%2Fgt&pr=1997&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22f%2Fsanity-save-edits%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22f%2Fsanity-save-edits%22.%0A%0A%23%23%23%20Issue%201%0Apackages%2Fsanity%2Fsrc%2Ftranslation%2FcollectExistingTranslations.ts%3A185-190%0A**Wrong%20locale%20passed%20to%20serializer%20for%20translated%20documents**%0A%0A%60serializeDocument%60%20is%20called%20with%20%60sourceLocale%60%20instead%20of%20%60localeId%60%20for%20every%20translated%20document.%20The%20third%20argument%2C%20%60baseLanguage%60%2C%20tells%20the%20serializer%20which%20locale%20the%20document%20belongs%20to%20%E2%80%94%20passing%20the%20source%20locale%20%28e.g.%20%60'en'%60%29%20when%20serializing%20a%20Spanish%20document%20means%20any%20locale-aware%20processing%20inside%20%60BaseDocumentSerializer.serializeDocument%60%20operates%20on%20the%20wrong%20language.%20The%20internationalized-array%20branch%20directly%20above%20%28line%2082%29%20correctly%20passes%20%60localeId%60%20here%3B%20this%20path%20should%20match.%20A%20concrete%20breakage%3A%20if%20GT%20or%20the%20serializer%20embeds%20a%20%60lang%60%20attribute%20in%20the%20serialized%20HTML%2C%20content%20will%20be%20mis-tagged%2C%20causing%20a%20locale%20mismatch%20when%20GT%20tries%20to%20associate%20uploaded%20translations%20with%20their%20target%20locale.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=generaltranslation%2Fgt&pr=1997&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/sanity/src/translation/collectExistingTranslations.ts:185-190
**Wrong locale passed to serializer for translated documents**

`serializeDocument` is called with `sourceLocale` instead of `localeId` for every translated document. The third argument, `baseLanguage`, tells the serializer which locale the document belongs to — passing the source locale (e.g. `'en'`) when serializing a Spanish document means any locale-aware processing inside `BaseDocumentSerializer.serializeDocument` operates on the wrong language. The internationalized-array branch directly above (line 82) correctly passes `localeId` here; this path should match. A concrete breakage: if GT or the serializer embeds a `lang` attribute in the serialized HTML, content will be mis-tagged, causing a locale mismatch when GT tries to associate uploaded translations with their target locale.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: review"](https://github.com/generaltranslation/gt/commit/448b79258a832720acff09311589e35395eeb3aa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48093158)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->