### PR TITLE
fix(ci): replace deprecated R2 uploader

### DIFF
--- a/.github/actions/r2-upload/action.yml
+++ b/.github/actions/r2-upload/action.yml
@@ -1,0 +1,66 @@
+name: Upload directory to R2
+description: Upload a directory to Cloudflare R2 with the AWS CLI
+
+inputs:
+  r2-account-id:
+    description: Cloudflare account ID
+    required: true
+  r2-access-key-id:
+    description: R2 access key ID
+    required: true
+  r2-secret-access-key:
+    description: R2 secret access key
+    required: true
+  r2-bucket:
+    description: R2 bucket name
+    required: true
+  source-dir:
+    description: Local directory whose contents should be uploaded
+    required: true
+  destination-dir:
+    description: Destination prefix in the R2 bucket
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Upload files
+      shell: bash
+      env:
+        AWS_ACCESS_KEY_ID: ${{ inputs.r2-access-key-id }}
+        AWS_SECRET_ACCESS_KEY: ${{ inputs.r2-secret-access-key }}
+        AWS_REGION: auto
+        AWS_REQUEST_CHECKSUM_CALCULATION: when_required
+        AWS_RETRY_MODE: standard
+        AWS_MAX_ATTEMPTS: '5'
+        R2_ACCOUNT_ID: ${{ inputs.r2-account-id }}
+        R2_BUCKET: ${{ inputs.r2-bucket }}
+        SOURCE_DIR: ${{ inputs.source-dir }}
+        DESTINATION_DIR: ${{ inputs.destination-dir }}
+      run: |
+        set -euo pipefail
+
+        if ! command -v aws >/dev/null; then
+          echo 'The AWS CLI is required to upload files to R2.' >&2
+          exit 1
+        fi
+
+        if [[ ! -d "$SOURCE_DIR" ]]; then
+          echo "R2 upload source directory does not exist: $SOURCE_DIR" >&2
+          exit 1
+        fi
+
+        destination="${DESTINATION_DIR#/}"
+        destination="${destination%/}"
+        if [[ -n "$destination" && "$destination" != '.' ]]; then
+          target="s3://${R2_BUCKET}/${destination}/"
+        else
+          target="s3://${R2_BUCKET}/"
+        fi
+
+        aws --version
+        aws s3 cp "$SOURCE_DIR" "$target" \
+          --recursive \
+          --endpoint-url "https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com" \
+          --no-progress

--- a/.github/workflows/asset-upload.yml
+++ b/.github/workflows/asset-upload.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
 
-      - uses: ryand56/r2-upload-action@v1.4
+      - uses: ./.github/actions/r2-upload
         with:
           r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
           r2-access-key-id: ${{ secrets.R2_ACCESS_KEY_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,7 +160,7 @@ jobs:
 
       - name: Upload gt binaries to R2
         if: steps.check-gt.outputs.should_release_bin == 'true'
-        uses: ryand56/r2-upload-action@v1.4
+        uses: ./.github/actions/r2-upload
         with:
           r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
           r2-access-key-id: ${{ secrets.R2_ACCESS_KEY_ID }}
@@ -171,7 +171,7 @@ jobs:
 
       - name: Upload gt binaries to R2 (latest)
         if: steps.check-gt.outputs.should_release_bin == 'true'
-        uses: ryand56/r2-upload-action@v1.4
+        uses: ./.github/actions/r2-upload
         with:
           r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
           r2-access-key-id: ${{ secrets.R2_ACCESS_KEY_ID }}
@@ -253,7 +253,7 @@ jobs:
 
       - name: Upload gtx-cli binaries to R2
         if: steps.check-gtx-cli.outputs.should_release_bin == 'true'
-        uses: ryand56/r2-upload-action@v1.4
+        uses: ./.github/actions/r2-upload
         with:
           r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
           r2-access-key-id: ${{ secrets.R2_ACCESS_KEY_ID }}
@@ -264,7 +264,7 @@ jobs:
 
       - name: Upload gtx-cli binaries to R2 (latest)
         if: steps.check-gtx-cli.outputs.should_release_bin == 'true'
-        uses: ryand56/r2-upload-action@v1.4
+        uses: ./.github/actions/r2-upload
         with:
           r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
           r2-access-key-id: ${{ secrets.R2_ACCESS_KEY_ID }}


### PR DESCRIPTION
## Summary

- replace the stale Node 20 R2 upload action with a repository-local AWS CLI uploader
- use standard retries and automatic multipart transfers for CLI binaries while preserving provider errors in failed logs
- share the uploader across versioned, latest, and static asset uploads

## Testing

- `pnpm exec oxfmt --check .github/actions/r2-upload/action.yml .github/workflows/asset-upload.yml .github/workflows/release.yml` — passed
- YAML parsing and embedded Bash syntax checks — passed
- mocked bucket-root and versioned-prefix upload target checks — passed
- `actionlint .github/workflows/asset-upload.yml .github/workflows/release.yml` — passed with actionlint v1.7.12

## Notes

- Changeset: not required for CI-only changes.
- A live upload was not run locally because R2 credentials are restricted to the release environment.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the third-party `ryand56/r2-upload-action@v1.4` with a repository-local composite action that drives the AWS CLI directly, gaining standard retry logic and automatic multipart support for large binary uploads.

- **New composite action** (`.github/actions/r2-upload/action.yml`): accepts six inputs, validates prerequisites (AWS CLI present, source directory exists), normalises the `destination-dir` input to handle empty, `./`, and bare-path forms, then runs `aws s3 cp --recursive` with credentials supplied via environment variables and retry config via `AWS_RETRY_MODE=standard` / `AWS_MAX_ATTEMPTS=5`.
- **`release.yml`** and **`asset-upload.yml`**: four upload steps and one asset-upload step are updated to `uses: ./.github/actions/r2-upload` with identical input mappings to the old action; no other workflow logic is changed.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the local composite action is a clean, self-contained replacement with no behavioural regressions relative to the removed third-party action.

The action handles all destination-dir edge cases correctly, credentials are never interpolated directly into the shell command, and retry/checksum settings are appropriate for Cloudflare R2. The one gap is that `aws s3 cp --recursive` cannot delete objects, so the `latest` prefix will accumulate binaries from any platforms that are later dropped.

**Files Needing Attention:** .github/actions/r2-upload/action.yml — worth a second look on the `aws s3 cp` vs `aws s3 sync --delete` choice for the `latest` destination prefix.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/actions/r2-upload/action.yml | New composite action replacing ryand56/r2-upload-action; correctly handles destination-dir edge cases (empty, "./", root); credentials passed via env vars; retry config set via AWS_ env vars; minor: `latest` uploads won't purge removed-platform binaries since `aws s3 cp` lacks --delete. |
| .github/workflows/asset-upload.yml | Swaps third-party action for local composite; passes destination-dir as "./" which the action correctly normalises to bucket root; all required inputs supplied. |
| .github/workflows/release.yml | Four upload steps updated to use the local action; versioned and latest destination paths are unchanged; all required inputs (account-id, key, secret, bucket, source-dir, destination-dir) provided consistently. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0A.github%2Factions%2Fr2-upload%2Faction.yml%3A63-66%0A**%60latest%60%20prefix%20retains%20removed-platform%20binaries**%0A%0A%60aws%20s3%20cp%20--recursive%60%20only%20adds%2Foverwrites%20objects%3B%20it%20has%20no%20%60--delete%60%20equivalent%20%28that%20flag%20belongs%20to%20%60aws%20s3%20sync%60%29.%20If%20a%20future%20release%20drops%20support%20for%20a%20platform%2C%20the%20stale%20binary%20will%20remain%20in%20the%20%60cli%2Flatest%60%20and%20%60gtx-cli%2Flatest%60%20prefixes%20indefinitely.%20Using%20%60aws%20s3%20sync%20--delete%60%20for%20the%20%60latest%60%20destination%20uploads%20%28not%20the%20versioned%20ones%29%20would%20keep%20that%20prefix%20clean%20and%20exactly%20matching%20the%20current%20release.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=generaltranslation%2Fgt&pr=2009&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fci%2Ffix-r2-uploads%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fci%2Ffix-r2-uploads%22.%0A%0A%23%23%23%20Issue%201%0A.github%2Factions%2Fr2-upload%2Faction.yml%3A63-66%0A**%60latest%60%20prefix%20retains%20removed-platform%20binaries**%0A%0A%60aws%20s3%20cp%20--recursive%60%20only%20adds%2Foverwrites%20objects%3B%20it%20has%20no%20%60--delete%60%20equivalent%20%28that%20flag%20belongs%20to%20%60aws%20s3%20sync%60%29.%20If%20a%20future%20release%20drops%20support%20for%20a%20platform%2C%20the%20stale%20binary%20will%20remain%20in%20the%20%60cli%2Flatest%60%20and%20%60gtx-cli%2Flatest%60%20prefixes%20indefinitely.%20Using%20%60aws%20s3%20sync%20--delete%60%20for%20the%20%60latest%60%20destination%20uploads%20%28not%20the%20versioned%20ones%29%20would%20keep%20that%20prefix%20clean%20and%20exactly%20matching%20the%20current%20release.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=generaltranslation%2Fgt&pr=2009&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/actions/r2-upload/action.yml:63-66
**`latest` prefix retains removed-platform binaries**

`aws s3 cp --recursive` only adds/overwrites objects; it has no `--delete` equivalent (that flag belongs to `aws s3 sync`). If a future release drops support for a platform, the stale binary will remain in the `cli/latest` and `gtx-cli/latest` prefixes indefinitely. Using `aws s3 sync --delete` for the `latest` destination uploads (not the versioned ones) would keep that prefix clean and exactly matching the current release.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): replace deprecated R2 uploader"](https://github.com/generaltranslation/gt/commit/1cebe3512e003408f6145782e8e662231d1d564f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48874877)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->