### PR TITLE
chore(ci): require team code-owner approvals

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,5 @@
 # Require someone from the @engineering team to approve all changes
 * @generaltranslation/engineering
+
+# Require someone from the @admins team to approve changes to code ownership
+/.github/CODEOWNERS @generaltranslation/admins

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,2 @@
-# Require someone from the @maintainers team to approve all changes
-* @generaltranslation/maintainers
-
+# Require someone from the @engineering team to approve all changes
+* @generaltranslation/engineering


### PR DESCRIPTION
## Summary

- Assign all repository paths to `@generaltranslation/engineering` in `CODEOWNERS`.
- Require `@generaltranslation/admins` approval for changes to `.github/CODEOWNERS` itself.
- Use the existing code-owner review ruleset to enforce the ownership entries.

## Testing

- `git diff --check origin/main...HEAD` — passed.
- Automated tests not run; this changes repository ownership metadata only.

## Notes

- Changeset: not required for repository metadata.
- The existing organization ruleset requires one code-owner approval on the default branch and retains its current bypass list.
- GitHub requires the Engineering and Admins teams to receive explicit write access to this repository before they can be recognized as code owners; that access is not currently assigned.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Assigns Engineering as the repository-wide code owner and Admins as the owner for changes to the CODEOWNERS file.
- Replaces the Maintainers wildcard ownership rule with Engineering.
- Adds a path-specific Admins ownership rule for `.github/CODEOWNERS`.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains within the eligible follow-up review scope.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/CODEOWNERS | Updates repository-wide ownership from Maintainers to Engineering and assigns CODEOWNERS-file changes to Admins. |

</details>

<sub>Reviews (2): Last reviewed commit: ["chore(ci): protect code ownership change..."](https://github.com/generaltranslation/gt/commit/1810935608da1fa103d52334c5d7076165cb3a4d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50987592)</sub>

<!-- /greptile_comment -->