### PR TITLE
feat(core): support organization API keys

### DIFF
--- a/.changeset/tidy-oranges-agree.md
+++ b/.changeset/tidy-oranges-agree.md
@@ -1,0 +1,5 @@
+---
+'generaltranslation': minor
+---
+
+Add organization-scoped API key support to project API operations.

--- a/.changeset/tidy-oranges-agree.md
+++ b/.changeset/tidy-oranges-agree.md
@@ -1,5 +1,5 @@
 ---
-'generaltranslation': minor
+'generaltranslation': patch
 ---
 
 Add organization-scoped API key support to project API operations.

--- a/packages/core/src/__tests__/index.test.ts
+++ b/packages/core/src/__tests__/index.test.ts
@@ -566,18 +566,16 @@ describe.sequential('GT Translation Methods', () => {
       expect(gt.baseUrl).toBe('https://api.test.com');
     });
 
-    it('should normalize API key aliases to one configured key', () => {
+    it('should normalize the development API key alias', () => {
       const gt = new GT({
-        apiKey: 'test-key',
         devApiKey: 'dev-key',
-        orgApiKey: 'gtx-org-test-key',
         projectId: 'test-project',
         baseUrl: 'https://api.test.com',
         targetLocale: 'es',
       });
 
-      expect(gt.apiKey).toBe('test-key');
-      expect(gt.devApiKey).toBe('test-key');
+      expect(gt.apiKey).toBe('dev-key');
+      expect(gt.devApiKey).toBe('dev-key');
       expect(gt.projectId).toBe('test-project');
       expect(gt.baseUrl).toBe('https://api.test.com');
       expect(gt.targetLocale).toBe('es');

--- a/packages/core/src/__tests__/index.test.ts
+++ b/packages/core/src/__tests__/index.test.ts
@@ -135,6 +135,54 @@ describe.sequential('GT Translation Methods', () => {
       );
     });
 
+    it('should prefer explicitly configured API keys over environment fallbacks', async () => {
+      vi.stubEnv('GT_API_KEY', 'gtx-api-env-key');
+      vi.stubEnv('GT_DEV_API_KEY', 'gtx-dev-env-key');
+
+      try {
+        const mockTranslateMany = vi.mocked(_translateMany);
+        mockTranslateMany.mockResolvedValue([mockTranslationResult]);
+        const constructorConfig = new GT({
+          orgApiKey: 'gtx-org-explicit-key',
+          projectId: 'test-project',
+          baseUrl: 'https://api.test.com',
+        });
+        const setConfig = new GT({
+          apiKey: 'gtx-api-project-a-key',
+          projectId: 'project-a',
+          baseUrl: 'https://api.test.com',
+        });
+        const allExplicitKeys = new GT({
+          apiKey: 'gtx-api-explicit-key',
+          devApiKey: 'gtx-dev-explicit-key',
+          orgApiKey: 'gtx-org-explicit-key',
+          projectId: 'test-project',
+          baseUrl: 'https://api.test.com',
+        });
+
+        setConfig.setConfig({
+          orgApiKey: 'gtx-org-explicit-key',
+          projectId: 'test-project',
+        });
+        await constructorConfig.translate('Hello world', 'fr');
+        await setConfig.translate('Hello world', 'fr');
+        await allExplicitKeys.translate('Hello world', 'fr');
+
+        expect(
+          mockTranslateMany.mock.calls.map(([, , config]) => [
+            config.apiKey,
+            config.projectId,
+          ])
+        ).toEqual([
+          ['gtx-org-explicit-key', 'test-project'],
+          ['gtx-org-explicit-key', 'test-project'],
+          ['gtx-api-explicit-key', 'test-project'],
+        ]);
+      } finally {
+        vi.unstubAllEnvs();
+      }
+    });
+
     it('should require a project ID with an organization API key', async () => {
       const gtNoProject = new GT({
         orgApiKey: 'gtx-org-test-key',

--- a/packages/core/src/__tests__/index.test.ts
+++ b/packages/core/src/__tests__/index.test.ts
@@ -109,6 +109,54 @@ describe.sequential('GT Translation Methods', () => {
       );
     });
 
+    it('should use an organization API key with a project ID', async () => {
+      const mockTranslateMany = vi.mocked(_translateMany);
+      mockTranslateMany.mockResolvedValue([mockTranslationResult]);
+      const gtWithOrgKey = new GT({
+        orgApiKey: 'gtx-org-test-key',
+        projectId: 'test-project',
+        baseUrl: 'https://api.test.com',
+      });
+
+      await gtWithOrgKey.translate('Hello world', 'fr');
+
+      expect(mockTranslateMany).toHaveBeenCalledWith(
+        ['Hello world'],
+        expect.objectContaining({
+          targetLocale: 'fr',
+          sourceLocale: 'en',
+        }),
+        {
+          baseUrl: 'https://api.test.com',
+          apiKey: 'gtx-org-test-key',
+          projectId: 'test-project',
+        },
+        undefined
+      );
+    });
+
+    it('should require a project ID with an organization API key', async () => {
+      const gtNoProject = new GT({
+        orgApiKey: 'gtx-org-test-key',
+        baseUrl: 'https://api.test.com',
+      });
+
+      await expect(gtNoProject.translate('Hello world', 'es')).rejects.toThrow(
+        'GT Error: Cannot call `translate` without a specified project ID.'
+      );
+    });
+
+    it('should require an API key with a project ID', async () => {
+      const gtNoKey = new GT({
+        projectId: 'test-project',
+        baseUrl: 'https://api.test.com',
+      });
+
+      await expect(gtNoKey.translate('Hello world', 'es')).rejects.toThrow(
+        'GT Error: Cannot call `translate` without a specified API key.'
+      );
+    });
+
     it('should handle empty metadata', async () => {
       const mockTranslateMany = vi.mocked(_translateMany);
       mockTranslateMany.mockResolvedValue([mockTranslationResult]);
@@ -474,6 +522,7 @@ describe.sequential('GT Translation Methods', () => {
       const gt = new GT({
         apiKey: 'test-key',
         devApiKey: 'dev-key',
+        orgApiKey: 'gtx-org-test-key',
         projectId: 'test-project',
         baseUrl: 'https://api.test.com',
         targetLocale: 'es',
@@ -481,9 +530,23 @@ describe.sequential('GT Translation Methods', () => {
 
       expect(gt.apiKey).toBe('test-key');
       expect(gt.devApiKey).toBe('dev-key');
+      expect(gt.orgApiKey).toBe('gtx-org-test-key');
       expect(gt.projectId).toBe('test-project');
       expect(gt.baseUrl).toBe('https://api.test.com');
       expect(gt.targetLocale).toBe('es');
+    });
+
+    it('should read the organization API key from the environment and prefer explicit config', () => {
+      vi.stubEnv('GT_ORG_API_KEY', 'gtx-org-env-key');
+
+      try {
+        expect(new GT().orgApiKey).toBe('gtx-org-env-key');
+        expect(new GT({ orgApiKey: 'gtx-org-explicit-key' }).orgApiKey).toBe(
+          'gtx-org-explicit-key'
+        );
+      } finally {
+        vi.unstubAllEnvs();
+      }
     });
   });
 
@@ -667,6 +730,7 @@ describe('GT LocaleConfig delegation', () => {
     expect(gt.localeConfig).toBeInstanceOf(LocaleConfig);
     expect('apiKey' in gt.localeConfig).toBe(false);
     expect('devApiKey' in gt.localeConfig).toBe(false);
+    expect('orgApiKey' in gt.localeConfig).toBe(false);
     expect('projectId' in gt.localeConfig).toBe(false);
 
     gt.setConfig({

--- a/packages/core/src/__tests__/index.test.ts
+++ b/packages/core/src/__tests__/index.test.ts
@@ -583,15 +583,9 @@ describe.sequential('GT Translation Methods', () => {
       });
 
       expect(gt.apiKey).toBe('dev-key');
-      expect(gt.devApiKey).toBe('dev-key');
       expect(gt.projectId).toBe('test-project');
       expect(gt.baseUrl).toBe('https://api.test.com');
       expect(gt.targetLocale).toBe('es');
-
-      gt.apiKey = 'api-key';
-      expect(gt.devApiKey).toBeUndefined();
-      gt.devApiKey = 'next-dev-key';
-      expect(gt.apiKey).toBe('next-dev-key');
     });
 
     it('should normalize environment keys in priority order and prefer explicit config', () => {
@@ -600,17 +594,11 @@ describe.sequential('GT Translation Methods', () => {
       vi.stubEnv('GT_ORG_API_KEY', 'gtx-org-env-key');
 
       try {
-        const apiConfig = new GT();
-        expect(apiConfig.apiKey).toBe('gtx-api-env-key');
-        expect(apiConfig.devApiKey).toBeUndefined();
+        expect(new GT().apiKey).toBe('gtx-api-env-key');
         vi.stubEnv('GT_API_KEY', '');
-        const devConfig = new GT();
-        expect(devConfig.apiKey).toBe('gtx-dev-env-key');
-        expect(devConfig.devApiKey).toBe('gtx-dev-env-key');
+        expect(new GT().apiKey).toBe('gtx-dev-env-key');
         vi.stubEnv('GT_DEV_API_KEY', '');
-        const orgConfig = new GT();
-        expect(orgConfig.apiKey).toBe('gtx-org-env-key');
-        expect(orgConfig.devApiKey).toBeUndefined();
+        expect(new GT().apiKey).toBe('gtx-org-env-key');
         expect(new GT({ orgApiKey: 'gtx-org-explicit-key' }).apiKey).toBe(
           'gtx-org-explicit-key'
         );

--- a/packages/core/src/__tests__/index.test.ts
+++ b/packages/core/src/__tests__/index.test.ts
@@ -161,10 +161,16 @@ describe.sequential('GT Translation Methods', () => {
         });
 
         setConfig.setConfig({
+          devApiKey: 'gtx-dev-explicit-key',
+          projectId: 'project-b',
+        });
+        setConfig.setConfig({});
+        await constructorConfig.translate('Hello world', 'fr');
+        await setConfig.translate('Hello world', 'fr');
+        setConfig.setConfig({
           orgApiKey: 'gtx-org-explicit-key',
           projectId: 'test-project',
         });
-        await constructorConfig.translate('Hello world', 'fr');
         await setConfig.translate('Hello world', 'fr');
         await allExplicitKeys.translate('Hello world', 'fr');
 
@@ -175,6 +181,7 @@ describe.sequential('GT Translation Methods', () => {
           ])
         ).toEqual([
           ['gtx-org-explicit-key', 'test-project'],
+          ['gtx-dev-explicit-key', 'project-b'],
           ['gtx-org-explicit-key', 'test-project'],
           ['gtx-api-explicit-key', 'test-project'],
         ]);
@@ -569,22 +576,28 @@ describe.sequential('GT Translation Methods', () => {
     it('should normalize the development API key alias', () => {
       const gt = new GT({
         devApiKey: 'dev-key',
+        orgApiKey: 'gtx-org-test-key',
         projectId: 'test-project',
         baseUrl: 'https://api.test.com',
         targetLocale: 'es',
       });
 
       expect(gt.apiKey).toBe('dev-key');
-      expect(gt.devApiKey).toBe('dev-key');
       expect(gt.projectId).toBe('test-project');
       expect(gt.baseUrl).toBe('https://api.test.com');
       expect(gt.targetLocale).toBe('es');
     });
 
-    it('should read the organization API key from the environment and prefer explicit config', () => {
+    it('should normalize environment keys in priority order and prefer explicit config', () => {
+      vi.stubEnv('GT_API_KEY', 'gtx-api-env-key');
+      vi.stubEnv('GT_DEV_API_KEY', 'gtx-dev-env-key');
       vi.stubEnv('GT_ORG_API_KEY', 'gtx-org-env-key');
 
       try {
+        expect(new GT().apiKey).toBe('gtx-api-env-key');
+        vi.stubEnv('GT_API_KEY', '');
+        expect(new GT().apiKey).toBe('gtx-dev-env-key');
+        vi.stubEnv('GT_DEV_API_KEY', '');
         expect(new GT().apiKey).toBe('gtx-org-env-key');
         expect(new GT({ orgApiKey: 'gtx-org-explicit-key' }).apiKey).toBe(
           'gtx-org-explicit-key'

--- a/packages/core/src/__tests__/index.test.ts
+++ b/packages/core/src/__tests__/index.test.ts
@@ -583,9 +583,15 @@ describe.sequential('GT Translation Methods', () => {
       });
 
       expect(gt.apiKey).toBe('dev-key');
+      expect(gt.devApiKey).toBe('dev-key');
       expect(gt.projectId).toBe('test-project');
       expect(gt.baseUrl).toBe('https://api.test.com');
       expect(gt.targetLocale).toBe('es');
+
+      gt.apiKey = 'api-key';
+      expect(gt.devApiKey).toBeUndefined();
+      gt.devApiKey = 'next-dev-key';
+      expect(gt.apiKey).toBe('next-dev-key');
     });
 
     it('should normalize environment keys in priority order and prefer explicit config', () => {
@@ -594,11 +600,17 @@ describe.sequential('GT Translation Methods', () => {
       vi.stubEnv('GT_ORG_API_KEY', 'gtx-org-env-key');
 
       try {
-        expect(new GT().apiKey).toBe('gtx-api-env-key');
+        const apiConfig = new GT();
+        expect(apiConfig.apiKey).toBe('gtx-api-env-key');
+        expect(apiConfig.devApiKey).toBeUndefined();
         vi.stubEnv('GT_API_KEY', '');
-        expect(new GT().apiKey).toBe('gtx-dev-env-key');
+        const devConfig = new GT();
+        expect(devConfig.apiKey).toBe('gtx-dev-env-key');
+        expect(devConfig.devApiKey).toBe('gtx-dev-env-key');
         vi.stubEnv('GT_DEV_API_KEY', '');
-        expect(new GT().apiKey).toBe('gtx-org-env-key');
+        const orgConfig = new GT();
+        expect(orgConfig.apiKey).toBe('gtx-org-env-key');
+        expect(orgConfig.devApiKey).toBeUndefined();
         expect(new GT({ orgApiKey: 'gtx-org-explicit-key' }).apiKey).toBe(
           'gtx-org-explicit-key'
         );

--- a/packages/core/src/__tests__/index.test.ts
+++ b/packages/core/src/__tests__/index.test.ts
@@ -566,7 +566,7 @@ describe.sequential('GT Translation Methods', () => {
       expect(gt.baseUrl).toBe('https://api.test.com');
     });
 
-    it('should handle GT configuration with all options', () => {
+    it('should normalize API key aliases to one configured key', () => {
       const gt = new GT({
         apiKey: 'test-key',
         devApiKey: 'dev-key',
@@ -577,8 +577,7 @@ describe.sequential('GT Translation Methods', () => {
       });
 
       expect(gt.apiKey).toBe('test-key');
-      expect(gt.devApiKey).toBe('dev-key');
-      expect(gt.orgApiKey).toBe('gtx-org-test-key');
+      expect(gt.devApiKey).toBe('test-key');
       expect(gt.projectId).toBe('test-project');
       expect(gt.baseUrl).toBe('https://api.test.com');
       expect(gt.targetLocale).toBe('es');
@@ -588,8 +587,8 @@ describe.sequential('GT Translation Methods', () => {
       vi.stubEnv('GT_ORG_API_KEY', 'gtx-org-env-key');
 
       try {
-        expect(new GT().orgApiKey).toBe('gtx-org-env-key');
-        expect(new GT({ orgApiKey: 'gtx-org-explicit-key' }).orgApiKey).toBe(
+        expect(new GT().apiKey).toBe('gtx-org-env-key');
+        expect(new GT({ orgApiKey: 'gtx-org-explicit-key' }).apiKey).toBe(
           'gtx-org-explicit-key'
         );
       } finally {

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -49,6 +49,7 @@ import { TranslateOptions } from './types-dir/api/entry';
  * @typedef {Object} GTConstructorParams
  * @property {string} [apiKey] - The API key for accessing the translation service
  * @property {string} [devApiKey] - The development API key for accessing the translation service
+ * @property {string} [orgApiKey] - The organization API key for accessing the translation service
  * @property {string} [sourceLocale] - The default source locale for translations
  * @property {string} [targetLocale] - The default target locale for translations
  * @property {string[]} [locales] - Array of supported locales
@@ -59,6 +60,7 @@ import { TranslateOptions } from './types-dir/api/entry';
 export type GTConstructorParams = {
   apiKey?: string;
   devApiKey?: string;
+  orgApiKey?: string;
   sourceLocale?: string;
   targetLocale?: string;
   locales?: string[];
@@ -94,6 +96,9 @@ export class GTRuntime {
 
   /** Development API key for accessing the translation service */
   devApiKey?: string;
+
+  /** Organization API key for accessing the translation service */
+  orgApiKey?: string;
 
   /** Source locale for translations */
   sourceLocale?: string;
@@ -141,6 +146,7 @@ export class GTRuntime {
     if (typeof process !== 'undefined') {
       this.apiKey ||= process.env?.GT_API_KEY;
       this.devApiKey ||= process.env?.GT_DEV_API_KEY;
+      this.orgApiKey ||= process.env?.GT_ORG_API_KEY;
       this.projectId ||= process.env?.GT_PROJECT_ID;
     }
     // Set up config
@@ -150,6 +156,7 @@ export class GTRuntime {
   setConfig({
     apiKey,
     devApiKey,
+    orgApiKey,
     sourceLocale,
     targetLocale,
     locales,
@@ -160,6 +167,7 @@ export class GTRuntime {
     // ----- Environment properties ----- //
     if (apiKey) this.apiKey = apiKey;
     if (devApiKey) this.devApiKey = devApiKey;
+    if (orgApiKey) this.orgApiKey = orgApiKey;
     if (projectId) this.projectId = projectId;
 
     // ----- Standardize locales ----- //
@@ -220,14 +228,14 @@ export class GTRuntime {
   protected _getTranslationConfig(): TranslationRequestConfig {
     return {
       baseUrl: this.baseUrl,
-      apiKey: this.apiKey || this.devApiKey,
+      apiKey: this.apiKey || this.devApiKey || this.orgApiKey,
       projectId: this.projectId || '',
     };
   }
 
   protected _validateAuth(functionName: string) {
     const errors: string[] = [];
-    if (!this.apiKey && !this.devApiKey) {
+    if (!this.apiKey && !this.devApiKey && !this.orgApiKey) {
       const error = noApiKeyProvidedError(functionName);
       errors.push(error);
     }

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -91,8 +91,31 @@ export class GTRuntime {
   /** Project ID for the translation service */
   projectId?: string;
 
+  /** Active API key for accessing the translation service */
+  private _apiKey?: string;
+
+  /** Whether the active API key was configured through the development alias */
+  private _isDevApiKey = false;
+
   /** API key for accessing the translation service */
-  apiKey?: string;
+  get apiKey() {
+    return this._apiKey;
+  }
+
+  set apiKey(apiKey: string | undefined) {
+    this._apiKey = apiKey;
+    this._isDevApiKey = false;
+  }
+
+  /** Development API key compatibility alias */
+  get devApiKey() {
+    return this._isDevApiKey ? this._apiKey : undefined;
+  }
+
+  set devApiKey(devApiKey: string | undefined) {
+    this._apiKey = devApiKey;
+    this._isDevApiKey = true;
+  }
 
   /** Source locale for translations */
   sourceLocale?: string;
@@ -138,10 +161,11 @@ export class GTRuntime {
   constructor(params: GTConstructorParams = {}) {
     // Read environment
     if (typeof process !== 'undefined') {
-      this.apiKey ||=
-        process.env?.GT_API_KEY ||
-        process.env?.GT_DEV_API_KEY ||
-        process.env?.GT_ORG_API_KEY;
+      this._setApiKey(
+        process.env?.GT_API_KEY,
+        process.env?.GT_DEV_API_KEY,
+        process.env?.GT_ORG_API_KEY
+      );
       this.projectId ||= process.env?.GT_PROJECT_ID;
     }
     // Set up config
@@ -160,7 +184,7 @@ export class GTRuntime {
     baseUrl,
   }: GTConstructorParams) {
     // ----- Environment properties ----- //
-    this.apiKey = apiKey || devApiKey || orgApiKey || this.apiKey;
+    this._setApiKey(apiKey, devApiKey, orgApiKey);
     if (projectId) this.projectId = projectId;
 
     // ----- Standardize locales ----- //
@@ -217,6 +241,12 @@ export class GTRuntime {
   }
 
   // -------------- Private Methods -------------- //
+
+  private _setApiKey(apiKey?: string, devApiKey?: string, orgApiKey?: string) {
+    if (apiKey) this.apiKey = apiKey;
+    else if (devApiKey) this.devApiKey = devApiKey;
+    else if (orgApiKey) this.apiKey = orgApiKey;
+  }
 
   protected _getTranslationConfig(): TranslationRequestConfig {
     return {

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -91,31 +91,8 @@ export class GTRuntime {
   /** Project ID for the translation service */
   projectId?: string;
 
-  /** Active API key for accessing the translation service */
-  private _apiKey?: string;
-
-  /** Whether the active API key was configured through the development alias */
-  private _isDevApiKey = false;
-
   /** API key for accessing the translation service */
-  get apiKey() {
-    return this._apiKey;
-  }
-
-  set apiKey(apiKey: string | undefined) {
-    this._apiKey = apiKey;
-    this._isDevApiKey = false;
-  }
-
-  /** Development API key compatibility alias */
-  get devApiKey() {
-    return this._isDevApiKey ? this._apiKey : undefined;
-  }
-
-  set devApiKey(devApiKey: string | undefined) {
-    this._apiKey = devApiKey;
-    this._isDevApiKey = true;
-  }
+  apiKey?: string;
 
   /** Source locale for translations */
   sourceLocale?: string;
@@ -161,11 +138,10 @@ export class GTRuntime {
   constructor(params: GTConstructorParams = {}) {
     // Read environment
     if (typeof process !== 'undefined') {
-      this._setApiKey(
-        process.env?.GT_API_KEY,
-        process.env?.GT_DEV_API_KEY,
-        process.env?.GT_ORG_API_KEY
-      );
+      this.apiKey ||=
+        process.env?.GT_API_KEY ||
+        process.env?.GT_DEV_API_KEY ||
+        process.env?.GT_ORG_API_KEY;
       this.projectId ||= process.env?.GT_PROJECT_ID;
     }
     // Set up config
@@ -184,7 +160,7 @@ export class GTRuntime {
     baseUrl,
   }: GTConstructorParams) {
     // ----- Environment properties ----- //
-    this._setApiKey(apiKey, devApiKey, orgApiKey);
+    this.apiKey = apiKey || devApiKey || orgApiKey || this.apiKey;
     if (projectId) this.projectId = projectId;
 
     // ----- Standardize locales ----- //
@@ -241,12 +217,6 @@ export class GTRuntime {
   }
 
   // -------------- Private Methods -------------- //
-
-  private _setApiKey(apiKey?: string, devApiKey?: string, orgApiKey?: string) {
-    if (apiKey) this.apiKey = apiKey;
-    else if (devApiKey) this.devApiKey = devApiKey;
-    else if (orgApiKey) this.apiKey = orgApiKey;
-  }
 
   protected _getTranslationConfig(): TranslationRequestConfig {
     return {

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -94,14 +94,13 @@ export class GTRuntime {
   /** API key for accessing the translation service */
   apiKey?: string;
 
-  /** Development API key for accessing the translation service */
-  devApiKey?: string;
-
-  /** Organization API key for accessing the translation service */
-  orgApiKey?: string;
-
-  /** API key selected by the latest explicit configuration */
-  private _configuredApiKey?: string;
+  /** Backwards-compatible development API key alias */
+  get devApiKey() {
+    return this.apiKey;
+  }
+  set devApiKey(apiKey: string | undefined) {
+    this.apiKey = apiKey;
+  }
 
   /** Source locale for translations */
   sourceLocale?: string;
@@ -147,9 +146,10 @@ export class GTRuntime {
   constructor(params: GTConstructorParams = {}) {
     // Read environment
     if (typeof process !== 'undefined') {
-      this.apiKey ||= process.env?.GT_API_KEY;
-      this.devApiKey ||= process.env?.GT_DEV_API_KEY;
-      this.orgApiKey ||= process.env?.GT_ORG_API_KEY;
+      this.apiKey ||=
+        process.env?.GT_API_KEY ||
+        process.env?.GT_DEV_API_KEY ||
+        process.env?.GT_ORG_API_KEY;
       this.projectId ||= process.env?.GT_PROJECT_ID;
     }
     // Set up config
@@ -168,11 +168,7 @@ export class GTRuntime {
     baseUrl,
   }: GTConstructorParams) {
     // ----- Environment properties ----- //
-    this._configuredApiKey =
-      apiKey || devApiKey || orgApiKey || this._configuredApiKey;
-    if (apiKey) this.apiKey = apiKey;
-    if (devApiKey) this.devApiKey = devApiKey;
-    if (orgApiKey) this.orgApiKey = orgApiKey;
+    this.apiKey = apiKey || devApiKey || orgApiKey || this.apiKey;
     if (projectId) this.projectId = projectId;
 
     // ----- Standardize locales ----- //
@@ -233,18 +229,14 @@ export class GTRuntime {
   protected _getTranslationConfig(): TranslationRequestConfig {
     return {
       baseUrl: this.baseUrl,
-      apiKey:
-        this._configuredApiKey ||
-        this.apiKey ||
-        this.devApiKey ||
-        this.orgApiKey,
+      apiKey: this.apiKey,
       projectId: this.projectId || '',
     };
   }
 
   protected _validateAuth(functionName: string) {
     const errors: string[] = [];
-    if (!this.apiKey && !this.devApiKey && !this.orgApiKey) {
+    if (!this.apiKey) {
       const error = noApiKeyProvidedError(functionName);
       errors.push(error);
     }

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -100,6 +100,9 @@ export class GTRuntime {
   /** Organization API key for accessing the translation service */
   orgApiKey?: string;
 
+  /** API key selected by the latest explicit configuration */
+  private _configuredApiKey?: string;
+
   /** Source locale for translations */
   sourceLocale?: string;
 
@@ -165,6 +168,8 @@ export class GTRuntime {
     baseUrl,
   }: GTConstructorParams) {
     // ----- Environment properties ----- //
+    this._configuredApiKey =
+      apiKey || devApiKey || orgApiKey || this._configuredApiKey;
     if (apiKey) this.apiKey = apiKey;
     if (devApiKey) this.devApiKey = devApiKey;
     if (orgApiKey) this.orgApiKey = orgApiKey;
@@ -228,7 +233,11 @@ export class GTRuntime {
   protected _getTranslationConfig(): TranslationRequestConfig {
     return {
       baseUrl: this.baseUrl,
-      apiKey: this.apiKey || this.devApiKey || this.orgApiKey,
+      apiKey:
+        this._configuredApiKey ||
+        this.apiKey ||
+        this.devApiKey ||
+        this.orgApiKey,
       projectId: this.projectId || '',
     };
   }

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -94,14 +94,6 @@ export class GTRuntime {
   /** API key for accessing the translation service */
   apiKey?: string;
 
-  /** Backwards-compatible development API key alias */
-  get devApiKey() {
-    return this.apiKey;
-  }
-  set devApiKey(apiKey: string | undefined) {
-    this.apiKey = apiKey;
-  }
-
   /** Source locale for translations */
   sourceLocale?: string;
 


### PR DESCRIPTION
## Summary

- Accept `apiKey`, `devApiKey`, and `orgApiKey` as configuration aliases normalized into one stored API key.
- Read `GT_ORG_API_KEY` as an environment fallback while continuing to require a project ID for project operations.

## Testing

- `pnpm --filter generaltranslation test` — passed (31 files, 504 tests)
- `pnpm --filter generaltranslation typecheck` — passed
- `pnpm check:library-defaults` — passed (4 tests)
- `pnpm build` — passed (20 packages)
- `pnpm exec oxfmt --check packages/core/src/runtime.ts packages/core/src/__tests__/index.test.ts .changeset/tidy-oranges-agree.md` — passed

## Notes

- Changeset: added a patch release for `generaltranslation`.
- Follow-up: [#2022](https://github.com/generaltranslation/gt/pull/2022) adds organization-authenticated project creation and is stacked on this branch.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR consolidates three API key aliases (`apiKey`, `devApiKey`, `orgApiKey`) and the new `GT_ORG_API_KEY` environment variable into a single `this.apiKey` field, establishing a clear left-to-right priority (`apiKey > devApiKey > orgApiKey`, and env fallbacks in the same order). Explicit constructor/`setConfig` values now always override environment-loaded keys, fixing a previously-noted silent precedence bug.

- **New `orgApiKey` alias**: accepted in both `GTConstructorParams` and `setConfig`, normalized into `this.apiKey` with the lowest priority among the three aliases; `GT_ORG_API_KEY` is added as an env fallback.
- **`devApiKey` field removed**: the public `devApiKey` class property on `GTRuntime` is removed; both dev and org keys are now stored under `this.apiKey`. This is a breaking API change for any consumer that reads `instance.devApiKey` directly.
- **Changeset bump**: the changeset is classified as `patch`, but the removal of the public field warrants at least a `minor` bump.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge after confirming the semver classification — the logic changes are correct and well-tested, but the changeset bump needs to be revisited.

The key-resolution logic is sound and the explicit-over-env priority is now correctly enforced. The only real concern is that removing the public `devApiKey` field from `GTRuntime` is a breaking API surface change for TypeScript consumers who access that property directly, yet the changeset marks this as a patch release.

**Files Needing Attention:** `packages/core/src/runtime.ts` (removal of `devApiKey` public field) and `.changeset/tidy-oranges-agree.md` (version classification).
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/runtime.ts | Merges apiKey/devApiKey/orgApiKey into a single `this.apiKey` field with ||-chain priority; removes the `devApiKey` public class property, which is a breaking API change mislabeled as a patch release. |
| packages/core/src/__tests__/index.test.ts | Adds four new test cases covering orgApiKey construction, env-vs-explicit priority order, missing projectId, and missing apiKey validation; updates the all-options config test to match the new normalized-key behaviour. |
| .changeset/tidy-oranges-agree.md | Changeset is marked `patch`; removing the public `devApiKey` field makes this at least a `minor` bump. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Constructor called with GTConstructorParams] --> B{process defined?}
    B -- Yes --> C["this.apiKey ||= GT_API_KEY || GT_DEV_API_KEY || GT_ORG_API_KEY"]
    B -- No --> D[skip env read]
    C --> E[setConfig called with params]
    D --> E
    E --> F["this.apiKey = apiKey || devApiKey || orgApiKey || this.apiKey"]
    F --> G{Explicit key passed?}
    G -- Yes --> H[Explicit key wins - env key overwritten]
    G -- No --> I[Env key preserved]
    H --> J[_getTranslationConfig returns this.apiKey]
    I --> J
    J --> K{apiKey && projectId?}
    K -- No --> L[_validateAuth throws error]
    K -- Yes --> M[Translation request sent]
```
</details>

<sub>Reviews (8): Last reviewed commit: ["refactor(core): expose one API key field"](https://github.com/generaltranslation/gt/commit/d6da6d41009218f096da6693a33452eed5ace95c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50188295)</sub>

<!-- /greptile_comment -->