### PR TITLE
feat(cli): enable save-local by default

### DIFF
--- a/.changeset/bright-pandas-save.md
+++ b/.changeset/bright-pandas-save.md
@@ -1,5 +1,5 @@
 ---
-'gt': minor
+'gt': patch
 ---
 
 Save local edits before translation by default, with a `--no-save-local` flag to opt out.

--- a/.changeset/bright-pandas-save.md
+++ b/.changeset/bright-pandas-save.md
@@ -1,0 +1,5 @@
+---
+'gt': minor
+---
+
+Save local edits before translation by default, with a `--no-save-local` flag to opt out.

--- a/packages/cli/src/cli/__tests__/flags.test.ts
+++ b/packages/cli/src/cli/__tests__/flags.test.ts
@@ -1,0 +1,27 @@
+import { Command } from 'commander';
+import { describe, expect, it, vi } from 'vitest';
+import { attachTranslateFlags } from '../flags.js';
+
+vi.mock('../../fs/findFilepath.js', () => ({
+  default: vi.fn(() => ''),
+}));
+
+function parseTranslateFlags(args: string[] = []) {
+  const command = attachTranslateFlags(new Command());
+  command.exitOverride().parse(args, { from: 'user' });
+  return command.opts();
+}
+
+describe('attachTranslateFlags', () => {
+  it('saves local edits by default', () => {
+    expect(parseTranslateFlags().saveLocal).toBe(true);
+  });
+
+  it('keeps the explicit save-local flag enabled', () => {
+    expect(parseTranslateFlags(['--save-local']).saveLocal).toBe(true);
+  });
+
+  it('allows saving local edits to be disabled', () => {
+    expect(parseTranslateFlags(['--no-save-local']).saveLocal).toBe(false);
+  });
+});

--- a/packages/cli/src/cli/flags.ts
+++ b/packages/cli/src/cli/flags.ts
@@ -50,7 +50,11 @@ export function attachTranslateFlags(command: Command) {
     .option(
       '--save-local',
       'Detect and save local edits before enqueuing translations',
-      false
+      true
+    )
+    .option(
+      '--no-save-local',
+      'Skip detecting and saving local edits before enqueuing translations'
     )
     .option('--publish', 'Publish translations to the CDN', false)
     .option(


### PR DESCRIPTION
## Summary

- Save local edits before enqueuing translations by default.
- Keep `--save-local` compatible and add `--no-save-local` as an explicit opt-out.

## Testing

- `pnpm exec turbo run build --filter=gt --ui=stream` — passed (7 tasks).
- `pnpm --filter gt test` — passed (105 test files, 2,129 tests).
- `pnpm --filter gt typecheck` — passed.
- `pnpm exec oxlint packages/cli/src/cli/flags.ts packages/cli/src/cli/__tests__/flags.test.ts` — passed.
- `pnpm exec oxfmt --check packages/cli/src/cli/flags.ts packages/cli/src/cli/__tests__/flags.test.ts .changeset/bright-pandas-save.md` — passed.
- `git diff --check` — passed.
- `pnpm changeset status` — passed and reports patch bumps for `gt` and its fixed-version sibling `gtx-cli`.
- Initial `pnpm --filter gt test -- src/cli/__tests__/flags.test.ts` attempt failed because workspace dependency build outputs were absent; after building the dependency graph, the complete package suite passed as reported above.

## Notes

- Changeset: added a patch release entry for `gt`; the fixed release group also bumps `gtx-cli`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes the `--save-local` flag default from `false` to `true` in the CLI's `translate` command, so local edits are now detected and saved before enqueuing translations without requiring an explicit flag. A new `--no-save-local` flag is added as an explicit opt-out for users who want the previous behavior.

- `packages/cli/src/cli/flags.ts`: default for `--save-local` flipped to `true`; `--no-save-local` option added via Commander.js boolean-negation convention.
- `packages/cli/src/cli/__tests__/flags.test.ts`: new test file verifying all three states (default, explicit enable, explicit disable).
- `.changeset/bright-pandas-save.md`: patch changeset for `gt` (and its fixed-version sibling `gtx-cli`).

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the only behavioral change is that saveLocal now defaults to true, which is the intended goal of this PR and is well-tested.

The change is minimal and focused: one default value flipped, one Commander.js negation option added, and three tests confirming all states. The userEditDiffsStep path was already exercised by users who passed --save-local explicitly, so making it the default does not introduce untested code paths.

**Files Needing Attention:** No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/cli/flags.ts | Flips --save-local default from false to true and adds an explicit --no-save-local opt-out; logic is correct for Commander.js boolean-negation handling. |
| packages/cli/src/cli/__tests__/flags.test.ts | New test file covering all three saveLocal states: default true, explicit --save-local, and --no-save-local opt-out. |
| .changeset/bright-pandas-save.md | Patch changeset entry for gt accurately describing the behavioral default change. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[gt translate] --> B{saveLocal flag}
    B -- "default (true) or --save-local" --> C[Run userEditDiffsStep]
    B -- "--no-save-local" --> D[Skip userEditDiffsStep]
    C --> E[Continue: tag, setup, enqueue]
    D --> E
```
</details>

<sub>Reviews (2): Last reviewed commit: ["chore(cli): use patch changeset"](https://github.com/generaltranslation/gt/commit/6332a1ba0161ad948bd530d3985fb722003bf4aa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49274120)</sub>

<!-- /greptile_comment -->