### PR TITLE
fix(ci): replace deprecated R2 upload action

### DIFF
--- a/.github/actions/r2-upload/action.yml
+++ b/.github/actions/r2-upload/action.yml
@@ -1,0 +1,60 @@
+name: Upload directory to Cloudflare R2
+description: Upload a directory to Cloudflare R2 with the AWS CLI
+
+inputs:
+  r2-account-id:
+    description: Cloudflare account ID
+    required: true
+  r2-access-key-id:
+    description: Cloudflare R2 access key ID
+    required: true
+  r2-secret-access-key:
+    description: Cloudflare R2 secret access key
+    required: true
+  r2-bucket:
+    description: Cloudflare R2 bucket name
+    required: true
+  source-dir:
+    description: Local directory whose contents should be uploaded
+    required: true
+  destination-dir:
+    description: Destination prefix within the bucket
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Upload directory
+      shell: bash
+      env:
+        AWS_ACCESS_KEY_ID: ${{ inputs.r2-access-key-id }}
+        AWS_SECRET_ACCESS_KEY: ${{ inputs.r2-secret-access-key }}
+        AWS_DEFAULT_REGION: auto
+        AWS_EC2_METADATA_DISABLED: 'true'
+        AWS_RETRY_MODE: standard
+        AWS_MAX_ATTEMPTS: '5'
+        R2_ACCOUNT_ID: ${{ inputs.r2-account-id }}
+        R2_BUCKET: ${{ inputs.r2-bucket }}
+        SOURCE_DIR: ${{ inputs.source-dir }}
+        DESTINATION_DIR: ${{ inputs.destination-dir }}
+      run: |
+        set -euo pipefail
+
+        if [[ ! -d "$SOURCE_DIR" ]]; then
+          echo "::error::R2 source directory does not exist: $SOURCE_DIR"
+          exit 1
+        fi
+
+        destination_dir="${DESTINATION_DIR#./}"
+        destination_dir="${destination_dir#/}"
+        destination_dir="${destination_dir%/}"
+        destination_uri="s3://${R2_BUCKET}/"
+        if [[ -n "$destination_dir" && "$destination_dir" != "." ]]; then
+          destination_uri="${destination_uri}${destination_dir}/"
+        fi
+
+        aws s3 cp "${SOURCE_DIR%/}/" "$destination_uri" \
+          --recursive \
+          --endpoint-url "https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com" \
+          --only-show-errors

--- a/.github/workflows/asset-upload.yml
+++ b/.github/workflows/asset-upload.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
 
-      - uses: ryand56/r2-upload-action@v1.4
+      - uses: ./.github/actions/r2-upload
         with:
           r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
           r2-access-key-id: ${{ secrets.R2_ACCESS_KEY_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,7 +160,7 @@ jobs:
 
       - name: Upload gt binaries to R2
         if: steps.check-gt.outputs.should_release_bin == 'true'
-        uses: ryand56/r2-upload-action@v1.4
+        uses: ./.github/actions/r2-upload
         with:
           r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
           r2-access-key-id: ${{ secrets.R2_ACCESS_KEY_ID }}
@@ -171,7 +171,7 @@ jobs:
 
       - name: Upload gt binaries to R2 (latest)
         if: steps.check-gt.outputs.should_release_bin == 'true'
-        uses: ryand56/r2-upload-action@v1.4
+        uses: ./.github/actions/r2-upload
         with:
           r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
           r2-access-key-id: ${{ secrets.R2_ACCESS_KEY_ID }}
@@ -253,7 +253,7 @@ jobs:
 
       - name: Upload gtx-cli binaries to R2
         if: steps.check-gtx-cli.outputs.should_release_bin == 'true'
-        uses: ryand56/r2-upload-action@v1.4
+        uses: ./.github/actions/r2-upload
         with:
           r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
           r2-access-key-id: ${{ secrets.R2_ACCESS_KEY_ID }}
@@ -264,7 +264,7 @@ jobs:
 
       - name: Upload gtx-cli binaries to R2 (latest)
         if: steps.check-gtx-cli.outputs.should_release_bin == 'true'
-        uses: ryand56/r2-upload-action@v1.4
+        uses: ./.github/actions/r2-upload
         with:
           r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
           r2-access-key-id: ${{ secrets.R2_ACCESS_KEY_ID }}


### PR DESCRIPTION
## Summary

- replace the deprecated Node 20 R2 upload action with a shared local action backed by AWS CLI
- upload release binaries through AWS CLI's automatic multipart transfer path and retain five-attempt retries
- use the same upload implementation for versioned, latest, and asset-bucket destinations

## Testing

- `actionlint .github/workflows/asset-upload.yml .github/workflows/release.yml` — passed with actionlint v1.7.12
- `pnpm exec oxfmt --check .github/actions/r2-upload/action.yml .github/workflows/asset-upload.yml .github/workflows/release.yml` — passed
- `aws s3 cp <temporary-source>/ s3://test-bucket/{cli/v2.15.0/,} --recursive --endpoint-url https://test.r2.cloudflarestorage.com --dryrun` — mapped the file to the expected versioned and bucket-root keys
- live R2 upload — not run because the credentials are only available in GitHub Actions

## Notes

- Changeset: not required for CI-only changes.
