### PR TITLE
fix(next): resolve server builds on worker runtimes

### DIFF
--- a/.changeset/gt-next-worker-exports.md
+++ b/.changeset/gt-next-worker-exports.md
@@ -1,0 +1,5 @@
+---
+'gt-next': patch
+---
+
+Resolve the server build in worker runtimes by prioritizing `workerd` and `worker` export conditions ahead of `browser`, while preserving the React Server Components entrypoint's precedence.

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -82,6 +82,14 @@
         "import": "./dist/index.rsc.mjs",
         "default": "./dist/index.rsc.js"
       },
+      "workerd": {
+        "import": "./dist/index.server.mjs",
+        "default": "./dist/index.server.js"
+      },
+      "worker": {
+        "import": "./dist/index.server.mjs",
+        "default": "./dist/index.server.js"
+      },
       "browser": {
         "import": "./dist/index.client.mjs",
         "default": "./dist/index.client.js"

--- a/packages/next/src/__tests__/packageExports.test.ts
+++ b/packages/next/src/__tests__/packageExports.test.ts
@@ -8,6 +8,15 @@ const packageRoot = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
 const distInitGTServerPath = join(packageRoot, 'dist/setup/initGT.server.mjs');
 const distClientPath = join(packageRoot, 'dist/index.client.mjs');
 
+function runNode(args: string[]): void {
+  const result = spawnSync(process.execPath, args, {
+    cwd: packageRoot,
+    encoding: 'utf8',
+  });
+
+  expect(result.status, result.stderr).toBe(0);
+}
+
 function collectStaticModuleGraph(entryPath: string): Set<string> {
   const modules = new Set<string>();
   const pending = [entryPath];
@@ -49,6 +58,69 @@ describe('gt-next package exports', () => {
       './dist/index.rsc.d.ts'
     );
     expect(packageJson.exports['.'].types).toBe('./dist/index.types.d.ts');
+  });
+
+  it.each(['workerd', 'worker'])(
+    'resolves the server entrypoint when %s and browser conditions are active',
+    (workerCondition) => {
+      const packageJson = JSON.parse(
+        readFileSync(join(packageRoot, 'package.json'), 'utf8')
+      ) as {
+        exports: {
+          '.': Record<
+            string,
+            | string
+            | {
+                import?: string;
+                default?: string;
+              }
+          >;
+        };
+      };
+
+      expect(packageJson.exports['.'][workerCondition]).toEqual({
+        import: './dist/index.server.mjs',
+        default: './dist/index.server.js',
+      });
+
+      runNode([
+        `--conditions=${workerCondition}`,
+        '--conditions=browser',
+        '--input-type=module',
+        '--eval',
+        `
+          import assert from 'node:assert/strict';
+          import { basename } from 'node:path';
+          import { fileURLToPath } from 'node:url';
+
+          assert.equal(
+            basename(fileURLToPath(import.meta.resolve('gt-next'))),
+            'index.server.mjs'
+          );
+        `,
+      ]);
+    }
+  );
+
+  it('prefers the RSC entrypoint over worker and browser conditions', () => {
+    runNode([
+      '--conditions=react-server',
+      '--conditions=workerd',
+      '--conditions=worker',
+      '--conditions=browser',
+      '--input-type=module',
+      '--eval',
+      `
+        import assert from 'node:assert/strict';
+        import { basename } from 'node:path';
+        import { fileURLToPath } from 'node:url';
+
+        assert.equal(
+          basename(fileURLToPath(import.meta.resolve('gt-next'))),
+          'index.rsc.mjs'
+        );
+      `,
+    ]);
   });
 
   const distIt = existsSync(distInitGTServerPath) ? it : it.skip;


### PR DESCRIPTION
## Summary

- Route the `workerd` and `worker` root export conditions to the `gt-next` server build before the `browser` condition can match.
- Keep `react-server` first so React Server Components continue to resolve the RSC build on OpenNext and Cloudflare.
- Add regression coverage for both worker conditions and their ordering relative to `react-server` and `browser`.

## Testing

- `pnpm --filter gt-next... build` — passed
- `pnpm --filter gt-next test` — passed (554 tests)
- `pnpm --filter gt-next typecheck` — passed
- `pnpm exec oxlint packages/next/src/__tests__/packageExports.test.ts --deny-warnings` — passed
- `pnpm exec oxfmt --check packages/next/package.json packages/next/src/__tests__/packageExports.test.ts .changeset/gt-next-worker-exports.md` — passed
- `pnpm exec opennextjs-cloudflare build --noMinify` in an isolated app using packed workspace packages — passed
- Local Cloudflare workerd preview checked in Playwright — `/` returned 200 and rendered both `Server locale: en` and hydrated `Client locale: en`

## Notes

- Changeset: added a patch release for `gt-next`.
- Follow-up to #1998; no public API or documentation changes.
