### PR TITLE
ci: retrigger Iris prerelease publish

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -54,7 +54,5 @@
     "gt-test-vite-react": "0.1.1",
     "gt-test-webpack-react": "0.1.1"
   },
-  "changesets": [
-    "test-iris-gt-patch"
-  ]
+  "changesets": ["test-iris-gt-patch"]
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Release
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 name: Release
 
 on:
-  workflow_dispatch:
   push:
     branches:
       - main
@@ -301,6 +300,8 @@ jobs:
           pnpm --filter gtx-cli run bin:restore
           pnpm --filter gtx-cli run build:clean
 
+  # A no-changeset push after merging the generated Iris release PR enters
+  # Changesets' publish path for the versions committed by that PR.
   iris-release:
     if: github.ref_name == 'iris'
     name: Iris Prerelease


### PR DESCRIPTION
## Summary

- Supply the fresh no-changeset `iris` push needed to publish the already-versioned `gt@2.16.3-iris.0`, `gtx-cli@2.16.3-iris.0`, and `locadex@1.0.206-iris.0` packages.
- Document why merging a generated Iris release PR should enter Changesets' publish path on the next Iris workflow run.

## Testing

- `git diff --check` — passed
- Ruby YAML parse of `.github/workflows/release.yml` — passed
- `oxfmt --check .` — passed (1,977 files)
- Confirmed no changeset contents or package versions are changed by this PR

## Notes

- Base branch: `iris`.
- Changeset intentionally omitted: the generated Iris release PR has already versioned the packages, so this run must take the Changesets publish path.
- Formats the existing Iris prerelease state without changing its values.
- This PR does not change package versions or release commands.
