### PR TITLE
fix(sanity): dedupe locales

### DIFF
--- a/.changeset/sanity-dedupe-supported-languages.md
+++ b/.changeset/sanity-dedupe-supported-languages.md
@@ -1,0 +1,20 @@
+---
+'gt-sanity': patch
+---
+
+Fix a Studio crash when `locales` repeats a locale or includes the source locale
+
+`gtPlugin` built the `supportedLanguages` list as `[sourceLocale, ...locales]`
+without deduplicating, so a config like `{sourceLocale: 'en-US', locales:
+['de-DE', 'en-US', ...]}` — the shape you get from spreading `gt.config.json` —
+registered `en-US` twice with `@sanity/document-internationalization`.
+
+That duplicate made the Translations menu list the locale twice and offset every
+language after it in `sanity-plugin-internationalized-array`, whose reorder
+effect then rewrote the translations array on every render and crashed the
+Studio with "Maximum update depth exceeded". It also produced duplicate
+initial-value template ids for each translatable document type.
+
+`locales` is now normalized to unique translation targets with the source locale
+removed, and a redundant entry logs a warning instead of being silently
+misapplied.

--- a/.changeset/sanity-dedupe-supported-languages.md
+++ b/.changeset/sanity-dedupe-supported-languages.md
@@ -16,5 +16,4 @@ Studio with "Maximum update depth exceeded". It also produced duplicate
 initial-value template ids for each translatable document type.
 
 `locales` is now normalized to unique translation targets with the source locale
-removed, and a redundant entry logs a warning instead of being silently
-misapplied.
+removed.

--- a/packages/sanity/src/index.ts
+++ b/packages/sanity/src/index.ts
@@ -25,6 +25,7 @@ import './schema/schemaOptions';
 import TranslationsTool from './components/page/TranslationsTool';
 import { documentInternationalization } from './documentInternationalization';
 import type { CustomDeserializers } from './serialization/types';
+import { resolveTargetLocales } from './utils/locales';
 import { SECRETS_NAMESPACE } from './utils/shared';
 
 // ===== Document Internationalization ===== //
@@ -175,6 +176,13 @@ export const gtPlugin = definePlugin<GTPluginConfig>(
     const resolvedSourceLocale =
       sourceLocale ?? defaultLocale ?? libraryDefaultLocale;
 
+    // `locales` holds translation targets only. Drop duplicates and the source
+    // locale before anything downstream sees them — a repeated locale reaches
+    // the Studio as a duplicate language and breaks the translations UI.
+    const { targets: targetLocales, redundant: redundantLocales } =
+      resolveTargetLocales(resolvedSourceLocale, locales);
+    warnOnRedundantLocales(resolvedSourceLocale, redundantLocales);
+
     // Normalize translateDocuments: string[] → TranslateDocumentFilter[]
     const normalizeFilters = (
       entries: (TranslateDocumentFilter | string)[] | undefined
@@ -197,7 +205,7 @@ export const gtPlugin = definePlugin<GTPluginConfig>(
       secretsNamespace,
       languageField,
       resolvedSourceLocale,
-      locales,
+      targetLocales,
       singletons || [],
       // singletons is a string array of singleton document ids
       singletonMapping ||
@@ -246,7 +254,7 @@ export const gtPlugin = definePlugin<GTPluginConfig>(
           .filter((type): type is string => !!type)
           .filter((type) => !arrayLocalizedTypes.has(type)) ?? [];
       if (schemaTypes.length > 0) {
-        const allLocales = [resolvedSourceLocale, ...locales];
+        const allLocales = [resolvedSourceLocale, ...targetLocales];
         const supportedLanguages = allLocales.map((locale) => {
           const props = getLocaleProperties(
             locale,
@@ -281,7 +289,7 @@ export const gtPlugin = definePlugin<GTPluginConfig>(
         buildInternationalizedArrayPlugin(
           fieldLevelConfig,
           resolvedSourceLocale,
-          locales,
+          targetLocales,
           customMapping
         )
       );
@@ -306,6 +314,23 @@ export const gtPlugin = definePlugin<GTPluginConfig>(
     };
   }
 );
+
+function warnOnRedundantLocales(
+  sourceLocale: string,
+  redundant: string[]
+): void {
+  if (redundant.length === 0) return;
+  console.warn(
+    createDiagnosticMessage({
+      source: 'gt-sanity',
+      severity: 'Warning',
+      whatHappened: `Ignored redundant ${redundant.length === 1 ? 'entry' : 'entries'} in locales`,
+      why: `locales lists translation targets, so it should not repeat a locale or include the source locale (${sourceLocale})`,
+      fix: 'Remove them from the gtPlugin configuration',
+      details: redundant,
+    })
+  );
+}
 
 // Options that existed while gt-sanity shipped its own field-level UI (v2.1.x)
 // and have no equivalent in sanity-plugin-internationalized-array.

--- a/packages/sanity/src/index.ts
+++ b/packages/sanity/src/index.ts
@@ -179,9 +179,7 @@ export const gtPlugin = definePlugin<GTPluginConfig>(
     // `locales` holds translation targets only. Drop duplicates and the source
     // locale before anything downstream sees them — a repeated locale reaches
     // the Studio as a duplicate language and breaks the translations UI.
-    const { targets: targetLocales, redundant: redundantLocales } =
-      resolveTargetLocales(resolvedSourceLocale, locales);
-    warnOnRedundantLocales(resolvedSourceLocale, redundantLocales);
+    const targetLocales = resolveTargetLocales(resolvedSourceLocale, locales);
 
     // Normalize translateDocuments: string[] → TranslateDocumentFilter[]
     const normalizeFilters = (
@@ -314,23 +312,6 @@ export const gtPlugin = definePlugin<GTPluginConfig>(
     };
   }
 );
-
-function warnOnRedundantLocales(
-  sourceLocale: string,
-  redundant: string[]
-): void {
-  if (redundant.length === 0) return;
-  console.warn(
-    createDiagnosticMessage({
-      source: 'gt-sanity',
-      severity: 'Warning',
-      whatHappened: `Ignored redundant ${redundant.length === 1 ? 'entry' : 'entries'} in locales`,
-      why: `locales lists translation targets, so it should not repeat a locale or include the source locale (${sourceLocale})`,
-      fix: 'Remove them from the gtPlugin configuration',
-      details: redundant,
-    })
-  );
-}
 
 // Options that existed while gt-sanity shipped its own field-level UI (v2.1.x)
 // and have no equivalent in sanity-plugin-internationalized-array.

--- a/packages/sanity/src/utils/__tests__/locales.test.ts
+++ b/packages/sanity/src/utils/__tests__/locales.test.ts
@@ -3,58 +3,46 @@ import { resolveTargetLocales } from '../locales';
 
 describe('resolveTargetLocales', () => {
   test('passes through a clean target list', () => {
-    const { targets, redundant } = resolveTargetLocales('en-US', [
+    expect(resolveTargetLocales('en-US', ['de-DE', 'es-ES'])).toEqual([
       'de-DE',
       'es-ES',
     ]);
-    expect(targets).toEqual(['de-DE', 'es-ES']);
-    expect(redundant).toEqual([]);
   });
 
   test('drops the source locale from the targets', () => {
     // The gt.config.json shape: `locales` lists every locale, source included.
-    const { targets, redundant } = resolveTargetLocales('en-US', [
+    expect(resolveTargetLocales('en-US', ['de-DE', 'en-US', 'es-ES'])).toEqual([
       'de-DE',
-      'en-US',
       'es-ES',
     ]);
-    expect(targets).toEqual(['de-DE', 'es-ES']);
-    expect(redundant).toEqual(['en-US']);
   });
 
   test('drops repeated targets and keeps first-seen order', () => {
-    const { targets, redundant } = resolveTargetLocales('en-US', [
+    expect(resolveTargetLocales('en-US', ['fr-FR', 'de-DE', 'fr-FR'])).toEqual([
       'fr-FR',
       'de-DE',
-      'fr-FR',
     ]);
-    expect(targets).toEqual(['fr-FR', 'de-DE']);
-    expect(redundant).toEqual(['fr-FR']);
   });
 
   test('never yields a language list with duplicates', () => {
-    const { targets } = resolveTargetLocales('en-US', [
-      'de-DE',
+    const supportedLanguages = [
       'en-US',
-      'es-ES',
-      'fr-FR',
-      'ja-JP',
-      'ko-KR',
-      'en-GB',
-      'de-DE',
-    ]);
-    const supportedLanguages = ['en-US', ...targets];
+      ...resolveTargetLocales('en-US', [
+        'de-DE',
+        'en-US',
+        'es-ES',
+        'fr-FR',
+        'ja-JP',
+        'ko-KR',
+        'en-GB',
+        'de-DE',
+      ]),
+    ];
     expect(supportedLanguages).toEqual([...new Set(supportedLanguages)]);
   });
 
   test('tolerates an empty or missing locales list', () => {
-    expect(resolveTargetLocales('en-US', [])).toEqual({
-      targets: [],
-      redundant: [],
-    });
-    expect(resolveTargetLocales('en-US', undefined)).toEqual({
-      targets: [],
-      redundant: [],
-    });
+    expect(resolveTargetLocales('en-US', [])).toEqual([]);
+    expect(resolveTargetLocales('en-US', undefined)).toEqual([]);
   });
 });

--- a/packages/sanity/src/utils/__tests__/locales.test.ts
+++ b/packages/sanity/src/utils/__tests__/locales.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from 'vitest';
+import { resolveTargetLocales } from '../locales';
+
+describe('resolveTargetLocales', () => {
+  test('passes through a clean target list', () => {
+    const { targets, redundant } = resolveTargetLocales('en-US', [
+      'de-DE',
+      'es-ES',
+    ]);
+    expect(targets).toEqual(['de-DE', 'es-ES']);
+    expect(redundant).toEqual([]);
+  });
+
+  test('drops the source locale from the targets', () => {
+    // The gt.config.json shape: `locales` lists every locale, source included.
+    const { targets, redundant } = resolveTargetLocales('en-US', [
+      'de-DE',
+      'en-US',
+      'es-ES',
+    ]);
+    expect(targets).toEqual(['de-DE', 'es-ES']);
+    expect(redundant).toEqual(['en-US']);
+  });
+
+  test('drops repeated targets and keeps first-seen order', () => {
+    const { targets, redundant } = resolveTargetLocales('en-US', [
+      'fr-FR',
+      'de-DE',
+      'fr-FR',
+    ]);
+    expect(targets).toEqual(['fr-FR', 'de-DE']);
+    expect(redundant).toEqual(['fr-FR']);
+  });
+
+  test('never yields a language list with duplicates', () => {
+    const { targets } = resolveTargetLocales('en-US', [
+      'de-DE',
+      'en-US',
+      'es-ES',
+      'fr-FR',
+      'ja-JP',
+      'ko-KR',
+      'en-GB',
+      'de-DE',
+    ]);
+    const supportedLanguages = ['en-US', ...targets];
+    expect(supportedLanguages).toEqual([...new Set(supportedLanguages)]);
+  });
+
+  test('tolerates an empty or missing locales list', () => {
+    expect(resolveTargetLocales('en-US', [])).toEqual({
+      targets: [],
+      redundant: [],
+    });
+    expect(resolveTargetLocales('en-US', undefined)).toEqual({
+      targets: [],
+      redundant: [],
+    });
+  });
+});

--- a/packages/sanity/src/utils/locales.ts
+++ b/packages/sanity/src/utils/locales.ts
@@ -1,0 +1,38 @@
+/**
+ * `locales` is the list of translation *targets*. Configs often repeat the
+ * source locale there — spreading `gt.config.json`, which pairs `defaultLocale`
+ * with a `locales` array, is the common way to end up with it.
+ *
+ * A repeated locale is not cosmetic: it reaches
+ * `@sanity/document-internationalization` as a duplicate `supportedLanguages`
+ * entry, and `sanity-plugin-internationalized-array` then resolves every
+ * language after the duplicate to the wrong array index. Its reorder effect
+ * rewrites the array, re-renders, and re-flags the same mismatch forever, which
+ * crashes the Studio with "Maximum update depth exceeded".
+ */
+export type ResolvedTargetLocales = {
+  /** Deduplicated targets, with the source locale removed. */
+  targets: string[];
+  /** Entries dropped from the input, in the order they appeared. */
+  redundant: string[];
+};
+
+export function resolveTargetLocales(
+  sourceLocale: string,
+  locales: string[] | undefined
+): ResolvedTargetLocales {
+  const seen = new Set<string>([sourceLocale]);
+  const targets: string[] = [];
+  const redundant: string[] = [];
+
+  for (const locale of locales ?? []) {
+    if (seen.has(locale)) {
+      redundant.push(locale);
+      continue;
+    }
+    seen.add(locale);
+    targets.push(locale);
+  }
+
+  return { targets, redundant };
+}

--- a/packages/sanity/src/utils/locales.ts
+++ b/packages/sanity/src/utils/locales.ts
@@ -1,5 +1,5 @@
 /**
- * `locales` is the list of translation *targets*. Configs often repeat the
+ * `locales` is the list of translation *targets*, but configs often repeat the
  * source locale there — spreading `gt.config.json`, which pairs `defaultLocale`
  * with a `locales` array, is the common way to end up with it.
  *
@@ -10,29 +10,11 @@
  * rewrites the array, re-renders, and re-flags the same mismatch forever, which
  * crashes the Studio with "Maximum update depth exceeded".
  */
-export type ResolvedTargetLocales = {
-  /** Deduplicated targets, with the source locale removed. */
-  targets: string[];
-  /** Entries dropped from the input, in the order they appeared. */
-  redundant: string[];
-};
-
 export function resolveTargetLocales(
   sourceLocale: string,
   locales: string[] | undefined
-): ResolvedTargetLocales {
-  const seen = new Set<string>([sourceLocale]);
-  const targets: string[] = [];
-  const redundant: string[] = [];
-
-  for (const locale of locales ?? []) {
-    if (seen.has(locale)) {
-      redundant.push(locale);
-      continue;
-    }
-    seen.add(locale);
-    targets.push(locale);
-  }
-
-  return { targets, redundant };
+): string[] {
+  return Array.from(new Set(locales)).filter(
+    (locale) => locale !== sourceLocale
+  );
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a Sanity Studio crash caused by duplicate entries in `supportedLanguages` when users spread `gt.config.json` directly into `gtPlugin`, which puts the source locale in both `sourceLocale` and `locales`. The new `resolveTargetLocales` utility strips the source locale and deduplicates targets before any downstream plugin sees them.

- **`packages/sanity/src/utils/locales.ts`**: New `resolveTargetLocales` function that builds a deduplicated target list and returns any dropped entries so callers can warn on them.
- **`packages/sanity/src/index.ts`**: Calls `resolveTargetLocales` immediately after resolving the source locale; all three downstream consumers (`pluginConfig.init`, `allLocales`/`supportedLanguages`, `buildInternationalizedArrayPlugin`) now receive the cleaned `targetLocales` list.
- **`packages/sanity/src/utils/__tests__/locales.test.ts`**: Five test cases covering the clean-list, source-in-locales, duplicate-target, complex-mix, and empty/undefined scenarios.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the deduplication logic is straightforward, all three downstream call sites are updated, and the test suite covers the main scenarios including the exact spread-gt.config.json pattern that caused the crash.

The change is small and well-contained: a single pure utility function, three call-site updates that are easy to verify visually, and a test file that exercises clean, source-included, duplicate-target, and empty inputs. No existing tests are modified, and the warning path gracefully handles the zero-redundant case before touching console.warn.

**Files Needing Attention:** No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/sanity/src/utils/locales.ts | New utility that deduplicates locales and strips the source locale from the target list; logic is correct and well-documented. |
| packages/sanity/src/utils/__tests__/locales.test.ts | New test file covering clean list, source-in-locales, duplicate targets, complex mix, and empty/undefined inputs — good coverage of the happy and edge-case paths. |
| packages/sanity/src/index.ts | All three downstream consumers (pluginConfig.init, allLocales, buildInternationalizedArrayPlugin) correctly switched from raw locales to targetLocales; no stale usages remain. |
| .changeset/sanity-dedupe-supported-languages.md | Changeset correctly categorises this as a patch and accurately describes the root cause, the crash symptom, and the fix. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["gtPlugin({ sourceLocale, locales, ... })"] --> B["Resolve sourceLocale\n(explicit > defaultLocale > libraryDefault)"]
    B --> C["resolveTargetLocales(resolvedSourceLocale, locales)"]
    C --> D{For each locale in locales}
    D -->|"already in seen set\n(source or duplicate)"| E["redundant[]"]
    D -->|"new"| F["targets[] + seen.add()"]
    E --> G["warnOnRedundantLocales()\n→ console.warn"]
    F --> H["targetLocales"]
    H --> I["pluginConfig.init(... targetLocales ...)"]
    H --> J["allLocales = [source, ...targetLocales]\n→ documentInternationalization(supportedLanguages)"]
    H --> K["buildInternationalizedArrayPlugin(... targetLocales ...)"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: dedupe locales"](https://github.com/generaltranslation/gt/commit/72ed35e2b520a4ea731c5fe6b5e1ecde66795b6e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48515824)</sub>

<!-- /greptile_comment -->