### PR TITLE
fix(cli): use the configured locale tag in file and JSON transforms

### DIFF
--- a/.changeset/olive-donkeys-attend.md
+++ b/.changeset/olive-donkeys-attend.md
@@ -2,4 +2,4 @@
 'gt': patch
 ---
 
-Use the locale exactly as configured when substituting `{locale}` in file and JSON transforms, instead of canonicalizing it. Projects that configure a non-canonical tag such as `fr-ca` or `ja-jp` were getting content written to `docs/fr-CA/` while `[locale]` substitution and localized URLs used `docs/fr-ca/`, so every internal link in the translated output pointed at a directory that did not exist. Locales that are already canonical are unaffected.
+Use the locale exactly as configured when substituting `{locale}` in file and JSON transforms, instead of canonicalizing it. Projects that configure a non-canonical tag such as `fr-ca` or `ja-jp` were getting content written to `docs/fr-CA/` while `[locale]` substitution and localized URLs used `docs/fr-ca/`, so every internal link in the translated output pointed at a directory that did not exist.

--- a/.changeset/olive-donkeys-attend.md
+++ b/.changeset/olive-donkeys-attend.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+Use the locale exactly as configured when substituting `{locale}` in file and JSON transforms, instead of canonicalizing it. Projects that configure a non-canonical tag such as `fr-ca` or `ja-jp` were getting content written to `docs/fr-CA/` while `[locale]` substitution and localized URLs used `docs/fr-ca/`, so every internal link in the translated output pointed at a directory that did not exist. Locales that are already canonical are unaffected.

--- a/packages/cli/src/formats/__tests__/utils.test.ts
+++ b/packages/cli/src/formats/__tests__/utils.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { getLocaleProperties } from '@generaltranslation/format';
+import {
+  getConfiguredLocaleProperties,
+  replaceLocalePlaceholders,
+} from '../utils.js';
+
+describe('getConfiguredLocaleProperties', () => {
+  it('reports the locale exactly as configured, not the canonical tag', () => {
+    expect(getLocaleProperties('fr-ca').code).toBe('fr-CA');
+    expect(getConfiguredLocaleProperties('fr-ca').code).toBe('fr-ca');
+
+    expect(getLocaleProperties('ja-jp').code).toBe('ja-JP');
+    expect(getConfiguredLocaleProperties('ja-jp').code).toBe('ja-jp');
+  });
+
+  it('is a no-op for tags that are already canonical', () => {
+    for (const locale of ['en', 'es', 'ja', 'fr-CA', 'zh-Hans']) {
+      expect(getConfiguredLocaleProperties(locale)).toEqual(
+        getLocaleProperties(locale)
+      );
+    }
+  });
+
+  it('leaves every other property canonical', () => {
+    const props = getConfiguredLocaleProperties('fr-ca');
+
+    expect(props.languageCode).toBe('fr');
+    expect(props.regionCode).toBe('CA');
+    expect(props.name).toBe(getLocaleProperties('fr-ca').name);
+  });
+});
+
+describe('replaceLocalePlaceholders with configured locale properties', () => {
+  it('substitutes {locale} with the configured tag', () => {
+    const props = getConfiguredLocaleProperties('ja-jp');
+
+    expect(replaceLocalePlaceholders('docs/{locale}/$1', props)).toBe(
+      'docs/ja-jp/$1'
+    );
+    expect(replaceLocalePlaceholders('{localeCode}', props)).toBe('ja-jp');
+  });
+
+  it('still substitutes canonical values for explicitly-named properties', () => {
+    const props = getConfiguredLocaleProperties('fr-ca');
+
+    expect(
+      replaceLocalePlaceholders('{languageCode}-{regionCode}', props)
+    ).toBe('fr-CA');
+  });
+});

--- a/packages/cli/src/formats/files/__tests__/fileMapping.test.ts
+++ b/packages/cli/src/formats/files/__tests__/fileMapping.test.ts
@@ -36,4 +36,92 @@ describe('createFileMapping', () => {
       'locales/fr/messages.po'
     );
   });
+
+  describe('non-canonical locale tags', () => {
+    // A locale written as "fr-ca" canonicalizes to "fr-CA". Everything that
+    // names a path must use the tag as configured, because [locale]
+    // substitution and static URL localization both use it verbatim. If
+    // {locale} canonicalized here, content would be written to docs/fr-CA/
+    // while links pointed at /docs/fr-ca/.
+    const mapWith = (transform: { match: string; replace: string }) =>
+      createFileMapping(
+        { mdx: [path.resolve('docs/guide.mdx')] },
+        { mdx: [path.resolve('docs/guide.mdx')] },
+        { mdx: transform },
+        {},
+        ['fr-ca', 'ja-jp'],
+        'en'
+      );
+
+    it('uses the configured tag, not the canonical one, for object transforms', () => {
+      const mapping = mapWith({
+        match: '^docs/(.*)$',
+        replace: 'docs/{locale}/$1',
+      });
+
+      expect(mapping['fr-ca']['docs/guide.mdx']).toBe('docs/fr-ca/guide.mdx');
+      expect(mapping['ja-jp']['docs/guide.mdx']).toBe('docs/ja-jp/guide.mdx');
+    });
+
+    it('uses the configured tag for array transforms', () => {
+      const mapping = createFileMapping(
+        { json: [path.resolve('docs/oas/api.json')] },
+        { json: [path.resolve('docs/oas/api.json')] },
+        {
+          json: [{ match: '^docs/oas/(.*)$', replace: 'docs/{locale}/oas/$1' }],
+        },
+        {},
+        ['fr-ca'],
+        'en'
+      );
+
+      expect(mapping['fr-ca']['docs/oas/api.json']).toBe(
+        'docs/fr-ca/oas/api.json'
+      );
+    });
+
+    it('agrees with the [locale] substitution used by the string transform form', () => {
+      // The string form of transform has always substituted [locale]
+      // verbatim. The object form must produce the same directory.
+      const objectForm = mapWith({
+        match: '^docs/(.*)$',
+        replace: 'docs/{locale}/$1',
+      });
+      const stringForm = createFileMapping(
+        { mdx: [path.resolve('docs/guide.mdx')] },
+        { mdx: [path.resolve('docs/[locale]/guide.mdx')] },
+        {},
+        {},
+        ['fr-ca'],
+        'en'
+      );
+
+      expect(objectForm['fr-ca']['docs/guide.mdx']).toBe(
+        stringForm['fr-ca']['docs/guide.mdx']
+      );
+    });
+
+    it('leaves already-canonical tags unchanged', () => {
+      const mapping = createFileMapping(
+        { mdx: [path.resolve('docs/guide.mdx')] },
+        { mdx: [path.resolve('docs/guide.mdx')] },
+        { mdx: { match: '^docs/(.*)$', replace: 'docs/{locale}/$1' } },
+        {},
+        ['fr-CA', 'ja'],
+        'en'
+      );
+
+      expect(mapping['fr-CA']['docs/guide.mdx']).toBe('docs/fr-CA/guide.mdx');
+      expect(mapping['ja']['docs/guide.mdx']).toBe('docs/ja/guide.mdx');
+    });
+
+    it('still exposes canonical values via explicitly-named properties', () => {
+      const mapping = mapWith({
+        match: '^docs/(.*)$',
+        replace: 'docs/{languageCode}-{regionCode}/$1',
+      });
+
+      expect(mapping['fr-ca']['docs/guide.mdx']).toBe('docs/fr-CA/guide.mdx');
+    });
+  });
 });

--- a/packages/cli/src/formats/files/fileMapping.ts
+++ b/packages/cli/src/formats/files/fileMapping.ts
@@ -7,8 +7,10 @@ import { SUPPORTED_FILE_EXTENSIONS } from '../files/supportedFiles.js';
 import { resolveLocaleFiles } from '../../fs/config/parseFilesConfig.js';
 import path from 'node:path';
 import { getRelative } from '../../fs/findFilepath.js';
-import { getLocaleProperties } from '@generaltranslation/format';
-import { replaceLocalePlaceholders } from '../utils.js';
+import {
+  getConfiguredLocaleProperties,
+  replaceLocalePlaceholders,
+} from '../utils.js';
 import { FileMapping } from '../../types/files.js';
 import { TEMPLATE_FILE_NAME } from '../../utils/constants.js';
 import { replaceFileExtensionForFormat } from './transformFormat.js';
@@ -67,8 +69,9 @@ export function createFileMapping(
           });
         } else if (Array.isArray(transformPath)) {
           // transformPath is an array of TransformOption objects
-          const targetLocaleProperties = getLocaleProperties(locale);
-          const defaultLocaleProperties = getLocaleProperties(defaultLocale);
+          const targetLocaleProperties = getConfiguredLocaleProperties(locale);
+          const defaultLocaleProperties =
+            getConfiguredLocaleProperties(defaultLocale);
 
           translatedFiles = translatedFiles.map((filePath) => {
             const relativePath = getRelative(filePath);
@@ -113,8 +116,9 @@ export function createFileMapping(
           });
         } else {
           // transformPath is an object
-          const targetLocaleProperties = getLocaleProperties(locale);
-          const defaultLocaleProperties = getLocaleProperties(defaultLocale);
+          const targetLocaleProperties = getConfiguredLocaleProperties(locale);
+          const defaultLocaleProperties =
+            getConfiguredLocaleProperties(defaultLocale);
           if (
             !transformPath.replace ||
             typeof transformPath.replace !== 'string'

--- a/packages/cli/src/formats/json/__tests__/mergeJson.test.ts
+++ b/packages/cli/src/formats/json/__tests__/mergeJson.test.ts
@@ -1622,6 +1622,73 @@ describe('mergeJson', () => {
       expect(frenchNav.tabs[0].pages[0]).toBe('docs/fr-ca/index');
     });
 
+    it('uses the configured locale tag for keys and transforms by default', () => {
+      // Without experimentalCanonicalLocaleKeys, the locale key and any
+      // {locale} in a transform must both use the tag exactly as configured.
+      // Canonicalizing here would emit a "fr-CA" key and docs/fr-CA/ paths
+      // while the files on disk and the localized URLs both use "fr-ca".
+      const originalContent = JSON.stringify({
+        navigation: {
+          languages: [
+            {
+              language: 'en',
+              tabs: [{ tab: 'Home', pages: ['docs/index'] }],
+            },
+          ],
+        },
+      });
+
+      const targets = [
+        {
+          translatedContent: JSON.stringify({
+            '/navigation/languages': {
+              '/0': {
+                '/tabs/0/tab': 'Accueil',
+                '/tabs/0/pages/0': 'docs/index',
+              },
+            },
+          }),
+          targetLocale: 'fr-ca',
+        },
+      ];
+
+      const result = mergeJson(
+        originalContent,
+        'docs.json',
+        {
+          jsonSchema: {
+            '**/*.json': {
+              composite: {
+                '$.navigation.languages': {
+                  type: 'array',
+                  include: ['$.tabs[*].tab', '$.tabs[*].pages[*]'],
+                  key: '$.language',
+                  transform: {
+                    '$..pages[*]': {
+                      match: '^docs/(.*)$',
+                      replace: 'docs/{locale}/$1',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        targets,
+        'en',
+        ['fr-ca']
+      );
+
+      const parsed = JSON.parse(result[0]);
+      const frenchNav = parsed.navigation.languages.find(hasLanguage('fr-ca'));
+
+      expect(frenchNav).toBeDefined();
+      expect(
+        parsed.navigation.languages.find(hasLanguage('fr-CA'))
+      ).toBeUndefined();
+      expect(frenchNav.tabs[0].pages[0]).toBe('docs/fr-ca/index');
+    });
+
     it('should order array items to match locales when sort is set to locale', () => {
       const originalContent = JSON.stringify({
         navigation: {

--- a/packages/cli/src/formats/json/mergeJson.ts
+++ b/packages/cli/src/formats/json/mergeJson.ts
@@ -9,8 +9,10 @@ import {
   getSourceObjectOptionsArray,
   validateJsonSchema,
 } from './utils.js';
-import { getLocaleProperties } from '@generaltranslation/format';
-import { replaceLocalePlaceholders } from '../utils.js';
+import {
+  getConfiguredLocaleProperties,
+  replaceLocalePlaceholders,
+} from '../utils.js';
 import { gt } from '../../utils/gt.js';
 import {
   applyStructuralTransforms,
@@ -562,8 +564,8 @@ export function applyTransformations(
 ): void {
   if (!transform) return;
 
-  const targetLocaleProperties = getLocaleProperties(targetLocale);
-  const defaultLocaleProperties = getLocaleProperties(defaultLocale);
+  const targetLocaleProperties = getConfiguredLocaleProperties(targetLocale);
+  const defaultLocaleProperties = getConfiguredLocaleProperties(defaultLocale);
 
   for (const [transformPath, transformOptions] of Object.entries(transform)) {
     if (

--- a/packages/cli/src/formats/json/utils.ts
+++ b/packages/cli/src/formats/json/utils.ts
@@ -1,4 +1,4 @@
-import { getLocaleProperties } from '@generaltranslation/format';
+import { getConfiguredLocaleProperties } from '../utils.js';
 import { exitSync } from '../../console/logging.js';
 import { logger } from '../../console/logger.js';
 import type { LocaleProperties } from '@generaltranslation/format/types';
@@ -123,7 +123,9 @@ export function getIdentifyingLocaleProperty(
   // Validate localeProperty
   const localeProperty = sourceObjectOptions.localeProperty || 'code';
   const identifyingLocaleProperty =
-    getLocaleProperties(locale)[localeProperty as keyof LocaleProperties];
+    getConfiguredLocaleProperties(locale)[
+      localeProperty as keyof LocaleProperties
+    ];
   if (!identifyingLocaleProperty) {
     logger.error(
       `Source object options localeProperty is not a valid locale property at path: ${sourceObjectPointer}`

--- a/packages/cli/src/formats/utils.ts
+++ b/packages/cli/src/formats/utils.ts
@@ -1,4 +1,33 @@
+import { getLocaleProperties } from '@generaltranslation/format';
 import type { LocaleProperties } from '@generaltranslation/format/types';
+
+/**
+ * Locale properties for a locale as it is written in the user's `locales` config.
+ *
+ * `getLocaleProperties(locale).code` returns the *canonical* BCP-47 form of a
+ * tag, so "fr-ca" becomes "fr-CA" and "ja-jp" becomes "ja-JP". That is correct
+ * when talking to the API, but it is wrong for anything that names a file, a
+ * directory, a URL segment, or a locale key on disk: those must use the locale
+ * exactly as the user configured it, because that is the spelling every other
+ * part of the CLI uses. `resolveLocaleFiles` substitutes `[locale]` verbatim,
+ * the string form of `transform` substitutes `[locale]` verbatim, and
+ * `localizeStaticUrls` splices the raw locale into URL paths. If placeholder
+ * substitution canonicalizes while those do not, a project that configures a
+ * non-canonical tag gets content written to one directory and links pointing
+ * at another.
+ *
+ * Locales that are already canonical (the common case) are unaffected: for
+ * those, `code` and the configured string are identical.
+ *
+ * Callers that genuinely want the canonical tag should use
+ * `gt.resolveCanonicalLocale`, or one of the explicitly-named properties such
+ * as `{minimizedCode}` / `{maximizedCode}` / `{regionCode}`.
+ */
+export function getConfiguredLocaleProperties(
+  locale: string
+): LocaleProperties {
+  return { ...getLocaleProperties(locale), code: locale };
+}
 
 // helper function to replace locale placeholders in a string
 // with the corresponding locale properties


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR preserves locale tags exactly as configured when generating file destinations, JSON locale identifiers, and `{locale}` substitutions.

- Adds a shared helper that retains the configured locale code while preserving canonical derived properties.
- Applies configured locale spelling to file and JSON transforms.
- Adds regression coverage for non-canonical tags such as `fr-ca` and `ja-jp`.
- Adds a patch changeset describing the corrected path and link behavior.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the configured locale spelling applied consistently across the changed file and JSON transform paths.

The implementation preserves canonical derived locale properties while overriding only the code used for configured path and key substitutions, and the regression tests cover the affected non-canonical locale cases.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/formats/utils.ts | Adds the configured-locale property helper while retaining canonical language, region, and other derived properties. |
| packages/cli/src/formats/files/fileMapping.ts | Uses configured locale spelling consistently in object and array file-path transforms. |
| packages/cli/src/formats/json/mergeJson.ts | Uses configured locale spelling when applying JSON value transformations. |
| packages/cli/src/formats/json/utils.ts | Matches default JSON locale identifiers against the configured locale spelling. |
| packages/cli/src/formats/files/__tests__/fileMapping.test.ts | Covers configured spelling across object, array, and string file transforms. |
| packages/cli/src/formats/json/__tests__/mergeJson.test.ts | Covers configured locale keys and transformed paths for non-canonical tags. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(cli): use the configured locale tag ..."](https://github.com/generaltranslation/gt/commit/0d0f9719cf972d83de249d77173ee9d1df6b5b11) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50915257)</sub>

**Context used:**

- Knowledge Base — [CLI package (`gt`)](https://app.greptile.com/generaltranslation/-/custom-context/knowledge-base/generaltranslation/gt/-/docs/cli-package.md)

<!-- /greptile_comment -->