### PR TITLE
test(vue): add Vite integration example

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -30,6 +30,7 @@
     "vite-create-app",
     "rollup-spa",
     "vite-spa",
+    "vite-vue",
     "webpack-spa",
     "cli-test-app",
     "compiler-cli-parity",

--- a/examples/vite-vue/README.md
+++ b/examples/vite-vue/README.md
@@ -39,10 +39,11 @@ pnpm --filter vite-vue generate
 pnpm --filter vite-vue validate
 ```
 
-The app demonstrates `<T>`, child-only `<Var>`, `<Num>`, `<DateTime>`,
-`<Currency>`, `<Plural>`, `<Branch>`, `useGT()`, `msg()` with `useMessages()`,
-and reactive `useLocale()` / `useSetLocale()` locale switching. Plain string
-lookups accept only `$context`; braces are intentionally left uninterpolated.
+The app demonstrates `<T>`, child-only `<Var>`, typed `value` bindings for
+`<Num>`, `<DateTime>`, and `<Currency>`, plus `<Plural>`, `<Branch>`, `useGT()`,
+`msg()` with `useMessages()`, and reactive `useLocale()` / `useSetLocale()`
+locale switching. Plain string lookups accept only `$context`; braces are
+intentionally left uninterpolated.
 
 ## Production Build
 

--- a/examples/vite-vue/README.md
+++ b/examples/vite-vue/README.md
@@ -1,0 +1,52 @@
+<p align="center">
+  <a href="https://generaltranslation.com" target="_blank">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://generaltranslation.com/brand/gt-logo-dark.svg">
+      <img src="https://generaltranslation.com/brand/gt-logo-light.svg" alt="General Translation" width="100" height="100">
+    </picture>
+  </a>
+</p>
+
+# gt-vue + Vite Example
+
+A production Vite app showing the complete lightweight `gt-vue` API. It uses
+Vue's standard Vite plugin only: there is no GT compiler plugin, server, or
+development hot-reload integration.
+
+## Quick Start
+
+From the monorepo root:
+
+```bash
+pnpm install
+pnpm --filter vite-vue dev
+```
+
+Switch between English and French in the app. The French JSON catalog is loaded
+asynchronously on first use and then cached by `gt-vue`.
+
+## Translation Workflow
+
+The package's `generate` script runs the workspace `gt` CLI. It extracts Vue
+single-file components and writes the hash-keyed source catalog while preserving
+the matching keys in the French catalog.
+
+```bash
+pnpm --filter vite-vue generate
+pnpm --filter vite-vue validate
+```
+
+The app demonstrates `<T>`, child-only `<Var>`, `<Num>`, `<DateTime>`,
+`<Currency>`, `<Plural>`, `<Branch>`, `useGT()`, `msg()` with `useMessages()`,
+and reactive `useLocale()` / `useSetLocale()` locale switching. Plain string
+lookups accept only `$context`; braces are intentionally left uninterpolated.
+
+## Production Build
+
+```bash
+pnpm --filter vite-vue build
+pnpm --filter vite-vue preview
+```
+
+Vite emits a static client bundle. Hosting is bring-your-own: serve the `dist/`
+directory from any static host.

--- a/examples/vite-vue/README.md
+++ b/examples/vite-vue/README.md
@@ -10,8 +10,8 @@
 # gt-vue + Vite Example
 
 A production Vite app showing the complete lightweight `gt-vue` API. It uses
-Vue's standard Vite plugin only: there is no GT compiler plugin, server, or
-development hot-reload integration.
+Vue's standard SFC and JSX Vite plugins: there is no GT compiler plugin, server,
+or development hot-reload integration.
 
 ## Quick Start
 
@@ -44,6 +44,11 @@ The app demonstrates `<T>`, child-only `<Var>`, typed `value` bindings for
 `msg()` with `useMessages()`, and reactive `useLocale()` / `useSetLocale()`
 locale switching. Plain string lookups accept only `$context`; braces are
 intentionally left uninterpolated.
+
+`TsxCompatibilityCard.tsx` also exercises Vue TSX with `<GT.T>`, a `<T>` and
+`Vue.Fragment` imported through a local ESM barrel, and a translator passed to
+an imported helper. The same catalog therefore release-gates both SFC and TSX
+extraction against the linked runtime.
 
 ## Production Build
 

--- a/examples/vite-vue/README.md
+++ b/examples/vite-vue/README.md
@@ -22,6 +22,9 @@ pnpm install
 pnpm --filter vite-vue dev
 ```
 
+The `predev` script builds `gt-vue` and its linked workspace dependencies before
+Vite starts, so the example also works from a fresh monorepo checkout.
+
 Switch between English and French in the app. The French JSON catalog is loaded
 asynchronously on first use and then cached by `gt-vue`.
 

--- a/examples/vite-vue/README.md
+++ b/examples/vite-vue/README.md
@@ -22,8 +22,8 @@ pnpm install
 pnpm --filter vite-vue dev
 ```
 
-The `predev` script builds `gt-vue` and its linked workspace dependencies before
-Vite starts, so the example also works from a fresh monorepo checkout.
+Lifecycle scripts build the linked GT runtime and CLI dependencies needed by
+each command, so the example also works from a fresh monorepo checkout.
 
 Switch between English and French in the app. The French JSON catalog is loaded
 asynchronously on first use and then cached by `gt-vue`.

--- a/examples/vite-vue/gt.config.json
+++ b/examples/vite-vue/gt.config.json
@@ -1,0 +1,9 @@
+{
+  "defaultLocale": "en",
+  "locales": ["fr"],
+  "files": {
+    "gt": {
+      "output": "src/_gt/[locale].json"
+    }
+  }
+}

--- a/examples/vite-vue/index.html
+++ b/examples/vite-vue/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="A lightweight gt-vue internationalization example built with Vite."
+    />
+    <link
+      rel="icon"
+      href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 64 64%22><rect width=%2264%22 height=%2264%22 rx=%2216%22 fill=%22%23116841%22/><text x=%2232%22 y=%2241%22 text-anchor=%22middle%22 font-size=%2230%22 fill=%22white%22>GT</text></svg>"
+    />
+    <title>gt-vue + Vite</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/examples/vite-vue/package.json
+++ b/examples/vite-vue/package.json
@@ -11,6 +11,7 @@
     "generate": "gt generate && oxfmt src/_gt/*.json",
     "prevalidate": "pnpm exec turbo run build --filter=gt",
     "validate": "gt validate",
+    "pretypecheck": "pnpm exec turbo run build --filter=gt-vue",
     "typecheck": "vue-tsc -b",
     "prebuild": "pnpm exec turbo run build --filter=gt-vue",
     "build": "pnpm generate && vue-tsc -b && vite build",

--- a/examples/vite-vue/package.json
+++ b/examples/vite-vue/package.json
@@ -5,11 +5,14 @@
   "packageManager": "pnpm@10.20.0",
   "type": "module",
   "scripts": {
-    "predev": "pnpm --filter gt-vue... build",
+    "predev": "pnpm exec turbo run build --filter=gt-vue",
     "dev": "vite",
+    "pregenerate": "pnpm exec turbo run build --filter=gt",
     "generate": "gt generate && oxfmt src/_gt/*.json",
+    "prevalidate": "pnpm exec turbo run build --filter=gt",
     "validate": "gt validate",
     "typecheck": "vue-tsc -b",
+    "prebuild": "pnpm exec turbo run build --filter=gt-vue",
     "build": "pnpm generate && vue-tsc -b && vite build",
     "preview": "vite preview"
   },

--- a/examples/vite-vue/package.json
+++ b/examples/vite-vue/package.json
@@ -5,6 +5,7 @@
   "packageManager": "pnpm@10.20.0",
   "type": "module",
   "scripts": {
+    "predev": "pnpm --filter gt-vue... build",
     "dev": "vite",
     "generate": "gt generate && oxfmt src/_gt/*.json",
     "validate": "gt validate",

--- a/examples/vite-vue/package.json
+++ b/examples/vite-vue/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "@types/node": "catalog:",
     "@vitejs/plugin-vue": "^6.0.3",
+    "@vitejs/plugin-vue-jsx": "5.0.0",
     "gt": "workspace:*",
     "oxfmt": "catalog:",
     "typescript": "catalog:",

--- a/examples/vite-vue/package.json
+++ b/examples/vite-vue/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "vite-vue",
+  "private": true,
+  "version": "0.0.0",
+  "packageManager": "pnpm@10.20.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "generate": "gt generate && oxfmt src/_gt/*.json",
+    "validate": "gt validate",
+    "typecheck": "vue-tsc -b",
+    "build": "pnpm generate && vue-tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "gt-vue": "workspace:*",
+    "vue": "^3.5.0"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "@vitejs/plugin-vue": "^6.0.3",
+    "gt": "workspace:*",
+    "oxfmt": "catalog:",
+    "typescript": "catalog:",
+    "vite": "^7.0.5",
+    "vue-tsc": "~3.2.0"
+  }
+}

--- a/examples/vite-vue/src/App.vue
+++ b/examples/vite-vue/src/App.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, watch } from 'vue';
+import { TsxCompatibilityCard } from './components/TsxCompatibilityCard';
 import {
   Branch,
   Currency,
@@ -184,6 +185,8 @@ async function selectLocale(nextLocale: string) {
           }}
         </p>
       </article>
+
+      <TsxCompatibilityCard />
     </section>
   </main>
 </template>

--- a/examples/vite-vue/src/App.vue
+++ b/examples/vite-vue/src/App.vue
@@ -1,0 +1,190 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue';
+import {
+  Branch,
+  Currency,
+  DateTime,
+  Num,
+  Plural,
+  T,
+  Var,
+  msg,
+  useGT,
+  useLocale,
+  useMessages,
+  useSetLocale,
+} from 'gt-vue';
+
+const gt = useGT();
+const m = useMessages();
+const locale = useLocale();
+const setLocale = useSetLocale();
+
+const name = 'Ada';
+const itemCount = ref(2);
+const tone = ref<'formal' | 'casual'>('formal');
+const changingLocale = ref(false);
+const launchDate = new Date('2026-06-18T12:00:00.000Z');
+const projectBudget = 1299.5;
+const savedMessage = msg('Your preferences are saved.', {
+  $context: 'status message',
+});
+
+watch(
+  locale,
+  (currentLocale) => {
+    document.documentElement.lang = currentLocale;
+  },
+  { immediate: true }
+);
+
+async function selectLocale(nextLocale: string) {
+  if (nextLocale === locale.value) return;
+  changingLocale.value = true;
+  try {
+    await setLocale(nextLocale);
+  } finally {
+    changingLocale.value = false;
+  }
+}
+</script>
+
+<template>
+  <main>
+    <nav class="language-switcher" aria-label="Language">
+      <span class="language-label">{{ gt('Language') }}</span>
+      <button
+        type="button"
+        :aria-pressed="locale === 'en'"
+        :disabled="changingLocale"
+        @click="selectLocale('en')"
+      >
+        English
+      </button>
+      <button
+        type="button"
+        :aria-pressed="locale === 'fr'"
+        :disabled="changingLocale"
+        @click="selectLocale('fr')"
+      >
+        Français
+      </button>
+    </nav>
+
+    <section class="hero" :aria-busy="changingLocale">
+      <p class="eyebrow">gt-vue + Vite</p>
+      <T context="hero">
+        <h1>
+          Hello,
+          <Var>{{ name }}</Var>
+          !
+        </h1>
+        <p>A small Vue app powered by lightweight translation lookups.</p>
+      </T>
+      <p class="lookup">
+        {{ gt('This sentence comes from useGT().', { $context: 'demo' }) }}
+      </p>
+      <p class="status" role="status">{{ m(savedMessage) }}</p>
+    </section>
+
+    <section class="demo-grid" aria-label="Translation examples">
+      <article>
+        <h2>{{ gt('Plural and number') }}</h2>
+        <T context="item count">
+          <Plural :n="itemCount">
+            <template #one>You have one item.</template>
+            <template #other>
+              You have
+              <Num>{{ itemCount }}</Num>
+              items.
+            </template>
+            You have no items.
+          </Plural>
+        </T>
+        <div class="controls">
+          <button
+            type="button"
+            :aria-label="gt('Remove one item')"
+            :disabled="itemCount === 0"
+            @click="itemCount--"
+          >
+            −
+          </button>
+          <output :aria-label="gt('Item count')">{{ itemCount }}</output>
+          <button
+            type="button"
+            :aria-label="gt('Add one item')"
+            @click="itemCount++"
+          >
+            +
+          </button>
+        </div>
+      </article>
+
+      <article>
+        <h2>{{ gt('Branch selection') }}</h2>
+        <T context="welcome tone">
+          <Branch :branch="tone">
+            <template #formal>It is a pleasure to welcome you.</template>
+            <template #casual>Great to see you!</template>
+            Welcome.
+          </Branch>
+        </T>
+        <div class="controls segmented">
+          <button
+            type="button"
+            :aria-pressed="tone === 'formal'"
+            @click="tone = 'formal'"
+          >
+            {{ gt('Formal') }}
+          </button>
+          <button
+            type="button"
+            :aria-pressed="tone === 'casual'"
+            @click="tone = 'casual'"
+          >
+            {{ gt('Casual') }}
+          </button>
+        </div>
+      </article>
+
+      <article>
+        <h2>{{ gt('Locale-aware values') }}</h2>
+        <dl>
+          <div>
+            <dt>{{ gt('Budget') }}</dt>
+            <dd>
+              <Currency currency="EUR">{{ projectBudget }}</Currency>
+            </dd>
+          </div>
+          <div>
+            <dt>{{ gt('Launch date') }}</dt>
+            <dd>
+              <DateTime
+                :options="{
+                  day: 'numeric',
+                  month: 'long',
+                  timeZone: 'UTC',
+                  year: 'numeric',
+                }"
+              >
+                {{ launchDate }}
+              </DateTime>
+            </dd>
+          </div>
+        </dl>
+      </article>
+
+      <article>
+        <h2>{{ gt('Plain strings stay plain') }}</h2>
+        <p>
+          {{
+            gt('Braces are literal: {name}', {
+              $context: 'literal braces example',
+            })
+          }}
+        </p>
+      </article>
+    </section>
+  </main>
+</template>

--- a/examples/vite-vue/src/App.vue
+++ b/examples/vite-vue/src/App.vue
@@ -95,7 +95,7 @@ async function selectLocale(nextLocale: string) {
             <template #one>You have one item.</template>
             <template #other>
               You have
-              <Num>{{ itemCount }}</Num>
+              <Num :value="itemCount" />
               items.
             </template>
             You have no items.
@@ -154,22 +154,21 @@ async function selectLocale(nextLocale: string) {
           <div>
             <dt>{{ gt('Budget') }}</dt>
             <dd>
-              <Currency currency="EUR">{{ projectBudget }}</Currency>
+              <Currency :value="projectBudget" currency="EUR" />
             </dd>
           </div>
           <div>
             <dt>{{ gt('Launch date') }}</dt>
             <dd>
               <DateTime
+                :value="launchDate"
                 :options="{
                   day: 'numeric',
                   month: 'long',
                   timeZone: 'UTC',
                   year: 'numeric',
                 }"
-              >
-                {{ launchDate }}
-              </DateTime>
+              />
             </dd>
           </div>
         </dl>

--- a/examples/vite-vue/src/_gt/en.json
+++ b/examples/vite-vue/src/_gt/en.json
@@ -65,5 +65,16 @@
   "9ed7179a22363eaf": "Budget",
   "d88372c9c1e9e4f5": "Launch date",
   "0d013c8f6ffd22a8": "Plain strings stay plain",
-  "5fb10dc1bf5106d9": "Braces are literal: {name}"
+  "5fb10dc1bf5106d9": "Braces are literal: {name}",
+  "9b8297df593df5ad": {
+    "t": "h2",
+    "i": 1,
+    "c": "Local re-exports work in TSX"
+  },
+  "c7d97d97d0769df7": {
+    "t": "p",
+    "i": 1,
+    "c": "Namespace components work in TSX."
+  },
+  "ac1d0e7941fbc48f": "Translator forwarding works in TSX."
 }

--- a/examples/vite-vue/src/_gt/en.json
+++ b/examples/vite-vue/src/_gt/en.json
@@ -1,0 +1,69 @@
+{
+  "66f5915ccc76af67": "Your preferences are saved.",
+  "d0e4315ff74c2dbd": "Language",
+  "2e0703058b1b24d8": [
+    {
+      "t": "h1",
+      "i": 1,
+      "c": [
+        " Hello, ",
+        {
+          "i": 2,
+          "k": "_gt_value_2",
+          "v": "v"
+        },
+        " ! "
+      ]
+    },
+    {
+      "t": "p",
+      "i": 3,
+      "c": "A small Vue app powered by lightweight translation lookups."
+    }
+  ],
+  "4d1d2cf71724ed0e": "This sentence comes from useGT().",
+  "df7d087dcc38e44a": "Plural and number",
+  "a7dde4d7243f916e": {
+    "t": "Plural",
+    "i": 1,
+    "d": {
+      "b": {
+        "one": "You have one item.",
+        "other": [
+          " You have ",
+          {
+            "i": 2,
+            "k": "_gt_n_2",
+            "v": "n"
+          },
+          " items. "
+        ]
+      },
+      "t": "p"
+    },
+    "c": " You have no items. "
+  },
+  "45fb6ab4ee60997d": "Remove one item",
+  "1caf7a41a09d361f": "Item count",
+  "08bd07d186d6ef9c": "Add one item",
+  "0810b57eb8f7cbb7": "Branch selection",
+  "14e7b0f19c19b16a": {
+    "t": "Branch",
+    "i": 1,
+    "d": {
+      "b": {
+        "formal": "It is a pleasure to welcome you.",
+        "casual": "Great to see you!"
+      },
+      "t": "b"
+    },
+    "c": " Welcome. "
+  },
+  "1bfea8e931bd6c6e": "Formal",
+  "c874c19f8a9f5e49": "Casual",
+  "40bee04f09f65f7d": "Locale-aware values",
+  "9ed7179a22363eaf": "Budget",
+  "d88372c9c1e9e4f5": "Launch date",
+  "0d013c8f6ffd22a8": "Plain strings stay plain",
+  "5fb10dc1bf5106d9": "Braces are literal: {name}"
+}

--- a/examples/vite-vue/src/_gt/fr.json
+++ b/examples/vite-vue/src/_gt/fr.json
@@ -65,5 +65,16 @@
   "9ed7179a22363eaf": "Budget",
   "d88372c9c1e9e4f5": "Date de lancement",
   "0d013c8f6ffd22a8": "Les chaînes simples restent simples",
-  "5fb10dc1bf5106d9": "Les accolades restent littérales : {name}"
+  "5fb10dc1bf5106d9": "Les accolades restent littérales : {name}",
+  "9b8297df593df5ad": {
+    "t": "h2",
+    "i": 1,
+    "c": "Les réexportations locales fonctionnent en TSX"
+  },
+  "c7d97d97d0769df7": {
+    "t": "p",
+    "i": 1,
+    "c": "Les composants avec espace de noms fonctionnent en TSX."
+  },
+  "ac1d0e7941fbc48f": "Le transfert du traducteur fonctionne en TSX."
 }

--- a/examples/vite-vue/src/_gt/fr.json
+++ b/examples/vite-vue/src/_gt/fr.json
@@ -1,0 +1,69 @@
+{
+  "66f5915ccc76af67": "Vos préférences sont enregistrées.",
+  "d0e4315ff74c2dbd": "Langue",
+  "2e0703058b1b24d8": [
+    {
+      "t": "h1",
+      "i": 1,
+      "c": [
+        " Bonjour, ",
+        {
+          "i": 2,
+          "k": "_gt_value_2",
+          "v": "v"
+        },
+        " ! "
+      ]
+    },
+    {
+      "t": "p",
+      "i": 3,
+      "c": "Une petite application Vue fondée sur de simples recherches de traduction."
+    }
+  ],
+  "4d1d2cf71724ed0e": "Cette phrase provient de useGT().",
+  "df7d087dcc38e44a": "Pluriel et nombre",
+  "a7dde4d7243f916e": {
+    "t": "Plural",
+    "i": 1,
+    "d": {
+      "b": {
+        "one": "Vous avez un article.",
+        "other": [
+          " Vous avez ",
+          {
+            "i": 2,
+            "k": "_gt_n_2",
+            "v": "n"
+          },
+          " articles. "
+        ]
+      },
+      "t": "p"
+    },
+    "c": " Vous n’avez aucun article. "
+  },
+  "45fb6ab4ee60997d": "Retirer un article",
+  "1caf7a41a09d361f": "Nombre d’articles",
+  "08bd07d186d6ef9c": "Ajouter un article",
+  "0810b57eb8f7cbb7": "Sélection de branche",
+  "14e7b0f19c19b16a": {
+    "t": "Branch",
+    "i": 1,
+    "d": {
+      "b": {
+        "formal": "Nous avons le plaisir de vous accueillir.",
+        "casual": "Ravi de vous voir !"
+      },
+      "t": "b"
+    },
+    "c": " Bienvenue. "
+  },
+  "1bfea8e931bd6c6e": "Formel",
+  "c874c19f8a9f5e49": "Décontracté",
+  "40bee04f09f65f7d": "Valeurs adaptées à la langue",
+  "9ed7179a22363eaf": "Budget",
+  "d88372c9c1e9e4f5": "Date de lancement",
+  "0d013c8f6ffd22a8": "Les chaînes simples restent simples",
+  "5fb10dc1bf5106d9": "Les accolades restent littérales : {name}"
+}

--- a/examples/vite-vue/src/components/TsxCompatibilityCard.tsx
+++ b/examples/vite-vue/src/components/TsxCompatibilityCard.tsx
@@ -1,0 +1,24 @@
+import { defineComponent } from 'vue';
+import { GT, T, Vue, translateTsxStatus } from '../i18n';
+
+/** Demonstrates the gt-vue forms used by Vue JSX and TSX applications. */
+export const TsxCompatibilityCard = defineComponent({
+  name: 'TsxCompatibilityCard',
+  setup() {
+    const gt = GT.useGT();
+
+    return () => (
+      <article data-testid='tsx-compatibility-card'>
+        <T context='TSX local reexport'>
+          <Vue.Fragment>
+            <h2>Local re-exports work in TSX</h2>
+          </Vue.Fragment>
+        </T>
+        <GT.T context='TSX namespace component'>
+          <p>Namespace components work in TSX.</p>
+        </GT.T>
+        <p data-testid='tsx-forwarded-string'>{translateTsxStatus(gt)}</p>
+      </article>
+    );
+  },
+});

--- a/examples/vite-vue/src/i18n.ts
+++ b/examples/vite-vue/src/i18n.ts
@@ -1,0 +1,12 @@
+import type { GTFunction } from 'gt-vue';
+
+export { T } from 'gt-vue';
+export * as GT from 'gt-vue';
+export * as Vue from 'vue';
+
+/** Translates a static label through a translator supplied by its consumer. */
+export function translateTsxStatus(gt: GTFunction): string {
+  return gt('Translator forwarding works in TSX.', {
+    $context: 'TSX compatibility status',
+  });
+}

--- a/examples/vite-vue/src/main.ts
+++ b/examples/vite-vue/src/main.ts
@@ -1,0 +1,12 @@
+import { createApp } from 'vue';
+import { createGT } from 'gt-vue';
+import App from './App.vue';
+import { loadTranslations } from './translations';
+import './style.css';
+
+const gt = createGT({
+  defaultLocale: 'en',
+  loadTranslations,
+});
+
+createApp(App).use(gt).mount('#app');

--- a/examples/vite-vue/src/style.css
+++ b/examples/vite-vue/src/style.css
@@ -1,0 +1,200 @@
+:root {
+  color: #17221d;
+  background: #f4f8f5;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    sans-serif;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-width: 320px;
+  min-height: 100vh;
+  margin: 0;
+}
+
+button {
+  min-height: 2.5rem;
+  padding: 0.5rem 0.9rem;
+  color: inherit;
+  background: #ffffff;
+  border: 1px solid #bfd0c6;
+  border-radius: 999px;
+  font: inherit;
+  font-weight: 650;
+  cursor: pointer;
+}
+
+button:hover:not(:disabled) {
+  border-color: #18865a;
+}
+
+button:focus-visible {
+  outline: 3px solid #78d7ad;
+  outline-offset: 2px;
+}
+
+button[aria-pressed='true'] {
+  color: #ffffff;
+  background: #116841;
+  border-color: #116841;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+main {
+  width: min(70rem, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 1.5rem 0 4rem;
+}
+
+.language-switcher {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.language-label {
+  margin-right: 0.25rem;
+  color: #52645b;
+  font-size: 0.875rem;
+  font-weight: 700;
+}
+
+.hero {
+  padding: clamp(4rem, 10vw, 7rem) 0;
+  text-align: center;
+}
+
+.hero h1 {
+  max-width: 15ch;
+  margin: 0 auto 1rem;
+  font-size: clamp(2.75rem, 8vw, 5.5rem);
+  line-height: 0.96;
+  letter-spacing: -0.055em;
+}
+
+.hero > p:not(.eyebrow) {
+  max-width: 42rem;
+  margin: 0.6rem auto 0;
+  color: #52645b;
+  font-size: 1.1rem;
+  line-height: 1.6;
+}
+
+.eyebrow {
+  margin: 0 0 1rem;
+  color: #116841;
+  font-size: 0.8rem;
+  font-weight: 800;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.status {
+  min-height: 1.7em;
+}
+
+.demo-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+article {
+  min-height: 13rem;
+  padding: 1.5rem;
+  background: rgba(255, 255, 255, 0.85);
+  border: 1px solid #d8e4dd;
+  border-radius: 1.25rem;
+  box-shadow: 0 1rem 2.5rem rgba(21, 73, 49, 0.06);
+}
+
+h2 {
+  margin: 0 0 1rem;
+  font-size: 1.1rem;
+}
+
+article p {
+  color: #52645b;
+  line-height: 1.55;
+}
+
+.controls {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  margin-top: 1.5rem;
+}
+
+.controls output {
+  min-width: 2rem;
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+}
+
+.segmented button {
+  border-radius: 0.7rem;
+}
+
+dl {
+  display: grid;
+  gap: 0.8rem;
+  margin: 0;
+}
+
+dl div {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  padding-bottom: 0.8rem;
+  border-bottom: 1px solid #e4ece7;
+}
+
+dt {
+  color: #52645b;
+}
+
+dd {
+  margin: 0;
+  font-weight: 750;
+}
+
+@media (max-width: 700px) {
+  .language-label {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  .demo-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  button {
+    transition:
+      background-color 140ms ease,
+      border-color 140ms ease;
+  }
+}

--- a/examples/vite-vue/src/translations.ts
+++ b/examples/vite-vue/src/translations.ts
@@ -1,0 +1,12 @@
+import type { TranslationCatalog } from 'gt-vue';
+
+const catalogs = import.meta.glob<TranslationCatalog>('./_gt/*.json', {
+  import: 'default',
+});
+
+export async function loadTranslations(
+  locale: string
+): Promise<TranslationCatalog> {
+  const loadCatalog = catalogs[`./_gt/${locale}.json`];
+  return loadCatalog ? loadCatalog() : {};
+}

--- a/examples/vite-vue/tsconfig.app.json
+++ b/examples/vite-vue/tsconfig.app.json
@@ -12,10 +12,12 @@
     "moduleDetection": "force",
     "noEmit": true,
     "strict": true,
+    "jsx": "preserve",
+    "jsxImportSource": "vue",
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "types": ["vite/client"]
   },
-  "include": ["src/**/*.ts", "src/**/*.vue"]
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue"]
 }

--- a/examples/vite-vue/tsconfig.app.json
+++ b/examples/vite-vue/tsconfig.app.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.vue"]
+}

--- a/examples/vite-vue/tsconfig.json
+++ b/examples/vite-vue/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ]
+}

--- a/examples/vite-vue/tsconfig.node.json
+++ b/examples/vite-vue/tsconfig.node.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "target": "ES2023",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": ["node"]
+  },
+  "include": ["vite.config.ts"]
+}

--- a/examples/vite-vue/vite.config.ts
+++ b/examples/vite-vue/vite.config.ts
@@ -1,8 +1,9 @@
 import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
+import vueJsx from '@vitejs/plugin-vue-jsx';
 
 export default defineConfig({
-  plugins: [vue()],
+  plugins: [vue(), vueJsx()],
   resolve: {
     // Linked workspace packages must share the app's Vue instance.
     dedupe: ['vue'],

--- a/examples/vite-vue/vite.config.ts
+++ b/examples/vite-vue/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+
+export default defineConfig({
+  plugins: [vue()],
+  resolve: {
+    // Linked workspace packages must share the app's Vue instance.
+    dedupe: ['vue'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -726,6 +726,9 @@ importers:
       '@vitejs/plugin-vue':
         specifier: ^6.0.3
         version: 6.0.8(vite@7.3.1(@types/node@22.13.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.40(typescript@5.9.3))
+      '@vitejs/plugin-vue-jsx':
+        specifier: 5.0.0
+        version: 5.0.0(vite@7.3.1(@types/node@22.13.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.40(typescript@5.9.3))
       gt:
         specifier: workspace:*
         version: link:../../packages/cli

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -711,6 +711,37 @@ importers:
         specifier: ^8.1.1
         version: 8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
 
+  examples/vite-vue:
+    dependencies:
+      gt-vue:
+        specifier: workspace:*
+        version: link:../../packages/vue
+      vue:
+        specifier: ^3.5.0
+        version: 3.5.40(typescript@5.9.3)
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.13.10
+      '@vitejs/plugin-vue':
+        specifier: ^6.0.3
+        version: 6.0.8(vite@7.3.1(@types/node@22.13.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.40(typescript@5.9.3))
+      gt:
+        specifier: workspace:*
+        version: link:../../packages/cli
+      oxfmt:
+        specifier: 'catalog:'
+        version: 0.47.0
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vite:
+        specifier: ^7.0.5
+        version: 7.3.1(@types/node@22.13.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
+      vue-tsc:
+        specifier: ~3.2.0
+        version: 3.2.9(typescript@5.9.3)
+
   examples/webpack-spa:
     dependencies:
       gt:
@@ -9841,6 +9872,13 @@ packages:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0
       vue: ^3.0.0
 
+  '@vitejs/plugin-vue@6.0.8':
+    resolution: {integrity: sha512-0ZjgOg7oO6farnNGup7yvoM/YXZV84OZxHAwtflItNa/6zzQyVb5LNxyea3FEKEX2XlagIKzrlH7wwxkKgtiew==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+      vue: ^3.2.25
+
   '@vitest/coverage-v8@3.2.4':
     resolution: {integrity: sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==}
     peerDependencies:
@@ -9879,6 +9917,15 @@ packages:
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
+  '@volar/language-core@2.4.28':
+    resolution: {integrity: sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==}
+
+  '@volar/source-map@2.4.28':
+    resolution: {integrity: sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==}
+
+  '@volar/typescript@2.4.28':
+    resolution: {integrity: sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==}
+
   '@vscode/sudo-prompt@9.3.2':
     resolution: {integrity: sha512-gcXoCN00METUNFeQOFJ+C9xUI0DKB+0EGMVg7wbVYRHBw2Eq3fKisDZOkRdOz3kqXRKOENMfShPOmypw1/8nOw==}
 
@@ -9909,6 +9956,9 @@ packages:
 
   '@vue/compiler-ssr@3.5.40':
     resolution: {integrity: sha512-rrE5xiXG663+vHCHa3J9p2z5OcBRjXmoqenprJxAFQxg5pSshzeBiCE6pu46axapRJ2Adk0YDA2BRZVjiHXnhg==}
+
+  '@vue/language-core@3.2.9':
+    resolution: {integrity: sha512-ie0ojt/0fU/GfIogh+zgHbaYRPlt9S+cLOxcWwF7nTSFh897BVgnFKL2byT4kpp1mlqYWZ2psGwSniyE2xsxYw==}
 
   '@vue/reactivity@3.5.40':
     resolution: {integrity: sha512-B7ot9UlUZOi1zbq61/LvE88ZLTV8IlajTdiZTAEiDQgrnIMIZoPr9kGw0Zw46ObW62O9+H/Be3kMbfb7kYPQZA==}
@@ -10143,6 +10193,9 @@ packages:
 
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+
+  alien-signals@3.2.1:
+    resolution: {integrity: sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==}
 
   anser@1.4.10:
     resolution: {integrity: sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww==}
@@ -15169,6 +15222,9 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  muggle-string@0.4.1:
+    resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
+
   multicast-dns@7.2.5:
     resolution: {integrity: sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==}
     hasBin: true
@@ -15831,6 +15887,9 @@ packages:
   patch-console@2.0.0:
     resolution: {integrity: sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
   path-exists@3.0.0:
     resolution: {integrity: sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==}
@@ -19374,6 +19433,15 @@ packages:
   void-elements@3.1.0:
     resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
     engines: {node: '>=0.10.0'}
+
+  vscode-uri@3.1.0:
+    resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
+
+  vue-tsc@3.2.9:
+    resolution: {integrity: sha512-qm8/nbo+9eZc1SCndm9wT+gq23pM+wRIdHY0wjm83B3lIginHTwcdrLUyTrKjDWXbMVNjKegNrnymhpdqnCL3A==}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.0.0'
 
   vue@3.5.40:
     resolution: {integrity: sha512-+8PJ4SJXdn/cHGImF4CKdxlWHIN5Dkt7DoufRREM6h6uVCx2m7QxgcEQmmzyOK8A9mcafg7sFbJFYsdFVubTig==}
@@ -28827,6 +28895,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitejs/plugin-vue@6.0.8(vite@7.3.1(@types/node@22.13.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.40(typescript@5.9.3))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.1
+      vite: 7.3.1(@types/node@22.13.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
+      vue: 3.5.40(typescript@5.9.3)
+
   '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@edge-runtime/vm@4.0.4)(@types/debug@4.1.12)(@types/node@24.13.3)(jiti@2.7.0)(jsdom@29.0.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@ampproject/remapping': 2.3.0
@@ -28912,6 +28986,18 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
+  '@volar/language-core@2.4.28':
+    dependencies:
+      '@volar/source-map': 2.4.28
+
+  '@volar/source-map@2.4.28': {}
+
+  '@volar/typescript@2.4.28':
+    dependencies:
+      '@volar/language-core': 2.4.28
+      path-browserify: 1.0.1
+      vscode-uri: 3.1.0
+
   '@vscode/sudo-prompt@9.3.2':
     optional: true
 
@@ -28973,6 +29059,16 @@ snapshots:
     dependencies:
       '@vue/compiler-dom': 3.5.40
       '@vue/shared': 3.5.40
+
+  '@vue/language-core@3.2.9':
+    dependencies:
+      '@volar/language-core': 2.4.28
+      '@vue/compiler-dom': 3.5.40
+      '@vue/shared': 3.5.40
+      alien-signals: 3.2.1
+      muggle-string: 0.4.1
+      path-browserify: 1.0.1
+      picomatch: 4.0.5
 
   '@vue/reactivity@3.5.40':
     dependencies:
@@ -29248,6 +29344,8 @@ snapshots:
       fast-uri: 3.1.0
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
+
+  alien-signals@3.2.1: {}
 
   anser@1.4.10: {}
 
@@ -35883,6 +35981,8 @@ snapshots:
 
   ms@2.1.3: {}
 
+  muggle-string@0.4.1: {}
+
   multicast-dns@7.2.5:
     dependencies:
       dns-packet: 5.6.1
@@ -36650,6 +36750,8 @@ snapshots:
       tslib: 2.8.1
 
   patch-console@2.0.0: {}
+
+  path-browserify@1.0.1: {}
 
   path-exists@3.0.0: {}
 
@@ -41186,6 +41288,14 @@ snapshots:
   vlq@1.0.1: {}
 
   void-elements@3.1.0: {}
+
+  vscode-uri@3.1.0: {}
+
+  vue-tsc@3.2.9(typescript@5.9.3):
+    dependencies:
+      '@volar/typescript': 2.4.28
+      '@vue/language-core': 3.2.9
+      typescript: 5.9.3
 
   vue@3.5.40(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
## Summary

- Add a production Vite + Vue example covering the complete lightweight `gt-vue` surface, including child-only `Var`, typed `value` bindings, and Vue TSX through local re-exports, namespace components, and forwarded translators.
- Demonstrate async English/French catalogs, reactive locale switching, plural/branch state, literal STRING lookups, and the bring-your-own-static-hosting model.
- Use only Vite's standard Vue plugin: no GT compiler plugin, framework server, or development hot-reload integration.

## Testing

- `gt generate` and `gt validate` — passed with exactly 21 entries; regenerated English/French catalogs remained byte-for-byte unchanged
- `vue-tsc -b` and Vite 7.3.1 production build — passed
- Dev and production-preview Chromium loops — passed EN → FR → EN → FR, number/plural and branch updates, localized currency/date values, literal braces, document language, and ARIA states with zero browser warnings/errors
- Lazy loading — French chunk fetched exactly once; no English catalog chunk fetched for the source locale
- Fresh tarball consumers on Vue 3.3.13 and 3.5.40 — all five GT packages resolved from local archives with zero `workspace:` references; packed CLI generate/validate, typecheck, build, and browser loops passed

## Notes

- No changeset: this PR adds only an example and lockfile workspace entry.
- Diff is limited to 14 files under `examples/vite-vue` plus `pnpm-lock.yaml`.
- Stack 3/4. Base: #2013. Next: #2033.
- This PR is not being merged or published yet.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new `examples/vite-vue` workspace that demonstrates the full lightweight `gt-vue` API on top of Vite 7 and Vue 3, using only the standard `@vitejs/plugin-vue` and `@vitejs/plugin-vue-jsx` plugins — no GT compiler, server, or hot-reload integration. The PR description documents comprehensive manual testing (EN ↔ FR loops, lazy loading, typecheck, production build) and confirms `gt generate`/`gt validate` passed with exactly 21 entries.

- **`App.vue`** exercises `<T>`, child-only `<Var>`, `<Plural>`, `<Branch>`, `<Num>`, `<Currency>`, `<DateTime>`, `useGT()`, `msg()`/`useMessages()`, and reactive `useLocale()`/`useSetLocale()` with correct ARIA state management and `document.lang` synchronisation via a watcher.
- **`TsxCompatibilityCard.tsx`** demonstrates three TSX patterns against the same catalog: a locally re-exported `<T>` with `<Vue.Fragment>`, a namespace `<GT.T>`, and a forwarded `GTFunction` helper.
- **`translations.ts`** uses `import.meta.glob` for per-locale lazy-loading; `vite.config.ts` adds `resolve.dedupe: ['vue']` to prevent duplicate Vue instances from linked workspace packages.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR adds only a self-contained example workspace with no changes to library source code, no published packages, and no modifications to shared build infrastructure beyond a one-line changeset ignore entry.
- All changes are confined to a new `examples/vite-vue` directory and a single `pnpm-lock.yaml` update. No library code, shared utilities, or CI pipelines are modified. The example is correctly structured, TypeScript-strict, and the PR author reports full test coverage including typecheck, production build, and browser verification loops.
- No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| examples/vite-vue/src/App.vue | Main SFC demonstrating the complete gt-vue API: T, Var, Plural, Branch, Currency, DateTime, Num, useGT, useMessages, useLocale, useSetLocale, and msg. Locale switching correctly uses try/finally to reset loading state. ARIA states and document.lang are properly managed. |
| examples/vite-vue/src/translations.ts | Uses import.meta.glob for lazy-loaded per-locale JSON chunks. Returns an empty catalog for unknown locales (graceful degradation). Vite will code-split each locale into its own chunk; the French chunk is only fetched on first locale switch. |
| examples/vite-vue/src/components/TsxCompatibilityCard.tsx | Demonstrates three TSX usage patterns: local re-exported T with Vue.Fragment, namespace GT.T component, and a forwarded GTFunction. All patterns exercise the same catalog keys validated by gt generate/validate. |
| examples/vite-vue/src/i18n.ts | Barrel re-exporting gt-vue as both named exports and as a GT namespace, and vue as a Vue namespace, to enable namespace-style component usage in TSX (GT.T, Vue.Fragment). Intentional pattern for the compatibility demo. |
| examples/vite-vue/vite.config.ts | Registers vue and vueJsx plugins. The resolve.dedupe: ['vue'] entry is important and correct — it prevents duplicate Vue instances when workspace packages also depend on Vue. |
| examples/vite-vue/package.json | Pre-scripts build the relevant workspace packages before each command (dev, generate, typecheck, build). The build script chains generate → tsc → vite build, ensuring catalogs are always up to date before a production build. |
| .changeset/config.json | Adds vite-vue to the changeset ignored packages list, consistent with other example workspaces. Correct — example apps should not generate changesets. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant App.vue
    participant gt-vue
    participant translations.ts
    participant ViteChunk as Vite JSON chunk

    User->>App.vue: Click language button
    App.vue->>App.vue: selectLocale(nextLocale)
    Note over App.vue: changingLocale = true
    App.vue->>gt-vue: setLocale(nextLocale)
    gt-vue->>translations.ts: loadTranslations(locale)
    translations.ts->>ViteChunk: dynamic import('./_gt/fr.json')
    ViteChunk-->>translations.ts: TranslationCatalog
    translations.ts-->>gt-vue: "TranslationCatalog (or {} if not found)"
    gt-vue-->>App.vue: locale Ref updated
    Note over App.vue: changingLocale = false (finally)
    App.vue->>App.vue: watch(locale) fires
    App.vue->>App.vue: "document.documentElement.lang = locale"
    App.vue-->>User: UI re-renders with new locale
```
</details>

<sub>Reviews (17): Last reviewed commit: ["test(vue): exercise TSX extraction in Vi..."](https://github.com/generaltranslation/gt/commit/91371924a263579b91677cee118c7847c099d309) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48900179)</sub>

<!-- /greptile_comment -->