### PR TITLE
fix(ci): retrigger Iris release generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -353,6 +353,7 @@ jobs:
         with:
           version: bash scripts/version-packages-iris.sh
           publish: pnpm run release
+          branch: iris
           commit: '[ci] iris release'
           title: '[ci] iris release'
         env:


### PR DESCRIPTION
## Summary

- Pin the Changesets action to the `iris` branch and retrigger Iris release generation after the workflow-activation race skipped the existing test changeset.
- Preserve the proven Odysseus flow: this merge opens the generated Iris release PR; packages publish only after that generated PR is merged.

## Testing

- `pnpm lint` — passed
- `pnpm test` — passed (40/40 tasks)
- workflow YAML parse and formatting checks — passed
- `pnpm changeset status` — found the expected patch release for `gt`, `gtx-cli`, and `locadex`

## Notes

- Changeset: intentionally omitted; this is CI-only.
- Base branch: `iris`.
- Merging this PR supplies the fresh Iris push needed to process `.changeset/test-iris-gt-patch.md`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Pins the Iris Changesets release flow to the `iris` base branch so a fresh push retriggers generation of the pending prerelease PR.
- Adds `branch: iris` to the existing `changesets/action@v1` step.
- Leaves package versioning and publishing commands unchanged.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the release action now explicitly aligned to the Iris branch.

The added branch input matches the Iris-only job and its existing Iris versioning configuration, without changing package publishing behavior or introducing a concrete workflow failure.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | The Iris release action now explicitly targets the `iris` branch; no actionable defect was identified in the one-line workflow change. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): retrigger Iris release generati..."](https://github.com/generaltranslation/gt/commit/91d4fc82e15c90966305eb15bea1a3dbe12366f4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50953779)</sub>

<!-- /greptile_comment -->