### PR TITLE
fix(cli): support logical && expressions inside <Derive>

### DIFF
--- a/.changeset/derive-logical-and-expressions.md
+++ b/.changeset/derive-logical-and-expressions.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+Support logical `&&` expressions inside `<Derive>`. The CLI's JSX extraction handled ternaries but not `&&`, so content like `{show && <li>...</li>}` wrapped in `<Derive>` errored as children that could change at runtime. A `cond && content` expression now derives two entries — the right-hand content and an empty branch — matching React's render-nothing behavior for falsy conditions. `||` and `??` expressions are unchanged and still require `<Var>`.

--- a/packages/cli/src/react/jsx/utils/jsxParsing/__tests__/deriveLogicalExpression.test.ts
+++ b/packages/cli/src/react/jsx/utils/jsxParsing/__tests__/deriveLogicalExpression.test.ts
@@ -1,0 +1,333 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as t from '@babel/types';
+import { parse } from '@babel/parser';
+import traverse from '@babel/traverse';
+import { parseTranslationComponent } from '../parseJsx.js';
+import { ParsingConfigOptions } from '../../../../../types/parsing.js';
+import { Updates } from '../../../../../types/index.js';
+import { Libraries } from '../../../../../types/libraries.js';
+
+// Mock fs and resolveImportPath (required by parseJsx internals)
+vi.mock('node:fs');
+vi.mock('../../resolveImportPath.js');
+
+/**
+ * Helper: parses source code containing a <T> component with Derive,
+ * returns the extracted updates, errors, and warnings.
+ *
+ * The source must `import { T, Derive } from "gt-next"`.
+ */
+function parseDerive(
+  source: string,
+  opts?: { filePath?: string }
+): { updates: Updates; errors: string[]; warnings: Set<string> } {
+  const filePath = opts?.filePath ?? '/test/derive-logical/page.tsx';
+  const updates: Updates = [];
+  const errors: string[] = [];
+  const warnings: Set<string> = new Set();
+  const parsingOptions: ParsingConfigOptions = { conditionNames: [] };
+
+  const ast = parse(source, {
+    sourceType: 'module',
+    plugins: ['jsx', 'typescript'],
+  });
+
+  let tLocalName = '';
+  const importAliases: Record<string, string> = {};
+
+  traverse(ast, {
+    ImportDeclaration(path) {
+      if (path.node.source.value === 'gt-next') {
+        path.node.specifiers.forEach((spec) => {
+          if (t.isImportSpecifier(spec) && t.isIdentifier(spec.imported)) {
+            const name = spec.imported.name;
+            importAliases[spec.local.name] = name;
+            if (name === 'T') {
+              tLocalName = spec.local.name;
+            }
+          }
+        });
+      }
+    },
+  });
+
+  traverse(ast, {
+    Program(programPath) {
+      const tBinding = programPath.scope.getBinding(tLocalName);
+      if (tBinding) {
+        parseTranslationComponent({
+          originalName: 'T',
+          localName: tLocalName,
+          path: tBinding.path,
+          updates,
+          config: {
+            importAliases,
+            parsingOptions,
+            pkgs: [Libraries.GT_NEXT],
+            file: filePath,
+          },
+          output: {
+            errors,
+            warnings,
+            unwrappedExpressions: [],
+          },
+        });
+      }
+    },
+  });
+
+  return { updates, errors, warnings };
+}
+
+describe('Derive with logical && expressions in JSX', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('derives condition && JSX element into content and empty branches', () => {
+    const source = `
+      import { T, Derive } from "gt-next";
+
+      export default function Page({ show }) {
+        return (
+          <T>
+            Hello
+            <Derive>{show && <li>Extra item</li>}</Derive>
+          </T>
+        );
+      }
+    `;
+
+    const { updates, errors } = parseDerive(source);
+
+    expect(errors).toHaveLength(0);
+    expect(updates).toHaveLength(2);
+
+    const sources = updates.map((u) => u.source);
+    expect(sources).toContainEqual([
+      'Hello',
+      { t: 'Derive', i: 1, c: { t: 'li', i: 2, c: 'Extra item' } },
+    ]);
+    expect(sources).toContainEqual(['Hello', { t: 'Derive', i: 1 }]);
+  });
+
+  it('derives condition && parenthesized JSX with nested elements', () => {
+    const source = `
+      import { T, Derive } from "gt-next";
+      import Link from "next/link";
+
+      export default function Page({ showFullDegree }) {
+        return (
+          <T>
+            <ul>
+              <li>Studied Computer Science.</li>
+              <Derive>
+                {
+                  showFullDegree && (
+                    <li><Link href='https://example.com'>Computer Science</Link>, and more.</li>
+                  )
+                }
+              </Derive>
+            </ul>
+          </T>
+        );
+      }
+    `;
+
+    const { updates, errors } = parseDerive(source);
+
+    expect(errors).toHaveLength(0);
+    expect(updates).toHaveLength(2);
+
+    const serialized = updates.map((u) => JSON.stringify(u.source));
+    expect(serialized.some((s) => s.includes(', and more.'))).toBe(true);
+    // The empty branch keeps the Derive element but drops its children
+    expect(
+      serialized.some(
+        (s) => !s.includes(', and more.') && s.includes('"t":"Derive"')
+      )
+    ).toBe(true);
+    // The static sibling <li> is present in both variants
+    expect(
+      serialized.every((s) => s.includes('Studied Computer Science.'))
+    ).toBe(true);
+  });
+
+  it('derives condition && string literal', () => {
+    const source = `
+      import { T, Derive } from "gt-next";
+
+      export default function Page({ cond }) {
+        return (
+          <T>
+            Status: <Derive>{cond && "active"}</Derive>
+          </T>
+        );
+      }
+    `;
+
+    const { updates, errors } = parseDerive(source);
+
+    expect(errors).toHaveLength(0);
+    expect(updates).toHaveLength(2);
+
+    const sources = updates.map((u) => u.source);
+    expect(sources).toContainEqual([
+      'Status: ',
+      { t: 'Derive', i: 1, c: 'active' },
+    ]);
+    expect(sources).toContainEqual(['Status: ', { t: 'Derive', i: 1 }]);
+  });
+
+  it('derives condition && function invocation into all variants plus empty branch', () => {
+    const source = `
+      import { T, Derive } from "gt-next";
+
+      function getSubject(gender) {
+        return gender === 'male' ? 'boy' : 'girl';
+      }
+
+      export default function Page({ cond, gender }) {
+        return (
+          <T>
+            The <Derive>{cond && getSubject(gender)}</Derive> runs.
+          </T>
+        );
+      }
+    `;
+
+    const { updates, errors } = parseDerive(source);
+
+    expect(errors).toHaveLength(0);
+    expect(updates).toHaveLength(3);
+
+    const serialized = updates.map((u) => JSON.stringify(u.source));
+    expect(serialized.some((s) => s.includes('boy'))).toBe(true);
+    expect(serialized.some((s) => s.includes('girl'))).toBe(true);
+    expect(
+      serialized.some((s) => !s.includes('boy') && !s.includes('girl'))
+    ).toBe(true);
+  });
+
+  it('derives chained conditions a && b && content into two branches', () => {
+    const source = `
+      import { T, Derive } from "gt-next";
+
+      export default function Page({ a, b }) {
+        return (
+          <T>
+            Hello
+            <Derive>{a && b && <li>Both true</li>}</Derive>
+          </T>
+        );
+      }
+    `;
+
+    const { updates, errors } = parseDerive(source);
+
+    expect(errors).toHaveLength(0);
+    expect(updates).toHaveLength(2);
+  });
+
+  it('derives condition && ternary into all ternary variants plus empty branch', () => {
+    const source = `
+      import { T, Derive } from "gt-next";
+
+      export default function Page({ cond, flag }) {
+        return (
+          <T>
+            Hello <Derive>{cond && (flag ? "first" : "second")}</Derive>
+          </T>
+        );
+      }
+    `;
+
+    const { updates, errors } = parseDerive(source);
+
+    expect(errors).toHaveLength(0);
+    expect(updates).toHaveLength(3);
+
+    const sources = updates.map((u) => u.source);
+    expect(sources).toContainEqual([
+      'Hello ',
+      { t: 'Derive', i: 1, c: 'first' },
+    ]);
+    expect(sources).toContainEqual([
+      'Hello ',
+      { t: 'Derive', i: 1, c: 'second' },
+    ]);
+    expect(sources).toContainEqual(['Hello ', { t: 'Derive', i: 1 }]);
+  });
+
+  it('still errors when the right side of && is dynamic', () => {
+    const source = `
+      import { T, Derive } from "gt-next";
+
+      export default function Page({ cond, userName }) {
+        return (
+          <T>
+            Hello <Derive>{cond && userName}</Derive>
+          </T>
+        );
+      }
+    `;
+
+    const { updates, errors } = parseDerive(source);
+
+    expect(errors.length).toBeGreaterThan(0);
+    expect(updates).toHaveLength(0);
+  });
+
+  it('still errors on || expressions with dynamic content', () => {
+    const source = `
+      import { T, Derive } from "gt-next";
+
+      export default function Page({ name }) {
+        return (
+          <T>
+            Hello <Derive>{name || "Anonymous"}</Derive>
+          </T>
+        );
+      }
+    `;
+
+    const { updates, errors } = parseDerive(source);
+
+    expect(errors.length).toBeGreaterThan(0);
+    expect(updates).toHaveLength(0);
+  });
+
+  it('derives && returned from a function wrapped in Derive', () => {
+    const source = `
+      import { T, Derive } from "gt-next";
+
+      export default function Page({ show }) {
+        function getExtra() {
+          return show && <li>Extra item</li>;
+        }
+        return (
+          <T>
+            Hello
+            <Derive>{getExtra()}</Derive>
+          </T>
+        );
+      }
+    `;
+
+    const { updates, errors } = parseDerive(source);
+
+    expect(errors).toHaveLength(0);
+    expect(updates).toHaveLength(2);
+
+    const sources = updates.map((u) => u.source);
+    expect(sources).toContainEqual([
+      'Hello',
+      { t: 'Derive', i: 1, c: { t: 'li', i: 2, c: 'Extra item' } },
+    ]);
+    expect(sources).toContainEqual(['Hello', { t: 'Derive', i: 1 }]);
+  });
+});

--- a/packages/cli/src/react/jsx/utils/jsxParsing/__tests__/deriveLogicalExpression.test.ts
+++ b/packages/cli/src/react/jsx/utils/jsxParsing/__tests__/deriveLogicalExpression.test.ts
@@ -263,6 +263,38 @@ describe('Derive with logical && expressions in JSX', () => {
     expect(sources).toContainEqual(['Hello ', { t: 'Derive', i: 1 }]);
   });
 
+  it('derives && alongside static sibling content inside Derive', () => {
+    const source = `
+      import { T, Derive } from "gt-next";
+
+      export default function Page({ cond }) {
+        return (
+          <T>
+            Hello
+            <Derive>prefix {cond && "x"}</Derive>
+          </T>
+        );
+      }
+    `;
+
+    const { updates, errors } = parseDerive(source);
+
+    expect(errors).toHaveLength(0);
+    expect(updates).toHaveLength(2);
+
+    const sources = updates.map((u) => u.source);
+    expect(sources).toContainEqual([
+      'Hello',
+      { t: 'Derive', i: 1, c: ['prefix ', 'x'] },
+    ]);
+    // The empty variant drops the falsy child but keeps the static sibling,
+    // matching the runtime serialization of <Derive>prefix {false}</Derive>
+    expect(sources).toContainEqual([
+      'Hello',
+      { t: 'Derive', i: 1, c: ['prefix '] },
+    ]);
+  });
+
   it('still errors when the right side of && is dynamic', () => {
     const source = `
       import { T, Derive } from "gt-next";

--- a/packages/cli/src/react/jsx/utils/jsxParsing/__tests__/deriveLogicalExpression.test.ts
+++ b/packages/cli/src/react/jsx/utils/jsxParsing/__tests__/deriveLogicalExpression.test.ts
@@ -263,6 +263,59 @@ describe('Derive with logical && expressions in JSX', () => {
     expect(sources).toContainEqual(['Hello ', { t: 'Derive', i: 1 }]);
   });
 
+  it('does not duplicate the empty branch for nested parenthesized &&', () => {
+    const source = `
+      import { T, Derive } from "gt-next";
+
+      export default function Page({ a, b }) {
+        return (
+          <T>
+            Hello
+            <Derive>{a && (b && <li>Both true</li>)}</Derive>
+          </T>
+        );
+      }
+    `;
+
+    const { updates, errors } = parseDerive(source);
+
+    expect(errors).toHaveLength(0);
+    expect(updates).toHaveLength(2);
+
+    const sources = updates.map((u) => u.source);
+    expect(sources).toContainEqual([
+      'Hello',
+      { t: 'Derive', i: 1, c: { t: 'li', i: 2, c: 'Both true' } },
+    ]);
+    expect(sources).toContainEqual(['Hello', { t: 'Derive', i: 1 }]);
+  });
+
+  it('does not duplicate the empty branch for && wrapping a ternary with a null branch', () => {
+    const source = `
+      import { T, Derive } from "gt-next";
+
+      export default function Page({ cond, flag }) {
+        return (
+          <T>
+            Hello <Derive>{cond && (flag ? "text" : null)}</Derive>
+          </T>
+        );
+      }
+    `;
+
+    const { updates, errors } = parseDerive(source);
+
+    expect(errors).toHaveLength(0);
+    expect(updates).toHaveLength(2);
+
+    const sources = updates.map((u) => u.source);
+    expect(sources).toContainEqual([
+      'Hello ',
+      { t: 'Derive', i: 1, c: 'text' },
+    ]);
+    expect(sources).toContainEqual(['Hello ', { t: 'Derive', i: 1 }]);
+  });
+
   it('derives && alongside static sibling content inside Derive', () => {
     const source = `
       import { T, Derive } from "gt-next";

--- a/packages/cli/src/react/jsx/utils/jsxParsing/parseJsx.ts
+++ b/packages/cli/src/react/jsx/utils/jsxParsing/parseJsx.ts
@@ -44,7 +44,12 @@ import { buildImportMap } from '../buildImportMap.js';
 import { getPathsAndAliases } from '../getPathsAndAliases.js';
 import { parseTProps } from './parseTProps.js';
 import { handleChildrenWhitespace } from './handleChildrenWhitespace.js';
-import { MultiplicationNode, JsxTree, isElementNode } from './types.js';
+import {
+  MultiplicationNode,
+  JsxTree,
+  isElementNode,
+  isMultiplicationNode,
+} from './types.js';
 import { multiplyJsxTree } from './multiplication/multiplyJsxTree.js';
 import { removeNullChildrenFields } from './removeNullChildrenFields.js';
 import {
@@ -1448,12 +1453,16 @@ function processDeriveExpression({
         'right'
       ) as NodePath<t.Expression>,
     });
+    // Skip the extra empty branch when the right side already derived one
+    // (e.g. cond && (b && <li/>) or cond && (b ? <li/> : null)) so identical
+    // empty variants aren't produced
+    const branches = Array.isArray(rightResult) ? rightResult : [rightResult];
     const result: MultiplicationNode = {
       nodeType: 'multiplication' as const,
-      branches: [
-        ...(Array.isArray(rightResult) ? rightResult : [rightResult]),
-        null,
-      ],
+      branches:
+        !Array.isArray(rightResult) && containsEmptyBranch(rightResult)
+          ? branches
+          : [...branches, null],
     };
     return result;
   } else if (t.isConditionalExpression(expressionNodePath.node)) {
@@ -1572,4 +1581,17 @@ function processDeriveExpression({
       output,
     });
   }
+}
+
+/**
+ * Whether a derive result already yields an empty (null) variant, looking
+ * through nested multiplication branches. Elements and strings are content,
+ * not empty variants.
+ */
+function containsEmptyBranch(node: JsxTree | MultiplicationNode): boolean {
+  if (node === null) return true;
+  if (isMultiplicationNode(node)) {
+    return node.branches.some(containsEmptyBranch);
+  }
+  return false;
 }

--- a/packages/cli/src/react/jsx/utils/jsxParsing/parseJsx.ts
+++ b/packages/cli/src/react/jsx/utils/jsxParsing/parseJsx.ts
@@ -1432,6 +1432,30 @@ function processDeriveExpression({
       state,
       output,
     });
+  } else if (
+    t.isLogicalExpression(expressionNodePath.node) &&
+    expressionNodePath.node.operator === '&&'
+  ) {
+    // ex: return condition && <div>Jsx content</div>
+    // React renders nothing when the condition is falsy, so this derives to
+    // the right-hand content plus an empty branch
+    const rightResult = processDeriveExpression({
+      config,
+      state,
+      output,
+      scopeNode,
+      expressionNodePath: expressionNodePath.get(
+        'right'
+      ) as NodePath<t.Expression>,
+    });
+    const result: MultiplicationNode = {
+      nodeType: 'multiplication' as const,
+      branches: [
+        ...(Array.isArray(rightResult) ? rightResult : [rightResult]),
+        null,
+      ],
+    };
+    return result;
   } else if (t.isConditionalExpression(expressionNodePath.node)) {
     // ex: return condition ? <div>Jsx content</div> : <div>Jsx content</div>
     // since two options here we must construct a new multiplication node

--- a/packages/react-core/src/utils/internal/__tests__/deriveLogicalAndHashParity.test.tsx
+++ b/packages/react-core/src/utils/internal/__tests__/deriveLogicalAndHashParity.test.tsx
@@ -97,4 +97,62 @@ describe('<Derive> logical && hash parity with the CLI', () => {
     ] as JsxChildren;
     expect(runtimeHash(runtimeChildren)).toBe(cliHash(cliSource));
   });
+
+  // `cond && x` returns the left operand when falsy, so at runtime the Derive
+  // children can be any falsy value, not just false. As the sole child, every
+  // falsy value fails the props.children truthiness checks in addGTIdentifier
+  // and writeChildrenAsObjects, so `c` is omitted and the hash matches the
+  // registered empty branch — even for 0 and NaN, which React would render
+  it.each([
+    ['false', false],
+    ['null', null],
+    ['undefined', undefined],
+    ['zero', 0],
+    ['empty string', ''],
+    ['NaN', NaN],
+  ])(
+    'sole-child falsy guard result (%s) hashes to the CLI empty-branch entry',
+    (_label, value) => {
+      const runtimeChildren = childrenOf(
+        <>
+          Hello
+          <Derive>{value as ReactNode}</Derive>
+        </>
+      );
+      expect(runtimeHash(runtimeChildren)).toBe(cliHash(CLI_EMPTY_SOURCE));
+    }
+  );
+
+  // KNOWN LIMITATION: beside sibling content, falsy-but-renderable guard
+  // results ('' stays in the runtime children array; 0/NaN serialize as
+  // "0"/"NaN") do not match either registered variant, so lookup falls back
+  // to the untranslated source. This mirrors React's own guidance against
+  // non-boolean && guards; guards must be falsy-safe (boolean/null/undefined)
+  // when the Derive has sibling content. If serialization of falsy children
+  // is ever normalized, update these expectations.
+  it.each([
+    ['zero', 0],
+    ['empty string', ''],
+    ['NaN', NaN],
+  ])(
+    'sibling-content non-boolean falsy guard (%s) misses both registered variants',
+    (_label, value) => {
+      const runtimeChildren = childrenOf(
+        <>
+          Hello
+          <Derive>prefix {value as ReactNode}</Derive>
+        </>
+      );
+      const cliEmptySource = [
+        'Hello',
+        { t: 'Derive', i: 1, c: ['prefix '] },
+      ] as JsxChildren;
+      const cliContentSource = [
+        'Hello',
+        { t: 'Derive', i: 1, c: ['prefix ', 'x'] },
+      ] as JsxChildren;
+      expect(runtimeHash(runtimeChildren)).not.toBe(cliHash(cliEmptySource));
+      expect(runtimeHash(runtimeChildren)).not.toBe(cliHash(cliContentSource));
+    }
+  );
 });

--- a/packages/react-core/src/utils/internal/__tests__/deriveLogicalAndHashParity.test.tsx
+++ b/packages/react-core/src/utils/internal/__tests__/deriveLogicalAndHashParity.test.tsx
@@ -1,0 +1,100 @@
+import { it, expect, describe } from 'vitest';
+import type { ReactElement, ReactNode } from 'react';
+import { addGTIdentifier } from '../addGTIdentifier';
+import { writeChildrenAsObjects } from '../writeChildrenAsObjects';
+import { removeInjectedT } from '../removeInjectedT';
+import { Derive } from '../../../components/derivation/Derive';
+import { hashSource } from 'generaltranslation/id';
+import type { JsxChildren } from '@generaltranslation/format/types';
+
+// Mirrors prepareT.shared.ts: the pipeline the runtime uses to compute the
+// lookup hash for a <T> component's children
+function runtimeHash(children: ReactNode): string {
+  const source = writeChildrenAsObjects(
+    addGTIdentifier(removeInjectedT(children))
+  );
+  return hashSource({ source, dataFormat: 'JSX' });
+}
+
+// Mirrors extraction/postProcess.ts calculateHashes in the CLI
+function cliHash(source: JsxChildren): string {
+  return hashSource({ source, dataFormat: 'JSX' });
+}
+
+function childrenOf(element: ReactElement): ReactNode {
+  return (element as ReactElement<{ children: ReactNode }>).props.children;
+}
+
+/**
+ * The CLI derives `cond && content` inside <Derive> into two entries: the
+ * right-hand content, and an empty (null) branch. At runtime the falsy case
+ * leaves `false` (not null) as the Derive children, so these tests pin that
+ * both serialize identically and the registered hashes match what the
+ * runtime looks up.
+ *
+ * The CLI_* sources are the exact extraction outputs asserted in
+ * packages/cli/src/react/jsx/utils/jsxParsing/__tests__/deriveLogicalExpression.test.ts
+ * for <T>Hello<Derive>{show && <li>Extra item</li>}</Derive></T> and
+ * <T>Hello<Derive>prefix {cond && "x"}</Derive></T>.
+ */
+describe('<Derive> logical && hash parity with the CLI', () => {
+  const CLI_CONTENT_SOURCE = [
+    'Hello',
+    { t: 'Derive', i: 1, c: { t: 'li', i: 2, c: 'Extra item' } },
+  ] as JsxChildren;
+  const CLI_EMPTY_SOURCE = ['Hello', { t: 'Derive', i: 1 }] as JsxChildren;
+
+  function tChildren(show: boolean): ReactNode {
+    return childrenOf(
+      <>
+        Hello
+        <Derive>{show && <li>Extra item</li>}</Derive>
+      </>
+    );
+  }
+
+  it('falsy && at runtime hashes to the CLI empty-branch entry', () => {
+    expect(runtimeHash(tChildren(false))).toBe(cliHash(CLI_EMPTY_SOURCE));
+  });
+
+  it('truthy && at runtime hashes to the CLI content-branch entry', () => {
+    expect(runtimeHash(tChildren(true))).toBe(cliHash(CLI_CONTENT_SOURCE));
+  });
+
+  it('empty and content branches hash differently', () => {
+    expect(cliHash(CLI_EMPTY_SOURCE)).not.toBe(cliHash(CLI_CONTENT_SOURCE));
+  });
+
+  it('false (from &&) and null (from ternaries) children hash identically', () => {
+    const withFalse = (
+      <>
+        Hello
+        <Derive>{false}</Derive>
+      </>
+    );
+    const withNull = (
+      <>
+        Hello
+        <Derive>{null}</Derive>
+      </>
+    );
+    expect(runtimeHash(childrenOf(withFalse))).toBe(
+      runtimeHash(childrenOf(withNull))
+    );
+  });
+
+  it('falsy && beside static sibling content matches the CLI-filtered source', () => {
+    const runtimeChildren = childrenOf(
+      <>
+        Hello
+        <Derive>prefix {false}</Derive>
+      </>
+    );
+    // CLI empty variant keeps the static sibling and filters out the null
+    const cliSource = [
+      'Hello',
+      { t: 'Derive', i: 1, c: ['prefix '] },
+    ] as JsxChildren;
+    expect(runtimeHash(runtimeChildren)).toBe(cliHash(cliSource));
+  });
+});


### PR DESCRIPTION
## Problem

Wrapping a conditional `&&` expression in `<Derive>` fails extraction:

```tsx
<Derive>
  {showFullDegree && (
    <li>...</li>
  )}
</Derive>
```

The CLI reports that the `<T>` component "has children that could change at runtime", even though this is exactly the kind of finite-variant content `<Derive>` exists to handle.

## Cause

`processDeriveExpression` in `packages/cli/src/react/jsx/utils/jsxParsing/parseJsx.ts` handles ternaries (`ConditionalExpression`) by producing a multiplication node with one branch per outcome, but has no case for `LogicalExpression`. A `cond && <jsx>` expression fell through to `buildJSXTree`, which flags logical expressions as unwrapped dynamic content.

## Fix

Add a `LogicalExpression` case for the `&&` operator that derives two branches:

- the right-hand content (condition truthy), resolved recursively so nested ternaries, string literals, and function invocations all keep working
- an empty (`null`) branch (condition falsy), matching React's render-nothing behavior

`||` and `??` are intentionally unchanged (both operands are content in those cases, and the left side is typically dynamic); they still produce the existing error.

## Runtime hash parity

At runtime the falsy case resolves to `false` (not `null`) as the Derive children, so the null branch is only correct if both serialize identically. Verified end-to-end and pinned with a react-core test suite that pushes real React elements through the runtime pipeline (`removeInjectedT` → `addGTIdentifier` → `writeChildrenAsObjects` → `hashSource`) and compares against the CLI extraction output hashed the way `calculateHashes` does:

- falsy `&&` at runtime hashes byte-identically to the CLI's registered empty-branch entry (`hashSource` drops falsy `c` fields on both sides, and element tag names/indices are stripped by sanitization)
- truthy `&&` hashes to the content-branch entry
- `false` (from `&&`) and `null` (from ternaries) children hash identically
- with sibling content (`<Derive>prefix {cond && "x"}</Derive>`), the runtime drops the `false` from the children array exactly where the CLI filters the `null`, including array-shape agreement (`c: ["prefix "]`)

## Testing

- New CLI test suite covering: `&&` with a JSX element, parenthesized JSX with nested elements, string literal, function invocation (variants × empty), chained `a && b && x`, `&&` wrapping a ternary, `&&` returned from a function wrapped in `<Derive>`, sibling content, and controls asserting that dynamic right-hand sides and `||` still error
- New react-core hash-parity suite (above)
- Verified the full reported `<T>` component end-to-end: extracts 2 variants with no errors
- `pnpm --filter gt test` (2120 tests), react-core tests, typecheck, lint, and format all pass
- Patch changeset for `gt` included (`gtx-cli` bumps via the fixed group)

## Non-boolean guard limitation

`cond && x` returns the falsy left operand itself, so at runtime the Derive children can be `false`, `null`, `undefined`, `''`, `0`, or `NaN` — not just `false`. Verified behavior (pinned in the parity suite):

- **Sole child (the canonical case): correct for every falsy value.** All falsy sole children fail the `props.children` truthiness checks in `addGTIdentifier`/`writeChildrenAsObjects`, so `c` is omitted and the hash matches the registered empty branch — including `0` and `NaN`.
- **Beside sibling content (`<Derive>prefix {cond && "x"}</Derive>`): falsy-but-renderable guards (`0`, `NaN`, `''`) miss both registered variants** and that render falls back to the untranslated source. Boolean/null/undefined guards are exact.

Modeling these variants would register junk entries (`"prefix 0"`) for every `&&` even with boolean guards, and rejecting non-provably-boolean operands is impossible without type information (it would reject bare identifiers, the dominant case — ternary conditions are equally untyped and are accepted today). There is also a fundamental runtime ambiguity: `<Derive>{0}</Derive>` is indistinguishable between "falsy guard → empty branch" and "numeric variant → `"0"`", so no runtime normalization satisfies both. The falsy-children serialization gap is a pre-existing class (e.g. a legitimate `0` variant as sole child already serializes without `c` today). The limitation mirrors React's own guidance against non-boolean `&&` guards; the docs' Derive page should state that guards must be falsy-safe when the `<Derive>` has sibling content.

