### PR TITLE
fix(ci): run required checks on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,6 @@ name: CI - Run Tests
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    paths-ignore:
-      - 'packages/*/CHANGELOG.md'
-      - 'packages/*/package.json'
-      - '.changeset/**'
 
 env:
   CI: true


### PR DESCRIPTION
## Summary

- Run the required CI workflow for every opened, updated, or reopened pull request, including release-only PRs.
- Remove the workflow-level path exclusions that prevented the required `run-tests` check from being created for package manifest, changelog, and Changeset-only changes.
- Preserve the existing affected-package and specialized matrix filtering inside the workflow.

## Testing

- `pnpm lint` — passed (19 existing non-fatal warnings)
- `pnpm exec oxfmt --check .github/workflows/ci.yml` — passed
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml')"` — passed
- `git diff --check origin/main...HEAD` — passed
- Full unit suite not run locally because this change only alters the GitHub Actions trigger; the PR now exercises that trigger in CI.

## Notes

- Changeset: not required; this only changes repository automation.
