### PR TITLE
test(vue): add Vite SSR example

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -31,6 +31,7 @@
     "rollup-spa",
     "vite-spa",
     "vite-vue",
+    "vite-vue-ssr",
     "webpack-spa",
     "cli-test-app",
     "compiler-cli-parity",

--- a/.github/workflows/test-apps-e2e-cron.yml
+++ b/.github/workflows/test-apps-e2e-cron.yml
@@ -49,7 +49,7 @@ jobs:
         run: pnpm install
 
       - name: Build local GT packages
-        run: pnpm exec turbo build --filter='@generaltranslation/format' --filter='@generaltranslation/compiler' --filter=generaltranslation --filter=gt-i18n --filter='@generaltranslation/react-core' --filter=gt-react --filter=gt-node --filter=gt-tanstack-start --filter=gt-next
+        run: pnpm exec turbo build --filter='@generaltranslation/format' --filter='@generaltranslation/compiler' --filter=generaltranslation --filter=gt-i18n --filter='@generaltranslation/react-core' --filter=gt-react --filter=gt-vue --filter=gt-node --filter=gt-tanstack-start --filter=gt-next
 
       - name: Install Chromium
         run: pnpm --filter gt-test-apps-e2e test:e2e:install

--- a/examples/vite-vue-ssr/README.md
+++ b/examples/vite-vue-ssr/README.md
@@ -7,8 +7,14 @@ example's scope.
 
 The example covers lazy routes, `RouterView` scoped slots, async SSR,
 `Suspense`, `Transition`, a client-side `Teleport`, module-scope `msg()`
-records, accessibility attributes, locale-prefixed routes, and repeatable
-server rendering. It uses local catalogs, so no GT API key is required.
+records, accessibility attributes, locale-prefixed routes, Vue TSX, and
+repeatable server rendering. It uses local catalogs, so no GT API key is
+required.
+
+`TsxCompatibilityCard.tsx` exercises local ESM re-exports, `<T>`, `<GT.T>`,
+`<Vue.Fragment>`, and a translator forwarded into a cross-file helper. The
+SPA and SSR examples intentionally use the same source strings and contexts,
+so extraction and runtime behavior can be compared against identical hashes.
 
 ## Development
 
@@ -24,16 +30,17 @@ Open `http://localhost:5181` or the French deep link
 
 ## SSR bootstrap requirement
 
-The server creates an isolated GT plugin and router, selects the route locale,
-and awaits its catalog before `renderToString()`. The client reads the locale
-serialized into the HTML and awaits the same catalog before `app.mount()`.
-That ordering is required to prevent translated server HTML from hydrating
-against source-language client VNodes.
+The server's `render()` entry point creates a fresh GT plugin, Vue app, and
+router for every request, selects the route locale, and awaits its catalog
+before `renderToString()`. Never hoist or reuse the GT plugin across requests:
+its active locale is mutable request state. A translation loader may maintain
+an outer cache of immutable catalog data, but that does not make the plugin
+itself safe to share.
 
-A translation cache reused across sequential renders must call `setLocale()`
-for every route. Each render still creates a fresh app and router. Concurrent
-requests must use separate GT plugin instances because their active locale is
-mutable request state.
+The server serializes the locale reported by that request's GT plugin into the
+HTML. The client creates its own plugin from the serialized locale and awaits
+the same catalog before `app.mount()`. That ordering prevents translated
+server HTML from hydrating against source-language client VNodes.
 
 ## Verification
 
@@ -46,5 +53,5 @@ pnpm --filter vite-vue-ssr build
 ```
 
 The repository's app browser suite also checks translated server responses,
-hydration without console warnings, lazy navigation, locale switching,
-deep-link reloads, scoped slots, and the teleported search dialog.
+TSX output, hydration without console warnings, lazy navigation, locale
+switching, deep-link reloads, scoped slots, and the teleported search dialog.

--- a/examples/vite-vue-ssr/README.md
+++ b/examples/vite-vue-ssr/README.md
@@ -1,0 +1,50 @@
+# gt-vue + Vite SSR Example
+
+A small server-rendered documentation shell showing how to use `gt-vue` with
+Vue Router and Vite SSR. It deliberately translates only framework-owned Vue
+copy; routed document content and route configuration are outside this
+example's scope.
+
+The example covers lazy routes, `RouterView` scoped slots, async SSR,
+`Suspense`, `Transition`, a client-side `Teleport`, module-scope `msg()`
+records, accessibility attributes, locale-prefixed routes, and repeatable
+server rendering. It uses local catalogs, so no GT API key is required.
+
+## Development
+
+From the monorepo root:
+
+```bash
+pnpm install
+pnpm --filter vite-vue-ssr dev
+```
+
+Open `http://localhost:5181` or the French deep link
+`http://localhost:5181/fr/reference`.
+
+## SSR bootstrap requirement
+
+The server creates an isolated GT plugin and router, selects the route locale,
+and awaits its catalog before `renderToString()`. The client reads the locale
+serialized into the HTML and awaits the same catalog before `app.mount()`.
+That ordering is required to prevent translated server HTML from hydrating
+against source-language client VNodes.
+
+A translation cache reused across sequential renders must call `setLocale()`
+for every route. Each render still creates a fresh app and router. Concurrent
+requests must use separate GT plugin instances because their active locale is
+mutable request state.
+
+## Verification
+
+```bash
+pnpm --filter vite-vue-ssr generate
+pnpm --filter vite-vue-ssr validate
+pnpm --filter vite-vue-ssr typecheck
+pnpm --filter vite-vue-ssr test
+pnpm --filter vite-vue-ssr build
+```
+
+The repository's app browser suite also checks translated server responses,
+hydration without console warnings, lazy navigation, locale switching,
+deep-link reloads, scoped slots, and the teleported search dialog.

--- a/examples/vite-vue-ssr/gt.config.json
+++ b/examples/vite-vue-ssr/gt.config.json
@@ -1,0 +1,9 @@
+{
+  "defaultLocale": "en",
+  "locales": ["fr"],
+  "files": {
+    "gt": {
+      "output": "src/_gt/[locale].json"
+    }
+  }
+}

--- a/examples/vite-vue-ssr/index.html
+++ b/examples/vite-vue-ssr/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="<!--app-locale-->">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" href="data:," />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>gt-vue SSR example</title>
+  </head>
+  <body>
+    <div id="app"><!--app-html--></div>
+    <div id="teleports"><!--app-teleports--></div>
+    <script id="gt-state" type="application/json">
+      <!--app-state-->
+    </script>
+    <script type="module" src="/src/entry-client.ts"></script>
+  </body>
+</html>

--- a/examples/vite-vue-ssr/package.json
+++ b/examples/vite-vue-ssr/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "vite-vue-ssr",
+  "private": true,
+  "version": "0.0.0",
+  "packageManager": "pnpm@10.20.0",
+  "type": "module",
+  "scripts": {
+    "predev": "pnpm exec turbo run build --filter=gt-vue",
+    "dev": "tsx server.ts",
+    "pregenerate": "pnpm exec turbo run build --filter=gt",
+    "generate": "gt generate && oxfmt src/_gt/*.json",
+    "prevalidate": "pnpm exec turbo run build --filter=gt",
+    "validate": "gt validate",
+    "pretypecheck": "pnpm exec turbo run build --filter=gt-vue",
+    "typecheck": "vue-tsc -b",
+    "pretest": "pnpm exec turbo run build --filter=gt-vue",
+    "test": "vitest run",
+    "prebuild": "pnpm exec turbo run build --filter=gt-vue",
+    "build": "pnpm generate && vue-tsc -b && pnpm build:client && pnpm build:server",
+    "build:client": "vite build --outDir dist/client",
+    "build:server": "vite build --ssr src/entry-server.ts --outDir dist/server",
+    "start": "NODE_ENV=production tsx server.ts"
+  },
+  "dependencies": {
+    "express": "^5.2.1",
+    "gt-vue": "workspace:*",
+    "vue": "^3.5.0",
+    "vue-router": "5.0.4"
+  },
+  "devDependencies": {
+    "@types/express": "^5.0.6",
+    "@types/node": "catalog:",
+    "@vitejs/plugin-vue": "^6.0.3",
+    "gt": "workspace:*",
+    "oxfmt": "catalog:",
+    "tsx": "^4.20.6",
+    "typescript": "catalog:",
+    "vite": "^8.0.16",
+    "vitest": "catalog:",
+    "vue-tsc": "~3.2.0"
+  }
+}

--- a/examples/vite-vue-ssr/package.json
+++ b/examples/vite-vue-ssr/package.json
@@ -31,6 +31,7 @@
     "@types/express": "^5.0.6",
     "@types/node": "catalog:",
     "@vitejs/plugin-vue": "^6.0.3",
+    "@vitejs/plugin-vue-jsx": "5.1.6",
     "gt": "workspace:*",
     "oxfmt": "catalog:",
     "tsx": "^4.20.6",

--- a/examples/vite-vue-ssr/server.ts
+++ b/examples/vite-vue-ssr/server.ts
@@ -1,0 +1,93 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import express from 'express';
+import { createServer as createViteServer, type ViteDevServer } from 'vite';
+
+interface RenderResult {
+  html: string;
+  locale: string;
+  teleports: string;
+}
+
+type RenderApplication = (url: string) => Promise<RenderResult>;
+
+const root = path.dirname(fileURLToPath(import.meta.url));
+const production = process.env.NODE_ENV === 'production';
+const port = Number(process.env.PORT ?? 5181);
+const server = express();
+let vite: ViteDevServer | undefined;
+let productionTemplate = '';
+let productionRender: RenderApplication | undefined;
+
+if (production) {
+  const clientDirectory = path.join(root, 'dist/client');
+  productionTemplate = await fs.readFile(
+    path.join(clientDirectory, 'index.html'),
+    'utf8'
+  );
+  productionRender = (
+    await import(
+      pathToFileURL(path.join(root, 'dist/server/entry-server.js')).href
+    )
+  ).render;
+  server.use(express.static(clientDirectory, { index: false }));
+} else {
+  vite = await createViteServer({
+    appType: 'custom',
+    root,
+    server: { middlewareMode: true },
+  });
+  server.use(vite.middlewares);
+}
+
+server.use(async (request, response, next) => {
+  const url = request.originalUrl;
+
+  try {
+    const template = production
+      ? productionTemplate
+      : await vite!.transformIndexHtml(
+          url,
+          await fs.readFile(path.join(root, 'index.html'), 'utf8')
+        );
+    const render = production
+      ? productionRender!
+      : (await vite!.ssrLoadModule('/src/entry-server.ts')).render;
+    const result = await render(url);
+    const html = template
+      .replace('<!--app-locale-->', escapeHtml(result.locale))
+      .replace('<!--app-html-->', result.html)
+      .replace('<!--app-teleports-->', result.teleports)
+      .replace(
+        '<!--app-state-->',
+        escapeJson(JSON.stringify({ locale: result.locale }))
+      );
+
+    response
+      .status(200)
+      .set({ 'Content-Type': 'text/html; charset=utf-8' })
+      .end(html);
+  } catch (error) {
+    vite?.ssrFixStacktrace(error as Error);
+    next(error);
+  }
+});
+
+server.listen(port, () => {
+  process.stdout.write(
+    `gt-vue SSR example running at http://localhost:${port}\n`
+  );
+});
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('"', '&quot;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;');
+}
+
+function escapeJson(value: string): string {
+  return value.replaceAll('<', '\\u003c');
+}

--- a/examples/vite-vue-ssr/server.ts
+++ b/examples/vite-vue-ssr/server.ts
@@ -18,6 +18,7 @@ const port = Number(process.env.PORT ?? 5181);
 const server = express();
 let vite: ViteDevServer | undefined;
 let productionTemplate = '';
+let developmentTemplate = '';
 let productionRender: RenderApplication | undefined;
 
 if (production) {
@@ -33,6 +34,10 @@ if (production) {
   ).render;
   server.use(express.static(clientDirectory, { index: false }));
 } else {
+  developmentTemplate = await fs.readFile(
+    path.join(root, 'index.html'),
+    'utf8'
+  );
   vite = await createViteServer({
     appType: 'custom',
     root,
@@ -47,10 +52,7 @@ server.use(async (request, response, next) => {
   try {
     const template = production
       ? productionTemplate
-      : await vite!.transformIndexHtml(
-          url,
-          await fs.readFile(path.join(root, 'index.html'), 'utf8')
-        );
+      : await vite!.transformIndexHtml(url, developmentTemplate);
     const render = production
       ? productionRender!
       : (await vite!.ssrLoadModule('/src/entry-server.ts')).render;

--- a/examples/vite-vue-ssr/src/App.vue
+++ b/examples/vite-vue-ssr/src/App.vue
@@ -4,6 +4,7 @@ import { RouterLink, RouterView, useRoute } from 'vue-router';
 import { useGT, useLocale, useMessages } from 'gt-vue';
 import DisclosurePanel from './components/DisclosurePanel.vue';
 import SearchDialog from './components/SearchDialog.vue';
+import { TsxCompatibilityCard } from './components/TsxCompatibilityCard';
 import { linkCopiedMessage } from './messages';
 
 const gt = useGT();
@@ -113,6 +114,7 @@ function copyPageLink() {
           </button>
           <p v-if="toast" class="toast" role="status">{{ toast }}</p>
         </div>
+        <TsxCompatibilityCard />
       </main>
     </div>
 

--- a/examples/vite-vue-ssr/src/App.vue
+++ b/examples/vite-vue-ssr/src/App.vue
@@ -1,0 +1,121 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue';
+import { RouterLink, RouterView, useRoute } from 'vue-router';
+import { useGT, useLocale, useMessages } from 'gt-vue';
+import DisclosurePanel from './components/DisclosurePanel.vue';
+import SearchDialog from './components/SearchDialog.vue';
+import { linkCopiedMessage } from './messages';
+
+const gt = useGT();
+const m = useMessages();
+const locale = useLocale();
+const route = useRoute();
+const searchOpen = ref(false);
+const toast = ref('');
+const routeSuffix = computed(() => {
+  const suffix = route.path.replace(/^\/fr(?=\/|$)/, '');
+  return suffix || '/';
+});
+const guidePath = computed(() => (locale.value === 'fr' ? '/fr' : '/'));
+const referencePath = computed(() =>
+  locale.value === 'fr' ? '/fr/reference' : '/reference'
+);
+
+if (typeof document !== 'undefined') {
+  watch(
+    locale,
+    (nextLocale) => {
+      document.documentElement.lang = nextLocale;
+      document.documentElement.dir = 'ltr';
+    },
+    { immediate: true }
+  );
+}
+
+function localePath(nextLocale: 'en' | 'fr'): string {
+  if (nextLocale === 'fr') {
+    return routeSuffix.value === '/' ? '/fr' : `/fr${routeSuffix.value}`;
+  }
+  return routeSuffix.value;
+}
+
+function copyPageLink() {
+  toast.value = m(linkCopiedMessage);
+}
+</script>
+
+<template>
+  <div class="docs-shell">
+    <header class="topbar">
+      <RouterLink class="brand" :to="guidePath">
+        {{ gt('Developer hub') }}
+      </RouterLink>
+      <nav :aria-label="gt('Primary navigation')">
+        <RouterLink :to="guidePath">{{ gt('Guides') }}</RouterLink>
+        <RouterLink :to="referencePath">{{ gt('API reference') }}</RouterLink>
+      </nav>
+      <div class="topbar-actions">
+        <button
+          type="button"
+          :aria-label="gt('Open search')"
+          @click="searchOpen = true"
+        >
+          {{ gt('Search') }}
+        </button>
+        <div class="locale-links" :aria-label="gt('Language')">
+          <RouterLink
+            :aria-current="locale === 'en' ? 'true' : undefined"
+            :to="localePath('en')"
+          >
+            English
+          </RouterLink>
+          <RouterLink
+            :aria-current="locale === 'fr' ? 'true' : undefined"
+            :to="localePath('fr')"
+          >
+            Français
+          </RouterLink>
+        </div>
+      </div>
+    </header>
+
+    <div class="shell-body">
+      <aside>
+        <DisclosurePanel v-slot="{ open, toggle }">
+          <button type="button" :aria-expanded="open" @click="toggle">
+            {{ open ? gt('Hide quick links') : gt('Show quick links') }}
+          </button>
+          <Transition name="slide">
+            <nav v-if="open" :aria-label="gt('Quick links')">
+              <RouterLink :to="guidePath">{{ gt('Overview') }}</RouterLink>
+              <RouterLink :to="referencePath">
+                {{ gt('Endpoints') }}
+              </RouterLink>
+            </nav>
+          </Transition>
+        </DisclosurePanel>
+      </aside>
+
+      <main>
+        <RouterView v-slot="{ Component }">
+          <Suspense timeout="0">
+            <template #default>
+              <component :is="Component" />
+            </template>
+            <template #fallback>
+              <p role="status">{{ gt('Loading page…') }}</p>
+            </template>
+          </Suspense>
+        </RouterView>
+        <div class="page-actions">
+          <button type="button" @click="copyPageLink">
+            {{ gt('Copy page link') }}
+          </button>
+          <p v-if="toast" class="toast" role="status">{{ toast }}</p>
+        </div>
+      </main>
+    </div>
+
+    <SearchDialog :open="searchOpen" @close="searchOpen = false" />
+  </div>
+</template>

--- a/examples/vite-vue-ssr/src/_gt/en.json
+++ b/examples/vite-vue-ssr/src/_gt/en.json
@@ -48,6 +48,17 @@
       "t": "p"
     }
   },
+  "9b8297df593df5ad": {
+    "t": "h2",
+    "i": 1,
+    "c": "Local re-exports work in TSX"
+  },
+  "c7d97d97d0769df7": {
+    "t": "p",
+    "i": 1,
+    "c": "Namespace components work in TSX."
+  },
+  "ac1d0e7941fbc48f": "Translator forwarding works in TSX.",
   "3537261f4c26e6b1": [
     {
       "t": "h1",

--- a/examples/vite-vue-ssr/src/_gt/en.json
+++ b/examples/vite-vue-ssr/src/_gt/en.json
@@ -1,0 +1,138 @@
+{
+  "00cfc4a5e80ea2a4": "Developer hub",
+  "00b9e24db838e584": "Primary navigation",
+  "51afdf0a32c1d6d1": "Guides",
+  "150126ae0f1fc166": "API reference",
+  "c627e7a94d768fec": "Open search",
+  "0d7d9bbd91f8b2d0": "Search",
+  "d0e4315ff74c2dbd": "Language",
+  "83911e47c91906b7": "Hide quick links",
+  "89829f8e417b6af7": "Show quick links",
+  "224e5d6b189247e7": "Quick links",
+  "d9d5d3049be20ca2": "Overview",
+  "6b05641ddbc5b497": "Endpoints",
+  "3a8cbf22f92f978b": "Loading page…",
+  "e12516280916c994": "Copy page link",
+  "29791eae3a17d39c": "The page link was copied.",
+  "7e86516155c311c5": "Documentation search",
+  "bb1a8e721dd8462d": "Close search",
+  "2e8d6c5fc414c783": [
+    {
+      "t": "h2",
+      "i": 1,
+      "c": "Search documentation"
+    },
+    {
+      "t": "p",
+      "i": 2,
+      "c": "Find any guide or API endpoint."
+    }
+  ],
+  "0897fb5aa03e5b33": "Search all documentation",
+  "6d1358e69d516304": {
+    "t": "Plural",
+    "i": 1,
+    "d": {
+      "b": {
+        "zero": "No results yet",
+        "one": "One result",
+        "other": [
+          {
+            "i": 2,
+            "k": "_gt_n_2",
+            "v": "n"
+          },
+          " results "
+        ]
+      },
+      "t": "p"
+    }
+  },
+  "3537261f4c26e6b1": [
+    {
+      "t": "h1",
+      "i": 1,
+      "c": "Developer documentation"
+    },
+    {
+      "t": "p",
+      "i": 2,
+      "c": [
+        " Build reliable integrations with ",
+        {
+          "i": 3,
+          "k": "_gt_value_3",
+          "v": "v"
+        },
+        " . "
+      ]
+    }
+  ],
+  "34c87fdd94f5666c": "Guide sections",
+  "baa652b34a69daee": "Quickstart",
+  "1db9c6007dcc3049": "Core concepts",
+  "4469015d81667495": [
+    {
+      "t": "h2",
+      "i": 1,
+      "c": "Make your first request"
+    },
+    {
+      "t": "p",
+      "i": 2,
+      "c": "Create a client and send a request in a few lines of code."
+    }
+  ],
+  "faea24374a2abceb": [
+    {
+      "t": "h2",
+      "i": 1,
+      "c": "Understand the platform"
+    },
+    {
+      "t": "p",
+      "i": 2,
+      "c": "Learn how projects, environments, and releases fit together."
+    }
+  ],
+  "c60b089f22c5a09b": [
+    {
+      "t": "h1",
+      "i": 1,
+      "c": [
+        " Explore the ",
+        {
+          "i": 2,
+          "k": "_gt_value_2",
+          "v": "v"
+        }
+      ]
+    },
+    {
+      "t": "p",
+      "i": 3,
+      "c": "Use this reference to understand every endpoint and response."
+    }
+  ],
+  "29ae9c1245dc3e0b": "Available operations",
+  "e355b5d9202b7339": {
+    "t": "Plural",
+    "i": 1,
+    "d": {
+      "b": {
+        "one": "One documented operation",
+        "other": [
+          {
+            "i": 2,
+            "k": "_gt_n_2",
+            "v": "n"
+          },
+          " documented operations "
+        ]
+      },
+      "t": "p"
+    },
+    "c": " No documented operations "
+  },
+  "7a7a261e449598de": "Last updated"
+}

--- a/examples/vite-vue-ssr/src/_gt/fr.json
+++ b/examples/vite-vue-ssr/src/_gt/fr.json
@@ -48,6 +48,17 @@
       "t": "p"
     }
   },
+  "9b8297df593df5ad": {
+    "t": "h2",
+    "i": 1,
+    "c": "Les réexportations locales fonctionnent en TSX"
+  },
+  "c7d97d97d0769df7": {
+    "t": "p",
+    "i": 1,
+    "c": "Les composants avec espace de noms fonctionnent en TSX."
+  },
+  "ac1d0e7941fbc48f": "Le transfert du traducteur fonctionne en TSX.",
   "3537261f4c26e6b1": [
     {
       "t": "h1",

--- a/examples/vite-vue-ssr/src/_gt/fr.json
+++ b/examples/vite-vue-ssr/src/_gt/fr.json
@@ -1,0 +1,138 @@
+{
+  "00cfc4a5e80ea2a4": "Portail développeurs",
+  "00b9e24db838e584": "Navigation principale",
+  "51afdf0a32c1d6d1": "Guides",
+  "150126ae0f1fc166": "Référence de l’API",
+  "c627e7a94d768fec": "Ouvrir la recherche",
+  "0d7d9bbd91f8b2d0": "Rechercher",
+  "d0e4315ff74c2dbd": "Langue",
+  "83911e47c91906b7": "Masquer les liens rapides",
+  "89829f8e417b6af7": "Afficher les liens rapides",
+  "224e5d6b189247e7": "Liens rapides",
+  "d9d5d3049be20ca2": "Vue d’ensemble",
+  "6b05641ddbc5b497": "Points de terminaison",
+  "3a8cbf22f92f978b": "Chargement de la page…",
+  "e12516280916c994": "Copier le lien de la page",
+  "29791eae3a17d39c": "Le lien de la page a été copié.",
+  "7e86516155c311c5": "Recherche dans la documentation",
+  "bb1a8e721dd8462d": "Fermer la recherche",
+  "2e8d6c5fc414c783": [
+    {
+      "t": "h2",
+      "i": 1,
+      "c": "Rechercher dans la documentation"
+    },
+    {
+      "t": "p",
+      "i": 2,
+      "c": "Trouvez n’importe quel guide ou point de terminaison d’API."
+    }
+  ],
+  "0897fb5aa03e5b33": "Rechercher dans toute la documentation",
+  "6d1358e69d516304": {
+    "t": "Plural",
+    "i": 1,
+    "d": {
+      "b": {
+        "zero": "Aucun résultat pour le moment",
+        "one": "Un résultat",
+        "other": [
+          {
+            "i": 2,
+            "k": "_gt_n_2",
+            "v": "n"
+          },
+          " résultats "
+        ]
+      },
+      "t": "p"
+    }
+  },
+  "3537261f4c26e6b1": [
+    {
+      "t": "h1",
+      "i": 1,
+      "c": "Documentation pour les développeurs"
+    },
+    {
+      "t": "p",
+      "i": 2,
+      "c": [
+        " Créez des intégrations fiables avec ",
+        {
+          "i": 3,
+          "k": "_gt_value_3",
+          "v": "v"
+        },
+        " . "
+      ]
+    }
+  ],
+  "34c87fdd94f5666c": "Sections du guide",
+  "baa652b34a69daee": "Démarrage rapide",
+  "1db9c6007dcc3049": "Concepts fondamentaux",
+  "4469015d81667495": [
+    {
+      "t": "h2",
+      "i": 1,
+      "c": "Effectuez votre première requête"
+    },
+    {
+      "t": "p",
+      "i": 2,
+      "c": "Créez un client et envoyez une requête en quelques lignes de code."
+    }
+  ],
+  "faea24374a2abceb": [
+    {
+      "t": "h2",
+      "i": 1,
+      "c": "Comprendre la plateforme"
+    },
+    {
+      "t": "p",
+      "i": 2,
+      "c": "Découvrez comment les projets, les environnements et les versions s’articulent."
+    }
+  ],
+  "c60b089f22c5a09b": [
+    {
+      "t": "h1",
+      "i": 1,
+      "c": [
+        " Explorez l’API ",
+        {
+          "i": 2,
+          "k": "_gt_value_2",
+          "v": "v"
+        }
+      ]
+    },
+    {
+      "t": "p",
+      "i": 3,
+      "c": "Utilisez cette référence pour comprendre chaque point de terminaison et chaque réponse."
+    }
+  ],
+  "29ae9c1245dc3e0b": "Opérations disponibles",
+  "e355b5d9202b7339": {
+    "t": "Plural",
+    "i": 1,
+    "d": {
+      "b": {
+        "one": "Une opération documentée",
+        "other": [
+          {
+            "i": 2,
+            "k": "_gt_n_2",
+            "v": "n"
+          },
+          " opérations documentées "
+        ]
+      },
+      "t": "p"
+    },
+    "c": " Aucune opération documentée "
+  },
+  "7a7a261e449598de": "Dernière mise à jour"
+}

--- a/examples/vite-vue-ssr/src/app.ts
+++ b/examples/vite-vue-ssr/src/app.ts
@@ -8,7 +8,7 @@ import './style.css';
 export async function createDocsApp(
   url: string,
   server: boolean,
-  gt = createDocsGT(getLocaleFromUrl(url))
+  gt: GTPlugin
 ) {
   const app = createSSRApp(App);
   const router = createDocsRouter(server);
@@ -29,7 +29,7 @@ export async function createDocsApp(
   return { app, gt, router };
 }
 
-/** Creates an isolated translation cache for one SSR request or worker. */
+/** Creates isolated translation state for one SSR request or client app. */
 export function createDocsGT(locale: string): GTPlugin {
   return createGT({
     defaultLocale: 'en',

--- a/examples/vite-vue-ssr/src/app.ts
+++ b/examples/vite-vue-ssr/src/app.ts
@@ -1,0 +1,39 @@
+import { createSSRApp } from 'vue';
+import { createGT, type GTPlugin } from 'gt-vue';
+import App from './App.vue';
+import { getLocaleFromUrl, createDocsRouter } from './router';
+import { loadTranslations } from './translations';
+import './style.css';
+
+export async function createDocsApp(
+  url: string,
+  server: boolean,
+  gt = createDocsGT(getLocaleFromUrl(url))
+) {
+  const app = createSSRApp(App);
+  const router = createDocsRouter(server);
+
+  router.beforeResolve(async (to) => {
+    await gt.setLocale(getLocaleFromUrl(to.fullPath));
+  });
+
+  app.use(gt);
+  app.use(router);
+
+  if (server) await router.push(url);
+  await router.isReady();
+  await gt.loadTranslations(
+    getLocaleFromUrl(router.currentRoute.value.fullPath)
+  );
+
+  return { app, gt, router };
+}
+
+/** Creates an isolated translation cache for one SSR request or worker. */
+export function createDocsGT(locale: string): GTPlugin {
+  return createGT({
+    defaultLocale: 'en',
+    loadTranslations,
+    locale,
+  });
+}

--- a/examples/vite-vue-ssr/src/components/DisclosurePanel.vue
+++ b/examples/vite-vue-ssr/src/components/DisclosurePanel.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+
+const open = ref(true);
+
+defineSlots<{
+  default(props: { open: boolean; toggle: () => void }): unknown;
+}>();
+
+function toggle() {
+  open.value = !open.value;
+}
+</script>
+
+<template>
+  <slot :open="open" :toggle="toggle" />
+</template>

--- a/examples/vite-vue-ssr/src/components/SearchDialog.vue
+++ b/examples/vite-vue-ssr/src/components/SearchDialog.vue
@@ -1,0 +1,57 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { Num, Plural, T, useGT } from 'gt-vue';
+
+defineProps<{ open: boolean }>();
+const emit = defineEmits<{ close: [] }>();
+const gt = useGT();
+const query = ref('');
+const resultCount = computed(() => (query.value.trim() ? 2 : 0));
+</script>
+
+<template>
+  <Teleport to="#teleports">
+    <Transition name="fade">
+      <div v-if="open" class="dialog-backdrop" @click.self="emit('close')">
+        <section
+          class="search-dialog"
+          role="dialog"
+          aria-modal="true"
+          :aria-label="gt('Documentation search')"
+        >
+          <button
+            class="dialog-close"
+            type="button"
+            :aria-label="gt('Close search')"
+            @click="emit('close')"
+          >
+            ×
+          </button>
+          <T context="search dialog introduction">
+            <h2>Search documentation</h2>
+            <p>Find any guide or API endpoint.</p>
+          </T>
+          <label for="docs-search">{{ gt('Search') }}</label>
+          <input
+            id="docs-search"
+            v-model="query"
+            autofocus
+            :placeholder="gt('Search all documentation')"
+          />
+          <p class="result-count" role="status">
+            <T context="search result count">
+              <Plural :n="resultCount">
+                <template #zero>No results yet</template>
+                <template #one>One result</template>
+                <template #other>
+                  <Num :value="resultCount" />
+                  results
+                </template>
+              </Plural>
+            </T>
+          </p>
+        </section>
+      </div>
+    </Transition>
+  </Teleport>
+</template>

--- a/examples/vite-vue-ssr/src/components/TsxCompatibilityCard.tsx
+++ b/examples/vite-vue-ssr/src/components/TsxCompatibilityCard.tsx
@@ -1,0 +1,24 @@
+import { defineComponent } from 'vue';
+import { GT, T, Vue, translateTsxStatus } from '../i18n';
+
+/** Demonstrates the gt-vue forms used by Vue JSX and TSX applications. */
+export const TsxCompatibilityCard = defineComponent({
+  name: 'TsxCompatibilityCard',
+  setup() {
+    const gt = GT.useGT();
+
+    return () => (
+      <article data-testid='tsx-compatibility-card'>
+        <T context='TSX local reexport'>
+          <Vue.Fragment>
+            <h2>Local re-exports work in TSX</h2>
+          </Vue.Fragment>
+        </T>
+        <GT.T context='TSX namespace component'>
+          <p>Namespace components work in TSX.</p>
+        </GT.T>
+        <p data-testid='tsx-forwarded-string'>{translateTsxStatus(gt)}</p>
+      </article>
+    );
+  },
+});

--- a/examples/vite-vue-ssr/src/entry-client.ts
+++ b/examples/vite-vue-ssr/src/entry-client.ts
@@ -1,0 +1,28 @@
+import { createDocsApp, createDocsGT } from './app';
+import { getLocaleFromUrl, type SupportedLocale } from './router';
+
+interface SerializedState {
+  locale: SupportedLocale;
+}
+
+void bootstrap();
+
+async function bootstrap() {
+  const url = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+  const state = readState();
+  const { app } = await createDocsApp(url, false, createDocsGT(state.locale));
+  app.mount('#app');
+  document.documentElement.dataset.hydrated = 'true';
+}
+
+function readState(): SerializedState {
+  const fallback = { locale: getLocaleFromUrl(window.location.href) };
+  const element = document.querySelector('#gt-state');
+  if (!element?.textContent) return fallback;
+
+  try {
+    return JSON.parse(element.textContent) as SerializedState;
+  } catch {
+    return fallback;
+  }
+}

--- a/examples/vite-vue-ssr/src/entry-server.test.ts
+++ b/examples/vite-vue-ssr/src/entry-server.test.ts
@@ -1,5 +1,50 @@
 import { describe, expect, it } from 'vitest';
-import { createReusableRenderer, render } from './entry-server';
+import { render, type RenderResult } from './entry-server';
+
+interface RenderCase {
+  locale: 'en' | 'fr';
+  expected: readonly string[];
+  unexpected: readonly string[];
+  url: string;
+}
+
+const englishTsx = [
+  'Local re-exports work in TSX',
+  'Namespace components work in TSX.',
+  'Translator forwarding works in TSX.',
+] as const;
+const frenchTsx = [
+  'Les réexportations locales fonctionnent en TSX',
+  'Les composants avec espace de noms fonctionnent en TSX.',
+  'Le transfert du traducteur fonctionne en TSX.',
+] as const;
+
+const renderCases: readonly RenderCase[] = [
+  {
+    locale: 'en',
+    expected: ['Developer documentation', ...englishTsx],
+    unexpected: ['Documentation pour les développeurs', ...frenchTsx],
+    url: '/',
+  },
+  {
+    locale: 'fr',
+    expected: ['Documentation pour les développeurs', ...frenchTsx],
+    unexpected: ['Developer documentation', ...englishTsx],
+    url: '/fr',
+  },
+  {
+    locale: 'en',
+    expected: ['Available operations', ...englishTsx],
+    unexpected: ['Opérations disponibles', ...frenchTsx],
+    url: '/reference',
+  },
+  {
+    locale: 'fr',
+    expected: ['Opérations disponibles', ...frenchTsx],
+    unexpected: ['Available operations', ...englishTsx],
+    url: '/fr/reference',
+  },
+] as const;
 
 describe('Vue SSR translation isolation', () => {
   it('renders the selected locale before HTML is sent', async () => {
@@ -10,29 +55,30 @@ describe('Vue SSR translation isolation', () => {
     expect(result.html).toContain('Opérations disponibles');
   });
 
-  it('sets the locale on every render when a renderer is reused', async () => {
-    const renderRoute = await createReusableRenderer();
-
-    expect((await renderRoute('/')).html).toContain('Developer documentation');
-    expect((await renderRoute('/fr')).html).toContain(
-      'Documentation pour les développeurs'
+  it('isolates 128 overlapping English and French requests', async () => {
+    const requests = Array.from(
+      { length: 128 },
+      (_, index) => renderCases[index % renderCases.length]
     );
-    expect((await renderRoute('/reference')).html).toContain('API reference');
-  });
+    const results = await Promise.all(
+      requests.map(async (request) => ({
+        request,
+        result: await render(request.url),
+      }))
+    );
 
-  it('keeps independent renderers isolated when locales overlap', async () => {
-    const [renderEnglish, renderFrench] = await Promise.all([
-      createReusableRenderer(),
-      createReusableRenderer(),
-    ]);
-    const [english, french] = await Promise.all([
-      renderEnglish('/reference'),
-      renderFrench('/fr/reference'),
-    ]);
-
-    expect(english.html).toContain('Available operations');
-    expect(english.html).not.toContain('Opérations disponibles');
-    expect(french.html).toContain('Opérations disponibles');
-    expect(french.html).not.toContain('Available operations');
+    for (const { request, result } of results) {
+      expectRequestLocale(result, request);
+    }
   });
 });
+
+function expectRequestLocale(result: RenderResult, request: RenderCase) {
+  expect(result.locale).toBe(request.locale);
+  for (const expected of request.expected) {
+    expect(result.html).toContain(expected);
+  }
+  for (const unexpected of request.unexpected) {
+    expect(result.html).not.toContain(unexpected);
+  }
+}

--- a/examples/vite-vue-ssr/src/entry-server.test.ts
+++ b/examples/vite-vue-ssr/src/entry-server.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { createReusableRenderer, render } from './entry-server';
+
+describe('Vue SSR translation isolation', () => {
+  it('renders the selected locale before HTML is sent', async () => {
+    const result = await render('/fr/reference');
+
+    expect(result.locale).toBe('fr');
+    expect(result.html).toContain('Référence de l’API');
+    expect(result.html).toContain('Opérations disponibles');
+  });
+
+  it('sets the locale on every render when a renderer is reused', async () => {
+    const renderRoute = await createReusableRenderer();
+
+    expect((await renderRoute('/')).html).toContain('Developer documentation');
+    expect((await renderRoute('/fr')).html).toContain(
+      'Documentation pour les développeurs'
+    );
+    expect((await renderRoute('/reference')).html).toContain('API reference');
+  });
+
+  it('keeps independent renderers isolated when locales overlap', async () => {
+    const [renderEnglish, renderFrench] = await Promise.all([
+      createReusableRenderer(),
+      createReusableRenderer(),
+    ]);
+    const [english, french] = await Promise.all([
+      renderEnglish('/reference'),
+      renderFrench('/fr/reference'),
+    ]);
+
+    expect(english.html).toContain('Available operations');
+    expect(english.html).not.toContain('Opérations disponibles');
+    expect(french.html).toContain('Opérations disponibles');
+    expect(french.html).not.toContain('Available operations');
+  });
+});

--- a/examples/vite-vue-ssr/src/entry-server.ts
+++ b/examples/vite-vue-ssr/src/entry-server.ts
@@ -8,20 +8,17 @@ export interface RenderResult {
   teleports: string;
 }
 
+/**
+ * Renders one request with a fresh app, router, and GT plugin.
+ *
+ * A GT plugin owns mutable locale state, so it must never be shared between
+ * concurrent server requests. Translation data may be cached by an outer
+ * loader, but each request still needs its own plugin instance.
+ */
 export async function render(url: string): Promise<RenderResult> {
-  const { app } = await createDocsApp(url, true);
-  return renderApp(app, getLocaleFromUrl(url));
-}
-
-export async function createReusableRenderer() {
-  const gt = createDocsGT('en');
-
-  return async (url: string): Promise<RenderResult> => {
-    const locale = getLocaleFromUrl(url);
-    await gt.setLocale(locale);
-    const { app } = await createDocsApp(url, true, gt);
-    return renderApp(app, locale);
-  };
+  const gt = createDocsGT(getLocaleFromUrl(url));
+  const { app } = await createDocsApp(url, true, gt);
+  return renderApp(app, gt.getLocale());
 }
 
 async function renderApp(

--- a/examples/vite-vue-ssr/src/entry-server.ts
+++ b/examples/vite-vue-ssr/src/entry-server.ts
@@ -1,0 +1,38 @@
+import { renderToString, type SSRContext } from 'vue/server-renderer';
+import { createDocsApp, createDocsGT } from './app';
+import { getLocaleFromUrl } from './router';
+
+export interface RenderResult {
+  html: string;
+  locale: string;
+  teleports: string;
+}
+
+export async function render(url: string): Promise<RenderResult> {
+  const { app } = await createDocsApp(url, true);
+  return renderApp(app, getLocaleFromUrl(url));
+}
+
+export async function createReusableRenderer() {
+  const gt = createDocsGT('en');
+
+  return async (url: string): Promise<RenderResult> => {
+    const locale = getLocaleFromUrl(url);
+    await gt.setLocale(locale);
+    const { app } = await createDocsApp(url, true, gt);
+    return renderApp(app, locale);
+  };
+}
+
+async function renderApp(
+  app: Awaited<ReturnType<typeof createDocsApp>>['app'],
+  locale: string
+): Promise<RenderResult> {
+  const context: SSRContext = {};
+  const html = await renderToString(app, context);
+  return {
+    html,
+    locale,
+    teleports: context.teleports?.['#teleports'] ?? '',
+  };
+}

--- a/examples/vite-vue-ssr/src/i18n.ts
+++ b/examples/vite-vue-ssr/src/i18n.ts
@@ -1,0 +1,12 @@
+import type { GTFunction } from 'gt-vue';
+
+export { T } from 'gt-vue';
+export * as GT from 'gt-vue';
+export * as Vue from 'vue';
+
+/** Translates a static label through a translator supplied by its consumer. */
+export function translateTsxStatus(gt: GTFunction): string {
+  return gt('Translator forwarding works in TSX.', {
+    $context: 'TSX compatibility status',
+  });
+}

--- a/examples/vite-vue-ssr/src/messages.ts
+++ b/examples/vite-vue-ssr/src/messages.ts
@@ -1,0 +1,5 @@
+import { msg } from 'gt-vue';
+
+export const linkCopiedMessage = msg('The page link was copied.', {
+  $context: 'copy confirmation',
+});

--- a/examples/vite-vue-ssr/src/router.ts
+++ b/examples/vite-vue-ssr/src/router.ts
@@ -1,0 +1,32 @@
+import {
+  createMemoryHistory,
+  createRouter,
+  createWebHistory,
+  type Router,
+} from 'vue-router';
+
+export const supportedLocales = ['en', 'fr'] as const;
+export type SupportedLocale = (typeof supportedLocales)[number];
+
+export function getLocaleFromUrl(url: string): SupportedLocale {
+  const pathname = new URL(url, 'http://gt.local').pathname;
+  return pathname === '/fr' || pathname.startsWith('/fr/') ? 'fr' : 'en';
+}
+
+export function createDocsRouter(server: boolean): Router {
+  return createRouter({
+    history: server ? createMemoryHistory() : createWebHistory(),
+    routes: [
+      {
+        path: '/:locale(fr)?',
+        name: 'guide',
+        component: () => import('./views/GuidePage.vue'),
+      },
+      {
+        path: '/:locale(fr)?/reference',
+        name: 'reference',
+        component: () => import('./views/ReferencePage.vue'),
+      },
+    ],
+  });
+}

--- a/examples/vite-vue-ssr/src/style.css
+++ b/examples/vite-vue-ssr/src/style.css
@@ -1,0 +1,201 @@
+:root {
+  color: #152238;
+  background: #f6f8fc;
+  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+  font-synthesis: none;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+}
+
+button,
+input {
+  font: inherit;
+}
+
+button,
+a {
+  color: inherit;
+}
+
+button {
+  cursor: pointer;
+}
+
+.docs-shell {
+  min-height: 100vh;
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  gap: 2rem;
+  min-height: 4rem;
+  padding: 0.75rem 1.5rem;
+  color: white;
+  background: #14213d;
+}
+
+.topbar nav,
+.topbar-actions,
+.locale-links {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+}
+
+.topbar-actions {
+  margin-left: auto;
+}
+
+.brand {
+  font-weight: 750;
+  text-decoration: none;
+}
+
+.locale-links [aria-current='true'] {
+  font-weight: 750;
+  text-decoration-thickness: 0.16rem;
+}
+
+.shell-body {
+  display: grid;
+  grid-template-columns: minmax(12rem, 17rem) minmax(0, 1fr);
+  min-height: calc(100vh - 4rem);
+}
+
+aside {
+  padding: 1.5rem;
+  border-right: 1px solid #d9e0ec;
+  background: white;
+}
+
+aside nav {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+main {
+  width: min(56rem, 100%);
+  padding: 4rem clamp(1.5rem, 5vw, 5rem);
+}
+
+h1 {
+  max-width: 18ch;
+  margin: 0.2rem 0 1rem;
+  font-size: clamp(2.3rem, 5vw, 4.4rem);
+  line-height: 1;
+}
+
+.eyebrow {
+  color: #5d45d8;
+  font-weight: 750;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.card {
+  margin-top: 2rem;
+  padding: 1.4rem;
+  border: 1px solid #d9e0ec;
+  border-radius: 1rem;
+  background: white;
+  box-shadow: 0 1rem 3rem rgb(20 33 61 / 8%);
+}
+
+.tabs,
+.page-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 2rem;
+}
+
+.tabs [aria-selected='true'] {
+  color: white;
+  background: #5d45d8;
+}
+
+.toast {
+  margin: 0;
+  color: #24633f;
+}
+
+.dialog-backdrop {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: start center;
+  padding-top: 12vh;
+  background: rgb(20 33 61 / 62%);
+}
+
+.search-dialog {
+  position: relative;
+  width: min(38rem, calc(100vw - 2rem));
+  padding: 2rem;
+  border-radius: 1rem;
+  background: white;
+  box-shadow: 0 2rem 5rem rgb(0 0 0 / 30%);
+}
+
+.search-dialog h2 {
+  margin-top: 0;
+}
+
+.search-dialog label,
+.search-dialog input {
+  display: block;
+  width: 100%;
+}
+
+.search-dialog input {
+  margin-top: 0.4rem;
+  padding: 0.8rem;
+}
+
+.dialog-close {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+}
+
+.fade-enter-active,
+.fade-leave-active,
+.slide-enter-active,
+.slide-leave-active {
+  transition: opacity 120ms ease;
+}
+
+.fade-enter-from,
+.fade-leave-to,
+.slide-enter-from,
+.slide-leave-to {
+  opacity: 0;
+}
+
+@media (max-width: 760px) {
+  .topbar,
+  .topbar-actions {
+    flex-wrap: wrap;
+  }
+
+  .topbar-actions {
+    margin-left: 0;
+  }
+
+  .shell-body {
+    grid-template-columns: 1fr;
+  }
+
+  aside {
+    border-right: 0;
+    border-bottom: 1px solid #d9e0ec;
+  }
+}

--- a/examples/vite-vue-ssr/src/translations.ts
+++ b/examples/vite-vue-ssr/src/translations.ts
@@ -1,0 +1,12 @@
+import type { TranslationCatalog } from 'gt-vue';
+
+const catalogs = import.meta.glob<TranslationCatalog>('./_gt/*.json', {
+  import: 'default',
+});
+
+export async function loadTranslations(
+  locale: string
+): Promise<TranslationCatalog> {
+  const loadCatalog = catalogs[`./_gt/${locale}.json`];
+  return loadCatalog ? loadCatalog() : {};
+}

--- a/examples/vite-vue-ssr/src/views/GuidePage.vue
+++ b/examples/vite-vue-ssr/src/views/GuidePage.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { T, Var, useGT } from 'gt-vue';
+
+const gt = useGT();
+const productName = 'Orbit';
+const selectedTab = ref<'quickstart' | 'concepts'>('quickstart');
+</script>
+
+<template>
+  <article data-page="guide">
+    <p class="eyebrow">gt-vue · SSR</p>
+    <T context="docs landing introduction">
+      <h1>Developer documentation</h1>
+      <p>
+        Build reliable integrations with
+        <Var>{{ productName }}</Var>
+        .
+      </p>
+    </T>
+
+    <div class="tabs" role="tablist" :aria-label="gt('Guide sections')">
+      <button
+        role="tab"
+        type="button"
+        :aria-selected="selectedTab === 'quickstart'"
+        @click="selectedTab = 'quickstart'"
+      >
+        {{ gt('Quickstart') }}
+      </button>
+      <button
+        role="tab"
+        type="button"
+        :aria-selected="selectedTab === 'concepts'"
+        @click="selectedTab = 'concepts'"
+      >
+        {{ gt('Core concepts') }}
+      </button>
+    </div>
+
+    <Transition name="fade" mode="out-in">
+      <section :key="selectedTab" class="card" role="tabpanel">
+        <T v-if="selectedTab === 'quickstart'" context="quickstart card">
+          <h2>Make your first request</h2>
+          <p>Create a client and send a request in a few lines of code.</p>
+        </T>
+        <T v-else context="concepts card">
+          <h2>Understand the platform</h2>
+          <p>Learn how projects, environments, and releases fit together.</p>
+        </T>
+      </section>
+    </Transition>
+  </article>
+</template>

--- a/examples/vite-vue-ssr/src/views/ReferencePage.vue
+++ b/examples/vite-vue-ssr/src/views/ReferencePage.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+import { onServerPrefetch, ref } from 'vue';
+import { DateTime, Num, Plural, T, Var, useGT } from 'gt-vue';
+
+const gt = useGT();
+const operationCount = ref(12);
+const serviceName = 'Launch API';
+const updatedAt = new Date('2026-08-01T12:00:00.000Z');
+
+onServerPrefetch(async () => {
+  await Promise.resolve();
+});
+</script>
+
+<template>
+  <article data-page="reference">
+    <p class="eyebrow">GET /v1/launches</p>
+    <T context="API reference introduction">
+      <h1>
+        Explore the
+        <Var>{{ serviceName }}</Var>
+      </h1>
+      <p>Use this reference to understand every endpoint and response.</p>
+    </T>
+
+    <section class="card">
+      <h2>{{ gt('Available operations') }}</h2>
+      <T context="operation count">
+        <Plural :n="operationCount">
+          <template #one>One documented operation</template>
+          <template #other>
+            <Num :value="operationCount" />
+            documented operations
+          </template>
+          No documented operations
+        </Plural>
+      </T>
+      <p>
+        {{ gt('Last updated') }}:
+        <DateTime
+          :value="updatedAt"
+          :options="{
+            day: 'numeric',
+            month: 'long',
+            timeZone: 'UTC',
+            year: 'numeric',
+          }"
+        />
+      </p>
+    </section>
+  </article>
+</template>

--- a/examples/vite-vue-ssr/tsconfig.app.json
+++ b/examples/vite-vue-ssr/tsconfig.app.json
@@ -12,10 +12,12 @@
     "moduleDetection": "force",
     "noEmit": true,
     "strict": true,
+    "jsx": "preserve",
+    "jsxImportSource": "vue",
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "types": ["vite/client"]
   },
-  "include": ["src/**/*.ts", "src/**/*.vue"]
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue"]
 }

--- a/examples/vite-vue-ssr/tsconfig.app.json
+++ b/examples/vite-vue-ssr/tsconfig.app.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.vue"]
+}

--- a/examples/vite-vue-ssr/tsconfig.json
+++ b/examples/vite-vue-ssr/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ]
+}

--- a/examples/vite-vue-ssr/tsconfig.node.json
+++ b/examples/vite-vue-ssr/tsconfig.node.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "target": "ES2023",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": ["node"]
+  },
+  "include": ["server.ts", "vite.config.ts"]
+}

--- a/examples/vite-vue-ssr/vite.config.ts
+++ b/examples/vite-vue-ssr/vite.config.ts
@@ -1,8 +1,9 @@
 import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
+import vueJsx from '@vitejs/plugin-vue-jsx';
 
 export default defineConfig({
-  plugins: [vue()],
+  plugins: [vue(), vueJsx()],
   resolve: {
     // Linked packages and the host must share one Vue injection context.
     dedupe: ['vue'],

--- a/examples/vite-vue-ssr/vite.config.ts
+++ b/examples/vite-vue-ssr/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+
+export default defineConfig({
+  plugins: [vue()],
+  resolve: {
+    // Linked packages and the host must share one Vue injection context.
+    dedupe: ['vue'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -745,6 +745,52 @@ importers:
         specifier: ~3.2.0
         version: 3.2.9(typescript@5.9.3)
 
+  examples/vite-vue-ssr:
+    dependencies:
+      express:
+        specifier: ^5.2.1
+        version: 5.2.1
+      gt-vue:
+        specifier: workspace:*
+        version: link:../../packages/vue
+      vue:
+        specifier: ^3.5.0
+        version: 3.5.40(typescript@5.9.3)
+      vue-router:
+        specifier: 5.0.4
+        version: 5.0.4(@vue/compiler-sfc@3.5.40)(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.4(@types/node@22.13.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.40(typescript@5.9.3))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19))
+    devDependencies:
+      '@types/express':
+        specifier: ^5.0.6
+        version: 5.0.6
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.13.10
+      '@vitejs/plugin-vue':
+        specifier: ^6.0.3
+        version: 6.0.8(vite@8.1.4(@types/node@22.13.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.40(typescript@5.9.3))
+      gt:
+        specifier: workspace:*
+        version: link:../../packages/cli
+      oxfmt:
+        specifier: 'catalog:'
+        version: 0.47.0
+      tsx:
+        specifier: ^4.20.6
+        version: 4.21.0
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vite:
+        specifier: ^8.0.16
+        version: 8.1.4(@types/node@22.13.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
+      vitest:
+        specifier: 'catalog:'
+        version: 3.2.4(@edge-runtime/vm@4.0.4)(@types/debug@4.1.12)(@types/node@22.13.10)(jiti@2.7.0)(jsdom@29.0.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
+      vue-tsc:
+        specifier: ~3.2.0
+        version: 3.2.9(typescript@5.9.3)
+
   examples/webpack-spa:
     dependencies:
       gt:
@@ -9932,6 +9978,15 @@ packages:
   '@vscode/sudo-prompt@9.3.2':
     resolution: {integrity: sha512-gcXoCN00METUNFeQOFJ+C9xUI0DKB+0EGMVg7wbVYRHBw2Eq3fKisDZOkRdOz3kqXRKOENMfShPOmypw1/8nOw==}
 
+  '@vue-macros/common@3.1.4':
+    resolution: {integrity: sha512-/5Fv+6DgIcM9ajY05ZmKBv+LMX1M9A0X+IUwDRVdt67ciw8OV9bvG2r34p3RiEadlsQybjhKPRKNXDC8Bp23cw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      vue: ^2.7.0 || ^3.2.25
+    peerDependenciesMeta:
+      vue:
+        optional: true
+
   '@vue/babel-helper-vue-transform-on@1.5.0':
     resolution: {integrity: sha512-0dAYkerNhhHutHZ34JtTl2czVQHUNWv6xEbkdF5W+Yrv5pCWsqjeORdOgbtW2I9gWlt+wBmVn+ttqN9ZxR5tzA==}
 
@@ -9959,6 +10014,15 @@ packages:
 
   '@vue/compiler-ssr@3.5.40':
     resolution: {integrity: sha512-rrE5xiXG663+vHCHa3J9p2z5OcBRjXmoqenprJxAFQxg5pSshzeBiCE6pu46axapRJ2Adk0YDA2BRZVjiHXnhg==}
+
+  '@vue/devtools-api@8.2.1':
+    resolution: {integrity: sha512-6u4vXBlIBAC1wMplIZgpyPn7uh/s4Bf6F5bMzvLv+EdJ0aHs/+4B7Ygv864EStQSjRbsRzTko/kUG1A1IejQ3A==}
+
+  '@vue/devtools-kit@8.2.1':
+    resolution: {integrity: sha512-FIGIuq3AWReEpbAHY/cRGeHDfI0qOb8OCQ3YjbEAX04uaxIDbGc9rhkbVcG7rnfHPXE3RsU5KrWOu9V/okd8AQ==}
+
+  '@vue/devtools-shared@8.2.1':
+    resolution: {integrity: sha512-Fkac7lUdGReh6pVOi3AYPRGe82LQqRmAfThW7RRligOAP0ZA/Z1z9XLHDM9dv34pV2HRc79DK8uKPeG2fLnA/g==}
 
   '@vue/language-core@3.2.9':
     resolution: {integrity: sha512-ie0ojt/0fU/GfIogh+zgHbaYRPlt9S+cLOxcWwF7nTSFh897BVgnFKL2byT4kpp1mlqYWZ2psGwSniyE2xsxYw==}
@@ -10372,6 +10436,10 @@ packages:
     resolution: {integrity: sha512-cl76xfBQM6pztbrFWRnxbrDm9EOqDr1BF6+qQnnDZG2Co2LjyUktkN9GTJfBAfdae+DbT2nJf2nCGAdDDN7W2g==}
     engines: {node: '>=20.18.0'}
 
+  ast-kit@2.2.0:
+    resolution: {integrity: sha512-m1Q/RaVOnTp9JxPX+F+Zn7IcLYMzM8kZofDImfsKZd8MbR+ikdOzTeztStWqfrqIxZnYWryyI9ePm3NGjnZgGw==}
+    engines: {node: '>=20.19.0'}
+
   ast-kit@3.0.0-beta.1:
     resolution: {integrity: sha512-trmleAnZ2PxN/loHWVhhx1qeOHSRXq4TDsBBxq3GqeJitfk3+jTQ+v/C1km/KYq9M7wKqCewMh+/NAvVH7m+bw==}
     engines: {node: '>=20.19.0'}
@@ -10385,6 +10453,10 @@ packages:
 
   ast-v8-to-istanbul@0.3.5:
     resolution: {integrity: sha512-9SdXjNheSiE8bALAQCQQuT6fgQaoxJh7IRYrRGZ8/9nv8WhJeC1aXAwN8TbaOssGOukUvyvnkgD9+Yuykvl1aA==}
+
+  ast-walker-scope@0.8.3:
+    resolution: {integrity: sha512-cbdCP0PGOBq0ASG+sjnKIoYkWMKhhz+F/h9pRexUdX2Hd38+WOlBkRKlqkGOSm0YQpcFMQBJeK4WspUAkwsEdg==}
+    engines: {node: '>=20.19.0'}
 
   astral-regex@1.0.0:
     resolution: {integrity: sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==}
@@ -11167,6 +11239,9 @@ packages:
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  confbox@0.2.4:
+    resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
 
   config-chain@1.1.13:
     resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
@@ -13132,6 +13207,9 @@ packages:
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
+  hookable@5.5.3:
+    resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
+
   hookable@6.1.1:
     resolution: {integrity: sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==}
 
@@ -14492,6 +14570,10 @@ packages:
     resolution: {integrity: sha512-XfegD5pyTAfb+GY6chk283Ox5z8WexG56OvM06RWLpAc/UHozO8X6xAxEkIitZOtsSMM1Yr3DkHgW5W+onLhCw==}
     engines: {node: '>=6'}
 
+  local-pkg@1.2.1:
+    resolution: {integrity: sha512-++gUqRDEvcnN6Zhqrr+y/CkVEHhlrR96vZn3nZZPYzMcBUyBtTKzB9NadClFIsIVSsu+3i9tfk/erqy9kAmt7Q==}
+    engines: {node: '>=14'}
+
   locate-path@3.0.0:
     resolution: {integrity: sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==}
     engines: {node: '>=6'}
@@ -14596,6 +14678,10 @@ packages:
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
+
+  magic-string-ast@1.0.3:
+    resolution: {integrity: sha512-CvkkH1i81zl7mmb94DsRiFeG9V2fR2JeuK8yDgS8oiZSFa++wWLEgZ5ufEOyLHbvSbD1gTRKv9NdX69Rnvr9JA==}
+    engines: {node: '>=20.19.0'}
 
   magic-string@0.25.9:
     resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
@@ -15964,6 +16050,9 @@ packages:
   peek-stream@1.1.3:
     resolution: {integrity: sha512-FhJ+YbOSBb9/rIl2ZeE/QHEsWn7PqNYt8ARAY3kIgNGOk13g9FGyIY6JIl/xB/3TFRVoTv5as0l11weORrTekA==}
 
+  perfect-debounce@2.1.0:
+    resolution: {integrity: sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==}
+
   performance-now@2.1.0:
     resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
 
@@ -16052,6 +16141,9 @@ packages:
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  pkg-types@2.3.1:
+    resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
 
   pkg-up@3.1.0:
     resolution: {integrity: sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==}
@@ -17669,6 +17761,9 @@ packages:
   scrollmirror@1.2.4:
     resolution: {integrity: sha512-UkEHHOV6j5cE3IsObQRK6vO4twSuhE4vtLD4UmX+doHgrtg2jRwXkz4O6cz0jcoxK5NGU7rFjyvLcWHzw7eQ5A==}
 
+  scule@1.3.0:
+    resolution: {integrity: sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==}
+
   secure-json-parse@2.7.0:
     resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
 
@@ -19021,6 +19116,10 @@ packages:
     resolution: {integrity: sha512-gwXJnPRewT4rT7sBi/IvxKTjsms7jX7QIDLOClApuZwR49SXbrB1z2NLUZ+vDHyqCj/n58OzRRqaW+B8OZi8vg==}
     engines: {node: '>=18.12.0'}
 
+  unplugin-utils@0.3.2:
+    resolution: {integrity: sha512-xVToRh2CTmLk2HnEG7ac4rl1MJTT3RFkpS8B++/SnB0kXvuaavD+n3m/vrzyWQOdJNSZQACnbz01pnppbwV5BA==}
+    engines: {node: '>=20.19.0'}
+
   unplugin@2.3.10:
     resolution: {integrity: sha512-6NCPkv1ClwH+/BGE9QeoTIl09nuiAt0gS28nn1PvYXsGKRwM2TCbFA2QiilmehPDTXIe684k4rZI1yl3A1PCUw==}
     engines: {node: '>=18.12.0'}
@@ -19439,6 +19538,21 @@ packages:
 
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
+
+  vue-router@5.0.4:
+    resolution: {integrity: sha512-lCqDLCI2+fKVRl2OzXuzdSWmxXFLQRxQbmHugnRpTMyYiT+hNaycV0faqG5FBHDXoYrZ6MQcX87BvbY8mQ20Bg==}
+    peerDependencies:
+      '@pinia/colada': '>=0.21.2'
+      '@vue/compiler-sfc': ^3.5.17
+      pinia: ^3.0.4
+      vue: ^3.5.0
+    peerDependenciesMeta:
+      '@pinia/colada':
+        optional: true
+      '@vue/compiler-sfc':
+        optional: true
+      pinia:
+        optional: true
 
   vue-tsc@3.2.9:
     resolution: {integrity: sha512-qm8/nbo+9eZc1SCndm9wT+gq23pM+wRIdHY0wjm83B3lIginHTwcdrLUyTrKjDWXbMVNjKegNrnymhpdqnCL3A==}
@@ -28904,6 +29018,12 @@ snapshots:
       vite: 7.3.1(@types/node@22.13.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
       vue: 3.5.40(typescript@5.9.3)
 
+  '@vitejs/plugin-vue@6.0.8(vite@8.1.4(@types/node@22.13.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.40(typescript@5.9.3))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.1
+      vite: 8.1.4(@types/node@22.13.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
+      vue: 3.5.40(typescript@5.9.3)
+
   '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@edge-runtime/vm@4.0.4)(@types/debug@4.1.12)(@types/node@24.13.3)(jiti@2.7.0)(jsdom@29.0.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@ampproject/remapping': 2.3.0
@@ -29004,6 +29124,16 @@ snapshots:
   '@vscode/sudo-prompt@9.3.2':
     optional: true
 
+  '@vue-macros/common@3.1.4(vue@3.5.40(typescript@5.9.3))':
+    dependencies:
+      '@vue/compiler-sfc': 3.5.40
+      ast-kit: 2.1.2
+      local-pkg: 1.2.1
+      magic-string-ast: 1.0.3
+      unplugin-utils: 0.3.2
+    optionalDependencies:
+      vue: 3.5.40(typescript@5.9.3)
+
   '@vue/babel-helper-vue-transform-on@1.5.0': {}
 
   '@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.0)':
@@ -29062,6 +29192,19 @@ snapshots:
     dependencies:
       '@vue/compiler-dom': 3.5.40
       '@vue/shared': 3.5.40
+
+  '@vue/devtools-api@8.2.1':
+    dependencies:
+      '@vue/devtools-kit': 8.2.1
+
+  '@vue/devtools-kit@8.2.1':
+    dependencies:
+      '@vue/devtools-shared': 8.2.1
+      birpc: 2.6.1
+      hookable: 5.5.3
+      perfect-debounce: 2.1.0
+
+  '@vue/devtools-shared@8.2.1': {}
 
   '@vue/language-core@3.2.9':
     dependencies:
@@ -29534,6 +29677,11 @@ snapshots:
       '@babel/parser': 7.29.7
       pathe: 2.0.3
 
+  ast-kit@2.2.0:
+    dependencies:
+      '@babel/parser': 7.29.7
+      pathe: 2.0.3
+
   ast-kit@3.0.0-beta.1:
     dependencies:
       '@babel/parser': 8.0.0-rc.3
@@ -29551,6 +29699,11 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       estree-walker: 3.0.3
       js-tokens: 9.0.1
+
+  ast-walker-scope@0.8.3:
+    dependencies:
+      '@babel/parser': 7.29.7
+      ast-kit: 2.2.0
 
   astral-regex@1.0.0:
     optional: true
@@ -30563,6 +30716,8 @@ snapshots:
       yargs: 17.7.2
 
   confbox@0.1.8: {}
+
+  confbox@0.2.4: {}
 
   config-chain@1.1.13:
     dependencies:
@@ -33104,6 +33259,8 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
+  hookable@5.5.3: {}
+
   hookable@6.1.1: {}
 
   hoopy@0.1.4: {}
@@ -34767,6 +34924,12 @@ snapshots:
 
   local-access@1.1.0: {}
 
+  local-pkg@1.2.1:
+    dependencies:
+      mlly: 1.8.0
+      pkg-types: 2.3.1
+      quansync: 0.2.11
+
   locate-path@3.0.0:
     dependencies:
       p-locate: 3.0.0
@@ -34858,6 +35021,10 @@ snapshots:
       react: 18.3.1
 
   lz-string@1.5.0: {}
+
+  magic-string-ast@1.0.3:
+    dependencies:
+      magic-string: 0.30.21
 
   magic-string@0.25.9:
     dependencies:
@@ -36810,6 +36977,8 @@ snapshots:
       duplexify: 3.7.1
       through2: 2.0.5
 
+  perfect-debounce@2.1.0: {}
+
   performance-now@2.1.0: {}
 
   pg-int8@1.0.1: {}
@@ -36888,6 +37057,12 @@ snapshots:
     dependencies:
       confbox: 0.1.8
       mlly: 1.8.0
+      pathe: 2.0.3
+
+  pkg-types@2.3.1:
+    dependencies:
+      confbox: 0.2.4
+      exsolve: 1.0.8
       pathe: 2.0.3
 
   pkg-up@3.1.0:
@@ -39139,6 +39314,8 @@ snapshots:
 
   scrollmirror@1.2.4: {}
 
+  scule@1.3.0: {}
+
   secure-json-parse@2.7.0: {}
 
   select-hose@2.0.0: {}
@@ -40660,6 +40837,11 @@ snapshots:
       pathe: 2.0.3
       picomatch: 4.0.5
 
+  unplugin-utils@0.3.2:
+    dependencies:
+      pathe: 2.0.3
+      picomatch: 4.0.5
+
   unplugin@2.3.10:
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -40677,6 +40859,18 @@ snapshots:
       rolldown: 1.1.5
       rollup: 4.62.2
       vite: 8.1.4(@types/node@20.19.17)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
+      webpack: 5.108.4(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19)
+
+  unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.4(@types/node@22.13.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19)):
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      picomatch: 4.0.5
+      webpack-virtual-modules: 0.6.2
+    optionalDependencies:
+      esbuild: 0.28.1
+      rolldown: 1.1.5
+      rollup: 4.62.2
+      vite: 8.1.4(@types/node@22.13.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
       webpack: 5.108.4(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19)
 
   unquote@1.1.1: {}
@@ -41088,6 +41282,22 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.3
 
+  vite@8.1.4(@types/node@22.13.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.5
+      postcss: 8.5.19
+      rolldown: 1.1.5
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 22.13.10
+      esbuild: 0.28.1
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      terser: 5.44.0
+      tsx: 4.21.0
+      yaml: 2.8.3
+
   vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
@@ -41293,6 +41503,39 @@ snapshots:
   void-elements@3.1.0: {}
 
   vscode-uri@3.1.0: {}
+
+  vue-router@5.0.4(@vue/compiler-sfc@3.5.40)(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.4(@types/node@22.13.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.40(typescript@5.9.3))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19)):
+    dependencies:
+      '@babel/generator': 7.29.1
+      '@vue-macros/common': 3.1.4(vue@3.5.40(typescript@5.9.3))
+      '@vue/devtools-api': 8.2.1
+      ast-walker-scope: 0.8.3
+      chokidar: 5.0.0
+      json5: 2.2.3
+      local-pkg: 1.2.1
+      magic-string: 0.30.21
+      mlly: 1.8.0
+      muggle-string: 0.4.1
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      scule: 1.3.0
+      tinyglobby: 0.2.17
+      unplugin: 3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.4(@types/node@22.13.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19))
+      unplugin-utils: 0.3.2
+      vue: 3.5.40(typescript@5.9.3)
+      yaml: 2.8.3
+    optionalDependencies:
+      '@vue/compiler-sfc': 3.5.40
+    transitivePeerDependencies:
+      - '@farmfe/core'
+      - '@rspack/core'
+      - bun-types-no-globals
+      - esbuild
+      - rolldown
+      - rollup
+      - unloader
+      - vite
+      - webpack
 
   vue-tsc@3.2.9(typescript@5.9.3):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -769,6 +769,9 @@ importers:
       '@vitejs/plugin-vue':
         specifier: ^6.0.3
         version: 6.0.8(vite@8.1.4(@types/node@22.13.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.40(typescript@5.9.3))
+      '@vitejs/plugin-vue-jsx':
+        specifier: 5.1.6
+        version: 5.1.6(vite@8.1.4(@types/node@22.13.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.40(typescript@5.9.3))
       gt:
         specifier: workspace:*
         version: link:../../packages/cli
@@ -9920,6 +9923,122 @@ packages:
     peerDependencies:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0
       vue: ^3.0.0
+
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+
+  '@babel/generator@7.29.8':
+    resolution: {integrity: sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==}
+    engines: {node: '>=6.9.0'}
+
+
+  '@babel/helper-annotate-as-pure@7.29.7':
+    resolution: {integrity: sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==}
+    engines: {node: '>=6.9.0'}
+
+
+  '@babel/helper-create-class-features-plugin@7.29.7':
+    resolution: {integrity: sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
+    engines: {node: '>=6.9.0'}
+
+
+  '@babel/helper-member-expression-to-functions@7.29.7':
+    resolution: {integrity: sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==}
+    engines: {node: '>=6.9.0'}
+
+
+  '@babel/helper-optimise-call-expression@7.29.7':
+    resolution: {integrity: sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==}
+    engines: {node: '>=6.9.0'}
+
+
+  '@babel/helper-plugin-utils@7.29.7':
+    resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
+    engines: {node: '>=6.9.0'}
+
+
+  '@babel/helper-replace-supers@7.29.7':
+    resolution: {integrity: sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+
+  '@babel/helper-skip-transparent-expression-wrappers@7.29.7':
+    resolution: {integrity: sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==}
+    engines: {node: '>=6.9.0'}
+
+
+  '@babel/parser@7.29.8':
+    resolution: {integrity: sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+
+  '@babel/plugin-syntax-typescript@7.29.7':
+    resolution: {integrity: sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+
+  '@babel/plugin-transform-typescript@7.29.7':
+    resolution: {integrity: sha512-jK52h8LaLc7JarhQV2ofeFMts4H7vnOXnqZNA6fYglBTZewRBE51KWt3BUltW1P+KoPsYkHoJeXePuz4zo2LMw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
+    engines: {node: '>=6.9.0'}
+
+
+  '@babel/traverse@7.29.8':
+    resolution: {integrity: sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==}
+    engines: {node: '>=6.9.0'}
+
+
+  '@babel/types@7.29.8':
+    resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
+    engines: {node: '>=6.9.0'}
+
+
+  '@vitejs/plugin-vue-jsx@5.1.6':
+    resolution: {integrity: sha512-YXvi4as2clxt6DFw5+a0tTA97ntiQXm/raR8ofNj3aNwwdlVGTiG2gp7EvfZW17P50acL/9bP0ccF4XnqNmlgA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+      vue: ^3.0.0
+
+
+  '@vue/babel-helper-vue-transform-on@2.0.1':
+    resolution: {integrity: sha512-uZ66EaFbnnZSYqYEyplWvn46GhZ1KuYSThdT68p+am7MgBNbQ3hphTL9L+xSIsWkdktwhPYLwPgVWqo96jDdRA==}
+
+
+  '@vue/babel-plugin-jsx@2.0.1':
+    resolution: {integrity: sha512-a8CaLQjD/s4PVdhrLD/zT574ZNPnZBOY+IhdtKWRB4HRZ0I2tXBi5ne7d9eCfaYwp5gU5+4KIyFTV1W1YL9xZA==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+
+
+  '@vue/babel-plugin-resolve-type@2.0.1':
+    resolution: {integrity: sha512-ybwgIuRGRRBhOU37GImDoWQoz+TlSqap65qVI6iwg/J7FfLTLmMf97TS7xQH9I7Qtr/gp161kYVdhr1ZMraSYQ==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
 
   '@vitejs/plugin-vue@6.0.8':
     resolution: {integrity: sha512-0ZjgOg7oO6farnNGup7yvoM/YXZV84OZxHAwtflItNa/6zzQyVb5LNxyea3FEKEX2XlagIKzrlH7wwxkKgtiew==}
@@ -29011,6 +29130,172 @@ snapshots:
       vue: 3.5.40(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
+
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+
+  '@babel/generator@7.29.8':
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+
+  '@babel/helper-annotate-as-pure@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
+
+  '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-annotate-as-pure': 7.29.7
+      '@babel/helper-member-expression-to-functions': 7.29.7
+      '@babel/helper-optimise-call-expression': 7.29.7
+      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.0)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
+      '@babel/traverse': 7.29.8
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+
+  '@babel/helper-globals@7.29.7': {}
+
+
+  '@babel/helper-member-expression-to-functions@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.8
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+
+  '@babel/helper-optimise-call-expression@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
+
+  '@babel/helper-plugin-utils@7.29.7': {}
+
+
+  '@babel/helper-replace-supers@7.29.7(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-member-expression-to-functions': 7.29.7
+      '@babel/helper-optimise-call-expression': 7.29.7
+      '@babel/traverse': 7.29.8
+    transitivePeerDependencies:
+      - supports-color
+
+
+  '@babel/helper-skip-transparent-expression-wrappers@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.8
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+
+  '@babel/parser@7.29.8':
+    dependencies:
+      '@babel/types': 7.29.8
+
+
+  '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.29.7
+
+
+  '@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-annotate-as-pure': 7.29.7
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
+      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.0)
+    transitivePeerDependencies:
+      - supports-color
+
+
+  '@babel/template@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+
+
+  '@babel/traverse@7.29.8':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.8
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.8
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.8
+      debug: 4.4.3(supports-color@5.5.0)
+    transitivePeerDependencies:
+      - supports-color
+
+
+  '@babel/types@7.29.8':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+
+  '@vitejs/plugin-vue-jsx@5.1.6(vite@8.1.4(@types/node@22.13.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.40(typescript@5.9.3))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.0)
+      '@rolldown/pluginutils': 1.0.1
+      '@vue/babel-plugin-jsx': 2.0.1(@babel/core@7.29.0)
+      vite: 8.1.4(@types/node@22.13.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
+      vue: 3.5.40(typescript@5.9.3)
+    transitivePeerDependencies:
+      - supports-color
+
+
+  '@vue/babel-helper-vue-transform-on@2.0.1': {}
+
+
+  '@vue/babel-plugin-jsx@2.0.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.0)
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.7
+      '@vue/babel-helper-vue-transform-on': 2.0.1
+      '@vue/babel-plugin-resolve-type': 2.0.1(@babel/core@7.29.0)
+      '@vue/shared': 3.5.40
+    optionalDependencies:
+      '@babel/core': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+
+  '@vue/babel-plugin-resolve-type@2.0.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/parser': 7.29.7
+      '@vue/compiler-sfc': 3.5.40
+    transitivePeerDependencies:
+      - supports-color
+
 
   '@vitejs/plugin-vue@6.0.8(vite@7.3.1(@types/node@22.13.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.40(typescript@5.9.3))':
     dependencies:

--- a/tests/apps/test-apps-e2e/apps.mjs
+++ b/tests/apps/test-apps-e2e/apps.mjs
@@ -65,6 +65,22 @@ export const apps = Object.freeze({
     command: 'pnpm --filter gt-test-vite-react dev',
     readyPath: '/',
   },
+  'vite-vue': {
+    packageName: 'vite-vue',
+    entryPackage: 'gt-vue',
+    kind: 'vue-spa',
+    baseURL: 'http://localhost:5180',
+    command: 'pnpm --filter vite-vue exec vite --port 5180 --strictPort',
+    readyPath: '/',
+  },
+  'vite-vue-ssr': {
+    packageName: 'vite-vue-ssr',
+    entryPackage: 'gt-vue',
+    kind: 'vue-ssr',
+    baseURL: 'http://localhost:5181',
+    command: 'pnpm --filter vite-vue-ssr dev',
+    readyPath: '/fr/reference',
+  },
   'webpack-react': {
     packageName: 'gt-test-webpack-react',
     entryPackage: 'gt-react',

--- a/tests/apps/test-apps-e2e/e2e/app.spec.ts
+++ b/tests/apps/test-apps-e2e/e2e/app.spec.ts
@@ -78,6 +78,15 @@ async function testVueSpa(page: Page) {
   await expect(
     page.getByText('This sentence comes from useGT().')
   ).toBeVisible();
+  await expect(
+    page.getByRole('heading', { name: 'Local re-exports work in TSX' })
+  ).toBeVisible();
+  await expect(
+    page.getByText('Namespace components work in TSX.')
+  ).toBeVisible();
+  await expect(
+    page.getByText('Translator forwarding works in TSX.')
+  ).toBeVisible();
 
   await page.getByRole('button', { name: 'Français' }).click();
   await expect(
@@ -86,11 +95,25 @@ async function testVueSpa(page: Page) {
   await expect(
     page.getByText('Cette phrase provient de useGT().')
   ).toBeVisible();
+  await expect(
+    page.getByRole('heading', {
+      name: 'Les réexportations locales fonctionnent en TSX',
+    })
+  ).toBeVisible();
+  await expect(
+    page.getByText('Les composants avec espace de noms fonctionnent en TSX.')
+  ).toBeVisible();
+  await expect(
+    page.getByText('Le transfert du traducteur fonctionne en TSX.')
+  ).toBeVisible();
   await expect(page.locator('html')).toHaveAttribute('lang', 'fr');
 
   await page.getByRole('button', { name: 'English' }).click();
   await expect(
     page.getByRole('heading', { name: /Hello,\s*Ada\s*!/ })
+  ).toBeVisible();
+  await expect(
+    page.getByRole('heading', { name: 'Local re-exports work in TSX' })
   ).toBeVisible();
   await expect(page.locator('html')).toHaveAttribute('lang', 'en');
 }
@@ -102,6 +125,13 @@ async function testVueSsr(page: Page, request: APIRequestContext) {
   expect(serverHtml).toContain('<html lang="fr"');
   expect(serverHtml).toContain('Référence de l’API');
   expect(serverHtml).toContain('Opérations disponibles');
+  expect(serverHtml).toContain(
+    'Les réexportations locales fonctionnent en TSX'
+  );
+  expect(serverHtml).toContain(
+    'Les composants avec espace de noms fonctionnent en TSX.'
+  );
+  expect(serverHtml).toContain('Le transfert du traducteur fonctionne en TSX.');
 
   const isolatedResponses = await Promise.all(
     Array.from({ length: 8 }, (_, index) =>
@@ -112,10 +142,16 @@ async function testVueSsr(page: Page, request: APIRequestContext) {
     const html = await response.text();
     if (index % 2 === 0) {
       expect(html).toContain('Available operations');
+      expect(html).toContain('Local re-exports work in TSX');
       expect(html).not.toContain('Opérations disponibles');
+      expect(html).not.toContain(
+        'Les réexportations locales fonctionnent en TSX'
+      );
     } else {
       expect(html).toContain('Opérations disponibles');
+      expect(html).toContain('Les réexportations locales fonctionnent en TSX');
       expect(html).not.toContain('Available operations');
+      expect(html).not.toContain('Local re-exports work in TSX');
     }
   }
 
@@ -126,6 +162,17 @@ async function testVueSsr(page: Page, request: APIRequestContext) {
     page.getByRole('heading', { name: 'Opérations disponibles' })
   ).toBeVisible();
   await expect(page.getByText('12 opérations documentées')).toBeVisible();
+  await expect(
+    page.getByRole('heading', {
+      name: 'Les réexportations locales fonctionnent en TSX',
+    })
+  ).toBeVisible();
+  await expect(
+    page.getByText('Les composants avec espace de noms fonctionnent en TSX.')
+  ).toBeVisible();
+  await expect(
+    page.getByText('Le transfert du traducteur fonctionne en TSX.')
+  ).toBeVisible();
 
   await page.getByRole('button', { name: 'Ouvrir la recherche' }).click();
   const dialog = page.getByRole('dialog', {
@@ -160,6 +207,15 @@ async function testVueSsr(page: Page, request: APIRequestContext) {
     page.getByRole('heading', { name: 'Available operations' })
   ).toBeVisible();
   await expect(page.getByText('12 documented operations')).toBeVisible();
+  await expect(
+    page.getByRole('heading', { name: 'Local re-exports work in TSX' })
+  ).toBeVisible();
+  await expect(
+    page.getByText('Namespace components work in TSX.')
+  ).toBeVisible();
+  await expect(
+    page.getByText('Translator forwarding works in TSX.')
+  ).toBeVisible();
 
   await page.goBack();
   await expect(page).toHaveURL(/\/fr\/reference$/);
@@ -167,10 +223,20 @@ async function testVueSsr(page: Page, request: APIRequestContext) {
   await expect(
     page.getByRole('heading', { name: 'Opérations disponibles' })
   ).toBeVisible();
+  await expect(
+    page.getByRole('heading', {
+      name: 'Les réexportations locales fonctionnent en TSX',
+    })
+  ).toBeVisible();
   await page.reload();
   await expect(page.locator('html')).toHaveAttribute('data-hydrated', 'true');
   await expect(
     page.getByRole('heading', { name: 'Opérations disponibles' })
+  ).toBeVisible();
+  await expect(
+    page.getByRole('heading', {
+      name: 'Les réexportations locales fonctionnent en TSX',
+    })
   ).toBeVisible();
 }
 

--- a/tests/apps/test-apps-e2e/e2e/app.spec.ts
+++ b/tests/apps/test-apps-e2e/e2e/app.spec.ts
@@ -15,6 +15,12 @@ test(`${appName} renders local translations and switches locales`, async ({
     case 'react':
       await testReactApp(page);
       break;
+    case 'vue-spa':
+      await testVueSpa(page);
+      break;
+    case 'vue-ssr':
+      await testVueSsr(page, request);
+      break;
     case 'next':
       await testNextApp(page);
       break;
@@ -62,6 +68,110 @@ async function testReactApp(page: Page) {
   await selectLocale(page, 'en');
   await expect(page.getByText('Locale: en')).toBeVisible();
   await expect(page.getByText('A string translated with useGT.')).toBeVisible();
+}
+
+async function testVueSpa(page: Page) {
+  await page.goto('/');
+  await expect(
+    page.getByRole('heading', { name: /Hello,\s*Ada\s*!/ })
+  ).toBeVisible();
+  await expect(
+    page.getByText('This sentence comes from useGT().')
+  ).toBeVisible();
+
+  await page.getByRole('button', { name: 'Français' }).click();
+  await expect(
+    page.getByRole('heading', { name: /Bonjour,\s*Ada\s*!/ })
+  ).toBeVisible();
+  await expect(
+    page.getByText('Cette phrase provient de useGT().')
+  ).toBeVisible();
+  await expect(page.locator('html')).toHaveAttribute('lang', 'fr');
+
+  await page.getByRole('button', { name: 'English' }).click();
+  await expect(
+    page.getByRole('heading', { name: /Hello,\s*Ada\s*!/ })
+  ).toBeVisible();
+  await expect(page.locator('html')).toHaveAttribute('lang', 'en');
+}
+
+async function testVueSsr(page: Page, request: APIRequestContext) {
+  const serverResponse = await request.get('/fr/reference');
+  expect(serverResponse.ok()).toBe(true);
+  const serverHtml = await serverResponse.text();
+  expect(serverHtml).toContain('<html lang="fr"');
+  expect(serverHtml).toContain('Référence de l’API');
+  expect(serverHtml).toContain('Opérations disponibles');
+
+  const isolatedResponses = await Promise.all(
+    Array.from({ length: 8 }, (_, index) =>
+      request.get(index % 2 === 0 ? '/reference' : '/fr/reference')
+    )
+  );
+  for (const [index, response] of isolatedResponses.entries()) {
+    const html = await response.text();
+    if (index % 2 === 0) {
+      expect(html).toContain('Available operations');
+      expect(html).not.toContain('Opérations disponibles');
+    } else {
+      expect(html).toContain('Opérations disponibles');
+      expect(html).not.toContain('Available operations');
+    }
+  }
+
+  await page.goto('/fr/reference');
+  await expect(page.locator('html')).toHaveAttribute('lang', 'fr');
+  await expect(page.locator('html')).toHaveAttribute('data-hydrated', 'true');
+  await expect(
+    page.getByRole('heading', { name: 'Opérations disponibles' })
+  ).toBeVisible();
+  await expect(page.getByText('12 opérations documentées')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Ouvrir la recherche' }).click();
+  const dialog = page.getByRole('dialog', {
+    name: 'Recherche dans la documentation',
+  });
+  await expect(dialog).toBeVisible();
+  await expect(
+    dialog.getByRole('heading', {
+      name: 'Rechercher dans la documentation',
+    })
+  ).toBeVisible();
+  await expect(dialog.getByText('Aucun résultat pour le moment')).toBeVisible();
+  await dialog
+    .getByPlaceholder('Rechercher dans toute la documentation')
+    .fill('launch');
+  await expect(dialog.getByText('2 résultats')).toBeVisible();
+  await dialog.getByRole('button', { name: 'Fermer la recherche' }).click();
+  await expect(dialog).toBeHidden();
+
+  await page.getByRole('button', { name: 'Masquer les liens rapides' }).click();
+  await expect(
+    page.getByRole('button', { name: 'Afficher les liens rapides' })
+  ).toBeVisible();
+
+  await page.getByRole('button', { name: 'Copier le lien de la page' }).click();
+  await expect(page.getByText('Le lien de la page a été copié.')).toBeVisible();
+
+  await page.getByRole('link', { name: 'English', exact: true }).click();
+  await expect(page).toHaveURL(/\/reference$/);
+  await expect(page.locator('html')).toHaveAttribute('lang', 'en');
+  await expect(
+    page.getByRole('heading', { name: 'Available operations' })
+  ).toBeVisible();
+  await expect(page.getByText('12 documented operations')).toBeVisible();
+
+  await page.goBack();
+  await expect(page).toHaveURL(/\/fr\/reference$/);
+  await expect(page.locator('html')).toHaveAttribute('lang', 'fr');
+  await expect(
+    page.getByRole('heading', { name: 'Opérations disponibles' })
+  ).toBeVisible();
+  await page.reload();
+  await expect(page.locator('html')).toHaveAttribute('data-hydrated', 'true');
+  await expect(
+    page.getByRole('heading', { name: 'Opérations disponibles' })
+  ).toBeVisible();
 }
 
 async function testNextApp(page: Page) {

--- a/tests/apps/test-apps-e2e/e2e/fixtures.ts
+++ b/tests/apps/test-apps-e2e/e2e/fixtures.ts
@@ -11,7 +11,13 @@ export const test = base.extend<{ runtimeErrors: void }>({
         errors.push(`pageerror: ${error.message}`);
       });
       page.on('console', (message) => {
-        if (message.type() !== 'error' || isIgnoredFaviconError(message)) {
+        const capturesVueWarning =
+          message.type() === 'warning' &&
+          process.env.GT_TEST_APP?.startsWith('vite-vue');
+        if (
+          (message.type() !== 'error' && !capturesVueWarning) ||
+          isIgnoredFaviconError(message)
+        ) {
           return;
         }
         errors.push(`console: ${message.text()}`);


### PR DESCRIPTION
## Summary

- Add a Vite 8 / Vue 3.5 / Vue Router 5 SSR documentation-shell example using linked `gt-vue` packages and local catalogs.
- Demonstrate fresh per-request translation state across SSR, hydration, lazy routes, scoped slots, `Suspense`, `Transition`, `Teleport`, formatters, `msg()`, Vue TSX, and locale-prefixed navigation.
- Add the SPA and SSR examples to the persistent Chromium app matrix, fail Vue runs on browser warnings, and build `gt-vue` in the scheduled workflow.

## Testing

- `pnpm install --frozen-lockfile` — passed
- `pnpm --filter vite-vue-ssr generate` — passed (33 extracted entries, stable across repeated generation)
- `pnpm --filter vite-vue-ssr validate` — passed
- `pnpm --filter vite-vue-ssr typecheck` — passed
- `pnpm --filter vite-vue-ssr test` — passed (2 tests, including 128 overlapping English/French requests)
- `pnpm --filter vite-vue-ssr build` — passed (client and SSR production bundles)
- `GT_TEST_APPS=vite-vue,vite-vue-ssr pnpm --filter gt-test-apps-e2e test:e2e` — passed in Chromium
- `pnpm --filter gt-test-apps-e2e lint` — passed
- `pnpm --filter gt-test-apps-e2e typecheck` — passed

## Notes

- Stack 4/4. Base: #2014. #2032 is closed as superseded by #2012.
- Uses deterministic local catalogs; no GT API key is required.
- Both private Vue examples are excluded from Changesets release versioning.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a Vite 8 / Vue 3.5 / Vue Router 5 SSR documentation-shell example (`vite-vue-ssr`) that demonstrates per-request translation state isolation, client-side hydration, lazy routes, scoped slots, `Suspense`, `Transition`, `Teleport`, formatters, `msg()`, and Vue TSX compatibility. It also wires both Vue examples into the persistent Chromium E2E matrix and adds `gt-vue` to the scheduled cron build.

- **SSR isolation**: every call to `render()` constructs a fresh `GTPlugin`, router, and Vue app instance, verified by 128 concurrent overlapping English/French renders in the unit test suite and 8 parallel requests in the E2E test.
- **Client hydration**: locale is serialised into a `type="application/json"` script tag with `\u003c`-escaped JSON and read back in `entry-client.ts` with a URL-derived fallback, preventing mismatch on initial paint.
- **Fixture update**: Vue console warnings are now treated as test failures for `vite-vue*` apps via an additive condition that does not alter behaviour for existing non-Vue tests.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge — it adds a self-contained example package and test infrastructure with no changes to any published library code.
- All changes are confined to a new private example app, its unit and E2E tests, and CI workflow additions. The SSR isolation pattern is sound (fresh plugin instance per request), escaping is applied correctly in both HTML-attribute and JSON-in-script contexts, and the concurrent-render test suite directly validates the isolation guarantee.
- No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| examples/vite-vue-ssr/src/entry-server.ts | Stateless render function that creates a fresh GT plugin and app per request, with a clear JSDoc explaining the isolation contract. No shared mutable state. |
| examples/vite-vue-ssr/src/app.ts | Shared app factory for both SSR and client; registers a beforeResolve guard to sync locale on navigation, then explicitly loads translations after the router is ready. |
| examples/vite-vue-ssr/server.ts | Express SSR server with dev/prod branching; locale value is HTML-escaped before injection into the lang attribute and JSON is escaped with \u003c to prevent script-injection. |
| examples/vite-vue-ssr/src/entry-client.ts | Client hydration bootstrap; reads locale from the injected #gt-state JSON script tag with a safe try/catch fallback to URL-derived locale before mounting. |
| examples/vite-vue-ssr/src/entry-server.test.ts | Unit tests for SSR isolation — verifies correct locale in rendered HTML and runs 128 concurrent overlapping English/French renders to validate per-request state isolation. |
| tests/apps/test-apps-e2e/e2e/fixtures.ts | Extends the error-collection fixture to treat Vue console warnings as test failures for vite-vue apps; logic is correct and backward-compatible with non-Vue test apps. |
| tests/apps/test-apps-e2e/e2e/app.spec.ts | Adds testVueSpa and testVueSsr E2E test paths covering SSR HTML content, locale isolation under 8 parallel requests, hydration, locale switching via navigation, dialog interactions, and page reload. |
| examples/vite-vue-ssr/src/router.ts | Simple two-route router with locale-prefixed paths; getLocaleFromUrl uses URL constructor for safe parsing and handles both absolute URLs and relative paths correctly. |
| examples/vite-vue-ssr/src/views/ReferencePage.vue | Exercises onServerPrefetch, Plural, Num, DateTime, and Var components; onServerPrefetch resolves immediately as a demo stub for the SSR lifecycle hook. |
| tests/apps/test-apps-e2e/apps.mjs | Adds vite-vue (SPA) and vite-vue-ssr entries to the persistent Chromium app matrix with correct ports and ready-check paths. |
| .github/workflows/test-apps-e2e-cron.yml | Adds gt-vue to the scheduled build step so the Vue package is compiled before E2E tests run against it in the cron workflow. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant B as Browser
    participant S as server.ts (Express)
    participant ES as entry-server.ts
    participant A as app.ts
    participant R as router.ts
    participant T as translations.ts
    participant VR as vue/server-renderer

    B->>S: GET /fr/reference
    S->>ES: render('/fr/reference')
    ES->>R: getLocaleFromUrl('/fr/reference') → 'fr'
    ES->>A: createDocsGT('fr')
    ES->>A: createDocsApp('/fr/reference', true, gt)
    A->>R: "createDocsRouter(server=true)"
    A->>R: router.push('/fr/reference')
    Note over A,R: beforeResolve guard fires
    A->>A: gt.setLocale('fr')
    A->>T: loadTranslations('fr')
    T-->>A: fr.json catalog
    A-->>ES: "{ app, gt, router }"
    ES->>VR: renderToString(app, context)
    VR-->>ES: "{ html, teleports }"
    ES-->>S: "{ html, locale:'fr', teleports }"
    S->>S: inject locale/html/teleports/state into index.html
    S-->>B: 200 text/html (SSR-rendered French page)

    Note over B: Hydration
    B->>B: "readState() → { locale: 'fr' } from #gt-state"
    B->>A: createDocsGT('fr')
    B->>A: createDocsApp(url, false, gt)
    B->>B: "app.mount('#app')"
    B->>B: "data-hydrated='true'"
```
</details>

<sub>Reviews (8): Last reviewed commit: ["test(vue): validate TSX and per-request ..."](https://github.com/generaltranslation/gt/commit/714a9607d7ff693ca1cd8e0c31b59fc2d9534469) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50601758)</sub>

<!-- /greptile_comment -->