### PR TITLE
fix(vue): preserve formatter hydration boundaries

### DIFF
--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -173,7 +173,7 @@ static literals.
 rerenders consumers. Locale persistence and development hot reload are outside
 this package; applications can persist their chosen locale separately.
 
-For SSR, call and await `plugin.loadTranslations(locale)` or
-`plugin.setLocale(locale)` before rendering the app, and create a fresh
-`createGT()` instance for each request so locale and catalog state stay
-request-scoped.
+For SSR, either create the plugin with the request locale and await
+`plugin.loadTranslations(locale)`, or await `plugin.setLocale(locale)` before
+rendering the app. Create a fresh `createGT()` instance for each concurrent
+request so locale and catalog state stay request-scoped.

--- a/packages/vue/src/__tests__/runtime.test.ts
+++ b/packages/vue/src/__tests__/runtime.test.ts
@@ -1539,7 +1539,9 @@ describe('gt-vue runtime', () => {
     });
     const html = await renderWithPlugin(Root, plugin);
 
-    expect(html).toContain('1,234.5|$12.00|2024|items|Welcome');
+    expect(stripFragmentMarkers(html)).toContain(
+      '1,234.5|$12.00|2024|items|Welcome'
+    );
   });
 
   it('falls back safely for inherited object-property branch names', async () => {

--- a/packages/vue/src/__tests__/variables.test.ts
+++ b/packages/vue/src/__tests__/variables.test.ts
@@ -4,6 +4,36 @@ import { describe, expect, it } from 'vitest';
 import { Currency, DateTime, Num, Var, createGT } from '../index';
 
 describe('gt-vue formatting components', () => {
+  it('preserves SSR boundaries around formatter text', async () => {
+    const Root = defineComponent({
+      setup() {
+        return () =>
+          h('p', [
+            'Count: ',
+            h(Num, { locales: ['en-US'], value: 1234 }),
+            ' · Date: ',
+            h(DateTime, {
+              locales: ['en-US'],
+              options: { timeZone: 'UTC', year: 'numeric' },
+              value: new Date('2026-08-01T12:00:00.000Z'),
+            }),
+            ' · Total: ',
+            h(Currency, {
+              currency: 'USD',
+              locales: ['en-US'],
+              value: 12,
+            }),
+          ]);
+      },
+    });
+
+    const html = await render(Root);
+
+    expect(html).toContain('Count: <!--[-->1,234<!--]--> · Date: ');
+    expect(html).toContain('<!--[-->2026<!--]--> · Total: ');
+    expect(html).toContain('<!--[-->$12.00<!--]-->');
+  });
+
   it('formats typed number, currency, Date, and epoch values', async () => {
     const Root = defineComponent({
       setup() {
@@ -32,7 +62,9 @@ describe('gt-vue formatting components', () => {
       },
     });
 
-    expect(await render(Root)).toContain('1,234.5|$12.00|2024|2024');
+    expect(stripFragmentMarkers(await render(Root))).toContain(
+      '1,234.5|$12.00|2024|2024'
+    );
   });
 
   it('gives value props precedence over static slot text', async () => {
@@ -43,7 +75,7 @@ describe('gt-vue formatting components', () => {
       },
     });
 
-    expect(await render(Root)).toBe('2');
+    expect(stripFragmentMarkers(await render(Root))).toBe('2');
   });
 
   it('returns partially parseable slot text unchanged', async () => {
@@ -62,7 +94,9 @@ describe('gt-vue formatting components', () => {
       },
     });
 
-    expect(await render(Root)).toContain('1,234.5|12 dollars');
+    expect(stripFragmentMarkers(await render(Root))).toContain(
+      '1,234.5|12 dollars'
+    );
   });
 
   it('returns invalid dates unchanged', async () => {
@@ -143,4 +177,8 @@ describe('gt-vue formatting components', () => {
 
 async function render(root: Component): Promise<string> {
   return renderToString(createSSRApp(root).use(createGT()));
+}
+
+function stripFragmentMarkers(html: string): string {
+  return html.replaceAll('<!--[-->', '').replaceAll('<!--]-->', '');
 }

--- a/packages/vue/src/components/variables.ts
+++ b/packages/vue/src/components/variables.ts
@@ -79,12 +79,13 @@ export const Num = withGTMetadata<NumberFormatProps>(
           return null;
         }
         const number = typeof value === 'number' ? value : Number(value);
-        return Number.isNaN(number)
+        const formatted = Number.isNaN(number)
           ? String(value)
           : new Intl.NumberFormat(
               getFormatLocales(props.locales, state.locale.value),
               props.options
             ).format(number);
+        return textFragment(formatted);
       };
     },
   }),
@@ -121,13 +122,14 @@ export const DateTime = withGTMetadata<DateTimeProps>(
           return null;
         }
         const date = value instanceof Date ? value : new Date(value);
-        if (Number.isNaN(date.getTime())) return String(value);
-        return new Intl.DateTimeFormat(
+        if (Number.isNaN(date.getTime())) return textFragment(String(value));
+        const formatted = new Intl.DateTimeFormat(
           getFormatLocales(props.locales, state.locale.value),
           props.options
         )
           .format(date)
           .replace(/[\u200F\u202B\u202E]/g, '');
+        return textFragment(formatted);
       };
     },
   }),
@@ -169,7 +171,7 @@ export const Currency = withGTMetadata<CurrencyProps>(
           return null;
         }
         const number = typeof value === 'number' ? value : Number(value);
-        return Number.isNaN(number)
+        const formatted = Number.isNaN(number)
           ? String(value)
           : new Intl.NumberFormat(
               getFormatLocales(props.locales, state.locale.value),
@@ -179,8 +181,18 @@ export const Currency = withGTMetadata<CurrencyProps>(
                 style: 'currency',
               }
             ).format(number);
+        return textFragment(formatted);
       };
     },
   }),
   'variable-currency'
 );
+
+/**
+ * Preserves a component boundary around formatter text. Vue otherwise merges
+ * adjacent text during SSR, leaving hydration unable to distinguish the
+ * formatter's root from text rendered by its parent.
+ */
+function textFragment(value: string): string[] {
+  return [value];
+}


### PR DESCRIPTION
## Summary

- Preserve a distinct Vue SSR fragment boundary around `Num`, `DateTime`, and `Currency` output.
- Prevent adjacent parent text from being merged into formatter roots and producing hydration mismatches in the browser.
- Clarify that concurrent SSR requests need isolated `createGT()` instances.

## Testing

- `pnpm --filter gt-vue typecheck` — passed
- `pnpm --filter gt-vue test` — passed (109 tests)
- `pnpm --filter gt-vue build` — passed
- Packed consumers on Vue 3.3/Vite 6 and Vue 3.5/Vite 8 — production SSR build and Chromium hydration passed without warnings

## Notes

- Stacked on #2014 (`e/vue/add-vue-vite-example`).
- Followed by `e/vue/add-spa-ssr-examples`.
- Changeset intentionally omitted: `gt-vue` is unreleased and its existing minor changeset covers the initial release. This fix should land before that changeset is consumed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes SSR hydration mismatches in the Vue formatter components (`Num`, `DateTime`, `Currency`) by wrapping their rendered text in a single-element array via `textFragment`. In Vue 3, returning `[value]` instead of `value` from a render function forces a fragment boundary (`<!--[-->…<!--]-->`) in SSR output, preventing Vue from merging the formatter's text node into adjacent parent text and enabling the hydrator to correctly identify the component's root.

- **`variables.ts`**: All three formatter components now return `textFragment(formatted)` (`string[]`) instead of a bare `string`, creating distinct SSR fragment markers. The new module-private `textFragment` helper is added with a clarifying doc-comment.
- **`variables.test.ts`**: A new test explicitly asserts that the `<!--[-->` / `<!--]-->` markers appear in the rendered HTML; existing tests that asserted full output strings are updated to strip those markers before comparing.
- **`runtime.test.ts`**: One existing cross-component test is also updated to strip markers before the `toContain` assertion.
- **`README.md`**: Documentation clarifies that each *concurrent* SSR request needs its own `createGT()` instance.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the change is narrowly scoped to three formatter components and is backed by an explicit new test for the fragment markers plus a full passing test suite.

The `textFragment` helper is a one-liner with a clear doc-comment, the return-type change from string to string[] is valid VNodeChild in Vue 3, and the PR author verified production SSR hydration on both Vue 3.3/Vite 6 and Vue 3.5/Vite 8. All existing tests are correctly updated, and no behaviour is changed for the null/empty early-return paths.

**Files Needing Attention:** No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/vue/src/components/variables.ts | Adds `textFragment` helper and applies it to all three formatter components; return type changes from string to string[] are valid VNodeChild in Vue 3 and produce the correct SSR fragment markers. |
| packages/vue/src/__tests__/variables.test.ts | Adds a new positive test for fragment marker presence; updates four existing tests to strip markers before string comparison; all assertions remain logically correct. |
| packages/vue/src/__tests__/runtime.test.ts | Single test updated to use already-present stripFragmentMarkers helper around a cross-component assertion; change is minimal and correct. |
| packages/vue/README.md | Documentation clarification only; adds 'concurrent' to the createGT() isolation guidance and rewrites the SSR setup sentence for clarity. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Parent as Parent Component
    participant Fmt as Num / DateTime / Currency
    participant VueSSR as Vue SSR Renderer
    participant Browser as Browser Hydrator

    Note over Parent,Browser: Before fix - text merged, no boundary
    Parent->>VueSSR: Num returns bare string
    VueSSR-->>Browser: merged text with no markers
    Browser--xBrowser: Cannot locate Num root - hydration mismatch

    Note over Parent,Browser: After fix - fragment markers preserve boundary
    Parent->>Fmt: mount Num component
    Fmt->>VueSSR: returns string array as fragment
    VueSSR-->>Browser: text wrapped in fragment open and close markers
    Browser->>Browser: Markers identify Num boundary
    Browser-->>Browser: Hydration succeeds
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(vue): preserve formatter hydration b..."](https://github.com/generaltranslation/gt/commit/9f8f5b5fb6b736a868b92bbdb892253ac74211f1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50601617)</sub>

<!-- /greptile_comment -->