### PR TITLE
test: cover worker runtime export resolution

### DIFF
--- a/packages/react/src/__tests__/react-package.test.ts
+++ b/packages/react/src/__tests__/react-package.test.ts
@@ -127,6 +127,39 @@ describe('gt-react package exports', () => {
     ]);
   });
 
+  it.each(['workerd', 'worker'])(
+    'resolves server entrypoints when %s and browser conditions are active',
+    (workerCondition) => {
+      node([
+        `--conditions=${workerCondition}`,
+        '--conditions=browser',
+        '-e',
+        `
+          const assert = require('node:assert/strict');
+
+          assert.equal(
+            require.resolve('gt-react').endsWith('/dist/index.server.cjs'),
+            true
+          );
+        `,
+      ]);
+      node([
+        `--conditions=${workerCondition}`,
+        '--conditions=browser',
+        '--input-type=module',
+        '-e',
+        `
+          import assert from 'node:assert/strict';
+
+          assert.equal(
+            import.meta.resolve('gt-react').endsWith('/dist/index.server.mjs'),
+            true
+          );
+        `,
+      ]);
+    }
+  );
+
   it('throws when the condition-store factory is called from the server entrypoint', () => {
     node([
       '--input-type=module',
@@ -166,9 +199,12 @@ describe('gt-react package exports', () => {
     }
   });
 
-  it('resolves gt-react to the RSC implementation under react-server', () => {
+  it('prefers the RSC implementation over worker and browser conditions', () => {
     node([
       '--conditions=react-server',
+      '--conditions=workerd',
+      '--conditions=worker',
+      '--conditions=browser',
       '-e',
       `
           const assert = require('node:assert/strict');

--- a/packages/tanstack-start/src/__tests__/packageExports.test.ts
+++ b/packages/tanstack-start/src/__tests__/packageExports.test.ts
@@ -103,4 +103,24 @@ describe('gt-tanstack-start package exports', () => {
       `,
     ]);
   });
+
+  it.each(['workerd', 'worker'])(
+    'resolves the server ESM entrypoint when %s and browser conditions are active',
+    (workerCondition) => {
+      node([
+        `--conditions=${workerCondition}`,
+        '--conditions=browser',
+        '--input-type=module',
+        '-e',
+        `
+          import assert from 'node:assert/strict';
+
+          assert.equal(
+            import.meta.resolve('gt-tanstack-start').endsWith('/dist/index.server.mjs'),
+            true
+          );
+        `,
+      ]);
+    }
+  );
 });


### PR DESCRIPTION
## Summary

- Add Node resolution regression coverage for the worker runtime export conditions introduced in #1998.
- Verify `workerd` and `worker` select server entrypoints ahead of `browser` in `gt-react` and `gt-tanstack-start`, while `react-server` retains precedence for the RSC build.

## Testing

- `pnpm --filter gt-tanstack-start... build` — passed
- `pnpm --filter gt-react test` — passed (30 tests)
- `pnpm --filter gt-tanstack-start test` — passed (35 tests)
- `pnpm exec oxfmt --check packages/react/src/__tests__/react-package.test.ts packages/tanstack-start/src/__tests__/packageExports.test.ts` — passed
- `pnpm exec oxlint packages/react/src/__tests__/react-package.test.ts packages/tanstack-start/src/__tests__/packageExports.test.ts --deny-warnings` — passed
- Full monorepo test suite not run; the complete suites for both touched packages passed.

## Notes

- Targets `main` after #1998 was merged.
- Changeset: not required for test-only coverage.
