### PR TITLE
test(release): exercise Iris CLI patch publishing

### DIFF
--- a/.changeset/test-iris-gt-patch.md
+++ b/.changeset/test-iris-gt-patch.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+Exercise Iris prerelease publishing for the CLI.


### PR DESCRIPTION
## Summary

- Add a patch changeset for `gt` to exercise the Iris prerelease channel.
- Keep the test isolated to one Changesets file with no implementation changes.

## Testing

- `pnpm changeset status` — passed; recognizes `gt` as a patch release
- `git diff --check` — passed
- Exact diff against `iris` — one commit adding only `.changeset/test-iris-gt-patch.md`

## Notes

- The changeset itself names only `gt`.
- Changesets also reports `gtx-cli` through the fixed package group and `locadex` through dependency propagation.
