### PR TITLE
fix(cli): warn instead of erroring when <T> with id or hash contains <Derive>

### DIFF
--- a/.changeset/derive-static-lookup-warning.md
+++ b/.changeset/derive-static-lookup-warning.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+Warn clearly when a `<T>` component with an explicit `id` or `hash` prop contains `<Derive>` content. Previously the derive variants tripped the generic "Hashes don't match on two components with the same id" error and every variant was dropped from extraction. Now the CLI keeps all variants and emits a warning explaining that the static `id`/`hash` overrides the lookup behavior for `<Derive>`, leaving the component stuck with one hard-coded option at runtime, with the fix being to remove the prop.

--- a/packages/cli/src/console/index.ts
+++ b/packages/cli/src/console/index.ts
@@ -83,6 +83,32 @@ export const warnHasUnwrappedExpressionSync = (
     location
   );
 
+export const warnDeriveWithStaticLookupSync = (
+  file: string,
+  propName: string,
+  id?: string,
+  location?: string
+): string =>
+  withLocation(
+    file,
+    createDiagnosticMessage({
+      whatHappened: `A ${colorizeComponent('<T>')} component${
+        id ? ` with id ${colorizeIdString(id)}` : ''
+      } has an explicit ${colorizeIdString(propName)} prop but contains ${colorizeComponent(
+        '<Derive>'
+      )} content`,
+      why: `the ${colorizeIdString(
+        propName
+      )} overrides the lookup behavior for ${colorizeComponent(
+        '<Derive>'
+      )}, so at runtime the component is stuck with one hard-coded option instead of translating every variant`,
+      fix: `Remove the ${colorizeIdString(propName)} prop from this ${colorizeComponent(
+        '<T>'
+      )} component`,
+    }),
+    location
+  );
+
 export const warnFailedToConstructJsxTreeSync = (
   file: string,
   code: string,

--- a/packages/cli/src/react/jsx/utils/jsxParsing/__tests__/deriveStaticLookupWarning.test.ts
+++ b/packages/cli/src/react/jsx/utils/jsxParsing/__tests__/deriveStaticLookupWarning.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as t from '@babel/types';
+import { parse } from '@babel/parser';
+import traverse from '@babel/traverse';
+import { parseTranslationComponent } from '../parseJsx.js';
+import { ParsingConfigOptions } from '../../../../../types/parsing.js';
+import { Updates } from '../../../../../types/index.js';
+import { Libraries } from '../../../../../types/libraries.js';
+
+// Mock fs and resolveImportPath (required by parseJsx internals)
+vi.mock('node:fs');
+vi.mock('../../resolveImportPath.js');
+
+/**
+ * Helper: parses source code containing a <T> component with Derive,
+ * returns the extracted updates, errors, and warnings.
+ *
+ * The source must `import { T, Derive } from "gt-next"`.
+ */
+function parseDerive(
+  source: string,
+  opts?: { filePath?: string }
+): { updates: Updates; errors: string[]; warnings: Set<string> } {
+  const filePath = opts?.filePath ?? '/test/derive-static-lookup/page.tsx';
+  const updates: Updates = [];
+  const errors: string[] = [];
+  const warnings: Set<string> = new Set();
+  const parsingOptions: ParsingConfigOptions = { conditionNames: [] };
+
+  const ast = parse(source, {
+    sourceType: 'module',
+    plugins: ['jsx', 'typescript'],
+  });
+
+  let tLocalName = '';
+  const importAliases: Record<string, string> = {};
+
+  traverse(ast, {
+    ImportDeclaration(path) {
+      if (path.node.source.value === 'gt-next') {
+        path.node.specifiers.forEach((spec) => {
+          if (t.isImportSpecifier(spec) && t.isIdentifier(spec.imported)) {
+            const name = spec.imported.name;
+            importAliases[spec.local.name] = name;
+            if (name === 'T') {
+              tLocalName = spec.local.name;
+            }
+          }
+        });
+      }
+    },
+  });
+
+  traverse(ast, {
+    Program(programPath) {
+      const tBinding = programPath.scope.getBinding(tLocalName);
+      if (tBinding) {
+        parseTranslationComponent({
+          originalName: 'T',
+          localName: tLocalName,
+          path: tBinding.path,
+          updates,
+          config: {
+            importAliases,
+            parsingOptions,
+            pkgs: [Libraries.GT_NEXT],
+            file: filePath,
+          },
+          output: {
+            errors,
+            warnings,
+            unwrappedExpressions: [],
+          },
+        });
+      }
+    },
+  });
+
+  return { updates, errors, warnings };
+}
+
+describe('<T> with id or hash prop containing <Derive>', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('warns (not errors) when a <T> with an id contains <Derive> variants', () => {
+    const source = `
+      import { T, Derive } from "gt-next";
+
+      export default function Page({ show }) {
+        return (
+          <T id="landing">
+            Hello
+            <Derive>{show && <li>Extra item</li>}</Derive>
+          </T>
+        );
+      }
+    `;
+
+    const { updates, errors, warnings } = parseDerive(source);
+
+    expect(errors).toHaveLength(0);
+    // All variants are still extracted, carrying the user-supplied id
+    expect(updates).toHaveLength(2);
+    expect(updates.every((u) => u.metadata.id === 'landing')).toBe(true);
+    expect(updates.every((u) => u.metadata.staticId)).toBeTruthy();
+
+    expect(warnings.size).toBe(1);
+    const warning = [...warnings][0];
+    expect(warning).toContain('landing');
+    expect(warning).toContain('overrides the lookup behavior');
+    expect(warning).toContain('one hard-coded option');
+  });
+
+  it('warns when a <T> with a hash prop contains <Derive> variants', () => {
+    const source = `
+      import { T, Derive } from "gt-next";
+
+      export default function Page({ show }) {
+        return (
+          <T hash="0123456789abcdef">
+            Hello
+            <Derive>{show && <li>Extra item</li>}</Derive>
+          </T>
+        );
+      }
+    `;
+
+    const { updates, errors, warnings } = parseDerive(source);
+
+    expect(errors).toHaveLength(0);
+    expect(updates).toHaveLength(2);
+
+    expect(warnings.size).toBe(1);
+    const warning = [...warnings][0];
+    expect(warning).toContain('hash');
+    expect(warning).toContain('overrides the lookup behavior');
+  });
+
+  it('warns when a <T> with a _hash prop contains <Derive> variants', () => {
+    const source = `
+      import { T, Derive } from "gt-next";
+
+      export default function Page({ show }) {
+        return (
+          <T _hash="0123456789abcdef">
+            Hello
+            <Derive>{show && <li>Extra item</li>}</Derive>
+          </T>
+        );
+      }
+    `;
+
+    const { errors, warnings } = parseDerive(source);
+
+    expect(errors).toHaveLength(0);
+    expect(warnings.size).toBe(1);
+    expect([...warnings][0]).toContain('_hash');
+  });
+
+  it('does not warn for a <T> with an id and no derived variants', () => {
+    const source = `
+      import { T } from "gt-next";
+
+      export default function Page() {
+        return (
+          <T id="landing">
+            Hello world
+          </T>
+        );
+      }
+    `;
+
+    const { updates, errors, warnings } = parseDerive(source);
+
+    expect(errors).toHaveLength(0);
+    expect(warnings.size).toBe(0);
+    expect(updates).toHaveLength(1);
+  });
+
+  it('does not warn for <Derive> variants without an id or hash', () => {
+    const source = `
+      import { T, Derive } from "gt-next";
+
+      export default function Page({ show }) {
+        return (
+          <T>
+            Hello
+            <Derive>{show && <li>Extra item</li>}</Derive>
+          </T>
+        );
+      }
+    `;
+
+    const { updates, errors, warnings } = parseDerive(source);
+
+    expect(errors).toHaveLength(0);
+    expect(warnings.size).toBe(0);
+    expect(updates).toHaveLength(2);
+  });
+
+  it('warns for a ternary <Derive> with an id', () => {
+    const source = `
+      import { T, Derive } from "gt-next";
+
+      export default function Page({ gender }) {
+        return (
+          <T id="subject">
+            The <Derive>{gender === 'male' ? 'boy' : 'girl'}</Derive> runs.
+          </T>
+        );
+      }
+    `;
+
+    const { updates, errors, warnings } = parseDerive(source);
+
+    expect(errors).toHaveLength(0);
+    expect(updates).toHaveLength(2);
+    expect(warnings.size).toBe(1);
+    expect([...warnings][0]).toContain('subject');
+  });
+});

--- a/packages/cli/src/react/jsx/utils/jsxParsing/parseJsx.ts
+++ b/packages/cli/src/react/jsx/utils/jsxParsing/parseJsx.ts
@@ -20,6 +20,7 @@ import {
   warnNestedInternalTComponent,
   warnDeriveNonConstVariableSync,
   warnDeriveDestructuringSync,
+  warnDeriveWithStaticLookupSync,
 } from '../../../../console/index.js';
 import { isAcceptedPluralForm } from 'generaltranslation/internal';
 import { isStaticExpression } from '../../evaluateJsx.js';
@@ -838,6 +839,25 @@ function parseJSXElement({
     });
     if (contextNode) {
       contextVariants = nodeToStrings(contextNode);
+    }
+  }
+
+  // Warn when an explicit id or hash prop is combined with derived variants:
+  // the static lookup key pins the component to a single variant at runtime
+  const variantCount = minifiedTress.length * (contextVariants?.length ?? 1);
+  if (variantCount > 1) {
+    const staticLookupProp = (['id', 'hash', '_hash', '$_hash'] as const).find(
+      (prop) => metadata[prop]
+    );
+    if (staticLookupProp) {
+      output.warnings.add(
+        warnDeriveWithStaticLookupSync(
+          config.file,
+          staticLookupProp,
+          metadata.id,
+          `${node.loc?.start?.line}:${node.loc?.start?.column}`
+        )
+      );
     }
   }
 

--- a/packages/cli/src/translation/__tests__/parse.test.ts
+++ b/packages/cli/src/translation/__tests__/parse.test.ts
@@ -52,6 +52,50 @@ describe('createUpdates', () => {
     expect(result.updates).toEqual([]);
   });
 
+  it('allows derive variants (staticId) to share an id with distinct hashes', async () => {
+    vi.mocked(createInlineUpdates).mockResolvedValue({
+      updates: [
+        {
+          dataFormat: 'JSX',
+          source: ['Hello', { t: 'Derive', i: 1, c: 'boy' }],
+          metadata: {
+            id: 'landing',
+            hash: 'first-hash',
+            staticId: 'shared-derive-id',
+          },
+        },
+        {
+          dataFormat: 'JSX',
+          source: ['Hello', { t: 'Derive', i: 1, c: 'girl' }],
+          metadata: {
+            id: 'landing',
+            hash: 'second-hash',
+            staticId: 'shared-derive-id',
+          },
+        },
+      ],
+      errors: [],
+      warnings: [],
+    });
+
+    const result = await createUpdates(
+      {} as TranslateFlags,
+      [],
+      undefined,
+      Libraries.GT_REACT,
+      false,
+      {},
+      {} as ParsingConfigOptions
+    );
+
+    expect(result.errors).toEqual([]);
+    expect(result.updates).toHaveLength(2);
+    expect(result.updates.map((update) => update.metadata.id)).toEqual([
+      'landing',
+      'landing',
+    ]);
+  });
+
   it('allows duplicate custom ids when entries have matching hashes', async () => {
     vi.mocked(createInlineUpdates).mockResolvedValue({
       updates: [

--- a/packages/cli/src/translation/parse.ts
+++ b/packages/cli/src/translation/parse.ts
@@ -105,8 +105,13 @@ export async function createUpdates(
   };
 
   updates = updates.map((update) => {
-    const { id, hash } = update.metadata;
+    const { id, hash, staticId } = update.metadata;
     if (!id) return update;
+    // Derive variants intentionally share their <T>'s id, one entry per
+    // variant hash. Extraction already warns that a static id or hash pins
+    // the runtime lookup to a single variant, so don't also report them as
+    // accidentally duplicated ids.
+    if (staticId) return update;
     if (!hash) {
       if (hashlessIds.has(id) || idHashMap.has(id)) {
         warnHashlessDuplicateId(id);


### PR DESCRIPTION
Stacked on #2025.

## Problem

A `<T>` component with an explicit `id` (or `hash`) prop that contains `<Derive>` content fails extraction with a confusing, generic error:

> Hashes don't match on two components with the same id: **landing**. Check your `<T>` tags and dictionary entries and make sure you're not accidentally duplicating IDs.

The user didn't duplicate anything — the derive variants of a single `<T>` intentionally share its `id` while carrying one hash per variant. Worse, the duplicate-id validation then **dropped every variant** from extraction.

## Fix

- **Clear warning at extraction** (`parseJSXElement`): when a `<T>` produces more than one derived variant and has an explicit `id`, `hash`, `_hash`, or `$_hash` prop, the CLI warns:

  > A `<T>` component with id **landing** has an explicit **id** prop but contains `<Derive>` content because the **id** overrides the lookup behavior for `<Derive>`, so at runtime the component is stuck with one hard-coded option instead of translating every variant. Remove the **id** prop from this `<T>` component.

  Formatted with `createDiagnosticMessage()` per the repo's diagnostics conventions. It's a warning, not an error — extraction continues and all variants are registered.

- **Duplicate-id validation exemption** (`translation/parse.ts`): derive variant groups (identified by `metadata.staticId`) are skipped by the "Hashes don't match on two components with the same id" check, since they legitimately share their `<T>`'s id and the clearer warning above already fired. Genuine accidental id duplication between non-derive components still errors exactly as before.

## Testing

- New test suite: warns for `id`, `hash`, and `_hash` props with `&&` and ternary `<Derive>` content (asserting variants are still extracted with the id intact); no warning for id-without-Derive or Derive-without-id
- `createUpdates` test: derive variants sharing an id with distinct hashes pass validation and are kept; the existing accidental-duplicate error cases still pass unchanged
- `pnpm --filter gt test` (2129 tests), typecheck, lint, and format all pass
- Patch changeset for `gt` included

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR converts a confusing generic "Hashes don't match" extraction error into a clear, targeted warning when a `<T>` component carries an explicit `id`/`hash` prop alongside `<Derive>` content, and also ensures that derive-variant groups are not mistakenly dropped by the duplicate-id validation in `createUpdates`.

- **`parseJsx.ts`**: After computing `variantCount`, checks for any of four static-lookup props and emits `warnDeriveWithStaticLookupSync` via `output.warnings.add()`; extraction continues and all variants are registered with `staticId`.
- **`parse.ts`**: Derive-variant updates (identified by `staticId`) return early from the duplicate-id `.map()` step, exempting them from conflict detection; a matched set of tests verifies both the exemption and that pre-existing genuine-duplicate error cases are unaffected.
- **Tests**: A new suite in `deriveStaticLookupWarning.test.ts` covers `id`, `hash`, and `_hash` props with both `&&` and ternary derive patterns, plus negative cases.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the core warning and exemption logic work correctly for all realistic cases, with one narrow edge-case in the filter.

The main extraction and validation paths work correctly. The one gap is the `.filter()` in `parse.ts` that does not mirror the `staticId` exemption from `.map()`, meaning derive variants could be silently dropped in a contrived triple-conflict scenario. The missing `$_hash` test is a small coverage gap.

**Files Needing Attention:** The `.filter()` in `packages/cli/src/translation/parse.ts` (lines 145-147) and the missing `$_hash` test in `deriveStaticLookupWarning.test.ts` are the two spots worth a second look.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/cli/src/translation/parse.ts | Exempts derive-variant updates (those with `staticId`) from the duplicate-id conflict check. The early `return update` in `.map()` is correct, but the downstream `.filter()` still drops any update whose `id` is in `duplicateIds`, which could silently remove derive variants if their `id` coincidentally matches a separately-duplicated non-derive component. |
| packages/cli/src/react/jsx/utils/jsxParsing/parseJsx.ts | New warning block computes `variantCount` correctly from `minifiedTrees x contextVariants` and checks for the four static lookup props. Logic and placement look correct. |
| packages/cli/src/console/index.ts | Adds `warnDeriveWithStaticLookupSync` following the same `createDiagnosticMessage` / `withLocation` pattern as neighbouring functions. Implementation is consistent with the rest of the file. |
| packages/cli/src/react/jsx/utils/jsxParsing/__tests__/deriveStaticLookupWarning.test.ts | Good coverage of `id`, `hash`, and `_hash` props across `&&` and ternary derive patterns; negative cases (id-without-Derive, Derive-without-id) are also tested. Missing: a test for the `$_hash` prop that is listed in the production check. |
| packages/cli/src/translation/__tests__/parse.test.ts | New test verifies that derive variants sharing an `id` with distinct hashes are kept and generate no errors; existing duplicate-id error cases remain unchanged. |
| .changeset/derive-static-lookup-warning.md | Patch-level changeset entry for the `gt` package; description matches the PR intent. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["parseJSXElement()"] --> B["Build minifiedTrees\n(one per derive variant)"]
    B --> C["Resolve contextVariants\n(from _contextDeriveExpr)"]
    C --> D["variantCount =\nminifiedTrees.length x contextVariants.length"]
    D --> E{variantCount > 1?}
    E -- No --> H
    E -- Yes --> F{Static lookup prop\npresent in metadata?\nid / hash / _hash / $_hash}
    F -- No --> H
    F -- Yes --> G["output.warnings.add(warnDeriveWithStaticLookupSync())"]
    G --> H["Push updates with staticId = temporaryDeriveId"]
    H --> I["createUpdates()"]
    I --> J["updates.map() - validate IDs"]
    J --> K{update.metadata.staticId?}
    K -- Yes --> L["Skip duplicate-id check (return update early)"]
    K -- No --> M["Consult idHashMap, add to duplicateIds if conflict"]
    L --> N["updates.filter()"]
    M --> N
    N --> O{update.metadata.id in duplicateIds?}
    O -- Yes --> P["Drop update"]
    O -- No --> Q["Keep update"]
    P --> R["Return updates / errors / warnings"]
    Q --> R
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/cli/src/translation/parse.ts`, line 145-147 ([link](https://github.com/generaltranslation/gt/blob/67a2d201636d3eb5c11e0fde3145cb1ec20993b5/packages/cli/src/translation/parse.ts#L145-L147)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The `.filter()` does not carry over the `staticId` exemption that was added in `.map()`. If a derive `<T id="landing">` coexists with two separate non-derive `<T id="landing">` components that have different hashes, those non-derive pairs populate `duplicateIds` with `"landing"`. The filter then drops every update whose `id` is in `duplicateIds`, including the derive variants, even though they correctly bypassed the conflict check above. The derive variants are silently lost without any targeted error message pointing at them.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/cli/src/translation/parse.ts
   Line: 145-147

   Comment:
   The `.filter()` does not carry over the `staticId` exemption that was added in `.map()`. If a derive `<T id="landing">` coexists with two separate non-derive `<T id="landing">` components that have different hashes, those non-derive pairs populate `duplicateIds` with `"landing"`. The filter then drops every update whose `id` is in `duplicateIds`, including the derive variants, even though they correctly bypassed the conflict check above. The derive variants are silently lost without any targeted error message pointing at them.

   

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fcli%2Fsrc%2Ftranslation%2Fparse.ts%0ALine%3A%20145-147%0A%0AComment%3A%0AThe%20%60.filter%28%29%60%20does%20not%20carry%20over%20the%20%60staticId%60%20exemption%20that%20was%20added%20in%20%60.map%28%29%60.%20If%20a%20derive%20%60%3CT%20id%3D%22landing%22%3E%60%20coexists%20with%20two%20separate%20non-derive%20%60%3CT%20id%3D%22landing%22%3E%60%20components%20that%20have%20different%20hashes%2C%20those%20non-derive%20pairs%20populate%20%60duplicateIds%60%20with%20%60%22landing%22%60.%20The%20filter%20then%20drops%20every%20update%20whose%20%60id%60%20is%20in%20%60duplicateIds%60%2C%20including%20the%20derive%20variants%2C%20even%20though%20they%20correctly%20bypassed%20the%20conflict%20check%20above.%20The%20derive%20variants%20are%20silently%20lost%20without%20any%20targeted%20error%20message%20pointing%20at%20them.%0A%0A%60%60%60suggestion%0A%20%20updates%20%3D%20updates.filter%28%0A%20%20%20%20%28update%29%20%3D%3E%0A%20%20%20%20%20%20!update.metadata.id%20%7C%7C%0A%20%20%20%20%20%20update.metadata.staticId%20%7C%7C%0A%20%20%20%20%20%20!duplicateIds.has%28update.metadata.id%29%0A%20%20%29%3B%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=generaltranslation%2Fgt&pr=2026&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fcli%2Fderive-static-lookup-warning%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fcli%2Fderive-static-lookup-warning%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fcli%2Fsrc%2Ftranslation%2Fparse.ts%0ALine%3A%20145-147%0A%0AComment%3A%0AThe%20%60.filter%28%29%60%20does%20not%20carry%20over%20the%20%60staticId%60%20exemption%20that%20was%20added%20in%20%60.map%28%29%60.%20If%20a%20derive%20%60%3CT%20id%3D%22landing%22%3E%60%20coexists%20with%20two%20separate%20non-derive%20%60%3CT%20id%3D%22landing%22%3E%60%20components%20that%20have%20different%20hashes%2C%20those%20non-derive%20pairs%20populate%20%60duplicateIds%60%20with%20%60%22landing%22%60.%20The%20filter%20then%20drops%20every%20update%20whose%20%60id%60%20is%20in%20%60duplicateIds%60%2C%20including%20the%20derive%20variants%2C%20even%20though%20they%20correctly%20bypassed%20the%20conflict%20check%20above.%20The%20derive%20variants%20are%20silently%20lost%20without%20any%20targeted%20error%20message%20pointing%20at%20them.%0A%0A%60%60%60suggestion%0A%20%20updates%20%3D%20updates.filter%28%0A%20%20%20%20%28update%29%20%3D%3E%0A%20%20%20%20%20%20!update.metadata.id%20%7C%7C%0A%20%20%20%20%20%20update.metadata.staticId%20%7C%7C%0A%20%20%20%20%20%20!duplicateIds.has%28update.metadata.id%29%0A%20%20%29%3B%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=generaltranslation%2Fgt&pr=2026&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apackages%2Fcli%2Fsrc%2Ftranslation%2Fparse.ts%3A145-147%0AThe%20%60.filter%28%29%60%20does%20not%20carry%20over%20the%20%60staticId%60%20exemption%20that%20was%20added%20in%20%60.map%28%29%60.%20If%20a%20derive%20%60%3CT%20id%3D%22landing%22%3E%60%20coexists%20with%20two%20separate%20non-derive%20%60%3CT%20id%3D%22landing%22%3E%60%20components%20that%20have%20different%20hashes%2C%20those%20non-derive%20pairs%20populate%20%60duplicateIds%60%20with%20%60%22landing%22%60.%20The%20filter%20then%20drops%20every%20update%20whose%20%60id%60%20is%20in%20%60duplicateIds%60%2C%20including%20the%20derive%20variants%2C%20even%20though%20they%20correctly%20bypassed%20the%20conflict%20check%20above.%20The%20derive%20variants%20are%20silently%20lost%20without%20any%20targeted%20error%20message%20pointing%20at%20them.%0A%0A%60%60%60suggestion%0A%20%20updates%20%3D%20updates.filter%28%0A%20%20%20%20%28update%29%20%3D%3E%0A%20%20%20%20%20%20!update.metadata.id%20%7C%7C%0A%20%20%20%20%20%20update.metadata.staticId%20%7C%7C%0A%20%20%20%20%20%20!duplicateIds.has%28update.metadata.id%29%0A%20%20%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%0Apackages%2Fcli%2Fsrc%2Freact%2Fjsx%2Futils%2FjsxParsing%2F__tests__%2FderiveStaticLookupWarning.test.ts%3A127-145%0AThe%20production%20warning%20check%20lists%20four%20props%20%E2%80%94%20%60id%60%2C%20%60hash%60%2C%20%60_hash%60%2C%20and%20%60%24_hash%60%20%E2%80%94%20but%20the%20test%20suite%20only%20exercises%20the%20first%20three.%20There%20is%20no%20test%20asserting%20that%20a%20%60%3CT%20%24_hash%3D%22%E2%80%A6%22%3E%60%20with%20%60%3CDerive%3E%60%20content%20also%20triggers%20the%20warning.%20Consider%20adding%20a%20parallel%20test%20case%20for%20%60%24_hash%60%20to%20ensure%20the%20full%20prop%20list%20is%20covered.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=generaltranslation%2Fgt&pr=2026&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fcli%2Fderive-static-lookup-warning%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fcli%2Fderive-static-lookup-warning%22.%0A%0A%23%23%23%20Issue%201%0Apackages%2Fcli%2Fsrc%2Ftranslation%2Fparse.ts%3A145-147%0AThe%20%60.filter%28%29%60%20does%20not%20carry%20over%20the%20%60staticId%60%20exemption%20that%20was%20added%20in%20%60.map%28%29%60.%20If%20a%20derive%20%60%3CT%20id%3D%22landing%22%3E%60%20coexists%20with%20two%20separate%20non-derive%20%60%3CT%20id%3D%22landing%22%3E%60%20components%20that%20have%20different%20hashes%2C%20those%20non-derive%20pairs%20populate%20%60duplicateIds%60%20with%20%60%22landing%22%60.%20The%20filter%20then%20drops%20every%20update%20whose%20%60id%60%20is%20in%20%60duplicateIds%60%2C%20including%20the%20derive%20variants%2C%20even%20though%20they%20correctly%20bypassed%20the%20conflict%20check%20above.%20The%20derive%20variants%20are%20silently%20lost%20without%20any%20targeted%20error%20message%20pointing%20at%20them.%0A%0A%60%60%60suggestion%0A%20%20updates%20%3D%20updates.filter%28%0A%20%20%20%20%28update%29%20%3D%3E%0A%20%20%20%20%20%20!update.metadata.id%20%7C%7C%0A%20%20%20%20%20%20update.metadata.staticId%20%7C%7C%0A%20%20%20%20%20%20!duplicateIds.has%28update.metadata.id%29%0A%20%20%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%0Apackages%2Fcli%2Fsrc%2Freact%2Fjsx%2Futils%2FjsxParsing%2F__tests__%2FderiveStaticLookupWarning.test.ts%3A127-145%0AThe%20production%20warning%20check%20lists%20four%20props%20%E2%80%94%20%60id%60%2C%20%60hash%60%2C%20%60_hash%60%2C%20and%20%60%24_hash%60%20%E2%80%94%20but%20the%20test%20suite%20only%20exercises%20the%20first%20three.%20There%20is%20no%20test%20asserting%20that%20a%20%60%3CT%20%24_hash%3D%22%E2%80%A6%22%3E%60%20with%20%60%3CDerive%3E%60%20content%20also%20triggers%20the%20warning.%20Consider%20adding%20a%20parallel%20test%20case%20for%20%60%24_hash%60%20to%20ensure%20the%20full%20prop%20list%20is%20covered.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=generaltranslation%2Fgt&pr=2026&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/cli/src/translation/parse.ts:145-147
The `.filter()` does not carry over the `staticId` exemption that was added in `.map()`. If a derive `<T id="landing">` coexists with two separate non-derive `<T id="landing">` components that have different hashes, those non-derive pairs populate `duplicateIds` with `"landing"`. The filter then drops every update whose `id` is in `duplicateIds`, including the derive variants, even though they correctly bypassed the conflict check above. The derive variants are silently lost without any targeted error message pointing at them.

```suggestion
  updates = updates.filter(
    (update) =>
      !update.metadata.id ||
      update.metadata.staticId ||
      !duplicateIds.has(update.metadata.id)
  );
```

### Issue 2
packages/cli/src/react/jsx/utils/jsxParsing/__tests__/deriveStaticLookupWarning.test.ts:127-145
The production warning check lists four props — `id`, `hash`, `_hash`, and `$_hash` — but the test suite only exercises the first three. There is no test asserting that a `<T $_hash="…">` with `<Derive>` content also triggers the warning. Consider adding a parallel test case for `$_hash` to ensure the full prop list is covered.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(cli): warn instead of erroring when ..."](https://github.com/generaltranslation/gt/commit/67a2d201636d3eb5c11e0fde3145cb1ec20993b5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50293027)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->