### PR TITLE
fix: preserve proper nouns in diagnostic reasons

### DIFF
--- a/.changeset/calm-geckos-smile.md
+++ b/.changeset/calm-geckos-smile.md
@@ -1,0 +1,7 @@
+---
+'generaltranslation': patch
+'@generaltranslation/react-core': patch
+'gt-next': patch
+---
+
+Preserve proper-noun casing when diagnostic reasons are combined into user-facing messages.

--- a/packages/core/src/logging/__tests__/diagnostics.test.ts
+++ b/packages/core/src/logging/__tests__/diagnostics.test.ts
@@ -30,6 +30,18 @@ describe('createDiagnosticMessage', () => {
     );
   });
 
+  it('preserves proper nouns in combined why clauses', () => {
+    expect(
+      createDiagnosticMessage({
+        whatHappened:
+          'Next.js internationalized routing does not match the GT config file',
+        why: 'Next.js may select a locale that GT is not configured to translate',
+      })
+    ).toBe(
+      'Next.js internationalized routing does not match the GT config file because Next.js may select a locale that GT is not configured to translate.'
+    );
+  });
+
   it('formats details and docs links', () => {
     expect(
       createDiagnosticMessage({

--- a/packages/core/src/logging/diagnostics.ts
+++ b/packages/core/src/logging/diagnostics.ts
@@ -3,6 +3,8 @@ export type DiagnosticSeverity = 'Error' | 'Warning';
 /**
  * Text slots follow the five-part error message model:
  * what happened, reassurance, why it happened, how to fix it, and a way out.
+ * Clauses that are combined into another sentence should use their intended
+ * in-sentence casing.
  */
 export type DiagnosticMessageInput = {
   source?: string;
@@ -31,10 +33,6 @@ function stripSentence(text: string): string {
     end -= 1;
   }
   return trimmed.slice(0, end);
-}
-
-function lowercaseFirstWord(text: string): string {
-  return text.replace(/^[A-Z][a-z]/, (match) => match.toLowerCase());
 }
 
 function formatDetails(details: string | string[] | undefined): string {
@@ -70,12 +68,12 @@ export function createDiagnosticMessage({
       ? `${severity}:`
       : '';
   const whatAndWhy = why
-    ? `${stripSentence(whatHappened)} because ${lowercaseFirstWord(stripSentence(why))}`
+    ? `${stripSentence(whatHappened)} because ${stripSentence(why)}`
     : whatHappened;
   const shouldCombineWayOut =
     !!fix && !!wayOut && /^[a-z]/.test(stripSentence(wayOut));
   const fixAndWayOut = shouldCombineWayOut
-    ? `${stripSentence(fix)}, or ${lowercaseFirstWord(stripSentence(wayOut))}`
+    ? `${stripSentence(fix)}, or ${stripSentence(wayOut)}`
     : fix;
   const messageParts = [
     whatAndWhy,

--- a/packages/next/src/errors/__tests__/createErrors.test.ts
+++ b/packages/next/src/errors/__tests__/createErrors.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import { createWithGTStaticPropsClientError } from '../client';
-import { withGTStaticPropsRscError } from '../createErrors';
+import {
+  createNextI18nConfigMismatchWarning,
+  withGTStaticPropsRscError,
+} from '../createErrors';
 
 describe('withGTStaticProps errors', () => {
   it('provides an actionable browser diagnostic', () => {
@@ -12,6 +15,18 @@ describe('withGTStaticProps errors', () => {
   it('provides an actionable React Server Component diagnostic', () => {
     expect(withGTStaticPropsRscError).toBe(
       'gt-next Error: withGTStaticProps() is not available for React Server Components because this helper supports the Pages Router, not the App Router. Use gt-next build-time translation helpers in the App Router, or export withGTStaticProps() from a Pages Router page module.'
+    );
+  });
+});
+
+describe('createNextI18nConfigMismatchWarning', () => {
+  it('preserves the Next.js name in the reason clause', () => {
+    expect(
+      createNextI18nConfigMismatchWarning([
+        'defaultLocale: GT has "en"; Next.js has "en-US"',
+      ])
+    ).toBe(
+      'gt-next (plugin) Warning: Next.js internationalized routing does not match the GT config file because Next.js may select a locale that GT is not configured to translate. Use the same defaultLocale and locales values in both configurations. Details: defaultLocale: GT has "en"; Next.js has "en-US".'
     );
   });
 });

--- a/packages/next/src/errors/client.ts
+++ b/packages/next/src/errors/client.ts
@@ -4,6 +4,6 @@ export const createWithGTStaticPropsClientError = () =>
   createGtNextDiagnostic({
     severity: 'Error',
     whatHappened: 'withGTStaticProps() cannot run in the browser',
-    why: 'Static props are generated on the server by the Pages Router',
+    why: 'static props are generated on the server by the Pages Router',
     fix: 'Export withGTStaticProps() from a Pages Router page module',
   });

--- a/packages/next/src/errors/createErrors.ts
+++ b/packages/next/src/errors/createErrors.ts
@@ -94,7 +94,7 @@ export const withGTStaticPropsRscError = createGtNextDiagnostic({
   severity: 'Error',
   whatHappened:
     'withGTStaticProps() is not available for React Server Components',
-  why: 'This helper supports the Pages Router, not the App Router',
+  why: 'this helper supports the Pages Router, not the App Router',
   fix: 'Use gt-next build-time translation helpers in the App Router, or export withGTStaticProps() from a Pages Router page module',
 });
 

--- a/packages/next/src/errors/ssg.ts
+++ b/packages/next/src/errors/ssg.ts
@@ -15,7 +15,7 @@ export const withGTStaticPropsLocaleRoutingError = createGtNextDiagnostic({
   severity: 'Error',
   whatHappened:
     'withGTStaticProps() could not determine the statically generated locale',
-  why: 'Without Pages Router locale routing, Next.js generates only one version of this page',
+  why: 'without Pages Router locale routing, Next.js generates only one version of this page',
   fix: 'Add i18n locales and defaultLocale to your Next.js configuration',
 });
 
@@ -23,7 +23,7 @@ export const createMissingPagesRouterLocaleWarning = (fallbackLocale: string) =>
   createGtNextDiagnostic({
     severity: 'Warning',
     whatHappened: 'Next.js did not provide an active Pages Router locale',
-    why: 'The locale is normally available when internationalized routing is configured',
+    why: 'the locale is normally available when internationalized routing is configured',
     wayOut: `The locale "${fallbackLocale}" will be used for this request`,
     fix: 'Add i18n locales and defaultLocale to your Next.js configuration',
   });

--- a/packages/react-core/src/condition-store/singleton-operations.ts
+++ b/packages/react-core/src/condition-store/singleton-operations.ts
@@ -6,7 +6,7 @@ const conditionStoreNotInitializedError = createDiagnosticMessage({
   source: '@generaltranslation/react-core',
   severity: 'Error',
   whatHappened: 'Cannot read GT runtime context before it has been initialized',
-  why: 'The internal ConditionStore is unavailable',
+  why: 'the internal ConditionStore is unavailable',
   fix: 'Call initializeGT() during setup (gt-next runs this automatically) and add a <GTProvider> at the root of your component tree.',
 });
 


### PR DESCRIPTION
## Summary

- Preserve authored casing when diagnostic reasons are combined, so proper names such as `Next.js` are not lowercased.
- Normalize existing sentence-fragment reasons and cover the actual `gt-next` warning while keeping prior diagnostic output unchanged.

## Testing

- `pnpm build` — passed (20 packages)
- `pnpm --filter generaltranslation test` — passed (31 files, 499 tests)
- `pnpm --filter gt-next test:js` — passed (25 files, 273 tests)
- `pnpm --filter @generaltranslation/react-core test` — passed (11 files, 46 tests)
- `pnpm --filter gt-next exec vitest run src/errors/__tests__/createErrors.test.ts` — passed (1 file, 3 tests)
- `pnpm exec oxlint <changed TypeScript files>` — passed
- `pnpm exec oxfmt --check <changed files>` — passed

## Notes

- Closes #2016.
- Changeset: patch releases for `generaltranslation`, `@generaltranslation/react-core`, and `gt-next`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug in `createDiagnosticMessage` where the `lowercaseFirstWord` helper was incorrectly downcasing proper nouns (e.g. `Next.js` → `next.js`) when combining `why` clauses into a single sentence. The fix removes `lowercaseFirstWord` entirely and shifts the responsibility to each call site, which must now author `why` strings as sentence fragments using their intended in-sentence casing.

- **`diagnostics.ts`**: Removes `lowercaseFirstWord`; `why` and `wayOut` clauses are now passed directly to `stripSentence`. The `wayOut` path is effectively a no-op change since `shouldCombineWayOut` already required `wayOut` to start with a lowercase letter via `/^[a-z]/`.
- **Call-site updates** (`client.ts`, `createErrors.ts`, `ssg.ts`, `singleton-operations.ts`): Existing `why` clauses that started with common English words (`This`, `The`, `Static`, `Without`) are lowercased to match the new convention.
- **Tests**: New cases in both `diagnostics.test.ts` and `createErrors.test.ts` verify that `Next.js` casing is preserved end-to-end, and that the `createNextI18nConfigMismatchWarning` helper produces the correct full message string.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is narrow, well-tested, and all call sites have been updated to the new convention.

The removal of lowercaseFirstWord is clean: the why path is the only place producing wrong output, all affected call sites have been updated to lowercase-start fragments, and a grep across the monorepo confirms no remaining why clause would produce an awkward combined sentence. The wayOut removal is provably inert because shouldCombineWayOut already gates on the clause starting lowercase. New tests cover both the core utility and the specific createNextI18nConfigMismatchWarning entry point that triggered the issue.

**Files Needing Attention:** No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/logging/diagnostics.ts | Removes lowercaseFirstWord helper and passes why/wayOut clauses directly to stripSentence; fixes proper-noun casing without behavioral regression for wayOut (already gated by a /^[a-z]/ check). |
| packages/next/src/errors/createErrors.ts | Adds createNextI18nConfigMismatchWarning export with proper proper-noun casing; updates two why clauses to sentence-fragment form (lowercase start). |
| packages/next/src/errors/ssg.ts | Two why clauses updated to lowercase sentence-fragment form, consistent with the new convention. |
| packages/next/src/errors/client.ts | Single why clause lowercased to match new sentence-fragment convention. |
| packages/react-core/src/condition-store/singleton-operations.ts | why clause lowercased to match new sentence-fragment convention. |
| packages/core/src/logging/__tests__/diagnostics.test.ts | New test case verifies proper-noun casing is preserved in combined why clauses. |
| packages/next/src/errors/__tests__/createErrors.test.ts | New test suite for createNextI18nConfigMismatchWarning validates the full message string including preserved Next.js casing. |
| .changeset/calm-geckos-smile.md | Patch changeset for generaltranslation, @generaltranslation/react-core, and gt-next — appropriately scoped. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["createDiagnosticMessage(input)"] --> B{why provided?}
    B -- Yes --> C["stripSentence(whatHappened) + ' because ' + stripSentence(why)"]
    B -- No --> D["whatHappened as-is"]
    C --> E{fix AND wayOut AND wayOut starts with a-z?}
    D --> E
    E -- Yes --> F["stripSentence(fix) + ', or ' + stripSentence(wayOut)"]
    E -- No --> G["fix as-is"]
    F --> H["Assemble parts via ensureSentence and join"]
    G --> H
    H --> I["Add source/severity prefix"]
    I --> J["Final diagnostic string"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: preserve proper nouns in diagnostic..."](https://github.com/generaltranslation/gt/commit/fe1077eb53463a95714854a103b173d2c692bd0e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49257659)</sub>

<!-- /greptile_comment -->