### PR TITLE
fix(cli): clarify explicit id hash collisions

### DIFF
--- a/packages/cli/src/translation/__tests__/parse.test.ts
+++ b/packages/cli/src/translation/__tests__/parse.test.ts
@@ -18,18 +18,26 @@ describe('createUpdates', () => {
     vi.clearAllMocks();
   });
 
-  it('rejects duplicate custom ids when entries have distinct hashes', async () => {
+  it('rejects derived <T> entries when one explicit id has distinct hashes', async () => {
     vi.mocked(createInlineUpdates).mockResolvedValue({
       updates: [
         {
           dataFormat: 'ICU',
           source: 'Hello',
-          metadata: { id: 'shared-id', hash: 'first-hash' },
+          metadata: {
+            id: 'landing',
+            hash: 'first-hash',
+            staticId: 'derive-id',
+          },
         },
         {
           dataFormat: 'ICU',
           source: 'Goodbye',
-          metadata: { id: 'shared-id', hash: 'second-hash' },
+          metadata: {
+            id: 'landing',
+            hash: 'second-hash',
+            staticId: 'derive-id',
+          },
         },
       ],
       errors: [],
@@ -46,9 +54,9 @@ describe('createUpdates', () => {
       {} as ParsingConfigOptions
     );
 
-    expect(result.errors).toHaveLength(1);
-    expect(result.errors[0]).toContain('same id');
-    expect(result.errors[0]).toContain('shared-id');
+    expect(result.errors).toEqual([
+      'Explicit id landing cannot map to multiple source messages or hashes because one explicit id must map to exactly one source message and hash. Remove or rename duplicated IDs, or ensure every <T> component and dictionary entry using this id has matching content.',
+    ]);
     expect(result.updates).toEqual([]);
   });
 

--- a/packages/cli/src/translation/parse.ts
+++ b/packages/cli/src/translation/parse.ts
@@ -10,6 +10,22 @@ import chalk from 'chalk';
 import type { ParsingConfigOptions, GTParsingFlags } from '../types/parsing.js';
 import { exitSync } from '../console/logging.js';
 import { InlineLibrary, isPythonLibrary } from '../types/libraries.js';
+import { createDiagnosticMessage } from 'generaltranslation/internal';
+
+/**
+ * Explains why an explicit id cannot identify multiple source messages.
+ */
+function createDuplicateIdHashDiagnostic(id: string): string {
+  return createDiagnosticMessage({
+    whatHappened: `Explicit id ${chalk.blue(
+      id
+    )} cannot map to multiple source messages or hashes`,
+    why: 'one explicit id must map to exactly one source message and hash',
+    fix: `Remove or rename duplicated IDs, or ensure every ${chalk.green(
+      '<T>'
+    )} component and dictionary entry using this id has matching content`,
+  });
+}
 
 /**
  * Searches for gt-react or gt-next dictionary files and creates updates for them,
@@ -122,13 +138,7 @@ export async function createUpdates(
     const existingHash = idHashMap.get(id);
     if (existingHash !== undefined) {
       if (existingHash !== hash) {
-        errors.push(
-          `Hashes don't match on two components with the same id: ${chalk.blue(
-            id
-          )}. Check your ${chalk.green(
-            '<T>'
-          )} tags and dictionary entries and make sure you're not accidentally duplicating IDs.`
-        );
+        errors.push(createDuplicateIdHashDiagnostic(id));
         duplicateIds.add(id);
       }
     } else {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- explain that each explicit `id` must map to exactly one source message and hash
- identify the duplicated ID and give actionable fixes for `<T>` components and dictionary entries
- add regression coverage for derived entries that share an explicit ID but have distinct hashes

## Testing
- confirmed the regression test fails against the previous message and passes with the new diagnostic
- `pnpm --filter gt exec vitest run --config=./vitest.config.ts src/translation/__tests__/parse.test.ts`
- `pnpm --filter gt typecheck`
- `pnpm exec oxlint packages/cli/src/translation/parse.ts packages/cli/src/translation/__tests__/parse.test.ts`
- `pnpm exec oxfmt --check packages/cli/src/translation/parse.ts packages/cli/src/translation/__tests__/parse.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://generaltranslation.slack.com/archives/C0BJA1M93QC/p1785885329768019?thread_ts=1785885329.768019&cid=C0BJA1M93QC)

<div><a href="https://cursor.com/agents/bc-7cf166d7-4be0-5260-aab9-fd5c9ae1a865?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7cf166d7-4be0-5260-aab9-fd5c9ae1a865&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

