### PR TITLE
fix(tanstack-start): export middleware to browser builds

### DIFF
--- a/.changeset/fuzzy-cats-start.md
+++ b/.changeset/fuzzy-cats-start.md
@@ -1,0 +1,5 @@
+---
+'gt-tanstack-start': patch
+---
+
+Export `gtMiddleware` from the browser condition so TanStack Start client builds can evaluate application setup files that register it.

--- a/packages/tanstack-start/src/__tests__/packageExports.test.ts
+++ b/packages/tanstack-start/src/__tests__/packageExports.test.ts
@@ -95,10 +95,11 @@ describe('gt-tanstack-start package exports', () => {
       '-e',
       `
         import assert from 'node:assert/strict';
-        import { getGT, getLocale, initializeGT } from 'gt-tanstack-start';
+        import { getGT, getLocale, gtMiddleware, initializeGT } from 'gt-tanstack-start';
 
         assert.equal(typeof getGT, 'function');
         assert.equal(typeof getLocale, 'function');
+        assert.equal(typeof gtMiddleware, 'object');
         assert.equal(typeof initializeGT, 'function');
       `,
     ]);

--- a/packages/tanstack-start/src/index.client.ts
+++ b/packages/tanstack-start/src/index.client.ts
@@ -1,3 +1,2 @@
 export * from './index.shared';
-export { gtMiddleware } from './middleware/gtMiddleware';
 export { initializeGT } from './setup/initializeGT.client';

--- a/packages/tanstack-start/src/index.client.ts
+++ b/packages/tanstack-start/src/index.client.ts
@@ -1,2 +1,3 @@
 export * from './index.shared';
+export { gtMiddleware } from './middleware/gtMiddleware';
 export { initializeGT } from './setup/initializeGT.client';

--- a/packages/tanstack-start/src/index.server.ts
+++ b/packages/tanstack-start/src/index.server.ts
@@ -1,3 +1,2 @@
 export * from './index.shared';
-export { gtMiddleware } from './middleware/gtMiddleware';
 export { initializeGT } from './setup/initializeGT.server';

--- a/packages/tanstack-start/src/index.shared.ts
+++ b/packages/tanstack-start/src/index.shared.ts
@@ -1,4 +1,5 @@
 export { parseLocale } from './functions/parseLocale';
+export { gtMiddleware } from './middleware/gtMiddleware';
 export type { InitializeGTParams } from './types/InitializeGTParams';
 export {
   getLocale,

--- a/tests/apps/tanstack-start/src/start.ts
+++ b/tests/apps/tanstack-start/src/start.ts
@@ -1,5 +1,5 @@
 import { createCsrfMiddleware, createStart } from '@tanstack/react-start';
-import { gtMiddleware } from 'gt-tanstack-start/server';
+import { gtMiddleware } from 'gt-tanstack-start';
 
 const csrfMiddleware = createCsrfMiddleware({
   filter: ({ handlerType }) => handlerType === 'serverFn',


### PR DESCRIPTION
## Summary

- export `gtMiddleware` from the browser-conditioned main entry so TanStack Start client builds can evaluate setup files that import it from `gt-tanstack-start`
- cover the browser named export and move the TanStack Start test app off the deprecated `/server` workaround

## Testing

- `pnpm --filter gt-tanstack-start... build` — passed
- `pnpm --filter gt-tanstack-start test` — passed (35 tests)
- `pnpm --filter gt-tanstack-start typecheck` — passed
- `pnpm exec oxlint packages/tanstack-start` — passed
- `pnpm --filter gt-test-tanstack-start build` — passed (client and SSR builds)
- `pnpm --filter gt-test-tanstack-start typecheck` — passed
- `pnpm --filter gt-test-tanstack-start lint` — passed
- `pnpm exec oxfmt --check packages/tanstack-start/src/index.client.ts packages/tanstack-start/src/__tests__/packageExports.test.ts tests/apps/tanstack-start/src/start.ts` — passed

## Notes

- Changeset: added a patch release for `gt-tanstack-start`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a client-build failure in `gt-tanstack-start` by moving the `gtMiddleware` export from `index.server.ts` into the shared module (`index.shared.ts`), which is re-exported by both the server and browser entrypoints. A new test assertion verifies the export works under the `--conditions=browser` flag, and the test app is migrated off the deprecated `/server` sub-path import.

- **`index.shared.ts`**: `gtMiddleware` is added here (and removed from `index.server.ts`'s direct re-export), making it available in both `index.server.mjs` and `index.client.mjs` without duplication.
- **Test coverage**: The existing browser-conditions test is extended with an `import` + `typeof` assertion for `gtMiddleware`, confirming it evaluates correctly in browser builds.
- **Test app**: `start.ts` now imports `gtMiddleware` from `gt-tanstack-start` (the canonical entry) instead of the deprecated `gt-tanstack-start/server` sub-path.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a targeted export reorganization with no behavioural changes and full build + test coverage confirmed in the PR.

Moving `gtMiddleware` from `index.server.ts` to `index.shared.ts` is a purely additive re-export change. The server bundle is unaffected because `index.server.ts` already does `export * from './index.shared'`. The browser bundle now correctly exposes the middleware for TanStack Start client builds to register it. The new test assertion under `--conditions=browser` confirms the export shape, and the test-app migration to the canonical entry removes a deprecated import path. No logic changes, no removed APIs.

**Files Needing Attention:** No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/tanstack-start/src/index.shared.ts | Adds gtMiddleware re-export so it flows into both the server and browser (client) entrypoints via `export *` |
| packages/tanstack-start/src/index.server.ts | Removes the now-redundant direct gtMiddleware export; it is still re-exported via `export * from './index.shared'` |
| packages/tanstack-start/src/__tests__/packageExports.test.ts | Extends the browser-conditioned entrypoint test to assert gtMiddleware is importable and is an object under `--conditions=browser` |
| tests/apps/tanstack-start/src/start.ts | Migrates gtMiddleware import from deprecated `gt-tanstack-start/server` to the canonical `gt-tanstack-start` entrypoint |
| .changeset/fuzzy-cats-start.md | Patch release changeset for gt-tanstack-start describing the browser export fix |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    shared["index.shared.ts\n+ gtMiddleware\n+ parseLocale\n+ getLocale / getGT / …"]
    server["index.server.ts\nexport * from shared\n+ initializeGT (server)"]
    client["index.client.ts\nexport * from shared\n+ initializeGT (client)"]
    legacyServer["server.ts (deprecated /server)\ngtMiddleware (re-export)"]
    middleware["middleware/gtMiddleware.ts\ncreateMiddleware().server(…)"]

    middleware --> shared
    shared --> server
    shared --> client
    middleware --> legacyServer

    server -->|"browser condition\nindex.client.mjs"| browserBundle["Browser Bundle\ngtMiddleware ✓"]
    server -->|"default / workerd / worker\nindex.server.mjs"| serverBundle["Server Bundle\ngtMiddleware ✓"]
    legacyServer --> deprecatedBundle["server.mjs (deprecated)"]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["refactor(tanstack-start): share middlewa..."](https://github.com/generaltranslation/gt/commit/696ba187c875bb62c0ef84e852b5d4df98e1a47e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48877044)</sub>

<!-- /greptile_comment -->