### PR TITLE
fix(tanstack-start, react): resolve the server build on worker runtimes

### DIFF
--- a/.changeset/tanstack-start-worker-exports.md
+++ b/.changeset/tanstack-start-worker-exports.md
@@ -1,5 +1,8 @@
 ---
 'gt-tanstack-start': patch
+'gt-react': patch
 ---
 
-Resolve the server build on worker runtimes. The `.` export listed `browser` ahead of `import`, and Node's exports algorithm lets the target's own key order decide which condition wins, so worker runtimes — whose condition sets include `browser`, such as Cloudflare's `["workerd", "worker", "module", "browser"]` — loaded the browser build during SSR and crashed with `ReferenceError: document is not defined` when `initializeGT()` read `document.cookie`. `workerd` and `worker` now come first and take the server build, which installs the AsyncLocalStorage request condition store. Browsers still match `browser` and Node SSR still falls through to `import`, so no existing consumer changes.
+Resolve the server build on worker runtimes. The `.` export listed `browser` ahead of `import`, and Node's exports algorithm lets the target's own key order decide which condition wins, so worker runtimes — whose condition sets include `browser`, such as Cloudflare's `["workerd", "worker", "module", "browser"]` — loaded the browser build during SSR. `gt-tanstack-start` crashed with `ReferenceError: document is not defined` when `initializeGT()` read `document.cookie`; `gt-react` silently handed back `BrowserGTProvider` and `initializeGTSRAClient`, so SSR ran on the isolate-global `BrowserConditionStore` shared across concurrent requests instead of the request-scoped store.
+
+Both packages now list `workerd` and `worker` ahead of `browser` and resolve them to the server build. In `gt-react` they sit after `react-server`, so RSC runtimes on workerd keep the RSC build. Browsers still match `browser` and Node SSR still falls through to `import`, so no existing consumer changes.

--- a/.changeset/tanstack-start-worker-exports.md
+++ b/.changeset/tanstack-start-worker-exports.md
@@ -1,0 +1,5 @@
+---
+'gt-tanstack-start': patch
+---
+
+Resolve the server build on worker runtimes. The `.` export listed `browser` ahead of `import`, and Node's exports algorithm lets the target's own key order decide which condition wins, so worker runtimes — whose condition sets include `browser`, such as Cloudflare's `["workerd", "worker", "module", "browser"]` — loaded the browser build during SSR and crashed with `ReferenceError: document is not defined` when `initializeGT()` read `document.cookie`. `workerd` and `worker` now come first and take the server build, which installs the AsyncLocalStorage request condition store. Browsers still match `browser` and Node SSR still falls through to `import`, so no existing consumer changes.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -65,6 +65,28 @@
         },
         "default": "./dist/index.rsc.mjs"
       },
+      "workerd": {
+        "require": {
+          "types": "./dist/index.types.d.cts",
+          "default": "./dist/index.server.cjs"
+        },
+        "import": {
+          "types": "./dist/index.types.d.mts",
+          "default": "./dist/index.server.mjs"
+        },
+        "default": "./dist/index.server.mjs"
+      },
+      "worker": {
+        "require": {
+          "types": "./dist/index.types.d.cts",
+          "default": "./dist/index.server.cjs"
+        },
+        "import": {
+          "types": "./dist/index.types.d.mts",
+          "default": "./dist/index.server.mjs"
+        },
+        "default": "./dist/index.server.mjs"
+      },
       "browser": {
         "require": {
           "types": "./dist/index.types.d.cts",

--- a/packages/tanstack-start/package.json
+++ b/packages/tanstack-start/package.json
@@ -53,6 +53,20 @@
   },
   "exports": {
     ".": {
+      "workerd": {
+        "import": {
+          "types": "./dist/index.server.d.mts",
+          "default": "./dist/index.server.mjs"
+        },
+        "default": "./dist/index.server.mjs"
+      },
+      "worker": {
+        "import": {
+          "types": "./dist/index.server.d.mts",
+          "default": "./dist/index.server.mjs"
+        },
+        "default": "./dist/index.server.mjs"
+      },
       "browser": {
         "import": {
           "types": "./dist/index.client.d.mts",


### PR DESCRIPTION
## Problem

Vite apps targeting Cloudflare Workers SSR with the **client** build of `gt-tanstack-start` and `gt-react`. Both `exports` maps list `browser` ahead of `import`, and Node's exports algorithm lets the target's own key order decide which condition wins — workerd's condition set includes `browser` (`["workerd", "worker", "module", "browser"]`), so it matched first.

This reproduces in plain `vite dev`: the Cloudflare Vite plugin runs the SSR environment in workerd locally, so no deploy is needed to hit it.

- `gt-tanstack-start` crashed: `ReferenceError: document is not defined` when `initializeGT()` read `document.cookie`.
- `gt-react` failed *silently*: `GTProvider` resolved to `BrowserGTProvider` over the isolate-global `BrowserConditionStore`, shared across concurrent requests, with cookie reads no-op'ing to the default locale.

The `gt-react` half is required, not just consistency: `gt-react` is in `neverBundle` for `gt-tanstack-start`, so `dist/index.server.mjs` imports `GTProvider` and `initializeGT` as bare externals resolved by the consumer's bundler.

## Solution

Add `workerd` and `worker` conditions resolving to the server build, ahead of `browser`. In `gt-react` they sit **after `react-server`**, so RSC runtimes on workerd keep the RSC build.

## Test

Verified with real Node resolution (`node --conditions=...`) against the built `dist`, before and after:

| conditions | before | after |
|---|---|---|
| `workerd,worker,browser` | `index.client.mjs` :x: | `index.server.mjs` :white_check_mark: |
| `react-server,workerd,worker,browser` | — | `index.rsc.mjs` :white_check_mark: |
| `browser` | `index.client.mjs` | `index.client.mjs` :white_check_mark: |
| node ESM / CJS | `index.server.mjs` / `.cjs` | unchanged :white_check_mark: |

Also confirmed with the patched packages built locally and run under `vite dev` on the Cloudflare Workers environment.

No existing consumer changes: browsers still match `browser`, Node SSR still falls through to `import`/`require`.

## Other

`gt-next` (`packages/next/package.json`) has the same `browser`-before-`import` ordering and is likely affected on OpenNext/Cloudflare. Left out of this PR as unverified — happy to follow up.